### PR TITLE
Previous shell core freezing and ECPs

### DIFF
--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -288,6 +288,7 @@ int BasisSet::n_frozen_core(const std::string &depth, SharedMolecule mol) {
                 int current_shell = atom_to_period(Z + ECP);
                 int delta = period_to_full_shell(std::max(current_shell - req_shell, 0));
                 // If this center has an ECP, some electrons are already frozen
+                if (delta < ECP) throw PSIEXCEPTION("ECP on atom freezes more electrons than requested by choosing a previous shell.");
                 if (ECP > 0) delta -= ECP;
                 // Keep track of current valence electrons
                 mol_valence = mol_valence + Z - delta;

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -64,7 +64,7 @@ Eghne = energy('mp2', molecule=ghne)
 Eghxe = energy('mp2', molecule=ghxe)
 compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy frozen [He] and [Kr] by hand")  #TEST
 
-molecule bih3 {
+molecule sbh3 {
 0 1
    Sb         0.00000000      0.76521375      0.00000000
    H          1.43645600     -0.25507125      0.00000000
@@ -73,13 +73,26 @@ molecule bih3 {
 }
 
 set freeze_core 0
-E, wfn = energy("mp2/def2-svp", return_wfn=True)
+E, wfn = energy("mp2/def2-svp", return_wfn=True, molecule=sbh3)
 
 compare_values(wfn.nfrzc(), 0, 1, "Number of frozen e- with freeze_core = 0")
 compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core = 0")
 
 set freeze_core 1
-E, wfn = energy("mp2/def2-svp", return_wfn=True)
+E, wfn = energy("mp2/def2-svp", return_wfn=True, molecule=sbh3)
 compare_values(wfn.nfrzc(), 4, 1, "Number of frozen orbitals with freeze_core = 1")
 compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core = 1")
+
+molecule hi {
+  0 1
+  H 0 0 0
+  I 0 0 3
+}
+
+set freeze_core -2
+try:
+    energy("mp2/def2-svp", molecule=hi)
+    compare_values(0, 1, "Exception raised when ECP larger than requested freeze_core?")
+except RuntimeError as e:
+    compare_values(1, 1, "Exception raised when ECP larger than requested freeze_core?")
 

--- a/tests/dfmp2-ecp/output.ref
+++ b/tests/dfmp2-ecp/output.ref
@@ -1,34 +1,42 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.3a2.dev373 
+                               Psi4 1.4rc3.dev11 
 
-                         Git: Rev {fc_valence_fix} 5045950 dirty
-
-
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+                         Git: Rev {i2012} 35c91d5 dirty
 
 
-                         Additional Contributions by
-    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, and R. A. Shaw
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Wednesday, 09 January 2019 07:37PM
+    Psi4 started on: Monday, 28 June 2021 07:08PM
 
-    Process ID: 2078
-    Host:       dream
-    PSIDATADIR: /home/kraus/Applications/psi4-dev-1350/share/psi4
+    Process ID: 3912
+    Host:       dorje
+    PSIDATADIR: /home/kraus/Applications/psi4-i2206/share/psi4
     Memory:     500.0 MiB
-    Threads:    1
+    Threads:    8
     
   ==> Input File <==
 
@@ -98,19 +106,54 @@ set guess sad
 Eghne = energy('mp2', molecule=ghne)
 Eghxe = energy('mp2', molecule=ghxe)
 compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy frozen [He] and [Kr] by hand")  #TEST
+
+molecule sbh3 {
+0 1
+   Sb         0.00000000      0.76521375      0.00000000
+   H          1.43645600     -0.25507125      0.00000000
+   H         -0.71822800     -0.25507125      1.24400700
+   H         -0.71822800     -0.25507125     -1.24400700
+}
+
+set freeze_core 0
+E, wfn = energy("mp2/def2-svp", return_wfn=True, molecule=sbh3)
+
+compare_values(wfn.nfrzc(), 0, 1, "Number of frozen e- with freeze_core = 0")
+compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core = 0")
+
+set freeze_core 1
+E, wfn = energy("mp2/def2-svp", return_wfn=True, molecule=sbh3)
+compare_values(wfn.nfrzc(), 4, 1, "Number of frozen orbitals with freeze_core = 1")
+compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core = 1")
+
+molecule hi {
+  0 1
+  H 0 0 0
+  I 0 0 3
+}
+
+set freeze_core -2
+try:
+    energy("mp2/def2-svp", molecule=hi)
+    compare_values(0, 1, "Exception raised when ECP larger than requested freeze_core?")
+except RuntimeError as e:
+    compare_values(1, 1, "Exception raised when ECP larger than requested freeze_core?")
+
 --------------------------------------------------------------------------
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:37:57 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:08:58 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -120,7 +163,7 @@ compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy froze
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -156,7 +199,7 @@ compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy froze
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -193,21 +236,8 @@ compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy froze
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        28      28       0       0       0       0
-     A2         6       6       0       0       0       0
-     B1        15      15       0       0       0       0
-     B2        15      15       0       0       0       0
-   -------------------------------------------------------
-    Total      64      64      18      18      18       0
-   -------------------------------------------------------
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -218,18 +248,18 @@ compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy froze
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       6.1523
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 71
     Number of primitives   = 86
     Number of AO           = 402
@@ -244,61 +274,39 @@ compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy froze
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0588497777E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6855117058E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        28      28 
+     A2         6       6 
+     B1        15      15 
+     B2        15      15 
+   -------------------------
+    Total      64      64
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   150.91088460573965    1.50911e+02   0.00000e+00 
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     8,    2,    4,    4 ]
-
-   @DF-RHF iter   1:  -315.35446041154722   -4.66265e+02   5.02473e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   2:  -313.66874798554386    1.68571e+00   3.77629e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     8,    2,    4,    4 ]
-
-   @DF-RHF iter   3:  -420.22766164934905   -1.06559e+02   1.34975e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   4:  -418.33430401600879    1.89336e+00   8.23316e-02 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [    10,    1,    3,    4 ]
-
-   @DF-RHF iter   5:  -425.83243965540208   -7.49814e+00   1.18451e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   6:  -436.84474748414749   -1.10123e+01   1.10184e-01 DIIS
-   @DF-RHF iter   7:  -452.27184710324229   -1.54271e+01   8.84775e-02 DIIS
-   @DF-RHF iter   8:  -451.17218406787134    1.09966e+00   9.79200e-02 DIIS
-   @DF-RHF iter   9:  -452.56178906070562   -1.38960e+00   8.44963e-02 DIIS
-   @DF-RHF iter  10:  -453.94421812060847   -1.38243e+00   7.04612e-02 DIIS
-   @DF-RHF iter  11:  -455.24174023881000   -1.29752e+00   5.36622e-02 DIIS
-   @DF-RHF iter  12:  -456.37049379906153   -1.12875e+00   2.63132e-02 DIIS
-   @DF-RHF iter  13:  -456.63951095717778   -2.69017e-01   9.04879e-03 DIIS
-   @DF-RHF iter  14:  -456.67093828414380   -3.14273e-02   4.76707e-04 DIIS
-   @DF-RHF iter  15:  -456.67108533498077   -1.47051e-04   1.03930e-04 DIIS
-   @DF-RHF iter  16:  -456.67109564770345   -1.03127e-05   3.08262e-05 DIIS
-   @DF-RHF iter  17:  -456.67109626052661   -6.12823e-07   1.31089e-05 DIIS
-   @DF-RHF iter  18:  -456.67109632914554   -6.86189e-08   1.62001e-06 DIIS
-   @DF-RHF iter  19:  -456.67109633070152   -1.55597e-09   1.50194e-07 DIIS
-   @DF-RHF iter  20:  -456.67109633073773   -3.62093e-11   2.66643e-08 DIIS
-   @DF-RHF iter  21:  -456.67109633073926   -1.53477e-12   5.22871e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -452.92385352595147   -4.52924e+02   0.00000e+00 
+   @DF-RHF iter   1:  -456.56813543533667   -3.64428e+00   1.59620e-02 DIIS
+   @DF-RHF iter   2:  -456.65809095223710   -8.99555e-02   7.30837e-03 DIIS
+   @DF-RHF iter   3:  -456.67106390286784   -1.29730e-02   3.16728e-04 DIIS
+   @DF-RHF iter   4:  -456.67109576589530   -3.18630e-05   2.94413e-05 DIIS
+   @DF-RHF iter   5:  -456.67109630313450   -5.37239e-07   8.16327e-06 DIIS
+   @DF-RHF iter   6:  -456.67109632924337   -2.61089e-08   1.41328e-06 DIIS
+   @DF-RHF iter   7:  -456.67109633054343   -1.30007e-09   2.25250e-07 DIIS
+   @DF-RHF iter   8:  -456.67109633057180   -2.83649e-11   9.07246e-08 DIIS
+   @DF-RHF iter   9:  -456.67109633057544   -3.63798e-12   9.62810e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -310,42 +318,42 @@ compare_values(refEin, Efzc - Eghne - Eghxe, 8, "MP2 CP interaction energy froze
 
        1A1   -32.759855     2A1    -8.395838     1B2    -6.129623  
        1B1    -6.129623     3A1    -6.129417     1A2    -2.660067  
-       4A1    -2.660067     2B1    -2.659818     2B2    -2.659818  
+       4A1    -2.660067     2B2    -2.659818     2B1    -2.659818  
        5A1    -2.659755     6A1    -1.889304     7A1    -1.007151  
-       8A1    -0.846795     3B1    -0.845650     3B2    -0.845650  
-       4B2    -0.453436     4B1    -0.453436     9A1    -0.451324  
+       8A1    -0.846795     3B2    -0.845650     3B1    -0.845650  
+       4B1    -0.453436     4B2    -0.453436     9A1    -0.451324  
 
     Virtual:                                                              
 
-       5B2     0.300476     5B1     0.300476    10A1     0.314526  
-      11A1     0.354930     2A2     0.354930     6B1     0.354978  
-       6B2     0.354978    12A1     0.371453    13A1     0.516044  
+       5B1     0.300476     5B2     0.300476    10A1     0.314526  
+       2A2     0.354930    11A1     0.354930     6B2     0.354978  
+       6B1     0.354978    12A1     0.371454    13A1     0.516044  
       14A1     1.147785     7B2     1.152918     7B1     1.152918  
-       8B2     1.153132     8B1     1.153132    15A1     1.153213  
-       3A2     1.153213    16A1     1.532716     9B2     1.553626  
-       9B1     1.553626    17A1     1.598406    10B2     1.646537  
-      10B1     1.646537     4A2     1.687129    18A1     1.687129  
+       8B2     1.153132     8B1     1.153132     3A2     1.153213  
+      15A1     1.153213    16A1     1.532716     9B1     1.553626  
+       9B2     1.553626    17A1     1.598406    10B1     1.646537  
+      10B2     1.646537     4A2     1.687129    18A1     1.687129  
       19A1     1.703758    11B1     1.748135    11B2     1.748135  
       20A1     1.994860    12B2     3.645570    12B1     3.645570  
-       5A2     3.645789    21A1     3.645789    13B1     3.645994  
-      13B2     3.645994    22A1     3.649244    23A1     4.512135  
-       6A2     4.512135    14B2     4.512759    14B1     4.512759  
+       5A2     3.645789    21A1     3.645789    13B2     3.645994  
+      13B1     3.645994    22A1     3.649244     6A2     4.512135  
+      23A1     4.512135    14B1     4.512759    14B2     4.512759  
       24A1     4.516149    25A1     4.894649    15B2    34.655678  
       15B1    34.655678    26A1    34.664720    27A1    45.102918  
-      28A1   109.278497  
+      28A1   109.278498  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     9,    1,    4,    4 ]
 
-  @DF-RHF Final Energy:  -456.67109633073926
+  @DF-RHF Final Energy:  -456.67109633057544
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             45.8620249247333405
-    One-Electron Energy =                -845.7929919098778555
-    Two-Electron Energy =                 343.2598706544052902
-    Total Energy =                       -456.6710963307392603
+    One-Electron Energy =                -845.7929924983051251
+    Two-Electron Energy =                 343.2598712429963825
+    Total Energy =                       -456.6710963305754376
 
 Computation Completed
 
@@ -367,18 +375,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.2025     Total:     0.2025
 
 
-*** tstop() called on dream at Wed Jan  9 19:37:59 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:01 2021
 Module time:
-	user time   =       1.77 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       9.42 seconds =       0.16 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       1.77 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       9.42 seconds =       0.16 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:37:59 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:01 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -390,13 +398,13 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -430,47 +438,49 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -456.6710963307392603 [Eh]
+	 Reference Energy          =    -456.6710963305754376 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.2734241011870575 [Eh]
-	 Opposite-Spin Energy      =      -0.5286882515431338 [Eh]
-	 Correlation Energy        =      -0.8021123527301912 [Eh]
-	 Total Energy              =    -457.4732086834694655 [Eh]
+	 Same-Spin Energy          =      -0.2734241009581457 [Eh]
+	 Opposite-Spin Energy      =      -0.5286882508923462 [Eh]
+	 Correlation Energy        =      -0.8021123518504918 [Eh]
+	 Total Energy              =    -457.4732086824259341 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0911413670623525 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.6344259018517605 [Eh]
-	 SCS Correlation Energy    =      -0.7255672689141131 [Eh]
-	 SCS Total Energy          =    -457.3966635996533796 [Eh]
+	 SCS Same-Spin Energy      =      -0.0911413669860485 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.6344259010708154 [Eh]
+	 SCS Correlation Energy    =      -0.7255672680568640 [Eh]
+	 SCS Total Energy          =    -457.3966635986323013 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:00 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:01 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.87 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.95 seconds =       0.03 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =      11.29 seconds =       0.19 minutes
+	system time =       0.50 seconds =       0.01 minutes
 	total time  =          3 seconds =       0.05 minutes
-	Nuclear repulsion energy..........................................PASSED
-	MP2 energy with all-electron Ne and ECP on Xe.....................PASSED
+    Nuclear repulsion energy..............................................................PASSED
+    MP2 energy with all-electron Ne and ECP on Xe.........................................PASSED
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:00 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:01 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -480,7 +490,7 @@ Total time:
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -516,7 +526,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -553,21 +563,8 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        28      28       0       0       0       0
-     A2         6       6       0       0       0       0
-     B1        15      15       0       0       0       0
-     B2        15      15       0       0       0       0
-   -------------------------------------------------------
-    Total      64      64      18      18      18       0
-   -------------------------------------------------------
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -578,18 +575,18 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       6.1523
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 71
     Number of primitives   = 86
     Number of AO           = 402
@@ -604,61 +601,39 @@ Total time:
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0588497777E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6855117058E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        28      28 
+     A2         6       6 
+     B1        15      15 
+     B2        15      15 
+   -------------------------
+    Total      64      64
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   150.91088460574039    1.50911e+02   0.00000e+00 
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     8,    2,    4,    4 ]
-
-   @DF-RHF iter   1:  -315.35446041154688   -4.66265e+02   5.02473e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   2:  -313.66874798554136    1.68571e+00   3.77629e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     8,    2,    4,    4 ]
-
-   @DF-RHF iter   3:  -420.22766164934853   -1.06559e+02   1.34975e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   4:  -418.33430401600907    1.89336e+00   8.23316e-02 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [    10,    1,    3,    4 ]
-
-   @DF-RHF iter   5:  -425.83243965539714   -7.49814e+00   1.18451e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   6:  -436.84474748415022   -1.10123e+01   1.10184e-01 DIIS
-   @DF-RHF iter   7:  -452.27184710324030   -1.54271e+01   8.84775e-02 DIIS
-   @DF-RHF iter   8:  -451.17218406786589    1.09966e+00   9.79200e-02 DIIS
-   @DF-RHF iter   9:  -452.56178906070346   -1.38960e+00   8.44963e-02 DIIS
-   @DF-RHF iter  10:  -453.94421812060568   -1.38243e+00   7.04612e-02 DIIS
-   @DF-RHF iter  11:  -455.24174023880778   -1.29752e+00   5.36622e-02 DIIS
-   @DF-RHF iter  12:  -456.37049379906023   -1.12875e+00   2.63132e-02 DIIS
-   @DF-RHF iter  13:  -456.63951095717749   -2.69017e-01   9.04879e-03 DIIS
-   @DF-RHF iter  14:  -456.67093828414386   -3.14273e-02   4.76707e-04 DIIS
-   @DF-RHF iter  15:  -456.67108533498094   -1.47051e-04   1.03930e-04 DIIS
-   @DF-RHF iter  16:  -456.67109564770379   -1.03127e-05   3.08262e-05 DIIS
-   @DF-RHF iter  17:  -456.67109626052678   -6.12823e-07   1.31089e-05 DIIS
-   @DF-RHF iter  18:  -456.67109632914548   -6.86187e-08   1.62001e-06 DIIS
-   @DF-RHF iter  19:  -456.67109633070163   -1.55615e-09   1.50194e-07 DIIS
-   @DF-RHF iter  20:  -456.67109633073756   -3.59250e-11   2.66643e-08 DIIS
-   @DF-RHF iter  21:  -456.67109633073892   -1.36424e-12   5.22871e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -452.92385352595170   -4.52924e+02   0.00000e+00 
+   @DF-RHF iter   1:  -456.56813543533667   -3.64428e+00   1.59620e-02 DIIS
+   @DF-RHF iter   2:  -456.65809095223699   -8.99555e-02   7.30837e-03 DIIS
+   @DF-RHF iter   3:  -456.67106390286790   -1.29730e-02   3.16728e-04 DIIS
+   @DF-RHF iter   4:  -456.67109576589525   -3.18630e-05   2.94413e-05 DIIS
+   @DF-RHF iter   5:  -456.67109630313473   -5.37239e-07   8.16327e-06 DIIS
+   @DF-RHF iter   6:  -456.67109632924377   -2.61090e-08   1.41328e-06 DIIS
+   @DF-RHF iter   7:  -456.67109633054366   -1.29990e-09   2.25250e-07 DIIS
+   @DF-RHF iter   8:  -456.67109633057186   -2.81943e-11   9.07246e-08 DIIS
+   @DF-RHF iter   9:  -456.67109633057578   -3.92220e-12   9.62810e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -670,42 +645,42 @@ Total time:
 
        1A1   -32.759855     2A1    -8.395838     1B2    -6.129623  
        1B1    -6.129623     3A1    -6.129417     1A2    -2.660067  
