### PR TITLE
Revert behaviour of bsse_type='cp'

### DIFF
--- a/doc/sphinxman/source/nbody.rst
+++ b/doc/sphinxman/source/nbody.rst
@@ -50,26 +50,32 @@ The nbody function computes counterpoise-corrected (CP), non-CP (noCP), and Vali
 
 **Examples :** ::
 
-    # Counterpoise corrected CCSD(T) energy for the Helium dimer
+    # Counterpoise corrected CCSD(T) energies for the Helium dimer
     molecule mol {
       He
-      -- 
+      --
       He 1 3
     }
+    # Calculate interaction energies only (skips monomers in monomer basis):
+    energy('CCSD(T)', bsse_type='cp')
+    # Calculate interaction and total energies, return interaction energies:
+    energy('CCSD(T)', bsse_type=['cp','nocp'])
+    # Calculate and return counterpoise-corrected gradient
+    # Useful for e.g. CP-corrected geometry optimization
+    gradient('CCSD(T)', bsse_type='cp', return_total_data=True)
 
-    energy('CCSD(T)', bsse_type='cp')   
 
     # noCP, VMFC, and CP energy for a helium cluster, limited at 3 bodies
     molecule mol {
       He 0 0 0
-      -- 
+      --
       He 0 0 4
-      -- 
+      --
       He 0 4 0
       --
       He 4 0 0
     }
 
     # Returns the nocp energy as its first in the list
-    energy('CCSD(T)', bsse_type=['nocp', 'cp', 'vmfc'], max_nbody=3) 
+    energy('CCSD(T)', bsse_type=['nocp', 'cp', 'vmfc'], max_nbody=3)
 

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -192,7 +192,7 @@ def nbody_gufunc(func: Union[str, Callable], method_string: str, **kwargs):
         ``'on'`` for gradients and Hessians. Note that the calculation of total
         counterpoise corrected energies implies the calculation of the energies of
         monomers in the monomer basis, hence specifying ``return_total_data = True``
-        may carry out more computations than ``return_Total_data = False``.
+        may carry out more computations than ``return_total_data = False``.
 
     :type levels: dict
     :param levels: ``{1: 'ccsd(t)', 2: 'mp2', 'supersystem': 'scf'}`` || ``{1: 2, 2: 'ccsd(t)', 3: 'mp2'}`` || etc
@@ -776,7 +776,7 @@ def assemble_nbody_components(metadata, component_results):
     results = {}
     results['nbody'] = nbody_dict
     for b in ['cp', 'nocp', 'vmfc']:
-        if b in metadata['bsse_type_list'] and monomer_energies != 0.0:
+        if monomer_energies != 0.0:
             results['%s_energy_body_dict' % b] = eval('%s_energy_body_dict' % b)
             results['%s_energy_body_dict' % b] = {str(i) + b: j for i, j in results['%s_energy_body_dict' % b].items()}
         else:

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -168,8 +168,11 @@ def nbody_gufunc(func: Union[str, Callable], method_string: str, **kwargs):
     :type bsse_type: str or list
     :param bsse_type: ``'cp'`` || ``['nocp', 'vmfc']`` || |dl| ``None`` |dr| || etc.
 
-        Type of BSSE correction to compute: CP, NoCP, or VMFC. The first in this
-        list is returned by this function. By default, this function is not called.
+        Type of BSSE correction to compute: CP for counterpoise correction, NoCP
+        for plain supramolecular interaction energy, or VMFC for Valiron-Mayer
+        Function Counterpoise correction. If a list is provided, the first string in
+        the list determines which interaction or total energies/gradients/Hessians are
+        returned by this function. By default, this function is not called.
 
     :type max_nbody: int
     :param max_nbody: ``3`` || etc.
@@ -184,15 +187,18 @@ def nbody_gufunc(func: Union[str, Callable], method_string: str, **kwargs):
     :type return_total_data: :ref:`boolean <op_py_boolean>`
     :param return_total_data: ``'on'`` || |dl| ``'off'`` |dr|
 
-        If True returns the total data (energy/gradient/etc) of the system,
-        otherwise returns interaction data.
+        If True returns the total data (energy/gradient/Hessian) of the system,
+        otherwise returns interaction data. Note that the calculation of total
+        counterpoise corrected energies implies the calculation of the energies of
+        monomers in the monomer basis, hence specifying ``return_total_data = True``
+        may carry out more computations than ``return_Total_data = False``.
 
     :type levels: dict
     :param levels: ``{1: 'ccsd(t)', 2: 'mp2', 'supersystem': 'scf'}`` || ``{1: 2, 2: 'ccsd(t)', 3: 'mp2'}`` || etc
 
         Dictionary of different levels of theory for different levels of expansion
-        Note that method_string is not used in this case.
-        supersystem computes all higher order n-body effects up to the number of fragments.
+        Note that method_string is not used in this case. ``supersystem`` computes
+        all higher order n-body effects up to the number of fragments.
 
     :type embedding_charges: dict
     :param embedding_charges: ``{1: [-0.834, 0.417, 0.417], ..}``
@@ -202,7 +208,8 @@ def nbody_gufunc(func: Union[str, Callable], method_string: str, **kwargs):
     :type charge_method: str
     :param charge_method: ``scf/6-31g`` || ``b3lyp/6-31g*`` || etc
 
-        Method to compute point charges for monomers. Overridden by embedding_charges if both are provided.
+        Method to compute point charges for monomers. Overridden by ``embedding_charges``
+        if both are provided.
 
     :type charge_type: str
     :param charge_type: ``MULLIKEN_CHARGES`` || ``LOWDIN_CHARGES``
@@ -555,17 +562,17 @@ def assemble_nbody_components(metadata, component_results):
 
         Contents:
         ``'ret_energy'``: float64
-            Interaction data requested.  If multiple BSSE types requested in `bsse_type_list`, the
-            interaction data associated with the *first* BSSE type in the list is returned.
+            Interaction data requested.  If multiple BSSE types requested in `bsse_type_list`, the interaction data associated with the *first* BSSE
+            type in the list is returned.
         ``'nbody_dict'``: dict of str: float64
             Dictionary of relevant N-body psivars to be set
         ``'energy_body_dict'``: dict of int: float64
-            Dictionary of total energies at each N-body level, i.e., ``results['energy_body_dict'][2]``
-            is the sum of all 2-body total energies for the supersystem.
+            Dictionary of total energies at each N-body level, i.e., ``results['energy_body_dict'][2]`` is the sum of all 2-body total energies
+            for the supersystem. May be empty if ``return_total_data`` is ``False``.
         ``'ptype_body_dict'``: dict or dict of int: array_like
-            Empty dictionary if `ptype is ``'energy'``, or dictionary of total ptype arrays at each
-            N-body level; i.e., ``results['ptype_body_dict'][2]`` for `ptype` ``'gradient'``is the
-            total 2-body gradient.
+            Empty dictionary if `ptype is ``'energy'``, or dictionary of total ptype
+            arrays at each N-body level; i.e., ``results['ptype_body_dict'][2]``
+            for `ptype` ``'gradient'``is the total 2-body gradient.
     """
     # Unpack metadata
     kwargs = metadata['kwargs']

--- a/tests/dftd3/nbody-cp-gradient/input.dat
+++ b/tests/dftd3/nbody-cp-gradient/input.dat
@@ -205,7 +205,7 @@ for result in [  #TEST
 
 # compute nbody again with return_total_data=False
 # * note CURRENT ENERGY moved from first to second testing block
-g, wfn = gradient('SCF-d3bj/STO-3G', molecule=water_trimer, bsse_type='cp', max_nbody=2,
+g, wfn = gradient('SCF-d3bj/STO-3G', molecule=water_trimer, bsse_type=['cp', 'nocp'], max_nbody=2,
                                       return_total_data=False, return_wfn=True)
 core.clean()
 

--- a/tests/dftd3/nbody-cp-gradient/output.ref
+++ b/tests/dftd3/nbody-cp-gradient/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.4rc3.dev2 
+                               Psi4 1.4rc3.dev14 
 
-                         Git: Rev {libxc514} 1a04788 dirty
+                         Git: Rev {i1691} ea22d04 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,13 +30,13 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Friday, 11 June 2021 02:11AM
+    Psi4 started on: Monday, 28 June 2021 10:22AM
 
-    Process ID: 9912
-    Host:       psinet
-    PSIDATADIR: /psi/gits/hrw-l2/objdir39c/stage/share/psi4
+    Process ID: 60910
+    Host:       dorje
+    PSIDATADIR: /home/kraus/Applications/psi4-i2206/share/psi4
     Memory:     500.0 MiB
-    Threads:    1
+    Threads:    8
     
   ==> Input File <==
 
@@ -248,7 +248,7 @@ for result in [  #TEST
 
 # compute nbody again with return_total_data=False
 # * note CURRENT ENERGY moved from first to second testing block
-g, wfn = gradient('SCF-d3bj/STO-3G', molecule=water_trimer, bsse_type='cp', max_nbody=2,
+g, wfn = gradient('SCF-d3bj/STO-3G', molecule=water_trimer, bsse_type=['cp', 'nocp'], max_nbody=2,
                                       return_total_data=False, return_wfn=True)
 core.clean()
 
@@ -286,7 +286,7 @@ Scratch directory: /tmp/
    ===> N-Body Interaction Abacus <===
         BSSE Treatment:                     cp
         Number of 1-body computations:     6
-        Number of 2-body computations:     3
+        Number of 2-body computations:     6
 
    ==> N-Body: Now computing 1-body complexes <==
 
@@ -299,16 +299,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:35 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:32 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -326,7 +326,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -386,8 +386,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -398,7 +398,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -435,17 +435,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20742807468321   -7.42074e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92713508767751   -7.19707e-01   1.16865e-02 DIIS
-   @DF-RHF iter   2:   -74.97377725367502   -4.66422e-02   1.98794e-03 DIIS
-   @DF-RHF iter   3:   -74.97483304712009   -1.05579e-03   4.55406e-04 DIIS
-   @DF-RHF iter   4:   -74.97491824358181   -8.51965e-05   4.56427e-05 DIIS
-   @DF-RHF iter   5:   -74.97491959385142   -1.35027e-06   8.79231e-06 DIIS
-   @DF-RHF iter   6:   -74.97491964748843   -5.36370e-08   4.96493e-07 DIIS
-   @DF-RHF iter   7:   -74.97491964760290   -1.14468e-10   5.85646e-08 DIIS
-   @DF-RHF iter   8:   -74.97491964760474   -1.83320e-12   7.90968e-09 DIIS
-   @DF-RHF iter   9:   -74.97491964760471    2.84217e-14   1.91420e-09 DIIS
-   @DF-RHF iter  10:   -74.97491964760474   -2.84217e-14   3.64991e-10 DIIS
+   @DF-RHF iter SAD:   -74.20742807468231   -7.42074e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92713508767693   -7.19707e-01   1.16865e-02 DIIS
+   @DF-RHF iter   2:   -74.97377725367430   -4.66422e-02   1.98794e-03 DIIS
+   @DF-RHF iter   3:   -74.97483304711936   -1.05579e-03   4.55406e-04 DIIS
+   @DF-RHF iter   4:   -74.97491824358110   -8.51965e-05   4.56427e-05 DIIS
+   @DF-RHF iter   5:   -74.97491959385076   -1.35027e-06   8.79231e-06 DIIS
+   @DF-RHF iter   6:   -74.97491964748770   -5.36369e-08   4.96493e-07 DIIS
+   @DF-RHF iter   7:   -74.97491964760232   -1.14625e-10   5.85646e-08 DIIS
+   @DF-RHF iter   8:   -74.97491964760412   -1.80478e-12   7.90968e-09 DIIS
+   @DF-RHF iter   9:   -74.97491964760417   -4.26326e-14   1.91420e-09 DIIS
+   @DF-RHF iter  10:   -74.97491964760401    1.56319e-13   3.64991e-10 DIIS
   Energy and wave function converged.
 
 
@@ -472,14 +472,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97491964760474
+  @DF-RHF Final Energy:   -74.97491964760401
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.1889285363781426
-    Two-Electron Energy =                  38.0985795999683816
-    Total Energy =                        -74.9749196476047359
+    One-Electron Energy =                -122.1889285363744193
+    Two-Electron Energy =                  38.0985795999653902
+    Total Energy =                        -74.9749196476040112
 
 Computation Completed
 
@@ -501,18 +501,18 @@ Properties computed using the SCF density matrix
      X:     0.3868      Y:    -1.4204      Z:     1.0410     Total:     1.8030
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:37 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:34 2021
 Module time:
-	user time   =       0.70 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       1.85 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.70 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       1.85 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:37 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:34 2021
 
 
          ------------------------------------------------------------
@@ -558,8 +558,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -578,28 +578,28 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.005935059733    -0.047617424551     0.039074564901
-       2       -0.010137101230     0.015943073054    -0.009922311386
-       3        0.011055682440     0.023598316632    -0.029030216879
-       4        0.000148988991     0.000025243627    -0.000022690919
-       5        0.000010967308     0.000001674296    -0.000001547970
-       6        0.000207745721     0.000029486396    -0.000032447680
-       7        0.000572101763     0.000266556798     0.000029623490
-       8        0.004072970022     0.007742331248    -0.000093127011
-       9        0.000003704716     0.000010742498    -0.000001846546
+       1       -0.005935059683    -0.047617424947     0.039074565519
+       2       -0.010137101623     0.015943073255    -0.009922311473
+       3        0.011055682877     0.023598316996    -0.029030217397
+       4        0.000148988967     0.000025243674    -0.000022690913
+       5        0.000010967309     0.000001674294    -0.000001547972
+       6        0.000207745758     0.000029486344    -0.000032447683
+       7        0.000572101774     0.000266556850     0.000029623501
+       8        0.004072969897     0.007742331026    -0.000093127032
+       9        0.000003704722     0.000010742506    -0.000001846552
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:37 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:34 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.22 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.83 seconds =       0.01 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       3.28 seconds =       0.05 minutes
+	system time =       0.21 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
-       N-Body: Complex Energy (fragments = (1,), basis = (1, 2, 3):   -74.97491964760474)
+       N-Body: Complex Energy (fragments = (1,), basis = (1, 2, 3):   -74.97491964760401)
 
        N-Body: Computing complex (2/6) with fragments (2,) in the basis of fragments (1, 2, 3).
 
@@ -609,16 +609,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:37 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:34 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -636,7 +636,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -696,8 +696,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -708,7 +708,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -745,17 +745,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20662008189998   -7.42066e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92637739020094   -7.19757e-01   1.17111e-02 DIIS
-   @DF-RHF iter   2:   -74.97326949611072   -4.68921e-02   1.97672e-03 DIIS
-   @DF-RHF iter   3:   -74.97431247519025   -1.04298e-03   4.53262e-04 DIIS
-   @DF-RHF iter   4:   -74.97439653644450   -8.40613e-05   4.54754e-05 DIIS
-   @DF-RHF iter   5:   -74.97439787789627   -1.34145e-06   8.68396e-06 DIIS
-   @DF-RHF iter   6:   -74.97439793024081   -5.23445e-08   4.77771e-07 DIIS
-   @DF-RHF iter   7:   -74.97439793034638   -1.05572e-10   5.60429e-08 DIIS
-   @DF-RHF iter   8:   -74.97439793034803   -1.64846e-12   7.92543e-09 DIIS
-   @DF-RHF iter   9:   -74.97439793034800    2.84217e-14   1.91285e-09 DIIS
-   @DF-RHF iter  10:   -74.97439793034798    2.84217e-14   3.66385e-10 DIIS
+   @DF-RHF iter SAD:   -74.20662008191566   -7.42066e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92637739021673   -7.19757e-01   1.17111e-02 DIIS
+   @DF-RHF iter   2:   -74.97326949612669   -4.68921e-02   1.97672e-03 DIIS
+   @DF-RHF iter   3:   -74.97431247520608   -1.04298e-03   4.53262e-04 DIIS
+   @DF-RHF iter   4:   -74.97439653646047   -8.40613e-05   4.54754e-05 DIIS
+   @DF-RHF iter   5:   -74.97439787791227   -1.34145e-06   8.68396e-06 DIIS
+   @DF-RHF iter   6:   -74.97439793025669   -5.23444e-08   4.77771e-07 DIIS
+   @DF-RHF iter   7:   -74.97439793036231   -1.05629e-10   5.60429e-08 DIIS
+   @DF-RHF iter   8:   -74.97439793036386   -1.54898e-12   7.92543e-09 DIIS
+   @DF-RHF iter   9:   -74.97439793036396   -9.94760e-14   1.91285e-09 DIIS
+   @DF-RHF iter  10:   -74.97439793036402   -5.68434e-14   3.66385e-10 DIIS
   Energy and wave function converged.
 
 
@@ -782,14 +782,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97439793034798
+  @DF-RHF Final Energy:   -74.97439793036402
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.1879518597725678
-    Two-Electron Energy =                  38.1012744681087696
-    Total Energy =                        -74.9743979303479762
+    One-Electron Energy =                -122.1879518597816201
+    Two-Electron Energy =                  38.1012744681017637
+    Total Energy =                        -74.9743979303640344
 
 Computation Completed
 
@@ -811,18 +811,18 @@ Properties computed using the SCF density matrix
      X:     1.0185      Y:     1.0559      Z:     1.0384     Total:     1.7974
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:38 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:35 2021
 Module time:
-	user time   =       0.62 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       4.31 seconds =       0.07 minutes
+	system time =       0.21 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.46 seconds =       0.02 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       7.67 seconds =       0.13 minutes
+	system time =       0.43 seconds =       0.01 minutes
 	total time  =          3 seconds =       0.05 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:38 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:35 2021
 
 
          ------------------------------------------------------------
@@ -868,8 +868,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -888,28 +888,28 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000471411715     0.000356803526    -0.000054418348
-       2       -0.008168586790    -0.000377057152    -0.000347481001
-       3       -0.000010562665    -0.000002212593     0.000000346743
-       4        0.044104792300     0.018053620652     0.038832095194
-       5       -0.026707874117    -0.002453912338    -0.028547451305
-       6       -0.008502881784    -0.015883180896    -0.009838982335
-       7       -0.000111977626     0.000137295929    -0.000015716267
-       8       -0.000125841632     0.000163541055    -0.000028233206
-       9       -0.000005655967     0.000005101816    -0.000000159476
+       1       -0.000471411805     0.000356803533    -0.000054418346
+       2       -0.008168586416    -0.000377057160    -0.000347481004
+       3       -0.000010562662    -0.000002212593     0.000000346743
+       4        0.044104793086     0.018053621663     0.038832096215
+       5       -0.026707875141    -0.002453912163    -0.028547452160
+       6       -0.008502881826    -0.015883182085    -0.009838982503
+       7       -0.000111977593     0.000137295892    -0.000015716264
+       8       -0.000125841663     0.000163541079    -0.000028233203
+       9       -0.000005655977     0.000005101832    -0.000000159478
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:38 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:36 2021
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.81 seconds =       0.05 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.60 seconds =       0.03 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      11.04 seconds =       0.18 minutes
+	system time =       0.57 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-       N-Body: Complex Energy (fragments = (2,), basis = (1, 2, 3):   -74.97439793034798)
+       N-Body: Complex Energy (fragments = (2,), basis = (1, 2, 3):   -74.97439793036402)
 
        N-Body: Computing complex (3/6) with fragments (3,) in the basis of fragments (3,).
 
@@ -919,16 +919,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:38 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:36 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -946,7 +946,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1000,8 +1000,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1012,7 +1012,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1049,16 +1049,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20651452671358   -7.42065e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91808516758250   -7.11571e-01   3.55775e-02 DIIS
-   @DF-RHF iter   2:   -74.96709222478714   -4.90071e-02   5.42254e-03 DIIS
-   @DF-RHF iter   3:   -74.96797025129629   -8.78027e-04   1.28737e-03 DIIS
-   @DF-RHF iter   4:   -74.96804216953664   -7.19182e-05   1.29539e-04 DIIS
-   @DF-RHF iter   5:   -74.96804342339473   -1.25386e-06   8.90787e-06 DIIS
-   @DF-RHF iter   6:   -74.96804342803641   -4.64168e-09   5.24339e-07 DIIS
-   @DF-RHF iter   7:   -74.96804342805231   -1.59019e-11   5.17144e-08 DIIS
-   @DF-RHF iter   8:   -74.96804342805244   -1.27898e-13   1.18687e-09 DIIS
-   @DF-RHF iter   9:   -74.96804342805250   -5.68434e-14   1.51651e-10 DIIS
+   @DF-RHF iter SAD:   -74.20651452670239   -7.42065e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91808516757162   -7.11571e-01   3.55775e-02 DIIS
+   @DF-RHF iter   2:   -74.96709222477624   -4.90071e-02   5.42254e-03 DIIS
+   @DF-RHF iter   3:   -74.96797025128531   -8.78027e-04   1.28737e-03 DIIS
+   @DF-RHF iter   4:   -74.96804216952570   -7.19182e-05   1.29539e-04 DIIS
+   @DF-RHF iter   5:   -74.96804342338375   -1.25386e-06   8.90787e-06 DIIS
+   @DF-RHF iter   6:   -74.96804342802554   -4.64179e-09   5.24339e-07 DIIS
+   @DF-RHF iter   7:   -74.96804342804141   -1.58735e-11   5.17144e-08 DIIS
+   @DF-RHF iter   8:   -74.96804342804153   -1.13687e-13   1.18687e-09 DIIS
+   @DF-RHF iter   9:   -74.96804342804154   -1.42109e-14   1.51651e-10 DIIS
   Energy and wave function converged.
 
 
@@ -1080,14 +1080,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96804342805250
+  @DF-RHF Final Energy:   -74.96804342804154
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.2400220121474348
-    Two-Electron Energy =                  38.1601656051396816
-    Total Energy =                        -74.9680434280525105
+    One-Electron Energy =                -122.2400220121383683
+    Two-Electron Energy =                  38.1601656051415787
+    Total Energy =                        -74.9680434280415540
 
 Computation Completed
 
@@ -1109,18 +1109,18 @@ Properties computed using the SCF density matrix
      X:    -1.3005      Y:     0.1654      Z:    -1.0966     Total:     1.7092
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:38 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:36 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.96 seconds =       0.03 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.85 seconds =       0.03 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      13.13 seconds =       0.22 minutes
+	system time =       0.71 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:38 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:36 2021
 
 
          ------------------------------------------------------------
@@ -1160,8 +1160,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -1180,22 +1180,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.033217821649     0.017638388872    -0.040621608851
-       2        0.017823382996     0.002282578370     0.010748896984
-       3        0.015394438654    -0.019920967243     0.029872711867
+       1       -0.033217821252     0.017638388852    -0.040621608544
+       2        0.017823382667     0.002282578167     0.010748896938
+       3        0.015394438585    -0.019920967020     0.029872711606
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:38 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:36 2021
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.54 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.88 seconds =       0.03 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      13.88 seconds =       0.23 minutes
+	system time =       0.74 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-       N-Body: Complex Energy (fragments = (3,), basis = (3,):   -74.96804342805250)
+       N-Body: Complex Energy (fragments = (3,), basis = (3,):   -74.96804342804154)
 
        N-Body: Computing complex (4/6) with fragments (2,) in the basis of fragments (2,).
 
@@ -1205,16 +1205,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:38 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:36 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -1232,7 +1232,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1286,8 +1286,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1298,7 +1298,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1335,16 +1335,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20661951382856   -7.42066e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91806776496207   -7.11448e-01   3.55515e-02 DIIS
-   @DF-RHF iter   2:   -74.96699532969026   -4.89276e-02   5.41710e-03 DIIS
-   @DF-RHF iter   3:   -74.96787329380747   -8.77964e-04   1.28875e-03 DIIS
-   @DF-RHF iter   4:   -74.96794552409411   -7.22303e-05   1.30538e-04 DIIS
-   @DF-RHF iter   5:   -74.96794679834903   -1.27425e-06   8.88772e-06 DIIS
-   @DF-RHF iter   6:   -74.96794680297020   -4.62117e-09   5.28512e-07 DIIS
-   @DF-RHF iter   7:   -74.96794680298636   -1.61577e-11   5.37441e-08 DIIS
-   @DF-RHF iter   8:   -74.96794680298649   -1.27898e-13   1.21463e-09 DIIS
-   @DF-RHF iter   9:   -74.96794680298652   -2.84217e-14   1.58511e-10 DIIS
+   @DF-RHF iter SAD:   -74.20661951381696   -7.42066e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91806776495044   -7.11448e-01   3.55515e-02 DIIS
+   @DF-RHF iter   2:   -74.96699532967862   -4.89276e-02   5.41710e-03 DIIS
+   @DF-RHF iter   3:   -74.96787329379582   -8.77964e-04   1.28875e-03 DIIS
+   @DF-RHF iter   4:   -74.96794552408250   -7.22303e-05   1.30538e-04 DIIS
+   @DF-RHF iter   5:   -74.96794679833748   -1.27425e-06   8.88772e-06 DIIS
+   @DF-RHF iter   6:   -74.96794680295861   -4.62113e-09   5.28512e-07 DIIS
+   @DF-RHF iter   7:   -74.96794680297481   -1.62004e-11   5.37441e-08 DIIS
+   @DF-RHF iter   8:   -74.96794680297488   -7.10543e-14   1.21463e-09 DIIS
+   @DF-RHF iter   9:   -74.96794680297496   -8.52651e-14   1.58512e-10 DIIS
   Energy and wave function converged.
 
 
@@ -1366,14 +1366,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96794680298652
+  @DF-RHF Final Energy:   -74.96794680297496
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.2421812246935957
-    Two-Electron Energy =                  38.1619549603912418
-    Total Energy =                        -74.9679468029865319
+    One-Electron Energy =                -122.2421812246879682
+    Two-Electron Energy =                  38.1619549603971819
+    Total Energy =                        -74.9679468029749643
 
 Computation Completed
 
@@ -1395,18 +1395,18 @@ Properties computed using the SCF density matrix
      X:     0.8883      Y:     1.0391      Z:     1.0241     Total:     1.7081
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:38 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:36 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.94 seconds =       0.03 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.14 seconds =       0.04 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =      15.91 seconds =       0.27 minutes
+	system time =       0.89 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:38 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:36 2021
 
 
          ------------------------------------------------------------
@@ -1446,8 +1446,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -1466,22 +1466,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.036174275815     0.019888513002     0.038150921226
-       2       -0.027999708644    -0.003630506060    -0.027664272010
-       3       -0.008174567168    -0.016258006942    -0.010486649216
+       1        0.036174275328     0.019888512362     0.038150920652
+       2       -0.027999708149    -0.003630506160    -0.027664271546
+       3       -0.008174567176    -0.016258006203    -0.010486649106
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:39 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:37 2021
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.52 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.17 seconds =       0.04 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      16.62 seconds =       0.28 minutes
+	system time =       0.95 seconds =       0.02 minutes
+	total time  =          5 seconds =       0.08 minutes
 
-       N-Body: Complex Energy (fragments = (2,), basis = (2,):   -74.96794680298652)
+       N-Body: Complex Energy (fragments = (2,), basis = (2,):   -74.96794680297496)
 
        N-Body: Computing complex (5/6) with fragments (1,) in the basis of fragments (1,).
 
@@ -1491,16 +1491,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:39 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:37 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -1518,7 +1518,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1572,8 +1572,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1584,7 +1584,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1621,16 +1621,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20742717616535   -7.42074e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91808853105498   -7.10661e-01   3.55337e-02 DIIS
-   @DF-RHF iter   2:   -74.96695065050781   -4.88621e-02   5.41141e-03 DIIS
-   @DF-RHF iter   3:   -74.96782754053548   -8.76890e-04   1.28859e-03 DIIS
-   @DF-RHF iter   4:   -74.96789978922203   -7.22487e-05   1.30788e-04 DIIS
-   @DF-RHF iter   5:   -74.96790106816906   -1.27895e-06   8.84975e-06 DIIS
-   @DF-RHF iter   6:   -74.96790107274545   -4.57639e-09   5.30739e-07 DIIS
-   @DF-RHF iter   7:   -74.96790107276169   -1.62430e-11   4.98532e-08 DIIS
-   @DF-RHF iter   8:   -74.96790107276188   -1.84741e-13   1.19600e-09 DIIS
-   @DF-RHF iter   9:   -74.96790107276188    0.00000e+00   1.49181e-10 DIIS
+   @DF-RHF iter SAD:   -74.20742717616241   -7.42074e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91808853105053   -7.10661e-01   3.55337e-02 DIIS
+   @DF-RHF iter   2:   -74.96695065050336   -4.88621e-02   5.41141e-03 DIIS
+   @DF-RHF iter   3:   -74.96782754053109   -8.76890e-04   1.28859e-03 DIIS
+   @DF-RHF iter   4:   -74.96789978921765   -7.22487e-05   1.30788e-04 DIIS
+   @DF-RHF iter   5:   -74.96790106816455   -1.27895e-06   8.84975e-06 DIIS
+   @DF-RHF iter   6:   -74.96790107274099   -4.57644e-09   5.30739e-07 DIIS
+   @DF-RHF iter   7:   -74.96790107275729   -1.62999e-11   4.98532e-08 DIIS
+   @DF-RHF iter   8:   -74.96790107275746   -1.70530e-13   1.19600e-09 DIIS
+   @DF-RHF iter   9:   -74.96790107275748   -2.84217e-14   1.49182e-10 DIIS
   Energy and wave function converged.
 
 
@@ -1652,14 +1652,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96790107276188
+  @DF-RHF Final Energy:   -74.96790107275748
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.2481627620098124
-    Two-Electron Energy =                  38.1648324004429256
-    Total Energy =                        -74.9679010727618902
+    One-Electron Energy =                -122.2481627620103239
+    Two-Electron Energy =                  38.1648324004478425
+    Total Energy =                        -74.9679010727574848
 
 Computation Completed
 
@@ -1681,18 +1681,18 @@ Properties computed using the SCF density matrix
      X:     0.4415      Y:    -1.2890      Z:     1.0302     Total:     1.7081
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:39 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:37 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.09 seconds =       0.03 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.43 seconds =       0.04 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      18.80 seconds =       0.31 minutes
+	system time =       1.08 seconds =       0.02 minutes
+	total time  =          5 seconds =       0.08 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:39 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:37 2021
 
 
          ------------------------------------------------------------
@@ -1732,8 +1732,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -1752,22 +1752,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000120707477    -0.041248212738     0.038755311065
-       2       -0.010650338842     0.015909042579    -0.010603622945
-       3        0.010771046318     0.025339170158    -0.028151688120
+       1       -0.000120707289    -0.041248213240     0.038755311453
+       2       -0.010650339246     0.015909042832    -0.010603623015
+       3        0.010771046534     0.025339170407    -0.028151688439
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:39 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:37 2021
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.20 seconds =       0.02 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.46 seconds =       0.04 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      20.35 seconds =       0.34 minutes
+	system time =       1.19 seconds =       0.02 minutes
+	total time  =          5 seconds =       0.08 minutes
 
-       N-Body: Complex Energy (fragments = (1,), basis = (1,):   -74.96790107276188)
+       N-Body: Complex Energy (fragments = (1,), basis = (1,):   -74.96790107275748)
 
        N-Body: Computing complex (6/6) with fragments (3,) in the basis of fragments (1, 2, 3).
 
@@ -1777,16 +1777,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:39 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:37 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -1804,7 +1804,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1864,8 +1864,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1876,7 +1876,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -1913,17 +1913,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20651477843577   -7.42065e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92730458013231   -7.20790e-01   1.16966e-02 DIIS
-   @DF-RHF iter   2:   -74.97403011466274   -4.67255e-02   2.00055e-03 DIIS
-   @DF-RHF iter   3:   -74.97509650573888   -1.06639e-03   4.56359e-04 DIIS
-   @DF-RHF iter   4:   -74.97518197685694   -8.54711e-05   4.53537e-05 DIIS
-   @DF-RHF iter   5:   -74.97518330755325   -1.33070e-06   8.85963e-06 DIIS
-   @DF-RHF iter   6:   -74.97518336204838   -5.44951e-08   5.10780e-07 DIIS
-   @DF-RHF iter   7:   -74.97518336217013   -1.21744e-10   6.11794e-08 DIIS
-   @DF-RHF iter   8:   -74.97518336217209   -1.96110e-12   8.32843e-09 DIIS
-   @DF-RHF iter   9:   -74.97518336217210   -1.42109e-14   2.08217e-09 DIIS
-   @DF-RHF iter  10:   -74.97518336217213   -2.84217e-14   3.79028e-10 DIIS
+   @DF-RHF iter SAD:   -74.20651477847511   -7.42065e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92730458017247   -7.20790e-01   1.16966e-02 DIIS
+   @DF-RHF iter   2:   -74.97403011470304   -4.67255e-02   2.00055e-03 DIIS
+   @DF-RHF iter   3:   -74.97509650577919   -1.06639e-03   4.56359e-04 DIIS
+   @DF-RHF iter   4:   -74.97518197689728   -8.54711e-05   4.53537e-05 DIIS
+   @DF-RHF iter   5:   -74.97518330759354   -1.33070e-06   8.85963e-06 DIIS
+   @DF-RHF iter   6:   -74.97518336208861   -5.44951e-08   5.10780e-07 DIIS
+   @DF-RHF iter   7:   -74.97518336221044   -1.21830e-10   6.11794e-08 DIIS
+   @DF-RHF iter   8:   -74.97518336221241   -1.96110e-12   8.32843e-09 DIIS
+   @DF-RHF iter   9:   -74.97518336221232    8.52651e-14   2.08217e-09 DIIS
+   @DF-RHF iter  10:   -74.97518336221242   -9.94760e-14   3.79027e-10 DIIS
   Energy and wave function converged.
 
 
@@ -1950,14 +1950,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97518336217213
+  @DF-RHF Final Energy:   -74.97518336221242
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.1796494816868943
-    Two-Electron Energy =                  38.0926531405595128
-    Total Energy =                        -74.9751833621721318
+    One-Electron Energy =                -122.1796494817145913
+    Two-Electron Energy =                  38.0926531405469291
+    Total Energy =                        -74.9751833622124195
 
 Computation Completed
 
@@ -1979,18 +1979,18 @@ Properties computed using the SCF density matrix
      X:    -1.3881      Y:     0.2787      Z:    -1.1084     Total:     1.7980
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:39 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:38 2021
 Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.93 seconds =       0.05 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       3.06 seconds =       0.05 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      23.45 seconds =       0.39 minutes
+	system time =       1.40 seconds =       0.02 minutes
+	total time  =          6 seconds =       0.10 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:39 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:38 2021
 
 
          ------------------------------------------------------------
@@ -2036,8 +2036,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -2056,33 +2056,33 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000072680718    -0.000178930516     0.000016357965
-       2       -0.000082840329    -0.000198380482     0.000026349953
-       3       -0.000001789941    -0.000006925597     0.000000480285
-       4       -0.000053426750    -0.000634492522    -0.000043991627
-       5        0.000006717095    -0.000006864509     0.000001653334
-       6        0.004811504278    -0.007487779979     0.000107477804
-       7       -0.036158940824     0.026021139966    -0.040796981130
-       8        0.017715436438     0.001777503645     0.010044340206
-       9        0.013836020752    -0.019285270006     0.030644313210
+       1       -0.000072680702    -0.000178930504     0.000016357960
+       2       -0.000082840336    -0.000198380486     0.000026349953
+       3       -0.000001789948    -0.000006925597     0.000000480292
+       4       -0.000053426743    -0.000634492426    -0.000043991628
+       5        0.000006717098    -0.000006864511     0.000001653340
+       6        0.004811504275    -0.007487780085     0.000107477795
+       7       -0.036158940876     0.026021139566    -0.040796981066
+       8        0.017715436490     0.001777503846     0.010044340234
+       9        0.013836020742    -0.019285269805     0.030644313121
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:40 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:38 2021
 Module time:
-	user time   =       0.14 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.17 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.21 seconds =       0.05 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      24.83 seconds =       0.41 minutes
+	system time =       1.50 seconds =       0.03 minutes
+	total time  =          6 seconds =       0.10 minutes
 
-       N-Body: Complex Energy (fragments = (3,), basis = (1, 2, 3):   -74.97518336217213)
+       N-Body: Complex Energy (fragments = (3,), basis = (1, 2, 3):   -74.97518336221242)
 
    ==> N-Body: Now computing 2-body complexes <==
 
 
-       N-Body: Computing complex (1/3) with fragments (1, 2) in the basis of fragments (1, 2, 3).
+       N-Body: Computing complex (1/6) with fragments (2, 3) in the basis of fragments (1, 2, 3).
 
 
 Scratch directory: /tmp/
@@ -2090,16 +2090,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:40 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:38 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -2117,318 +2117,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
-         ---------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Bohr), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
-         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
-         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
-      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
-
-  Running in c1 symmetry.
-
-  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
-  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
-  Nuclear repulsion =   37.327766624605843
-
-  Charge       = 0
-  Multiplicity = 1
-  Electrons    = 20
-  Nalpha       = 10
-  Nbeta        = 10
-
-  ==> Algorithm <==
-
-  SCF Algorithm Type is DF.
-  DIIS enabled.
-  MOM disabled.
-  Fractional occupation disabled.
-  Guess Type is SAD.
-  Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-09
-  Integral threshold = 1.00e-12
-
-  ==> Primary Basis <==
-
-  Basis Set: STO-3G
-    Blend: STO-3G
-    Number of shells: 15
-    Number of basis functions: 21
-    Number of Cartesian functions: 21
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-   => Loading Basis Set <=
-
-    Name: (STO-3G AUX)
-    Role: JKFIT
-    Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-
-  ==> Integral Setup <==
-
-  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
-
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               1
-    Memory [MiB]:               375
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-10
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (STO-3G AUX)
-    Blend: DEF2-UNIVERSAL-JKFIT
-    Number of shells: 111
-    Number of basis functions: 339
-    Number of Cartesian functions: 399
-    Spherical Harmonics?: true
-    Max angular momentum: 4
-
-  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
-    Using symmetric orthogonalization.
-
-  ==> Pre-Iterations <==
-
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
-
-   -------------------------
-    Irrep   Nso     Nmo    
-   -------------------------
-     A         21      21 
-   -------------------------
-    Total      21      21
-   -------------------------
-
-  ==> Iterations <==
-
-                           Total Energy        Delta E     RMS |[F,P]|
-
-   @DF-RHF iter SAD:  -148.43444075217994   -1.48434e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86420073587024   -1.42976e+00   1.57310e-02 DIIS
-   @DF-RHF iter   2:  -149.95072463352707   -8.65239e-02   2.56698e-03 DIIS
-   @DF-RHF iter   3:  -149.95267920275188   -1.95457e-03   6.20766e-04 DIIS
-   @DF-RHF iter   4:  -149.95284427489619   -1.65072e-04   6.37604e-05 DIIS
-   @DF-RHF iter   5:  -149.95284692284852   -2.64795e-06   9.91316e-06 DIIS
-   @DF-RHF iter   6:  -149.95284698730151   -6.44530e-08   1.44085e-06 DIIS
-   @DF-RHF iter   7:  -149.95284698834982   -1.04831e-09   2.53217e-07 DIIS
-   @DF-RHF iter   8:  -149.95284698838111   -3.12923e-11   3.21508e-08 DIIS
-   @DF-RHF iter   9:  -149.95284698838165   -5.40012e-13   6.14624e-09 DIIS
-   @DF-RHF iter  10:  -149.95284698838171   -5.68434e-14   1.36596e-09 DIIS
-   @DF-RHF iter  11:  -149.95284698838145    2.55795e-13   2.33298e-10 DIIS
-  Energy and wave function converged.
-
-
-  ==> Post-Iterations <==
-
-    Orbital Energies [Eh]
-    ---------------------
-
-    Doubly Occupied:                                                      
-
-       1A    -20.265993     2A    -20.213835     3A     -1.286385  
-       4A     -1.240805     5A     -0.640800     6A     -0.595401  
-       7A     -0.475790     8A     -0.434446     9A     -0.400444  
-      10A     -0.367648  
-
-    Virtual:                                                              
-
-      11A      0.490528    12A      0.607402    13A      0.648556  
-      14A      0.734932    15A      0.785344    16A      1.032771  
-      17A      1.373710    18A      2.556576    19A      2.950978  
-      20A      3.280669    21A     31.265676  
-
-    Final Occupation by Irrep:
-              A 
-    DOCC [    10 ]
-
-  @DF-RHF Final Energy:  -149.95284698838145
-
-   => Energetics <=
-
-    Nuclear Repulsion Energy =             37.3277666246058430
-    One-Electron Energy =                -282.6935372844757239
-    Two-Electron Energy =                  95.4252223514884435
-    Total Energy =                       -149.9528469883814239
-
-Computation Completed
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
-
-Properties computed using the SCF density matrix
-
-  Nuclear Dipole Moment: [e a0]
-     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
-
-  Electronic Dipole Moment: [e a0]
-     X:     1.8989      Y:    30.1291      Z:     1.4353
-
-  Dipole Moment: [e a0]
-     X:     0.6812      Y:    -0.1488      Z:     0.8098     Total:     1.0686
-
-  Dipole Moment: [D]
-     X:     1.7314      Y:    -0.3781      Z:     2.0584     Total:     2.7162
-
-
-*** tstop() called on psinet at Fri Jun 11 02:11:40 2021
-Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       3.81 seconds =       0.06 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
-
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:40 2021
-
-
-         ------------------------------------------------------------
-                                   SCF GRAD                          
-                          Rob Parrish, Justin Turney,                
-                       Andy Simmonett, and Alex Sokolov              
-         ------------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Bohr), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
-         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
-         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
-      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
-
-  Nuclear repulsion =   37.327766624605843
-
-  ==> Basis Set <==
-
-  Basis Set: STO-3G
-    Blend: STO-3G
-    Number of shells: 15
-    Number of basis functions: 21
-    Number of Cartesian functions: 21
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-  ==> DFJKGrad: Density-Fitted SCF Gradients <==
-
-    Gradient:                    1
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory [MiB]:              375
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-10
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (STO-3G AUX)
-    Blend: DEF2-UNIVERSAL-JKFIT
-    Number of shells: 111
-    Number of basis functions: 339
-    Number of Cartesian functions: 399
-    Spherical Harmonics?: true
-    Max angular momentum: 4
-
-
-  -Total Gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1       -0.007243120855    -0.044085616393     0.035273238378
-       2       -0.013901653017     0.013131592981    -0.007062236505
-       3        0.011946785370     0.022317638573    -0.027758137791
-       4        0.039381360127     0.016095277160     0.034430949108
-       5       -0.026444406881    -0.001627029302    -0.026863202722
-       6       -0.008583781589    -0.014725496481    -0.007902080028
-       7        0.000487157341     0.000396299487     0.000017340999
-       8        0.004357241223     0.008480434581    -0.000133273880
-       9        0.000000418282     0.000016899393    -0.000002597559
-
-
-*** tstop() called on psinet at Fri Jun 11 02:11:40 2021
-Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       3.94 seconds =       0.07 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
-
-       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2, 3):  -149.95284698838145)
-
-       N-Body: Computing complex (2/3) with fragments (2, 3) in the basis of fragments (1, 2, 3).
-
-
-Scratch directory: /tmp/
-
-Scratch directory: /tmp/
-gradient() will perform analytic gradient computation.
-
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:40 2021
-
-   => Loading Basis Set <=
-
-    Name: STO-3G
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-
-   => HF-D3(BJ): Empirical Dispersion <=
-
-    Grimme's -D3 (BJ-damping) Dispersion Correction
-    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
-
-        s6 =       1.000000
-        s8 =       0.917100
-        a1 =       0.338500
-        a2 =       2.883000
-
-
-         ---------------------------------------------------------
-                                   SCF
-               by Justin Turney, Rob Parrish, Andy Simmonett
-                          and Daniel G. A. Smith
-                              RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2488,8 +2177,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -2500,7 +2189,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -2537,18 +2226,18 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -148.43517267796997   -1.48435e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86656939506480   -1.43140e+00   1.55631e-02 DIIS
-   @DF-RHF iter   2:  -149.95156180979393   -8.49924e-02   2.54620e-03 DIIS
-   @DF-RHF iter   3:  -149.95352452408389   -1.96271e-03   6.21126e-04 DIIS
-   @DF-RHF iter   4:  -149.95369039947198   -1.65875e-04   6.28806e-05 DIIS
-   @DF-RHF iter   5:  -149.95369295846828   -2.55900e-06   1.07266e-05 DIIS
-   @DF-RHF iter   6:  -149.95369303237317   -7.39049e-08   1.68546e-06 DIIS
-   @DF-RHF iter   7:  -149.95369303389646   -1.52329e-09   2.96963e-07 DIIS
-   @DF-RHF iter   8:  -149.95369303394028   -4.38263e-11   3.32323e-08 DIIS
-   @DF-RHF iter   9:  -149.95369303394085   -5.68434e-13   6.90158e-09 DIIS
-   @DF-RHF iter  10:  -149.95369303394082    2.84217e-14   1.53556e-09 DIIS
-   @DF-RHF iter  11:  -149.95369303394088   -5.68434e-14   2.49156e-10 DIIS
+   @DF-RHF iter SAD:  -148.43517267805356   -1.48435e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86656939514947   -1.43140e+00   1.55631e-02 DIIS
+   @DF-RHF iter   2:  -149.95156180987863   -8.49924e-02   2.54620e-03 DIIS
+   @DF-RHF iter   3:  -149.95352452416861   -1.96271e-03   6.21126e-04 DIIS
+   @DF-RHF iter   4:  -149.95369039955682   -1.65875e-04   6.28806e-05 DIIS
+   @DF-RHF iter   5:  -149.95369295855306   -2.55900e-06   1.07266e-05 DIIS
+   @DF-RHF iter   6:  -149.95369303245795   -7.39049e-08   1.68546e-06 DIIS
+   @DF-RHF iter   7:  -149.95369303398112   -1.52318e-09   2.96963e-07 DIIS
+   @DF-RHF iter   8:  -149.95369303402498   -4.38547e-11   3.32323e-08 DIIS
+   @DF-RHF iter   9:  -149.95369303402552   -5.40012e-13   6.90158e-09 DIIS
+   @DF-RHF iter  10:  -149.95369303402575   -2.27374e-13   1.53556e-09 DIIS
+   @DF-RHF iter  11:  -149.95369303402586   -1.13687e-13   2.49157e-10 DIIS
   Energy and wave function converged.
 
 
@@ -2575,14 +2264,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.95369303394088
+  @DF-RHF Final Energy:  -149.95369303402586
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4208727124812270
-    One-Electron Energy =                -282.8840412880541635
-    Two-Electron Energy =                  95.5218870516320351
-    Total Energy =                       -149.9536930339408798
+    One-Electron Energy =                -282.8840412881003203
+    Two-Electron Energy =                  95.5218870515932110
+    Total Energy =                       -149.9536930340258607
 
 Computation Completed
 
@@ -2604,18 +2293,18 @@ Properties computed using the SCF density matrix
      X:    -0.5295      Y:     1.6482      Z:    -0.1172     Total:     1.7351
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:41 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:39 2021
 Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.85 seconds =       0.05 minutes
+	system time =       0.17 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.54 seconds =       0.08 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      27.79 seconds =       0.46 minutes
+	system time =       1.67 seconds =       0.03 minutes
+	total time  =          7 seconds =       0.12 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:41 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:39 2021
 
 
          ------------------------------------------------------------
@@ -2661,8 +2350,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -2681,30 +2370,30 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000549823241     0.000209101783    -0.000043130495
-       2       -0.008948416565    -0.000509994605    -0.000335110328
-       3       -0.000014125244    -0.000007901240     0.000001129934
-       4        0.040811211570     0.015095923235     0.036386015354
-       5       -0.025241122852    -0.001270248483    -0.027165119482
-       6       -0.003996028547    -0.017821700756    -0.008609524208
-       7       -0.031630747581     0.022469177680    -0.037813158722
-       8        0.016835970199     0.000812297789     0.008719768934
-       9        0.012733082265    -0.018976655404     0.028859129014
+       1       -0.000549823236     0.000209101774    -0.000043130494
+       2       -0.008948416562    -0.000509994592    -0.000335110335
+       3       -0.000014125249    -0.000007901243     0.000001129937
+       4        0.040811211893     0.015095923763     0.036386015607
+       5       -0.025241123107    -0.001270248553    -0.027165119670
+       6       -0.003996028602    -0.017821701220    -0.008609524275
+       7       -0.031630747554     0.022469177710    -0.037813158808
+       8        0.016835970172     0.000812297811     0.008719768951
+       9        0.012733082248    -0.018976655452     0.028859129087
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:41 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:40 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.23 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.67 seconds =       0.08 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      29.22 seconds =       0.49 minutes
+	system time =       1.76 seconds =       0.03 minutes
+	total time  =          8 seconds =       0.13 minutes
 
-       N-Body: Complex Energy (fragments = (2, 3), basis = (1, 2, 3):  -149.95369303394088)
+       N-Body: Complex Energy (fragments = (2, 3), basis = (1, 2, 3):  -149.95369303402586)
 
-       N-Body: Computing complex (3/3) with fragments (1, 3) in the basis of fragments (1, 2, 3).
+       N-Body: Computing complex (2/6) with fragments (1, 3) in the basis of fragments (1, 2, 3).
 
 
 Scratch directory: /tmp/
@@ -2712,16 +2401,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:41 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:40 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -2739,7 +2428,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2799,8 +2488,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -2811,7 +2500,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -2848,18 +2537,18 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -148.43580517715009   -1.48436e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86749466726499   -1.43169e+00   1.55424e-02 DIIS
-   @DF-RHF iter   2:  -149.95221120159636   -8.47165e-02   2.55465e-03 DIIS
-   @DF-RHF iter   3:  -149.95418156362393   -1.97036e-03   6.22886e-04 DIIS
-   @DF-RHF iter   4:  -149.95434865132242   -1.67088e-04   6.29977e-05 DIIS
-   @DF-RHF iter   5:  -149.95435124125683   -2.58993e-06   9.62406e-06 DIIS
-   @DF-RHF iter   6:  -149.95435130203415   -6.07773e-08   1.35366e-06 DIIS
-   @DF-RHF iter   7:  -149.95435130294086   -9.06709e-10   2.43900e-07 DIIS
-   @DF-RHF iter   8:  -149.95435130297005   -2.91891e-11   3.14208e-08 DIIS
-   @DF-RHF iter   9:  -149.95435130297051   -4.54747e-13   6.02918e-09 DIIS
-   @DF-RHF iter  10:  -149.95435130297045    5.68434e-14   1.36824e-09 DIIS
-   @DF-RHF iter  11:  -149.95435130297062   -1.70530e-13   2.40354e-10 DIIS
+   @DF-RHF iter SAD:  -148.43580517720858   -1.48436e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86749466732599   -1.43169e+00   1.55424e-02 DIIS
+   @DF-RHF iter   2:  -149.95221120165732   -8.47165e-02   2.55465e-03 DIIS
+   @DF-RHF iter   3:  -149.95418156368487   -1.97036e-03   6.22886e-04 DIIS
+   @DF-RHF iter   4:  -149.95434865138347   -1.67088e-04   6.29977e-05 DIIS
+   @DF-RHF iter   5:  -149.95435124131768   -2.58993e-06   9.62406e-06 DIIS
+   @DF-RHF iter   6:  -149.95435130209495   -6.07773e-08   1.35366e-06 DIIS
+   @DF-RHF iter   7:  -149.95435130300180   -9.06851e-10   2.43900e-07 DIIS
+   @DF-RHF iter   8:  -149.95435130303090   -2.91038e-11   3.14208e-08 DIIS
+   @DF-RHF iter   9:  -149.95435130303153   -6.25278e-13   6.02918e-09 DIIS
+   @DF-RHF iter  10:  -149.95435130303142    1.13687e-13   1.36824e-09 DIIS
+   @DF-RHF iter  11:  -149.95435130303127    1.42109e-13   2.40355e-10 DIIS
   Energy and wave function converged.
 
 
@@ -2886,14 +2575,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.95435130297062
+  @DF-RHF Final Energy:  -149.95435130303127
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4153826933059008
-    One-Electron Energy =                -282.8726006393809485
-    Two-Electron Energy =                  95.5152412631044143
-    Total Energy =                       -149.9543513029706219
+    One-Electron Energy =                -282.8726006394036290
+    Two-Electron Energy =                  95.5152412630664429
+    Total Energy =                       -149.9543513030312738
 
 Computation Completed
 
@@ -2915,18 +2604,18 @@ Properties computed using the SCF density matrix
      X:    -1.2007      Y:    -1.4353      Z:    -0.0118     Total:     1.8713
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:42 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:40 2021
 Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.91 seconds =       0.05 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.27 seconds =       0.09 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      32.21 seconds =       0.54 minutes
+	system time =       1.95 seconds =       0.03 minutes
+	total time  =          8 seconds =       0.13 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:42 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:40 2021
 
 
          ------------------------------------------------------------
@@ -2972,8 +2661,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -2992,69 +2681,47 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.004942330718    -0.041488362285     0.036186692374
-       2       -0.008980263456     0.015308436810    -0.008624632839
-       3        0.011300058049     0.022206572790    -0.027266985277
-       4        0.000077877896    -0.000630171310    -0.000065662311
-       5        0.000017101487    -0.000007706072     0.000000960727
-       6        0.005333224391    -0.008144547159     0.000059160370
-       7       -0.032324440029     0.024966597843    -0.038237789423
-       8        0.017201527277     0.006497336818     0.008760629788
-       9        0.012317245099    -0.018708157436     0.029187626590
+       1       -0.004942331874    -0.041488359399     0.036186689852
+       2       -0.008980261028     0.015308435432    -0.008624632400
+       3        0.011300056517     0.022206571013    -0.027266983207
+       4        0.000077877777    -0.000630171385    -0.000065662307
+       5        0.000017101471    -0.000007706076     0.000000960722
+       6        0.005333224589    -0.008144547116     0.000059160372
+       7       -0.032324437820     0.024966599761    -0.038237788864
+       8        0.017201525718     0.006497335468     0.008760629580
+       9        0.012317244648    -0.018708157701     0.029187626251
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:42 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:41 2021
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.38 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.40 seconds =       0.09 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      33.83 seconds =       0.56 minutes
+	system time =       2.04 seconds =       0.03 minutes
+	total time  =          9 seconds =       0.15 minutes
 
-       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 2, 3):  -149.95435130297062)
+       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 2, 3):  -149.95435130303127)
 
-   ==> N-Body: Counterpoise Corrected (CP) energies <==
+       N-Body: Computing complex (3/6) with fragments (1, 2) in the basis of fragments (1, 2).
 
-   n-Body     Total Energy [Eh]       I.E. [kcal/mol]      Delta [kcal/mol]
-        1     -224.903891303801        0.000000000000        0.000000000000
-        2     -224.915780748844       -7.460739402607       -7.460739402607
-
-   => Loading Basis Set <=
-
-    Name: DEF2-SVP
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1, 4, 7       entry O          line   130 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    15 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-svp.gbs 
-
-    CP-Corrected Energy...................................................................PASSED
-    CP-Corrected Energy...................................................................PASSED
-    CP-Corrected Energy...................................................................PASSED
-    CP-Corrected Energy...................................................................PASSED
-    CP-Corrected Interaction Energy.......................................................PASSED
-    CP-Corrected Interaction Energy.......................................................PASSED
-    CP-Corrected Gradient.................................................................PASSED
-    CP-Corrected Gradient.................................................................PASSED
-    CP-Corrected Gradient.................................................................PASSED
-    CP-Corrected Gradient.................................................................PASSED
 
 Scratch directory: /tmp/
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:42 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:41 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -3072,7 +2739,307 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.67094  B =      0.23246  C =      0.17553 [cm^-1]
+  Rotational constants: A =  20114.15437  B =   6968.93165  C =   5262.27541 [MHz]
+  Nuclear repulsion =   37.327766624605843
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4074143904E-01.
+  Reciprocal condition number of the overlap matrix is 1.7130997866E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.43443923849546   -1.48434e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85470151214108   -1.42026e+00   2.37340e-02 DIIS
+   @DF-RHF iter   2:  -149.94341185893845   -8.87103e-02   3.67265e-03 DIIS
+   @DF-RHF iter   3:  -149.94521673035183   -1.80487e-03   8.96030e-04 DIIS
+   @DF-RHF iter   4:  -149.94536469266339   -1.47962e-04   9.43642e-05 DIIS
+   @DF-RHF iter   5:  -149.94536707980561   -2.38714e-06   2.53037e-05 DIIS
+   @DF-RHF iter   6:  -149.94536726856751   -1.88762e-07   2.37939e-06 DIIS
+   @DF-RHF iter   7:  -149.94536726994806   -1.38056e-09   2.69811e-07 DIIS
+   @DF-RHF iter   8:  -149.94536726996225   -1.41824e-11   3.51726e-08 DIIS
+   @DF-RHF iter   9:  -149.94536726996245   -1.98952e-13   6.07949e-09 DIIS
+   @DF-RHF iter  10:  -149.94536726996265   -1.98952e-13   1.34394e-09 DIIS
+   @DF-RHF iter  11:  -149.94536726996230    3.41061e-13   2.64818e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.265778     2A    -20.201128     3A     -1.286129  
+       4A     -1.234946     5A     -0.640245     6A     -0.590711  
+       7A     -0.474712     8A     -0.430649     9A     -0.397718  
+      10A     -0.361496  
+
+    Virtual:                                                              
+
+      11A      0.564996    12A      0.653937    13A      0.715582  
+      14A      0.790788  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94536726996230
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.3277666246058430
+    One-Electron Energy =                -282.7546452438275537
+    Two-Electron Energy =                  95.4938100292593788
+    Total Energy =                       -149.9453672699623326
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:     1.9166      Y:    30.1845      Z:     1.4308
+
+  Dipole Moment: [e a0]
+     X:     0.6989      Y:    -0.0934      Z:     0.8053     Total:     1.0704
+
+  Dipole Moment: [D]
+     X:     1.7764      Y:    -0.2373      Z:     2.0469     Total:     2.7207
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:41 2021
+Module time:
+	user time   =       2.38 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      36.32 seconds =       0.61 minutes
+	system time =       2.15 seconds =       0.04 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:41 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Nuclear repulsion =   37.327766624605843
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.001528314321    -0.037143165749     0.035063798108
+       2       -0.013846579342     0.013030346635    -0.007683691110
+       3        0.011681940742     0.024202420043    -0.027016236791
+       4        0.038901274975     0.016313417570     0.034513396134
+       5       -0.026489055804    -0.001678226913    -0.026796300138
+       6       -0.008719266249    -0.014724791588    -0.008080966203
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:41 2021
+Module time:
+	user time   =       0.72 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      37.26 seconds =       0.62 minutes
+	system time =       2.18 seconds =       0.04 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2):  -149.94536726996230)
+
+       N-Body: Computing complex (4/6) with fragments (1, 2) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:41 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+   => HF-D3(BJ): Empirical Dispersion <=
+
+    Grimme's -D3 (BJ-damping) Dispersion Correction
+    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
+
+        s6 =       1.000000
+        s8 =       0.917100
+        a1 =       0.338500
+        a2 =       2.883000
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3132,8 +3099,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -3144,7 +3111,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3181,18 +3148,18 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -148.43444075217994   -1.48434e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86420073587024   -1.42976e+00   1.57310e-02 DIIS
-   @DF-RHF iter   2:  -149.95072463352707   -8.65239e-02   2.56698e-03 DIIS
-   @DF-RHF iter   3:  -149.95267920275188   -1.95457e-03   6.20766e-04 DIIS
-   @DF-RHF iter   4:  -149.95284427489619   -1.65072e-04   6.37604e-05 DIIS
-   @DF-RHF iter   5:  -149.95284692284852   -2.64795e-06   9.91316e-06 DIIS
-   @DF-RHF iter   6:  -149.95284698730151   -6.44530e-08   1.44085e-06 DIIS
-   @DF-RHF iter   7:  -149.95284698834982   -1.04831e-09   2.53217e-07 DIIS
-   @DF-RHF iter   8:  -149.95284698838111   -3.12923e-11   3.21508e-08 DIIS
-   @DF-RHF iter   9:  -149.95284698838165   -5.40012e-13   6.14624e-09 DIIS
-   @DF-RHF iter  10:  -149.95284698838171   -5.68434e-14   1.36596e-09 DIIS
-   @DF-RHF iter  11:  -149.95284698838145    2.55795e-13   2.33298e-10 DIIS
+   @DF-RHF iter SAD:  -148.43444075219801   -1.48434e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86420073588852   -1.42976e+00   1.57310e-02 DIIS
+   @DF-RHF iter   2:  -149.95072463354543   -8.65239e-02   2.56698e-03 DIIS
+   @DF-RHF iter   3:  -149.95267920277010   -1.95457e-03   6.20766e-04 DIIS
+   @DF-RHF iter   4:  -149.95284427491450   -1.65072e-04   6.37604e-05 DIIS
+   @DF-RHF iter   5:  -149.95284692286663   -2.64795e-06   9.91316e-06 DIIS
+   @DF-RHF iter   6:  -149.95284698731987   -6.44532e-08   1.44085e-06 DIIS
+   @DF-RHF iter   7:  -149.95284698836790   -1.04802e-09   2.53217e-07 DIIS
+   @DF-RHF iter   8:  -149.95284698839947   -3.15765e-11   3.21508e-08 DIIS
+   @DF-RHF iter   9:  -149.95284698840010   -6.25278e-13   6.14624e-09 DIIS
+   @DF-RHF iter  10:  -149.95284698839995    1.42109e-13   1.36595e-09 DIIS
+   @DF-RHF iter  11:  -149.95284698839998   -2.84217e-14   2.33298e-10 DIIS
   Energy and wave function converged.
 
 
@@ -3219,14 +3186,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.95284698838145
+  @DF-RHF Final Energy:  -149.95284698839998
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.3277666246058430
-    One-Electron Energy =                -282.6935372844757239
-    Two-Electron Energy =                  95.4252223514884435
-    Total Energy =                       -149.9528469883814239
+    One-Electron Energy =                -282.6935372844794756
+    Two-Electron Energy =                  95.4252223514736500
+    Total Energy =                       -149.9528469883999833
 
 Computation Completed
 
@@ -3248,18 +3215,18 @@ Properties computed using the SCF density matrix
      X:     1.7314      Y:    -0.3781      Z:     2.0584     Total:     2.7162
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:43 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:42 2021
 Module time:
-	user time   =       0.63 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.83 seconds =       0.05 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.14 seconds =       0.10 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      40.18 seconds =       0.67 minutes
+	system time =       2.34 seconds =       0.04 minutes
+	total time  =         10 seconds =       0.17 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:43 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:42 2021
 
 
          ------------------------------------------------------------
@@ -3305,8 +3272,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -3325,26 +3292,959 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.007243120855    -0.044085616393     0.035273238378
-       2       -0.013901653017     0.013131592981    -0.007062236505
-       3        0.011946785370     0.022317638573    -0.027758137791
-       4        0.039381360127     0.016095277160     0.034430949108
-       5       -0.026444406881    -0.001627029302    -0.026863202722
-       6       -0.008583781589    -0.014725496481    -0.007902080028
-       7        0.000487157341     0.000396299487     0.000017340999
-       8        0.004357241223     0.008480434581    -0.000133273880
-       9        0.000000418282     0.000016899393    -0.000002597559
+       1       -0.007243122500    -0.044085615023     0.035273237521
+       2       -0.013901651325     0.013131592108    -0.007062236303
+       3        0.011946785161     0.022317637939    -0.027758137149
+       4        0.039381359446     0.016095276429     0.034430947925
+       5       -0.026444405864    -0.001627029621    -0.026863201733
+       6       -0.008583781848    -0.014725495470    -0.007902079834
+       7        0.000487157276     0.000396299356     0.000017341005
+       8        0.004357241373     0.008480434903    -0.000133273849
+       9        0.000000418282     0.000016899378    -0.000002597584
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:43 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:42 2021
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.15 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.28 seconds =       0.10 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      41.53 seconds =       0.69 minutes
+	system time =       2.42 seconds =       0.04 minutes
+	total time  =         10 seconds =       0.17 minutes
+
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2, 3):  -149.95284698839998)
+
+       N-Body: Computing complex (5/6) with fragments (2, 3) in the basis of fragments (2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:42 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+   => HF-D3(BJ): Empirical Dispersion <=
+
+    Grimme's -D3 (BJ-damping) Dispersion Correction
+    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
+
+        s6 =       1.000000
+        s8 =       0.917100
+        a1 =       0.338500
+        a2 =       2.883000
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.66182  B =      0.23462  C =      0.17637 [cm^-1]
+  Rotational constants: A =  19840.79823  B =   7033.78531  C =   5287.47319 [MHz]
+  Nuclear repulsion =   37.420872712481227
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4063509175E-01.
+  Reciprocal condition number of the overlap matrix is 1.7073707716E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.43517052194389   -1.48435e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85782955362282   -1.42266e+00   2.34649e-02 DIIS
+   @DF-RHF iter   2:  -149.94480860894910   -8.69791e-02   3.66308e-03 DIIS
+   @DF-RHF iter   3:  -149.94664078268187   -1.83217e-03   8.99010e-04 DIIS
+   @DF-RHF iter   4:  -149.94679053657137   -1.49754e-04   9.36437e-05 DIIS
+   @DF-RHF iter   5:  -149.94679284921767   -2.31265e-06   2.68389e-05 DIIS
+   @DF-RHF iter   6:  -149.94679306141444   -2.12197e-07   2.29950e-06 DIIS
+   @DF-RHF iter   7:  -149.94679306269646   -1.28202e-09   2.77310e-07 DIIS
+   @DF-RHF iter   8:  -149.94679306271146   -1.50067e-11   3.53087e-08 DIIS
+   @DF-RHF iter   9:  -149.94679306271189   -4.26326e-13   7.13004e-09 DIIS
+   @DF-RHF iter  10:  -149.94679306271195   -5.68434e-14   1.59469e-09 DIIS
+   @DF-RHF iter  11:  -149.94679306271183    1.13687e-13   2.84833e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267820     2A    -20.198469     3A     -1.287836  
+       4A     -1.233326     5A     -0.640430     6A     -0.591319  
+       7A     -0.477995     8A     -0.431952     9A     -0.395682  
+      10A     -0.360233  
+
+    Virtual:                                                              
+
+      11A      0.566153    12A      0.655627    13A      0.714253  
+      14A      0.791629  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94679306271183
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4208727124812270
+    One-Electron Energy =                -282.9403861622591876
+    Two-Electron Energy =                  95.5851318970660913
+    Total Energy =                       -149.9467930627118335
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    27.0414      Y:    14.0996      Z:     0.2271
+
+  Electronic Dipole Moment: [e a0]
+     X:   -27.3022      Y:   -13.4634      Z:    -0.2787
+
+  Dipole Moment: [e a0]
+     X:    -0.2608      Y:     0.6362      Z:    -0.0516     Total:     0.6895
+
+  Dipole Moment: [D]
+     X:    -0.6630      Y:     1.6170      Z:    -0.1313     Total:     1.7525
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:43 2021
+Module time:
+	user time   =       3.66 seconds =       0.06 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      45.27 seconds =       0.75 minutes
+	system time =       2.67 seconds =       0.04 minutes
+	total time  =         11 seconds =       0.18 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:43 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.420872712481227
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.032429564161     0.016579741724     0.035759943325
+       2       -0.026672032909    -0.002509965875    -0.026399802552
+       3       -0.003861318756    -0.017702182509    -0.009137246270
+       4       -0.031576393896     0.021934883099    -0.037901889878
+       5        0.016886631497     0.000693602023     0.008883978334
+       6        0.012793549907    -0.018996078464     0.028795017040
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:44 2021
+Module time:
+	user time   =       1.80 seconds =       0.03 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      47.54 seconds =       0.79 minutes
+	system time =       2.87 seconds =       0.05 minutes
+	total time  =         12 seconds =       0.20 minutes
+
+       N-Body: Complex Energy (fragments = (2, 3), basis = (2, 3):  -149.94679306271183)
+
+       N-Body: Computing complex (6/6) with fragments (1, 3) in the basis of fragments (1, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:44 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+   => HF-D3(BJ): Empirical Dispersion <=
+
+    Grimme's -D3 (BJ-damping) Dispersion Correction
+    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
+
+        s6 =       1.000000
+        s8 =       0.917100
+        a1 =       0.338500
+        a2 =       2.883000
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.66207  B =      0.23435  C =      0.17633 [cm^-1]
+  Rotational constants: A =  19848.38696  B =   7025.55974  C =   5286.37823 [MHz]
+  Nuclear repulsion =   37.415382693305901
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4069553340E-01.
+  Reciprocal condition number of the overlap matrix is 1.7095996847E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.43580290985733   -1.48436e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85784455007632   -1.42204e+00   2.34575e-02 DIIS
+   @DF-RHF iter   2:  -149.94477283743100   -8.69283e-02   3.65643e-03 DIIS
+   @DF-RHF iter   3:  -149.94659512124099   -1.82228e-03   8.97079e-04 DIIS
+   @DF-RHF iter   4:  -149.94674398133168   -1.48860e-04   9.32679e-05 DIIS
+   @DF-RHF iter   5:  -149.94674630523065   -2.32390e-06   2.53277e-05 DIIS
+   @DF-RHF iter   6:  -149.94674649353263   -1.88302e-07   2.29602e-06 DIIS
+   @DF-RHF iter   7:  -149.94674649480871   -1.27608e-09   2.76333e-07 DIIS
+   @DF-RHF iter   8:  -149.94674649482366   -1.49498e-11   3.37671e-08 DIIS
+   @DF-RHF iter   9:  -149.94674649482388   -2.27374e-13   6.15355e-09 DIIS
+   @DF-RHF iter  10:  -149.94674649482383    5.68434e-14   1.39739e-09 DIIS
+   @DF-RHF iter  11:  -149.94674649482397   -1.42109e-13   2.68754e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267572     2A    -20.197942     3A     -1.287848  
+       4A     -1.232673     5A     -0.641232     6A     -0.590389  
+       7A     -0.477963     8A     -0.430709     9A     -0.396328  
+      10A     -0.359544  
+
+    Virtual:                                                              
+
+      11A      0.565402    12A      0.656605    13A      0.715036  
+      14A      0.792872  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94674649482397
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4153826933059008
+    One-Electron Energy =                -282.9351101924352179
+    Two-Electron Energy =                  95.5853556243053504
+    Total Energy =                       -149.9467464948239694
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:   -25.8236      Y:    16.1783      Z:     0.3984
+
+  Electronic Dipole Moment: [e a0]
+     X:    25.3912      Y:   -16.7858      Z:    -0.3985
+
+  Dipole Moment: [e a0]
+     X:    -0.4325      Y:    -0.6075      Z:    -0.0002     Total:     0.7457
+
+  Dipole Moment: [D]
+     X:    -1.0992      Y:    -1.5441      Z:    -0.0004     Total:     1.8954
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:44 2021
+Module time:
+	user time   =       3.05 seconds =       0.05 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      50.70 seconds =       0.85 minutes
+	system time =       3.07 seconds =       0.05 minutes
+	total time  =         12 seconds =       0.20 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:44 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.415382693305901
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.004502436682    -0.041139592552     0.036267289855
+       2       -0.008923288166     0.015424658212    -0.008790506118
+       3        0.011284102625     0.022273357439    -0.027202228342
+       4       -0.028747490979     0.016334253509    -0.038157133378
+       5        0.016921512158     0.006530146950     0.009338942725
+       6        0.013967601042    -0.019422823561     0.028543635257
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:45 2021
+Module time:
+	user time   =       0.79 seconds =       0.01 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      51.77 seconds =       0.86 minutes
+	system time =       3.19 seconds =       0.05 minutes
+	total time  =         13 seconds =       0.22 minutes
+
+       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 3):  -149.94674649482397)
+
+   ==> N-Body: Counterpoise Corrected (CP) energies <==
+
+   n-Body     Total Energy [Eh]       I.E. [kcal/mol]      Delta [kcal/mol]
+        1     -224.903891303774        0.000000000000        0.000000000000
+        2     -224.915780748870       -7.460739435816       -7.460739435816
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line   130 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    15 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Interaction Energy.......................................................PASSED
+    CP-Corrected Interaction Energy.......................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:45 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+   => HF-D3(BJ): Empirical Dispersion <=
+
+    Grimme's -D3 (BJ-damping) Dispersion Correction
+    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
+
+        s6 =       1.000000
+        s8 =       0.917100
+        a1 =       0.338500
+        a2 =       2.883000
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =   37.327766624605843
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.43444075219807   -1.48434e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86420073588846   -1.42976e+00   1.57310e-02 DIIS
+   @DF-RHF iter   2:  -149.95072463354543   -8.65239e-02   2.56698e-03 DIIS
+   @DF-RHF iter   3:  -149.95267920276999   -1.95457e-03   6.20766e-04 DIIS
+   @DF-RHF iter   4:  -149.95284427491433   -1.65072e-04   6.37604e-05 DIIS
+   @DF-RHF iter   5:  -149.95284692286677   -2.64795e-06   9.91316e-06 DIIS
+   @DF-RHF iter   6:  -149.95284698731996   -6.44532e-08   1.44085e-06 DIIS
+   @DF-RHF iter   7:  -149.95284698836795   -1.04799e-09   2.53217e-07 DIIS
+   @DF-RHF iter   8:  -149.95284698839950   -3.15481e-11   3.21508e-08 DIIS
+   @DF-RHF iter   9:  -149.95284698840004   -5.40012e-13   6.14624e-09 DIIS
+   @DF-RHF iter  10:  -149.95284698840001    2.84217e-14   1.36595e-09 DIIS
+   @DF-RHF iter  11:  -149.95284698839995    5.68434e-14   2.33298e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.265993     2A    -20.213835     3A     -1.286385  
+       4A     -1.240805     5A     -0.640800     6A     -0.595401  
+       7A     -0.475790     8A     -0.434446     9A     -0.400444  
+      10A     -0.367648  
+
+    Virtual:                                                              
+
+      11A      0.490528    12A      0.607402    13A      0.648556  
+      14A      0.734932    15A      0.785344    16A      1.032771  
+      17A      1.373710    18A      2.556576    19A      2.950978  
+      20A      3.280669    21A     31.265676  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.95284698839995
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.3277666246058430
+    One-Electron Energy =                -282.6935372844795324
+    Two-Electron Energy =                  95.4252223514737210
+    Total Energy =                       -149.9528469883999549
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:     1.8989      Y:    30.1291      Z:     1.4353
+
+  Dipole Moment: [e a0]
+     X:     0.6812      Y:    -0.1488      Z:     0.8098     Total:     1.0686
+
+  Dipole Moment: [D]
+     X:     1.7314      Y:    -0.3781      Z:     2.0584     Total:     2.7162
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:46 2021
+Module time:
+	user time   =       1.98 seconds =       0.03 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      54.77 seconds =       0.91 minutes
+	system time =       3.35 seconds =       0.06 minutes
+	total time  =         14 seconds =       0.23 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:46 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.327766624605843
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.007243122658    -0.044085614653     0.035273237236
+       2       -0.013901651020     0.013131591893    -0.007062236253
+       3        0.011946784981     0.022317637723    -0.027758136919
+       4        0.039381359600     0.016095276571     0.034430947934
+       5       -0.026444405905    -0.001627029665    -0.026863201730
+       6       -0.008583781966    -0.014725495573    -0.007902079846
+       7        0.000487157240     0.000396299317     0.000017341008
+       8        0.004357241455     0.008480435011    -0.000133273839
+       9        0.000000418275     0.000016899376    -0.000002597592
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:46 2021
+Module time:
+	user time   =       1.23 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      56.20 seconds =       0.94 minutes
+	system time =       3.42 seconds =       0.06 minutes
+	total time  =         14 seconds =       0.23 minutes
     Energy of ((1, 2), (1, 2, 3)).........................................................PASSED
     Energy of ((1, 2), (1, 2, 3)).........................................................PASSED
     Energy of ((1, 2), (1, 2, 3)).........................................................PASSED
@@ -3360,16 +4260,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:43 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:46 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -3387,7 +4287,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3447,8 +4347,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -3459,7 +4359,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3496,18 +4396,18 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -148.43580517715009   -1.48436e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86749466726499   -1.43169e+00   1.55424e-02 DIIS
-   @DF-RHF iter   2:  -149.95221120159636   -8.47165e-02   2.55465e-03 DIIS
-   @DF-RHF iter   3:  -149.95418156362393   -1.97036e-03   6.22886e-04 DIIS
-   @DF-RHF iter   4:  -149.95434865132242   -1.67088e-04   6.29977e-05 DIIS
-   @DF-RHF iter   5:  -149.95435124125683   -2.58993e-06   9.62406e-06 DIIS
-   @DF-RHF iter   6:  -149.95435130203415   -6.07773e-08   1.35366e-06 DIIS
-   @DF-RHF iter   7:  -149.95435130294086   -9.06709e-10   2.43900e-07 DIIS
-   @DF-RHF iter   8:  -149.95435130297005   -2.91891e-11   3.14208e-08 DIIS
-   @DF-RHF iter   9:  -149.95435130297051   -4.54747e-13   6.02918e-09 DIIS
-   @DF-RHF iter  10:  -149.95435130297045    5.68434e-14   1.36824e-09 DIIS
-   @DF-RHF iter  11:  -149.95435130297062   -1.70530e-13   2.40354e-10 DIIS
+   @DF-RHF iter SAD:  -148.43580517720866   -1.48436e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86749466732581   -1.43169e+00   1.55424e-02 DIIS
+   @DF-RHF iter   2:  -149.95221120165729   -8.47165e-02   2.55465e-03 DIIS
+   @DF-RHF iter   3:  -149.95418156368484   -1.97036e-03   6.22886e-04 DIIS
+   @DF-RHF iter   4:  -149.95434865138353   -1.67088e-04   6.29977e-05 DIIS
+   @DF-RHF iter   5:  -149.95435124131774   -2.58993e-06   9.62406e-06 DIIS
+   @DF-RHF iter   6:  -149.95435130209501   -6.07773e-08   1.35366e-06 DIIS
+   @DF-RHF iter   7:  -149.95435130300189   -9.06880e-10   2.43900e-07 DIIS
+   @DF-RHF iter   8:  -149.95435130303099   -2.91038e-11   3.14208e-08 DIIS
+   @DF-RHF iter   9:  -149.95435130303150   -5.11591e-13   6.02918e-09 DIIS
+   @DF-RHF iter  10:  -149.95435130303150    0.00000e+00   1.36824e-09 DIIS
+   @DF-RHF iter  11:  -149.95435130303147    2.84217e-14   2.40355e-10 DIIS
   Energy and wave function converged.
 
 
@@ -3534,14 +4434,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.95435130297062
+  @DF-RHF Final Energy:  -149.95435130303147
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4153826933059008
-    One-Electron Energy =                -282.8726006393809485
-    Two-Electron Energy =                  95.5152412631044143
-    Total Energy =                       -149.9543513029706219
+    One-Electron Energy =                -282.8726006394039700
+    Two-Electron Energy =                  95.5152412630666277
+    Total Energy =                       -149.9543513030314443
 
 Computation Completed
 
@@ -3563,18 +4463,18 @@ Properties computed using the SCF density matrix
      X:    -1.2007      Y:    -1.4353      Z:    -0.0118     Total:     1.8713
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:43 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:47 2021
 Module time:
-	user time   =       0.61 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.99 seconds =       0.05 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.90 seconds =       0.12 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      59.29 seconds =       0.99 minutes
+	system time =       3.63 seconds =       0.06 minutes
+	total time  =         15 seconds =       0.25 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:44 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:47 2021
 
 
          ------------------------------------------------------------
@@ -3620,8 +4520,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -3640,26 +4540,26 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.004942330718    -0.041488362285     0.036186692374
-       2       -0.008980263456     0.015308436810    -0.008624632839
-       3        0.011300058049     0.022206572790    -0.027266985277
-       4        0.000077877896    -0.000630171310    -0.000065662311
-       5        0.000017101487    -0.000007706072     0.000000960727
-       6        0.005333224391    -0.008144547159     0.000059160370
-       7       -0.032324440029     0.024966597843    -0.038237789423
-       8        0.017201527277     0.006497336818     0.008760629788
-       9        0.012317245099    -0.018708157436     0.029187626590
+       1       -0.004942331888    -0.041488359566     0.036186690013
+       2       -0.008980261098     0.015308435498    -0.008624632431
+       3        0.011300056626     0.022206571141    -0.027266983336
+       4        0.000077877783    -0.000630171379    -0.000065662307
+       5        0.000017101472    -0.000007706075     0.000000960722
+       6        0.005333224583    -0.008144547130     0.000059160371
+       7       -0.032324437900     0.024966599611    -0.038237788844
+       8        0.017201525766     0.006497335538     0.008760629583
+       9        0.012317244654    -0.018708157640     0.029187626229
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:44 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:47 2021
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.04 seconds =       0.12 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      60.91 seconds =       1.02 minutes
+	system time =       3.70 seconds =       0.06 minutes
+	total time  =         15 seconds =       0.25 minutes
     Energy of ((1, 3), (1, 2, 3)).........................................................PASSED
     Energy of ((1, 3), (1, 2, 3)).........................................................PASSED
     Energy of ((1, 3), (1, 2, 3)).........................................................PASSED
@@ -3675,16 +4575,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:44 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:47 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -3702,7 +4602,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3762,8 +4662,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -3774,7 +4674,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -3811,18 +4711,18 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -148.43517267796997   -1.48435e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86656939506480   -1.43140e+00   1.55631e-02 DIIS
-   @DF-RHF iter   2:  -149.95156180979393   -8.49924e-02   2.54620e-03 DIIS
-   @DF-RHF iter   3:  -149.95352452408389   -1.96271e-03   6.21126e-04 DIIS
-   @DF-RHF iter   4:  -149.95369039947198   -1.65875e-04   6.28806e-05 DIIS
-   @DF-RHF iter   5:  -149.95369295846828   -2.55900e-06   1.07266e-05 DIIS
-   @DF-RHF iter   6:  -149.95369303237317   -7.39049e-08   1.68546e-06 DIIS
-   @DF-RHF iter   7:  -149.95369303389646   -1.52329e-09   2.96963e-07 DIIS
-   @DF-RHF iter   8:  -149.95369303394028   -4.38263e-11   3.32323e-08 DIIS
-   @DF-RHF iter   9:  -149.95369303394085   -5.68434e-13   6.90158e-09 DIIS
-   @DF-RHF iter  10:  -149.95369303394082    2.84217e-14   1.53556e-09 DIIS
-   @DF-RHF iter  11:  -149.95369303394088   -5.68434e-14   2.49156e-10 DIIS
+   @DF-RHF iter SAD:  -148.43517267805356   -1.48435e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86656939514944   -1.43140e+00   1.55631e-02 DIIS
+   @DF-RHF iter   2:  -149.95156180987865   -8.49924e-02   2.54620e-03 DIIS
+   @DF-RHF iter   3:  -149.95352452416850   -1.96271e-03   6.21126e-04 DIIS
+   @DF-RHF iter   4:  -149.95369039955685   -1.65875e-04   6.28806e-05 DIIS
+   @DF-RHF iter   5:  -149.95369295855329   -2.55900e-06   1.07266e-05 DIIS
+   @DF-RHF iter   6:  -149.95369303245809   -7.39048e-08   1.68546e-06 DIIS
+   @DF-RHF iter   7:  -149.95369303398124   -1.52315e-09   2.96963e-07 DIIS
+   @DF-RHF iter   8:  -149.95369303402481   -4.35705e-11   3.32323e-08 DIIS
+   @DF-RHF iter   9:  -149.95369303402552   -7.10543e-13   6.90158e-09 DIIS
+   @DF-RHF iter  10:  -149.95369303402563   -1.13687e-13   1.53556e-09 DIIS
+   @DF-RHF iter  11:  -149.95369303402569   -5.68434e-14   2.49157e-10 DIIS
   Energy and wave function converged.
 
 
@@ -3849,14 +4749,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.95369303394088
+  @DF-RHF Final Energy:  -149.95369303402569
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4208727124812270
-    One-Electron Energy =                -282.8840412880541635
-    Two-Electron Energy =                  95.5218870516320351
-    Total Energy =                       -149.9536930339408798
+    One-Electron Energy =                -282.8840412881002067
+    Two-Electron Energy =                  95.5218870515932679
+    Total Energy =                       -149.9536930340256902
 
 Computation Completed
 
@@ -3878,18 +4778,18 @@ Properties computed using the SCF density matrix
      X:    -0.5295      Y:     1.6482      Z:    -0.1172     Total:     1.7351
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:44 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:48 2021
 Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.88 seconds =       0.05 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.64 seconds =       0.13 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      63.91 seconds =       1.07 minutes
+	system time =       3.86 seconds =       0.06 minutes
+	total time  =         16 seconds =       0.27 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:44 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:48 2021
 
 
          ------------------------------------------------------------
@@ -3935,8 +4835,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -3955,26 +4855,26 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000549823241     0.000209101783    -0.000043130495
-       2       -0.008948416565    -0.000509994605    -0.000335110328
-       3       -0.000014125244    -0.000007901240     0.000001129934
-       4        0.040811211570     0.015095923235     0.036386015354
-       5       -0.025241122852    -0.001270248483    -0.027165119482
-       6       -0.003996028547    -0.017821700756    -0.008609524208
-       7       -0.031630747581     0.022469177680    -0.037813158722
-       8        0.016835970199     0.000812297789     0.008719768934
-       9        0.012733082265    -0.018976655404     0.028859129014
+       1       -0.000549823246     0.000209101778    -0.000043130493
+       2       -0.008948416490    -0.000509994598    -0.000335110333
+       3       -0.000014125250    -0.000007901242     0.000001129935
+       4        0.040811212034     0.015095923935     0.036386015782
+       5       -0.025241123303    -0.001270248481    -0.027165119823
+       6       -0.003996028609    -0.017821701466    -0.008609524296
+       7       -0.031630747472     0.022469177619    -0.037813158824
+       8        0.016835970124     0.000812297869     0.008719768955
+       9        0.012733082216    -0.018976655416     0.028859129096
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:44 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:48 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.77 seconds =       0.13 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      65.39 seconds =       1.09 minutes
+	system time =       3.94 seconds =       0.07 minutes
+	total time  =         16 seconds =       0.27 minutes
     Energy of ((2, 3), (1, 2, 3)).........................................................PASSED
     Energy of ((2, 3), (1, 2, 3)).........................................................PASSED
     Energy of ((2, 3), (1, 2, 3)).........................................................PASSED
@@ -3990,16 +4890,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:44 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:48 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -4017,7 +4917,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4077,8 +4977,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -4089,7 +4989,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4126,17 +5026,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20742807468321   -7.42074e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92713508767751   -7.19707e-01   1.16865e-02 DIIS
-   @DF-RHF iter   2:   -74.97377725367502   -4.66422e-02   1.98794e-03 DIIS
-   @DF-RHF iter   3:   -74.97483304712009   -1.05579e-03   4.55406e-04 DIIS
-   @DF-RHF iter   4:   -74.97491824358181   -8.51965e-05   4.56427e-05 DIIS
-   @DF-RHF iter   5:   -74.97491959385142   -1.35027e-06   8.79231e-06 DIIS
-   @DF-RHF iter   6:   -74.97491964748843   -5.36370e-08   4.96493e-07 DIIS
-   @DF-RHF iter   7:   -74.97491964760290   -1.14468e-10   5.85646e-08 DIIS
-   @DF-RHF iter   8:   -74.97491964760474   -1.83320e-12   7.90968e-09 DIIS
-   @DF-RHF iter   9:   -74.97491964760471    2.84217e-14   1.91420e-09 DIIS
-   @DF-RHF iter  10:   -74.97491964760474   -2.84217e-14   3.64991e-10 DIIS
+   @DF-RHF iter SAD:   -74.20742807468234   -7.42074e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92713508767689   -7.19707e-01   1.16865e-02 DIIS
+   @DF-RHF iter   2:   -74.97377725367429   -4.66422e-02   1.98794e-03 DIIS
+   @DF-RHF iter   3:   -74.97483304711936   -1.05579e-03   4.55406e-04 DIIS
+   @DF-RHF iter   4:   -74.97491824358110   -8.51965e-05   4.56427e-05 DIIS
+   @DF-RHF iter   5:   -74.97491959385079   -1.35027e-06   8.79231e-06 DIIS
+   @DF-RHF iter   6:   -74.97491964748768   -5.36369e-08   4.96493e-07 DIIS
+   @DF-RHF iter   7:   -74.97491964760221   -1.14525e-10   5.85646e-08 DIIS
+   @DF-RHF iter   8:   -74.97491964760408   -1.87583e-12   7.90968e-09 DIIS
+   @DF-RHF iter   9:   -74.97491964760411   -2.84217e-14   1.91420e-09 DIIS
+   @DF-RHF iter  10:   -74.97491964760401    9.94760e-14   3.64991e-10 DIIS
   Energy and wave function converged.
 
 
@@ -4163,14 +5063,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97491964760474
+  @DF-RHF Final Energy:   -74.97491964760401
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.1889285363781426
-    Two-Electron Energy =                  38.0985795999683816
-    Total Energy =                        -74.9749196476047359
+    One-Electron Energy =                -122.1889285363744051
+    Two-Electron Energy =                  38.0985795999653902
+    Total Energy =                        -74.9749196476040112
 
 Computation Completed
 
@@ -4192,18 +5092,18 @@ Properties computed using the SCF density matrix
      X:     0.3868      Y:    -1.4204      Z:     1.0410     Total:     1.8030
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:45 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:49 2021
 Module time:
-	user time   =       0.60 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       3.08 seconds =       0.05 minutes
+	system time =       0.20 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.38 seconds =       0.14 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      68.59 seconds =       1.14 minutes
+	system time =       4.15 seconds =       0.07 minutes
+	total time  =         17 seconds =       0.28 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:45 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:49 2021
 
 
          ------------------------------------------------------------
@@ -4249,8 +5149,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -4269,26 +5169,26 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.005935059733    -0.047617424551     0.039074564901
-       2       -0.010137101230     0.015943073054    -0.009922311386
-       3        0.011055682440     0.023598316632    -0.029030216879
-       4        0.000148988991     0.000025243627    -0.000022690919
-       5        0.000010967308     0.000001674296    -0.000001547970
-       6        0.000207745721     0.000029486396    -0.000032447680
-       7        0.000572101763     0.000266556798     0.000029623490
-       8        0.004072970022     0.007742331248    -0.000093127011
-       9        0.000003704716     0.000010742498    -0.000001846546
+       1       -0.005935059458    -0.047617425248     0.039074565849
+       2       -0.010137101975     0.015943073425    -0.009922311532
+       3        0.011055683053     0.023598317208    -0.029030217663
+       4        0.000148988953     0.000025243673    -0.000022690913
+       5        0.000010967308     0.000001674294    -0.000001547972
+       6        0.000207745772     0.000029486346    -0.000032447683
+       7        0.000572101780     0.000266556879     0.000029623506
+       8        0.004072969842     0.007742330912    -0.000093127040
+       9        0.000003704723     0.000010742510    -0.000001846553
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:45 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:49 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.11 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.51 seconds =       0.14 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      69.90 seconds =       1.17 minutes
+	system time =       4.22 seconds =       0.07 minutes
+	total time  =         17 seconds =       0.28 minutes
     Energy of ((1,), (1, 2, 3))...........................................................PASSED
     Energy of ((1,), (1, 2, 3))...........................................................PASSED
     Energy of ((1,), (1, 2, 3))...........................................................PASSED
@@ -4304,16 +5204,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:45 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:49 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -4331,7 +5231,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4391,8 +5291,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -4403,7 +5303,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4440,17 +5340,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20662008189998   -7.42066e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92637739020094   -7.19757e-01   1.17111e-02 DIIS
-   @DF-RHF iter   2:   -74.97326949611072   -4.68921e-02   1.97672e-03 DIIS
-   @DF-RHF iter   3:   -74.97431247519025   -1.04298e-03   4.53262e-04 DIIS
-   @DF-RHF iter   4:   -74.97439653644450   -8.40613e-05   4.54754e-05 DIIS
-   @DF-RHF iter   5:   -74.97439787789627   -1.34145e-06   8.68396e-06 DIIS
-   @DF-RHF iter   6:   -74.97439793024081   -5.23445e-08   4.77771e-07 DIIS
-   @DF-RHF iter   7:   -74.97439793034638   -1.05572e-10   5.60429e-08 DIIS
-   @DF-RHF iter   8:   -74.97439793034803   -1.64846e-12   7.92543e-09 DIIS
-   @DF-RHF iter   9:   -74.97439793034800    2.84217e-14   1.91285e-09 DIIS
-   @DF-RHF iter  10:   -74.97439793034798    2.84217e-14   3.66385e-10 DIIS
+   @DF-RHF iter SAD:   -74.20662008191566   -7.42066e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92637739021677   -7.19757e-01   1.17111e-02 DIIS
+   @DF-RHF iter   2:   -74.97326949612669   -4.68921e-02   1.97672e-03 DIIS
+   @DF-RHF iter   3:   -74.97431247520615   -1.04298e-03   4.53262e-04 DIIS
+   @DF-RHF iter   4:   -74.97439653646045   -8.40613e-05   4.54754e-05 DIIS
+   @DF-RHF iter   5:   -74.97439787791235   -1.34145e-06   8.68396e-06 DIIS
+   @DF-RHF iter   6:   -74.97439793025674   -5.23444e-08   4.77771e-07 DIIS
+   @DF-RHF iter   7:   -74.97439793036226   -1.05516e-10   5.60429e-08 DIIS
+   @DF-RHF iter   8:   -74.97439793036379   -1.53477e-12   7.92543e-09 DIIS
+   @DF-RHF iter   9:   -74.97439793036393   -1.42109e-13   1.91285e-09 DIIS
+   @DF-RHF iter  10:   -74.97439793036398   -4.26326e-14   3.66386e-10 DIIS
   Energy and wave function converged.
 
 
@@ -4477,14 +5377,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97439793034798
+  @DF-RHF Final Energy:   -74.97439793036398
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.1879518597725678
-    Two-Electron Energy =                  38.1012744681087696
-    Total Energy =                        -74.9743979303479762
+    One-Electron Energy =                -122.1879518597815064
+    Two-Electron Energy =                  38.1012744681017139
+    Total Energy =                        -74.9743979303639634
 
 Computation Completed
 
@@ -4506,18 +5406,18 @@ Properties computed using the SCF density matrix
      X:     1.0185      Y:     1.0559      Z:     1.0384     Total:     1.7974
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:46 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:50 2021
 Module time:
-	user time   =       0.58 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.96 seconds =       0.05 minutes
+	system time =       0.17 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       9.10 seconds =       0.15 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =      72.96 seconds =       1.22 minutes
+	system time =       4.40 seconds =       0.07 minutes
+	total time  =         18 seconds =       0.30 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:46 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:50 2021
 
 
          ------------------------------------------------------------
@@ -4563,8 +5463,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -4583,26 +5483,26 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000471411715     0.000356803526    -0.000054418348
-       2       -0.008168586790    -0.000377057152    -0.000347481001
-       3       -0.000010562665    -0.000002212593     0.000000346743
-       4        0.044104792300     0.018053620652     0.038832095194
-       5       -0.026707874117    -0.002453912338    -0.028547451305
-       6       -0.008502881784    -0.015883180896    -0.009838982335
-       7       -0.000111977626     0.000137295929    -0.000015716267
-       8       -0.000125841632     0.000163541055    -0.000028233206
-       9       -0.000005655967     0.000005101816    -0.000000159476
+       1       -0.000471411792     0.000356803535    -0.000054418348
+       2       -0.008168586486    -0.000377057159    -0.000347481002
+       3       -0.000010562662    -0.000002212594     0.000000346743
+       4        0.044104792971     0.018053621538     0.038832096002
+       5       -0.026707874934    -0.002453912246    -0.028547451971
+       6       -0.008502881862    -0.015883181877    -0.009838982479
+       7       -0.000111977592     0.000137295903    -0.000015716263
+       8       -0.000125841663     0.000163541069    -0.000028233204
+       9       -0.000005655976     0.000005101829    -0.000000159479
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:46 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:50 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.18 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.23 seconds =       0.15 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =      74.37 seconds =       1.24 minutes
+	system time =       4.46 seconds =       0.07 minutes
+	total time  =         18 seconds =       0.30 minutes
     Energy of ((2,), (1, 2, 3))...........................................................PASSED
     Energy of ((2,), (1, 2, 3))...........................................................PASSED
     Energy of ((2,), (1, 2, 3))...........................................................PASSED
@@ -4618,16 +5518,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:46 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:50 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -4645,7 +5545,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4705,8 +5605,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -4717,7 +5617,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -4754,17 +5654,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20651477843577   -7.42065e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92730458013231   -7.20790e-01   1.16966e-02 DIIS
-   @DF-RHF iter   2:   -74.97403011466274   -4.67255e-02   2.00055e-03 DIIS
-   @DF-RHF iter   3:   -74.97509650573888   -1.06639e-03   4.56359e-04 DIIS
-   @DF-RHF iter   4:   -74.97518197685694   -8.54711e-05   4.53537e-05 DIIS
-   @DF-RHF iter   5:   -74.97518330755325   -1.33070e-06   8.85963e-06 DIIS
-   @DF-RHF iter   6:   -74.97518336204838   -5.44951e-08   5.10780e-07 DIIS
-   @DF-RHF iter   7:   -74.97518336217013   -1.21744e-10   6.11794e-08 DIIS
-   @DF-RHF iter   8:   -74.97518336217209   -1.96110e-12   8.32843e-09 DIIS
-   @DF-RHF iter   9:   -74.97518336217210   -1.42109e-14   2.08217e-09 DIIS
-   @DF-RHF iter  10:   -74.97518336217213   -2.84217e-14   3.79028e-10 DIIS
+   @DF-RHF iter SAD:   -74.20651477847510   -7.42065e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92730458017245   -7.20790e-01   1.16966e-02 DIIS
+   @DF-RHF iter   2:   -74.97403011470301   -4.67255e-02   2.00055e-03 DIIS
+   @DF-RHF iter   3:   -74.97509650577922   -1.06639e-03   4.56359e-04 DIIS
+   @DF-RHF iter   4:   -74.97518197689728   -8.54711e-05   4.53537e-05 DIIS
+   @DF-RHF iter   5:   -74.97518330759340   -1.33070e-06   8.85963e-06 DIIS
+   @DF-RHF iter   6:   -74.97518336208850   -5.44951e-08   5.10780e-07 DIIS
+   @DF-RHF iter   7:   -74.97518336221047   -1.21972e-10   6.11794e-08 DIIS
+   @DF-RHF iter   8:   -74.97518336221243   -1.96110e-12   8.32843e-09 DIIS
+   @DF-RHF iter   9:   -74.97518336221236    7.10543e-14   2.08217e-09 DIIS
+   @DF-RHF iter  10:   -74.97518336221238   -1.42109e-14   3.79028e-10 DIIS
   Energy and wave function converged.
 
 
@@ -4791,14 +5691,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97518336217213
+  @DF-RHF Final Energy:   -74.97518336221238
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.1796494816868943
-    Two-Electron Energy =                  38.0926531405595128
-    Total Energy =                        -74.9751833621721318
+    One-Electron Energy =                -122.1796494817145060
+    Two-Electron Energy =                  38.0926531405468864
+    Total Energy =                        -74.9751833622123769
 
 Computation Completed
 
@@ -4820,18 +5720,18 @@ Properties computed using the SCF density matrix
      X:    -1.3881      Y:     0.2787      Z:    -1.1084     Total:     1.7980
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:47 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:51 2021
 Module time:
-	user time   =       0.60 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       3.61 seconds =       0.06 minutes
+	system time =       0.18 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       9.84 seconds =       0.16 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      78.08 seconds =       1.30 minutes
+	system time =       4.66 seconds =       0.08 minutes
+	total time  =         19 seconds =       0.32 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:47 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:51 2021
 
 
          ------------------------------------------------------------
@@ -4877,8 +5777,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -4897,26 +5797,26 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000072680718    -0.000178930516     0.000016357965
-       2       -0.000082840329    -0.000198380482     0.000026349953
-       3       -0.000001789941    -0.000006925597     0.000000480285
-       4       -0.000053426750    -0.000634492522    -0.000043991627
-       5        0.000006717095    -0.000006864509     0.000001653334
-       6        0.004811504278    -0.007487779979     0.000107477804
-       7       -0.036158940824     0.026021139966    -0.040796981130
-       8        0.017715436438     0.001777503645     0.010044340206
-       9        0.013836020752    -0.019285270006     0.030644313210
+       1       -0.000072680690    -0.000178930504     0.000016357960
+       2       -0.000082840351    -0.000198380487     0.000026349954
+       3       -0.000001789951    -0.000006925598     0.000000480290
+       4       -0.000053426735    -0.000634492412    -0.000043991630
+       5        0.000006717100    -0.000006864513     0.000001653343
+       6        0.004811504247    -0.007487780060     0.000107477797
+       7       -0.036158940958     0.026021139494    -0.040796981181
+       8        0.017715436602     0.001777503986     0.010044340231
+       9        0.013836020736    -0.019285269907     0.030644313236
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:47 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:52 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.11 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       9.97 seconds =       0.17 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      80.61 seconds =       1.34 minutes
+	system time =       4.78 seconds =       0.08 minutes
+	total time  =         20 seconds =       0.33 minutes
     Energy of ((3,), (1, 2, 3))...........................................................PASSED
     Energy of ((3,), (1, 2, 3))...........................................................PASSED
     Energy of ((3,), (1, 2, 3))...........................................................PASSED
@@ -4932,16 +5832,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:47 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:52 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -4959,7 +5859,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5013,8 +5913,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -5025,7 +5925,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5062,16 +5962,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20742717616535   -7.42074e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91808853105498   -7.10661e-01   3.55337e-02 DIIS
-   @DF-RHF iter   2:   -74.96695065050781   -4.88621e-02   5.41141e-03 DIIS
-   @DF-RHF iter   3:   -74.96782754053548   -8.76890e-04   1.28859e-03 DIIS
-   @DF-RHF iter   4:   -74.96789978922203   -7.22487e-05   1.30788e-04 DIIS
-   @DF-RHF iter   5:   -74.96790106816906   -1.27895e-06   8.84975e-06 DIIS
-   @DF-RHF iter   6:   -74.96790107274545   -4.57639e-09   5.30739e-07 DIIS
-   @DF-RHF iter   7:   -74.96790107276169   -1.62430e-11   4.98532e-08 DIIS
-   @DF-RHF iter   8:   -74.96790107276188   -1.84741e-13   1.19600e-09 DIIS
-   @DF-RHF iter   9:   -74.96790107276188    0.00000e+00   1.49181e-10 DIIS
+   @DF-RHF iter SAD:   -74.20742717616241   -7.42074e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91808853105051   -7.10661e-01   3.55337e-02 DIIS
+   @DF-RHF iter   2:   -74.96695065050332   -4.88621e-02   5.41141e-03 DIIS
+   @DF-RHF iter   3:   -74.96782754053112   -8.76890e-04   1.28859e-03 DIIS
+   @DF-RHF iter   4:   -74.96789978921774   -7.22487e-05   1.30788e-04 DIIS
+   @DF-RHF iter   5:   -74.96790106816462   -1.27895e-06   8.84975e-06 DIIS
+   @DF-RHF iter   6:   -74.96790107274107   -4.57645e-09   5.30739e-07 DIIS
+   @DF-RHF iter   7:   -74.96790107275724   -1.61720e-11   4.98532e-08 DIIS
+   @DF-RHF iter   8:   -74.96790107275741   -1.70530e-13   1.19600e-09 DIIS
+   @DF-RHF iter   9:   -74.96790107275744   -2.84217e-14   1.49181e-10 DIIS
   Energy and wave function converged.
 
 
@@ -5093,14 +5993,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96790107276188
+  @DF-RHF Final Energy:   -74.96790107275744
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.2481627620098124
-    Two-Electron Energy =                  38.1648324004429256
-    Total Energy =                        -74.9679010727618902
+    One-Electron Energy =                -122.2481627620103666
+    Two-Electron Energy =                  38.1648324004478994
+    Total Energy =                        -74.9679010727574564
 
 Computation Completed
 
@@ -5122,18 +6022,18 @@ Properties computed using the SCF density matrix
      X:     0.4415      Y:    -1.2890      Z:     1.0302     Total:     1.7081
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:47 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:52 2021
 Module time:
-	user time   =       0.26 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.91 seconds =       0.03 minutes
+	system time =       0.19 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.24 seconds =       0.17 minutes
-	system time =       0.25 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      82.63 seconds =       1.38 minutes
+	system time =       4.97 seconds =       0.08 minutes
+	total time  =         20 seconds =       0.33 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:47 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:52 2021
 
 
          ------------------------------------------------------------
@@ -5173,8 +6073,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -5193,20 +6093,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000120707477    -0.041248212738     0.038755311065
-       2       -0.010650338842     0.015909042579    -0.010603622945
-       3        0.010771046318     0.025339170158    -0.028151688120
+       1       -0.000120707302    -0.041248213198     0.038755311420
+       2       -0.010650339242     0.015909042811    -0.010603622997
+       3        0.010771046542     0.025339170385    -0.028151688422
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:47 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:52 2021
 Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.61 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.27 seconds =       0.17 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      83.44 seconds =       1.39 minutes
+	system time =       4.99 seconds =       0.08 minutes
+	total time  =         20 seconds =       0.33 minutes
     Energy of ((1,), (1,))................................................................PASSED
     Energy of ((1,), (1,))................................................................PASSED
     Energy of ((1,), (1,))................................................................PASSED
@@ -5222,16 +6122,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:47 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:52 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -5249,7 +6149,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5303,8 +6203,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -5315,7 +6215,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5352,16 +6252,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20661951382856   -7.42066e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91806776496207   -7.11448e-01   3.55515e-02 DIIS
-   @DF-RHF iter   2:   -74.96699532969026   -4.89276e-02   5.41710e-03 DIIS
-   @DF-RHF iter   3:   -74.96787329380747   -8.77964e-04   1.28875e-03 DIIS
-   @DF-RHF iter   4:   -74.96794552409411   -7.22303e-05   1.30538e-04 DIIS
-   @DF-RHF iter   5:   -74.96794679834903   -1.27425e-06   8.88772e-06 DIIS
-   @DF-RHF iter   6:   -74.96794680297020   -4.62117e-09   5.28512e-07 DIIS
-   @DF-RHF iter   7:   -74.96794680298636   -1.61577e-11   5.37441e-08 DIIS
-   @DF-RHF iter   8:   -74.96794680298649   -1.27898e-13   1.21463e-09 DIIS
-   @DF-RHF iter   9:   -74.96794680298652   -2.84217e-14   1.58511e-10 DIIS
+   @DF-RHF iter SAD:   -74.20661951381699   -7.42066e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91806776495049   -7.11448e-01   3.55515e-02 DIIS
+   @DF-RHF iter   2:   -74.96699532967870   -4.89276e-02   5.41710e-03 DIIS
+   @DF-RHF iter   3:   -74.96787329379585   -8.77964e-04   1.28875e-03 DIIS
+   @DF-RHF iter   4:   -74.96794552408251   -7.22303e-05   1.30538e-04 DIIS
+   @DF-RHF iter   5:   -74.96794679833745   -1.27425e-06   8.88772e-06 DIIS
+   @DF-RHF iter   6:   -74.96794680295859   -4.62114e-09   5.28512e-07 DIIS
+   @DF-RHF iter   7:   -74.96794680297481   -1.62146e-11   5.37441e-08 DIIS
+   @DF-RHF iter   8:   -74.96794680297492   -1.13687e-13   1.21463e-09 DIIS
+   @DF-RHF iter   9:   -74.96794680297495   -2.84217e-14   1.58512e-10 DIIS
   Energy and wave function converged.
 
 
@@ -5383,14 +6283,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96794680298652
+  @DF-RHF Final Energy:   -74.96794680297495
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.2421812246935957
-    Two-Electron Energy =                  38.1619549603912418
-    Total Energy =                        -74.9679468029865319
+    One-Electron Energy =                -122.2421812246879540
+    Two-Electron Energy =                  38.1619549603971748
+    Total Energy =                        -74.9679468029749643
 
 Computation Completed
 
@@ -5412,18 +6312,18 @@ Properties computed using the SCF density matrix
      X:     0.8883      Y:     1.0391      Z:     1.0241     Total:     1.7081
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:47 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:53 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.94 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      10.53 seconds =       0.18 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      85.49 seconds =       1.42 minutes
+	system time =       5.10 seconds =       0.09 minutes
+	total time  =         21 seconds =       0.35 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:47 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:53 2021
 
 
          ------------------------------------------------------------
@@ -5463,8 +6363,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -5483,20 +6383,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.036174275815     0.019888513002     0.038150921226
-       2       -0.027999708644    -0.003630506060    -0.027664272010
-       3       -0.008174567168    -0.016258006942    -0.010486649216
+       1        0.036174275429     0.019888512500     0.038150920770
+       2       -0.027999708251    -0.003630506140    -0.027664271642
+       3       -0.008174567174    -0.016258006361    -0.010486649129
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:47 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:53 2021
 Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.54 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.57 seconds =       0.18 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      86.24 seconds =       1.44 minutes
+	system time =       5.16 seconds =       0.09 minutes
+	total time  =         21 seconds =       0.35 minutes
     Energy of ((2,), (2,))................................................................PASSED
     Energy of ((2,), (2,))................................................................PASSED
     Energy of ((2,), (2,))................................................................PASSED
@@ -5512,16 +6412,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:47 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:53 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -5539,7 +6439,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5593,8 +6493,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -5605,7 +6505,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5642,16 +6542,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20651452671358   -7.42065e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91808516758250   -7.11571e-01   3.55775e-02 DIIS
-   @DF-RHF iter   2:   -74.96709222478714   -4.90071e-02   5.42254e-03 DIIS
-   @DF-RHF iter   3:   -74.96797025129629   -8.78027e-04   1.28737e-03 DIIS
-   @DF-RHF iter   4:   -74.96804216953664   -7.19182e-05   1.29539e-04 DIIS
-   @DF-RHF iter   5:   -74.96804342339473   -1.25386e-06   8.90787e-06 DIIS
-   @DF-RHF iter   6:   -74.96804342803641   -4.64168e-09   5.24339e-07 DIIS
-   @DF-RHF iter   7:   -74.96804342805231   -1.59019e-11   5.17144e-08 DIIS
-   @DF-RHF iter   8:   -74.96804342805244   -1.27898e-13   1.18687e-09 DIIS
-   @DF-RHF iter   9:   -74.96804342805250   -5.68434e-14   1.51651e-10 DIIS
+   @DF-RHF iter SAD:   -74.20651452670236   -7.42065e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91808516757169   -7.11571e-01   3.55775e-02 DIIS
+   @DF-RHF iter   2:   -74.96709222477614   -4.90071e-02   5.42254e-03 DIIS
+   @DF-RHF iter   3:   -74.96797025128529   -8.78027e-04   1.28737e-03 DIIS
+   @DF-RHF iter   4:   -74.96804216952573   -7.19182e-05   1.29539e-04 DIIS
+   @DF-RHF iter   5:   -74.96804342338373   -1.25386e-06   8.90787e-06 DIIS
+   @DF-RHF iter   6:   -74.96804342802550   -4.64176e-09   5.24339e-07 DIIS
+   @DF-RHF iter   7:   -74.96804342804138   -1.58877e-11   5.17144e-08 DIIS
+   @DF-RHF iter   8:   -74.96804342804157   -1.84741e-13   1.18687e-09 DIIS
+   @DF-RHF iter   9:   -74.96804342804154    2.84217e-14   1.51651e-10 DIIS
   Energy and wave function converged.
 
 
@@ -5673,14 +6573,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96804342805250
+  @DF-RHF Final Energy:   -74.96804342804154
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.2400220121474348
-    Two-Electron Energy =                  38.1601656051396816
-    Total Energy =                        -74.9680434280525105
+    One-Electron Energy =                -122.2400220121383114
+    Two-Electron Energy =                  38.1601656051415432
+    Total Energy =                        -74.9680434280415255
 
 Computation Completed
 
@@ -5702,18 +6602,18 @@ Properties computed using the SCF density matrix
      X:    -1.3005      Y:     0.1654      Z:    -1.0966     Total:     1.7092
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:48 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:53 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       2.06 seconds =       0.03 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.83 seconds =       0.18 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      88.45 seconds =       1.47 minutes
+	system time =       5.34 seconds =       0.09 minutes
+	total time  =         21 seconds =       0.35 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:48 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:53 2021
 
 
          ------------------------------------------------------------
@@ -5753,8 +6653,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -5773,20 +6673,20 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.033217821649     0.017638388872    -0.040621608851
-       2        0.017823382996     0.002282578370     0.010748896984
-       3        0.015394438654    -0.019920967243     0.029872711867
+       1       -0.033217821307     0.017638388852    -0.040621608587
+       2        0.017823382716     0.002282578199     0.010748896944
+       3        0.015394438592    -0.019920967053     0.029872711643
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:48 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:53 2021
 Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.86 seconds =       0.18 minutes
-	system time =       0.28 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      89.36 seconds =       1.49 minutes
+	system time =       5.38 seconds =       0.09 minutes
+	total time  =         21 seconds =       0.35 minutes
     Energy of ((3,), (3,))................................................................PASSED
     Energy of ((3,), (3,))................................................................PASSED
     Energy of ((3,), (3,))................................................................PASSED
@@ -5809,9 +6709,9 @@ Scratch directory: /tmp/
 
 
    ===> N-Body Interaction Abacus <===
-        BSSE Treatment:                     cp
+        BSSE Treatment:                     ['cp', 'nocp']
         Number of 1-body computations:     6
-        Number of 2-body computations:     3
+        Number of 2-body computations:     6
 
    ==> N-Body: Now computing 1-body complexes <==
 
@@ -5824,16 +6724,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:48 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:53 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -5851,7 +6751,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5911,8 +6811,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -5923,7 +6823,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -5960,17 +6860,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20742807468321   -7.42074e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92713508767751   -7.19707e-01   1.16865e-02 DIIS
-   @DF-RHF iter   2:   -74.97377725367502   -4.66422e-02   1.98794e-03 DIIS
-   @DF-RHF iter   3:   -74.97483304712009   -1.05579e-03   4.55406e-04 DIIS
-   @DF-RHF iter   4:   -74.97491824358181   -8.51965e-05   4.56427e-05 DIIS
-   @DF-RHF iter   5:   -74.97491959385142   -1.35027e-06   8.79231e-06 DIIS
-   @DF-RHF iter   6:   -74.97491964748843   -5.36370e-08   4.96493e-07 DIIS
-   @DF-RHF iter   7:   -74.97491964760290   -1.14468e-10   5.85646e-08 DIIS
-   @DF-RHF iter   8:   -74.97491964760474   -1.83320e-12   7.90968e-09 DIIS
-   @DF-RHF iter   9:   -74.97491964760471    2.84217e-14   1.91420e-09 DIIS
-   @DF-RHF iter  10:   -74.97491964760474   -2.84217e-14   3.64991e-10 DIIS
+   @DF-RHF iter SAD:   -74.20742807468235   -7.42074e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92713508767694   -7.19707e-01   1.16865e-02 DIIS
+   @DF-RHF iter   2:   -74.97377725367429   -4.66422e-02   1.98794e-03 DIIS
+   @DF-RHF iter   3:   -74.97483304711940   -1.05579e-03   4.55406e-04 DIIS
+   @DF-RHF iter   4:   -74.97491824358109   -8.51965e-05   4.56427e-05 DIIS
+   @DF-RHF iter   5:   -74.97491959385073   -1.35027e-06   8.79231e-06 DIIS
+   @DF-RHF iter   6:   -74.97491964748762   -5.36369e-08   4.96493e-07 DIIS
+   @DF-RHF iter   7:   -74.97491964760221   -1.14582e-10   5.85646e-08 DIIS
+   @DF-RHF iter   8:   -74.97491964760410   -1.89004e-12   7.90968e-09 DIIS
+   @DF-RHF iter   9:   -74.97491964760404    5.68434e-14   1.91420e-09 DIIS
+   @DF-RHF iter  10:   -74.97491964760398    5.68434e-14   3.64991e-10 DIIS
   Energy and wave function converged.
 
 
@@ -5997,14 +6897,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97491964760474
+  @DF-RHF Final Energy:   -74.97491964760398
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.1889285363781426
-    Two-Electron Energy =                  38.0985795999683816
-    Total Energy =                        -74.9749196476047359
+    One-Electron Energy =                -122.1889285363744477
+    Two-Electron Energy =                  38.0985795999654400
+    Total Energy =                        -74.9749196476039970
 
 Computation Completed
 
@@ -6026,18 +6926,18 @@ Properties computed using the SCF density matrix
      X:     0.3868      Y:    -1.4204      Z:     1.0410     Total:     1.8030
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:48 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:54 2021
 Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.68 seconds =       0.04 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      11.46 seconds =       0.19 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      92.19 seconds =       1.54 minutes
+	system time =       5.54 seconds =       0.09 minutes
+	total time  =         22 seconds =       0.37 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:48 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:54 2021
 
 
          ------------------------------------------------------------
@@ -6083,8 +6983,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -6103,28 +7003,28 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.005935059733    -0.047617424551     0.039074564901
-       2       -0.010137101230     0.015943073054    -0.009922311386
-       3        0.011055682440     0.023598316632    -0.029030216879
-       4        0.000148988991     0.000025243627    -0.000022690919
-       5        0.000010967308     0.000001674296    -0.000001547970
-       6        0.000207745721     0.000029486396    -0.000032447680
-       7        0.000572101763     0.000266556798     0.000029623490
-       8        0.004072970022     0.007742331248    -0.000093127011
-       9        0.000003704716     0.000010742498    -0.000001846546
+       1       -0.005935059738    -0.047617425037     0.039074565641
+       2       -0.010137101638     0.015943073291    -0.009922311496
+       3        0.011055682961     0.023598317074    -0.029030217495
+       4        0.000148988967     0.000025243681    -0.000022690912
+       5        0.000010967309     0.000001674293    -0.000001547972
+       6        0.000207745760     0.000029486337    -0.000032447683
+       7        0.000572101780     0.000266556857     0.000029623502
+       8        0.004072969876     0.007742330996    -0.000093127033
+       9        0.000003704723     0.000010742507    -0.000001846553
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:48 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:54 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.18 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.59 seconds =       0.19 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      93.59 seconds =       1.56 minutes
+	system time =       5.61 seconds =       0.09 minutes
+	total time  =         22 seconds =       0.37 minutes
 
-       N-Body: Complex Energy (fragments = (1,), basis = (1, 2, 3):   -74.97491964760474)
+       N-Body: Complex Energy (fragments = (1,), basis = (1, 2, 3):   -74.97491964760398)
 
        N-Body: Computing complex (2/6) with fragments (2,) in the basis of fragments (1, 2, 3).
 
@@ -6134,16 +7034,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:48 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:54 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -6161,7 +7061,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6221,8 +7121,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -6233,7 +7133,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -6270,17 +7170,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20662008189998   -7.42066e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92637739020094   -7.19757e-01   1.17111e-02 DIIS
-   @DF-RHF iter   2:   -74.97326949611072   -4.68921e-02   1.97672e-03 DIIS
-   @DF-RHF iter   3:   -74.97431247519025   -1.04298e-03   4.53262e-04 DIIS
-   @DF-RHF iter   4:   -74.97439653644450   -8.40613e-05   4.54754e-05 DIIS
-   @DF-RHF iter   5:   -74.97439787789627   -1.34145e-06   8.68396e-06 DIIS
-   @DF-RHF iter   6:   -74.97439793024081   -5.23445e-08   4.77771e-07 DIIS
-   @DF-RHF iter   7:   -74.97439793034638   -1.05572e-10   5.60429e-08 DIIS
-   @DF-RHF iter   8:   -74.97439793034803   -1.64846e-12   7.92543e-09 DIIS
-   @DF-RHF iter   9:   -74.97439793034800    2.84217e-14   1.91285e-09 DIIS
-   @DF-RHF iter  10:   -74.97439793034798    2.84217e-14   3.66385e-10 DIIS
+   @DF-RHF iter SAD:   -74.20662008191564   -7.42066e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92637739021671   -7.19757e-01   1.17111e-02 DIIS
+   @DF-RHF iter   2:   -74.97326949612669   -4.68921e-02   1.97672e-03 DIIS
+   @DF-RHF iter   3:   -74.97431247520612   -1.04298e-03   4.53262e-04 DIIS
+   @DF-RHF iter   4:   -74.97439653646045   -8.40613e-05   4.54754e-05 DIIS
+   @DF-RHF iter   5:   -74.97439787791230   -1.34145e-06   8.68396e-06 DIIS
+   @DF-RHF iter   6:   -74.97439793025667   -5.23444e-08   4.77771e-07 DIIS
+   @DF-RHF iter   7:   -74.97439793036231   -1.05643e-10   5.60429e-08 DIIS
+   @DF-RHF iter   8:   -74.97439793036386   -1.54898e-12   7.92543e-09 DIIS
+   @DF-RHF iter   9:   -74.97439793036389   -2.84217e-14   1.91285e-09 DIIS
+   @DF-RHF iter  10:   -74.97439793036403   -1.42109e-13   3.66386e-10 DIIS
   Energy and wave function converged.
 
 
@@ -6307,14 +7207,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97439793034798
+  @DF-RHF Final Energy:   -74.97439793036403
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.1879518597725678
-    Two-Electron Energy =                  38.1012744681087696
-    Total Energy =                        -74.9743979303479762
+    One-Electron Energy =                -122.1879518597815917
+    Two-Electron Energy =                  38.1012744681017352
+    Total Energy =                        -74.9743979303640344
 
 Computation Completed
 
@@ -6336,18 +7236,18 @@ Properties computed using the SCF density matrix
      X:     1.0185      Y:     1.0559      Z:     1.0384     Total:     1.7974
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:49 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:55 2021
 Module time:
-	user time   =       0.61 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       3.52 seconds =       0.06 minutes
+	system time =       0.18 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.21 seconds =       0.20 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =      97.19 seconds =       1.62 minutes
+	system time =       5.79 seconds =       0.10 minutes
+	total time  =         23 seconds =       0.38 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:49 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:55 2021
 
 
          ------------------------------------------------------------
@@ -6393,8 +7293,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -6413,28 +7313,28 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000471411715     0.000356803526    -0.000054418348
-       2       -0.008168586790    -0.000377057152    -0.000347481001
-       3       -0.000010562665    -0.000002212593     0.000000346743
-       4        0.044104792300     0.018053620652     0.038832095194
-       5       -0.026707874117    -0.002453912338    -0.028547451305
-       6       -0.008502881784    -0.015883180896    -0.009838982335
-       7       -0.000111977626     0.000137295929    -0.000015716267
-       8       -0.000125841632     0.000163541055    -0.000028233206
-       9       -0.000005655967     0.000005101816    -0.000000159476
+       1       -0.000471411778     0.000356803529    -0.000054418347
+       2       -0.008168586524    -0.000377057153    -0.000347481002
+       3       -0.000010562663    -0.000002212593     0.000000346743
+       4        0.044104792872     0.018053621458     0.038832095887
+       5       -0.026707874851    -0.002453912225    -0.028547451896
+       6       -0.008502881822    -0.015883181814    -0.009838982439
+       7       -0.000111977590     0.000137295904    -0.000015716261
+       8       -0.000125841665     0.000163541066    -0.000028233204
+       9       -0.000005655976     0.000005101829    -0.000000159481
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:49 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:56 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.18 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.34 seconds =       0.21 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =      98.59 seconds =       1.64 minutes
+	system time =       5.87 seconds =       0.10 minutes
+	total time  =         24 seconds =       0.40 minutes
 
-       N-Body: Complex Energy (fragments = (2,), basis = (1, 2, 3):   -74.97439793034798)
+       N-Body: Complex Energy (fragments = (2,), basis = (1, 2, 3):   -74.97439793036403)
 
        N-Body: Computing complex (3/6) with fragments (3,) in the basis of fragments (3,).
 
@@ -6444,16 +7344,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:49 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:56 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -6471,7 +7371,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6525,8 +7425,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -6537,7 +7437,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -6574,16 +7474,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20651452671358   -7.42065e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91808516758250   -7.11571e-01   3.55775e-02 DIIS
-   @DF-RHF iter   2:   -74.96709222478714   -4.90071e-02   5.42254e-03 DIIS
-   @DF-RHF iter   3:   -74.96797025129629   -8.78027e-04   1.28737e-03 DIIS
-   @DF-RHF iter   4:   -74.96804216953664   -7.19182e-05   1.29539e-04 DIIS
-   @DF-RHF iter   5:   -74.96804342339473   -1.25386e-06   8.90787e-06 DIIS
-   @DF-RHF iter   6:   -74.96804342803641   -4.64168e-09   5.24339e-07 DIIS
-   @DF-RHF iter   7:   -74.96804342805231   -1.59019e-11   5.17144e-08 DIIS
-   @DF-RHF iter   8:   -74.96804342805244   -1.27898e-13   1.18687e-09 DIIS
-   @DF-RHF iter   9:   -74.96804342805250   -5.68434e-14   1.51651e-10 DIIS
+   @DF-RHF iter SAD:   -74.20651452670241   -7.42065e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91808516757169   -7.11571e-01   3.55775e-02 DIIS
+   @DF-RHF iter   2:   -74.96709222477617   -4.90071e-02   5.42254e-03 DIIS
+   @DF-RHF iter   3:   -74.96797025128531   -8.78027e-04   1.28737e-03 DIIS
+   @DF-RHF iter   4:   -74.96804216952576   -7.19182e-05   1.29539e-04 DIIS
+   @DF-RHF iter   5:   -74.96804342338372   -1.25386e-06   8.90787e-06 DIIS
+   @DF-RHF iter   6:   -74.96804342802550   -4.64178e-09   5.24339e-07 DIIS
+   @DF-RHF iter   7:   -74.96804342804145   -1.59588e-11   5.17144e-08 DIIS
+   @DF-RHF iter   8:   -74.96804342804160   -1.42109e-13   1.18687e-09 DIIS
+   @DF-RHF iter   9:   -74.96804342804154    5.68434e-14   1.51651e-10 DIIS
   Energy and wave function converged.
 
 
@@ -6605,14 +7505,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96804342805250
+  @DF-RHF Final Energy:   -74.96804342804154
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.2400220121474348
-    Two-Electron Energy =                  38.1601656051396816
-    Total Energy =                        -74.9680434280525105
+    One-Electron Energy =                -122.2400220121383256
+    Two-Electron Energy =                  38.1601656051415361
+    Total Energy =                        -74.9680434280415540
 
 Computation Completed
 
@@ -6634,18 +7534,18 @@ Properties computed using the SCF density matrix
      X:    -1.3005      Y:     0.1654      Z:    -1.0966     Total:     1.7092
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:50 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:56 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.95 seconds =       0.03 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.60 seconds =       0.21 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =     100.62 seconds =       1.68 minutes
+	system time =       6.04 seconds =       0.10 minutes
+	total time  =         24 seconds =       0.40 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:50 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:56 2021
 
 
          ------------------------------------------------------------
@@ -6685,8 +7585,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -6705,22 +7605,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.033217821649     0.017638388872    -0.040621608851
-       2        0.017823382996     0.002282578370     0.010748896984
-       3        0.015394438654    -0.019920967243     0.029872711867
+       1       -0.033217821419     0.017638388867    -0.040621608680
+       2        0.017823382793     0.002282578229     0.010748896971
+       3        0.015394438626    -0.019920967097     0.029872711709
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:50 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:56 2021
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.83 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.63 seconds =       0.21 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =     101.66 seconds =       1.69 minutes
+	system time =       6.11 seconds =       0.10 minutes
+	total time  =         24 seconds =       0.40 minutes
 
-       N-Body: Complex Energy (fragments = (3,), basis = (3,):   -74.96804342805250)
+       N-Body: Complex Energy (fragments = (3,), basis = (3,):   -74.96804342804154)
 
        N-Body: Computing complex (4/6) with fragments (2,) in the basis of fragments (2,).
 
@@ -6730,16 +7630,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:50 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:56 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -6757,7 +7657,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6811,8 +7711,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -6823,7 +7723,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -6860,16 +7760,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20661951382856   -7.42066e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91806776496207   -7.11448e-01   3.55515e-02 DIIS
-   @DF-RHF iter   2:   -74.96699532969026   -4.89276e-02   5.41710e-03 DIIS
-   @DF-RHF iter   3:   -74.96787329380747   -8.77964e-04   1.28875e-03 DIIS
-   @DF-RHF iter   4:   -74.96794552409411   -7.22303e-05   1.30538e-04 DIIS
-   @DF-RHF iter   5:   -74.96794679834903   -1.27425e-06   8.88772e-06 DIIS
-   @DF-RHF iter   6:   -74.96794680297020   -4.62117e-09   5.28512e-07 DIIS
-   @DF-RHF iter   7:   -74.96794680298636   -1.61577e-11   5.37441e-08 DIIS
-   @DF-RHF iter   8:   -74.96794680298649   -1.27898e-13   1.21463e-09 DIIS
-   @DF-RHF iter   9:   -74.96794680298652   -2.84217e-14   1.58511e-10 DIIS
+   @DF-RHF iter SAD:   -74.20661951381700   -7.42066e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91806776495052   -7.11448e-01   3.55515e-02 DIIS
+   @DF-RHF iter   2:   -74.96699532967867   -4.89276e-02   5.41710e-03 DIIS
+   @DF-RHF iter   3:   -74.96787329379589   -8.77964e-04   1.28875e-03 DIIS
+   @DF-RHF iter   4:   -74.96794552408254   -7.22303e-05   1.30538e-04 DIIS
+   @DF-RHF iter   5:   -74.96794679833745   -1.27425e-06   8.88772e-06 DIIS
+   @DF-RHF iter   6:   -74.96794680295862   -4.62117e-09   5.28512e-07 DIIS
+   @DF-RHF iter   7:   -74.96794680297481   -1.61862e-11   5.37441e-08 DIIS
+   @DF-RHF iter   8:   -74.96794680297494   -1.27898e-13   1.21463e-09 DIIS
+   @DF-RHF iter   9:   -74.96794680297494    0.00000e+00   1.58512e-10 DIIS
   Energy and wave function converged.
 
 
@@ -6891,14 +7791,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96794680298652
+  @DF-RHF Final Energy:   -74.96794680297494
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.2421812246935957
-    Two-Electron Energy =                  38.1619549603912418
-    Total Energy =                        -74.9679468029865319
+    One-Electron Energy =                -122.2421812246879398
+    Two-Electron Energy =                  38.1619549603971819
+    Total Energy =                        -74.9679468029749358
 
 Computation Completed
 
@@ -6920,18 +7820,18 @@ Properties computed using the SCF density matrix
      X:     0.8883      Y:     1.0391      Z:     1.0241     Total:     1.7081
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:50 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:57 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.11 seconds =       0.04 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.89 seconds =       0.21 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =     103.86 seconds =       1.73 minutes
+	system time =       6.27 seconds =       0.10 minutes
+	total time  =         25 seconds =       0.42 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:50 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:57 2021
 
 
          ------------------------------------------------------------
@@ -6971,8 +7871,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -6991,22 +7891,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.036174275815     0.019888513002     0.038150921226
-       2       -0.027999708644    -0.003630506060    -0.027664272010
-       3       -0.008174567168    -0.016258006942    -0.010486649216
+       1        0.036174275273     0.019888512288     0.038150920587
+       2       -0.027999708088    -0.003630506177    -0.027664271491
+       3       -0.008174567181    -0.016258006111    -0.010486649096
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:50 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:57 2021
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.62 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.92 seconds =       0.22 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =     104.80 seconds =       1.75 minutes
+	system time =       6.33 seconds =       0.11 minutes
+	total time  =         25 seconds =       0.42 minutes
 
-       N-Body: Complex Energy (fragments = (2,), basis = (2,):   -74.96794680298652)
+       N-Body: Complex Energy (fragments = (2,), basis = (2,):   -74.96794680297494)
 
        N-Body: Computing complex (5/6) with fragments (1,) in the basis of fragments (1,).
 
@@ -7016,16 +7916,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:50 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:57 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -7043,7 +7943,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -7097,8 +7997,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -7109,7 +8009,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -7146,16 +8046,16 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20742717616535   -7.42074e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.91808853105498   -7.10661e-01   3.55337e-02 DIIS
-   @DF-RHF iter   2:   -74.96695065050781   -4.88621e-02   5.41141e-03 DIIS
-   @DF-RHF iter   3:   -74.96782754053548   -8.76890e-04   1.28859e-03 DIIS
-   @DF-RHF iter   4:   -74.96789978922203   -7.22487e-05   1.30788e-04 DIIS
-   @DF-RHF iter   5:   -74.96790106816906   -1.27895e-06   8.84975e-06 DIIS
-   @DF-RHF iter   6:   -74.96790107274545   -4.57639e-09   5.30739e-07 DIIS
-   @DF-RHF iter   7:   -74.96790107276169   -1.62430e-11   4.98532e-08 DIIS
-   @DF-RHF iter   8:   -74.96790107276188   -1.84741e-13   1.19600e-09 DIIS
-   @DF-RHF iter   9:   -74.96790107276188    0.00000e+00   1.49181e-10 DIIS
+   @DF-RHF iter SAD:   -74.20742717616243   -7.42074e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91808853105051   -7.10661e-01   3.55337e-02 DIIS
+   @DF-RHF iter   2:   -74.96695065050335   -4.88621e-02   5.41141e-03 DIIS
+   @DF-RHF iter   3:   -74.96782754053103   -8.76890e-04   1.28859e-03 DIIS
+   @DF-RHF iter   4:   -74.96789978921761   -7.22487e-05   1.30788e-04 DIIS
+   @DF-RHF iter   5:   -74.96790106816461   -1.27895e-06   8.84975e-06 DIIS
+   @DF-RHF iter   6:   -74.96790107274101   -4.57641e-09   5.30739e-07 DIIS
+   @DF-RHF iter   7:   -74.96790107275726   -1.62430e-11   4.98532e-08 DIIS
+   @DF-RHF iter   8:   -74.96790107275746   -1.98952e-13   1.19600e-09 DIIS
+   @DF-RHF iter   9:   -74.96790107275751   -5.68434e-14   1.49182e-10 DIIS
   Energy and wave function converged.
 
 
@@ -7177,14 +8077,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96790107276188
+  @DF-RHF Final Energy:   -74.96790107275751
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.2481627620098124
-    Two-Electron Energy =                  38.1648324004429256
-    Total Energy =                        -74.9679010727618902
+    One-Electron Energy =                -122.2481627620104661
+    Two-Electron Energy =                  38.1648324004479420
+    Total Energy =                        -74.9679010727575132
 
 Computation Completed
 
@@ -7206,18 +8106,18 @@ Properties computed using the SCF density matrix
      X:     0.4415      Y:    -1.2890      Z:     1.0302     Total:     1.7081
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:50 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:57 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.20 seconds =       0.04 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.18 seconds =       0.22 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =     107.08 seconds =       1.78 minutes
+	system time =       6.47 seconds =       0.11 minutes
+	total time  =         25 seconds =       0.42 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:50 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:57 2021
 
 
          ------------------------------------------------------------
@@ -7257,8 +8157,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -7277,22 +8177,22 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000120707477    -0.041248212738     0.038755311065
-       2       -0.010650338842     0.015909042579    -0.010603622945
-       3        0.010771046318     0.025339170158    -0.028151688120
+       1       -0.000120707287    -0.041248213244     0.038755311455
+       2       -0.010650339258     0.015909042834    -0.010603623011
+       3        0.010771046543     0.025339170408    -0.028151688444
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:50 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:57 2021
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.53 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.21 seconds =       0.22 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =     107.79 seconds =       1.80 minutes
+	system time =       6.51 seconds =       0.11 minutes
+	total time  =         25 seconds =       0.42 minutes
 
-       N-Body: Complex Energy (fragments = (1,), basis = (1,):   -74.96790107276188)
+       N-Body: Complex Energy (fragments = (1,), basis = (1,):   -74.96790107275751)
 
        N-Body: Computing complex (6/6) with fragments (3,) in the basis of fragments (1, 2, 3).
 
@@ -7302,16 +8202,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:50 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:57 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -7329,7 +8229,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -7389,8 +8289,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -7401,7 +8301,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -7438,17 +8338,17 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.20651477843577   -7.42065e+01   0.00000e+00 
-   @DF-RHF iter   1:   -74.92730458013231   -7.20790e-01   1.16966e-02 DIIS
-   @DF-RHF iter   2:   -74.97403011466274   -4.67255e-02   2.00055e-03 DIIS
-   @DF-RHF iter   3:   -74.97509650573888   -1.06639e-03   4.56359e-04 DIIS
-   @DF-RHF iter   4:   -74.97518197685694   -8.54711e-05   4.53537e-05 DIIS
-   @DF-RHF iter   5:   -74.97518330755325   -1.33070e-06   8.85963e-06 DIIS
-   @DF-RHF iter   6:   -74.97518336204838   -5.44951e-08   5.10780e-07 DIIS
-   @DF-RHF iter   7:   -74.97518336217013   -1.21744e-10   6.11794e-08 DIIS
-   @DF-RHF iter   8:   -74.97518336217209   -1.96110e-12   8.32843e-09 DIIS
-   @DF-RHF iter   9:   -74.97518336217210   -1.42109e-14   2.08217e-09 DIIS
-   @DF-RHF iter  10:   -74.97518336217213   -2.84217e-14   3.79028e-10 DIIS
+   @DF-RHF iter SAD:   -74.20651477847510   -7.42065e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92730458017243   -7.20790e-01   1.16966e-02 DIIS
+   @DF-RHF iter   2:   -74.97403011470291   -4.67255e-02   2.00055e-03 DIIS
+   @DF-RHF iter   3:   -74.97509650577902   -1.06639e-03   4.56359e-04 DIIS
+   @DF-RHF iter   4:   -74.97518197689722   -8.54711e-05   4.53537e-05 DIIS
+   @DF-RHF iter   5:   -74.97518330759343   -1.33070e-06   8.85963e-06 DIIS
+   @DF-RHF iter   6:   -74.97518336208864   -5.44952e-08   5.10780e-07 DIIS
+   @DF-RHF iter   7:   -74.97518336221036   -1.21716e-10   6.11794e-08 DIIS
+   @DF-RHF iter   8:   -74.97518336221236   -2.00373e-12   8.32843e-09 DIIS
+   @DF-RHF iter   9:   -74.97518336221235    1.42109e-14   2.08217e-09 DIIS
+   @DF-RHF iter  10:   -74.97518336221243   -8.52651e-14   3.79028e-10 DIIS
   Energy and wave function converged.
 
 
@@ -7475,14 +8375,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97518336217213
+  @DF-RHF Final Energy:   -74.97518336221243
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.1796494816868943
-    Two-Electron Energy =                  38.0926531405595128
-    Total Energy =                        -74.9751833621721318
+    One-Electron Energy =                -122.1796494817146055
+    Two-Electron Energy =                  38.0926531405469291
+    Total Energy =                        -74.9751833622124337
 
 Computation Completed
 
@@ -7504,18 +8404,18 @@ Properties computed using the SCF density matrix
      X:    -1.3881      Y:     0.2787      Z:    -1.1084     Total:     1.7980
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:51 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:59 2021
 Module time:
-	user time   =       0.58 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       3.85 seconds =       0.06 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      13.80 seconds =       0.23 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =     111.69 seconds =       1.86 minutes
+	system time =       6.73 seconds =       0.11 minutes
+	total time  =         27 seconds =       0.45 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:51 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:59 2021
 
 
          ------------------------------------------------------------
@@ -7561,8 +8461,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -7581,33 +8481,33 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000072680718    -0.000178930516     0.000016357965
-       2       -0.000082840329    -0.000198380482     0.000026349953
-       3       -0.000001789941    -0.000006925597     0.000000480285
-       4       -0.000053426750    -0.000634492522    -0.000043991627
-       5        0.000006717095    -0.000006864509     0.000001653334
-       6        0.004811504278    -0.007487779979     0.000107477804
-       7       -0.036158940824     0.026021139966    -0.040796981130
-       8        0.017715436438     0.001777503645     0.010044340206
-       9        0.013836020752    -0.019285270006     0.030644313210
+       1       -0.000072680692    -0.000178930509     0.000016357961
+       2       -0.000082840351    -0.000198380483     0.000026349954
+       3       -0.000001789949    -0.000006925596     0.000000480289
+       4       -0.000053426744    -0.000634492402    -0.000043991629
+       5        0.000006717099    -0.000006864512     0.000001653343
+       6        0.004811504269    -0.007487780091     0.000107477794
+       7       -0.036158940846     0.026021139561    -0.040796981115
+       8        0.017715436484     0.001777503877     0.010044340234
+       9        0.013836020729    -0.019285269846     0.030644313169
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:51 2021
+*** tstop() called on dorje at Mon Jun 28 10:22:59 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.28 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.93 seconds =       0.23 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =     113.16 seconds =       1.89 minutes
+	system time =       6.85 seconds =       0.11 minutes
+	total time  =         27 seconds =       0.45 minutes
 
-       N-Body: Complex Energy (fragments = (3,), basis = (1, 2, 3):   -74.97518336217213)
+       N-Body: Complex Energy (fragments = (3,), basis = (1, 2, 3):   -74.97518336221243)
 
    ==> N-Body: Now computing 2-body complexes <==
 
 
-       N-Body: Computing complex (1/3) with fragments (1, 2) in the basis of fragments (1, 2, 3).
+       N-Body: Computing complex (1/6) with fragments (2, 3) in the basis of fragments (1, 2, 3).
 
 
 Scratch directory: /tmp/
@@ -7615,16 +8515,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:51 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:59 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -7642,318 +8542,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
-         ---------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Bohr), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
-         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
-         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
-      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
-
-  Running in c1 symmetry.
-
-  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
-  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
-  Nuclear repulsion =   37.327766624605843
-
-  Charge       = 0
-  Multiplicity = 1
-  Electrons    = 20
-  Nalpha       = 10
-  Nbeta        = 10
-
-  ==> Algorithm <==
-
-  SCF Algorithm Type is DF.
-  DIIS enabled.
-  MOM disabled.
-  Fractional occupation disabled.
-  Guess Type is SAD.
-  Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-09
-  Integral threshold = 1.00e-12
-
-  ==> Primary Basis <==
-
-  Basis Set: STO-3G
-    Blend: STO-3G
-    Number of shells: 15
-    Number of basis functions: 21
-    Number of Cartesian functions: 21
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-   => Loading Basis Set <=
-
-    Name: (STO-3G AUX)
-    Role: JKFIT
-    Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-
-  ==> Integral Setup <==
-
-  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
-
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               1
-    Memory [MiB]:               375
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-10
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (STO-3G AUX)
-    Blend: DEF2-UNIVERSAL-JKFIT
-    Number of shells: 111
-    Number of basis functions: 339
-    Number of Cartesian functions: 399
-    Spherical Harmonics?: true
-    Max angular momentum: 4
-
-  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
-    Using symmetric orthogonalization.
-
-  ==> Pre-Iterations <==
-
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
-
-   -------------------------
-    Irrep   Nso     Nmo    
-   -------------------------
-     A         21      21 
-   -------------------------
-    Total      21      21
-   -------------------------
-
-  ==> Iterations <==
-
-                           Total Energy        Delta E     RMS |[F,P]|
-
-   @DF-RHF iter SAD:  -148.43444075217994   -1.48434e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86420073587024   -1.42976e+00   1.57310e-02 DIIS
-   @DF-RHF iter   2:  -149.95072463352707   -8.65239e-02   2.56698e-03 DIIS
-   @DF-RHF iter   3:  -149.95267920275188   -1.95457e-03   6.20766e-04 DIIS
-   @DF-RHF iter   4:  -149.95284427489619   -1.65072e-04   6.37604e-05 DIIS
-   @DF-RHF iter   5:  -149.95284692284852   -2.64795e-06   9.91316e-06 DIIS
-   @DF-RHF iter   6:  -149.95284698730151   -6.44530e-08   1.44085e-06 DIIS
-   @DF-RHF iter   7:  -149.95284698834982   -1.04831e-09   2.53217e-07 DIIS
-   @DF-RHF iter   8:  -149.95284698838111   -3.12923e-11   3.21508e-08 DIIS
-   @DF-RHF iter   9:  -149.95284698838165   -5.40012e-13   6.14624e-09 DIIS
-   @DF-RHF iter  10:  -149.95284698838171   -5.68434e-14   1.36596e-09 DIIS
-   @DF-RHF iter  11:  -149.95284698838145    2.55795e-13   2.33298e-10 DIIS
-  Energy and wave function converged.
-
-
-  ==> Post-Iterations <==
-
-    Orbital Energies [Eh]
-    ---------------------
-
-    Doubly Occupied:                                                      
-
-       1A    -20.265993     2A    -20.213835     3A     -1.286385  
-       4A     -1.240805     5A     -0.640800     6A     -0.595401  
-       7A     -0.475790     8A     -0.434446     9A     -0.400444  
-      10A     -0.367648  
-
-    Virtual:                                                              
-
-      11A      0.490528    12A      0.607402    13A      0.648556  
-      14A      0.734932    15A      0.785344    16A      1.032771  
-      17A      1.373710    18A      2.556576    19A      2.950978  
-      20A      3.280669    21A     31.265676  
-
-    Final Occupation by Irrep:
-              A 
-    DOCC [    10 ]
-
-  @DF-RHF Final Energy:  -149.95284698838145
-
-   => Energetics <=
-
-    Nuclear Repulsion Energy =             37.3277666246058430
-    One-Electron Energy =                -282.6935372844757239
-    Two-Electron Energy =                  95.4252223514884435
-    Total Energy =                       -149.9528469883814239
-
-Computation Completed
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
-
-Properties computed using the SCF density matrix
-
-  Nuclear Dipole Moment: [e a0]
-     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
-
-  Electronic Dipole Moment: [e a0]
-     X:     1.8989      Y:    30.1291      Z:     1.4353
-
-  Dipole Moment: [e a0]
-     X:     0.6812      Y:    -0.1488      Z:     0.8098     Total:     1.0686
-
-  Dipole Moment: [D]
-     X:     1.7314      Y:    -0.3781      Z:     2.0584     Total:     2.7162
-
-
-*** tstop() called on psinet at Fri Jun 11 02:11:52 2021
-Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =      14.53 seconds =       0.24 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
-
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:52 2021
-
-
-         ------------------------------------------------------------
-                                   SCF GRAD                          
-                          Rob Parrish, Justin Turney,                
-                       Andy Simmonett, and Alex Sokolov              
-         ------------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Bohr), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
-         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
-         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
-      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
-
-  Nuclear repulsion =   37.327766624605843
-
-  ==> Basis Set <==
-
-  Basis Set: STO-3G
-    Blend: STO-3G
-    Number of shells: 15
-    Number of basis functions: 21
-    Number of Cartesian functions: 21
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-  ==> DFJKGrad: Density-Fitted SCF Gradients <==
-
-    Gradient:                    1
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory [MiB]:              375
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-10
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (STO-3G AUX)
-    Blend: DEF2-UNIVERSAL-JKFIT
-    Number of shells: 111
-    Number of basis functions: 339
-    Number of Cartesian functions: 399
-    Spherical Harmonics?: true
-    Max angular momentum: 4
-
-
-  -Total Gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1       -0.007243120855    -0.044085616393     0.035273238378
-       2       -0.013901653017     0.013131592981    -0.007062236505
-       3        0.011946785370     0.022317638573    -0.027758137791
-       4        0.039381360127     0.016095277160     0.034430949108
-       5       -0.026444406881    -0.001627029302    -0.026863202722
-       6       -0.008583781589    -0.014725496481    -0.007902080028
-       7        0.000487157341     0.000396299487     0.000017340999
-       8        0.004357241223     0.008480434581    -0.000133273880
-       9        0.000000418282     0.000016899393    -0.000002597559
-
-
-*** tstop() called on psinet at Fri Jun 11 02:11:52 2021
-Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =      14.66 seconds =       0.24 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
-
-       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2, 3):  -149.95284698838145)
-
-       N-Body: Computing complex (2/3) with fragments (2, 3) in the basis of fragments (1, 2, 3).
-
-
-Scratch directory: /tmp/
-
-Scratch directory: /tmp/
-gradient() will perform analytic gradient computation.
-
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:52 2021
-
-   => Loading Basis Set <=
-
-    Name: STO-3G
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-
-   => HF-D3(BJ): Empirical Dispersion <=
-
-    Grimme's -D3 (BJ-damping) Dispersion Correction
-    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
-
-        s6 =       1.000000
-        s8 =       0.917100
-        a1 =       0.338500
-        a2 =       2.883000
-
-
-         ---------------------------------------------------------
-                                   SCF
-               by Justin Turney, Rob Parrish, Andy Simmonett
-                          and Daniel G. A. Smith
-                              RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -8013,8 +8602,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -8025,7 +8614,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -8062,18 +8651,18 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -148.43517267796997   -1.48435e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86656939506480   -1.43140e+00   1.55631e-02 DIIS
-   @DF-RHF iter   2:  -149.95156180979393   -8.49924e-02   2.54620e-03 DIIS
-   @DF-RHF iter   3:  -149.95352452408389   -1.96271e-03   6.21126e-04 DIIS
-   @DF-RHF iter   4:  -149.95369039947198   -1.65875e-04   6.28806e-05 DIIS
-   @DF-RHF iter   5:  -149.95369295846828   -2.55900e-06   1.07266e-05 DIIS
-   @DF-RHF iter   6:  -149.95369303237317   -7.39049e-08   1.68546e-06 DIIS
-   @DF-RHF iter   7:  -149.95369303389646   -1.52329e-09   2.96963e-07 DIIS
-   @DF-RHF iter   8:  -149.95369303394028   -4.38263e-11   3.32323e-08 DIIS
-   @DF-RHF iter   9:  -149.95369303394085   -5.68434e-13   6.90158e-09 DIIS
-   @DF-RHF iter  10:  -149.95369303394082    2.84217e-14   1.53556e-09 DIIS
-   @DF-RHF iter  11:  -149.95369303394088   -5.68434e-14   2.49156e-10 DIIS
+   @DF-RHF iter SAD:  -148.43517267805359   -1.48435e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86656939514933   -1.43140e+00   1.55631e-02 DIIS
+   @DF-RHF iter   2:  -149.95156180987865   -8.49924e-02   2.54620e-03 DIIS
+   @DF-RHF iter   3:  -149.95352452416850   -1.96271e-03   6.21126e-04 DIIS
+   @DF-RHF iter   4:  -149.95369039955693   -1.65875e-04   6.28806e-05 DIIS
+   @DF-RHF iter   5:  -149.95369295855315   -2.55900e-06   1.07266e-05 DIIS
+   @DF-RHF iter   6:  -149.95369303245809   -7.39049e-08   1.68546e-06 DIIS
+   @DF-RHF iter   7:  -149.95369303398107   -1.52298e-09   2.96963e-07 DIIS
+   @DF-RHF iter   8:  -149.95369303402495   -4.38831e-11   3.32323e-08 DIIS
+   @DF-RHF iter   9:  -149.95369303402560   -6.53699e-13   6.90158e-09 DIIS
+   @DF-RHF iter  10:  -149.95369303402555    5.68434e-14   1.53556e-09 DIIS
+   @DF-RHF iter  11:  -149.95369303402580   -2.55795e-13   2.49156e-10 DIIS
   Energy and wave function converged.
 
 
@@ -8100,14 +8689,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.95369303394088
+  @DF-RHF Final Energy:  -149.95369303402580
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4208727124812270
-    One-Electron Energy =                -282.8840412880541635
-    Two-Electron Energy =                  95.5218870516320351
-    Total Energy =                       -149.9536930339408798
+    One-Electron Energy =                -282.8840412881003203
+    Two-Electron Energy =                  95.5218870515932679
+    Total Energy =                       -149.9536930340258039
 
 Computation Completed
 
@@ -8129,18 +8718,18 @@ Properties computed using the SCF density matrix
      X:    -0.5295      Y:     1.6482      Z:    -0.1172     Total:     1.7351
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:52 2021
+*** tstop() called on dorje at Mon Jun 28 10:23:00 2021
 Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       3.18 seconds =       0.05 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      15.26 seconds =       0.25 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =     116.43 seconds =       1.94 minutes
+	system time =       7.03 seconds =       0.12 minutes
+	total time  =         28 seconds =       0.47 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:52 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:00 2021
 
 
          ------------------------------------------------------------
@@ -8186,8 +8775,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -8206,30 +8795,30 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000549823241     0.000209101783    -0.000043130495
-       2       -0.008948416565    -0.000509994605    -0.000335110328
-       3       -0.000014125244    -0.000007901240     0.000001129934
-       4        0.040811211570     0.015095923235     0.036386015354
-       5       -0.025241122852    -0.001270248483    -0.027165119482
-       6       -0.003996028547    -0.017821700756    -0.008609524208
-       7       -0.031630747581     0.022469177680    -0.037813158722
-       8        0.016835970199     0.000812297789     0.008719768934
-       9        0.012733082265    -0.018976655404     0.028859129014
+       1       -0.000549823240     0.000209101778    -0.000043130494
+       2       -0.008948416510    -0.000509994597    -0.000335110334
+       3       -0.000014125251    -0.000007901242     0.000001129937
+       4        0.040811212011     0.015095923841     0.036386015766
+       5       -0.025241123267    -0.001270248479    -0.027165119808
+       6       -0.003996028609    -0.017821701370    -0.008609524296
+       7       -0.031630747531     0.022469177585    -0.037813158797
+       8        0.016835970167     0.000812297877     0.008719768957
+       9        0.012733082234    -0.018976655395     0.028859129068
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:53 2021
+*** tstop() called on dorje at Mon Jun 28 10:23:00 2021
 Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      15.39 seconds =       0.26 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =         18 seconds =       0.30 minutes
+	user time   =     117.92 seconds =       1.97 minutes
+	system time =       7.12 seconds =       0.12 minutes
+	total time  =         28 seconds =       0.47 minutes
 
-       N-Body: Complex Energy (fragments = (2, 3), basis = (1, 2, 3):  -149.95369303394088)
+       N-Body: Complex Energy (fragments = (2, 3), basis = (1, 2, 3):  -149.95369303402580)
 
-       N-Body: Computing complex (3/3) with fragments (1, 3) in the basis of fragments (1, 2, 3).
+       N-Body: Computing complex (2/6) with fragments (1, 3) in the basis of fragments (1, 2, 3).
 
 
 Scratch directory: /tmp/
@@ -8237,16 +8826,16 @@ Scratch directory: /tmp/
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:53 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:00 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
    => HF-D3(BJ): Empirical Dispersion <=
 
@@ -8264,7 +8853,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -8324,8 +8913,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   318 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    18 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -8336,7 +8925,7 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
@@ -8373,18 +8962,18 @@ gradient() will perform analytic gradient computation.
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -148.43580517715009   -1.48436e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.86749466726499   -1.43169e+00   1.55424e-02 DIIS
-   @DF-RHF iter   2:  -149.95221120159636   -8.47165e-02   2.55465e-03 DIIS
-   @DF-RHF iter   3:  -149.95418156362393   -1.97036e-03   6.22886e-04 DIIS
-   @DF-RHF iter   4:  -149.95434865132242   -1.67088e-04   6.29977e-05 DIIS
-   @DF-RHF iter   5:  -149.95435124125683   -2.58993e-06   9.62406e-06 DIIS
-   @DF-RHF iter   6:  -149.95435130203415   -6.07773e-08   1.35366e-06 DIIS
-   @DF-RHF iter   7:  -149.95435130294086   -9.06709e-10   2.43900e-07 DIIS
-   @DF-RHF iter   8:  -149.95435130297005   -2.91891e-11   3.14208e-08 DIIS
-   @DF-RHF iter   9:  -149.95435130297051   -4.54747e-13   6.02918e-09 DIIS
-   @DF-RHF iter  10:  -149.95435130297045    5.68434e-14   1.36824e-09 DIIS
-   @DF-RHF iter  11:  -149.95435130297062   -1.70530e-13   2.40354e-10 DIIS
+   @DF-RHF iter SAD:  -148.43580517720858   -1.48436e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86749466732593   -1.43169e+00   1.55424e-02 DIIS
+   @DF-RHF iter   2:  -149.95221120165726   -8.47165e-02   2.55465e-03 DIIS
+   @DF-RHF iter   3:  -149.95418156368470   -1.97036e-03   6.22886e-04 DIIS
+   @DF-RHF iter   4:  -149.95434865138350   -1.67088e-04   6.29977e-05 DIIS
+   @DF-RHF iter   5:  -149.95435124131785   -2.58993e-06   9.62406e-06 DIIS
+   @DF-RHF iter   6:  -149.95435130209518   -6.07773e-08   1.35366e-06 DIIS
+   @DF-RHF iter   7:  -149.95435130300186   -9.06681e-10   2.43900e-07 DIIS
+   @DF-RHF iter   8:  -149.95435130303085   -2.89901e-11   3.14208e-08 DIIS
+   @DF-RHF iter   9:  -149.95435130303150   -6.53699e-13   6.02918e-09 DIIS
+   @DF-RHF iter  10:  -149.95435130303161   -1.13687e-13   1.36824e-09 DIIS
+   @DF-RHF iter  11:  -149.95435130303139    2.27374e-13   2.40355e-10 DIIS
   Energy and wave function converged.
 
 
@@ -8411,14 +9000,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.95435130297062
+  @DF-RHF Final Energy:  -149.95435130303139
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4153826933059008
-    One-Electron Energy =                -282.8726006393809485
-    Two-Electron Energy =                  95.5152412631044143
-    Total Energy =                       -149.9543513029706219
+    One-Electron Energy =                -282.8726006394039132
+    Two-Electron Energy =                  95.5152412630666277
+    Total Energy =                       -149.9543513030313875
 
 Computation Completed
 
@@ -8440,18 +9029,18 @@ Properties computed using the SCF density matrix
      X:    -1.2007      Y:    -1.4353      Z:    -0.0118     Total:     1.8713
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:53 2021
+*** tstop() called on dorje at Mon Jun 28 10:23:01 2021
 Module time:
-	user time   =       0.58 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       3.66 seconds =       0.06 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      15.98 seconds =       0.27 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =         18 seconds =       0.30 minutes
+	user time   =     121.66 seconds =       2.03 minutes
+	system time =       7.25 seconds =       0.12 minutes
+	total time  =         29 seconds =       0.48 minutes
 
-*** tstart() called on psinet
-*** at Fri Jun 11 02:11:53 2021
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:01 2021
 
 
          ------------------------------------------------------------
@@ -8497,8 +9086,8 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
     Fitting Condition:       1E-10
@@ -8517,42 +9106,1260 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.004942330718    -0.041488362285     0.036186692374
-       2       -0.008980263456     0.015308436810    -0.008624632839
-       3        0.011300058049     0.022206572790    -0.027266985277
-       4        0.000077877896    -0.000630171310    -0.000065662311
-       5        0.000017101487    -0.000007706072     0.000000960727
-       6        0.005333224391    -0.008144547159     0.000059160370
-       7       -0.032324440029     0.024966597843    -0.038237789423
-       8        0.017201527277     0.006497336818     0.008760629788
-       9        0.012317245099    -0.018708157436     0.029187626590
+       1       -0.004942331527    -0.041488359583     0.036186689952
+       2       -0.008980261350     0.015308435548    -0.008624632434
+       3        0.011300056491     0.022206571082    -0.027266983274
+       4        0.000077877778    -0.000630171357    -0.000065662312
+       5        0.000017101472    -0.000007706076     0.000000960728
+       6        0.005333224568    -0.008144547108     0.000059160373
+       7       -0.032324437918     0.024966599631    -0.038237788956
+       8        0.017201525834     0.006497335588     0.008760629599
+       9        0.012317244652    -0.018708157727     0.029187626322
 
 
-*** tstop() called on psinet at Fri Jun 11 02:11:53 2021
+*** tstop() called on dorje at Mon Jun 28 10:23:02 2021
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.32 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     123.21 seconds =       2.05 minutes
+	system time =       7.35 seconds =       0.12 minutes
+	total time  =         30 seconds =       0.50 minutes
+
+       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 2, 3):  -149.95435130303139)
+
+       N-Body: Computing complex (3/6) with fragments (1, 2) in the basis of fragments (1, 2).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:02 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+   => HF-D3(BJ): Empirical Dispersion <=
+
+    Grimme's -D3 (BJ-damping) Dispersion Correction
+    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
+
+        s6 =       1.000000
+        s8 =       0.917100
+        a1 =       0.338500
+        a2 =       2.883000
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.67094  B =      0.23246  C =      0.17553 [cm^-1]
+  Rotational constants: A =  20114.15437  B =   6968.93165  C =   5262.27541 [MHz]
+  Nuclear repulsion =   37.327766624605843
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4074143904E-01.
+  Reciprocal condition number of the overlap matrix is 1.7130997866E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.43443923849540   -1.48434e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85470151214093   -1.42026e+00   2.37340e-02 DIIS
+   @DF-RHF iter   2:  -149.94341185893842   -8.87103e-02   3.67265e-03 DIIS
+   @DF-RHF iter   3:  -149.94521673035180   -1.80487e-03   8.96030e-04 DIIS
+   @DF-RHF iter   4:  -149.94536469266330   -1.47962e-04   9.43642e-05 DIIS
+   @DF-RHF iter   5:  -149.94536707980566   -2.38714e-06   2.53037e-05 DIIS
+   @DF-RHF iter   6:  -149.94536726856745   -1.88762e-07   2.37939e-06 DIIS
+   @DF-RHF iter   7:  -149.94536726994801   -1.38056e-09   2.69811e-07 DIIS
+   @DF-RHF iter   8:  -149.94536726996219   -1.41824e-11   3.51726e-08 DIIS
+   @DF-RHF iter   9:  -149.94536726996242   -2.27374e-13   6.07949e-09 DIIS
+   @DF-RHF iter  10:  -149.94536726996247   -5.68434e-14   1.34394e-09 DIIS
+   @DF-RHF iter  11:  -149.94536726996239    8.52651e-14   2.64817e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.265778     2A    -20.201128     3A     -1.286129  
+       4A     -1.234946     5A     -0.640245     6A     -0.590711  
+       7A     -0.474712     8A     -0.430649     9A     -0.397718  
+      10A     -0.361496  
+
+    Virtual:                                                              
+
+      11A      0.564996    12A      0.653937    13A      0.715582  
+      14A      0.790788  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94536726996239
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.3277666246058430
+    One-Electron Energy =                -282.7546452438276106
+    Two-Electron Energy =                  95.4938100292594072
+    Total Energy =                       -149.9453672699623610
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:     1.9166      Y:    30.1845      Z:     1.4308
+
+  Dipole Moment: [e a0]
+     X:     0.6989      Y:    -0.0934      Z:     0.8053     Total:     1.0704
+
+  Dipole Moment: [D]
+     X:     1.7764      Y:    -0.2373      Z:     2.0469     Total:     2.7207
+
+
+*** tstop() called on dorje at Mon Jun 28 10:23:02 2021
+Module time:
+	user time   =       2.25 seconds =       0.04 minutes
+	system time =       0.18 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.12 seconds =       0.27 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =         18 seconds =       0.30 minutes
+	user time   =     125.56 seconds =       2.09 minutes
+	system time =       7.54 seconds =       0.13 minutes
+	total time  =         30 seconds =       0.50 minutes
 
-       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 2, 3):  -149.95435130297062)
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:02 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Nuclear repulsion =   37.327766624605843
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.001528314018    -0.037143165935     0.035063798201
+       2       -0.013846579615     0.013030346750    -0.007683691141
+       3        0.011681940724     0.024202420105    -0.027016236855
+       4        0.038901275133     0.016313417837     0.034513396369
+       5       -0.026489056006    -0.001678226871    -0.026796300326
+       6       -0.008719266216    -0.014724791888    -0.008080966249
+
+
+*** tstop() called on dorje at Mon Jun 28 10:23:02 2021
+Module time:
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     126.57 seconds =       2.11 minutes
+	system time =       7.63 seconds =       0.13 minutes
+	total time  =         30 seconds =       0.50 minutes
+
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2):  -149.94536726996239)
+
+       N-Body: Computing complex (4/6) with fragments (1, 2) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:02 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+   => HF-D3(BJ): Empirical Dispersion <=
+
+    Grimme's -D3 (BJ-damping) Dispersion Correction
+    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
+
+        s6 =       1.000000
+        s8 =       0.917100
+        a1 =       0.338500
+        a2 =       2.883000
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =   37.327766624605843
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.43444075219804   -1.48434e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.86420073588852   -1.42976e+00   1.57310e-02 DIIS
+   @DF-RHF iter   2:  -149.95072463354538   -8.65239e-02   2.56698e-03 DIIS
+   @DF-RHF iter   3:  -149.95267920277018   -1.95457e-03   6.20766e-04 DIIS
+   @DF-RHF iter   4:  -149.95284427491447   -1.65072e-04   6.37604e-05 DIIS
+   @DF-RHF iter   5:  -149.95284692286680   -2.64795e-06   9.91316e-06 DIIS
+   @DF-RHF iter   6:  -149.95284698732004   -6.44532e-08   1.44085e-06 DIIS
+   @DF-RHF iter   7:  -149.95284698836801   -1.04797e-09   2.53217e-07 DIIS
+   @DF-RHF iter   8:  -149.95284698839956   -3.15481e-11   3.21508e-08 DIIS
+   @DF-RHF iter   9:  -149.95284698840010   -5.40012e-13   6.14624e-09 DIIS
+   @DF-RHF iter  10:  -149.95284698840004    5.68434e-14   1.36595e-09 DIIS
+   @DF-RHF iter  11:  -149.95284698839993    1.13687e-13   2.33298e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.265993     2A    -20.213835     3A     -1.286385  
+       4A     -1.240805     5A     -0.640800     6A     -0.595401  
+       7A     -0.475790     8A     -0.434446     9A     -0.400444  
+      10A     -0.367648  
+
+    Virtual:                                                              
+
+      11A      0.490528    12A      0.607402    13A      0.648556  
+      14A      0.734932    15A      0.785344    16A      1.032771  
+      17A      1.373710    18A      2.556576    19A      2.950978  
+      20A      3.280669    21A     31.265676  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.95284698839993
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.3277666246058430
+    One-Electron Energy =                -282.6935372844793051
+    Two-Electron Energy =                  95.4252223514735505
+    Total Energy =                       -149.9528469883998980
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:     1.8989      Y:    30.1291      Z:     1.4353
+
+  Dipole Moment: [e a0]
+     X:     0.6812      Y:    -0.1488      Z:     0.8098     Total:     1.0686
+
+  Dipole Moment: [D]
+     X:     1.7314      Y:    -0.3781      Z:     2.0584     Total:     2.7162
+
+
+*** tstop() called on dorje at Mon Jun 28 10:23:04 2021
+Module time:
+	user time   =       3.67 seconds =       0.06 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     130.37 seconds =       2.17 minutes
+	system time =       7.73 seconds =       0.13 minutes
+	total time  =         32 seconds =       0.53 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:04 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.327766624605843
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.007243122754    -0.044085614566     0.035273237118
+       2       -0.013901650908     0.013131591835    -0.007062236219
+       3        0.011946784941     0.022317637661    -0.027758136837
+       4        0.039381359629     0.016095276395     0.034430947875
+       5       -0.026444405877    -0.001627029650    -0.026863201689
+       6       -0.008583782020    -0.014725495416    -0.007902079828
+       7        0.000487157245     0.000396299319     0.000017341004
+       8        0.004357241471     0.008480435049    -0.000133273837
+       9        0.000000418274     0.000016899371    -0.000002597588
+
+
+*** tstop() called on dorje at Mon Jun 28 10:23:04 2021
+Module time:
+	user time   =       1.18 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     131.77 seconds =       2.20 minutes
+	system time =       7.81 seconds =       0.13 minutes
+	total time  =         32 seconds =       0.53 minutes
+
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2, 3):  -149.95284698839993)
+
+       N-Body: Computing complex (5/6) with fragments (2, 3) in the basis of fragments (2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:04 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+   => HF-D3(BJ): Empirical Dispersion <=
+
+    Grimme's -D3 (BJ-damping) Dispersion Correction
+    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
+
+        s6 =       1.000000
+        s8 =       0.917100
+        a1 =       0.338500
+        a2 =       2.883000
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.66182  B =      0.23462  C =      0.17637 [cm^-1]
+  Rotational constants: A =  19840.79823  B =   7033.78531  C =   5287.47319 [MHz]
+  Nuclear repulsion =   37.420872712481227
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4063509175E-01.
+  Reciprocal condition number of the overlap matrix is 1.7073707716E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.43517052194403   -1.48435e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85782955362276   -1.42266e+00   2.34649e-02 DIIS
+   @DF-RHF iter   2:  -149.94480860894922   -8.69791e-02   3.66308e-03 DIIS
+   @DF-RHF iter   3:  -149.94664078268184   -1.83217e-03   8.99010e-04 DIIS
+   @DF-RHF iter   4:  -149.94679053657148   -1.49754e-04   9.36437e-05 DIIS
+   @DF-RHF iter   5:  -149.94679284921779   -2.31265e-06   2.68389e-05 DIIS
+   @DF-RHF iter   6:  -149.94679306141435   -2.12197e-07   2.29950e-06 DIIS
+   @DF-RHF iter   7:  -149.94679306269640   -1.28205e-09   2.77310e-07 DIIS
+   @DF-RHF iter   8:  -149.94679306271158   -1.51772e-11   3.53087e-08 DIIS
+   @DF-RHF iter   9:  -149.94679306271189   -3.12639e-13   7.13004e-09 DIIS
+   @DF-RHF iter  10:  -149.94679306271189    0.00000e+00   1.59469e-09 DIIS
+   @DF-RHF iter  11:  -149.94679306271189    0.00000e+00   2.84833e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267820     2A    -20.198469     3A     -1.287836  
+       4A     -1.233326     5A     -0.640430     6A     -0.591319  
+       7A     -0.477995     8A     -0.431952     9A     -0.395682  
+      10A     -0.360233  
+
+    Virtual:                                                              
+
+      11A      0.566153    12A      0.655627    13A      0.714253  
+      14A      0.791629  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94679306271189
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4208727124812270
+    One-Electron Energy =                -282.9403861622593013
+    Two-Electron Energy =                  95.5851318970661623
+    Total Energy =                       -149.9467930627118903
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    27.0414      Y:    14.0996      Z:     0.2271
+
+  Electronic Dipole Moment: [e a0]
+     X:   -27.3022      Y:   -13.4634      Z:    -0.2787
+
+  Dipole Moment: [e a0]
+     X:    -0.2608      Y:     0.6362      Z:    -0.0516     Total:     0.6895
+
+  Dipole Moment: [D]
+     X:    -0.6630      Y:     1.6170      Z:    -0.1313     Total:     1.7525
+
+
+*** tstop() called on dorje at Mon Jun 28 10:23:05 2021
+Module time:
+	user time   =       3.35 seconds =       0.06 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     135.21 seconds =       2.25 minutes
+	system time =       7.98 seconds =       0.13 minutes
+	total time  =         33 seconds =       0.55 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:05 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.420872712481227
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.032429563942     0.016579741545     0.035759943110
+       2       -0.026672032698    -0.002509965943    -0.026399802363
+       3       -0.003861318759    -0.017702182247    -0.009137246243
+       4       -0.031576393926     0.021934883224    -0.037901889887
+       5        0.016886631503     0.000693601935     0.008883978335
+       6        0.012793549941    -0.018996078515     0.028795017047
+
+
+*** tstop() called on dorje at Mon Jun 28 10:23:05 2021
+Module time:
+	user time   =       0.86 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     136.36 seconds =       2.27 minutes
+	system time =       8.07 seconds =       0.13 minutes
+	total time  =         33 seconds =       0.55 minutes
+
+       N-Body: Complex Energy (fragments = (2, 3), basis = (2, 3):  -149.94679306271189)
+
+       N-Body: Computing complex (6/6) with fragments (1, 3) in the basis of fragments (1, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:05 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+   => HF-D3(BJ): Empirical Dispersion <=
+
+    Grimme's -D3 (BJ-damping) Dispersion Correction
+    Grimme S.; Ehrlich S.; Goerigk L. (2011), J. Comput. Chem., 32: 1456
+
+        s6 =       1.000000
+        s8 =       0.917100
+        a1 =       0.338500
+        a2 =       2.883000
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.66207  B =      0.23435  C =      0.17633 [cm^-1]
+  Rotational constants: A =  19848.38696  B =   7025.55974  C =   5286.37823 [MHz]
+  Nuclear repulsion =   37.415382693305901
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4069553340E-01.
+  Reciprocal condition number of the overlap matrix is 1.7095996847E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.43580290985722   -1.48436e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85784455007638   -1.42204e+00   2.34575e-02 DIIS
+   @DF-RHF iter   2:  -149.94477283743100   -8.69283e-02   3.65643e-03 DIIS
+   @DF-RHF iter   3:  -149.94659512124099   -1.82228e-03   8.97079e-04 DIIS
+   @DF-RHF iter   4:  -149.94674398133171   -1.48860e-04   9.32679e-05 DIIS
+   @DF-RHF iter   5:  -149.94674630523065   -2.32390e-06   2.53277e-05 DIIS
+   @DF-RHF iter   6:  -149.94674649353266   -1.88302e-07   2.29602e-06 DIIS
+   @DF-RHF iter   7:  -149.94674649480862   -1.27596e-09   2.76333e-07 DIIS
+   @DF-RHF iter   8:  -149.94674649482360   -1.49782e-11   3.37671e-08 DIIS
+   @DF-RHF iter   9:  -149.94674649482403   -4.26326e-13   6.15355e-09 DIIS
+   @DF-RHF iter  10:  -149.94674649482383    1.98952e-13   1.39739e-09 DIIS
+   @DF-RHF iter  11:  -149.94674649482386   -2.84217e-14   2.68754e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267572     2A    -20.197942     3A     -1.287848  
+       4A     -1.232673     5A     -0.641232     6A     -0.590389  
+       7A     -0.477963     8A     -0.430709     9A     -0.396328  
+      10A     -0.359544  
+
+    Virtual:                                                              
+
+      11A      0.565402    12A      0.656605    13A      0.715036  
+      14A      0.792872  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94674649482386
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4153826933059008
+    One-Electron Energy =                -282.9351101924351042
+    Two-Electron Energy =                  95.5853556243053362
+    Total Energy =                       -149.9467464948238558
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:   -25.8236      Y:    16.1783      Z:     0.3984
+
+  Electronic Dipole Moment: [e a0]
+     X:    25.3912      Y:   -16.7858      Z:    -0.3985
+
+  Dipole Moment: [e a0]
+     X:    -0.4325      Y:    -0.6075      Z:    -0.0002     Total:     0.7457
+
+  Dipole Moment: [D]
+     X:    -1.0992      Y:    -1.5441      Z:    -0.0004     Total:     1.8954
+
+
+*** tstop() called on dorje at Mon Jun 28 10:23:06 2021
+Module time:
+	user time   =       4.17 seconds =       0.07 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     140.62 seconds =       2.34 minutes
+	system time =       8.29 seconds =       0.14 minutes
+	total time  =         34 seconds =       0.57 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:23:06 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.415382693305901
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.004502436664    -0.041139592394     0.036267289779
+       2       -0.008923288099     0.015424658131    -0.008790506117
+       3        0.011284102523     0.022273357340    -0.027202228268
+       4       -0.028747491080     0.016334253670    -0.038157133547
+       5        0.016921512259     0.006530146975     0.009338942742
+       6        0.013967601060    -0.019422823725     0.028543635411
+
+
+*** tstop() called on dorje at Mon Jun 28 10:23:06 2021
+Module time:
+	user time   =       1.48 seconds =       0.02 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     142.51 seconds =       2.38 minutes
+	system time =       8.41 seconds =       0.14 minutes
+	total time  =         34 seconds =       0.57 minutes
+
+       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 3):  -149.94674649482386)
 
    ==> N-Body: Counterpoise Corrected (CP) energies <==
 
    n-Body     Total Energy [Eh]       I.E. [kcal/mol]      Delta [kcal/mol]
-        1     -224.903891303801        0.000000000000        0.000000000000
-        2     -224.915780748844       -7.460739402607       -7.460739402607
+        1     -224.903891303774        0.000000000000        0.000000000000
+        2     -224.915780748870       -7.460739435816       -7.460739435816
+
+
+   ==> N-Body: Non-Counterpoise Corrected (NoCP) energies <==
+
+   n-Body     Total Energy [Eh]       I.E. [kcal/mol]      Delta [kcal/mol]
+        1     -224.903891303774        0.000000000000        0.000000000000
+        2     -224.935015523724      -19.530742882642      -19.530742882642
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line   130 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    15 file /psi/gits/hrw-l2/objdir39c/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1, 4, 7       entry O          line   130 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    15 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     rtd=F CP-Corrected Energy.............................................................PASSED
     rtd=F CP-Corrected Energy.............................................................PASSED
@@ -8565,7 +10372,7 @@ Total time:
     rtd=F CP-Corrected Interaction Gradient...............................................PASSED
     rtd=F CP-Corrected Interaction Gradient...............................................PASSED
 
-    Psi4 stopped on: Friday, 11 June 2021 02:11AM
-    Psi4 wall time for execution: 0:00:18.42
+    Psi4 stopped on: Monday, 28 June 2021 10:23AM
+    Psi4 wall time for execution: 0:00:34.84
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/nbody-cp-gradient/input.dat
+++ b/tests/nbody-cp-gradient/input.dat
@@ -166,7 +166,7 @@ for result in [  #TEST
 
 # compute nbody again with return_total_data=False
 # * note CURRENT ENERGY moved from first to second testing block
-g, wfn = gradient('SCF/STO-3G', molecule=water_trimer, bsse_type='cp', max_nbody=2,
+g, wfn = gradient('SCF/STO-3G', molecule=water_trimer, bsse_type=['cp','nocp'], max_nbody=2,
                                       return_total_data=False, return_wfn=True)
 core.clean()
 

--- a/tests/nbody-cp-gradient/output.ref
+++ b/tests/nbody-cp-gradient/output.ref
@@ -1,39 +1,89 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.3a2.dev179 
+                               Psi4 1.4rc3.dev14 
 
-                         Git: Rev {nbody} c46660a dirty
-
-
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+                         Git: Rev {i1691} ea22d04 dirty
 
 
-                         Additional Contributions by
-    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, and R. A. Shaw
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Wednesday, 21 November 2018 03:18PM
+    Psi4 started on: Monday, 28 June 2021 10:21AM
 
-    Process ID: 9267
-    Host:       ds1.sherrill.chemistry.gatech.edu
-    PSIDATADIR: /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4
+    Process ID: 60874
+    Host:       dorje
+    PSIDATADIR: /home/kraus/Applications/psi4-i2206/share/psi4
     Memory:     500.0 MiB
-    Threads:    1
+    Threads:    8
     
   ==> Input File <==
 
 --------------------------------------------------------------------------
 #! Computation of CP-corrected water trimer gradient (geometry from J. Chem. Theory Comput. 11, 2126-2136 (2015))
+
+ref = {
+"((1, 2, 3), (1, 2, 3))": (-224.91552989393287, 0.021848793840945943),
+"((1, 2), (1, 2, 3))": ( -149.94054830838144, 0.019116371778589655),
+"((1, 3), (1, 2, 3))": ( -149.94197668297062, 0.019002088007756268),
+"((2, 3), (1, 2, 3))": ( -149.94128152394086, 0.018939268786499593),
+"((1,), (1, 2, 3))": ( -74.97042065760473, 0.01477882932339267),
+"((2,), (1, 2, 3))": ( -74.96989892034797, 0.014675968393825936),
+"((3,), (1, 2, 3))": ( -74.97068360217213, 0.014481558269032477),
+"((1,), (1,))": ( -74.96340208276189, 0.024143516023737103),
+"((2,), (2,))": ( -74.96344779298651, 0.02398186931473767),
+"((3,), (3,))": ( -74.9635436680525, 0.02366990762961269),
+}
+
+ref_1cp_ene = -224.89039354380088
+
+ref_2cp_ene = -224.89219369884412
+ref_2cp_ie = -0.0018001550432131808
+ref_2cp_grad_rms = 0.01980609842746601
+ref_2cp_grad = [
+ [ 0.00179202, -0.03056288,  0.03218533],
+ [-0.00454805,  0.01423947, -0.00599154],
+ [ 0.01247021,  0.02299029, -0.0252948 ],
+ [ 0.02617686,  0.016441  ,  0.03146165],
+ [-0.02681671, -0.00129816, -0.02476424],
+ [-0.01001904, -0.00981053, -0.00733503],
+ [-0.02512132,  0.0105838 , -0.03520996],
+ [ 0.01328911, -0.00287095,  0.00811787],
+ [ 0.01277691, -0.01971204,  0.02683072]]
+ref_2cp_grad_ie = [
+ [ 0.001914149972,  0.01068903513 , -0.006574033629],
+ [ 0.00631228486 , -0.001668628285,  0.004525915615],
+ [ 0.001487748144, -0.002353528775,  0.002947106938],
+ [-0.010001441334, -0.00344793594 , -0.006693231883],
+ [ 0.001300152922,  0.002153765772,  0.00298506444 ],
+ [-0.001957602879,  0.00662647921 ,  0.003070555568],
+ [ 0.008098722312, -0.007057436202,  0.005415930792],
+ [-0.004637182641, -0.005331508324, -0.002538110932],
+ [-0.002516831355,  0.000389757415, -0.003139196908]]
+
+ref_3cp_ie = -0.004526713808019167
+ref_3cp_ene = -224.8949202576089
 
 import numpy as np
 
@@ -55,71 +105,180 @@ symmetry c1
 units bohr
 }
 
+set d_convergence 9
+
+# compute nbody
 g, wfn = gradient('SCF/STO-3G', molecule=water_trimer, bsse_type='cp', max_nbody=2,
                                       return_total_data=True, return_wfn=True)
 core.clean()
 
-cp_scheme = {'((1, 2), (1, 2, 3))': 1, '((1, 3), (1, 2, 3))': 1, '((2, 3), (1, 2, 3))': 1, #TEST
-             '((1,), (1, 2, 3))': -2, '((2,), (1, 2, 3))': -2, '((3,), (1, 2, 3))': -2, #TEST
-             '((1,), (1,))': 1, '((2,), (2,))': 1, '((3,), (3,))': 1} #TEST
+# test fresh env
+for result in [  #TEST
+    wfn.variable('2'),  #TEST
+    wfn.variable('2CP'),  #TEST
+    wfn.variable("CURRENT ENERGY"),  #TEST
+    variable("CURRENT ENERGY"),  #TEST
+]:  #TEST
+    compare_values(ref_2cp_ene, result, 8, 'CP-Corrected Energy')  #TEST
+
+for result in [  #TEST
+    wfn.variable("CP-CORRECTED 2-BODY INTERACTION ENERGY"),  #TEST
+    variable("CP-CORRECTED 2-BODY INTERACTION ENERGY"),  #TEST
+]:  #TEST
+    compare_values(ref_2cp_ie, result, 8, 'CP-Corrected Interaction Energy')  #TEST
+
+for result in [  #TEST
+    g,  #TEST
+    wfn.variable('GRADIENT 2'),  #TEST
+    wfn.variable("CURRENT GRADIENT"),  #TEST
+    variable("CURRENT GRADIENT"),  #TEST
+]:  #TEST
+    compare_values(ref_2cp_grad, result, 8, 'CP-Corrected Gradient')  #TEST
+
+# compute pieces
+cp_scheme = {  #TEST
+    '((1, 2), (1, 2, 3))': 1,  #TEST
+    '((1, 3), (1, 2, 3))': 1,  #TEST
+    '((2, 3), (1, 2, 3))': 1,  #TEST
+    '((1,), (1, 2, 3))': -2,  #TEST
+    '((2,), (1, 2, 3))': -2,  #TEST
+    '((3,), (1, 2, 3))': -2,  #TEST
+    '((1,), (1,))': 1,  #TEST
+    '((2,), (2,))': 1,  #TEST
+    '((3,), (3,))': 1,  #TEST
+}  #TEST
 
 energy_dict, gradient_dict = {}, {} #TEST
 for i in cp_scheme: #TEST
     mol = water_trimer.extract_subsets(eval(i)[0], list(set(eval(i)[1]) - set(eval(i)[0]))) #TEST
     gradient_dict[i], wfn_mol = gradient('SCF/STO-3G', molecule=mol, return_wfn=True) #TEST
-    energy_dict[i] = core.get_variable('CURRENT ENERGY') #TEST
+    energy_dict[i] = core.variable('CURRENT ENERGY') #TEST
     core.clean() #TEST
 
-    compare_values(energy_dict[i], wfn.variables()[i], 8, 'Energy of %s' %i) #TEST
-    compare_arrays(gradient_dict[i], wfn.arrays()['PTYPE %s' %i], 8, 'Gradient of %s' %i) #TEST
+    for result in [
+        energy_dict[i],
+        wfn.variable(i),
+        wfn_mol.variable("CURRENT ENERGY"),
+        variable("CURRENT ENERGY"),
+    ]:
+        compare_values(ref[i][0], result, 8, f"Energy of {i}")  #TEST
 
-energy, gradient = 0, np.zeros((9, 3)) #TEST
+    for result in [
+        gradient_dict[i],
+        wfn.variable(f"PTYPE {i}"),
+        wfn_mol.variable("CURRENT GRADIENT"),
+        variable("CURRENT GRADIENT"),
+    ]:
+        compare_arrays(ref[i][1], result.rms(), 8, f"Gradient RMS of {i}")  #TEST
+
+
+# recompute from pieces
+ene, grad = 0, np.zeros((9, 3)) #TEST
+
 for i in cp_scheme: #TEST
-    energy += cp_scheme[i] * energy_dict[i] #TEST
-
-compare_values(energy, wfn.variables()['2'], 8, 'CP-Corrected Energy') #TEST
+    ene += cp_scheme[i] * energy_dict[i] #TEST
 
 for i in range(3): #TEST
     key = '((%i,), (%i,))' %(i + 1, i + 1) #TEST
-    gradient[i*3: i*3 + 3, :] += cp_scheme.pop(key) * np.array(gradient_dict[key]) #TEST
+    grad[i*3: i*3 + 3, :] += cp_scheme.pop(key) * np.array(gradient_dict[key]) #TEST
 
 for i in cp_scheme: #TEST
-    gradient += cp_scheme[i] * np.array(gradient_dict[i]) #TEST
-    
-compare_arrays(gradient, wfn.arrays()['GRADIENT 2'], 8, 'CP-Corrected Gradient') #TEST
+    grad += cp_scheme[i] * np.array(gradient_dict[i]) #TEST
+
+# test
+for result in [  #TEST
+    wfn.variable('2'),  #TEST
+    wfn.variable('2CP'),  #TEST
+    wfn.variable("CURRENT ENERGY"),  #TEST
+    ene,  #TEST
+]:  #TEST
+    compare_values(ref_2cp_ene, result, 8, 'CP-Corrected Energy')  #TEST
+
+for result in [  #TEST
+    wfn.variable("CP-CORRECTED 2-BODY INTERACTION ENERGY"),  #TEST
+]:  #TEST
+    compare_values(ref_2cp_ie, result, 8, 'CP-Corrected Interaction Energy')  #TEST
+
+for result in [  #TEST
+    wfn.variable('GRADIENT 2'),  #TEST
+    wfn.variable("CURRENT GRADIENT"),  #TEST
+    grad,  #TEST
+]:  #TEST
+    compare_values(ref_2cp_grad, result, 8, 'CP-Corrected Gradient')  #TEST
+
+
+# compute nbody again with return_total_data=False
+# * note CURRENT ENERGY moved from first to second testing block
+g, wfn = gradient('SCF/STO-3G', molecule=water_trimer, bsse_type=['cp','nocp'], max_nbody=2,
+                                      return_total_data=False, return_wfn=True)
+core.clean()
+
+# test fresh env
+for result in [  #TEST
+    wfn.variable('2'),  #TEST
+    wfn.variable('2CP'),  #TEST
+]:  #TEST
+    compare_values(ref_2cp_ene, result, 8, 'rtd=F CP-Corrected Energy')  #TEST
+
+for result in [  #TEST
+    wfn.variable("CP-CORRECTED 2-BODY INTERACTION ENERGY"),  #TEST
+    variable("CP-CORRECTED 2-BODY INTERACTION ENERGY"),  #TEST
+    wfn.variable("CURRENT ENERGY"),  #TEST
+    variable("CURRENT ENERGY"),  #TEST
+]:  #TEST
+    compare_values(ref_2cp_ie, result, 8, 'rtd=F CP-Corrected Interaction Energy')  #TEST
+
+for result in [  #TEST
+    wfn.variable('GRADIENT 2'),  #TEST
+]:  #TEST
+    compare_values(ref_2cp_grad, result, 8, 'rtd=F CP-Corrected Gradient')  #TEST
+
+for result in [  #TEST
+    g,  #TEST
+    wfn.variable("CURRENT GRADIENT"),  #TEST
+    variable("CURRENT GRADIENT"),  #TEST
+]:  #TEST
+    compare_values(ref_2cp_grad_ie, result, 8, 'rtd=F CP-Corrected Gradient')  #TEST
+
 --------------------------------------------------------------------------
+
+Scratch directory: /tmp/
 
 
    ===> N-Body Interaction Abacus <===
         BSSE Treatment:                     cp
         Number of 1-body computations:     6
-        Number of 2-body computations:     3
+        Number of 2-body computations:     6
 
    ==> N-Body: Now computing 1-body complexes <==
 
 
-       N-Body: Computing complex (1/6) with fragments (3,) in the basis of fragments (1, 2, 3).
+       N-Body: Computing complex (1/6) with fragments (1,) in the basis of fragments (1, 2, 3).
 
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:46 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:51 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -131,21 +290,21 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
       Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
       Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
       Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
-         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
 
   Running in c1 symmetry.
 
   Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
   Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
-  Nuclear repulsion =    9.116312738955250
+  Nuclear repulsion =    9.119928278805013
 
   Charge       = 0
   Multiplicity = 1
@@ -161,15 +320,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -179,66 +338,67 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21       5       5       5       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.74352584946223   -7.47435e+01   7.04541e-02 
-   @DF-RHF iter   1:   -74.94070851381785   -1.97183e-01   8.92274e-03 
-   @DF-RHF iter   2:   -74.96828286733202   -2.75744e-02   2.00327e-03 DIIS
-   @DF-RHF iter   3:   -74.97018707742531   -1.90421e-03   8.28261e-04 DIIS
-   @DF-RHF iter   4:   -74.97066958085989   -4.82503e-04   1.42696e-04 DIIS
-   @DF-RHF iter   5:   -74.97068351486794   -1.39340e-05   1.19113e-05 DIIS
-   @DF-RHF iter   6:   -74.97068359590988   -8.10419e-08   3.05028e-06 DIIS
-   @DF-RHF iter   7:   -74.97068360204098   -6.13110e-09   4.74794e-07 DIIS
-   @DF-RHF iter   8:   -74.97068360220021   -1.59233e-10   5.68810e-08 DIIS
-   @DF-RHF iter   9:   -74.97068360220231   -2.10321e-12   1.27274e-08 DIIS
-   @DF-RHF iter  10:   -74.97068360220246   -1.42109e-13   2.16017e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20292908468235   -7.42029e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92263609767691   -7.19707e-01   1.16865e-02 DIIS
+   @DF-RHF iter   2:   -74.96927826367437   -4.66422e-02   1.98794e-03 DIIS
+   @DF-RHF iter   3:   -74.97033405711935   -1.05579e-03   4.55406e-04 DIIS
+   @DF-RHF iter   4:   -74.97041925358110   -8.51965e-05   4.56427e-05 DIIS
+   @DF-RHF iter   5:   -74.97042060385073   -1.35027e-06   8.79231e-06 DIIS
+   @DF-RHF iter   6:   -74.97042065748772   -5.36370e-08   4.96493e-07 DIIS
+   @DF-RHF iter   7:   -74.97042065760219   -1.14468e-10   5.85646e-08 DIIS
+   @DF-RHF iter   8:   -74.97042065760408   -1.89004e-12   7.90968e-09 DIIS
+   @DF-RHF iter   9:   -74.97042065760401    7.10543e-14   1.91420e-09 DIIS
+   @DF-RHF iter  10:   -74.97042065760398    2.84217e-14   3.64991e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -248,30 +408,30 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1A    -20.254358     2A     -1.269377     3A     -0.620681  
-       4A     -0.456484     5A     -0.396271  
+       1A    -20.253702     2A     -1.269156     3A     -0.621192  
+       4A     -0.455830     5A     -0.396005  
 
     Virtual:                                                              
 
-       6A      0.464891     7A      0.564110     8A      0.621931  
-       9A      0.744473    10A      0.971111    11A      1.053369  
-      12A      1.329751    13A      1.405389    14A      2.539403  
-      15A      2.551066    16A      2.884117    17A      3.011959  
-      18A      3.262578    19A      3.331827    20A     31.229332  
-      21A     31.304830  
+       6A      0.465977     7A      0.565921     8A      0.620284  
+       9A      0.743952    10A      0.976070    11A      1.052373  
+      12A      1.331031    13A      1.404480    14A      2.536284  
+      15A      2.553862    16A      2.893569    17A      3.009824  
+      18A      3.267055    19A      3.329230    20A     31.229191  
+      21A     31.307207  
 
     Final Occupation by Irrep:
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97068360220246
+  @DF-RHF Final Energy:   -74.97042065760398
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.1796494730542690
-    Two-Electron Energy =                  38.0926531318965687
-    Total Energy =                        -74.9706836022024561
+    Nuclear Repulsion Energy =              9.1199282788050127
+    One-Electron Energy =                -122.1889285363743767
+    Two-Electron Energy =                  38.0985795999653902
+    Total Energy =                        -74.9704206576039809
 
 Computation Completed
 
@@ -281,30 +441,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:     1.2177      Y:    30.2778      Z:     0.6255
+     X:   -27.0414      Y:   -14.0996      Z:    -0.2271
 
   Electronic Dipole Moment: [e a0]
-     X:    -1.7638      Y:   -30.1682      Z:    -1.0616
+     X:    27.1935      Y:    13.5407      Z:     0.6366
 
   Dipole Moment: [e a0]
-     X:    -0.5461      Y:     0.1097      Z:    -0.4361     Total:     0.7074
+     X:     0.1522      Y:    -0.5588      Z:     0.4095     Total:     0.7093
 
   Dipole Moment: [D]
-     X:    -1.3881      Y:     0.2787      Z:    -1.1084     Total:     1.7980
+     X:     0.3868      Y:    -1.4204      Z:     1.0410     Total:     1.8030
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:47 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:51 2021
 Module time:
-	user time   =       0.77 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.60 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.77 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.60 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:47 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:51 2021
 
 
          ------------------------------------------------------------
@@ -322,24 +482,24 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
       Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
       Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
       Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
-         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
 
-  Nuclear repulsion =    9.116312738955250
+  Nuclear repulsion =    9.119928278805013
 
   ==> Basis Set <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -350,18 +510,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -370,51 +530,55 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000072680722    -0.000178930512     0.000016357961
-       2       -0.000082840323    -0.000198380484     0.000026349954
-       3       -0.000001789943    -0.000006925595     0.000000480290
-       4       -0.000053426761    -0.000634492454    -0.000043991627
-       5        0.000006717097    -0.000006864509     0.000001653337
-       6        0.004811504336    -0.007487780157     0.000107477799
-       7       -0.036161158703     0.026023988105    -0.040801269083
-       8        0.017818347879     0.001955482593     0.009951421428
-       9        0.013735327141    -0.019466096988     0.030741519942
+       1       -0.005936482549    -0.047621129397     0.039078619493
+       2       -0.010347097104     0.015942129095    -0.009836147855
+       3        0.011267101224     0.023602965604    -0.029120434989
+       4        0.000148988970     0.000025243675    -0.000022690912
+       5        0.000010967309     0.000001674293    -0.000001547972
+       6        0.000207745756     0.000029486342    -0.000032447683
+       7        0.000572101775     0.000266556847     0.000029623501
+       8        0.004072969896     0.007742331031    -0.000093127031
+       9        0.000003704722     0.000010742506    -0.000001846552
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:48 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:52 2021
 Module time:
-	user time   =       0.22 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.10 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.00 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.71 seconds =       0.05 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-       N-Body: Complex Energy (fragments = (3,), basis = (1, 2, 3):   -74.97068360220246)
+       N-Body: Complex Energy (fragments = (1,), basis = (1, 2, 3):   -74.97042065760398)
 
        N-Body: Computing complex (2/6) with fragments (2,) in the basis of fragments (1, 2, 3).
 
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:48 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:52 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -456,15 +620,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -474,66 +638,67 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21       5       5       5       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.74161239909179   -7.47416e+01   7.04296e-02 
-   @DF-RHF iter   1:   -74.94034780931990   -1.98735e-01   8.89702e-03 
-   @DF-RHF iter   2:   -74.96780267325647   -2.74549e-02   1.87395e-03 DIIS
-   @DF-RHF iter   3:   -74.96947675629890   -1.67408e-03   7.56219e-04 DIIS
-   @DF-RHF iter   4:   -74.96988674258280   -4.09986e-04   1.31631e-04 DIIS
-   @DF-RHF iter   5:   -74.96989885332574   -1.21107e-05   1.09474e-05 DIIS
-   @DF-RHF iter   6:   -74.96989891766563   -6.43399e-08   2.17116e-06 DIIS
-   @DF-RHF iter   7:   -74.96989892024926   -2.58363e-09   4.01916e-07 DIIS
-   @DF-RHF iter   8:   -74.96989892036362   -1.14355e-10   8.94580e-08 DIIS
-   @DF-RHF iter   9:   -74.96989892036963   -6.01119e-12   1.47667e-08 DIIS
-   @DF-RHF iter  10:   -74.96989892036983   -1.98952e-13   1.80780e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20212107191564   -7.42021e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92187838021671   -7.19757e-01   1.17111e-02 DIIS
+   @DF-RHF iter   2:   -74.96877048612669   -4.68921e-02   1.97672e-03 DIIS
+   @DF-RHF iter   3:   -74.96981346520610   -1.04298e-03   4.53262e-04 DIIS
+   @DF-RHF iter   4:   -74.96989752646044   -8.40613e-05   4.54754e-05 DIIS
+   @DF-RHF iter   5:   -74.96989886791232   -1.34145e-06   8.68396e-06 DIIS
+   @DF-RHF iter   6:   -74.96989892025671   -5.23444e-08   4.77771e-07 DIIS
+   @DF-RHF iter   7:   -74.96989892036225   -1.05544e-10   5.60429e-08 DIIS
+   @DF-RHF iter   8:   -74.96989892036387   -1.62004e-12   7.92543e-09 DIIS
+   @DF-RHF iter   9:   -74.96989892036395   -7.10543e-14   1.91285e-09 DIIS
+   @DF-RHF iter  10:   -74.96989892036397   -2.84217e-14   3.66386e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -559,14 +724,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96989892036983
+  @DF-RHF Final Energy:   -74.96989892036397
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.1879518296377682
-    Two-Electron Energy =                  38.1012744379521138
-    Total Energy =                        -74.9698989203698289
+    One-Electron Energy =                -122.1879518597815490
+    Two-Electron Energy =                  38.1012744681017494
+    Total Energy =                        -74.9698989203639741
 
 Computation Completed
 
@@ -588,18 +753,18 @@ Properties computed using the SCF density matrix
      X:     1.0185      Y:     1.0559      Z:     1.0384     Total:     1.7974
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:48 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:52 2021
 Module time:
-	user time   =       0.76 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.68 seconds =       0.04 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.77 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       5.47 seconds =       0.09 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:48 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:52 2021
 
 
          ------------------------------------------------------------
@@ -634,7 +799,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -645,18 +810,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -665,323 +830,55 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000471411769     0.000356803525    -0.000054418346
-       2       -0.008168586621    -0.000377057152    -0.000347480989
-       3       -0.000010562664    -0.000002212593     0.000000346743
-       4        0.044108822262     0.018054048616     0.038836059653
-       5       -0.026825034420    -0.002275333736    -0.028632481029
-       6       -0.008389751555    -0.016062187463    -0.009757917087
-       7       -0.000111977619     0.000137295900    -0.000015716268
-       8       -0.000125841639     0.000163541076    -0.000028233204
-       9       -0.000005655971     0.000005101826    -0.000000159474
+       1       -0.000471411792     0.000356803540    -0.000054418348
+       2       -0.008168586495    -0.000377057164    -0.000347481001
+       3       -0.000010562663    -0.000002212594     0.000000346743
+       4        0.044108819730     0.018054045577     0.038836058931
+       5       -0.026825033536    -0.002275332280    -0.028632480034
+       6       -0.008389750009    -0.016062185881    -0.009757917344
+       7       -0.000111977594     0.000137295906    -0.000015716264
+       8       -0.000125841662     0.000163541068    -0.000028233204
+       9       -0.000005655977     0.000005101827    -0.000000159477
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:49 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:52 2021
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.04 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.52 seconds =       0.11 minutes
+	system time =       0.33 seconds =       0.01 minutes
 	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       2.00 seconds =       0.03 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
 
-       N-Body: Complex Energy (fragments = (2,), basis = (1, 2, 3):   -74.96989892036983)
+       N-Body: Complex Energy (fragments = (2,), basis = (1, 2, 3):   -74.96989892036397)
 
-       N-Body: Computing complex (3/6) with fragments (1,) in the basis of fragments (1,).
+       N-Body: Computing complex (3/6) with fragments (3,) in the basis of fragments (3,).
 
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:49 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:52 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
-         ---------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Bohr), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-
-  Running in c1 symmetry.
-
-  Rotational constants: A =     17.14656  B =      0.35250  C =      0.35060 [cm^-1]
-  Rotational constants: A = 514040.82446  B =  10567.72688  C =  10510.70065 [MHz]
-  Nuclear repulsion =    9.119928278805013
-
-  Charge       = 0
-  Multiplicity = 1
-  Electrons    = 10
-  Nalpha       = 5
-  Nbeta        = 5
-
-  ==> Algorithm <==
-
-  SCF Algorithm Type is DF.
-  DIIS enabled.
-  MOM disabled.
-  Fractional occupation disabled.
-  Guess Type is SAD.
-  Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
-
-  ==> Primary Basis <==
-
-  Basis Set: STO-3G
-    Blend: STO-3G
-    Number of shells: 5
-    Number of basis function: 7
-    Number of Cartesian functions: 7
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-   => Loading Basis Set <=
-
-    Name: (STO-3G AUX)
-    Role: JKFIT
-    Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A          7       7       0       0       0       0
-   -------------------------------------------------------
-    Total       7       7       5       5       5       0
-   -------------------------------------------------------
-
-  ==> Integral Setup <==
-
-  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
-
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               1
-    Memory [MiB]:               375
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
-    Number of shells: 37
-    Number of basis function: 113
-    Number of Cartesian functions: 133
-    Spherical Harmonics?: true
-    Max angular momentum: 4
-
-  Minimum eigenvalue in the overlap matrix is 3.4706319112E-01.
-  Using Symmetric Orthogonalization.
-
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
-
-  ==> Iterations <==
-
-                           Total Energy        Delta E     RMS |[F,P]|
-
-   @DF-RHF iter   0:   -74.76943609450502   -7.47694e+01   2.11257e-01 
-   @DF-RHF iter   1:   -74.92195923618446   -1.52523e-01   3.12912e-02 
-   @DF-RHF iter   2:   -74.96095707653201   -3.89978e-02   6.14970e-03 DIIS
-   @DF-RHF iter   3:   -74.96294367231238   -1.98660e-03   2.39782e-03 DIIS
-   @DF-RHF iter   4:   -74.96338572851374   -4.42056e-04   4.51735e-04 DIIS
-   @DF-RHF iter   5:   -74.96340201916767   -1.62907e-05   3.31720e-05 DIIS
-   @DF-RHF iter   6:   -74.96340207974856   -6.05809e-08   7.33403e-06 DIIS
-   @DF-RHF iter   7:   -74.96340208265826   -2.90970e-09   1.14193e-06 DIIS
-   @DF-RHF iter   8:   -74.96340208275730   -9.90354e-11   2.20890e-07 DIIS
-   @DF-RHF iter   9:   -74.96340208276128   -3.97904e-12   4.99270e-08 DIIS
-   @DF-RHF iter  10:   -74.96340208276142   -1.42109e-13   3.74030e-09 DIIS
-  Energy converged.
-
-
-  ==> Post-Iterations <==
-
-    Orbital Energies [Eh]
-    ---------------------
-
-    Doubly Occupied:                                                      
-
-       1A    -20.241218     2A     -1.263189     3A     -0.615741  
-       4A     -0.449250     5A     -0.389851  
-
-    Virtual:                                                              
-
-       6A      0.595605     7A      0.737218  
-
-    Final Occupation by Irrep:
-              A 
-    DOCC [     5 ]
-
-  @DF-RHF Final Energy:   -74.96340208276142
-
-   => Energetics <=
-
-    Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.2481627378251261
-    Two-Electron Energy =                  38.1648323762587012
-    Total Energy =                        -74.9634020827614194
-
-Computation Completed
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
-
-Properties computed using the SCF density matrix
-
-  Nuclear Dipole Moment: [e a0]
-     X:   -27.0414      Y:   -14.0996      Z:    -0.2271
-
-  Electronic Dipole Moment: [e a0]
-     X:    27.2151      Y:    13.5924      Z:     0.6324
-
-  Dipole Moment: [e a0]
-     X:     0.1737      Y:    -0.5071      Z:     0.4053     Total:     0.6720
-
-  Dipole Moment: [D]
-     X:     0.4415      Y:    -1.2890      Z:     1.0302     Total:     1.7081
-
-
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:49 2018
-Module time:
-	user time   =       0.32 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       2.33 seconds =       0.04 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:49 2018
-
-
-         ------------------------------------------------------------
-                                   SCF GRAD                          
-                          Rob Parrish, Justin Turney,                
-                       Andy Simmonett, and Alex Sokolov              
-         ------------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Bohr), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-
-  Nuclear repulsion =    9.119928278805013
-
-  ==> Basis Set <==
-
-  Basis Set: STO-3G
-    Blend: STO-3G
-    Number of shells: 5
-    Number of basis function: 7
-    Number of Cartesian functions: 7
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-  ==> DFJKGrad: Density-Fitted SCF Gradients <==
-
-    Gradient:                    1
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
-    Number of shells: 37
-    Number of basis function: 113
-    Number of Cartesian functions: 133
-    Spherical Harmonics?: true
-    Max angular momentum: 4
-
-
-  -Total Gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1       -0.000122129191    -0.041251919656     0.038759367274
-       2       -0.010860335684     0.015908099073    -0.010517460458
-       3        0.010982464874     0.025343820582    -0.028241906817
-
-
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:49 2018
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       2.40 seconds =       0.04 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-       N-Body: Complex Energy (fragments = (1,), basis = (1,):   -74.96340208276142)
-
-       N-Body: Computing complex (4/6) with fragments (3,) in the basis of fragments (3,).
-
-gradient() will perform analytic gradient computation.
-
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:49 2018
-
-   => Loading Basis Set <=
-
-    Name: STO-3G
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1   entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-
-
-         ---------------------------------------------------------
-                                   SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
-                              RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1017,15 +914,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -1035,18 +932,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A          7       7       0       0       0       0
-   -------------------------------------------------------
-    Total       7       7       5       5       5       0
-   -------------------------------------------------------
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1057,44 +944,54 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.4730300753E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.8113509098E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.74352657585351   -7.47435e+01   2.11015e-01 
-   @DF-RHF iter   1:   -74.93232039674074   -1.88794e-01   2.72761e-02 
-   @DF-RHF iter   2:   -74.96122749398771   -2.89071e-02   5.77034e-03 DIIS
-   @DF-RHF iter   3:   -74.96305605978020   -1.82857e-03   2.45049e-03 DIIS
-   @DF-RHF iter   4:   -74.96353267254993   -4.76613e-04   3.86874e-04 DIIS
-   @DF-RHF iter   5:   -74.96354361734123   -1.09448e-05   2.68749e-05 DIIS
-   @DF-RHF iter   6:   -74.96354366279775   -4.54565e-08   8.59594e-06 DIIS
-   @DF-RHF iter   7:   -74.96354366800938   -5.21163e-09   7.92455e-07 DIIS
-   @DF-RHF iter   8:   -74.96354366804913   -3.97478e-11   1.23739e-07 DIIS
-   @DF-RHF iter   9:   -74.96354366804998   -8.52651e-13   2.69980e-08 DIIS
-   @DF-RHF iter  10:   -74.96354366805008   -9.94760e-14   3.38035e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20201476670238   -7.42020e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91358540757162   -7.11571e-01   3.55775e-02 DIIS
+   @DF-RHF iter   2:   -74.96259246477617   -4.90071e-02   5.42254e-03 DIIS
+   @DF-RHF iter   3:   -74.96347049128536   -8.78027e-04   1.28737e-03 DIIS
+   @DF-RHF iter   4:   -74.96354240952572   -7.19182e-05   1.29539e-04 DIIS
+   @DF-RHF iter   5:   -74.96354366338385   -1.25386e-06   8.90787e-06 DIIS
+   @DF-RHF iter   6:   -74.96354366802545   -4.64161e-09   5.24339e-07 DIIS
+   @DF-RHF iter   7:   -74.96354366804142   -1.59730e-11   5.17144e-08 DIIS
+   @DF-RHF iter   8:   -74.96354366804155   -1.27898e-13   1.18687e-09 DIIS
+   @DF-RHF iter   9:   -74.96354366804157   -1.42109e-14   1.51651e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -1115,14 +1012,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96354366805008
+  @DF-RHF Final Energy:   -74.96354366804157
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.2400220139105187
-    Two-Electron Energy =                  38.1601656069051955
-    Total Energy =                        -74.9635436680500788
+    One-Electron Energy =                -122.2400220121383825
+    Two-Electron Energy =                  38.1601656051415645
+    Total Energy =                        -74.9635436680415808
 
 Computation Completed
 
@@ -1144,18 +1041,18 @@ Properties computed using the SCF density matrix
      X:    -1.3005      Y:     0.1654      Z:    -1.0966     Total:     1.7092
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:49 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:53 2021
 Module time:
-	user time   =       0.32 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       2.04 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.73 seconds =       0.05 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       8.64 seconds =       0.14 minutes
+	system time =       0.43 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:49 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:53 2021
 
 
          ------------------------------------------------------------
@@ -1184,7 +1081,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -1195,18 +1092,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -1215,340 +1112,49 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.033220039065     0.017641239645    -0.040625895938
-       2        0.017926294734     0.002460556689     0.010655977980
-       3        0.015293744332    -0.020101796334     0.029969917958
+       1       -0.033220038531     0.017641240890    -0.040625894970
+       2        0.017926294608     0.002460555085     0.010655978170
+       3        0.015293743923    -0.020101795976     0.029969916800
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:50 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:53 2021
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       2.80 seconds =       0.05 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
-
-       N-Body: Complex Energy (fragments = (3,), basis = (3,):   -74.96354366805008)
-
-       N-Body: Computing complex (5/6) with fragments (1,) in the basis of fragments (1, 2, 3).
-
-gradient() will perform analytic gradient computation.
-
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:50 2018
-
-   => Loading Basis Set <=
-
-    Name: STO-3G
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-
-
-         ---------------------------------------------------------
-                                   SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
-                              RHF Reference
-                        1 Threads,    500 MiB Core
-         ---------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Bohr), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
-      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
-      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
-      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
-
-  Running in c1 symmetry.
-
-  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
-  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
-  Nuclear repulsion =    9.119928278805013
-
-  Charge       = 0
-  Multiplicity = 1
-  Electrons    = 10
-  Nalpha       = 5
-  Nbeta        = 5
-
-  ==> Algorithm <==
-
-  SCF Algorithm Type is DF.
-  DIIS enabled.
-  MOM disabled.
-  Fractional occupation disabled.
-  Guess Type is SAD.
-  Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
-
-  ==> Primary Basis <==
-
-  Basis Set: STO-3G
-    Blend: STO-3G
-    Number of shells: 15
-    Number of basis function: 21
-    Number of Cartesian functions: 21
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-   => Loading Basis Set <=
-
-    Name: (STO-3G AUX)
-    Role: JKFIT
-    Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21       5       5       5       0
-   -------------------------------------------------------
-
-  ==> Integral Setup <==
-
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
-
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               1
-    Memory [MiB]:               375
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
-    Number of shells: 111
-    Number of basis function: 339
-    Number of Cartesian functions: 399
-    Spherical Harmonics?: true
-    Max angular momentum: 4
-
-  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
-
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
-
-  ==> Iterations <==
-
-                           Total Energy        Delta E     RMS |[F,P]|
-
-   @DF-RHF iter   0:   -74.76943578326231   -7.47694e+01   7.05177e-02 
-   @DF-RHF iter   1:   -74.93057291213378   -1.61137e-01   1.02237e-02 
-   @DF-RHF iter   2:   -74.96785478643716   -3.72819e-02   2.15969e-03 DIIS
-   @DF-RHF iter   3:   -74.96995859978860   -2.10381e-03   8.09360e-04 DIIS
-   @DF-RHF iter   4:   -74.97040122927963   -4.42629e-04   1.62299e-04 DIIS
-   @DF-RHF iter   5:   -74.97042051515783   -1.92859e-05   1.53629e-05 DIIS
-   @DF-RHF iter   6:   -74.97042065381785   -1.38660e-07   2.59848e-06 DIIS
-   @DF-RHF iter   7:   -74.97042065743258   -3.61473e-09   4.82097e-07 DIIS
-   @DF-RHF iter   8:   -74.97042065758917   -1.56589e-10   1.01437e-07 DIIS
-   @DF-RHF iter   9:   -74.97042065759673   -7.56017e-12   1.95152e-08 DIIS
-   @DF-RHF iter  10:   -74.97042065759720   -4.68958e-13   2.37661e-09 DIIS
-  Energy converged.
-
-
-  ==> Post-Iterations <==
-
-    Orbital Energies [Eh]
-    ---------------------
-
-    Doubly Occupied:                                                      
-
-       1A    -20.253702     2A     -1.269156     3A     -0.621192  
-       4A     -0.455830     5A     -0.396005  
-
-    Virtual:                                                              
-
-       6A      0.465977     7A      0.565921     8A      0.620284  
-       9A      0.743952    10A      0.976070    11A      1.052373  
-      12A      1.331031    13A      1.404480    14A      2.536284  
-      15A      2.553862    16A      2.893569    17A      3.009824  
-      18A      3.267055    19A      3.329230    20A     31.229191  
-      21A     31.307207  
-
-    Final Occupation by Irrep:
-              A 
-    DOCC [     5 ]
-
-  @DF-RHF Final Energy:   -74.97042065759720
-
-   => Energetics <=
-
-    Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.1889284979931887
-    Two-Electron Energy =                  38.0985795615909950
-    Total Energy =                        -74.9704206575971881
-
-Computation Completed
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
-
-Properties computed using the SCF density matrix
-
-  Nuclear Dipole Moment: [e a0]
-     X:   -27.0414      Y:   -14.0996      Z:    -0.2271
-
-  Electronic Dipole Moment: [e a0]
-     X:    27.1935      Y:    13.5407      Z:     0.6366
-
-  Dipole Moment: [e a0]
-     X:     0.1522      Y:    -0.5588      Z:     0.4095     Total:     0.7093
-
-  Dipole Moment: [D]
-     X:     0.3868      Y:    -1.4204      Z:     1.0410     Total:     1.8030
-
-
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:50 2018
-Module time:
-	user time   =       0.75 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.49 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.56 seconds =       0.06 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       9.14 seconds =       0.15 minutes
+	system time =       0.45 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:50 2018
+       N-Body: Complex Energy (fragments = (3,), basis = (3,):   -74.96354366804157)
 
-
-         ------------------------------------------------------------
-                                   SCF GRAD                          
-                          Rob Parrish, Justin Turney,                
-                       Andy Simmonett, and Alex Sokolov              
-         ------------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Bohr), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
-         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
-         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
-      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
-      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
-      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
-
-  Nuclear repulsion =    9.119928278805013
-
-  ==> Basis Set <==
-
-  Basis Set: STO-3G
-    Blend: STO-3G
-    Number of shells: 15
-    Number of basis function: 21
-    Number of Cartesian functions: 21
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-  ==> DFJKGrad: Density-Fitted SCF Gradients <==
-
-    Gradient:                    1
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
-
-   => Auxiliary Basis Set <=
-
-  Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
-    Number of shells: 111
-    Number of basis function: 339
-    Number of Cartesian functions: 399
-    Spherical Harmonics?: true
-    Max angular momentum: 4
+       N-Body: Computing complex (4/6) with fragments (2,) in the basis of fragments (2,).
 
 
-  -Total Gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1       -0.005936480254    -0.047621130807     0.039078622230
-       2       -0.010347098089     0.015942129571    -0.009836149688
-       3        0.011267099763     0.023602966299    -0.029120435901
-       4        0.000148988996     0.000025243629    -0.000022690921
-       5        0.000010967308     0.000001674296    -0.000001547970
-       6        0.000207745728     0.000029486396    -0.000032447681
-       7        0.000572101774     0.000266556806     0.000029623492
-       8        0.004072970054     0.007742331308    -0.000093127015
-       9        0.000003704719     0.000010742501    -0.000001846547
+Scratch directory: /tmp/
 
-
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:51 2018
-Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       3.79 seconds =       0.06 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
-
-       N-Body: Complex Energy (fragments = (1,), basis = (1, 2, 3):   -74.97042065759720)
-
-       N-Body: Computing complex (6/6) with fragments (2,) in the basis of fragments (2,).
-
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:51 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:53 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1584,15 +1190,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -1602,18 +1208,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A          7       7       0       0       0       0
-   -------------------------------------------------------
-    Total       7       7       5       5       5       0
-   -------------------------------------------------------
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1624,44 +1220,54 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.4724660626E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.8115562909E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.74161284996681   -7.47416e+01   2.10812e-01 
-   @DF-RHF iter   1:   -74.93326619471010   -1.91653e-01   2.67089e-02 
-   @DF-RHF iter   2:   -74.96140227456995   -2.81361e-02   5.44371e-03 DIIS
-   @DF-RHF iter   3:   -74.96303335073614   -1.63108e-03   2.23919e-03 DIIS
-   @DF-RHF iter   4:   -74.96343674337052   -4.03393e-04   3.77861e-04 DIIS
-   @DF-RHF iter   5:   -74.96344775248927   -1.10091e-05   2.69115e-05 DIIS
-   @DF-RHF iter   6:   -74.96344779068281   -3.81935e-08   6.09415e-06 DIIS
-   @DF-RHF iter   7:   -74.96344779287553   -2.19272e-09   1.00883e-06 DIIS
-   @DF-RHF iter   8:   -74.96344779295715   -8.16271e-11   1.76519e-07 DIIS
-   @DF-RHF iter   9:   -74.96344779295960   -2.44427e-12   3.71973e-08 DIIS
-   @DF-RHF iter  10:   -74.96344779295968   -8.52651e-14   3.15321e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20212050381699   -7.42021e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91356875495052   -7.11448e-01   3.55515e-02 DIIS
+   @DF-RHF iter   2:   -74.96249631967865   -4.89276e-02   5.41710e-03 DIIS
+   @DF-RHF iter   3:   -74.96337428379589   -8.77964e-04   1.28875e-03 DIIS
+   @DF-RHF iter   4:   -74.96344651408256   -7.22303e-05   1.30538e-04 DIIS
+   @DF-RHF iter   5:   -74.96344778833750   -1.27425e-06   8.88772e-06 DIIS
+   @DF-RHF iter   6:   -74.96344779295855   -4.62104e-09   5.28512e-07 DIIS
+   @DF-RHF iter   7:   -74.96344779297476   -1.62146e-11   5.37441e-08 DIIS
+   @DF-RHF iter   8:   -74.96344779297497   -2.13163e-13   1.21463e-09 DIIS
+   @DF-RHF iter   9:   -74.96344779297497    0.00000e+00   1.58511e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -1682,14 +1288,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96344779295968
+  @DF-RHF Final Energy:   -74.96344779297497
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.2421812098822755
-    Two-Electron Energy =                  38.1619549456067659
-    Total Energy =                        -74.9634477929596841
+    One-Electron Energy =                -122.2421812246879398
+    Two-Electron Energy =                  38.1619549603971393
+    Total Energy =                        -74.9634477929749750
 
 Computation Completed
 
@@ -1711,18 +1317,18 @@ Properties computed using the SCF density matrix
      X:     0.8883      Y:     1.0391      Z:     1.0241     Total:     1.7081
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:51 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:53 2021
 Module time:
-	user time   =       0.32 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.00 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.11 seconds =       0.07 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      11.22 seconds =       0.19 minutes
+	system time =       0.56 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:51 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:53 2021
 
 
          ------------------------------------------------------------
@@ -1751,7 +1357,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -1762,18 +1368,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -1782,48 +1388,49 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.036178303755     0.019888938711     0.038154885164
-       2       -0.028116867828    -0.003451926908    -0.027749301126
-       3       -0.008061435924    -0.016437011804    -0.010405584037
+       1        0.036178301920     0.019888936327     0.038154883443
+       2       -0.028116866599    -0.003451926262    -0.027749299482
+       3       -0.008061435318    -0.016437010065    -0.010405583961
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:51 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:53 2021
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.19 seconds =       0.07 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =      11.68 seconds =       0.19 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-       N-Body: Complex Energy (fragments = (2,), basis = (2,):   -74.96344779295968)
+       N-Body: Complex Energy (fragments = (2,), basis = (2,):   -74.96344779297497)
 
-   ==> N-Body: Now computing 2-body complexes <==
+       N-Body: Computing complex (5/6) with fragments (1,) in the basis of fragments (1,).
 
 
-       N-Body: Computing complex (1/3) with fragments (1, 3) in the basis of fragments (1, 2, 3).
+Scratch directory: /tmp/
 
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:51 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:53 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1838,24 +1445,18 @@ gradient() will perform analytic gradient computation.
          O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
          H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
          H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
-      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
-      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
-      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
-         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
-         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
-         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
 
   Running in c1 symmetry.
 
-  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
-  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
-  Nuclear repulsion =   37.415382693305901
+  Rotational constants: A =     17.14656  B =      0.35250  C =      0.35060 [cm^-1]
+  Rotational constants: A = 514040.82446  B =  10567.72688  C =  10510.70065 [MHz]
+  Nuclear repulsion =    9.119928278805013
 
   Charge       = 0
   Multiplicity = 1
-  Electrons    = 20
-  Nalpha       = 10
-  Nbeta        = 10
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
 
   ==> Algorithm <==
 
@@ -1865,16 +1466,16 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
-    Number of shells: 15
-    Number of basis function: 21
-    Number of Cartesian functions: 21
+    Number of shells: 5
+    Number of basis functions: 7
+    Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
 
@@ -1883,66 +1484,66 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21      10      10      10       0
-   -------------------------------------------------------
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
-    Number of shells: 111
-    Number of basis function: 339
-    Number of Cartesian functions: 399
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
 
-  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 3.4706319112E-01.
+  Reciprocal condition number of the overlap matrix is 1.8103780232E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -149.53331342702992   -1.49533e+02   1.00079e-01 
-   @DF-RHF iter   1:  -149.87294430945232   -3.39631e-01   1.31754e-02 
-   @DF-RHF iter   2:  -149.93729770499769   -6.43534e-02   2.81606e-03 DIIS
-   @DF-RHF iter   3:  -149.94117629256391   -3.87859e-03   1.05498e-03 DIIS
-   @DF-RHF iter   4:  -149.94193951082062   -7.63218e-04   2.24461e-04 DIIS
-   @DF-RHF iter   5:  -149.94197655326627   -3.70424e-05   1.55085e-05 DIIS
-   @DF-RHF iter   6:  -149.94197667732826   -1.24062e-07   3.17441e-06 DIIS
-   @DF-RHF iter   7:  -149.94197668262368   -5.29542e-09   7.50058e-07 DIIS
-   @DF-RHF iter   8:  -149.94197668298361   -3.59933e-10   1.69720e-07 DIIS
-   @DF-RHF iter   9:  -149.94197668300373   -2.01226e-11   3.29334e-08 DIIS
-   @DF-RHF iter  10:  -149.94197668300447   -7.38964e-13   5.80204e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20292818616237   -7.42029e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91358954105050   -7.10661e-01   3.55337e-02 DIIS
+   @DF-RHF iter   2:   -74.96245166050336   -4.88621e-02   5.41141e-03 DIIS
+   @DF-RHF iter   3:   -74.96332855053103   -8.76890e-04   1.28859e-03 DIIS
+   @DF-RHF iter   4:   -74.96340079921768   -7.22487e-05   1.30788e-04 DIIS
+   @DF-RHF iter   5:   -74.96340207816462   -1.27895e-06   8.84975e-06 DIIS
+   @DF-RHF iter   6:   -74.96340208274100   -4.57638e-09   5.30739e-07 DIIS
+   @DF-RHF iter   7:   -74.96340208275730   -1.62999e-11   4.98532e-08 DIIS
+   @DF-RHF iter   8:   -74.96340208275747   -1.70530e-13   1.19600e-09 DIIS
+   @DF-RHF iter   9:   -74.96340208275743    4.26326e-14   1.49182e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -1952,30 +1553,25 @@ gradient() will perform analytic gradient computation.
 
     Doubly Occupied:                                                      
 
-       1A    -20.267811     2A    -20.210878     3A     -1.288127  
-       4A     -1.238662     5A     -0.641682     6A     -0.595283  
-       7A     -0.479087     8A     -0.434364     9A     -0.399371  
-      10A     -0.365796  
+       1A    -20.241218     2A     -1.263189     3A     -0.615741  
+       4A     -0.449250     5A     -0.389851  
 
     Virtual:                                                              
 
-      11A      0.493284    12A      0.606245    13A      0.650587  
-      14A      0.731276    15A      0.787335    16A      1.032393  
-      17A      1.375231    18A      2.549012    19A      2.952949  
-      20A      3.283171    21A     31.266059  
+       6A      0.595605     7A      0.737218  
 
     Final Occupation by Irrep:
               A 
-    DOCC [    10 ]
+    DOCC [     5 ]
 
-  @DF-RHF Final Energy:  -149.94197668300447
+  @DF-RHF Final Energy:   -74.96340208275743
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             37.4153826933059008
-    One-Electron Energy =                -282.8726007897899990
-    Two-Electron Energy =                  95.5152414134796146
-    Total Energy =                       -149.9419766830044978
+    Nuclear Repulsion Energy =              9.1199282788050127
+    One-Electron Energy =                -122.2481627620103382
+    Two-Electron Energy =                  38.1648324004478852
+    Total Energy =                        -74.9634020827574261
 
 Computation Completed
 
@@ -1985,30 +1581,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 Properties computed using the SCF density matrix
 
   Nuclear Dipole Moment: [e a0]
-     X:   -25.8236      Y:    16.1783      Z:     0.3984
+     X:   -27.0414      Y:   -14.0996      Z:    -0.2271
 
   Electronic Dipole Moment: [e a0]
-     X:    25.3512      Y:   -16.7430      Z:    -0.4030
+     X:    27.2151      Y:    13.5924      Z:     0.6324
 
   Dipole Moment: [e a0]
-     X:    -0.4724      Y:    -0.5647      Z:    -0.0046     Total:     0.7362
+     X:     0.1737      Y:    -0.5071      Z:     0.4053     Total:     0.6720
 
   Dipole Moment: [D]
-     X:    -1.2007      Y:    -1.4353      Z:    -0.0118     Total:     1.8713
+     X:     0.4415      Y:    -1.2890      Z:     1.0302     Total:     1.7081
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:52 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:54 2021
 Module time:
-	user time   =       0.76 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.01 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       4.95 seconds =       0.08 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      13.78 seconds =       0.23 minutes
+	system time =       0.72 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:52 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:54 2021
 
 
          ------------------------------------------------------------
@@ -2029,6 +1625,102 @@ Total time:
          O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
          H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
          H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+
+  Nuclear repulsion =    9.119928278805013
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis functions: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000122130096    -0.041251917686     0.038759365405
+       2       -0.010860334774     0.015908098682    -0.010517459389
+       3        0.010982464868     0.025343819003    -0.028241906016
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:54 2021
+Module time:
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      14.30 seconds =       0.24 minutes
+	system time =       0.75 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+       N-Body: Complex Energy (fragments = (1,), basis = (1,):   -74.96340208275743)
+
+       N-Body: Computing complex (6/6) with fragments (3,) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:54 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
       Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
       Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
       Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
@@ -2036,14 +1728,206 @@ Total time:
          H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
          H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
 
-  Nuclear repulsion =   37.415382693305901
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =    9.116312738955250
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -74.20201501847512   -7.42020e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92280482017243   -7.20790e-01   1.16966e-02 DIIS
+   @DF-RHF iter   2:   -74.96953035470298   -4.67255e-02   2.00055e-03 DIIS
+   @DF-RHF iter   3:   -74.97059674577909   -1.06639e-03   4.56359e-04 DIIS
+   @DF-RHF iter   4:   -74.97068221689719   -8.54711e-05   4.53537e-05 DIIS
+   @DF-RHF iter   5:   -74.97068354759350   -1.33070e-06   8.85963e-06 DIIS
+   @DF-RHF iter   6:   -74.97068360208863   -5.44951e-08   5.10780e-07 DIIS
+   @DF-RHF iter   7:   -74.97068360221039   -1.21759e-10   6.11794e-08 DIIS
+   @DF-RHF iter   8:   -74.97068360221235   -1.96110e-12   8.32843e-09 DIIS
+   @DF-RHF iter   9:   -74.97068360221230    4.26326e-14   2.08217e-09 DIIS
+   @DF-RHF iter  10:   -74.97068360221238   -7.10543e-14   3.79028e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.254358     2A     -1.269377     3A     -0.620681  
+       4A     -0.456484     5A     -0.396271  
+
+    Virtual:                                                              
+
+       6A      0.464891     7A      0.564110     8A      0.621931  
+       9A      0.744473    10A      0.971111    11A      1.053369  
+      12A      1.329751    13A      1.405389    14A      2.539403  
+      15A      2.551066    16A      2.884117    17A      3.011959  
+      18A      3.262578    19A      3.331827    20A     31.229332  
+      21A     31.304830  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -74.97068360221238
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1163127389552496
+    One-Electron Energy =                -122.1796494817144918
+    Two-Electron Energy =                  38.0926531405468722
+    Total Energy =                        -74.9706836022123753
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     1.2177      Y:    30.2778      Z:     0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:    -1.7638      Y:   -30.1682      Z:    -1.0616
+
+  Dipole Moment: [e a0]
+     X:    -0.5461      Y:     0.1097      Z:    -0.4361     Total:     0.7074
+
+  Dipole Moment: [D]
+     X:    -1.3881      Y:     0.2787      Z:    -1.1084     Total:     1.7980
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:54 2021
+Module time:
+	user time   =       2.65 seconds =       0.04 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      17.03 seconds =       0.28 minutes
+	system time =       0.89 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:54 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =    9.116312738955250
 
   ==> Basis Set <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -2054,18 +1938,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -2074,51 +1958,58 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.004267645613    -0.040337039032     0.036257505886
-       2       -0.009096766871     0.016148452367    -0.008510794777
-       3        0.011706157221     0.022501917739    -0.027420796425
-       4        0.000077877850    -0.000630171233    -0.000065662310
-       5        0.000017101481    -0.000007706069     0.000000960728
-       6        0.005333224388    -0.008144547108     0.000059160340
-       7       -0.032823753946     0.024083255072    -0.038289296288
-       8        0.016902902322     0.005424869235     0.008657960702
-       9        0.012150903166    -0.019039030973     0.029310962144
+       1       -0.000072680698    -0.000178930510     0.000016357961
+       2       -0.000082840343    -0.000198380482     0.000026349954
+       3       -0.000001789948    -0.000006925595     0.000000480290
+       4       -0.000053426752    -0.000634492399    -0.000043991628
+       5        0.000006717098    -0.000006864511     0.000001653342
+       6        0.004811504298    -0.007487780129     0.000107477792
+       7       -0.036161158030     0.026023991614    -0.040801267431
+       8        0.017818348337     0.001955480735     0.009951421448
+       9        0.013735326039    -0.019466098725     0.030741518272
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:52 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:54 2021
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.05 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.19 seconds =       0.09 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      18.09 seconds =       0.30 minutes
+	system time =       0.95 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
 
-       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 2, 3):  -149.94197668300447)
+       N-Body: Complex Energy (fragments = (3,), basis = (1, 2, 3):   -74.97068360221238)
 
-       N-Body: Computing complex (2/3) with fragments (2, 3) in the basis of fragments (1, 2, 3).
+   ==> N-Body: Now computing 2-body complexes <==
 
+
+       N-Body: Computing complex (1/6) with fragments (2, 3) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:52 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:54 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2160,15 +2051,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -2178,66 +2069,68 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21      10      10      10       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -149.52824159360756   -1.49528e+02   1.00087e-01 
-   @DF-RHF iter   1:  -149.87199144531388   -3.43750e-01   1.32915e-02 
-   @DF-RHF iter   2:  -149.93672991181495   -6.47385e-02   2.73808e-03 DIIS
-   @DF-RHF iter   3:  -149.94045820553387   -3.72829e-03   1.05471e-03 DIIS
-   @DF-RHF iter   4:  -149.94125060250929   -7.92397e-04   2.04814e-04 DIIS
-   @DF-RHF iter   5:  -149.94128129675170   -3.06942e-05   2.05991e-05 DIIS
-   @DF-RHF iter   6:  -149.94128151166075   -2.14909e-07   4.56707e-06 DIIS
-   @DF-RHF iter   7:  -149.94128152344112   -1.17804e-08   9.48299e-07 DIIS
-   @DF-RHF iter   8:  -149.94128152399941   -5.58288e-10   1.99235e-07 DIIS
-   @DF-RHF iter   9:  -149.94128152402277   -2.33626e-11   3.31202e-08 DIIS
-   @DF-RHF iter  10:  -149.94128152402365   -8.81073e-13   6.31001e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -148.42276116805363   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85415788514936   -1.43140e+00   1.55631e-02 DIIS
+   @DF-RHF iter   2:  -149.93915029987866   -8.49924e-02   2.54620e-03 DIIS
+   @DF-RHF iter   3:  -149.94111301416874   -1.96271e-03   6.21126e-04 DIIS
+   @DF-RHF iter   4:  -149.94127888955688   -1.65875e-04   6.28806e-05 DIIS
+   @DF-RHF iter   5:  -149.94128144855313   -2.55900e-06   1.07266e-05 DIIS
+   @DF-RHF iter   6:  -149.94128152245804   -7.39049e-08   1.68546e-06 DIIS
+   @DF-RHF iter   7:  -149.94128152398113   -1.52309e-09   2.96963e-07 DIIS
+   @DF-RHF iter   8:  -149.94128152402499   -4.38547e-11   3.32323e-08 DIIS
+   @DF-RHF iter   9:  -149.94128152402556   -5.68434e-13   6.90158e-09 DIIS
+   @DF-RHF iter  10:  -149.94128152402570   -1.42109e-13   1.53556e-09 DIIS
+   @DF-RHF iter  11:  -149.94128152402575   -5.68434e-14   2.49157e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2263,14 +2156,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.94128152402365
+  @DF-RHF Final Energy:  -149.94128152402575
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4208727124812270
-    One-Electron Energy =                -282.8840414848510818
-    Two-Electron Energy =                  95.5218872483462036
-    Total Energy =                       -149.9412815240236228
+    One-Electron Energy =                -282.8840412881003203
+    Two-Electron Energy =                  95.5218870515933247
+    Total Energy =                       -149.9412815240257544
 
 Computation Completed
 
@@ -2292,18 +2185,18 @@ Properties computed using the SCF density matrix
      X:    -0.5295      Y:     1.6482      Z:    -0.1172     Total:     1.7351
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:53 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:55 2021
 Module time:
-	user time   =       0.75 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.72 seconds =       0.05 minutes
+	system time =       0.17 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.94 seconds =       0.10 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      20.89 seconds =       0.35 minutes
+	system time =       1.13 seconds =       0.02 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:53 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:55 2021
 
 
          ------------------------------------------------------------
@@ -2338,7 +2231,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -2349,18 +2242,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -2369,51 +2262,646 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000549823201     0.000209101786    -0.000043130497
-       2       -0.008948416239    -0.000509994580    -0.000335110307
-       3       -0.000014125255    -0.000007901237     0.000001129946
-       4        0.040281690479     0.015979687680     0.036438957391
-       5       -0.025453232313    -0.000967657428    -0.027271682024
-       6       -0.004781568525    -0.017019208368    -0.008532117845
-       7       -0.030966750988     0.021318704658    -0.037886828234
-       8        0.017633625049     0.000485893189     0.008597324178
-       9        0.012798600996    -0.019488625700     0.029031457392
+       1       -0.000549823242     0.000209101776    -0.000043130493
+       2       -0.008948416565    -0.000509994598    -0.000335110332
+       3       -0.000014125246    -0.000007901242     0.000001129934
+       4        0.040281686903     0.015979687733     0.036438957469
+       5       -0.025453229771    -0.000967657192    -0.027271682421
+       6       -0.004781567369    -0.017019208190    -0.008532117537
+       7       -0.030966751843     0.021318701207    -0.037886837534
+       8        0.017633628208     0.000485891565     0.008597326025
+       9        0.012798598929    -0.019488621061     0.029031464889
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:53 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:55 2021
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.09 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.18 seconds =       0.10 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =      21.99 seconds =       0.37 minutes
+	system time =       1.16 seconds =       0.02 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-       N-Body: Complex Energy (fragments = (2, 3), basis = (1, 2, 3):  -149.94128152402365)
+       N-Body: Complex Energy (fragments = (2, 3), basis = (1, 2, 3):  -149.94128152402575)
 
-       N-Body: Computing complex (3/3) with fragments (1, 2) in the basis of fragments (1, 2, 3).
+       N-Body: Computing complex (2/6) with fragments (1, 3) in the basis of fragments (1, 2, 3).
 
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:53 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:55 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =   37.415382693305901
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42343055720860   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85512004732598   -1.43169e+00   1.55424e-02 DIIS
+   @DF-RHF iter   2:  -149.93983658165723   -8.47165e-02   2.55465e-03 DIIS
+   @DF-RHF iter   3:  -149.94180694368487   -1.97036e-03   6.22886e-04 DIIS
+   @DF-RHF iter   4:  -149.94197403138347   -1.67088e-04   6.29977e-05 DIIS
+   @DF-RHF iter   5:  -149.94197662131765   -2.58993e-06   9.62406e-06 DIIS
+   @DF-RHF iter   6:  -149.94197668209500   -6.07774e-08   1.35366e-06 DIIS
+   @DF-RHF iter   7:  -149.94197668300188   -9.06880e-10   2.43900e-07 DIIS
+   @DF-RHF iter   8:  -149.94197668303084   -2.89617e-11   3.14208e-08 DIIS
+   @DF-RHF iter   9:  -149.94197668303158   -7.38964e-13   6.02918e-09 DIIS
+   @DF-RHF iter  10:  -149.94197668303138    1.98952e-13   1.36824e-09 DIIS
+   @DF-RHF iter  11:  -149.94197668303150   -1.13687e-13   2.40355e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267811     2A    -20.210878     3A     -1.288127  
+       4A     -1.238662     5A     -0.641682     6A     -0.595283  
+       7A     -0.479087     8A     -0.434364     9A     -0.399371  
+      10A     -0.365796  
+
+    Virtual:                                                              
+
+      11A      0.493284    12A      0.606245    13A      0.650587  
+      14A      0.731276    15A      0.787335    16A      1.032393  
+      17A      1.375231    18A      2.549012    19A      2.952949  
+      20A      3.283171    21A     31.266059  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94197668303150
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4153826933059008
+    One-Electron Energy =                -282.8726006394040837
+    Two-Electron Energy =                  95.5152412630667129
+    Total Energy =                       -149.9419766830314700
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:   -25.8236      Y:    16.1783      Z:     0.3984
+
+  Electronic Dipole Moment: [e a0]
+     X:    25.3512      Y:   -16.7430      Z:    -0.4030
+
+  Dipole Moment: [e a0]
+     X:    -0.4724      Y:    -0.5647      Z:    -0.0046     Total:     0.7362
+
+  Dipole Moment: [D]
+     X:    -1.2007      Y:    -1.4353      Z:    -0.0118     Total:     1.8713
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:56 2021
+Module time:
+	user time   =       2.66 seconds =       0.04 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      24.73 seconds =       0.41 minutes
+	system time =       1.31 seconds =       0.02 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:56 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.415382693305901
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.004267649267    -0.040337037581     0.036257495302
+       2       -0.009096763259     0.016148452156    -0.008510788515
+       3        0.011706157050     0.022501916118    -0.027420792138
+       4        0.000077877783    -0.000630171390    -0.000065662305
+       5        0.000017101472    -0.000007706075     0.000000960721
+       6        0.005333224589    -0.008144547128     0.000059160371
+       7       -0.032823748906     0.024083254550    -0.038289292876
+       8        0.016902899857     0.005424869867     0.008657959184
+       9        0.012150900680    -0.019039030518     0.029310960256
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:56 2021
+Module time:
+	user time   =       1.32 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      26.06 seconds =       0.43 minutes
+	system time =       1.37 seconds =       0.02 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 2, 3):  -149.94197668303150)
+
+       N-Body: Computing complex (3/6) with fragments (1, 2) in the basis of fragments (1, 2).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:56 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.67094  B =      0.23246  C =      0.17553 [cm^-1]
+  Rotational constants: A =  20114.15437  B =   6968.93165  C =   5262.27541 [MHz]
+  Nuclear repulsion =   37.327766624605843
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4074143904E-01.
+  Reciprocal condition number of the overlap matrix is 1.7130997866E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42214055849547   -1.48422e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.84240283214106   -1.42026e+00   2.37340e-02 DIIS
+   @DF-RHF iter   2:  -149.93111317893846   -8.87103e-02   3.67265e-03 DIIS
+   @DF-RHF iter   3:  -149.93291805035179   -1.80487e-03   8.96030e-04 DIIS
+   @DF-RHF iter   4:  -149.93306601266352   -1.47962e-04   9.43642e-05 DIIS
+   @DF-RHF iter   5:  -149.93306839980573   -2.38714e-06   2.53037e-05 DIIS
+   @DF-RHF iter   6:  -149.93306858856747   -1.88762e-07   2.37939e-06 DIIS
+   @DF-RHF iter   7:  -149.93306858994799   -1.38053e-09   2.69811e-07 DIIS
+   @DF-RHF iter   8:  -149.93306858996209   -1.40972e-11   3.51726e-08 DIIS
+   @DF-RHF iter   9:  -149.93306858996249   -3.97904e-13   6.07949e-09 DIIS
+   @DF-RHF iter  10:  -149.93306858996249    0.00000e+00   1.34393e-09 DIIS
+   @DF-RHF iter  11:  -149.93306858996237    1.13687e-13   2.64817e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.265778     2A    -20.201128     3A     -1.286129  
+       4A     -1.234946     5A     -0.640245     6A     -0.590711  
+       7A     -0.474712     8A     -0.430649     9A     -0.397718  
+      10A     -0.361496  
+
+    Virtual:                                                              
+
+      11A      0.564996    12A      0.653937    13A      0.715582  
+      14A      0.790788  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.93306858996237
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.3277666246058430
+    One-Electron Energy =                -282.7546452438276674
+    Two-Electron Energy =                  95.4938100292594640
+    Total Energy =                       -149.9330685899623745
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:     1.9166      Y:    30.1845      Z:     1.4308
+
+  Dipole Moment: [e a0]
+     X:     0.6989      Y:    -0.0934      Z:     0.8053     Total:     1.0704
+
+  Dipole Moment: [D]
+     X:     1.7764      Y:    -0.2373      Z:     2.0469     Total:     2.7207
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:57 2021
+Module time:
+	user time   =       2.39 seconds =       0.04 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      28.54 seconds =       0.48 minutes
+	system time =       1.46 seconds =       0.02 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:57 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Nuclear repulsion =   37.327766624605843
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000514722108    -0.037127087441     0.035083275646
+       2       -0.012784506838     0.013325048939    -0.007564197332
+       3        0.012040366437     0.024224890095    -0.027130542573
+       4        0.037567671733     0.016310280228     0.034554671458
+       5       -0.026923064684    -0.001483113818    -0.026942059520
+       6       -0.009385744538    -0.015250018005    -0.008001147680
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:57 2021
+Module time:
+	user time   =       1.03 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      29.59 seconds =       0.49 minutes
+	system time =       1.53 seconds =       0.03 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2):  -149.93306858996237)
+
+       N-Body: Computing complex (4/6) with fragments (1, 2) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:57 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2455,15 +2943,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -2473,66 +2961,68 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21      10      10      10       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -149.49958431295681   -1.49500e+02   9.99255e-02 
-   @DF-RHF iter   1:  -149.88201378255411   -3.82429e-01   1.22758e-02 
-   @DF-RHF iter   2:  -149.93681036495354   -5.47966e-02   2.52423e-03 DIIS
-   @DF-RHF iter   3:  -149.93987775315614   -3.06739e-03   9.56796e-04 DIIS
-   @DF-RHF iter   4:  -149.94051798476517   -6.40232e-04   2.00940e-04 DIIS
-   @DF-RHF iter   5:  -149.94054813534385   -3.01506e-05   1.71701e-05 DIIS
-   @DF-RHF iter   6:  -149.94054830222427   -1.66880e-07   3.30234e-06 DIIS
-   @DF-RHF iter   7:  -149.94054830802949   -5.80522e-09   7.42610e-07 DIIS
-   @DF-RHF iter   8:  -149.94054830838618   -3.56692e-10   1.58756e-07 DIIS
-   @DF-RHF iter   9:  -149.94054830840383   -1.76499e-11   3.14480e-08 DIIS
-   @DF-RHF iter  10:  -149.94054830840446   -6.25278e-13   4.78075e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -148.42214207219814   -1.48422e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85190205588856   -1.42976e+00   1.57310e-02 DIIS
+   @DF-RHF iter   2:  -149.93842595354545   -8.65239e-02   2.56698e-03 DIIS
+   @DF-RHF iter   3:  -149.94038052277008   -1.95457e-03   6.20766e-04 DIIS
+   @DF-RHF iter   4:  -149.94054559491440   -1.65072e-04   6.37604e-05 DIIS
+   @DF-RHF iter   5:  -149.94054824286684   -2.64795e-06   9.91316e-06 DIIS
+   @DF-RHF iter   6:  -149.94054830732006   -6.44532e-08   1.44085e-06 DIIS
+   @DF-RHF iter   7:  -149.94054830836797   -1.04791e-09   2.53217e-07 DIIS
+   @DF-RHF iter   8:  -149.94054830839980   -3.18323e-11   3.21508e-08 DIIS
+   @DF-RHF iter   9:  -149.94054830840014   -3.41061e-13   6.14624e-09 DIIS
+   @DF-RHF iter  10:  -149.94054830840005    8.52651e-14   1.36595e-09 DIIS
+   @DF-RHF iter  11:  -149.94054830840005    0.00000e+00   2.33298e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2558,14 +3048,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.94054830840446
+  @DF-RHF Final Energy:  -149.94054830840005
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.3277666246058430
-    One-Electron Energy =                -282.6935374603000355
-    Two-Electron Energy =                  95.4252225272897476
-    Total Energy =                       -149.9405483084044590
+    One-Electron Energy =                -282.6935372844796461
+    Two-Electron Energy =                  95.4252223514737921
+    Total Energy =                       -149.9405483084000252
 
 Computation Completed
 
@@ -2587,18 +3077,18 @@ Properties computed using the SCF density matrix
      X:     1.7314      Y:    -0.3781      Z:     2.0584     Total:     2.7162
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:54 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:58 2021
 Module time:
-	user time   =       0.80 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       2.80 seconds =       0.05 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.98 seconds =       0.12 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      32.47 seconds =       0.54 minutes
+	system time =       1.69 seconds =       0.03 minutes
+	total time  =          7 seconds =       0.12 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:54 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:58 2021
 
 
          ------------------------------------------------------------
@@ -2633,7 +3123,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -2644,18 +3134,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -2664,63 +3154,657 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.006229530807    -0.044069543450     0.035292718312
-       2       -0.012839580074     0.013426298090    -0.006942744491
-       3        0.012305212436     0.022340111494    -0.027872444273
-       4        0.038047756017     0.016092140193     0.034472229573
-       5       -0.026878415010    -0.001431916762    -0.027008964285
-       6       -0.009250259241    -0.015250722777    -0.007822264425
-       7        0.000487157308     0.000396299429     0.000017340997
-       8        0.004357241077     0.008480434392    -0.000133273839
-       9        0.000000418296     0.000016899390    -0.000002597570
+       1       -0.006229531168    -0.044069536173     0.035292714653
+       2       -0.012839577968     0.013426294019    -0.006942742419
+       3        0.012305210764     0.022340107707    -0.027872442638
+       4        0.038047756039     0.016092138638     0.034472222756
+       5       -0.026878414324    -0.001431916653    -0.027008960704
+       6       -0.009250260362    -0.015250721339    -0.007822261229
+       7        0.000487157254     0.000396299312     0.000017340997
+       8        0.004357241490     0.008480435128    -0.000133273832
+       9        0.000000418275     0.000016899360    -0.000002597583
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:54 2018
+*** tstop() called on dorje at Mon Jun 28 10:21:58 2021
 Module time:
-	user time   =       0.32 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.35 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.30 seconds =       0.12 minutes
-	system time =       0.08 seconds =       0.00 minutes
+	user time   =      33.84 seconds =       0.56 minutes
+	system time =       1.75 seconds =       0.03 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2, 3):  -149.94054830840005)
+
+       N-Body: Computing complex (5/6) with fragments (2, 3) in the basis of fragments (2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:58 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.66182  B =      0.23462  C =      0.17637 [cm^-1]
+  Rotational constants: A =  19840.79823  B =   7033.78531  C =   5287.47319 [MHz]
+  Nuclear repulsion =   37.420872712481227
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4063509175E-01.
+  Reciprocal condition number of the overlap matrix is 1.7073707716E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42275901194398   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.84541804362291   -1.42266e+00   2.34649e-02 DIIS
+   @DF-RHF iter   2:  -149.93239709894922   -8.69791e-02   3.66308e-03 DIIS
+   @DF-RHF iter   3:  -149.93422927268182   -1.83217e-03   8.99010e-04 DIIS
+   @DF-RHF iter   4:  -149.93437902657135   -1.49754e-04   9.36437e-05 DIIS
+   @DF-RHF iter   5:  -149.93438133921768   -2.31265e-06   2.68389e-05 DIIS
+   @DF-RHF iter   6:  -149.93438155141448   -2.12197e-07   2.29950e-06 DIIS
+   @DF-RHF iter   7:  -149.93438155269646   -1.28199e-09   2.77310e-07 DIIS
+   @DF-RHF iter   8:  -149.93438155271139   -1.49214e-11   3.53087e-08 DIIS
+   @DF-RHF iter   9:  -149.93438155271184   -4.54747e-13   7.13004e-09 DIIS
+   @DF-RHF iter  10:  -149.93438155271184    0.00000e+00   1.59469e-09 DIIS
+   @DF-RHF iter  11:  -149.93438155271187   -2.84217e-14   2.84833e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267820     2A    -20.198469     3A     -1.287836  
+       4A     -1.233326     5A     -0.640430     6A     -0.591319  
+       7A     -0.477995     8A     -0.431952     9A     -0.395682  
+      10A     -0.360233  
+
+    Virtual:                                                              
+
+      11A      0.566153    12A      0.655627    13A      0.714253  
+      14A      0.791629  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.93438155271187
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4208727124812270
+    One-Electron Energy =                -282.9403861622593013
+    Two-Electron Energy =                  95.5851318970661907
+    Total Energy =                       -149.9343815527118693
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    27.0414      Y:    14.0996      Z:     0.2271
+
+  Electronic Dipole Moment: [e a0]
+     X:   -27.3022      Y:   -13.4634      Z:    -0.2787
+
+  Dipole Moment: [e a0]
+     X:    -0.2608      Y:     0.6362      Z:    -0.0516     Total:     0.6895
+
+  Dipole Moment: [D]
+     X:    -0.6630      Y:     1.6170      Z:    -0.1313     Total:     1.7525
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:58 2021
+Module time:
+	user time   =       2.32 seconds =       0.04 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      36.24 seconds =       0.60 minutes
+	system time =       1.88 seconds =       0.03 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:58 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.420872712481227
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.031900039037     0.017463505741     0.035812885098
+       2       -0.026884139456    -0.002207374601    -0.026506365209
+       3       -0.004646857501    -0.016899689458    -0.009059839540
+       4       -0.030912398333     0.020784406626    -0.037975568650
+       5        0.017684289633     0.000367195807     0.008761535423
+       6        0.012859066624    -0.019508044117     0.028967352877
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:58 2021
+Module time:
+	user time   =       0.70 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      36.95 seconds =       0.62 minutes
+	system time =       1.92 seconds =       0.03 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+       N-Body: Complex Energy (fragments = (2, 3), basis = (2, 3):  -149.93438155271187)
+
+       N-Body: Computing complex (6/6) with fragments (1, 3) in the basis of fragments (1, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:58 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.66207  B =      0.23435  C =      0.17633 [cm^-1]
+  Rotational constants: A =  19848.38696  B =   7025.55974  C =   5286.37823 [MHz]
+  Nuclear repulsion =   37.415382693305901
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4069553340E-01.
+  Reciprocal condition number of the overlap matrix is 1.7095996847E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42342828985721   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.84546993007632   -1.42204e+00   2.34575e-02 DIIS
+   @DF-RHF iter   2:  -149.93239821743103   -8.69283e-02   3.65643e-03 DIIS
+   @DF-RHF iter   3:  -149.93422050124096   -1.82228e-03   8.97079e-04 DIIS
+   @DF-RHF iter   4:  -149.93436936133170   -1.48860e-04   9.32679e-05 DIIS
+   @DF-RHF iter   5:  -149.93437168523073   -2.32390e-06   2.53277e-05 DIIS
+   @DF-RHF iter   6:  -149.93437187353260   -1.88302e-07   2.29602e-06 DIIS
+   @DF-RHF iter   7:  -149.93437187480879   -1.27619e-09   2.76333e-07 DIIS
+   @DF-RHF iter   8:  -149.93437187482354   -1.47509e-11   3.37671e-08 DIIS
+   @DF-RHF iter   9:  -149.93437187482388   -3.41061e-13   6.15355e-09 DIIS
+   @DF-RHF iter  10:  -149.93437187482385    2.84217e-14   1.39739e-09 DIIS
+   @DF-RHF iter  11:  -149.93437187482397   -1.13687e-13   2.68754e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267572     2A    -20.197942     3A     -1.287848  
+       4A     -1.232673     5A     -0.641232     6A     -0.590389  
+       7A     -0.477963     8A     -0.430709     9A     -0.396328  
+      10A     -0.359544  
+
+    Virtual:                                                              
+
+      11A      0.565402    12A      0.656605    13A      0.715036  
+      14A      0.792872  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.93437187482397
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4153826933059008
+    One-Electron Energy =                -282.9351101924351042
+    Two-Electron Energy =                  95.5853556243052367
+    Total Energy =                       -149.9343718748239667
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:   -25.8236      Y:    16.1783      Z:     0.3984
+
+  Electronic Dipole Moment: [e a0]
+     X:    25.3912      Y:   -16.7858      Z:    -0.3985
+
+  Dipole Moment: [e a0]
+     X:    -0.4325      Y:    -0.6075      Z:    -0.0002     Total:     0.7457
+
+  Dipole Moment: [D]
+     X:    -1.0992      Y:    -1.5441      Z:    -0.0004     Total:     1.8954
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:59 2021
+Module time:
+	user time   =       2.35 seconds =       0.04 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      39.39 seconds =       0.66 minutes
+	system time =       2.05 seconds =       0.03 minutes
 	total time  =          8 seconds =       0.13 minutes
 
-       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2, 3):  -149.94054830840446)
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:59 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.415382693305901
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.003827754042    -0.039988270618     0.036338095126
+       2       -0.009039790337     0.016264674898    -0.008676662196
+       3        0.011690203035     0.022568702438    -0.027356037131
+       4       -0.029246801695     0.015450908312    -0.038208637183
+       5        0.016622886062     0.005457681247     0.009236272270
+       6        0.013801256976    -0.019753696279     0.028666969114
+
+
+*** tstop() called on dorje at Mon Jun 28 10:21:59 2021
+Module time:
+	user time   =       0.72 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      40.12 seconds =       0.67 minutes
+	system time =       2.08 seconds =       0.03 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 3):  -149.93437187482397)
 
    ==> N-Body: Counterpoise Corrected (CP) energies <==
 
    n-Body     Total Energy [Eh]       I.E. [kcal/mol]      Delta [kcal/mol]
-        1     -224.890393543771        0.000000000000        0.000000000000
-        2     -224.892193698865       -1.129614375488       -1.129614375488
+        1     -224.890393543774        0.000000000000        0.000000000000
+        2     -224.892193698871       -1.129614377414       -1.129614377414
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line   130 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    15 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1, 4, 7       entry O          line   130 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    15 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Interaction Energy.......................................................PASSED
+    CP-Corrected Interaction Energy.......................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:54 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:21:59 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2762,15 +3846,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -2780,66 +3864,68 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21      10      10      10       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -149.49958431295681   -1.49500e+02   9.99255e-02 
-   @DF-RHF iter   1:  -149.88201378255411   -3.82429e-01   1.22758e-02 
-   @DF-RHF iter   2:  -149.93681036495354   -5.47966e-02   2.52423e-03 DIIS
-   @DF-RHF iter   3:  -149.93987775315614   -3.06739e-03   9.56796e-04 DIIS
-   @DF-RHF iter   4:  -149.94051798476517   -6.40232e-04   2.00940e-04 DIIS
-   @DF-RHF iter   5:  -149.94054813534385   -3.01506e-05   1.71701e-05 DIIS
-   @DF-RHF iter   6:  -149.94054830222427   -1.66880e-07   3.30234e-06 DIIS
-   @DF-RHF iter   7:  -149.94054830802949   -5.80522e-09   7.42610e-07 DIIS
-   @DF-RHF iter   8:  -149.94054830838618   -3.56692e-10   1.58756e-07 DIIS
-   @DF-RHF iter   9:  -149.94054830840383   -1.76499e-11   3.14480e-08 DIIS
-   @DF-RHF iter  10:  -149.94054830840446   -6.25278e-13   4.78075e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -148.42214207219808   -1.48422e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85190205588853   -1.42976e+00   1.57310e-02 DIIS
+   @DF-RHF iter   2:  -149.93842595354536   -8.65239e-02   2.56698e-03 DIIS
+   @DF-RHF iter   3:  -149.94038052277011   -1.95457e-03   6.20766e-04 DIIS
+   @DF-RHF iter   4:  -149.94054559491425   -1.65072e-04   6.37604e-05 DIIS
+   @DF-RHF iter   5:  -149.94054824286670   -2.64795e-06   9.91316e-06 DIIS
+   @DF-RHF iter   6:  -149.94054830731994   -6.44532e-08   1.44085e-06 DIIS
+   @DF-RHF iter   7:  -149.94054830836802   -1.04808e-09   2.53217e-07 DIIS
+   @DF-RHF iter   8:  -149.94054830839954   -3.15197e-11   3.21508e-08 DIIS
+   @DF-RHF iter   9:  -149.94054830840000   -4.54747e-13   6.14624e-09 DIIS
+   @DF-RHF iter  10:  -149.94054830840003   -2.84217e-14   1.36595e-09 DIIS
+   @DF-RHF iter  11:  -149.94054830839994    8.52651e-14   2.33298e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2865,14 +3951,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.94054830840446
+  @DF-RHF Final Energy:  -149.94054830839994
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.3277666246058430
-    One-Electron Energy =                -282.6935374603000355
-    Two-Electron Energy =                  95.4252225272897476
-    Total Energy =                       -149.9405483084044590
+    One-Electron Energy =                -282.6935372844794188
+    Two-Electron Energy =                  95.4252223514736500
+    Total Energy =                       -149.9405483083999400
 
 Computation Completed
 
@@ -2894,18 +3980,18 @@ Properties computed using the SCF density matrix
      X:     1.7314      Y:    -0.3781      Z:     2.0584     Total:     2.7162
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:55 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:00 2021
 Module time:
-	user time   =       0.77 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.54 seconds =       0.04 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.19 seconds =       0.14 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	user time   =      43.86 seconds =       0.73 minutes
+	system time =       2.25 seconds =       0.04 minutes
 	total time  =          9 seconds =       0.15 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:55 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:00 2021
 
 
          ------------------------------------------------------------
@@ -2940,7 +4026,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -2951,18 +4037,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -2971,48 +4057,58 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.006229530807    -0.044069543450     0.035292718312
-       2       -0.012839580074     0.013426298090    -0.006942744491
-       3        0.012305212436     0.022340111494    -0.027872444273
-       4        0.038047756017     0.016092140193     0.034472229573
-       5       -0.026878415010    -0.001431916762    -0.027008964285
-       6       -0.009250259241    -0.015250722777    -0.007822264425
-       7        0.000487157308     0.000396299429     0.000017340997
-       8        0.004357241077     0.008480434392    -0.000133273839
-       9        0.000000418296     0.000016899390    -0.000002597570
+       1       -0.006229530494    -0.044069536658     0.035292714999
+       2       -0.012839578652     0.013426294332    -0.006942742498
+       3        0.012305210854     0.022340107935    -0.027872442902
+       4        0.038047756276     0.016092139169     0.034472223229
+       5       -0.026878414728    -0.001431916583    -0.027008961088
+       6       -0.009250260239    -0.015250721921    -0.007822261319
+       7        0.000487157249     0.000396299334     0.000017341003
+       8        0.004357241462     0.008480435017    -0.000133273840
+       9        0.000000418273     0.000016899374    -0.000002597585
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:55 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:00 2021
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.12 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.42 seconds =       0.14 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	user time   =      44.99 seconds =       0.75 minutes
+	system time =       2.31 seconds =       0.04 minutes
 	total time  =          9 seconds =       0.15 minutes
-	Energy of ((1, 2), (1, 2, 3)).....................................PASSED
-	Gradient of ((1, 2), (1, 2, 3))...................................PASSED
+    Energy of ((1, 2), (1, 2, 3)).........................................................PASSED
+    Energy of ((1, 2), (1, 2, 3)).........................................................PASSED
+    Energy of ((1, 2), (1, 2, 3)).........................................................PASSED
+    Energy of ((1, 2), (1, 2, 3)).........................................................PASSED
+    Gradient RMS of ((1, 2), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((1, 2), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((1, 2), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((1, 2), (1, 2, 3))...................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:55 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:00 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3054,15 +4150,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -3072,66 +4168,68 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21      10      10      10       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -149.53331342702992   -1.49533e+02   1.00079e-01 
-   @DF-RHF iter   1:  -149.87294430945232   -3.39631e-01   1.31754e-02 
-   @DF-RHF iter   2:  -149.93729770499769   -6.43534e-02   2.81606e-03 DIIS
-   @DF-RHF iter   3:  -149.94117629256391   -3.87859e-03   1.05498e-03 DIIS
-   @DF-RHF iter   4:  -149.94193951082062   -7.63218e-04   2.24461e-04 DIIS
-   @DF-RHF iter   5:  -149.94197655326627   -3.70424e-05   1.55085e-05 DIIS
-   @DF-RHF iter   6:  -149.94197667732826   -1.24062e-07   3.17441e-06 DIIS
-   @DF-RHF iter   7:  -149.94197668262368   -5.29542e-09   7.50058e-07 DIIS
-   @DF-RHF iter   8:  -149.94197668298361   -3.59933e-10   1.69720e-07 DIIS
-   @DF-RHF iter   9:  -149.94197668300373   -2.01226e-11   3.29334e-08 DIIS
-   @DF-RHF iter  10:  -149.94197668300447   -7.38964e-13   5.80204e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -148.42343055720858   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85512004732593   -1.43169e+00   1.55424e-02 DIIS
+   @DF-RHF iter   2:  -149.93983658165723   -8.47165e-02   2.55465e-03 DIIS
+   @DF-RHF iter   3:  -149.94180694368481   -1.97036e-03   6.22886e-04 DIIS
+   @DF-RHF iter   4:  -149.94197403138352   -1.67088e-04   6.29977e-05 DIIS
+   @DF-RHF iter   5:  -149.94197662131762   -2.58993e-06   9.62406e-06 DIIS
+   @DF-RHF iter   6:  -149.94197668209506   -6.07774e-08   1.35366e-06 DIIS
+   @DF-RHF iter   7:  -149.94197668300171   -9.06653e-10   2.43900e-07 DIIS
+   @DF-RHF iter   8:  -149.94197668303090   -2.91891e-11   3.14208e-08 DIIS
+   @DF-RHF iter   9:  -149.94197668303144   -5.40012e-13   6.02918e-09 DIIS
+   @DF-RHF iter  10:  -149.94197668303133    1.13687e-13   1.36824e-09 DIIS
+   @DF-RHF iter  11:  -149.94197668303153   -1.98952e-13   2.40355e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -3157,14 +4255,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.94197668300447
+  @DF-RHF Final Energy:  -149.94197668303153
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4153826933059008
-    One-Electron Energy =                -282.8726007897899990
-    Two-Electron Energy =                  95.5152414134796146
-    Total Energy =                       -149.9419766830044978
+    One-Electron Energy =                -282.8726006394040837
+    Two-Electron Energy =                  95.5152412630666703
+    Total Energy =                       -149.9419766830314984
 
 Computation Completed
 
@@ -3186,18 +4284,18 @@ Properties computed using the SCF density matrix
      X:    -1.2007      Y:    -1.4353      Z:    -0.0118     Total:     1.8713
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:56 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:01 2021
 Module time:
-	user time   =       0.78 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       3.16 seconds =       0.05 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       9.21 seconds =       0.15 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	user time   =      48.26 seconds =       0.80 minutes
+	system time =       2.47 seconds =       0.04 minutes
 	total time  =         10 seconds =       0.17 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:56 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:01 2021
 
 
          ------------------------------------------------------------
@@ -3232,7 +4330,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -3243,18 +4341,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -3263,48 +4361,58 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.004267645613    -0.040337039032     0.036257505886
-       2       -0.009096766871     0.016148452367    -0.008510794777
-       3        0.011706157221     0.022501917739    -0.027420796425
-       4        0.000077877850    -0.000630171233    -0.000065662310
-       5        0.000017101481    -0.000007706069     0.000000960728
-       6        0.005333224388    -0.008144547108     0.000059160340
-       7       -0.032823753946     0.024083255072    -0.038289296288
-       8        0.016902902322     0.005424869235     0.008657960702
-       9        0.012150903166    -0.019039030973     0.029310962144
+       1       -0.004267649254    -0.040337037374     0.036257495213
+       2       -0.009096763207     0.016148452034    -0.008510788505
+       3        0.011706156977     0.022501916019    -0.027420792060
+       4        0.000077877783    -0.000630171406    -0.000065662306
+       5        0.000017101471    -0.000007706077     0.000000960721
+       6        0.005333224573    -0.008144547079     0.000059160375
+       7       -0.032823748985     0.024083254607    -0.038289292986
+       8        0.016902899943     0.005424869897     0.008657959201
+       9        0.012150900698    -0.019039030624     0.029310960348
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:57 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:01 2021
 Module time:
-	user time   =       0.22 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.43 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.43 seconds =       0.16 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
-	Energy of ((1, 3), (1, 2, 3)).....................................PASSED
-	Gradient of ((1, 3), (1, 2, 3))...................................PASSED
+	user time   =      49.70 seconds =       0.83 minutes
+	system time =       2.55 seconds =       0.04 minutes
+	total time  =         10 seconds =       0.17 minutes
+    Energy of ((1, 3), (1, 2, 3)).........................................................PASSED
+    Energy of ((1, 3), (1, 2, 3)).........................................................PASSED
+    Energy of ((1, 3), (1, 2, 3)).........................................................PASSED
+    Energy of ((1, 3), (1, 2, 3)).........................................................PASSED
+    Gradient RMS of ((1, 3), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((1, 3), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((1, 3), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((1, 3), (1, 2, 3))...................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:57 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:01 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3346,15 +4454,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -3364,66 +4472,68 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21      10      10      10       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -149.52824159360756   -1.49528e+02   1.00087e-01 
-   @DF-RHF iter   1:  -149.87199144531388   -3.43750e-01   1.32915e-02 
-   @DF-RHF iter   2:  -149.93672991181495   -6.47385e-02   2.73808e-03 DIIS
-   @DF-RHF iter   3:  -149.94045820553387   -3.72829e-03   1.05471e-03 DIIS
-   @DF-RHF iter   4:  -149.94125060250929   -7.92397e-04   2.04814e-04 DIIS
-   @DF-RHF iter   5:  -149.94128129675170   -3.06942e-05   2.05991e-05 DIIS
-   @DF-RHF iter   6:  -149.94128151166075   -2.14909e-07   4.56707e-06 DIIS
-   @DF-RHF iter   7:  -149.94128152344112   -1.17804e-08   9.48299e-07 DIIS
-   @DF-RHF iter   8:  -149.94128152399941   -5.58288e-10   1.99235e-07 DIIS
-   @DF-RHF iter   9:  -149.94128152402277   -2.33626e-11   3.31202e-08 DIIS
-   @DF-RHF iter  10:  -149.94128152402365   -8.81073e-13   6.31001e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -148.42276116805363   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85415788514945   -1.43140e+00   1.55631e-02 DIIS
+   @DF-RHF iter   2:  -149.93915029987866   -8.49924e-02   2.54620e-03 DIIS
+   @DF-RHF iter   3:  -149.94111301416854   -1.96271e-03   6.21126e-04 DIIS
+   @DF-RHF iter   4:  -149.94127888955686   -1.65875e-04   6.28806e-05 DIIS
+   @DF-RHF iter   5:  -149.94128144855313   -2.55900e-06   1.07266e-05 DIIS
+   @DF-RHF iter   6:  -149.94128152245807   -7.39049e-08   1.68546e-06 DIIS
+   @DF-RHF iter   7:  -149.94128152398127   -1.52320e-09   2.96963e-07 DIIS
+   @DF-RHF iter   8:  -149.94128152402487   -4.35989e-11   3.32323e-08 DIIS
+   @DF-RHF iter   9:  -149.94128152402558   -7.10543e-13   6.90158e-09 DIIS
+   @DF-RHF iter  10:  -149.94128152402567   -8.52651e-14   1.53556e-09 DIIS
+   @DF-RHF iter  11:  -149.94128152402567    0.00000e+00   2.49156e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -3449,14 +4559,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [    10 ]
 
-  @DF-RHF Final Energy:  -149.94128152402365
+  @DF-RHF Final Energy:  -149.94128152402567
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             37.4208727124812270
-    One-Electron Energy =                -282.8840414848510818
-    Two-Electron Energy =                  95.5218872483462036
-    Total Energy =                       -149.9412815240236228
+    One-Electron Energy =                -282.8840412881000930
+    Two-Electron Energy =                  95.5218870515931684
+    Total Energy =                       -149.9412815240256691
 
 Computation Completed
 
@@ -3478,18 +4588,18 @@ Properties computed using the SCF density matrix
      X:    -0.5295      Y:     1.6482      Z:    -0.1172     Total:     1.7351
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:57 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:02 2021
 Module time:
-	user time   =       0.75 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       3.14 seconds =       0.05 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      10.19 seconds =       0.17 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =      52.94 seconds =       0.88 minutes
+	system time =       2.71 seconds =       0.05 minutes
 	total time  =         11 seconds =       0.18 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:57 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:02 2021
 
 
          ------------------------------------------------------------
@@ -3524,7 +4634,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -3535,18 +4645,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -3555,48 +4665,58 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000549823201     0.000209101786    -0.000043130497
-       2       -0.008948416239    -0.000509994580    -0.000335110307
-       3       -0.000014125255    -0.000007901237     0.000001129946
-       4        0.040281690479     0.015979687680     0.036438957391
-       5       -0.025453232313    -0.000967657428    -0.027271682024
-       6       -0.004781568525    -0.017019208368    -0.008532117845
-       7       -0.030966750988     0.021318704658    -0.037886828234
-       8        0.017633625049     0.000485893189     0.008597324178
-       9        0.012798600996    -0.019488625700     0.029031457392
+       1       -0.000549823234     0.000209101776    -0.000043130495
+       2       -0.008948416488    -0.000509994593    -0.000335110336
+       3       -0.000014125254    -0.000007901243     0.000001129940
+       4        0.040281687045     0.015979688092     0.036438957764
+       5       -0.025453230022    -0.000967657137    -0.027271682660
+       6       -0.004781567322    -0.017019208621    -0.008532117596
+       7       -0.030966752225     0.021318701002    -0.037886837780
+       8        0.017633628523     0.000485891891     0.008597326077
+       9        0.012798598979    -0.019488621168     0.029031465086
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:58 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:02 2021
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.42 seconds =       0.17 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
-	Energy of ((2, 3), (1, 2, 3)).....................................PASSED
-	Gradient of ((2, 3), (1, 2, 3))...................................PASSED
+	user time   =      54.30 seconds =       0.90 minutes
+	system time =       2.76 seconds =       0.05 minutes
+	total time  =         11 seconds =       0.18 minutes
+    Energy of ((2, 3), (1, 2, 3)).........................................................PASSED
+    Energy of ((2, 3), (1, 2, 3)).........................................................PASSED
+    Energy of ((2, 3), (1, 2, 3)).........................................................PASSED
+    Energy of ((2, 3), (1, 2, 3)).........................................................PASSED
+    Gradient RMS of ((2, 3), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((2, 3), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((2, 3), (1, 2, 3))...................................................PASSED
+    Gradient RMS of ((2, 3), (1, 2, 3))...................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:58 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:02 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3638,15 +4758,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -3656,66 +4776,67 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21       5       5       5       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.76943578326231   -7.47694e+01   7.05177e-02 
-   @DF-RHF iter   1:   -74.93057291213378   -1.61137e-01   1.02237e-02 
-   @DF-RHF iter   2:   -74.96785478643716   -3.72819e-02   2.15969e-03 DIIS
-   @DF-RHF iter   3:   -74.96995859978860   -2.10381e-03   8.09360e-04 DIIS
-   @DF-RHF iter   4:   -74.97040122927963   -4.42629e-04   1.62299e-04 DIIS
-   @DF-RHF iter   5:   -74.97042051515783   -1.92859e-05   1.53629e-05 DIIS
-   @DF-RHF iter   6:   -74.97042065381785   -1.38660e-07   2.59848e-06 DIIS
-   @DF-RHF iter   7:   -74.97042065743258   -3.61473e-09   4.82097e-07 DIIS
-   @DF-RHF iter   8:   -74.97042065758917   -1.56589e-10   1.01437e-07 DIIS
-   @DF-RHF iter   9:   -74.97042065759673   -7.56017e-12   1.95152e-08 DIIS
-   @DF-RHF iter  10:   -74.97042065759720   -4.68958e-13   2.37661e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20292908468240   -7.42029e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92263609767691   -7.19707e-01   1.16865e-02 DIIS
+   @DF-RHF iter   2:   -74.96927826367435   -4.66422e-02   1.98794e-03 DIIS
+   @DF-RHF iter   3:   -74.97033405711942   -1.05579e-03   4.55406e-04 DIIS
+   @DF-RHF iter   4:   -74.97041925358101   -8.51965e-05   4.56427e-05 DIIS
+   @DF-RHF iter   5:   -74.97042060385074   -1.35027e-06   8.79231e-06 DIIS
+   @DF-RHF iter   6:   -74.97042065748768   -5.36369e-08   4.96493e-07 DIIS
+   @DF-RHF iter   7:   -74.97042065760219   -1.14511e-10   5.85646e-08 DIIS
+   @DF-RHF iter   8:   -74.97042065760409   -1.90425e-12   7.90968e-09 DIIS
+   @DF-RHF iter   9:   -74.97042065760405    4.26326e-14   1.91420e-09 DIIS
+   @DF-RHF iter  10:   -74.97042065760400    5.68434e-14   3.64990e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -3741,14 +4862,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97042065759720
+  @DF-RHF Final Energy:   -74.97042065760400
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.1889284979931887
-    Two-Electron Energy =                  38.0985795615909950
-    Total Energy =                        -74.9704206575971881
+    One-Electron Energy =                -122.1889285363744619
+    Two-Electron Energy =                  38.0985795999654684
+    Total Energy =                        -74.9704206576039951
 
 Computation Completed
 
@@ -3770,18 +4891,18 @@ Properties computed using the SCF density matrix
      X:     0.3868      Y:    -1.4204      Z:     1.0410     Total:     1.8030
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:58 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:03 2021
 Module time:
-	user time   =       0.79 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       3.72 seconds =       0.06 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      11.21 seconds =       0.19 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =      58.13 seconds =       0.97 minutes
+	system time =       2.95 seconds =       0.05 minutes
 	total time  =         12 seconds =       0.20 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:58 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:03 2021
 
 
          ------------------------------------------------------------
@@ -3816,7 +4937,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -3827,18 +4948,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -3847,48 +4968,58 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.005936480254    -0.047621130807     0.039078622230
-       2       -0.010347098089     0.015942129571    -0.009836149688
-       3        0.011267099763     0.023602966299    -0.029120435901
-       4        0.000148988996     0.000025243629    -0.000022690921
-       5        0.000010967308     0.000001674296    -0.000001547970
-       6        0.000207745728     0.000029486396    -0.000032447681
-       7        0.000572101774     0.000266556806     0.000029623492
-       8        0.004072970054     0.007742331308    -0.000093127015
-       9        0.000003704719     0.000010742501    -0.000001846547
+       1       -0.005936482488    -0.047621129400     0.039078619446
+       2       -0.010347097140     0.015942129105    -0.009836147844
+       3        0.011267101191     0.023602965581    -0.029120434953
+       4        0.000148988969     0.000025243665    -0.000022690914
+       5        0.000010967309     0.000001674294    -0.000001547972
+       6        0.000207745754     0.000029486354    -0.000032447682
+       7        0.000572101770     0.000266556845     0.000029623500
+       8        0.004072969913     0.007742331049    -0.000093127030
+       9        0.000003704721     0.000010742506    -0.000001846552
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:59 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:03 2021
 Module time:
-	user time   =       0.22 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =      11.43 seconds =       0.19 minutes
+	user time   =       2.41 seconds =       0.04 minutes
 	system time =       0.11 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
-	Energy of ((1,), (1, 2, 3)).......................................PASSED
-	Gradient of ((1,), (1, 2, 3)).....................................PASSED
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      60.57 seconds =       1.01 minutes
+	system time =       3.06 seconds =       0.05 minutes
+	total time  =         12 seconds =       0.20 minutes
+    Energy of ((1,), (1, 2, 3))...........................................................PASSED
+    Energy of ((1,), (1, 2, 3))...........................................................PASSED
+    Energy of ((1,), (1, 2, 3))...........................................................PASSED
+    Energy of ((1,), (1, 2, 3))...........................................................PASSED
+    Gradient RMS of ((1,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((1,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((1,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((1,), (1, 2, 3)).....................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:59 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:03 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3930,15 +5061,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -3948,66 +5079,67 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21       5       5       5       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.74161239909179   -7.47416e+01   7.04296e-02 
-   @DF-RHF iter   1:   -74.94034780931990   -1.98735e-01   8.89702e-03 
-   @DF-RHF iter   2:   -74.96780267325647   -2.74549e-02   1.87395e-03 DIIS
-   @DF-RHF iter   3:   -74.96947675629890   -1.67408e-03   7.56219e-04 DIIS
-   @DF-RHF iter   4:   -74.96988674258280   -4.09986e-04   1.31631e-04 DIIS
-   @DF-RHF iter   5:   -74.96989885332574   -1.21107e-05   1.09474e-05 DIIS
-   @DF-RHF iter   6:   -74.96989891766563   -6.43399e-08   2.17116e-06 DIIS
-   @DF-RHF iter   7:   -74.96989892024926   -2.58363e-09   4.01916e-07 DIIS
-   @DF-RHF iter   8:   -74.96989892036362   -1.14355e-10   8.94580e-08 DIIS
-   @DF-RHF iter   9:   -74.96989892036963   -6.01119e-12   1.47667e-08 DIIS
-   @DF-RHF iter  10:   -74.96989892036983   -1.98952e-13   1.80780e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20212107191563   -7.42021e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92187838021675   -7.19757e-01   1.17111e-02 DIIS
+   @DF-RHF iter   2:   -74.96877048612666   -4.68921e-02   1.97672e-03 DIIS
+   @DF-RHF iter   3:   -74.96981346520620   -1.04298e-03   4.53262e-04 DIIS
+   @DF-RHF iter   4:   -74.96989752646037   -8.40613e-05   4.54754e-05 DIIS
+   @DF-RHF iter   5:   -74.96989886791233   -1.34145e-06   8.68396e-06 DIIS
+   @DF-RHF iter   6:   -74.96989892025667   -5.23443e-08   4.77771e-07 DIIS
+   @DF-RHF iter   7:   -74.96989892036227   -1.05601e-10   5.60429e-08 DIIS
+   @DF-RHF iter   8:   -74.96989892036387   -1.60583e-12   7.92543e-09 DIIS
+   @DF-RHF iter   9:   -74.96989892036393   -5.68434e-14   1.91285e-09 DIIS
+   @DF-RHF iter  10:   -74.96989892036396   -2.84217e-14   3.66385e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -4033,14 +5165,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96989892036983
+  @DF-RHF Final Energy:   -74.96989892036396
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.1879518296377682
-    Two-Electron Energy =                  38.1012744379521138
-    Total Energy =                        -74.9698989203698289
+    One-Electron Energy =                -122.1879518597815490
+    Two-Electron Energy =                  38.1012744681017637
+    Total Energy =                        -74.9698989203639599
 
 Computation Completed
 
@@ -4062,18 +5194,18 @@ Properties computed using the SCF density matrix
      X:     1.0185      Y:     1.0559      Z:     1.0384     Total:     1.7974
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:18:59 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:04 2021
 Module time:
-	user time   =       0.74 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       3.58 seconds =       0.06 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.18 seconds =       0.20 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =      64.36 seconds =       1.07 minutes
+	system time =       3.21 seconds =       0.05 minutes
 	total time  =         13 seconds =       0.22 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:18:59 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:04 2021
 
 
          ------------------------------------------------------------
@@ -4108,7 +5240,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -4119,18 +5251,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -4139,48 +5271,58 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000471411769     0.000356803525    -0.000054418346
-       2       -0.008168586621    -0.000377057152    -0.000347480989
-       3       -0.000010562664    -0.000002212593     0.000000346743
-       4        0.044108822262     0.018054048616     0.038836059653
-       5       -0.026825034420    -0.002275333736    -0.028632481029
-       6       -0.008389751555    -0.016062187463    -0.009757917087
-       7       -0.000111977619     0.000137295900    -0.000015716268
-       8       -0.000125841639     0.000163541076    -0.000028233204
-       9       -0.000005655971     0.000005101826    -0.000000159474
+       1       -0.000471411764     0.000356803532    -0.000054418347
+       2       -0.008168586576    -0.000377057158    -0.000347481002
+       3       -0.000010562663    -0.000002212593     0.000000346743
+       4        0.044108819527     0.018054045271     0.038836058665
+       5       -0.026825033291    -0.002275332308    -0.028632479821
+       6       -0.008389749999    -0.016062185548    -0.009757917292
+       7       -0.000111977603     0.000137295913    -0.000015716265
+       8       -0.000125841654     0.000163541065    -0.000028233205
+       9       -0.000005655974     0.000005101824    -0.000000159477
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:00 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:05 2021
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.06 seconds =       0.03 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.41 seconds =       0.21 minutes
-	system time =       0.12 seconds =       0.00 minutes
+	user time   =      66.45 seconds =       1.11 minutes
+	system time =       3.30 seconds =       0.06 minutes
 	total time  =         14 seconds =       0.23 minutes
-	Energy of ((2,), (1, 2, 3)).......................................PASSED
-	Gradient of ((2,), (1, 2, 3)).....................................PASSED
+    Energy of ((2,), (1, 2, 3))...........................................................PASSED
+    Energy of ((2,), (1, 2, 3))...........................................................PASSED
+    Energy of ((2,), (1, 2, 3))...........................................................PASSED
+    Energy of ((2,), (1, 2, 3))...........................................................PASSED
+    Gradient RMS of ((2,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((2,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((2,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((2,), (1, 2, 3)).....................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:19:00 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:05 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 4, 7       entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4222,15 +5364,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -4240,66 +5382,67 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1, 4, 7       entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3, 5-6, 8-9 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         21      21       0       0       0       0
-   -------------------------------------------------------
-    Total      21      21       5       5       5       0
-   -------------------------------------------------------
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       1.3605
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.74352584946223   -7.47435e+01   7.04541e-02 
-   @DF-RHF iter   1:   -74.94070851381785   -1.97183e-01   8.92274e-03 
-   @DF-RHF iter   2:   -74.96828286733202   -2.75744e-02   2.00327e-03 DIIS
-   @DF-RHF iter   3:   -74.97018707742531   -1.90421e-03   8.28261e-04 DIIS
-   @DF-RHF iter   4:   -74.97066958085989   -4.82503e-04   1.42696e-04 DIIS
-   @DF-RHF iter   5:   -74.97068351486794   -1.39340e-05   1.19113e-05 DIIS
-   @DF-RHF iter   6:   -74.97068359590988   -8.10419e-08   3.05028e-06 DIIS
-   @DF-RHF iter   7:   -74.97068360204098   -6.13110e-09   4.74794e-07 DIIS
-   @DF-RHF iter   8:   -74.97068360220021   -1.59233e-10   5.68810e-08 DIIS
-   @DF-RHF iter   9:   -74.97068360220231   -2.10321e-12   1.27274e-08 DIIS
-   @DF-RHF iter  10:   -74.97068360220246   -1.42109e-13   2.16017e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20201501847511   -7.42020e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92280482017244   -7.20790e-01   1.16966e-02 DIIS
+   @DF-RHF iter   2:   -74.96953035470298   -4.67255e-02   2.00055e-03 DIIS
+   @DF-RHF iter   3:   -74.97059674577902   -1.06639e-03   4.56359e-04 DIIS
+   @DF-RHF iter   4:   -74.97068221689725   -8.54711e-05   4.53537e-05 DIIS
+   @DF-RHF iter   5:   -74.97068354759335   -1.33070e-06   8.85963e-06 DIIS
+   @DF-RHF iter   6:   -74.97068360208857   -5.44952e-08   5.10780e-07 DIIS
+   @DF-RHF iter   7:   -74.97068360221046   -1.21887e-10   6.11794e-08 DIIS
+   @DF-RHF iter   8:   -74.97068360221238   -1.91847e-12   8.32843e-09 DIIS
+   @DF-RHF iter   9:   -74.97068360221235    2.84217e-14   2.08217e-09 DIIS
+   @DF-RHF iter  10:   -74.97068360221238   -2.84217e-14   3.79028e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -4325,14 +5468,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.97068360220246
+  @DF-RHF Final Energy:   -74.97068360221238
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.1796494730542690
-    Two-Electron Energy =                  38.0926531318965687
-    Total Energy =                        -74.9706836022024561
+    One-Electron Energy =                -122.1796494817144776
+    Two-Electron Energy =                  38.0926531405468580
+    Total Energy =                        -74.9706836022123753
 
 Computation Completed
 
@@ -4354,18 +5497,18 @@ Properties computed using the SCF density matrix
      X:    -1.3881      Y:     0.2787      Z:    -1.1084     Total:     1.7980
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:01 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:05 2021
 Module time:
-	user time   =       0.77 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       3.87 seconds =       0.06 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.19 seconds =       0.22 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =      70.48 seconds =       1.17 minutes
+	system time =       3.50 seconds =       0.06 minutes
+	total time  =         14 seconds =       0.23 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:19:01 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:06 2021
 
 
          ------------------------------------------------------------
@@ -4400,7 +5543,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 15
-    Number of basis function: 21
+    Number of basis functions: 21
     Number of Cartesian functions: 21
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -4411,18 +5554,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 111
-    Number of basis function: 339
+    Number of basis functions: 339
     Number of Cartesian functions: 399
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -4431,48 +5574,58 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000072680722    -0.000178930512     0.000016357961
-       2       -0.000082840323    -0.000198380484     0.000026349954
-       3       -0.000001789943    -0.000006925595     0.000000480290
-       4       -0.000053426761    -0.000634492454    -0.000043991627
-       5        0.000006717097    -0.000006864509     0.000001653337
-       6        0.004811504336    -0.007487780157     0.000107477799
-       7       -0.036161158703     0.026023988105    -0.040801269083
-       8        0.017818347879     0.001955482593     0.009951421428
-       9        0.013735327141    -0.019466096988     0.030741519942
+       1       -0.000072680700    -0.000178930516     0.000016357963
+       2       -0.000082840346    -0.000198380480     0.000026349954
+       3       -0.000001789946    -0.000006925596     0.000000480287
+       4       -0.000053426749    -0.000634492433    -0.000043991629
+       5        0.000006717098    -0.000006864511     0.000001653340
+       6        0.004811504282    -0.007487780071     0.000107477796
+       7       -0.036161158080     0.026023991710    -0.040801267509
+       8        0.017818348383     0.001955480718     0.009951421451
+       9        0.013735326059    -0.019466098822     0.030741518346
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:01 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:06 2021
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.31 seconds =       0.04 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.42 seconds =       0.22 minutes
-	system time =       0.13 seconds =       0.00 minutes
+	user time   =      72.82 seconds =       1.21 minutes
+	system time =       3.64 seconds =       0.06 minutes
 	total time  =         15 seconds =       0.25 minutes
-	Energy of ((3,), (1, 2, 3)).......................................PASSED
-	Gradient of ((3,), (1, 2, 3)).....................................PASSED
+    Energy of ((3,), (1, 2, 3))...........................................................PASSED
+    Energy of ((3,), (1, 2, 3))...........................................................PASSED
+    Energy of ((3,), (1, 2, 3))...........................................................PASSED
+    Energy of ((3,), (1, 2, 3))...........................................................PASSED
+    Gradient RMS of ((3,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((3,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((3,), (1, 2, 3)).....................................................PASSED
+    Gradient RMS of ((3,), (1, 2, 3)).....................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:19:01 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:06 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4508,15 +5661,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -4526,18 +5679,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A          7       7       0       0       0       0
-   -------------------------------------------------------
-    Total       7       7       5       5       5       0
-   -------------------------------------------------------
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -4548,44 +5691,54 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.4706319112E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.8103780232E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.76943609450502   -7.47694e+01   2.11257e-01 
-   @DF-RHF iter   1:   -74.92195923618446   -1.52523e-01   3.12912e-02 
-   @DF-RHF iter   2:   -74.96095707653201   -3.89978e-02   6.14970e-03 DIIS
-   @DF-RHF iter   3:   -74.96294367231238   -1.98660e-03   2.39782e-03 DIIS
-   @DF-RHF iter   4:   -74.96338572851374   -4.42056e-04   4.51735e-04 DIIS
-   @DF-RHF iter   5:   -74.96340201916767   -1.62907e-05   3.31720e-05 DIIS
-   @DF-RHF iter   6:   -74.96340207974856   -6.05809e-08   7.33403e-06 DIIS
-   @DF-RHF iter   7:   -74.96340208265826   -2.90970e-09   1.14193e-06 DIIS
-   @DF-RHF iter   8:   -74.96340208275730   -9.90354e-11   2.20890e-07 DIIS
-   @DF-RHF iter   9:   -74.96340208276128   -3.97904e-12   4.99270e-08 DIIS
-   @DF-RHF iter  10:   -74.96340208276142   -1.42109e-13   3.74030e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20292818616242   -7.42029e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91358954105047   -7.10661e-01   3.55337e-02 DIIS
+   @DF-RHF iter   2:   -74.96245166050338   -4.88621e-02   5.41141e-03 DIIS
+   @DF-RHF iter   3:   -74.96332855053106   -8.76890e-04   1.28859e-03 DIIS
+   @DF-RHF iter   4:   -74.96340079921761   -7.22487e-05   1.30788e-04 DIIS
+   @DF-RHF iter   5:   -74.96340207816461   -1.27895e-06   8.84975e-06 DIIS
+   @DF-RHF iter   6:   -74.96340208274096   -4.57635e-09   5.30739e-07 DIIS
+   @DF-RHF iter   7:   -74.96340208275733   -1.63709e-11   4.98532e-08 DIIS
+   @DF-RHF iter   8:   -74.96340208275744   -1.13687e-13   1.19600e-09 DIIS
+   @DF-RHF iter   9:   -74.96340208275738    5.68434e-14   1.49182e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -4606,14 +5759,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96340208276142
+  @DF-RHF Final Energy:   -74.96340208275738
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1199282788050127
-    One-Electron Energy =                -122.2481627378251261
-    Two-Electron Energy =                  38.1648323762587012
-    Total Energy =                        -74.9634020827614194
+    One-Electron Energy =                -122.2481627620101818
+    Two-Electron Energy =                  38.1648324004477928
+    Total Energy =                        -74.9634020827573835
 
 Computation Completed
 
@@ -4635,18 +5788,18 @@ Properties computed using the SCF density matrix
      X:     0.4415      Y:    -1.2890      Z:     1.0302     Total:     1.7081
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:01 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:06 2021
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.96 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.78 seconds =       0.23 minutes
-	system time =       0.14 seconds =       0.00 minutes
+	user time   =      74.92 seconds =       1.25 minutes
+	system time =       3.78 seconds =       0.06 minutes
 	total time  =         15 seconds =       0.25 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:19:01 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:06 2021
 
 
          ------------------------------------------------------------
@@ -4675,7 +5828,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -4686,18 +5839,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -4706,42 +5859,52 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.000122129191    -0.041251919656     0.038759367274
-       2       -0.010860335684     0.015908099073    -0.010517460458
-       3        0.010982464874     0.025343820582    -0.028241906817
+       1       -0.000122130122    -0.041251917623     0.038759365356
+       2       -0.010860334708     0.015908098649    -0.010517459384
+       3        0.010982464829     0.025343818973    -0.028241905972
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:01 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:06 2021
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.86 seconds =       0.23 minutes
-	system time =       0.14 seconds =       0.00 minutes
+	user time   =      75.39 seconds =       1.26 minutes
+	system time =       3.83 seconds =       0.06 minutes
 	total time  =         15 seconds =       0.25 minutes
-	Energy of ((1,), (1,))............................................PASSED
-	Gradient of ((1,), (1,))..........................................PASSED
+    Energy of ((1,), (1,))................................................................PASSED
+    Energy of ((1,), (1,))................................................................PASSED
+    Energy of ((1,), (1,))................................................................PASSED
+    Energy of ((1,), (1,))................................................................PASSED
+    Gradient RMS of ((1,), (1,))..........................................................PASSED
+    Gradient RMS of ((1,), (1,))..........................................................PASSED
+    Gradient RMS of ((1,), (1,))..........................................................PASSED
+    Gradient RMS of ((1,), (1,))..........................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:19:01 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:06 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4777,15 +5940,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -4795,18 +5958,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A          7       7       0       0       0       0
-   -------------------------------------------------------
-    Total       7       7       5       5       5       0
-   -------------------------------------------------------
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -4817,44 +5970,54 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.4724660626E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.8115562909E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.74161284996681   -7.47416e+01   2.10812e-01 
-   @DF-RHF iter   1:   -74.93326619471010   -1.91653e-01   2.67089e-02 
-   @DF-RHF iter   2:   -74.96140227456995   -2.81361e-02   5.44371e-03 DIIS
-   @DF-RHF iter   3:   -74.96303335073614   -1.63108e-03   2.23919e-03 DIIS
-   @DF-RHF iter   4:   -74.96343674337052   -4.03393e-04   3.77861e-04 DIIS
-   @DF-RHF iter   5:   -74.96344775248927   -1.10091e-05   2.69115e-05 DIIS
-   @DF-RHF iter   6:   -74.96344779068281   -3.81935e-08   6.09415e-06 DIIS
-   @DF-RHF iter   7:   -74.96344779287553   -2.19272e-09   1.00883e-06 DIIS
-   @DF-RHF iter   8:   -74.96344779295715   -8.16271e-11   1.76519e-07 DIIS
-   @DF-RHF iter   9:   -74.96344779295960   -2.44427e-12   3.71973e-08 DIIS
-   @DF-RHF iter  10:   -74.96344779295968   -8.52651e-14   3.15321e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20212050381696   -7.42021e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91356875495052   -7.11448e-01   3.55515e-02 DIIS
+   @DF-RHF iter   2:   -74.96249631967869   -4.89276e-02   5.41710e-03 DIIS
+   @DF-RHF iter   3:   -74.96337428379582   -8.77964e-04   1.28875e-03 DIIS
+   @DF-RHF iter   4:   -74.96344651408241   -7.22303e-05   1.30538e-04 DIIS
+   @DF-RHF iter   5:   -74.96344778833745   -1.27426e-06   8.88772e-06 DIIS
+   @DF-RHF iter   6:   -74.96344779295865   -4.62120e-09   5.28512e-07 DIIS
+   @DF-RHF iter   7:   -74.96344779297476   -1.61151e-11   5.37441e-08 DIIS
+   @DF-RHF iter   8:   -74.96344779297489   -1.27898e-13   1.21463e-09 DIIS
+   @DF-RHF iter   9:   -74.96344779297492   -2.84217e-14   1.58511e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -4875,14 +6038,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96344779295968
+  @DF-RHF Final Energy:   -74.96344779297492
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1167784713158273
-    One-Electron Energy =                -122.2421812098822755
-    Two-Electron Energy =                  38.1619549456067659
-    Total Energy =                        -74.9634477929596841
+    One-Electron Energy =                -122.2421812246878687
+    Two-Electron Energy =                  38.1619549603971251
+    Total Energy =                        -74.9634477929749181
 
 Computation Completed
 
@@ -4904,18 +6067,18 @@ Properties computed using the SCF density matrix
      X:     0.8883      Y:     1.0391      Z:     1.0241     Total:     1.7081
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:02 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:07 2021
 Module time:
-	user time   =       0.31 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.02 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      14.18 seconds =       0.24 minutes
-	system time =       0.15 seconds =       0.00 minutes
+	user time   =      77.52 seconds =       1.29 minutes
+	system time =       3.94 seconds =       0.07 minutes
 	total time  =         16 seconds =       0.27 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:19:02 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:07 2021
 
 
          ------------------------------------------------------------
@@ -4944,7 +6107,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -4955,18 +6118,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -4975,42 +6138,52 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.036178303755     0.019888938711     0.038154885164
-       2       -0.028116867828    -0.003451926908    -0.027749301126
-       3       -0.008061435924    -0.016437011804    -0.010405584037
+       1        0.036178301961     0.019888936373     0.038154883492
+       2       -0.028116866639    -0.003451926255    -0.027749299521
+       3       -0.008061435319    -0.016437010119    -0.010405583971
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:02 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:07 2021
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.56 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.26 seconds =       0.24 minutes
-	system time =       0.15 seconds =       0.00 minutes
+	user time   =      78.10 seconds =       1.30 minutes
+	system time =       3.96 seconds =       0.07 minutes
 	total time  =         16 seconds =       0.27 minutes
-	Energy of ((2,), (2,))............................................PASSED
-	Gradient of ((2,), (2,))..........................................PASSED
+    Energy of ((2,), (2,))................................................................PASSED
+    Energy of ((2,), (2,))................................................................PASSED
+    Energy of ((2,), (2,))................................................................PASSED
+    Energy of ((2,), (2,))................................................................PASSED
+    Gradient RMS of ((2,), (2,))..........................................................PASSED
+    Gradient RMS of ((2,), (2,))..........................................................PASSED
+    Gradient RMS of ((2,), (2,))..........................................................PASSED
+    Gradient RMS of ((2,), (2,))..........................................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:19:02 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:07 2021
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line    81 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5046,15 +6219,15 @@ gradient() will perform analytic gradient computation.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -5064,18 +6237,8 @@ gradient() will perform analytic gradient computation.
     Name: (STO-3G AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   323 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2-3 entry H          line    23 file /theoryfs2/ds/alenaizan/Gits/psi4/objdir/stage/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A          7       7       0       0       0       0
-   -------------------------------------------------------
-    Total       7       7       5       5       5       0
-   -------------------------------------------------------
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -5086,44 +6249,54 @@ gradient() will perform analytic gradient computation.
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
 
   Minimum eigenvalue in the overlap matrix is 3.4730300753E-01.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.8113509098E-01.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   -74.74352657585351   -7.47435e+01   2.11015e-01 
-   @DF-RHF iter   1:   -74.93232039674074   -1.88794e-01   2.72761e-02 
-   @DF-RHF iter   2:   -74.96122749398771   -2.89071e-02   5.77034e-03 DIIS
-   @DF-RHF iter   3:   -74.96305605978020   -1.82857e-03   2.45049e-03 DIIS
-   @DF-RHF iter   4:   -74.96353267254993   -4.76613e-04   3.86874e-04 DIIS
-   @DF-RHF iter   5:   -74.96354361734123   -1.09448e-05   2.68749e-05 DIIS
-   @DF-RHF iter   6:   -74.96354366279775   -4.54565e-08   8.59594e-06 DIIS
-   @DF-RHF iter   7:   -74.96354366800938   -5.21163e-09   7.92455e-07 DIIS
-   @DF-RHF iter   8:   -74.96354366804913   -3.97478e-11   1.23739e-07 DIIS
-   @DF-RHF iter   9:   -74.96354366804998   -8.52651e-13   2.69980e-08 DIIS
-   @DF-RHF iter  10:   -74.96354366805008   -9.94760e-14   3.38035e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:   -74.20201476670233   -7.42020e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91358540757162   -7.11571e-01   3.55775e-02 DIIS
+   @DF-RHF iter   2:   -74.96259246477621   -4.90071e-02   5.42254e-03 DIIS
+   @DF-RHF iter   3:   -74.96347049128538   -8.78027e-04   1.28737e-03 DIIS
+   @DF-RHF iter   4:   -74.96354240952577   -7.19182e-05   1.29539e-04 DIIS
+   @DF-RHF iter   5:   -74.96354366338377   -1.25386e-06   8.90787e-06 DIIS
+   @DF-RHF iter   6:   -74.96354366802558   -4.64181e-09   5.24339e-07 DIIS
+   @DF-RHF iter   7:   -74.96354366804144   -1.58593e-11   5.17144e-08 DIIS
+   @DF-RHF iter   8:   -74.96354366804154   -9.94760e-14   1.18687e-09 DIIS
+   @DF-RHF iter   9:   -74.96354366804158   -4.26326e-14   1.51652e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -5144,14 +6317,14 @@ gradient() will perform analytic gradient computation.
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -74.96354366805008
+  @DF-RHF Final Energy:   -74.96354366804158
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1163127389552496
-    One-Electron Energy =                -122.2400220139105187
-    Two-Electron Energy =                  38.1601656069051955
-    Total Energy =                        -74.9635436680500788
+    One-Electron Energy =                -122.2400220121384393
+    Two-Electron Energy =                  38.1601656051416143
+    Total Energy =                        -74.9635436680415808
 
 Computation Completed
 
@@ -5173,18 +6346,18 @@ Properties computed using the SCF density matrix
      X:    -1.3005      Y:     0.1654      Z:    -1.0966     Total:     1.7092
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:02 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:07 2021
 Module time:
-	user time   =       0.31 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.02 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.58 seconds =       0.24 minutes
-	system time =       0.15 seconds =       0.00 minutes
+	user time   =      80.22 seconds =       1.34 minutes
+	system time =       4.05 seconds =       0.07 minutes
 	total time  =         16 seconds =       0.27 minutes
 
-*** tstart() called on ds1.sherrill.chemistry.gatech.edu
-*** at Wed Nov 21 15:19:02 2018
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:07 2021
 
 
          ------------------------------------------------------------
@@ -5213,7 +6386,7 @@ Total time:
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 5
-    Number of basis function: 7
+    Number of basis functions: 7
     Number of Cartesian functions: 7
     Spherical Harmonics?: true
     Max angular momentum: 1
@@ -5224,18 +6397,18 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
+    OpenMP threads:              8
+    Integrals threads:           8
     Memory [MiB]:              375
-    Schwarz Cutoff:          0E+00
-    Fitting Condition:       1E-12
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
   Basis Set: (STO-3G AUX)
-    Blend: DEF2-SVP-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
     Number of shells: 37
-    Number of basis function: 113
+    Number of basis functions: 113
     Number of Cartesian functions: 133
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -5244,26 +6417,3585 @@ Total time:
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.033220039065     0.017641239645    -0.040625895938
-       2        0.017926294734     0.002460556689     0.010655977980
-       3        0.015293744332    -0.020101796334     0.029969917958
+       1       -0.033220038735     0.017641240906    -0.040625895132
+       2        0.017926294769     0.002460555175     0.010655978202
+       3        0.015293743966    -0.020101796082     0.029969916930
 
 
-*** tstop() called on ds1.sherrill.chemistry.gatech.edu at Wed Nov 21 15:19:02 2018
+*** tstop() called on dorje at Mon Jun 28 10:22:07 2021
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.66 seconds =       0.24 minutes
-	system time =       0.15 seconds =       0.00 minutes
+	user time   =      80.71 seconds =       1.35 minutes
+	system time =       4.07 seconds =       0.07 minutes
 	total time  =         16 seconds =       0.27 minutes
-	Energy of ((3,), (3,))............................................PASSED
-	Gradient of ((3,), (3,))..........................................PASSED
-	CP-Corrected Energy...............................................PASSED
-	CP-Corrected Gradient.............................................PASSED
+    Energy of ((3,), (3,))................................................................PASSED
+    Energy of ((3,), (3,))................................................................PASSED
+    Energy of ((3,), (3,))................................................................PASSED
+    Energy of ((3,), (3,))................................................................PASSED
+    Gradient RMS of ((3,), (3,))..........................................................PASSED
+    Gradient RMS of ((3,), (3,))..........................................................PASSED
+    Gradient RMS of ((3,), (3,))..........................................................PASSED
+    Gradient RMS of ((3,), (3,))..........................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Energy...................................................................PASSED
+    CP-Corrected Interaction Energy.......................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
+    CP-Corrected Gradient.................................................................PASSED
 
-    Psi4 stopped on: Wednesday, 21 November 2018 03:19PM
-    Psi4 wall time for execution: 0:00:15.78
+Scratch directory: /tmp/
+
+
+   ===> N-Body Interaction Abacus <===
+        BSSE Treatment:                     ['cp', 'nocp']
+        Number of 1-body computations:     6
+        Number of 2-body computations:     6
+
+   ==> N-Body: Now computing 1-body complexes <==
+
+
+       N-Body: Computing complex (1/6) with fragments (1,) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:07 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =    9.119928278805013
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -74.20292908468238   -7.42029e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92263609767690   -7.19707e-01   1.16865e-02 DIIS
+   @DF-RHF iter   2:   -74.96927826367431   -4.66422e-02   1.98794e-03 DIIS
+   @DF-RHF iter   3:   -74.97033405711940   -1.05579e-03   4.55406e-04 DIIS
+   @DF-RHF iter   4:   -74.97041925358103   -8.51965e-05   4.56427e-05 DIIS
+   @DF-RHF iter   5:   -74.97042060385076   -1.35027e-06   8.79231e-06 DIIS
+   @DF-RHF iter   6:   -74.97042065748765   -5.36369e-08   4.96493e-07 DIIS
+   @DF-RHF iter   7:   -74.97042065760219   -1.14539e-10   5.85646e-08 DIIS
+   @DF-RHF iter   8:   -74.97042065760408   -1.89004e-12   7.90968e-09 DIIS
+   @DF-RHF iter   9:   -74.97042065760411   -2.84217e-14   1.91420e-09 DIIS
+   @DF-RHF iter  10:   -74.97042065760397    1.42109e-13   3.64990e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.253702     2A     -1.269156     3A     -0.621192  
+       4A     -0.455830     5A     -0.396005  
+
+    Virtual:                                                              
+
+       6A      0.465977     7A      0.565921     8A      0.620284  
+       9A      0.743952    10A      0.976070    11A      1.052373  
+      12A      1.331031    13A      1.404480    14A      2.536284  
+      15A      2.553862    16A      2.893569    17A      3.009824  
+      18A      3.267055    19A      3.329230    20A     31.229191  
+      21A     31.307207  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -74.97042065760397
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1199282788050127
+    One-Electron Energy =                -122.1889285363743625
+    Two-Electron Energy =                  38.0985795999653689
+    Total Energy =                        -74.9704206576039667
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:   -27.0414      Y:   -14.0996      Z:    -0.2271
+
+  Electronic Dipole Moment: [e a0]
+     X:    27.1935      Y:    13.5407      Z:     0.6366
+
+  Dipole Moment: [e a0]
+     X:     0.1522      Y:    -0.5588      Z:     0.4095     Total:     0.7093
+
+  Dipole Moment: [D]
+     X:     0.3868      Y:    -1.4204      Z:     1.0410     Total:     1.8030
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:08 2021
+Module time:
+	user time   =       3.76 seconds =       0.06 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      84.58 seconds =       1.41 minutes
+	system time =       4.25 seconds =       0.07 minutes
+	total time  =         17 seconds =       0.28 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:08 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =    9.119928278805013
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.005936482537    -0.047621129514     0.039078619587
+       2       -0.010347097171     0.015942129158    -0.009836147869
+       3        0.011267101287     0.023602965674    -0.029120435066
+       4        0.000148988969     0.000025243679    -0.000022690912
+       5        0.000010967310     0.000001674293    -0.000001547973
+       6        0.000207745758     0.000029486339    -0.000032447683
+       7        0.000572101787     0.000266556858     0.000029623501
+       8        0.004072969874     0.007742331004    -0.000093127033
+       9        0.000003704723     0.000010742506    -0.000001846552
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:08 2021
+Module time:
+	user time   =       1.13 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      85.72 seconds =       1.43 minutes
+	system time =       4.31 seconds =       0.07 minutes
+	total time  =         17 seconds =       0.28 minutes
+
+       N-Body: Complex Energy (fragments = (1,), basis = (1, 2, 3):   -74.97042065760397)
+
+       N-Body: Computing complex (2/6) with fragments (2,) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:08 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =    9.116778471315827
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -74.20212107191566   -7.42021e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92187838021675   -7.19757e-01   1.17111e-02 DIIS
+   @DF-RHF iter   2:   -74.96877048612669   -4.68921e-02   1.97672e-03 DIIS
+   @DF-RHF iter   3:   -74.96981346520607   -1.04298e-03   4.53262e-04 DIIS
+   @DF-RHF iter   4:   -74.96989752646041   -8.40613e-05   4.54754e-05 DIIS
+   @DF-RHF iter   5:   -74.96989886791226   -1.34145e-06   8.68396e-06 DIIS
+   @DF-RHF iter   6:   -74.96989892025660   -5.23443e-08   4.77771e-07 DIIS
+   @DF-RHF iter   7:   -74.96989892036235   -1.05757e-10   5.60429e-08 DIIS
+   @DF-RHF iter   8:   -74.96989892036383   -1.47793e-12   7.92543e-09 DIIS
+   @DF-RHF iter   9:   -74.96989892036393   -9.94760e-14   1.91285e-09 DIIS
+   @DF-RHF iter  10:   -74.96989892036397   -4.26326e-14   3.66386e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.252744     2A     -1.268558     3A     -0.620443  
+       4A     -0.455404     5A     -0.395552  
+
+    Virtual:                                                              
+
+       6A      0.463525     7A      0.563679     8A      0.622881  
+       9A      0.746339    10A      0.974324    11A      1.049872  
+      12A      1.326710    13A      1.406489    14A      2.543263  
+      15A      2.552524    16A      2.887125    17A      3.009341  
+      18A      3.264801    19A      3.331521    20A     31.228093  
+      21A     31.307322  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -74.96989892036397
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1167784713158273
+    One-Electron Energy =                -122.1879518597814922
+    Two-Electron Energy =                  38.1012744681016926
+    Total Energy =                        -74.9698989203639741
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    25.8236      Y:   -16.1783      Z:    -0.3984
+
+  Electronic Dipole Moment: [e a0]
+     X:   -25.4229      Y:    16.5937      Z:     0.8069
+
+  Dipole Moment: [e a0]
+     X:     0.4007      Y:     0.4154      Z:     0.4085     Total:     0.7071
+
+  Dipole Moment: [D]
+     X:     1.0185      Y:     1.0559      Z:     1.0384     Total:     1.7974
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:09 2021
+Module time:
+	user time   =       2.78 seconds =       0.05 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      88.59 seconds =       1.48 minutes
+	system time =       4.47 seconds =       0.07 minutes
+	total time  =         18 seconds =       0.30 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:09 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =    9.116778471315827
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000471411781     0.000356803539    -0.000054418349
+       2       -0.008168586550    -0.000377057161    -0.000347481000
+       3       -0.000010562663    -0.000002212594     0.000000346743
+       4        0.044108819593     0.018054045501     0.038836058746
+       5       -0.026825033359    -0.002275332336    -0.028632479879
+       6       -0.008389750006    -0.016062185747    -0.009757917315
+       7       -0.000111977592     0.000137295912    -0.000015716262
+       8       -0.000125841664     0.000163541060    -0.000028233205
+       9       -0.000005655976     0.000005101826    -0.000000159480
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:09 2021
+Module time:
+	user time   =       1.26 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      89.86 seconds =       1.50 minutes
+	system time =       4.52 seconds =       0.08 minutes
+	total time  =         18 seconds =       0.30 minutes
+
+       N-Body: Complex Energy (fragments = (2,), basis = (1, 2, 3):   -74.96989892036397)
+
+       N-Body: Computing complex (3/6) with fragments (3,) in the basis of fragments (3,).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:09 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     16.29746  B =      0.35535  C =      0.35390 [cm^-1]
+  Rotational constants: A = 488585.46321  B =  10652.99421  C =  10609.68719 [MHz]
+  Nuclear repulsion =    9.116312738955250
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis functions: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4730300753E-01.
+  Reciprocal condition number of the overlap matrix is 1.8113509098E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -74.20201476670236   -7.42020e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91358540757169   -7.11571e-01   3.55775e-02 DIIS
+   @DF-RHF iter   2:   -74.96259246477618   -4.90071e-02   5.42254e-03 DIIS
+   @DF-RHF iter   3:   -74.96347049128531   -8.78027e-04   1.28737e-03 DIIS
+   @DF-RHF iter   4:   -74.96354240952579   -7.19182e-05   1.29539e-04 DIIS
+   @DF-RHF iter   5:   -74.96354366338379   -1.25386e-06   8.90787e-06 DIIS
+   @DF-RHF iter   6:   -74.96354366802554   -4.64175e-09   5.24339e-07 DIIS
+   @DF-RHF iter   7:   -74.96354366804142   -1.58877e-11   5.17144e-08 DIIS
+   @DF-RHF iter   8:   -74.96354366804155   -1.27898e-13   1.18687e-09 DIIS
+   @DF-RHF iter   9:   -74.96354366804154    1.42109e-14   1.51651e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.241634     2A     -1.263271     3A     -0.615118  
+       4A     -0.449801     5A     -0.390021  
+
+    Virtual:                                                              
+
+       6A      0.595613     7A      0.735986  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -74.96354366804154
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1163127389552496
+    One-Electron Energy =                -122.2400220121383256
+    Two-Electron Energy =                  38.1601656051415432
+    Total Energy =                        -74.9635436680415381
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     1.2177      Y:    30.2778      Z:     0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:    -1.7294      Y:   -30.2127      Z:    -1.0569
+
+  Dipole Moment: [e a0]
+     X:    -0.5117      Y:     0.0651      Z:    -0.4314     Total:     0.6724
+
+  Dipole Moment: [D]
+     X:    -1.3005      Y:     0.1654      Z:    -1.0966     Total:     1.7092
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:10 2021
+Module time:
+	user time   =       2.02 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      91.97 seconds =       1.53 minutes
+	system time =       4.65 seconds =       0.08 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:10 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =    9.116312738955250
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis functions: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.033220038609     0.017641240892    -0.040625895028
+       2        0.017926294671     0.002460555121     0.010655978182
+       3        0.015293743939    -0.020101796014     0.029969916846
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:10 2021
+Module time:
+	user time   =       0.56 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      92.54 seconds =       1.54 minutes
+	system time =       4.68 seconds =       0.08 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+       N-Body: Complex Energy (fragments = (3,), basis = (3,):   -74.96354366804154)
+
+       N-Body: Computing complex (4/6) with fragments (2,) in the basis of fragments (2,).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:10 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     17.73733  B =      0.35284  C =      0.35071 [cm^-1]
+  Rotational constants: A = 531751.83709  B =  10577.84786  C =  10514.12905 [MHz]
+  Nuclear repulsion =    9.116778471315827
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis functions: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4724660626E-01.
+  Reciprocal condition number of the overlap matrix is 1.8115562909E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -74.20212050381699   -7.42021e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91356875495052   -7.11448e-01   3.55515e-02 DIIS
+   @DF-RHF iter   2:   -74.96249631967869   -4.89276e-02   5.41710e-03 DIIS
+   @DF-RHF iter   3:   -74.96337428379587   -8.77964e-04   1.28875e-03 DIIS
+   @DF-RHF iter   4:   -74.96344651408251   -7.22303e-05   1.30538e-04 DIIS
+   @DF-RHF iter   5:   -74.96344778833738   -1.27425e-06   8.88772e-06 DIIS
+   @DF-RHF iter   6:   -74.96344779295863   -4.62126e-09   5.28512e-07 DIIS
+   @DF-RHF iter   7:   -74.96344779297476   -1.61293e-11   5.37441e-08 DIIS
+   @DF-RHF iter   8:   -74.96344779297490   -1.42109e-13   1.21463e-09 DIIS
+   @DF-RHF iter   9:   -74.96344779297496   -5.68434e-14   1.58511e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.241351     2A     -1.263093     3A     -0.615459  
+       4A     -0.449355     5A     -0.389879  
+
+    Virtual:                                                              
+
+       6A      0.595326     7A      0.736674  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -74.96344779297496
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1167784713158273
+    One-Electron Energy =                -122.2421812246880108
+    Two-Electron Energy =                  38.1619549603972246
+    Total Energy =                        -74.9634477929749607
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    25.8236      Y:   -16.1783      Z:    -0.3984
+
+  Electronic Dipole Moment: [e a0]
+     X:   -25.4742      Y:    16.5871      Z:     0.8013
+
+  Dipole Moment: [e a0]
+     X:     0.3495      Y:     0.4088      Z:     0.4029     Total:     0.6720
+
+  Dipole Moment: [D]
+     X:     0.8883      Y:     1.0391      Z:     1.0241     Total:     1.7081
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:10 2021
+Module time:
+	user time   =       2.00 seconds =       0.03 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      94.63 seconds =       1.58 minutes
+	system time =       4.76 seconds =       0.08 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:10 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Nuclear repulsion =    9.116778471315827
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis functions: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.036178302056     0.019888936500     0.038154883602
+       2       -0.028116866734    -0.003451926239    -0.027749299608
+       3       -0.008061435319    -0.016437010262    -0.010405583993
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:10 2021
+Module time:
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      95.09 seconds =       1.58 minutes
+	system time =       4.79 seconds =       0.08 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+       N-Body: Complex Energy (fragments = (2,), basis = (2,):   -74.96344779297496)
+
+       N-Body: Computing complex (5/6) with fragments (1,) in the basis of fragments (1,).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:10 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     17.14656  B =      0.35250  C =      0.35060 [cm^-1]
+  Rotational constants: A = 514040.82446  B =  10567.72688  C =  10510.70065 [MHz]
+  Nuclear repulsion =    9.119928278805013
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis functions: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4706319112E-01.
+  Reciprocal condition number of the overlap matrix is 1.8103780232E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A          7       7 
+   -------------------------
+    Total       7       7
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -74.20292818616244   -7.42029e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.91358954105053   -7.10661e-01   3.55337e-02 DIIS
+   @DF-RHF iter   2:   -74.96245166050329   -4.88621e-02   5.41141e-03 DIIS
+   @DF-RHF iter   3:   -74.96332855053102   -8.76890e-04   1.28859e-03 DIIS
+   @DF-RHF iter   4:   -74.96340079921765   -7.22487e-05   1.30788e-04 DIIS
+   @DF-RHF iter   5:   -74.96340207816458   -1.27895e-06   8.84975e-06 DIIS
+   @DF-RHF iter   6:   -74.96340208274103   -4.57645e-09   5.30739e-07 DIIS
+   @DF-RHF iter   7:   -74.96340208275728   -1.62572e-11   4.98532e-08 DIIS
+   @DF-RHF iter   8:   -74.96340208275747   -1.84741e-13   1.19600e-09 DIIS
+   @DF-RHF iter   9:   -74.96340208275745    1.42109e-14   1.49182e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.241218     2A     -1.263189     3A     -0.615741  
+       4A     -0.449250     5A     -0.389851  
+
+    Virtual:                                                              
+
+       6A      0.595605     7A      0.737218  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -74.96340208275745
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1199282788050127
+    One-Electron Energy =                -122.2481627620103239
+    Two-Electron Energy =                  38.1648324004478710
+    Total Energy =                        -74.9634020827574545
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:   -27.0414      Y:   -14.0996      Z:    -0.2271
+
+  Electronic Dipole Moment: [e a0]
+     X:    27.2151      Y:    13.5924      Z:     0.6324
+
+  Dipole Moment: [e a0]
+     X:     0.1737      Y:    -0.5071      Z:     0.4053     Total:     0.6720
+
+  Dipole Moment: [D]
+     X:     0.4415      Y:    -1.2890      Z:     1.0302     Total:     1.7081
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:10 2021
+Module time:
+	user time   =       1.99 seconds =       0.03 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      97.16 seconds =       1.62 minutes
+	system time =       4.93 seconds =       0.08 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:10 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+
+  Nuclear repulsion =    9.119928278805013
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 5
+    Number of basis functions: 7
+    Number of Cartesian functions: 7
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000122130120    -0.041251917620     0.038759365352
+       2       -0.010860334711     0.015908098649    -0.010517459383
+       3        0.010982464829     0.025343818970    -0.028241905969
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:10 2021
+Module time:
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      97.65 seconds =       1.63 minutes
+	system time =       4.96 seconds =       0.08 minutes
+	total time  =         19 seconds =       0.32 minutes
+
+       N-Body: Complex Energy (fragments = (1,), basis = (1,):   -74.96340208275745)
+
+       N-Body: Computing complex (6/6) with fragments (3,) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:10 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =    9.116312738955250
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -74.20201501847514   -7.42020e+01   0.00000e+00 
+   @DF-RHF iter   1:   -74.92280482017242   -7.20790e-01   1.16966e-02 DIIS
+   @DF-RHF iter   2:   -74.96953035470300   -4.67255e-02   2.00055e-03 DIIS
+   @DF-RHF iter   3:   -74.97059674577912   -1.06639e-03   4.56359e-04 DIIS
+   @DF-RHF iter   4:   -74.97068221689727   -8.54711e-05   4.53537e-05 DIIS
+   @DF-RHF iter   5:   -74.97068354759348   -1.33070e-06   8.85963e-06 DIIS
+   @DF-RHF iter   6:   -74.97068360208861   -5.44951e-08   5.10780e-07 DIIS
+   @DF-RHF iter   7:   -74.97068360221037   -1.21759e-10   6.11794e-08 DIIS
+   @DF-RHF iter   8:   -74.97068360221228   -1.90425e-12   8.32843e-09 DIIS
+   @DF-RHF iter   9:   -74.97068360221238   -9.94760e-14   2.08217e-09 DIIS
+   @DF-RHF iter  10:   -74.97068360221235    2.84217e-14   3.79028e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.254358     2A     -1.269377     3A     -0.620681  
+       4A     -0.456484     5A     -0.396271  
+
+    Virtual:                                                              
+
+       6A      0.464891     7A      0.564110     8A      0.621931  
+       9A      0.744473    10A      0.971111    11A      1.053369  
+      12A      1.329751    13A      1.405389    14A      2.539403  
+      15A      2.551066    16A      2.884117    17A      3.011959  
+      18A      3.262578    19A      3.331827    20A     31.229332  
+      21A     31.304830  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -74.97068360221235
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1163127389552496
+    One-Electron Energy =                -122.1796494817144492
+    Two-Electron Energy =                  38.0926531405468651
+    Total Energy =                        -74.9706836022123468
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     1.2177      Y:    30.2778      Z:     0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:    -1.7638      Y:   -30.1682      Z:    -1.0616
+
+  Dipole Moment: [e a0]
+     X:    -0.5461      Y:     0.1097      Z:    -0.4361     Total:     0.7074
+
+  Dipole Moment: [D]
+     X:    -1.3881      Y:     0.2787      Z:    -1.1084     Total:     1.7980
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:12 2021
+Module time:
+	user time   =       4.22 seconds =       0.07 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     101.96 seconds =       1.70 minutes
+	system time =       5.15 seconds =       0.09 minutes
+	total time  =         21 seconds =       0.35 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:12 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =    9.116312738955250
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000072680700    -0.000178930520     0.000016357963
+       2       -0.000082840346    -0.000198380476     0.000026349955
+       3       -0.000001789946    -0.000006925594     0.000000480287
+       4       -0.000053426756    -0.000634492416    -0.000043991627
+       5        0.000006717097    -0.000006864510     0.000001653341
+       6        0.004811504305    -0.007487780118     0.000107477792
+       7       -0.036161158011     0.026023991655    -0.040801267398
+       8        0.017818348315     0.001955480690     0.009951421442
+       9        0.013735326041    -0.019466098712     0.030741518245
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:12 2021
+Module time:
+	user time   =       1.25 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     103.23 seconds =       1.72 minutes
+	system time =       5.23 seconds =       0.09 minutes
+	total time  =         21 seconds =       0.35 minutes
+
+       N-Body: Complex Energy (fragments = (3,), basis = (1, 2, 3):   -74.97068360221235)
+
+   ==> N-Body: Now computing 2-body complexes <==
+
+
+       N-Body: Computing complex (1/6) with fragments (2, 3) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:12 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =   37.420872712481227
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42276116805368   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85415788514942   -1.43140e+00   1.55631e-02 DIIS
+   @DF-RHF iter   2:  -149.93915029987858   -8.49924e-02   2.54620e-03 DIIS
+   @DF-RHF iter   3:  -149.94111301416865   -1.96271e-03   6.21126e-04 DIIS
+   @DF-RHF iter   4:  -149.94127888955686   -1.65875e-04   6.28806e-05 DIIS
+   @DF-RHF iter   5:  -149.94128144855307   -2.55900e-06   1.07266e-05 DIIS
+   @DF-RHF iter   6:  -149.94128152245796   -7.39049e-08   1.68546e-06 DIIS
+   @DF-RHF iter   7:  -149.94128152398130   -1.52335e-09   2.96963e-07 DIIS
+   @DF-RHF iter   8:  -149.94128152402490   -4.35989e-11   3.32323e-08 DIIS
+   @DF-RHF iter   9:  -149.94128152402553   -6.25278e-13   6.90158e-09 DIIS
+   @DF-RHF iter  10:  -149.94128152402581   -2.84217e-13   1.53556e-09 DIIS
+   @DF-RHF iter  11:  -149.94128152402570    1.13687e-13   2.49156e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.268121     2A    -20.210019     3A     -1.288133  
+       4A     -1.238661     5A     -0.640894     6A     -0.595696  
+       7A     -0.478962     8A     -0.435311     9A     -0.398446  
+      10A     -0.365891  
+
+    Virtual:                                                              
+
+      11A      0.490044    12A      0.608083    13A      0.649569  
+      14A      0.732536    15A      0.786522    16A      1.030049  
+      17A      1.373358    18A      2.552724    19A      2.950651  
+      20A      3.281380    21A     31.265309  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94128152402570
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4208727124812270
+    One-Electron Energy =                -282.8840412881002635
+    Two-Electron Energy =                  95.5218870515933247
+    Total Energy =                       -149.9412815240256975
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    27.0414      Y:    14.0996      Z:     0.2271
+
+  Electronic Dipole Moment: [e a0]
+     X:   -27.2497      Y:   -13.4511      Z:    -0.2732
+
+  Dipole Moment: [e a0]
+     X:    -0.2083      Y:     0.6485      Z:    -0.0461     Total:     0.6827
+
+  Dipole Moment: [D]
+     X:    -0.5295      Y:     1.6482      Z:    -0.1172     Total:     1.7351
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:13 2021
+Module time:
+	user time   =       3.79 seconds =       0.06 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     107.11 seconds =       1.79 minutes
+	system time =       5.34 seconds =       0.09 minutes
+	total time  =         22 seconds =       0.37 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:13 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+      Gh(O)          -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+      Gh(H)          -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+      Gh(H)          -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.420872712481227
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000549823236     0.000209101777    -0.000043130494
+       2       -0.008948416531    -0.000509994597    -0.000335110335
+       3       -0.000014125250    -0.000007901242     0.000001129938
+       4        0.040281686976     0.015979687827     0.036438957603
+       5       -0.025453229892    -0.000967657148    -0.027271682536
+       6       -0.004781567341    -0.017019208350    -0.008532117558
+       7       -0.030966751958     0.021318701085    -0.037886837578
+       8        0.017633628311     0.000485891704     0.008597326036
+       9        0.012798598926    -0.019488621058     0.029031464923
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:13 2021
+Module time:
+	user time   =       1.19 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     108.31 seconds =       1.81 minutes
+	system time =       5.40 seconds =       0.09 minutes
+	total time  =         22 seconds =       0.37 minutes
+
+       N-Body: Complex Energy (fragments = (2, 3), basis = (1, 2, 3):  -149.94128152402570)
+
+       N-Body: Computing complex (2/6) with fragments (1, 3) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:13 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =   37.415382693305901
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42343055720863   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85512004732601   -1.43169e+00   1.55424e-02 DIIS
+   @DF-RHF iter   2:  -149.93983658165740   -8.47165e-02   2.55465e-03 DIIS
+   @DF-RHF iter   3:  -149.94180694368490   -1.97036e-03   6.22886e-04 DIIS
+   @DF-RHF iter   4:  -149.94197403138341   -1.67088e-04   6.29977e-05 DIIS
+   @DF-RHF iter   5:  -149.94197662131771   -2.58993e-06   9.62406e-06 DIIS
+   @DF-RHF iter   6:  -149.94197668209512   -6.07774e-08   1.35366e-06 DIIS
+   @DF-RHF iter   7:  -149.94197668300183   -9.06709e-10   2.43900e-07 DIIS
+   @DF-RHF iter   8:  -149.94197668303090   -2.90754e-11   3.14208e-08 DIIS
+   @DF-RHF iter   9:  -149.94197668303158   -6.82121e-13   6.02918e-09 DIIS
+   @DF-RHF iter  10:  -149.94197668303141    1.70530e-13   1.36824e-09 DIIS
+   @DF-RHF iter  11:  -149.94197668303150   -8.52651e-14   2.40355e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267811     2A    -20.210878     3A     -1.288127  
+       4A     -1.238662     5A     -0.641682     6A     -0.595283  
+       7A     -0.479087     8A     -0.434364     9A     -0.399371  
+      10A     -0.365796  
+
+    Virtual:                                                              
+
+      11A      0.493284    12A      0.606245    13A      0.650587  
+      14A      0.731276    15A      0.787335    16A      1.032393  
+      17A      1.375231    18A      2.549012    19A      2.952949  
+      20A      3.283171    21A     31.266059  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94197668303150
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4153826933059008
+    One-Electron Energy =                -282.8726006394041974
+    Two-Electron Energy =                  95.5152412630667982
+    Total Energy =                       -149.9419766830314984
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:   -25.8236      Y:    16.1783      Z:     0.3984
+
+  Electronic Dipole Moment: [e a0]
+     X:    25.3512      Y:   -16.7430      Z:    -0.4030
+
+  Dipole Moment: [e a0]
+     X:    -0.4724      Y:    -0.5647      Z:    -0.0046     Total:     0.7362
+
+  Dipole Moment: [D]
+     X:    -1.2007      Y:    -1.4353      Z:    -0.0118     Total:     1.8713
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:14 2021
+Module time:
+	user time   =       4.08 seconds =       0.07 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     112.47 seconds =       1.87 minutes
+	system time =       5.56 seconds =       0.09 minutes
+	total time  =         23 seconds =       0.38 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:14 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+      Gh(O)           2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+      Gh(H)           3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+      Gh(H)           2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.415382693305901
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.004267649000    -0.040337037838     0.036257495443
+       2       -0.009096763569     0.016148452309    -0.008510788542
+       3        0.011706157105     0.022501916240    -0.027420792252
+       4        0.000077877786    -0.000630171364    -0.000065662307
+       5        0.000017101473    -0.000007706075     0.000000960724
+       6        0.005333224582    -0.008144547154     0.000059160369
+       7       -0.032823748917     0.024083254334    -0.038289292822
+       8        0.016902899877     0.005424869951     0.008657959183
+       9        0.012150900661    -0.019039030407     0.029310960204
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:14 2021
+Module time:
+	user time   =       1.22 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     113.70 seconds =       1.90 minutes
+	system time =       5.61 seconds =       0.09 minutes
+	total time  =         23 seconds =       0.38 minutes
+
+       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 2, 3):  -149.94197668303150)
+
+       N-Body: Computing complex (3/6) with fragments (1, 2) in the basis of fragments (1, 2).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:14 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.67094  B =      0.23246  C =      0.17553 [cm^-1]
+  Rotational constants: A =  20114.15437  B =   6968.93165  C =   5262.27541 [MHz]
+  Nuclear repulsion =   37.327766624605843
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4074143904E-01.
+  Reciprocal condition number of the overlap matrix is 1.7130997866E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42214055849541   -1.48422e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.84240283214115   -1.42026e+00   2.37340e-02 DIIS
+   @DF-RHF iter   2:  -149.93111317893843   -8.87103e-02   3.67265e-03 DIIS
+   @DF-RHF iter   3:  -149.93291805035193   -1.80487e-03   8.96030e-04 DIIS
+   @DF-RHF iter   4:  -149.93306601266346   -1.47962e-04   9.43642e-05 DIIS
+   @DF-RHF iter   5:  -149.93306839980571   -2.38714e-06   2.53037e-05 DIIS
+   @DF-RHF iter   6:  -149.93306858856744   -1.88762e-07   2.37939e-06 DIIS
+   @DF-RHF iter   7:  -149.93306858994811   -1.38067e-09   2.69811e-07 DIIS
+   @DF-RHF iter   8:  -149.93306858996218   -1.40687e-11   3.51726e-08 DIIS
+   @DF-RHF iter   9:  -149.93306858996249   -3.12639e-13   6.07949e-09 DIIS
+   @DF-RHF iter  10:  -149.93306858996255   -5.68434e-14   1.34394e-09 DIIS
+   @DF-RHF iter  11:  -149.93306858996243    1.13687e-13   2.64818e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.265778     2A    -20.201128     3A     -1.286129  
+       4A     -1.234946     5A     -0.640245     6A     -0.590711  
+       7A     -0.474712     8A     -0.430649     9A     -0.397718  
+      10A     -0.361496  
+
+    Virtual:                                                              
+
+      11A      0.564996    12A      0.653937    13A      0.715582  
+      14A      0.790788  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.93306858996243
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.3277666246058430
+    One-Electron Energy =                -282.7546452438277811
+    Two-Electron Energy =                  95.4938100292595209
+    Total Energy =                       -149.9330685899624314
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:     1.9166      Y:    30.1845      Z:     1.4308
+
+  Dipole Moment: [e a0]
+     X:     0.6989      Y:    -0.0934      Z:     0.8053     Total:     1.0704
+
+  Dipole Moment: [D]
+     X:     1.7764      Y:    -0.2373      Z:     2.0469     Total:     2.7207
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:15 2021
+Module time:
+	user time   =       2.38 seconds =       0.04 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     116.16 seconds =       1.94 minutes
+	system time =       5.75 seconds =       0.10 minutes
+	total time  =         24 seconds =       0.40 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:15 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+
+  Nuclear repulsion =   37.327766624605843
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000514722063    -0.037127087593     0.035083275772
+       2       -0.012784506952     0.013325049012    -0.007564197352
+       3        0.012040366513     0.024224890174    -0.027130542679
+       4        0.037567671720     0.016310280330     0.034554671507
+       5       -0.026923064700    -0.001483113831    -0.026942059552
+       6       -0.009385744517    -0.015250018094    -0.008001147697
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:15 2021
+Module time:
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     116.97 seconds =       1.95 minutes
+	system time =       5.80 seconds =       0.10 minutes
+	total time  =         24 seconds =       0.40 minutes
+
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2):  -149.93306858996243)
+
+       N-Body: Computing complex (4/6) with fragments (1, 2) in the basis of fragments (1, 2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:15 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.23211  B =      0.22918  C =      0.11739 [cm^-1]
+  Rotational constants: A =   6958.48914  B =   6870.69346  C =   3519.17419 [MHz]
+  Nuclear repulsion =   37.327766624605843
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4, 7       entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.3605
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.3916085987E-01.
+  Reciprocal condition number of the overlap matrix is 1.6340921935E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         21      21 
+   -------------------------
+    Total      21      21
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42214207219808   -1.48422e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.85190205588847   -1.42976e+00   1.57310e-02 DIIS
+   @DF-RHF iter   2:  -149.93842595354536   -8.65239e-02   2.56698e-03 DIIS
+   @DF-RHF iter   3:  -149.94038052277017   -1.95457e-03   6.20766e-04 DIIS
+   @DF-RHF iter   4:  -149.94054559491440   -1.65072e-04   6.37604e-05 DIIS
+   @DF-RHF iter   5:  -149.94054824286664   -2.64795e-06   9.91316e-06 DIIS
+   @DF-RHF iter   6:  -149.94054830731994   -6.44533e-08   1.44085e-06 DIIS
+   @DF-RHF iter   7:  -149.94054830836794   -1.04799e-09   2.53217e-07 DIIS
+   @DF-RHF iter   8:  -149.94054830839957   -3.16334e-11   3.21508e-08 DIIS
+   @DF-RHF iter   9:  -149.94054830840003   -4.54747e-13   6.14624e-09 DIIS
+   @DF-RHF iter  10:  -149.94054830840003    0.00000e+00   1.36595e-09 DIIS
+   @DF-RHF iter  11:  -149.94054830839997    5.68434e-14   2.33298e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.265993     2A    -20.213835     3A     -1.286385  
+       4A     -1.240805     5A     -0.640800     6A     -0.595401  
+       7A     -0.475790     8A     -0.434446     9A     -0.400444  
+      10A     -0.367648  
+
+    Virtual:                                                              
+
+      11A      0.490528    12A      0.607402    13A      0.648556  
+      14A      0.734932    15A      0.785344    16A      1.032771  
+      17A      1.373710    18A      2.556576    19A      2.950978  
+      20A      3.280669    21A     31.265676  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.94054830839997
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.3277666246058430
+    One-Electron Energy =                -282.6935372844795324
+    Two-Electron Energy =                  95.4252223514737068
+    Total Energy =                       -149.9405483083999968
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    -1.2177      Y:   -30.2778      Z:    -0.6255
+
+  Electronic Dipole Moment: [e a0]
+     X:     1.8989      Y:    30.1291      Z:     1.4353
+
+  Dipole Moment: [e a0]
+     X:     0.6812      Y:    -0.1488      Z:     0.8098     Total:     1.0686
+
+  Dipole Moment: [D]
+     X:     1.7314      Y:    -0.3781      Z:     2.0584     Total:     2.7162
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:16 2021
+Module time:
+	user time   =       3.24 seconds =       0.05 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     120.30 seconds =       2.00 minutes
+	system time =       5.94 seconds =       0.10 minutes
+	total time  =         25 seconds =       0.42 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:16 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+      Gh(O)           0.291279300000     3.008756250000     0.203085150000    15.994914619570
+      Gh(H)          -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+      Gh(H)           0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.327766624605843
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 15
+    Number of basis functions: 21
+    Number of Cartesian functions: 21
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 111
+    Number of basis functions: 339
+    Number of Cartesian functions: 399
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.006229531195    -0.044069536312     0.035292714793
+       2       -0.012839578035     0.013426294098    -0.006942742446
+       3        0.012305210871     0.022340107812    -0.027872442748
+       4        0.038047755850     0.016092138547     0.034472222644
+       5       -0.026878414203    -0.001431916656    -0.027008960617
+       6       -0.009250260278    -0.015250721244    -0.007822261205
+       7        0.000487157264     0.000396299317     0.000017340998
+       8        0.004357241449     0.008480435076    -0.000133273836
+       9        0.000000418279     0.000016899361    -0.000002597584
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:16 2021
+Module time:
+	user time   =       1.14 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     121.45 seconds =       2.02 minutes
+	system time =       5.99 seconds =       0.10 minutes
+	total time  =         25 seconds =       0.42 minutes
+
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2, 3):  -149.94054830839997)
+
+       N-Body: Computing complex (5/6) with fragments (2, 3) in the basis of fragments (2, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:16 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.66182  B =      0.23462  C =      0.17637 [cm^-1]
+  Rotational constants: A =  19840.79823  B =   7033.78531  C =   5287.47319 [MHz]
+  Nuclear repulsion =   37.420872712481227
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4063509175E-01.
+  Reciprocal condition number of the overlap matrix is 1.7073707716E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42275901194398   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.84541804362286   -1.42266e+00   2.34649e-02 DIIS
+   @DF-RHF iter   2:  -149.93239709894920   -8.69791e-02   3.66308e-03 DIIS
+   @DF-RHF iter   3:  -149.93422927268179   -1.83217e-03   8.99010e-04 DIIS
+   @DF-RHF iter   4:  -149.93437902657129   -1.49754e-04   9.36437e-05 DIIS
+   @DF-RHF iter   5:  -149.93438133921774   -2.31265e-06   2.68389e-05 DIIS
+   @DF-RHF iter   6:  -149.93438155141439   -2.12197e-07   2.29950e-06 DIIS
+   @DF-RHF iter   7:  -149.93438155269629   -1.28190e-09   2.77310e-07 DIIS
+   @DF-RHF iter   8:  -149.93438155271147   -1.51772e-11   3.53087e-08 DIIS
+   @DF-RHF iter   9:  -149.93438155271187   -3.97904e-13   7.13004e-09 DIIS
+   @DF-RHF iter  10:  -149.93438155271187    0.00000e+00   1.59469e-09 DIIS
+   @DF-RHF iter  11:  -149.93438155271187    0.00000e+00   2.84833e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267820     2A    -20.198469     3A     -1.287836  
+       4A     -1.233326     5A     -0.640430     6A     -0.591319  
+       7A     -0.477995     8A     -0.431952     9A     -0.395682  
+      10A     -0.360233  
+
+    Virtual:                                                              
+
+      11A      0.566153    12A      0.655627    13A      0.714253  
+      14A      0.791629  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.93438155271187
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4208727124812270
+    One-Electron Energy =                -282.9403861622592444
+    Two-Electron Energy =                  95.5851318970661339
+    Total Energy =                       -149.9343815527118693
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:    27.0414      Y:    14.0996      Z:     0.2271
+
+  Electronic Dipole Moment: [e a0]
+     X:   -27.3022      Y:   -13.4634      Z:    -0.2787
+
+  Dipole Moment: [e a0]
+     X:    -0.2608      Y:     0.6362      Z:    -0.0516     Total:     0.6895
+
+  Dipole Moment: [D]
+     X:    -0.6630      Y:     1.6170      Z:    -0.1313     Total:     1.7525
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:17 2021
+Module time:
+	user time   =       3.20 seconds =       0.05 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     124.73 seconds =       2.08 minutes
+	system time =       6.10 seconds =       0.10 minutes
+	total time  =         26 seconds =       0.43 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:17 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            2.469246140000    -1.754377390000    -0.170928840000    15.994914619570
+         H            3.763682600000    -2.214254030000     1.008461040000     1.007825032230
+         H            2.305983300000     0.070984450000    -0.039424730000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.420872712481227
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.031900038787     0.017463505515     0.035812884839
+       2       -0.026884139215    -0.002207374667    -0.026506364990
+       3       -0.004646857499    -0.016899689156    -0.009059839497
+       4       -0.030912398256     0.020784406748    -0.037975568577
+       5        0.017684289575     0.000367195713     0.008761535389
+       6        0.012859066612    -0.019508044154     0.028967352836
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:17 2021
+Module time:
+	user time   =       1.48 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     126.24 seconds =       2.10 minutes
+	system time =       6.18 seconds =       0.10 minutes
+	total time  =         26 seconds =       0.43 minutes
+
+       N-Body: Complex Energy (fragments = (2, 3), basis = (2, 3):  -149.93438155271187)
+
+       N-Body: Computing complex (6/6) with fragments (1, 3) in the basis of fragments (1, 3).
+
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:17 2021
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4     entry O          line    81 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3, 5-6 entry H          line    19 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/sto-3g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      0.66207  B =      0.23435  C =      0.17633 [cm^-1]
+  Rotational constants: A =  19848.38696  B =   7025.55974  C =   5286.37823 [MHz]
+  Nuclear repulsion =   37.415382693305901
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 20
+  Nalpha       = 10
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-09
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (STO-3G AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1, 4     entry O          line   318 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3, 5-6 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.0204
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4069553340E-01.
+  Reciprocal condition number of the overlap matrix is 1.7095996847E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         14      14 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -148.42342828985733   -1.48423e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.84546993007629   -1.42204e+00   2.34575e-02 DIIS
+   @DF-RHF iter   2:  -149.93239821743103   -8.69283e-02   3.65643e-03 DIIS
+   @DF-RHF iter   3:  -149.93422050124084   -1.82228e-03   8.97079e-04 DIIS
+   @DF-RHF iter   4:  -149.93436936133170   -1.48860e-04   9.32679e-05 DIIS
+   @DF-RHF iter   5:  -149.93437168523067   -2.32390e-06   2.53277e-05 DIIS
+   @DF-RHF iter   6:  -149.93437187353263   -1.88302e-07   2.29602e-06 DIIS
+   @DF-RHF iter   7:  -149.93437187480876   -1.27613e-09   2.76333e-07 DIIS
+   @DF-RHF iter   8:  -149.93437187482368   -1.49214e-11   3.37671e-08 DIIS
+   @DF-RHF iter   9:  -149.93437187482394   -2.55795e-13   6.15355e-09 DIIS
+   @DF-RHF iter  10:  -149.93437187482374    1.98952e-13   1.39739e-09 DIIS
+   @DF-RHF iter  11:  -149.93437187482388   -1.42109e-13   2.68754e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.267572     2A    -20.197942     3A     -1.287848  
+       4A     -1.232673     5A     -0.641232     6A     -0.590389  
+       7A     -0.477963     8A     -0.430709     9A     -0.396328  
+      10A     -0.359544  
+
+    Virtual:                                                              
+
+      11A      0.565402    12A      0.656605    13A      0.715036  
+      14A      0.792872  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    10 ]
+
+  @DF-RHF Final Energy:  -149.93437187482388
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             37.4153826933059008
+    One-Electron Energy =                -282.9351101924349905
+    Two-Electron Energy =                  95.5853556243052083
+    Total Energy =                       -149.9343718748238814
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:   -25.8236      Y:    16.1783      Z:     0.3984
+
+  Electronic Dipole Moment: [e a0]
+     X:    25.3912      Y:   -16.7858      Z:    -0.3985
+
+  Dipole Moment: [e a0]
+     X:    -0.4325      Y:    -0.6075      Z:    -0.0002     Total:     0.7457
+
+  Dipole Moment: [D]
+     X:    -1.0992      Y:    -1.5441      Z:    -0.0004     Total:     1.8954
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:18 2021
+Module time:
+	user time   =       2.35 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     128.76 seconds =       2.15 minutes
+	system time =       6.29 seconds =       0.10 minutes
+	total time  =         27 seconds =       0.45 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 10:22:18 2021
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -2.763732240000    -1.243777060000    -0.154445660000    15.994914619570
+         H           -1.123577910000    -2.062279700000    -0.052437990000     1.007825032230
+         H           -3.807923620000    -2.087055250000     1.060904070000     1.007825032230
+         O            0.291279300000     3.008756250000     0.203085150000    15.994914619570
+         H           -1.212530480000     1.958209000000     0.103033240000     1.007825032230
+         H            0.100020490000     4.249581150000    -1.102220790000     1.007825032230
+
+  Nuclear repulsion =   37.415382693305901
+
+  ==> Basis Set <==
+
+  Basis Set: STO-3G
+    Blend: STO-3G
+    Number of shells: 10
+    Number of basis functions: 14
+    Number of Cartesian functions: 14
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> DFJKGrad: Density-Fitted SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              8
+    Integrals threads:           8
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (STO-3G AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 74
+    Number of basis functions: 226
+    Number of Cartesian functions: 266
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.003827753800    -0.039988270686     0.036338095279
+       2       -0.009039790588     0.016264674933    -0.008676662242
+       3        0.011690203060     0.022568702480    -0.027356037239
+       4       -0.029246802273     0.015450908292    -0.038208637569
+       5        0.016622886495     0.005457681478     0.009236272356
+       6        0.013801257104    -0.019753696500     0.028666969414
+
+
+*** tstop() called on dorje at Mon Jun 28 10:22:18 2021
+Module time:
+	user time   =       0.70 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     129.47 seconds =       2.16 minutes
+	system time =       6.34 seconds =       0.11 minutes
+	total time  =         27 seconds =       0.45 minutes
+
+       N-Body: Complex Energy (fragments = (1, 3), basis = (1, 3):  -149.93437187482388)
+
+   ==> N-Body: Counterpoise Corrected (CP) energies <==
+
+   n-Body     Total Energy [Eh]       I.E. [kcal/mol]      Delta [kcal/mol]
+        1     -224.890393543774        0.000000000000        0.000000000000
+        2     -224.892193698870       -1.129614377343       -1.129614377343
+
+
+   ==> N-Body: Non-Counterpoise Corrected (NoCP) energies <==
+
+   n-Body     Total Energy [Eh]       I.E. [kcal/mol]      Delta [kcal/mol]
+        1     -224.890393543774        0.000000000000        0.000000000000
+        2     -224.911428473724      -13.199617824027      -13.199617824027
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 4, 7       entry O          line   130 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3, 5-6, 8-9 entry H          line    15 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+
+    rtd=F CP-Corrected Energy.............................................................PASSED
+    rtd=F CP-Corrected Energy.............................................................PASSED
+    rtd=F CP-Corrected Interaction Energy.................................................PASSED
+    rtd=F CP-Corrected Interaction Energy.................................................PASSED
+    rtd=F CP-Corrected Interaction Energy.................................................PASSED
+    rtd=F CP-Corrected Interaction Energy.................................................PASSED
+    rtd=F CP-Corrected Gradient...........................................................PASSED
+    rtd=F CP-Corrected Gradient...........................................................PASSED
+    rtd=F CP-Corrected Gradient...........................................................PASSED
+    rtd=F CP-Corrected Gradient...........................................................PASSED
+
+    Psi4 stopped on: Monday, 28 June 2021 10:22AM
+    Psi4 wall time for execution: 0:00:27.22
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This PR reverts the behaviour of standard `bsse_type='cp'` calculations to calculate all fragments (monomers) in the full (dimer) basis only. The PR also fixes printing interaction energies disguised as total energies in those tables.

When a calculation is requested with `bsse_type='cp', return_total_data=True`, an `bsse_type=['cp', 'nocp']` is automatically performed and the total energies are calculated & returned. With `bsse_type=['cp','nocp']` (and `return_total_data` unspecified or `False`), the total energies are calculated, but the interaction energies are returned.

The PR fixes #1691 .

## Checklist
- [x] Tests updated
- [x] `ctest -L nbody` passes

## Status
- [x] Ready for review
- [x] Ready for merge
