### PR TITLE
Really ensure xc functional names are capitalized in output

### DIFF
--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -262,7 +262,7 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
     # Either process the "xc_functionals" special case
     if "xc_functionals" in func_dictionary:
         for xc_key in func_dictionary["xc_functionals"]:
-            xc_name = "XC_" + xc_key
+            xc_name = ("XC_" + xc_key).upper()
         sup = core.SuperFunctional.XC_build(xc_name, restricted)
         descr = "    " + func_dictionary["name"] + " "
         if sup.is_gga():
@@ -287,7 +287,7 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
             for x_key in x_funcs:
 
                 # Lookup the functional in LibXC
-                x_name = "XC_" + x_key
+                x_name = ("XC_" + x_key).upper()
                 x_func = core.LibXCFunctional(x_name, restricted)
                 x_params = x_funcs[x_key]
 
@@ -319,7 +319,7 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
             # if "use_libxc" specified here, fetch parameters and set flag
             # Duplicate definition of "use_libxc" caught in check_consistency.
             if "use_libxc" in x_params:
-                x_name = "XC_" + x_params["use_libxc"]
+                x_name = ("XC_" + x_params["use_libxc"]).upper()
                 x_HF.update(core.LibXCFunctional(x_name, restricted).query_libxc("XC_HYB_CAM_COEF"))
                 x_HF["used"] = True
 
@@ -345,7 +345,7 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
         if "c_functionals" in func_dictionary:
             c_funcs = func_dictionary["c_functionals"]
             for c_key in c_funcs:
-                c_name = "XC_" + c_key
+                c_name = ("XC_" + c_key).upper()
                 c_func = core.LibXCFunctional(c_name, restricted)
                 c_params = func_dictionary["c_functionals"][c_key]
                 if "tweak" in c_params:

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -79,9 +79,6 @@ void SuperFunctional::common_init() {
 }
 std::shared_ptr<SuperFunctional> SuperFunctional::blank() { return std::make_shared<SuperFunctional>(); }
 std::shared_ptr<SuperFunctional> SuperFunctional::XC_build(std::string name, bool unpolarized) {
-    // Capitalize name for consistency
-    to_upper(name);
-
     // Only allow build from full XC kernels
     if (name.find("XC_") == std::string::npos) {
         throw PSIEXCEPTION("XC_build requires full XC_ functional names");


### PR DESCRIPTION
## Description
Now that I have set up a conda environment, I was able to check whether #2218 fixed the issue of the capitalization of the xc functional keywords. It did not. This merge solves the issue:
```

   => Exchange Functionals <=

    1.0000         XC_LDA_X

   => Correlation Functionals <=

    1.0000      XC_LDA_C_PW

   => LibXC Density Thresholds  <==

    XC_LDA_C_PW:  1.00E-15 
    XC_LDA_X:  1.00E-15 
```

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