-       4A1    -2.660067     2B1    -2.659818     2B2    -2.659818  
+       4A1    -2.660067     2B2    -2.659818     2B1    -2.659818  
        5A1    -2.659755     6A1    -1.889304     7A1    -1.007151  
-       8A1    -0.846795     3B1    -0.845650     3B2    -0.845650  
-       4B2    -0.453436     4B1    -0.453436     9A1    -0.451324  
+       8A1    -0.846795     3B2    -0.845650     3B1    -0.845650  
+       4B1    -0.453436     4B2    -0.453436     9A1    -0.451324  
 
     Virtual:                                                              
 
-       5B2     0.300476     5B1     0.300476    10A1     0.314526  
-      11A1     0.354930     2A2     0.354930     6B1     0.354978  
-       6B2     0.354978    12A1     0.371453    13A1     0.516044  
+       5B1     0.300476     5B2     0.300476    10A1     0.314526  
+       2A2     0.354930    11A1     0.354930     6B2     0.354978  
+       6B1     0.354978    12A1     0.371454    13A1     0.516044  
       14A1     1.147785     7B2     1.152918     7B1     1.152918  
-       8B2     1.153132     8B1     1.153132    15A1     1.153213  
-       3A2     1.153213    16A1     1.532716     9B2     1.553626  
-       9B1     1.553626    17A1     1.598406    10B2     1.646537  
-      10B1     1.646537     4A2     1.687129    18A1     1.687129  
+       8B2     1.153132     8B1     1.153132     3A2     1.153213  
+      15A1     1.153213    16A1     1.532716     9B1     1.553626  
+       9B2     1.553626    17A1     1.598406    10B1     1.646537  
+      10B2     1.646537     4A2     1.687129    18A1     1.687129  
       19A1     1.703758    11B1     1.748135    11B2     1.748135  
       20A1     1.994860    12B2     3.645570    12B1     3.645570  
-       5A2     3.645789    21A1     3.645789    13B1     3.645994  
-      13B2     3.645994    22A1     3.649244    23A1     4.512135  
-       6A2     4.512135    14B2     4.512759    14B1     4.512759  
+       5A2     3.645789    21A1     3.645789    13B2     3.645994  
+      13B1     3.645994    22A1     3.649244     6A2     4.512135  
+      23A1     4.512135    14B1     4.512759    14B2     4.512759  
       24A1     4.516149    25A1     4.894649    15B2    34.655678  
       15B1    34.655678    26A1    34.664720    27A1    45.102918  
-      28A1   109.278497  
+      28A1   109.278498  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     9,    1,    4,    4 ]
 
-  @DF-RHF Final Energy:  -456.67109633073892
+  @DF-RHF Final Energy:  -456.67109633057578
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             45.8620249247333405
-    One-Electron Energy =                -845.7929919098780829
-    Two-Electron Energy =                 343.2598706544058587
-    Total Energy =                       -456.6710963307389193
+    One-Electron Energy =                -845.7929924983055798
+    Two-Electron Energy =                 343.2598712429964962
+    Total Energy =                       -456.6710963305757787
 
 Computation Completed
 
@@ -727,18 +702,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.2025     Total:     0.2025
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:01 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:06 2021
 Module time:
-	user time   =       1.74 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =      15.28 seconds =       0.25 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
 Total time:
-	user time   =       3.70 seconds =       0.06 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =      26.62 seconds =       0.44 minutes
+	system time =       0.92 seconds =       0.02 minutes
+	total time  =          8 seconds =       0.13 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:01 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:06 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -750,13 +725,13 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -790,34 +765,36 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -456.6710963307389193 [Eh]
+	 Reference Energy          =    -456.6710963305757787 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.2465524816571197 [Eh]
-	 Opposite-Spin Energy      =      -0.4636233738367281 [Eh]
-	 Correlation Energy        =      -0.7101758554938478 [Eh]
-	 Total Energy              =    -457.3812721862327635 [Eh]
+	 Same-Spin Energy          =      -0.2465524813380407 [Eh]
+	 Opposite-Spin Energy      =      -0.4636233730100380 [Eh]
+	 Correlation Energy        =      -0.7101758543480787 [Eh]
+	 Total Energy              =    -457.3812721849238301 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0821841605523732 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.5563480486040737 [Eh]
-	 SCS Correlation Energy    =      -0.6385322091564469 [Eh]
-	 SCS Total Energy          =    -457.3096285398953569 [Eh]
+	 SCS Same-Spin Energy      =      -0.0821841604460136 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.5563480476120456 [Eh]
+	 SCS Correlation Energy    =      -0.6385322080580591 [Eh]
+	 SCS Total Energy          =    -457.3096285386338309 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:02 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:06 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.76 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.88 seconds =       0.06 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
-	MP2 energy with frozen [He] and [Kr]..............................PASSED
+	user time   =      28.39 seconds =       0.47 minutes
+	system time =       1.01 seconds =       0.02 minutes
+	total time  =          8 seconds =       0.13 minutes
+    MP2 energy with frozen [He] and [Kr]..................................................PASSED
+
+Scratch directory: /tmp/
 
 
    ===> N-Body Interaction Abacus <===
@@ -828,19 +805,306 @@ Total time:
    ==> N-Body: Now computing 1-body complexes <==
 
 
-       N-Body: Computing complex (1/4) with fragments (2,) in the basis of fragments (2,).
+       N-Body: Computing complex (1/4) with fragments (1,) in the basis of fragments (1,).
 
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:02 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:06 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         NE           0.000000000000     0.000000000000    -2.605143746473    19.992440176200
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =      0.12424  C =      0.12424 [cm^-1]
+  Rotational constants: A = ************  B =   3724.67180  C =   3724.67180 [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = DEF2-SVP
+    Blend                  = DEF2-SVP
+    Total number of shells = 6
+    Number of primitives   = 12
+    Number of AO           = 15
+    Number of SO           = 14
+    Maximum AM             = 2
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    NE     7s 4p 1d // 3s 2p 1d 
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-UNIVERSAL-JKFIT
+    Total number of shells = 25
+    Number of primitives   = 33
+    Number of AO           = 93
+    Number of SO           = 77
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    NE     14s 10p 6d 2f 1g // 10s 8p 4d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 1.9107712976E-01.
+  Reciprocal condition number of the overlap matrix is 9.9105788536E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1         7       7 
+     A2         1       1 
+     B1         3       3 
+     B2         3       3 
+   -------------------------
+    Total      14      14
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -128.37632153278159   -1.28376e+02   0.00000e+00 
+   @DF-RHF iter   1:  -128.37632385730251   -2.32452e-06   1.83252e-04 DIIS
+   @DF-RHF iter   2:  -128.37632432065166   -4.63349e-07   8.41663e-05 DIIS
+   @DF-RHF iter   3:  -128.37632444014514   -1.19493e-07   1.20850e-06 DIIS
+   @DF-RHF iter   4:  -128.37632444017936   -3.42197e-11   5.83970e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -32.752827     2A1    -1.882206     3A1    -0.838894  
+       1B1    -0.838894     1B2    -0.838894  
+
+    Virtual:                                                              
+
+       4A1     1.634945     2B1     1.696299     2B2     1.696299  
+       5A1     1.696299     3B1     4.518912     3B2     4.518912  
+       1A2     4.518912     6A1     4.518912     7A1     4.518912  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @DF-RHF Final Energy:  -128.37632444017936
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -182.4492217449454756
+    Two-Electron Energy =                  54.0728973047661228
+    Total Energy =                       -128.3763244401793600
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:   -49.2301
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    49.2301
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on dorje at Mon Jun 28 19:09:06 2021
+Module time:
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      30.16 seconds =       0.50 minutes
+	system time =       1.11 seconds =       0.02 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:06 2021
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   8 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-SVP-RI
+    Total number of shells = 16
+    Number of primitives   = 22
+    Number of AO           = 55
+    Number of SO           = 48
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    NE     8s 6p 5d 3f // 6s 5p 4d 1f 
+
+	 --------------------------------------------------------
+	                 NBF =    14, NAUX =    48
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       1       5       4       9       9       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =    -128.3763244401793600 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0507709258362007 [Eh]
+	 Opposite-Spin Energy      =      -0.1327583341489799 [Eh]
+	 Correlation Energy        =      -0.1835292599851806 [Eh]
+	 Total Energy              =    -128.5598537001645525 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0169236419454002 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1593100009787758 [Eh]
+	 SCS Correlation Energy    =      -0.1762336429241761 [Eh]
+	 SCS Total Energy          =    -128.5525580831035484 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dorje at Mon Jun 28 19:09:06 2021
+Module time:
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      30.50 seconds =       0.51 minutes
+	system time =       1.13 seconds =       0.02 minutes
+	total time  =          8 seconds =       0.13 minutes
+
+       N-Body: Complex Energy (fragments = (1,), basis = (1,):  -128.55985370016455)
+
+       N-Body: Computing complex (2/4) with fragments (2,) in the basis of fragments (2,).
+
+
+Scratch directory: /tmp/
+    SCF Algorithm Type (re)set to DF.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:06 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -850,7 +1114,7 @@ Total time:
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -883,7 +1147,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -918,20 +1182,7 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        21      21       0       0       0       0
-     A2         5       5       0       0       0       0
-     B1        12      12       0       0       0       0
-     B2        12      12       0       0       0       0
-   -------------------------------------------------------
-    Total      50      50      13      13      13       0
-   -------------------------------------------------------
+    atoms 1 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -942,18 +1193,18 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 46
     Number of primitives   = 53
     Number of AO           = 309
@@ -967,27 +1218,37 @@ Total time:
        1    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0783978001E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6910266412E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        21      21 
+     A2         5       5 
+     B1        12      12 
+     B2        12      12 
+   -------------------------
+    Total      50      50
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   279.28763695224291    2.79288e+02   0.00000e+00 
-   @DF-RHF iter   1:  -187.06234489873043   -4.66350e+02   6.51306e-01 DIIS
-   @DF-RHF iter   2:  -290.39835203326112   -1.03336e+02   3.48463e-01 DIIS
-   @DF-RHF iter   3:  -328.13416276550691   -3.77358e+01   3.29736e-02 DIIS
-   @DF-RHF iter   4:  -328.29242329581598   -1.58261e-01   4.34739e-03 DIIS
-   @DF-RHF iter   5:  -328.29814253961115   -5.71924e-03   1.04373e-03 DIIS
-   @DF-RHF iter   6:  -328.29834359490684   -2.01055e-04   1.88163e-04 DIIS
-   @DF-RHF iter   7:  -328.29835690184626   -1.33069e-05   3.13402e-05 DIIS
-   @DF-RHF iter   8:  -328.29835732269657   -4.20850e-07   3.26664e-06 DIIS
-   @DF-RHF iter   9:  -328.29835733478973   -1.20932e-08   3.26514e-07 DIIS
-   @DF-RHF iter  10:  -328.29835733486647   -7.67386e-11   1.61558e-08 DIIS
-   @DF-RHF iter  11:  -328.29835733486675   -2.84217e-13   1.09861e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -324.53314684553152   -3.24533e+02   0.00000e+00 
+   @DF-RHF iter   1:  -328.19660725971067   -3.66346e+00   2.06052e-02 DIIS
+   @DF-RHF iter   2:  -328.28542700695783   -8.88197e-02   9.45150e-03 DIIS
+   @DF-RHF iter   3:  -328.29832629848067   -1.28993e-02   4.09645e-04 DIIS
+   @DF-RHF iter   4:  -328.29835689704458   -3.05986e-05   3.30533e-05 DIIS
+   @DF-RHF iter   5:  -328.29835733023077   -4.33186e-07   2.96233e-06 DIIS
+   @DF-RHF iter   6:  -328.29835733492354   -4.69277e-09   1.76875e-07 DIIS
+   @DF-RHF iter   7:  -328.29835733493826   -1.47224e-11   6.05592e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -997,40 +1258,40 @@ Total time:
 
     Doubly Occupied:                                                      
 
-       1A1    -8.399948     1B1    -6.133651     1B2    -6.133651  
-       2A1    -6.133651     1A2    -2.663978     3A1    -2.663978  
-       2B1    -2.663978     2B2    -2.663978     4A1    -2.663978  
-       5A1    -1.009453     3B2    -0.456170     3B1    -0.456170  
-       6A1    -0.456170  
+       1A1    -8.399948     1B2    -6.133651     2A1    -6.133651  
+       1B1    -6.133651     3A1    -2.663978     2B2    -2.663978  
+       1A2    -2.663978     2B1    -2.663978     4A1    -2.663978  
+       5A1    -1.009453     3B1    -0.456170     6A1    -0.456170  
+       3B2    -0.456170  
 
     Virtual:                                                              
 
-       7A1     0.297812     4B1     0.297812     4B2     0.297812  
-       8A1     0.352992     5B2     0.352992     5B1     0.352992  
-       2A2     0.352992     9A1     0.352992    10A1     0.510919  
-       6B2     1.150078     6B1     1.150078    11A1     1.150078  
-       3A2     1.150078     7B2     1.150078     7B1     1.150078  
-      12A1     1.150078     8B1     1.553367     8B2     1.553367  
-      13A1     1.553367    14A1     1.684134     4A2     1.684134  
-       9B1     1.684134     9B2     1.684134    15A1     1.684134  
-      10B1     3.641925    10B2     3.641925     5A2     3.641925  
-      16A1     3.641925    11B1     3.641925    11B2     3.641925  
-      17A1     3.641925    18A1     4.872363    12B1    34.650967  
-      12B2    34.650967    19A1    34.650967    20A1    45.087926  
+       4B1     0.297812     7A1     0.297812     4B2     0.297812  
+       5B2     0.352992     8A1     0.352992     2A2     0.352992  
+       5B1     0.352992     9A1     0.352992    10A1     0.510919  
+      11A1     1.150078     6B2     1.150078     3A2     1.150078  
+       6B1     1.150078     7B2     1.150078    12A1     1.150078  
+       7B1     1.150078     8B1     1.553367    13A1     1.553367  
+       8B2     1.553367    14A1     1.684134     9B1     1.684134  
+       4A2     1.684134    15A1     1.684134     9B2     1.684134  
+      16A1     3.641925    10B2     3.641925     5A2     3.641925  
+      10B1     3.641925    11B2     3.641925    17A1     3.641925  
+      11B1     3.641925    18A1     4.872363    12B2    34.650967  
+      19A1    34.650967    12B1    34.650967    20A1    45.087926  
       21A1   109.272698  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     6,    1,    3,    3 ]
 
-  @DF-RHF Final Energy:  -328.29835733486675
+  @DF-RHF Final Energy:  -328.29835733493826
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.0000000000000000
-    One-Electron Energy =                -571.5992104783834975
-    Two-Electron Energy =                 243.3008531435167754
-    Total Energy =                       -328.2983573348667505
+    One-Electron Energy =                -571.5992114518638800
+    Two-Electron Energy =                 243.3008541169256489
+    Total Energy =                       -328.2983573349382596
 
 Computation Completed
 
@@ -1052,18 +1313,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:03 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:09 2021
 Module time:
-	user time   =       1.15 seconds =       0.02 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       9.77 seconds =       0.16 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       5.04 seconds =       0.08 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      40.32 seconds =       0.67 minutes
+	system time =       1.39 seconds =       0.02 minutes
+	total time  =         11 seconds =       0.18 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:03 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:09 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1075,12 +1336,12 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -1113,50 +1374,52 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -328.2983573348667505 [Eh]
+	 Reference Energy          =    -328.2983573349382596 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.1951462037180271 [Eh]
-	 Opposite-Spin Energy      =      -0.3299934474472215 [Eh]
-	 Correlation Energy        =      -0.5251396511652485 [Eh]
-	 Total Energy              =    -328.8234969860320120 [Eh]
+	 Same-Spin Energy          =      -0.1951462035494191 [Eh]
+	 Opposite-Spin Energy      =      -0.3299934471023991 [Eh]
+	 Correlation Energy        =      -0.5251396506518182 [Eh]
+	 Total Energy              =    -328.8234969855900545 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0650487345726757 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.3959921369366657 [Eh]
-	 SCS Correlation Energy    =      -0.4610408715093414 [Eh]
-	 SCS Total Energy          =    -328.7593982063760905 [Eh]
+	 SCS Same-Spin Energy      =      -0.0650487345164730 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.3959921365228790 [Eh]
+	 SCS Correlation Energy    =      -0.4610408710393520 [Eh]
+	 SCS Total Energy          =    -328.7593982059776181 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:03 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:10 2021
 Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.35 seconds =       0.02 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.17 seconds =       0.09 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =      41.68 seconds =       0.69 minutes
+	system time =       1.45 seconds =       0.02 minutes
+	total time  =         12 seconds =       0.20 minutes
 
-       N-Body: Complex Energy (fragments = (2,), basis = (2,):  -328.82349698603201)
+       N-Body: Complex Energy (fragments = (2,), basis = (2,):  -328.82349698559005)
 
-       N-Body: Computing complex (2/4) with fragments (2,) in the basis of fragments (1, 2).
+       N-Body: Computing complex (3/4) with fragments (2,) in the basis of fragments (1, 2).
 
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:03 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:10 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -1166,7 +1429,7 @@ Total time:
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1202,7 +1465,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -1239,21 +1502,8 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        28      28       0       0       0       0
-     A2         6       6       0       0       0       0
-     B1        15      15       0       0       0       0
-     B2        15      15       0       0       0       0
-   -------------------------------------------------------
-    Total      64      64      13      13      13       0
-   -------------------------------------------------------
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1264,18 +1514,18 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       6.1523
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 71
     Number of primitives   = 86
     Number of AO           = 402
@@ -1290,28 +1540,38 @@ Total time:
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0588497777E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6855117058E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        28      28 
+     A2         6       6 
+     B1        15      15 
+     B2        15      15 
+   -------------------------
+    Total      64      64
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   279.28780821698126    2.79288e+02   0.00000e+00 
-   @DF-RHF iter   1:  -184.69845210620366   -4.63986e+02   5.03779e-01 DIIS
-   @DF-RHF iter   2:  -290.33411840584347   -1.05636e+02   2.68806e-01 DIIS
-   @DF-RHF iter   3:  -328.13258938023790   -3.77985e+01   2.58542e-02 DIIS
-   @DF-RHF iter   4:  -328.29201710102387   -1.59428e-01   3.53156e-03 DIIS
-   @DF-RHF iter   5:  -328.29803419126478   -6.01709e-03   9.65105e-04 DIIS
-   @DF-RHF iter   6:  -328.29828752647450   -2.53335e-04   2.64494e-04 DIIS
-   @DF-RHF iter   7:  -328.29831227597748   -2.47495e-05   6.64606e-05 DIIS
-   @DF-RHF iter   8:  -328.29831499272240   -2.71674e-06   1.21156e-05 DIIS
-   @DF-RHF iter   9:  -328.29831510945576   -1.16733e-07   1.34910e-06 DIIS
-   @DF-RHF iter  10:  -328.29831511287102   -3.41527e-09   1.48847e-07 DIIS
-   @DF-RHF iter  11:  -328.29831511289751   -2.64890e-11   2.41028e-08 DIIS
-   @DF-RHF iter  12:  -328.29831511289842   -9.09495e-13   5.79061e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -324.53317828776380   -3.24533e+02   0.00000e+00 
+   @DF-RHF iter   1:  -328.19658201879423   -3.66340e+00   1.58794e-02 DIIS
+   @DF-RHF iter   2:  -328.28537588414667   -8.87939e-02   7.28416e-03 DIIS
+   @DF-RHF iter   3:  -328.29828398312333   -1.29081e-02   3.15211e-04 DIIS
+   @DF-RHF iter   4:  -328.29831466546887   -3.06823e-05   2.56402e-05 DIIS
+   @DF-RHF iter   5:  -328.29831510807361   -4.42605e-07   2.28640e-06 DIIS
+   @DF-RHF iter   6:  -328.29831511276393   -4.69032e-09   1.35325e-07 DIIS
+   @DF-RHF iter   7:  -328.29831511277791   -1.39835e-11   2.43670e-08 DIIS
+   @DF-RHF iter   8:  -328.29831511277808   -1.70530e-13   3.97857e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -1321,44 +1581,44 @@ Total time:
 
     Doubly Occupied:                                                      
 
-       1A1    -8.399824     2A1    -6.133527     1B1    -6.133527  
-       1B2    -6.133527     3A1    -2.663855     2B1    -2.663854  
-       2B2    -2.663854     4A1    -2.663853     1A2    -2.663853  
-       5A1    -1.009364     6A1    -0.456086     3B2    -0.456084  
-       3B1    -0.456084  
+       1A1    -8.399824     2A1    -6.133527     1B2    -6.133527  
+       1B1    -6.133527     3A1    -2.663855     2B2    -2.663854  
+       2B1    -2.663854     1A2    -2.663853     4A1    -2.663853  
+       5A1    -1.009364     6A1    -0.456086     3B1    -0.456084  
+       3B2    -0.456084  
 
     Virtual:                                                              
 
-       7A1     0.290754     4B2     0.298282     4B1     0.298282  
-       8A1     0.338862     5B1     0.352149     5B2     0.352149  
+       7A1     0.290754     4B1     0.298282     4B2     0.298282  
+       8A1     0.338862     5B2     0.352149     5B1     0.352149  
        2A2     0.353054     9A1     0.353054    10A1     0.494070  
-      11A1     0.651923     6B2     1.067644     6B1     1.067644  
+      11A1     0.651923     6B1     1.067644     6B2     1.067644  
       12A1     1.089820     7B2     1.150188     7B1     1.150188  
-       3A2     1.150189    13A1     1.150189     8B1     1.152296  
-       8B2     1.152296    14A1     1.197801     9B1     1.555274  
+       3A2     1.150189    13A1     1.150189     8B2     1.152296  
+       8B1     1.152296    14A1     1.197801     9B1     1.555274  
        9B2     1.555274    15A1     1.571444     4A2     1.684213  
       16A1     1.684213    10B1     1.689655    10B2     1.689655  
-      17A1     1.749128    18A1     3.331024    19A1     3.642041  
-       5A2     3.642041    11B2     3.642044    11B1     3.642044  
-      12B1     3.642106    12B2     3.642106    20A1     3.646045  
-      21A1     4.888036    22A1     6.607588     6A2     6.607588  
-      13B2     6.608222    13B1     6.608222    23A1     6.612446  
-      14B2     8.693842    14B1     8.693842    24A1     8.780228  
-      15B1    34.651699    15B2    34.651699    25A1    34.660589  
+      17A1     1.749128    18A1     3.331024     5A2     3.642041  
+      19A1     3.642041    11B2     3.642044    11B1     3.642044  
+      12B2     3.642106    12B1     3.642106    20A1     3.646045  
+      21A1     4.888036     6A2     6.607588    22A1     6.607588  
+      13B1     6.608222    13B2     6.608222    23A1     6.612446  
+      14B1     8.693842    14B2     8.693842    24A1     8.780228  
+      15B2    34.651699    15B1    34.651699    25A1    34.660589  
       26A1    45.098590    27A1    54.454862    28A1   109.274414  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     6,    1,    3,    3 ]
 
-  @DF-RHF Final Energy:  -328.29831511289842
+  @DF-RHF Final Energy:  -328.29831511277808
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.0000000000000000
-    One-Electron Energy =                -571.6020428525631587
-    Two-Electron Energy =                 243.3037277396647369
-    Total Energy =                       -328.2983151128984218
+    One-Electron Energy =                -571.6020431637489310
+    Two-Electron Energy =                 243.3037280509708751
+    Total Energy =                       -328.2983151127780275
 
 Computation Completed
 
@@ -1380,18 +1640,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.0005     Total:     0.0005
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:05 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:14 2021
 Module time:
-	user time   =       1.66 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =      16.81 seconds =       0.28 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 Total time:
-	user time   =       6.84 seconds =       0.11 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      58.55 seconds =       0.98 minutes
+	system time =       1.86 seconds =       0.03 minutes
+	total time  =         16 seconds =       0.27 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:05 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:14 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1403,13 +1663,13 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -1443,50 +1703,52 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -328.2983151128984218 [Eh]
+	 Reference Energy          =    -328.2983151127780843 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.1951729487443731 [Eh]
-	 Opposite-Spin Energy      =      -0.3300617792942319 [Eh]
-	 Correlation Energy        =      -0.5252347280386049 [Eh]
-	 Total Energy              =    -328.8235498409370052 [Eh]
+	 Same-Spin Energy          =      -0.1951729485387562 [Eh]
+	 Opposite-Spin Energy      =      -0.3300617789429393 [Eh]
+	 Correlation Energy        =      -0.5252347274816955 [Eh]
+	 Total Energy              =    -328.8235498402597727 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0650576495814577 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.3960741351530782 [Eh]
-	 SCS Correlation Energy    =      -0.4611317847345359 [Eh]
-	 SCS Total Energy          =    -328.7594468976329836 [Eh]
+	 SCS Same-Spin Energy      =      -0.0650576495129187 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.3960741347315271 [Eh]
+	 SCS Correlation Energy    =      -0.4611317842444458 [Eh]
+	 SCS Total Energy          =    -328.7594468970225421 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:05 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:15 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.70 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.02 seconds =       0.12 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =      60.26 seconds =       1.00 minutes
+	system time =       1.95 seconds =       0.03 minutes
+	total time  =         17 seconds =       0.28 minutes
 
-       N-Body: Complex Energy (fragments = (2,), basis = (1, 2):  -328.82354984093701)
+       N-Body: Complex Energy (fragments = (2,), basis = (1, 2):  -328.82354984025977)
 
-       N-Body: Computing complex (3/4) with fragments (1,) in the basis of fragments (1, 2).
+       N-Body: Computing complex (4/4) with fragments (1,) in the basis of fragments (1, 2).
 
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:05 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:15 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -1496,7 +1758,7 @@ Total time:
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1532,7 +1794,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -1569,21 +1831,8 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        28      28       0       0       0       0
-     A2         6       6       0       0       0       0
-     B1        15      15       0       0       0       0
-     B2        15      15       0       0       0       0
-   -------------------------------------------------------
-    Total      64      64       5       5       5       0
-   -------------------------------------------------------
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1594,18 +1843,18 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       6.1523
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 71
     Number of primitives   = 86
     Number of AO           = 402
@@ -1620,23 +1869,37 @@ Total time:
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0588497777E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6855117058E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        28      28 
+     A2         6       6 
+     B1        15      15 
+     B2        15      15 
+   -------------------------
+    Total      64      64
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -128.37632192122118   -1.28376e+02   0.00000e+00 
-   @DF-RHF iter   1:  -128.37791982599603   -1.59790e-03   2.41930e-04 DIIS
-   @DF-RHF iter   2:  -128.37798896851737   -6.91425e-05   5.62756e-05 DIIS
-   @DF-RHF iter   3:  -128.37799305208685   -4.08357e-06   6.21894e-06 DIIS
-   @DF-RHF iter   4:  -128.37799308442928   -3.23424e-08   4.86207e-07 DIIS
-   @DF-RHF iter   5:  -128.37799308456960   -1.40318e-10   1.52469e-07 DIIS
-   @DF-RHF iter   6:  -128.37799308457801   -8.41283e-12   2.42587e-08 DIIS
-   @DF-RHF iter   7:  -128.37799308457849   -4.83169e-13   2.18510e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -128.37632192120387   -1.28376e+02   0.00000e+00 
+   @DF-RHF iter   1:  -128.37791982597889   -1.59790e-03   2.41930e-04 DIIS
+   @DF-RHF iter   2:  -128.37798896850012   -6.91425e-05   5.62756e-05 DIIS
+   @DF-RHF iter   3:  -128.37799305206943   -4.08357e-06   6.21894e-06 DIIS
+   @DF-RHF iter   4:  -128.37799308441197   -3.23425e-08   4.86207e-07 DIIS
+   @DF-RHF iter   5:  -128.37799308455212   -1.40147e-10   1.52469e-07 DIIS
+   @DF-RHF iter   6:  -128.37799308456079   -8.66862e-12   2.42587e-08 DIIS
+   @DF-RHF iter   7:  -128.37799308456107   -2.84217e-13   2.18510e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -1646,27 +1909,27 @@ Total time:
 
     Doubly Occupied:                                                      
 
-       1A1   -32.758303     2A1    -1.885965     1B1    -0.842902  
-       1B2    -0.842902     3A1    -0.841799  
+       1A1   -32.758303     2A1    -1.885965     1B2    -0.842902  
+       1B1    -0.842902     3A1    -0.841799  
 
     Virtual:                                                              
 
-       2B1     0.187450     2B2     0.187450     4A1     0.198446  
-       5A1     0.213803     3B1     0.601623     3B2     0.601623  
-       1A2     0.601739     6A1     0.601739     7A1     0.611240  
-       4B2     0.718986     4B1     0.718986     8A1     0.729308  
-       9A1     1.122191    10A1     1.661076     5B2     1.702173  
-       5B1     1.702173    11A1     1.829930     6B2     2.189439  
-       6B1     2.189439    12A1     2.203441     7B2     2.217579  
+       2B2     0.187450     2B1     0.187450     4A1     0.198446  
+       5A1     0.213803     3B2     0.601623     3B1     0.601623  
+       6A1     0.601739     1A2     0.601739     7A1     0.611240  
+       4B1     0.718986     4B2     0.718986     8A1     0.729308  
+       9A1     1.122191    10A1     1.661076     5B1     1.702173  
+       5B2     1.702173    11A1     1.829930     6B1     2.189439  
+       6B2     2.189439    12A1     2.203441     7B2     2.217579  
        7B1     2.217579     2A2     2.217690    13A1     2.217690  
-       8B2     2.218544     8B1     2.218544    14A1     2.236521  
-       3A2     2.403755    15A1     2.403755     9B2     2.408149  
+       8B1     2.218544     8B2     2.218544    14A1     2.236521  
+      15A1     2.403755     3A2     2.403755     9B2     2.408149  
        9B1     2.408149    16A1     2.480897    17A1     4.493311  
-      18A1     4.514899     4A2     4.514899    10B2     4.515996  
-      10B1     4.515996    19A1     4.536836    11B1    11.071812  
+       4A2     4.514899    18A1     4.514899    10B1     4.515996  
+      10B2     4.515996    19A1     4.536836    11B1    11.071812  
       11B2    11.071812    20A1    11.083159    12B2    11.657350  
-      12B1    11.657350    21A1    11.657385     5A2    11.657385  
-      13B1    11.657439    13B2    11.657439    22A1    11.658345  
+      12B1    11.657350     5A2    11.657385    21A1    11.657385  
+      13B2    11.657439    13B1    11.657439    22A1    11.658345  
        6A2    13.742302    23A1    13.742302    14B1    13.744020  
       14B2    13.744020    24A1    13.773782    25A1    18.888053  
       15B1    86.259549    15B2    86.259549    26A1    86.270217  
@@ -1676,14 +1939,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:  -128.37799308457849
+  @DF-RHF Final Energy:  -128.37799308456107
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.0000000000000000
-    One-Electron Energy =                -182.4122468679940710
-    Two-Electron Energy =                  54.0342537834155792
-    Total Energy =                       -128.3779930845784918
+    One-Electron Energy =                -182.4122468679864539
+    Two-Electron Energy =                  54.0342537834253775
+    Total Energy =                       -128.3779930845610693
 
 Computation Completed
 
@@ -1705,18 +1968,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.0644     Total:     0.0644
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:06 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:16 2021
 Module time:
-	user time   =       1.60 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       6.86 seconds =       0.11 minutes
+	system time =       0.26 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.63 seconds =       0.14 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =      67.18 seconds =       1.12 minutes
+	system time =       2.22 seconds =       0.04 minutes
+	total time  =         18 seconds =       0.30 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:06 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:16 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -1728,13 +1991,13 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -1768,335 +2031,55 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -128.3779930845784918 [Eh]
+	 Reference Energy          =    -128.3779930845610693 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0510301008199825 [Eh]
-	 Opposite-Spin Energy      =      -0.1333808598090839 [Eh]
-	 Correlation Energy        =      -0.1844109606290664 [Eh]
-	 Total Energy              =    -128.5624040452075576 [Eh]
+	 Same-Spin Energy          =      -0.0510301008199992 [Eh]
+	 Opposite-Spin Energy      =      -0.1333808598091291 [Eh]
+	 Correlation Energy        =      -0.1844109606291283 [Eh]
+	 Total Energy              =    -128.5624040451901919 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0170100336066608 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.1600570317709007 [Eh]
-	 SCS Correlation Energy    =      -0.1770670653775615 [Eh]
-	 SCS Total Energy          =    -128.5550601499560628 [Eh]
+	 SCS Same-Spin Energy      =      -0.0170100336066664 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1600570317709549 [Eh]
+	 SCS Correlation Energy    =      -0.1770670653776213 [Eh]
+	 SCS Total Energy          =    -128.5550601499386971 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:07 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:16 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       8.81 seconds =       0.15 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
-
-       N-Body: Complex Energy (fragments = (1,), basis = (1, 2):  -128.56240404520756)
-
-       N-Body: Computing complex (4/4) with fragments (1,) in the basis of fragments (1,).
-
-    SCF Algorithm Type (re)set to DF.
-
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:07 2019
-
-   => Loading Basis Set <=
-
-    Name: DEF2-SVP
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-
-
-         ---------------------------------------------------------
-                                   SCF
-               by Justin Turney, Rob Parrish, Andy Simmonett
-                          and Daniel G. A. Smith
-                              RHF Reference
-                        1 Threads,    500 MiB Core
-         ---------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c2v
-    Geometry (in Angstrom), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-         NE           0.000000000000     0.000000000000    -2.605143746473    19.992440176200
-
-  Running in c2v symmetry.
-
-  Rotational constants: A = ************  B =      0.12424  C =      0.12424 [cm^-1]
-  Rotational constants: A = ************  B =   3724.67180  C =   3724.67180 [MHz]
-  Nuclear repulsion =    0.000000000000000
-
-  Charge       = 0
-  Multiplicity = 1
-  Electrons    = 10
-  Nalpha       = 5
-  Nbeta        = 5
-
-  ==> Algorithm <==
-
-  SCF Algorithm Type is DF.
-  DIIS enabled.
-  MOM disabled.
-  Fractional occupation disabled.
-  Guess Type is SAD.
-  Energy threshold   = 1.00e-08
-  Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
-
-  ==> Primary Basis <==
-
-  -AO BASIS SET INFORMATION:
-    Name                   = DEF2-SVP
-    Blend                  = DEF2-SVP
-    Total number of shells = 6
-    Number of primitives   = 12
-    Number of AO           = 15
-    Number of SO           = 14
-    Maximum AM             = 2
-    Spherical Harmonics    = TRUE
-
-  -Contraction Scheme:
-    Atom   Type   All Primitives // Shells:
-   ------ ------ --------------------------
-       1    NE     7s 4p 1d // 3s 2p 1d 
-
-   => Loading Basis Set <=
-
-    Name: (DEF2-SVP AUX)
-    Role: JKFIT
-    Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1         7       7       0       0       0       0
-     A2         1       1       0       0       0       0
-     B1         3       3       0       0       0       0
-     B2         3       3       0       0       0       0
-   -------------------------------------------------------
-    Total      14      14       5       5       5       0
-   -------------------------------------------------------
-
-  ==> Integral Setup <==
-
-  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
-
-  ==> MemDFJK: Density-Fitted J/K Matrices <==
-
-    J tasked:                   Yes
-    K tasked:                   Yes
-    wK tasked:                   No
-    OpenMP threads:               1
-    Memory [MiB]:               375
-    Algorithm:                 Core
-    Schwarz Cutoff:           1E-12
-    Mask sparsity (%):       0.0000
-    Fitting Condition:        1E-12
-
-   => Auxiliary Basis Set <=
-
-  -AO BASIS SET INFORMATION:
-    Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
-    Total number of shells = 25
-    Number of primitives   = 33
-    Number of AO           = 93
-    Number of SO           = 77
-    Maximum AM             = 4
-    Spherical Harmonics    = TRUE
-
-  -Contraction Scheme:
-    Atom   Type   All Primitives // Shells:
-   ------ ------ --------------------------
-       1    NE     14s 10p 6d 2f 1g // 10s 8p 4d 2f 1g 
-
-  Minimum eigenvalue in the overlap matrix is 1.9107712976E-01.
-  Using Symmetric Orthogonalization.
-
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
-
-  ==> Iterations <==
-
-                           Total Energy        Delta E     RMS |[F,P]|
-
-   @DF-RHF iter   0:  -128.37632153277781   -1.28376e+02   0.00000e+00 
-   @DF-RHF iter   1:  -128.37632385729896   -2.32452e-06   1.83252e-04 DIIS
-   @DF-RHF iter   2:  -128.37632432064811   -4.63349e-07   8.41663e-05 DIIS
-   @DF-RHF iter   3:  -128.37632444014145   -1.19493e-07   1.20850e-06 DIIS
-   @DF-RHF iter   4:  -128.37632444017569   -3.42482e-11   5.83970e-09 DIIS
-  Energy converged.
-
-
-  ==> Post-Iterations <==
-
-    Orbital Energies [Eh]
-    ---------------------
-
-    Doubly Occupied:                                                      
-
-       1A1   -32.752827     2A1    -1.882206     1B2    -0.838894  
-       3A1    -0.838894     1B1    -0.838894  
-
-    Virtual:                                                              
-
-       4A1     1.634945     5A1     1.696299     2B1     1.696299  
-       2B2     1.696299     6A1     4.518912     7A1     4.518912  
-       1A2     4.518912     3B1     4.518912     3B2     4.518912  
-
-    Final Occupation by Irrep:
-             A1    A2    B1    B2 
-    DOCC [     3,    0,    1,    1 ]
-
-  @DF-RHF Final Energy:  -128.37632444017569
-
-   => Energetics <=
-
-    Nuclear Repulsion Energy =              0.0000000000000000
-    One-Electron Energy =                -182.4492217449433156
-    Two-Electron Energy =                  54.0728973047676220
-    Total Energy =                       -128.3763244401756936
-
-Computation Completed
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
-
-Properties computed using the SCF density matrix
-
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:   -49.2301
-
-  Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    49.2301
-
-  Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
-
-  Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
-
-
-*** tstop() called on dream at Wed Jan  9 19:38:07 2019
-Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.70 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.04 seconds =       0.15 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	user time   =      68.89 seconds =       1.15 minutes
+	system time =       2.32 seconds =       0.04 minutes
+	total time  =         18 seconds =       0.30 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:07 2019
-
-
-  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
-  //               DFMP2               //
-  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
-
-   => Loading Basis Set <=
-
-    Name: (DEF2-SVP AUX)
-    Role: RIFIT
-    Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-
-	 --------------------------------------------------------
-	                          DF-MP2                         
-	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
-	                                                         
-	        Rob Parrish, Justin Turney, Andy Simmonett,      
-	           Ed Hohenstein, and C. David Sherrill          
-	 --------------------------------------------------------
-
-   => Auxiliary Basis Set <=
-
-  -AO BASIS SET INFORMATION:
-    Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-RI
-    Total number of shells = 16
-    Number of primitives   = 22
-    Number of AO           = 55
-    Number of SO           = 48
-    Maximum AM             = 3
-    Spherical Harmonics    = TRUE
-
-  -Contraction Scheme:
-    Atom   Type   All Primitives // Shells:
-   ------ ------ --------------------------
-       1    NE     8s 6p 5d 3f // 6s 5p 4d 1f 
-
-	 --------------------------------------------------------
-	                 NBF =    14, NAUX =    48
-	 --------------------------------------------------------
-	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
-	   PAIRS       1       5       4       9       9       0
-	 --------------------------------------------------------
-
-	-----------------------------------------------------------
-	 ==================> DF-MP2 Energies <==================== 
-	-----------------------------------------------------------
-	 Reference Energy          =    -128.3763244401756936 [Eh]
-	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0507709258361965 [Eh]
-	 Opposite-Spin Energy      =      -0.1327583341489696 [Eh]
-	 Correlation Energy        =      -0.1835292599851661 [Eh]
-	 Total Energy              =    -128.5598537001608577 [Eh]
-	-----------------------------------------------------------
-	 ================> DF-SCS-MP2 Energies <================== 
-	-----------------------------------------------------------
-	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
-	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0169236419453988 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.1593100009787635 [Eh]
-	 SCS Correlation Energy    =      -0.1762336429241623 [Eh]
-	 SCS Total Energy          =    -128.5525580830998535 [Eh]
-	-----------------------------------------------------------
-
-
-*** tstop() called on dream at Wed Jan  9 19:38:07 2019
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       9.11 seconds =       0.15 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
-
-       N-Body: Complex Energy (fragments = (1,), basis = (1,):  -128.55985370016086)
+       N-Body: Complex Energy (fragments = (1,), basis = (1, 2):  -128.56240404519019)
 
    ==> N-Body: Now computing 2-body complexes <==
 
 
        N-Body: Computing complex (1/1) with fragments (1, 2) in the basis of fragments (1, 2).
 
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:07 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:16 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -2106,7 +2089,7 @@ Total time:
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2142,7 +2125,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -2179,21 +2162,8 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        28      28       0       0       0       0
-     A2         6       6       0       0       0       0
-     B1        15      15       0       0       0       0
-     B2        15      15       0       0       0       0
-   -------------------------------------------------------
-    Total      64      64      18      18      18       0
-   -------------------------------------------------------
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -2204,18 +2174,18 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       6.1523
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 71
     Number of primitives   = 86
     Number of AO           = 402
@@ -2230,61 +2200,39 @@ Total time:
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0588497777E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6855117058E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        28      28 
+     A2         6       6 
+     B1        15      15 
+     B2        15      15 
+   -------------------------
+    Total      64      64
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   150.91088460574039    1.50911e+02   0.00000e+00 
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     8,    2,    4,    4 ]
-
-   @DF-RHF iter   1:  -315.35446041154688   -4.66265e+02   5.02473e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   2:  -313.66874798554136    1.68571e+00   3.77629e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     8,    2,    4,    4 ]
-
-   @DF-RHF iter   3:  -420.22766164934853   -1.06559e+02   1.34975e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   4:  -418.33430401600907    1.89336e+00   8.23316e-02 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [    10,    1,    3,    4 ]
-
-   @DF-RHF iter   5:  -425.83243965539714   -7.49814e+00   1.18451e-01 DIIS
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     9,    1,    4,    4 ]
-
-   @DF-RHF iter   6:  -436.84474748415022   -1.10123e+01   1.10184e-01 DIIS
-   @DF-RHF iter   7:  -452.27184710324030   -1.54271e+01   8.84775e-02 DIIS
-   @DF-RHF iter   8:  -451.17218406786589    1.09966e+00   9.79200e-02 DIIS
-   @DF-RHF iter   9:  -452.56178906070346   -1.38960e+00   8.44963e-02 DIIS
-   @DF-RHF iter  10:  -453.94421812060568   -1.38243e+00   7.04612e-02 DIIS
-   @DF-RHF iter  11:  -455.24174023880778   -1.29752e+00   5.36622e-02 DIIS
-   @DF-RHF iter  12:  -456.37049379906023   -1.12875e+00   2.63132e-02 DIIS
-   @DF-RHF iter  13:  -456.63951095717749   -2.69017e-01   9.04879e-03 DIIS
-   @DF-RHF iter  14:  -456.67093828414386   -3.14273e-02   4.76707e-04 DIIS
-   @DF-RHF iter  15:  -456.67108533498094   -1.47051e-04   1.03930e-04 DIIS
-   @DF-RHF iter  16:  -456.67109564770379   -1.03127e-05   3.08262e-05 DIIS
-   @DF-RHF iter  17:  -456.67109626052678   -6.12823e-07   1.31089e-05 DIIS
-   @DF-RHF iter  18:  -456.67109632914548   -6.86187e-08   1.62001e-06 DIIS
-   @DF-RHF iter  19:  -456.67109633070163   -1.55615e-09   1.50194e-07 DIIS
-   @DF-RHF iter  20:  -456.67109633073756   -3.59250e-11   2.66643e-08 DIIS
-   @DF-RHF iter  21:  -456.67109633073892   -1.36424e-12   5.22871e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -452.92385352595096   -4.52924e+02   0.00000e+00 
+   @DF-RHF iter   1:  -456.56813543533627   -3.64428e+00   1.59620e-02 DIIS
+   @DF-RHF iter   2:  -456.65809095223705   -8.99555e-02   7.30837e-03 DIIS
+   @DF-RHF iter   3:  -456.67106390286790   -1.29730e-02   3.16728e-04 DIIS
+   @DF-RHF iter   4:  -456.67109576589525   -3.18630e-05   2.94413e-05 DIIS
+   @DF-RHF iter   5:  -456.67109630313462   -5.37239e-07   8.16327e-06 DIIS
+   @DF-RHF iter   6:  -456.67109632924365   -2.61090e-08   1.41328e-06 DIIS
+   @DF-RHF iter   7:  -456.67109633054361   -1.29995e-09   2.25250e-07 DIIS
+   @DF-RHF iter   8:  -456.67109633057191   -2.83080e-11   9.07246e-08 DIIS
+   @DF-RHF iter   9:  -456.67109633057561   -3.69482e-12   9.62810e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2296,42 +2244,42 @@ Total time:
 
        1A1   -32.759855     2A1    -8.395838     1B2    -6.129623  
        1B1    -6.129623     3A1    -6.129417     1A2    -2.660067  
-       4A1    -2.660067     2B1    -2.659818     2B2    -2.659818  
+       4A1    -2.660067     2B2    -2.659818     2B1    -2.659818  
        5A1    -2.659755     6A1    -1.889304     7A1    -1.007151  
-       8A1    -0.846795     3B1    -0.845650     3B2    -0.845650  
-       4B2    -0.453436     4B1    -0.453436     9A1    -0.451324  
+       8A1    -0.846795     3B2    -0.845650     3B1    -0.845650  
+       4B1    -0.453436     4B2    -0.453436     9A1    -0.451324  
 
     Virtual:                                                              
 
-       5B2     0.300476     5B1     0.300476    10A1     0.314526  
-      11A1     0.354930     2A2     0.354930     6B1     0.354978  
-       6B2     0.354978    12A1     0.371453    13A1     0.516044  
+       5B1     0.300476     5B2     0.300476    10A1     0.314526  
+       2A2     0.354930    11A1     0.354930     6B2     0.354978  
+       6B1     0.354978    12A1     0.371454    13A1     0.516044  
       14A1     1.147785     7B2     1.152918     7B1     1.152918  
-       8B2     1.153132     8B1     1.153132    15A1     1.153213  
-       3A2     1.153213    16A1     1.532716     9B2     1.553626  
-       9B1     1.553626    17A1     1.598406    10B2     1.646537  
-      10B1     1.646537     4A2     1.687129    18A1     1.687129  
+       8B2     1.153132     8B1     1.153132     3A2     1.153213  
+      15A1     1.153213    16A1     1.532716     9B1     1.553626  
+       9B2     1.553626    17A1     1.598406    10B1     1.646537  
+      10B2     1.646537     4A2     1.687129    18A1     1.687129  
       19A1     1.703758    11B1     1.748135    11B2     1.748135  
       20A1     1.994860    12B2     3.645570    12B1     3.645570  
-       5A2     3.645789    21A1     3.645789    13B1     3.645994  
-      13B2     3.645994    22A1     3.649244    23A1     4.512135  
-       6A2     4.512135    14B2     4.512759    14B1     4.512759  
+       5A2     3.645789    21A1     3.645789    13B2     3.645994  
+      13B1     3.645994    22A1     3.649244     6A2     4.512135  
+      23A1     4.512135    14B1     4.512759    14B2     4.512759  
       24A1     4.516149    25A1     4.894649    15B2    34.655678  
       15B1    34.655678    26A1    34.664720    27A1    45.102918  
-      28A1   109.278497  
+      28A1   109.278498  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     9,    1,    4,    4 ]
 
-  @DF-RHF Final Energy:  -456.67109633073892
+  @DF-RHF Final Energy:  -456.67109633057561
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             45.8620249247333405
-    One-Electron Energy =                -845.7929919098780829
-    Two-Electron Energy =                 343.2598706544058587
-    Total Energy =                       -456.6710963307389193
+    One-Electron Energy =                -845.7929924983056935
+    Two-Electron Energy =                 343.2598712429967804
+    Total Energy =                       -456.6710963305756081
 
 Computation Completed
 
@@ -2353,18 +2301,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.2025     Total:     0.2025
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:09 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:20 2021
 Module time:
-	user time   =       1.75 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =      10.81 seconds =       0.18 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 Total time:
-	user time   =      10.86 seconds =       0.18 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      79.74 seconds =       1.33 minutes
+	system time =       2.66 seconds =       0.04 minutes
+	total time  =         22 seconds =       0.37 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:09 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:20 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2376,13 +2324,13 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -2416,65 +2364,67 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -456.6710963307389193 [Eh]
+	 Reference Energy          =    -456.6710963305756081 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.2465524816571197 [Eh]
-	 Opposite-Spin Energy      =      -0.4636233738367281 [Eh]
-	 Correlation Energy        =      -0.7101758554938478 [Eh]
-	 Total Energy              =    -457.3812721862327635 [Eh]
+	 Same-Spin Energy          =      -0.2465524813380416 [Eh]
+	 Opposite-Spin Energy      =      -0.4636233730100380 [Eh]
+	 Correlation Energy        =      -0.7101758543480796 [Eh]
+	 Total Energy              =    -457.3812721849236596 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0821841605523732 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.5563480486040737 [Eh]
-	 SCS Correlation Energy    =      -0.6385322091564469 [Eh]
-	 SCS Total Energy          =    -457.3096285398953569 [Eh]
+	 SCS Same-Spin Energy      =      -0.0821841604460139 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.5563480476120456 [Eh]
+	 SCS Correlation Energy    =      -0.6385322080580594 [Eh]
+	 SCS Total Energy          =    -457.3096285386336604 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:09 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:20 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.78 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.04 seconds =       0.18 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      81.53 seconds =       1.36 minutes
+	system time =       2.76 seconds =       0.05 minutes
+	total time  =         22 seconds =       0.37 minutes
 
-       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2):  -457.38127218623276)
+       N-Body: Complex Energy (fragments = (1, 2), basis = (1, 2):  -457.38127218492366)
 
    ==> N-Body: Counterpoise Corrected (CP) energies <==
 
    n-Body     Total Energy [Eh]       I.E. [kcal/mol]      Delta [kcal/mol]
-        1     -457.383350686193        0.000000000000        0.000000000000
-        2     -457.378668986281        2.937811048020        2.937811048020
+        1     -457.383350685755        0.000000000000        0.000000000000
+        2     -457.378668985228        2.937811433646        2.937811433646
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
-	MP2 CP interaction energy frozen [He] and [Kr]....................PASSED
+    MP2 CP interaction energy frozen [He] and [Kr]........................................PASSED
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:09 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:20 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -2484,7 +2434,7 @@ Total time:
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2520,7 +2470,7 @@ Total time:
   Guess Type is READ.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -2557,33 +2507,20 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
   Reading orbitals from file 180, no projection.
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        28      28       0       0       0       0
-     A2         6       6       0       0       0       0
-     B1        15      15       0       0       0       0
-     B2        15      15       0       0       0       0
-   -------------------------------------------------------
-    Total      64      64      18      18      18       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -2594,18 +2531,18 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       6.1523
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 71
     Number of primitives   = 86
     Number of AO           = 402
@@ -2620,17 +2557,31 @@ Total time:
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0588497777E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6855117058E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        28      28       9       9       9       0
+     A2         6       6       1       1       1       0
+     B1        15      15       4       4       4       0
+     B2        15      15       4       4       4       0
+   -------------------------------------------------------
+    Total      64      64      18      18      18       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -456.67109633073869   -4.56671e+02   7.11516e-10 
-   @DF-RHF iter   1:  -456.67109633073875   -5.68434e-14   2.67543e-10 DIIS
-  Energy converged.
+   @DF-RHF iter   0:  -456.67109633057629   -4.56671e+02   1.67234e-09 
+   @DF-RHF iter   1:  -456.67109633057606    2.27374e-13   6.98393e-10 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2640,44 +2591,44 @@ Total time:
 
     Doubly Occupied:                                                      
 
-       1A1   -32.759855     2A1    -8.395838     1B1    -6.129623  
-       1B2    -6.129623     3A1    -6.129417     1A2    -2.660067  
-       4A1    -2.660067     2B1    -2.659818     2B2    -2.659818  
+       1A1   -32.759855     2A1    -8.395838     1B2    -6.129623  
+       1B1    -6.129623     3A1    -6.129417     1A2    -2.660067  
+       4A1    -2.660067     2B2    -2.659818     2B1    -2.659818  
        5A1    -2.659755     6A1    -1.889304     7A1    -1.007151  
-       8A1    -0.846795     3B1    -0.845650     3B2    -0.845650  
-       4B2    -0.453436     4B1    -0.453436     9A1    -0.451324  
+       8A1    -0.846795     3B2    -0.845650     3B1    -0.845650  
+       4B1    -0.453436     4B2    -0.453436     9A1    -0.451324  
 
     Virtual:                                                              
 
-       5B2     0.300476     5B1     0.300476    10A1     0.314526  
-      11A1     0.354930     2A2     0.354930     6B1     0.354978  
-       6B2     0.354978    12A1     0.371453    13A1     0.516044  
-      14A1     1.147785     7B1     1.152918     7B2     1.152918  
-       8B2     1.153132     8B1     1.153132    15A1     1.153213  
-       3A2     1.153213    16A1     1.532716     9B2     1.553626  
-       9B1     1.553626    17A1     1.598406    10B1     1.646537  
+       5B1     0.300476     5B2     0.300476    10A1     0.314526  
+       2A2     0.354930    11A1     0.354930     6B2     0.354978  
+       6B1     0.354978    12A1     0.371454    13A1     0.516044  
+      14A1     1.147785     7B2     1.152918     7B1     1.152918  
+       8B2     1.153132     8B1     1.153132     3A2     1.153213  
+      15A1     1.153213    16A1     1.532716     9B1     1.553626  
+       9B2     1.553626    17A1     1.598406    10B1     1.646537  
       10B2     1.646537     4A2     1.687129    18A1     1.687129  
-      19A1     1.703758    11B1     1.748135    11B2     1.748135  
+      19A1     1.703758    11B2     1.748135    11B1     1.748135  
       20A1     1.994860    12B2     3.645570    12B1     3.645570  
-       5A2     3.645789    21A1     3.645789    13B1     3.645994  
-      13B2     3.645994    22A1     3.649244    23A1     4.512135  
-       6A2     4.512135    14B1     4.512759    14B2     4.512759  
-      24A1     4.516149    25A1     4.894649    15B1    34.655678  
-      15B2    34.655678    26A1    34.664720    27A1    45.102918  
+       5A2     3.645789    21A1     3.645789    13B2     3.645994  
+      13B1     3.645994    22A1     3.649244     6A2     4.512135  
+      23A1     4.512135    14B1     4.512759    14B2     4.512759  
+      24A1     4.516149    25A1     4.894649    15B2    34.655678  
+      15B1    34.655678    26A1    34.664720    27A1    45.102918  
       28A1   109.278498  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     9,    1,    4,    4 ]
 
-  @DF-RHF Final Energy:  -456.67109633073875
+  @DF-RHF Final Energy:  -456.67109633057606
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             45.8620249247333405
-    One-Electron Energy =                -845.7929923023917809
-    Two-Electron Energy =                 343.2598710469197272
-    Total Energy =                       -456.6710963307387487
+    One-Electron Energy =                -845.7929923836353510
+    Two-Electron Energy =                 343.2598711283259831
+    Total Energy =                       -456.6710963305760629
 
 Computation Completed
 
@@ -2699,18 +2650,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.2025     Total:     0.2025
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:10 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:22 2021
 Module time:
-	user time   =       1.45 seconds =       0.02 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =      10.72 seconds =       0.18 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      12.53 seconds =       0.21 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      92.69 seconds =       1.54 minutes
+	system time =       3.10 seconds =       0.05 minutes
+	total time  =         24 seconds =       0.40 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:10 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:22 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -2722,13 +2673,13 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -2762,46 +2713,48 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -456.6710963307387487 [Eh]
+	 Reference Energy          =    -456.6710963305760629 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.2727087562832222 [Eh]
-	 Opposite-Spin Energy      =      -0.5275044322782343 [Eh]
-	 Correlation Energy        =      -0.8002131885614565 [Eh]
-	 Total Energy              =    -457.4713095193001777 [Eh]
+	 Same-Spin Energy          =      -0.2727087563228627 [Eh]
+	 Opposite-Spin Energy      =      -0.5275044323454559 [Eh]
+	 Correlation Energy        =      -0.8002131886683186 [Eh]
+	 Total Energy              =    -457.4713095192443575 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0909029187610741 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.6330053187338811 [Eh]
-	 SCS Correlation Energy    =      -0.7239082374949551 [Eh]
-	 SCS Total Energy          =    -457.3950045682337304 [Eh]
+	 SCS Same-Spin Energy      =      -0.0909029187742876 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.6330053188145470 [Eh]
+	 SCS Correlation Energy    =      -0.7239082375888346 [Eh]
+	 SCS Total Energy          =    -457.3950045681648930 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:11 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:23 2021
 Module time:
-	user time   =       0.19 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       3.54 seconds =       0.06 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.72 seconds =       0.21 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
-	MP2 energy with frozen [He] and ECP...............................PASSED
+	user time   =      96.27 seconds =       1.60 minutes
+	system time =       3.20 seconds =       0.05 minutes
+	total time  =         25 seconds =       0.42 minutes
+    MP2 energy with frozen [He] and ECP...................................................PASSED
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:11 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:23 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -2811,7 +2764,7 @@ Total time:
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2847,7 +2800,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -2884,21 +2837,8 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        28      28       0       0       0       0
-     A2         6       6       0       0       0       0
-     B1        15      15       0       0       0       0
-     B2        15      15       0       0       0       0
-   -------------------------------------------------------
-    Total      64      64      13      13      13       0
-   -------------------------------------------------------
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -2909,18 +2849,18 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       6.1523
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 71
     Number of primitives   = 86
     Number of AO           = 402
@@ -2935,28 +2875,38 @@ Total time:
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0588497777E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6855117058E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        28      28 
+     A2         6       6 
+     B1        15      15 
+     B2        15      15 
+   -------------------------
+    Total      64      64
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:   279.28780821698143    2.79288e+02   0.00000e+00 
-   @DF-RHF iter   1:  -184.69845210620375   -4.63986e+02   5.03779e-01 DIIS
-   @DF-RHF iter   2:  -290.33411840584370   -1.05636e+02   2.68806e-01 DIIS
-   @DF-RHF iter   3:  -328.13258938023802   -3.77985e+01   2.58542e-02 DIIS
-   @DF-RHF iter   4:  -328.29201710102370   -1.59428e-01   3.53156e-03 DIIS
-   @DF-RHF iter   5:  -328.29803419126495   -6.01709e-03   9.65105e-04 DIIS
-   @DF-RHF iter   6:  -328.29828752647438   -2.53335e-04   2.64494e-04 DIIS
-   @DF-RHF iter   7:  -328.29831227597742   -2.47495e-05   6.64606e-05 DIIS
-   @DF-RHF iter   8:  -328.29831499272245   -2.71675e-06   1.21156e-05 DIIS
-   @DF-RHF iter   9:  -328.29831510945598   -1.16734e-07   1.34910e-06 DIIS
-   @DF-RHF iter  10:  -328.29831511287097   -3.41498e-09   1.48847e-07 DIIS
-   @DF-RHF iter  11:  -328.29831511289757   -2.66027e-11   2.41028e-08 DIIS
-   @DF-RHF iter  12:  -328.29831511289825   -6.82121e-13   5.79061e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -324.53317828776375   -3.24533e+02   0.00000e+00 
+   @DF-RHF iter   1:  -328.19658201879429   -3.66340e+00   1.58794e-02 DIIS
+   @DF-RHF iter   2:  -328.28537588414667   -8.87939e-02   7.28416e-03 DIIS
+   @DF-RHF iter   3:  -328.29828398312287   -1.29081e-02   3.15211e-04 DIIS
+   @DF-RHF iter   4:  -328.29831466546864   -3.06823e-05   2.56402e-05 DIIS
+   @DF-RHF iter   5:  -328.29831510807355   -4.42605e-07   2.28640e-06 DIIS
+   @DF-RHF iter   6:  -328.29831511276387   -4.69032e-09   1.35325e-07 DIIS
+   @DF-RHF iter   7:  -328.29831511277780   -1.39266e-11   2.43670e-08 DIIS
+   @DF-RHF iter   8:  -328.29831511277803   -2.27374e-13   3.97857e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -2966,44 +2916,44 @@ Total time:
 
     Doubly Occupied:                                                      
 
-       1A1    -8.399824     2A1    -6.133527     1B1    -6.133527  
-       1B2    -6.133527     3A1    -2.663855     2B1    -2.663854  
-       2B2    -2.663854     4A1    -2.663853     1A2    -2.663853  
-       5A1    -1.009364     6A1    -0.456086     3B2    -0.456084  
-       3B1    -0.456084  
+       1A1    -8.399824     2A1    -6.133527     1B2    -6.133527  
+       1B1    -6.133527     3A1    -2.663855     2B2    -2.663854  
+       2B1    -2.663854     1A2    -2.663853     4A1    -2.663853  
+       5A1    -1.009364     6A1    -0.456086     3B1    -0.456084  
+       3B2    -0.456084  
 
     Virtual:                                                              
 
-       7A1     0.290754     4B2     0.298282     4B1     0.298282  
-       8A1     0.338862     5B1     0.352149     5B2     0.352149  
+       7A1     0.290754     4B1     0.298282     4B2     0.298282  
+       8A1     0.338862     5B2     0.352149     5B1     0.352149  
        2A2     0.353054     9A1     0.353054    10A1     0.494070  
-      11A1     0.651923     6B2     1.067644     6B1     1.067644  
+      11A1     0.651923     6B1     1.067644     6B2     1.067644  
       12A1     1.089820     7B2     1.150188     7B1     1.150188  
-       3A2     1.150189    13A1     1.150189     8B1     1.152296  
-       8B2     1.152296    14A1     1.197801     9B1     1.555274  
+       3A2     1.150189    13A1     1.150189     8B2     1.152296  
+       8B1     1.152296    14A1     1.197801     9B1     1.555274  
        9B2     1.555274    15A1     1.571444     4A2     1.684213  
       16A1     1.684213    10B1     1.689655    10B2     1.689655  
-      17A1     1.749128    18A1     3.331024    19A1     3.642041  
-       5A2     3.642041    11B2     3.642044    11B1     3.642044  
-      12B1     3.642106    12B2     3.642106    20A1     3.646045  
+      17A1     1.749128    18A1     3.331024     5A2     3.642041  
+      19A1     3.642041    11B2     3.642044    11B1     3.642044  
+      12B2     3.642106    12B1     3.642106    20A1     3.646045  
       21A1     4.888036     6A2     6.607588    22A1     6.607588  
-      13B2     6.608222    13B1     6.608222    23A1     6.612446  
-      14B2     8.693842    14B1     8.693842    24A1     8.780228  
-      15B1    34.651699    15B2    34.651699    25A1    34.660589  
+      13B1     6.608222    13B2     6.608222    23A1     6.612446  
+      14B1     8.693842    14B2     8.693842    24A1     8.780228  
+      15B2    34.651699    15B1    34.651699    25A1    34.660589  
       26A1    45.098590    27A1    54.454862    28A1   109.274414  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     6,    1,    3,    3 ]
 
-  @DF-RHF Final Energy:  -328.29831511289825
+  @DF-RHF Final Energy:  -328.29831511277803
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.0000000000000000
-    One-Electron Energy =                -571.6020428525628176
-    Two-Electron Energy =                 243.3037277396645948
-    Total Energy =                       -328.2983151128981945
+    One-Electron Energy =                -571.6020431637482488
+    Two-Electron Energy =                 243.3037280509702214
+    Total Energy =                       -328.2983151127780275
 
 Computation Completed
 
@@ -3025,18 +2975,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.0005     Total:     0.0005
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:12 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:28 2021
 Module time:
-	user time   =       1.70 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =      13.55 seconds =       0.23 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
 Total time:
-	user time   =      14.42 seconds =       0.24 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =     109.97 seconds =       1.83 minutes
+	system time =       3.57 seconds =       0.06 minutes
+	total time  =         30 seconds =       0.50 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:12 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:28 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -3048,13 +2998,13 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -3088,45 +3038,47 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -328.2983151128982513 [Eh]
+	 Reference Energy          =    -328.2983151127780275 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.1951729487443744 [Eh]
-	 Opposite-Spin Energy      =      -0.3300617792942355 [Eh]
-	 Correlation Energy        =      -0.5252347280386098 [Eh]
-	 Total Energy              =    -328.8235498409368347 [Eh]
+	 Same-Spin Energy          =      -0.1951729485387554 [Eh]
+	 Opposite-Spin Energy      =      -0.3300617789429389 [Eh]
+	 Correlation Energy        =      -0.5252347274816943 [Eh]
+	 Total Energy              =    -328.8235498402597159 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0650576495814581 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.3960741351530825 [Eh]
-	 SCS Correlation Energy    =      -0.4611317847345406 [Eh]
-	 SCS Total Energy          =    -328.7594468976328130 [Eh]
+	 SCS Same-Spin Energy      =      -0.0650576495129185 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.3960741347315267 [Eh]
+	 SCS Correlation Energy    =      -0.4611317842444451 [Eh]
+	 SCS Total Energy          =    -328.7594468970224852 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:12 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:28 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.77 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.60 seconds =       0.24 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =     111.75 seconds =       1.86 minutes
+	system time =       3.69 seconds =       0.06 minutes
+	total time  =         30 seconds =       0.50 minutes
+
+Scratch directory: /tmp/
     SCF Algorithm Type (re)set to DF.
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:12 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:28 2021
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
-    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp.gbs 
+    atoms 1 entry NE         line   170 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry XE         line  1722 (ECP: line  2827) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
 
     !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
 
@@ -3136,7 +3088,7 @@ Total time:
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        1 Threads,    500 MiB Core
+                        8 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3172,7 +3124,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -3209,21 +3161,8 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NE         line   443 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-    atoms 2 entry XE         line  5086 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        28      28       0       0       0       0
-     A2         6       6       0       0       0       0
-     B1        15      15       0       0       0       0
-     B2        15      15       0       0       0       0
-   -------------------------------------------------------
-    Total      64      64       5       5       5       0
-   -------------------------------------------------------
+    atoms 1 entry NE         line   438 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry XE         line  5081 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -3234,18 +3173,18 @@ Total time:
     J tasked:                   Yes
     K tasked:                   Yes
     wK tasked:                   No
-    OpenMP threads:               1
+    OpenMP threads:               8
     Memory [MiB]:               375
     Algorithm:                 Core
     Schwarz Cutoff:           1E-12
     Mask sparsity (%):       6.1523
-    Fitting Condition:        1E-12
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
   -AO BASIS SET INFORMATION:
     Name                   = (DEF2-SVP AUX)
-    Blend                  = DEF2-SVP-JKFIT
+    Blend                  = DEF2-UNIVERSAL-JKFIT
     Total number of shells = 71
     Number of primitives   = 86
     Number of AO           = 402
@@ -3260,23 +3199,37 @@ Total time:
        2    XE     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
 
   Minimum eigenvalue in the overlap matrix is 6.0588497777E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.6855117058E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        28      28 
+     A2         6       6 
+     B1        15      15 
+     B2        15      15 
+   -------------------------
+    Total      64      64
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -128.37632192122118   -1.28376e+02   0.00000e+00 
-   @DF-RHF iter   1:  -128.37791982599606   -1.59790e-03   2.41930e-04 DIIS
-   @DF-RHF iter   2:  -128.37798896851729   -6.91425e-05   5.62756e-05 DIIS
-   @DF-RHF iter   3:  -128.37799305208691   -4.08357e-06   6.21894e-06 DIIS
-   @DF-RHF iter   4:  -128.37799308442931   -3.23424e-08   4.86207e-07 DIIS
-   @DF-RHF iter   5:  -128.37799308456951   -1.40204e-10   1.52469e-07 DIIS
-   @DF-RHF iter   6:  -128.37799308457832   -8.81073e-12   2.42587e-08 DIIS
-   @DF-RHF iter   7:  -128.37799308457852   -1.98952e-13   2.18510e-09 DIIS
-  Energy converged.
+   @DF-RHF iter SAD:  -128.37632192120392   -1.28376e+02   0.00000e+00 
+   @DF-RHF iter   1:  -128.37791982597861   -1.59790e-03   2.41930e-04 DIIS
+   @DF-RHF iter   2:  -128.37798896849989   -6.91425e-05   5.62756e-05 DIIS
+   @DF-RHF iter   3:  -128.37799305206937   -4.08357e-06   6.21894e-06 DIIS
+   @DF-RHF iter   4:  -128.37799308441200   -3.23426e-08   4.86207e-07 DIIS
+   @DF-RHF iter   5:  -128.37799308455195   -1.39948e-10   1.52469e-07 DIIS
+   @DF-RHF iter   6:  -128.37799308456067   -8.72546e-12   2.42587e-08 DIIS
+   @DF-RHF iter   7:  -128.37799308456087   -1.98952e-13   2.18510e-09 DIIS
+  Energy and wave function converged.
 
 
   ==> Post-Iterations <==
@@ -3286,28 +3239,28 @@ Total time:
 
     Doubly Occupied:                                                      
 
-       1A1   -32.758303     2A1    -1.885965     1B1    -0.842902  
-       1B2    -0.842902     3A1    -0.841799  
+       1A1   -32.758303     2A1    -1.885965     1B2    -0.842902  
+       1B1    -0.842902     3A1    -0.841799  
 
     Virtual:                                                              
 
-       2B1     0.187450     2B2     0.187450     4A1     0.198446  
-       5A1     0.213803     3B1     0.601623     3B2     0.601623  
-       1A2     0.601739     6A1     0.601739     7A1     0.611240  
-       4B2     0.718986     4B1     0.718986     8A1     0.729308  
+       2B2     0.187450     2B1     0.187450     4A1     0.198446  
+       5A1     0.213803     3B2     0.601623     3B1     0.601623  
+       6A1     0.601739     1A2     0.601739     7A1     0.611240  
+       4B1     0.718986     4B2     0.718986     8A1     0.729308  
        9A1     1.122191    10A1     1.661076     5B2     1.702173  
-       5B1     1.702173    11A1     1.829930     6B2     2.189439  
-       6B1     2.189439    12A1     2.203441     7B2     2.217579  
-       7B1     2.217579    13A1     2.217690     2A2     2.217690  
-       8B2     2.218544     8B1     2.218544    14A1     2.236521  
-       3A2     2.403755    15A1     2.403755     9B2     2.408149  
-       9B1     2.408149    16A1     2.480897    17A1     4.493311  
-      18A1     4.514899     4A2     4.514899    10B2     4.515996  
+       5B1     1.702173    11A1     1.829930     6B1     2.189439  
+       6B2     2.189439    12A1     2.203441     7B2     2.217579  
+       7B1     2.217579     2A2     2.217690    13A1     2.217690  
+       8B1     2.218544     8B2     2.218544    14A1     2.236521  
+      15A1     2.403755     3A2     2.403755     9B1     2.408149  
+       9B2     2.408149    16A1     2.480897    17A1     4.493311  
+       4A2     4.514899    18A1     4.514899    10B2     4.515996  
       10B1     4.515996    19A1     4.536836    11B2    11.071812  
       11B1    11.071812    20A1    11.083159    12B2    11.657350  
       12B1    11.657350     5A2    11.657385    21A1    11.657385  
-      13B1    11.657439    13B2    11.657439    22A1    11.658345  
-       6A2    13.742302    23A1    13.742302    14B2    13.744020  
+      13B2    11.657439    13B1    11.657439    22A1    11.658345  
+      23A1    13.742302     6A2    13.742302    14B2    13.744020  
       14B1    13.744020    24A1    13.773782    25A1    18.888053  
       15B2    86.259549    15B1    86.259549    26A1    86.270217  
       27A1    95.849746    28A1   299.418137  
@@ -3316,14 +3269,14 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @DF-RHF Final Energy:  -128.37799308457852
+  @DF-RHF Final Energy:  -128.37799308456087
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              0.0000000000000000
-    One-Electron Energy =                -182.4122468679940141
-    Two-Electron Energy =                  54.0342537834154797
-    Total Energy =                       -128.3779930845785202
+    One-Electron Energy =                -182.4122468679861413
+    Two-Electron Energy =                  54.0342537834252568
+    Total Energy =                       -128.3779930845608988
 
 Computation Completed
 
@@ -3345,18 +3298,18 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.0644     Total:     0.0644
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:14 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:29 2021
 Module time:
-	user time   =       1.64 seconds =       0.03 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       6.63 seconds =       0.11 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      16.24 seconds =       0.27 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =     118.41 seconds =       1.97 minutes
+	system time =       3.99 seconds =       0.07 minutes
+	total time  =         31 seconds =       0.52 minutes
 
-*** tstart() called on dream
-*** at Wed Jan  9 19:38:14 2019
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:29 2021
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -3368,13 +3321,13 @@ Total time:
     Name: (DEF2-SVP AUX)
     Role: RIFIT
     Keyword: DF_BASIS_MP2
-    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
-    atoms 2 entry XE         line  2974 file /home/kraus/Applications/psi4-dev-1350/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 1 entry NE         line   313 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2 entry XE         line  2973 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
 
 	 --------------------------------------------------------
 	                          DF-MP2                         
 	      2nd-Order Density-Fitted Moller-Plesset Theory     
-	              RMP2 Wavefunction,   1 Threads             
+	              RMP2 Wavefunction,   8 Threads             
 	                                                         
 	        Rob Parrish, Justin Turney, Andy Simmonett,      
 	           Ed Hohenstein, and C. David Sherrill          
@@ -3408,36 +3361,905 @@ Total time:
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
-	 Reference Energy          =    -128.3779930845785202 [Eh]
+	 Reference Energy          =    -128.3779930845608703 [Eh]
 	 Singles Energy            =      -0.0000000000000000 [Eh]
-	 Same-Spin Energy          =      -0.0510301008199825 [Eh]
-	 Opposite-Spin Energy      =      -0.1333808598090843 [Eh]
-	 Correlation Energy        =      -0.1844109606290669 [Eh]
-	 Total Energy              =    -128.5624040452075860 [Eh]
+	 Same-Spin Energy          =      -0.0510301008199994 [Eh]
+	 Opposite-Spin Energy      =      -0.1333808598091291 [Eh]
+	 Correlation Energy        =      -0.1844109606291285 [Eh]
+	 Total Energy              =    -128.5624040451899930 [Eh]
 	-----------------------------------------------------------
 	 ================> DF-SCS-MP2 Energies <================== 
 	-----------------------------------------------------------
 	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
 	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
-	 SCS Same-Spin Energy      =      -0.0170100336066608 [Eh]
-	 SCS Opposite-Spin Energy  =      -0.1600570317709012 [Eh]
-	 SCS Correlation Energy    =      -0.1770670653775620 [Eh]
-	 SCS Total Energy          =    -128.5550601499560912 [Eh]
+	 SCS Same-Spin Energy      =      -0.0170100336066665 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1600570317709549 [Eh]
+	 SCS Correlation Energy    =      -0.1770670653776214 [Eh]
+	 SCS Total Energy          =    -128.5550601499384982 [Eh]
 	-----------------------------------------------------------
 
 
-*** tstop() called on dream at Wed Jan  9 19:38:14 2019
+*** tstop() called on dorje at Mon Jun 28 19:09:30 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.69 seconds =       0.03 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     120.11 seconds =       2.00 minutes
+	system time =       4.10 seconds =       0.07 minutes
+	total time  =         32 seconds =       0.53 minutes
+    MP2 CP interaction energy frozen [He] and [Kr] by hand................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+    SCF Algorithm Type (re)set to DF.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:30 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry SB         line  1617 (ECP: line  2732) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+
+    !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         SB           0.000000000000     0.024892066641     0.000000000000   120.903812000000
+         H            1.436456000000    -0.995392933359     0.000000000000     1.007825032230
+         H           -0.718228000000    -0.995392933359     1.244007000000     1.007825032230
+         H           -0.718228000000    -0.995392933359    -1.244007000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      2.72340  B =      2.72340  C =      2.70213 [cm^-1]
+  Rotational constants: A =  81645.47621  B =  81645.45058  C =  81007.69659 [MHz]
+  Nuclear repulsion =   21.361534147648253
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 26
+  Nalpha       = 13
+  Nbeta        = 13
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = DEF2-SVP
+    Blend                  = DEF2-SVP
+    Total number of shells = 19
+    Number of primitives   = 38
+    Number of AO           = 43
+    Number of SO           = 41
+    Maximum AM             = 2
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    SB     10s 7p 6d // 4s 4p 2d 
+       2     H     4s 1p // 2s 1p 
+       3     H     4s 1p // 2s 1p 
+       4     H     4s 1p // 2s 1p 
+
+  -CORE POTENTIAL INFORMATION:
+    Total number of shells   = 4
+    Number of terms          = 18
+    Number of core electrons = 28
+    Maximum AM               = 3
+
+  -Contraction Scheme:
+    Atom   Type  #elec    All terms // Shells:   
+   ------ ------ ----- --------------------------
+       1    SB     28   4s 6p 6d 2f // 1s 1p 1d 1f 
+       2     H      0   
+       3     H      0   
+       4     H      0   
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry SB         line  4778 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.004 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-UNIVERSAL-JKFIT
+    Total number of shells = 64
+    Number of primitives   = 77
+    Number of AO           = 369
+    Number of SO           = 272
+    Maximum AM             = 5
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    SB     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
+       2     H     4s 2p 2d // 2s 2p 2d 
+       3     H     4s 2p 2d // 2s 2p 2d 
+       4     H     4s 2p 2d // 2s 2p 2d 
+
+  Minimum eigenvalue in the overlap matrix is 1.4897031822E-02.
+  Reciprocal condition number of the overlap matrix is 3.9818657430E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        27      27 
+     A"        14      14 
+   -------------------------
+    Total      41      41
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -238.56217360088706   -2.38562e+02   0.00000e+00 
+   @DF-RHF iter   1:  -240.94381516374605   -2.38164e+00   6.06314e-03 DIIS
+   @DF-RHF iter   2:  -240.96363351783734   -1.98184e-02   1.94245e-03 DIIS
+   @DF-RHF iter   3:  -240.96535295390285   -1.71944e-03   4.04841e-04 DIIS
+   @DF-RHF iter   4:  -240.96569237670226   -3.39423e-04   7.76554e-05 DIIS
+   @DF-RHF iter   5:  -240.96570450412869   -1.21274e-05   1.33227e-05 DIIS
+   @DF-RHF iter   6:  -240.96570486099330   -3.56865e-07   2.66516e-06 DIIS
+   @DF-RHF iter   7:  -240.96570487227874   -1.12854e-08   2.63165e-07 DIIS
+   @DF-RHF iter   8:  -240.96570487238444   -1.05700e-10   4.56337e-08 DIIS
+   @DF-RHF iter   9:  -240.96570487238921   -4.77485e-12   1.08510e-08 DIIS
+   @DF-RHF iter  10:  -240.96570487238935   -1.42109e-13   2.38567e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap    -6.527834     1App   -4.598021     2Ap    -4.598021  
+       3Ap    -4.592419     2App   -1.628956     4Ap    -1.628956  
+       3App   -1.623034     5Ap    -1.623034     6Ap    -1.619076  
+       7Ap    -0.740651     8Ap    -0.451134     4App   -0.451134  
+       9Ap    -0.363398  
+
+    Virtual:                                                              
+
+       5App    0.100995    10Ap     0.100995    11Ap     0.170471  
+       6App    0.403208    12Ap     0.403208    13Ap     0.414549  
+      14Ap     0.477439    15Ap     0.497148     7App    0.497148  
+      16Ap     0.504356     8App    0.592534    17Ap     0.592534  
+      18Ap     0.733754     9App    0.936407    19Ap     0.936407  
+      10App    1.638753    20Ap     1.674589    11App    1.674589  
+      12App    1.830106    21Ap     1.830106    22Ap     1.872302  
+      23Ap     2.142701    13App    2.166166    24Ap     2.166166  
+      25Ap    18.930905    14App   18.987484    26Ap    18.987484  
+      27Ap    55.047362  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    4 ]
+
+  @DF-RHF Final Energy:  -240.96570487238935
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             21.3615341476482534
+    One-Electron Energy =                -463.7631382135621720
+    Two-Electron Energy =                 201.4358991935245911
+    Total Energy =                       -240.9657048723893524
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -4.5612      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     4.7866      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.2254      Z:     0.0000     Total:     0.2254
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.5730      Z:     0.0000     Total:     0.5730
+
+
+*** tstop() called on dorje at Mon Jun 28 19:09:31 2021
+Module time:
+	user time   =      10.47 seconds =       0.17 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     130.65 seconds =       2.18 minutes
+	system time =       4.51 seconds =       0.08 minutes
+	total time  =         33 seconds =       0.55 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:31 2021
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry SB         line  2787 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2-4 entry H          line    22 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   8 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-SVP-RI
+    Total number of shells = 48
+    Number of primitives   = 57
+    Number of AO           = 190
+    Number of SO           = 156
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    SB     9s 8p 7d 4f 2g // 9s 8p 7d 4f 2g 
+       2     H     4s 3p 2d // 3s 2p 1d 
+       3     H     4s 3p 2d // 3s 2p 1d 
+       4     H     4s 3p 2d // 3s 2p 1d 
+
+	 --------------------------------------------------------
+	                 NBF =    41, NAUX =   156
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       0      13      13      28      28       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =    -240.9657048723893524 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0294973884092921 [Eh]
+	 Opposite-Spin Energy      =      -0.1189353250951685 [Eh]
+	 Correlation Energy        =      -0.1484327135044605 [Eh]
+	 Total Energy              =    -241.1141375858938147 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0098324628030973 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1427223901142022 [Eh]
+	 SCS Correlation Energy    =      -0.1525548529172995 [Eh]
+	 SCS Total Energy          =    -241.1182597253066433 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dorje at Mon Jun 28 19:09:32 2021
+Module time:
+	user time   =       1.26 seconds =       0.02 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     131.92 seconds =       2.20 minutes
+	system time =       4.56 seconds =       0.08 minutes
+	total time  =         34 seconds =       0.57 minutes
+    Number of frozen e- with freeze_core = 0..............................................PASSED
+    Number of occupied orbitals with freeze_core = 0......................................PASSED
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+    SCF Algorithm Type (re)set to DF.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:32 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry SB         line  1617 (ECP: line  2732) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+
+    !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         SB          -0.000000000000     0.024892066641     0.000000000000   120.903812000000
+         H            1.436456000000    -0.995392933359     0.000000000000     1.007825032230
+         H           -0.718228000000    -0.995392933359     1.244007000000     1.007825032230
+         H           -0.718228000000    -0.995392933359    -1.244007000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      2.72340  B =      2.72340  C =      2.70213 [cm^-1]
+  Rotational constants: A =  81645.47621  B =  81645.45058  C =  81007.69659 [MHz]
+  Nuclear repulsion =   21.361534147648253
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 26
+  Nalpha       = 13
+  Nbeta        = 13
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = DEF2-SVP
+    Blend                  = DEF2-SVP
+    Total number of shells = 19
+    Number of primitives   = 38
+    Number of AO           = 43
+    Number of SO           = 41
+    Maximum AM             = 2
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    SB     10s 7p 6d // 4s 4p 2d 
+       2     H     4s 1p // 2s 1p 
+       3     H     4s 1p // 2s 1p 
+       4     H     4s 1p // 2s 1p 
+
+  -CORE POTENTIAL INFORMATION:
+    Total number of shells   = 4
+    Number of terms          = 18
+    Number of core electrons = 28
+    Maximum AM               = 3
+
+  -Contraction Scheme:
+    Atom   Type  #elec    All terms // Shells:   
+   ------ ------ ----- --------------------------
+       1    SB     28   4s 6p 6d 2f // 1s 1p 1d 1f 
+       2     H      0   
+       3     H      0   
+       4     H      0   
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry SB         line  4778 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.004 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-UNIVERSAL-JKFIT
+    Total number of shells = 64
+    Number of primitives   = 77
+    Number of AO           = 369
+    Number of SO           = 272
+    Maximum AM             = 5
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    SB     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
+       2     H     4s 2p 2d // 2s 2p 2d 
+       3     H     4s 2p 2d // 2s 2p 2d 
+       4     H     4s 2p 2d // 2s 2p 2d 
+
+  Minimum eigenvalue in the overlap matrix is 1.4897031822E-02.
+  Reciprocal condition number of the overlap matrix is 3.9818657430E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        27      27 
+     A"        14      14 
+   -------------------------
+    Total      41      41
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -238.62316662335945   -2.38623e+02   0.00000e+00 
+   @DF-RHF iter   1:  -240.94418992980178   -2.32102e+00   6.06131e-03 DIIS
+   @DF-RHF iter   2:  -240.96386583697901   -1.96759e-02   1.86851e-03 DIIS
+   @DF-RHF iter   3:  -240.96540320537952   -1.53737e-03   3.74794e-04 DIIS
+   @DF-RHF iter   4:  -240.96569179274260   -2.88587e-04   7.97375e-05 DIIS
+   @DF-RHF iter   5:  -240.96570448072404   -1.26880e-05   1.36624e-05 DIIS
+   @DF-RHF iter   6:  -240.96570486152524   -3.80801e-07   2.58262e-06 DIIS
+   @DF-RHF iter   7:  -240.96570487220106   -1.06758e-08   3.42062e-07 DIIS
+   @DF-RHF iter   8:  -240.96570487241581   -2.14754e-10   6.88056e-08 DIIS
+   @DF-RHF iter   9:  -240.96570487242556   -9.74865e-12   1.48288e-08 DIIS
+   @DF-RHF iter  10:  -240.96570487242622   -6.53699e-13   4.34340e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap    -6.527834     1App   -4.598021     2Ap    -4.598021  
+       3Ap    -4.592419     2App   -1.628956     4Ap    -1.628956  
+       3App   -1.623034     5Ap    -1.623034     6Ap    -1.619076  
+       7Ap    -0.740651     8Ap    -0.451134     4App   -0.451134  
+       9Ap    -0.363398  
+
+    Virtual:                                                              
+
+       5App    0.100995    10Ap     0.100995    11Ap     0.170471  
+       6App    0.403208    12Ap     0.403208    13Ap     0.414549  
+      14Ap     0.477439    15Ap     0.497148     7App    0.497148  
+      16Ap     0.504356     8App    0.592534    17Ap     0.592534  
+      18Ap     0.733754    19Ap     0.936407     9App    0.936407  
+      10App    1.638753    20Ap     1.674589    11App    1.674589  
+      12App    1.830106    21Ap     1.830106    22Ap     1.872302  
+      23Ap     2.142701    13App    2.166166    24Ap     2.166166  
+      25Ap    18.930905    14App   18.987484    26Ap    18.987484  
+      27Ap    55.047362  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    4 ]
+
+  @DF-RHF Final Energy:  -240.96570487242622
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             21.3615341476482534
+    One-Electron Energy =                -463.7631383253477111
+    Two-Electron Energy =                 201.4358993052732671
+    Total Energy =                       -240.9657048724262154
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -4.5612      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     4.7866      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.2254      Z:     0.0000     Total:     0.2254
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.5730      Z:     0.0000     Total:     0.5730
+
+
+*** tstop() called on dorje at Mon Jun 28 19:09:33 2021
+Module time:
+	user time   =       6.11 seconds =       0.10 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     138.09 seconds =       2.30 minutes
+	system time =       4.79 seconds =       0.08 minutes
+	total time  =         35 seconds =       0.58 minutes
+
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:33 2021
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1   entry SB         line  2787 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2-4 entry H          line    22 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              RMP2 Wavefunction,   8 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-SVP-RI
+    Total number of shells = 48
+    Number of primitives   = 57
+    Number of AO           = 190
+    Number of SO           = 156
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1    SB     9s 8p 7d 4f 2g // 9s 8p 7d 4f 2g 
+       2     H     4s 3p 2d // 3s 2p 1d 
+       3     H     4s 3p 2d // 3s 2p 1d 
+       4     H     4s 3p 2d // 3s 2p 1d 
+
+	 --------------------------------------------------------
+	                 NBF =    41, NAUX =   156
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   PAIRS       4      13       9      28      28       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =    -240.9657048724262154 [Eh]
+	 Singles Energy            =      -0.0000000000000000 [Eh]
+	 Same-Spin Energy          =      -0.0247231795472016 [Eh]
+	 Opposite-Spin Energy      =      -0.1085567532926917 [Eh]
+	 Correlation Energy        =      -0.1332799328398933 [Eh]
+	 Total Energy              =    -241.0989848052660989 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =      -0.0082410598490672 [Eh]
+	 SCS Opposite-Spin Energy  =      -0.1302681039512300 [Eh]
+	 SCS Correlation Energy    =      -0.1385091638002972 [Eh]
+	 SCS Total Energy          =    -241.1042140362265229 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on dorje at Mon Jun 28 19:09:33 2021
+Module time:
+	user time   =       1.37 seconds =       0.02 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.42 seconds =       0.27 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =         17 seconds =       0.28 minutes
-	MP2 CP interaction energy frozen [He] and [Kr] by hand............PASSED
+	user time   =     139.47 seconds =       2.32 minutes
+	system time =       4.89 seconds =       0.08 minutes
+	total time  =         35 seconds =       0.58 minutes
+    Number of frozen orbitals with freeze_core = 1........................................PASSED
+    Number of occupied orbitals with freeze_core = 1......................................PASSED
 
-    Psi4 stopped on: Wednesday, 09 January 2019 07:38PM
-    Psi4 wall time for execution: 0:00:17.54
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+    SCF Algorithm Type (re)set to DF.
+
+*** tstart() called on dorje
+*** at Mon Jun 28 19:09:33 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    15 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+    atoms 2 entry I          line  1687 (ECP: line  2788) file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-svp.gbs 
+
+    !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000    -2.976362905137     1.007825032230
+         I            0.000000000000     0.000000000000     0.023637094863   126.904471900000
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =      1.87329  C =      1.87329 [cm^-1]
+  Rotational constants: A = ************  B =  56159.71825  C =  56159.71825 [MHz]
+  Nuclear repulsion =    4.409810088916667
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 26
+  Nalpha       = 13
+  Nbeta        = 13
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = DEF2-SVP
+    Blend                  = DEF2-SVP
+    Total number of shells = 13
+    Number of primitives   = 28
+    Number of AO           = 33
+    Number of SO           = 31
+    Maximum AM             = 2
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     H     4s 1p // 2s 1p 
+       2     I     10s 7p 6d // 4s 4p 2d 
+
+  -CORE POTENTIAL INFORMATION:
+    Total number of shells   = 4
+    Number of terms          = 29
+    Number of core electrons = 28
+    Maximum AM               = 3
+
+  -Contraction Scheme:
+    Atom   Type  #elec    All terms // Shells:   
+   ------ ------ ----- --------------------------
+       1     H      0   
+       2     I     28   7s 8p 10d 4f // 1s 1p 1d 1f 
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    18 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry I          line  4980 file /home/kraus/Applications/psi4-i2206/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = (DEF2-SVP AUX)
+    Blend                  = DEF2-UNIVERSAL-JKFIT
+    Total number of shells = 52
+    Number of primitives   = 61
+    Number of AO           = 329
+    Number of SO           = 236
+    Maximum AM             = 5
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     H     4s 2p 2d // 2s 2p 2d 
+       2     I     13s 12p 11d 8f 6g 3h // 11s 10p 10d 7f 5g 3h 
+
+  Minimum eigenvalue in the overlap matrix is 6.6527688531E-02.
+  Reciprocal condition number of the overlap matrix is 2.2996700786E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        15      15 
+     A2         2       2 
+     B1         7       7 
+     B2         7       7 
+   -------------------------
+    Total      31      31
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -293.28882862043980   -2.93289e+02   0.00000e+00 
+   @DF-RHF iter   1:  -296.85043970732306   -3.56161e+00   2.55279e-02 DIIS
+   @DF-RHF iter   2:  -296.91886432190455   -6.84246e-02   2.27638e-02 DIIS
+   @DF-RHF iter   3:  -297.06266566138817   -1.43801e-01   1.66871e-03 DIIS
+   @DF-RHF iter   4:  -297.06351494405465   -8.49283e-04   6.92232e-04 DIIS
+   @DF-RHF iter   5:  -297.06367138343620   -1.56439e-04   1.16931e-04 DIIS
+   @DF-RHF iter   6:  -297.06367713283862   -5.74940e-06   1.47654e-05 DIIS
+   @DF-RHF iter   7:  -297.06367721857731   -8.57387e-08   5.61376e-06 DIIS
+   @DF-RHF iter   8:  -297.06367722727066   -8.69335e-09   1.20396e-06 DIIS
+   @DF-RHF iter   9:  -297.06367722770057   -4.29907e-10   1.14970e-07 DIIS
+   @DF-RHF iter  10:  -297.06367722770517   -4.60432e-12   9.12263e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1    -7.761736     2A1    -5.620442     1B2    -5.604005  
+       1B1    -5.604005     3A1    -2.314524     2B2    -2.308819  
+       2B1    -2.308819     1A2    -2.291638     4A1    -2.291638  
+       5A1    -0.873131     3B1    -0.385045     3B2    -0.385045  
+       6A1    -0.373792  
+
+    Virtual:                                                              
+
+       7A1    -0.110219     8A1     0.415728     4B2     0.561503  
+       4B1     0.561503     9A1     0.572879    10A1     0.580811  
+       5B2     0.601816     5B1     0.601816     2A2     0.607952  
+      11A1     0.607952    12A1     0.690077     6B2     1.586536  
+       6B1     1.586536    13A1     1.638022     7B2    19.110208  
+       7B1    19.110208    14A1    19.172209    15A1    56.336938  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     6,    1,    3,    3 ]
+
+  @DF-RHF Final Energy:  -297.06367722770517
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.4098100889166671
+    One-Electron Energy =                -526.7016967761635442
+    Two-Electron Energy =                 225.2282094595417448
+    Total Energy =                       -297.0636772277051705
+    Exception raised when ECP larger than requested freeze_core?..........................PASSED
+
+    Psi4 stopped on: Monday, 28 June 2021 07:09PM
+    Psi4 wall time for execution: 0:00:36.45
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
This PR fixes a part of #2012, where requesting to freeze n-th fixed previous shell (using `set freeze_core -n` syntax) would happily carry on, even if an ECP present on a certain atom would substitute more electrons than in the n-th shell. This means the example in #2012 using `freeze_core -2` now throws an exception.

The issue of "smart freezing" of electrons of alkali metals and a further revamp of the interface (per-atom or per-element spec.) is for a different PR.

## Questions
- [x] Do I need to add a test?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
