### PR TITLE
DF-DCT with Linear Dependencies

### DIFF
--- a/psi4/src/psi4/dct/dct_oo_RHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_RHF.cc
@@ -308,8 +308,8 @@ void DCTSolver::compute_orbital_gradient_OV_RHF(bool separate_gbargamma) {
         // and not the full gamma for the other 2RDM terms.
         // All we need is (gbargamma)^i_p gamma^p_a.
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, soccpi_ + doccpi_), Slice(zero, nsopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(soccpi_ + doccpi_, nsopi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, soccpi_ + doccpi_), Slice(zero, nmopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(soccpi_ + doccpi_, nmopi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
 
         global_dpd_->file2_init(&H, PSIF_DCT_DPD, 0, ID('O'), ID('V'), "X JK <O|V>");
@@ -494,8 +494,8 @@ void DCTSolver::compute_orbital_gradient_VO_RHF(bool separate_gbargamma) {
         // and not the full gamma for the other 2RDM terms.
         // All we need is (gbargamma)^a_p gamma^p_i.
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(soccpi_ + doccpi_, nsopi_), Slice(zero, nsopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(zero, soccpi_ + doccpi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(soccpi_ + doccpi_, nmopi_), Slice(zero, nmopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(zero, soccpi_ + doccpi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
 
         global_dpd_->file2_init(&H, PSIF_DCT_DPD, 0, ID('V'), ID('O'), "X JK <V|O>");

--- a/psi4/src/psi4/dct/dct_oo_UHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_UHF.cc
@@ -700,10 +700,10 @@ void DCTSolver::compute_orbital_gradient_VO(bool separate_gbargamma) {
         // and not the full gamma for the other 2RDM terms.
         // All we need is (gbargamma)^a_p gamma^p_i.
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(soccpi_ + doccpi_, nsopi_), Slice(zero, nsopi_));
-        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(doccpi_, nsopi_), Slice(zero, nsopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(zero, soccpi_ + doccpi_));
-        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nsopi_), Slice(zero, doccpi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(soccpi_ + doccpi_, nmopi_), Slice(zero, nmopi_));
+        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(doccpi_, nmopi_), Slice(zero, nmopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(zero, soccpi_ + doccpi_));
+        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nmopi_), Slice(zero, doccpi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
         auto beta_jk = linalg::doublet(gbar_beta_block, gamma_beta_block, false, false);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,8 +45,8 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   cepa2 cepa3 cepa-module ci-multi cisd-h2o+-0 cisd-h2o+-1
                   cisd-h2o+-2 cisd-h2o-clpse cisd-opt-fd cisd-sp cisd-sp-2
                   ci-property cubeprop cubeprop-frontier decontract dct-grad1 dct-grad2
-                  dct-grad3 dct-grad4 dct1 dct2 dct3 dct4 dct5 dct6
-                  dct7 dct8 dct9 dct10 ao-dfcasscf-sp dfcasscf-sa-sp dfcasscf-fzc-sp dfcasscf-sp
+                  dct-grad3 dct-grad4 dct1 dct2 dct3 dct4 dct5 dct6 dct7 dct8 dct9
+                  dct10 dct11 ao-dfcasscf-sp dfcasscf-sa-sp dfcasscf-fzc-sp dfcasscf-sp
                   dfccd1 dfccdl1 dfccd-grad1 dfccsd1 dfccsdl1 dfccsd-grad1 dfccsd-t-grad1
                   dfccsdt1 dfccsdat1 dfmp2-1 dfmp2-2 dfmp2-3 dfmp2-4 dfmp2-ecp dfmp2-fc dfmp2-grad1
                   dfmp2-grad2 dfmp2-grad3 dfmp2-grad4 dfmp2-grad5 dfomp2-1 dfomp2-2 dfomp2-3

--- a/tests/dct10/output.ref
+++ b/tests/dct10/output.ref
@@ -1,0 +1,1145 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.4rc3.dev55 
+
+                         Git: Rev {lindep2} 9e87a7b dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 07 July 2021 12:59PM
+
+    Process ID: 43764
+    Host:       dhcp189-161.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! The multiple guesses for DCT amplitudes for ODC-12.
+
+refodc12     = -5.7749813965267096 #TEST
+
+molecule he2 {
+    He
+    He 1 3.2
+}
+
+set {
+    r_convergence 12
+    ao_basis    none
+    algorithm   simultaneous
+    basis       6-31G**
+    df_scf_guess false
+    reference   uhf
+}
+
+set dct_functional odc-12
+energy('dct')
+compare_values(refodc12, variable("DCT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST
+
+set dct_guess cc
+energy('dct')
+compare_values(refodc12, variable("DCT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST
+
+set dct_guess bcc
+wfn = energy('dct', return_wfn=True)[1]
+compare_values(refodc12, variable("DCT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST
+
+set dct_guess dct
+set dct maxiter 3 
+energy('dct', ref_wfn = wfn)
+compare_values(refodc12, variable("DCT TOTAL ENERGY"), 10, "ODC-12 Energy");                #TEST
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:24 2021
+
+   => Loading Basis Set <=
+
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    54 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/6-31gss.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         HE           0.000000000000     0.000000000000    -1.600000000000     4.002603254130
+         HE           0.000000000000     0.000000000000     1.600000000000     4.002603254130
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.82259  C =      0.82259 [cm^-1]
+  Rotational constants: A = ************  B =  24660.65993  C =  24660.65993 [MHz]
+  Nuclear repulsion =    0.661471513337500
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 6
+    Number of basis functions: 10
+    Number of Cartesian functions: 10
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3080 doubles for integral storage.
+  We computed 212 shell quartets total.
+  Whereas there are 231 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6457028609E-01.
+  Reciprocal condition number of the overlap matrix is 2.2292017993E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag         3       3 
+     B1g        0       0 
+     B2g        1       1 
+     B3g        1       1 
+     Au         0       0 
+     B1u        3       3 
+     B2u        1       1 
+     B3u        1       1 
+   -------------------------
+    Total      10      10
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:    -5.71032270527206   -5.71032e+00   0.00000e+00 
+   @UHF iter   1:    -5.71032243225501    2.73017e-07   5.04685e-05 DIIS
+   @UHF iter   2:    -5.71032245810353   -2.58485e-08   3.62238e-06 DIIS
+   @UHF iter   3:    -5.71032245823732   -1.33795e-10   2.70921e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:  -1.776356839E-15
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:               -1.776356839E-15
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.915192     1B1u   -0.913062  
+
+    Alpha Virtual:                                                        
+
+       2Ag     1.385550     2B1u    1.414364     3Ag     2.181995  
+       1B2u    2.182002     1B3u    2.182002     1B2g    2.182002  
+       1B3g    2.182002     3B1u    2.182025  
+
+    Beta Occupied:                                                        
+
+       1Ag    -0.915192     1B1u   -0.913062  
+
+    Beta Virtual:                                                         
+
+       2Ag     1.385550     2B1u    1.414364     3Ag     2.181995  
+       1B2u    2.182002     1B3u    2.182002     1B2g    2.182002  
+       1B3g    2.182002     3B1u    2.182025  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @UHF Final Energy:    -5.71032245823732
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.6614715133374998
+    One-Electron Energy =                  -9.0870793185850758
+    Two-Electron Energy =                   2.7152853470102554
+    Total Energy =                         -5.7103224582373215
+
+  UHF NO Occupations:
+  HONO-1 :    1 Ag 2.0000000
+  HONO-0 :    1B1u 2.0000000
+  LUNO+0 :    2 Ag 0.0000000
+  LUNO+1 :    1B3u 0.0000000
+  LUNO+2 :    1B2u 0.0000000
+  LUNO+3 :    1B3g 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:24 2021
+Module time:
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of SO shells:               3
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Number of irreps:                  8
+      Integral cutoff                 1.00e-12
+      Number of functions per irrep: [   3    0    1    1    0    3    1    1 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 292 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:24 2021
+
+
+
+	***********************************************************************************
+	*                             Density Cumulant Theory                             *
+	*                by Alexander Sokolov, Andy Simmonett, and Xiao Wang              *
+	***********************************************************************************
+
+
+	Transforming two-electron integrals (transformation type: unrestricted)...
+	Computing MP2 amplitude guess...
+
+	*Total Hartree-Fock energy        =   -5.710322458237322
+	 Alpha - Alpha MP2 energy         =   -0.000001349511491
+	 Alpha - Beta  MP2 energy         =   -0.050956934979691
+	 Beta  - Beta  MP2 energy         =   -0.000001349511491
+	 Total MP2 correlation energy     =   -0.050959634002672
+	*Total MP2 energy                 =   -5.761282092239993
+
+	DCT Functional:    		 ODC-12
+	DCT Type:          		 CONV
+	Algorithm:          		 SIMULTANEOUS
+	AO-Basis Integrals: 		 NONE
+
+	*=================================================================================*
+	* Cycle   Max Orb Grad    RMS Lambda Error   delta E        Total Energy     DIIS *
+	*---------------------------------------------------------------------------------*
+	* 1        6.572e-03         1.421e-02     -3.452e-02     -5.795797924415168      *
+	* 2        6.846e-04         2.930e-03      1.599e-02     -5.779803993482203      *
+	* 3        1.128e-04         6.236e-04      3.800e-03     -5.776004187401702  S   *
+	* 4        2.315e-05         1.381e-04      8.055e-04     -5.775198715823068  S   *
+	* 5        5.138e-06         3.162e-05      1.705e-04     -5.775028254657019  S   *
+	* 6        1.175e-06         7.422e-06      3.658e-05     -5.774991672214745  S/E *
+	* 7        7.314e-11         1.445e-09      1.028e-05     -5.774981396634269  S/E *
+	* 8        4.393e-12         3.505e-10      1.107e-10     -5.774981396523528  S/E *
+	* 9        8.793e-13         9.090e-11     -2.814e-12     -5.774981396526342  S/E *
+	* 10       5.423e-13         1.318e-11     -7.425e-13     -5.774981396527084  S/E *
+	* 11       1.258e-13         3.200e-12      1.856e-13     -5.774981396526899  S/E *
+	* 12       7.264e-15         1.336e-13      2.220e-14     -5.774981396526877  S/E *
+	*=================================================================================*
+
+	*   ODC-12 SCF Energy                                 =      -5.628545163417097
+	*   ODC-12 Lambda Energy                              =      -0.146436233109780
+	*   ODC-12 Total Energy                               =      -5.774981396526877
+
+	Orbital occupations:
+		Alpha occupied orbitals
+		   1Ag       0.9923     1B1u      0.9923  
+
+		Beta occupied orbitals
+		   1Ag       0.9923     1B1u      0.9923  
+
+		Alpha virtual orbitals
+		   2Ag       0.0042     2B1u      0.0042     3Ag       0.0012     3B1u      0.0012  
+		   1B3g      0.0012     1B2g      0.0012     1B3u      0.0012     1B2u      0.0012  
+		
+
+		Beta virtual orbitals
+		   2Ag       0.0042     2B1u      0.0042     3Ag       0.0012     3B1u      0.0012  
+		   1B3g      0.0012     1B2g      0.0012     1B3u      0.0012     1B2u      0.0012  
+		
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:26 2021
+Module time:
+	user time   =       0.34 seconds =       0.01 minutes
+	system time =       1.01 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       1.03 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:26 2021
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:26 2021
+Module time:
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       1.03 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+    ODC-12 Energy.........................................................................PASSED
+
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:26 2021
+
+   => Loading Basis Set <=
+
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    54 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/6-31gss.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         HE           0.000000000000     0.000000000000    -1.600000000000     4.002603254130
+         HE           0.000000000000     0.000000000000     1.600000000000     4.002603254130
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.82259  C =      0.82259 [cm^-1]
+  Rotational constants: A = ************  B =  24660.65993  C =  24660.65993 [MHz]
+  Nuclear repulsion =    0.661471513337500
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 6
+    Number of basis functions: 10
+    Number of Cartesian functions: 10
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3080 doubles for integral storage.
+  We computed 212 shell quartets total.
+  Whereas there are 231 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6457028609E-01.
+  Reciprocal condition number of the overlap matrix is 2.2292017993E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag         3       3 
+     B1g        0       0 
+     B2g        1       1 
+     B3g        1       1 
+     Au         0       0 
+     B1u        3       3 
+     B2u        1       1 
+     B3u        1       1 
+   -------------------------
+    Total      10      10
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:    -5.71032270527206   -5.71032e+00   0.00000e+00 
+   @UHF iter   1:    -5.71032243225501    2.73017e-07   5.04685e-05 DIIS
+   @UHF iter   2:    -5.71032245810353   -2.58485e-08   3.62238e-06 DIIS
+   @UHF iter   3:    -5.71032245823732   -1.33795e-10   2.70921e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:  -1.776356839E-15
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:               -1.776356839E-15
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.915192     1B1u   -0.913062  
+
+    Alpha Virtual:                                                        
+
+       2Ag     1.385550     2B1u    1.414364     3Ag     2.181995  
+       1B2u    2.182002     1B3u    2.182002     1B2g    2.182002  
+       1B3g    2.182002     3B1u    2.182025  
+
+    Beta Occupied:                                                        
+
+       1Ag    -0.915192     1B1u   -0.913062  
+
+    Beta Virtual:                                                         
+
+       2Ag     1.385550     2B1u    1.414364     3Ag     2.181995  
+       1B2u    2.182002     1B3u    2.182002     1B2g    2.182002  
+       1B3g    2.182002     3B1u    2.182025  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @UHF Final Energy:    -5.71032245823732
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.6614715133374998
+    One-Electron Energy =                  -9.0870793185850758
+    Two-Electron Energy =                   2.7152853470102554
+    Total Energy =                         -5.7103224582373215
+
+  UHF NO Occupations:
+  HONO-1 :    1 Ag 2.0000000
+  HONO-0 :    1B1u 2.0000000
+  LUNO+0 :    2 Ag 0.0000000
+  LUNO+1 :    1B3u 0.0000000
+  LUNO+2 :    1B2u 0.0000000
+  LUNO+3 :    1B3g 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:26 2021
+Module time:
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       1.04 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of SO shells:               3
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Number of irreps:                  8
+      Integral cutoff                 1.00e-12
+      Number of functions per irrep: [   3    0    1    1    0    3    1    1 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 292 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:26 2021
+
+
+
+	***********************************************************************************
+	*                             Density Cumulant Theory                             *
+	*                by Alexander Sokolov, Andy Simmonett, and Xiao Wang              *
+	***********************************************************************************
+
+
+	Transforming two-electron integrals (transformation type: unrestricted)...
+	Reading existing coupled cluster amplitudes
+
+
+	DCT Functional:    		 ODC-12
+	DCT Type:          		 CONV
+	Algorithm:          		 SIMULTANEOUS
+	AO-Basis Integrals: 		 NONE
+
+	*=================================================================================*
+	* Cycle   Max Orb Grad    RMS Lambda Error   delta E        Total Energy     DIIS *
+	*---------------------------------------------------------------------------------*
+	* 1        5.102e-03         6.838e-02     -5.828e+00     -5.812241726242776      *
+	* 2        1.741e-03         1.422e-02      1.640e-02     -5.795841471588557      *
+	* 3        4.389e-04         2.917e-03      1.605e-02     -5.779786617072336      *
+	* 4        9.919e-05         6.192e-04      3.788e-03     -5.775998458348154  S   *
+	* 5        2.224e-05         1.369e-04      8.012e-04     -5.775197261601458  S   *
+	* 6        5.043e-06         3.129e-05      1.694e-04     -5.775027900711518  S   *
+	* 7        1.159e-06         7.338e-06      3.631e-05     -5.774991586592064  S/E *
+	* 8        1.173e-10         1.389e-09      1.019e-05     -5.774981396121207  S/E *
+	* 9        9.700e-12         3.165e-10     -3.919e-10     -5.774981396513062  S/E *
+	* 10       1.370e-12         8.518e-11     -1.256e-11     -5.774981396525622  S/E *
+	* 11       7.931e-13         1.395e-11     -2.072e-12     -5.774981396527694  S/E *
+	* 12       9.628e-14         6.636e-13      8.535e-13     -5.774981396526840  S/E *
+	*=================================================================================*
+
+	*   ODC-12 SCF Energy                                 =      -5.628545163417022
+	*   ODC-12 Lambda Energy                              =      -0.146436233109818
+	*   ODC-12 Total Energy                               =      -5.774981396526840
+
+	Orbital occupations:
+		Alpha occupied orbitals
+		   1Ag       0.9923     1B1u      0.9923  
+
+		Beta occupied orbitals
+		   1Ag       0.9923     1B1u      0.9923  
+
+		Alpha virtual orbitals
+		   2Ag       0.0042     2B1u      0.0042     3Ag       0.0012     3B1u      0.0012  
+		   1B3g      0.0012     1B2g      0.0012     1B3u      0.0012     1B2u      0.0012  
+		
+
+		Beta virtual orbitals
+		   2Ag       0.0042     2B1u      0.0042     3Ag       0.0012     3B1u      0.0012  
+		   1B3g      0.0012     1B2g      0.0012     1B3u      0.0012     1B2u      0.0012  
+		
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:27 2021
+Module time:
+	user time   =       0.32 seconds =       0.01 minutes
+	system time =       0.97 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.11 seconds =       0.02 minutes
+	system time =       2.01 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:27 2021
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:27 2021
+Module time:
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.11 seconds =       0.02 minutes
+	system time =       2.01 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
+    ODC-12 Energy.........................................................................PASSED
+
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:27 2021
+
+   => Loading Basis Set <=
+
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    54 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/6-31gss.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         HE           0.000000000000     0.000000000000    -1.600000000000     4.002603254130
+         HE           0.000000000000     0.000000000000     1.600000000000     4.002603254130
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.82259  C =      0.82259 [cm^-1]
+  Rotational constants: A = ************  B =  24660.65993  C =  24660.65993 [MHz]
+  Nuclear repulsion =    0.661471513337500
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 6
+    Number of basis functions: 10
+    Number of Cartesian functions: 10
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3080 doubles for integral storage.
+  We computed 212 shell quartets total.
+  Whereas there are 231 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6457028609E-01.
+  Reciprocal condition number of the overlap matrix is 2.2292017993E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag         3       3 
+     B1g        0       0 
+     B2g        1       1 
+     B3g        1       1 
+     Au         0       0 
+     B1u        3       3 
+     B2u        1       1 
+     B3u        1       1 
+   -------------------------
+    Total      10      10
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:    -5.71032270527206   -5.71032e+00   0.00000e+00 
+   @UHF iter   1:    -5.71032243225501    2.73017e-07   5.04685e-05 DIIS
+   @UHF iter   2:    -5.71032245810353   -2.58485e-08   3.62238e-06 DIIS
+   @UHF iter   3:    -5.71032245823732   -1.33795e-10   2.70921e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:  -1.776356839E-15
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:               -1.776356839E-15
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.915192     1B1u   -0.913062  
+
+    Alpha Virtual:                                                        
+
+       2Ag     1.385550     2B1u    1.414364     3Ag     2.181995  
+       1B2u    2.182002     1B3u    2.182002     1B2g    2.182002  
+       1B3g    2.182002     3B1u    2.182025  
+
+    Beta Occupied:                                                        
+
+       1Ag    -0.915192     1B1u   -0.913062  
+
+    Beta Virtual:                                                         
+
+       2Ag     1.385550     2B1u    1.414364     3Ag     2.181995  
+       1B2u    2.182002     1B3u    2.182002     1B2g    2.182002  
+       1B3g    2.182002     3B1u    2.182025  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @UHF Final Energy:    -5.71032245823732
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.6614715133374998
+    One-Electron Energy =                  -9.0870793185850758
+    Two-Electron Energy =                   2.7152853470102554
+    Total Energy =                         -5.7103224582373215
+
+  UHF NO Occupations:
+  HONO-1 :    1 Ag 2.0000000
+  HONO-0 :    1B1u 2.0000000
+  LUNO+0 :    2 Ag 0.0000000
+  LUNO+1 :    1B3u 0.0000000
+  LUNO+2 :    1B2u 0.0000000
+  LUNO+3 :    1B3g 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:27 2021
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       2.01 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of SO shells:               3
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Number of irreps:                  8
+      Integral cutoff                 1.00e-12
+      Number of functions per irrep: [   3    0    1    1    0    3    1    1 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 292 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:27 2021
+
+
+
+	***********************************************************************************
+	*                             Density Cumulant Theory                             *
+	*                by Alexander Sokolov, Andy Simmonett, and Xiao Wang              *
+	***********************************************************************************
+
+
+	Transforming two-electron integrals (transformation type: unrestricted)...
+	Reading existing coupled cluster amplitudes
+
+
+	DCT Functional:    		 ODC-12
+	DCT Type:          		 CONV
+	Algorithm:          		 SIMULTANEOUS
+	AO-Basis Integrals: 		 NONE
+
+	*=================================================================================*
+	* Cycle   Max Orb Grad    RMS Lambda Error   delta E        Total Energy     DIIS *
+	*---------------------------------------------------------------------------------*
+	* 1        5.102e-03         6.838e-02     -6.242e+00     -5.812241726242776      *
+	* 2        1.741e-03         1.422e-02      1.640e-02     -5.795841471588557      *
+	* 3        4.389e-04         2.917e-03      1.605e-02     -5.779786617072336      *
+	* 4        9.919e-05         6.192e-04      3.788e-03     -5.775998458348154  S   *
+	* 5        2.224e-05         1.369e-04      8.012e-04     -5.775197261601458  S   *
+	* 6        5.043e-06         3.129e-05      1.694e-04     -5.775027900711518  S   *
+	* 7        1.159e-06         7.338e-06      3.631e-05     -5.774991586592064  S/E *
+	* 8        1.173e-10         1.389e-09      1.019e-05     -5.774981396121207  S/E *
+	* 9        9.700e-12         3.165e-10     -3.919e-10     -5.774981396513062  S/E *
+	* 10       1.370e-12         8.518e-11     -1.256e-11     -5.774981396525622  S/E *
+	* 11       7.931e-13         1.395e-11     -2.072e-12     -5.774981396527694  S/E *
+	* 12       9.628e-14         6.636e-13      8.535e-13     -5.774981396526840  S/E *
+	*=================================================================================*
+
+	*   ODC-12 SCF Energy                                 =      -5.628545163417022
+	*   ODC-12 Lambda Energy                              =      -0.146436233109818
+	*   ODC-12 Total Energy                               =      -5.774981396526840
+
+	Orbital occupations:
+		Alpha occupied orbitals
+		   1Ag       0.9923     1B1u      0.9923  
+
+		Beta occupied orbitals
+		   1Ag       0.9923     1B1u      0.9923  
+
+		Alpha virtual orbitals
+		   2Ag       0.0042     2B1u      0.0042     3Ag       0.0012     3B1u      0.0012  
+		   1B3g      0.0012     1B2g      0.0012     1B3u      0.0012     1B2u      0.0012  
+		
+
+		Beta virtual orbitals
+		   2Ag       0.0042     2B1u      0.0042     3Ag       0.0012     3B1u      0.0012  
+		   1B3g      0.0012     1B2g      0.0012     1B3u      0.0012     1B2u      0.0012  
+		
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:29 2021
+Module time:
+	user time   =       0.32 seconds =       0.01 minutes
+	system time =       0.95 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       1.61 seconds =       0.03 minutes
+	system time =       2.97 seconds =       0.05 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:29 2021
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:29 2021
+Module time:
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.61 seconds =       0.03 minutes
+	system time =       2.97 seconds =       0.05 minutes
+	total time  =          5 seconds =       0.08 minutes
+    ODC-12 Energy.........................................................................PASSED
+
+Scratch directory: /tmp/
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of SO shells:               3
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Number of irreps:                  8
+      Integral cutoff                 1.00e-12
+      Number of functions per irrep: [   3    0    1    1    0    3    1    1 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 292 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:29 2021
+
+
+
+	***********************************************************************************
+	*                             Density Cumulant Theory                             *
+	*                by Alexander Sokolov, Andy Simmonett, and Xiao Wang              *
+	***********************************************************************************
+
+
+	Transforming two-electron integrals (transformation type: unrestricted)...
+
+	DCT Functional:    		 ODC-12
+	DCT Type:          		 CONV
+	Algorithm:          		 SIMULTANEOUS
+	AO-Basis Integrals: 		 NONE
+
+	*=================================================================================*
+	* Cycle   Max Orb Grad    RMS Lambda Error   delta E        Total Energy     DIIS *
+	*---------------------------------------------------------------------------------*
+	 Exact Tau didn't converge. Evaluating it non-iteratively
+	* 1        5.258e-15         1.478e-13     -5.775e+00     -5.774981396526858  S   *
+	 Exact Tau didn't converge. Evaluating it non-iteratively
+	* 2        1.651e-15         3.462e-14     -5.329e-15     -5.774981396526863  S   *
+	*=================================================================================*
+
+	*   ODC-12 SCF Energy                                 =      -5.628545163417079
+	*   ODC-12 Lambda Energy                              =      -0.146436233109785
+	*   ODC-12 Total Energy                               =      -5.774981396526863
+
+	Orbital occupations:
+		Alpha occupied orbitals
+		   1Ag       0.9923     1B1u      0.9923  
+
+		Beta occupied orbitals
+		   1Ag       0.9923     1B1u      0.9923  
+
+		Alpha virtual orbitals
+		   2Ag       0.0042     2B1u      0.0042     3Ag       0.0012     3B1u      0.0012  
+		   1B3g      0.0012     1B2g      0.0012     1B3u      0.0012     1B2u      0.0012  
+		
+
+		Beta virtual orbitals
+		   2Ag       0.0042     2B1u      0.0042     3Ag       0.0012     3B1u      0.0012  
+		   1B3g      0.0012     1B2g      0.0012     1B3u      0.0012     1B2u      0.0012  
+		
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:29 2021
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.69 seconds =       0.03 minutes
+	system time =       3.21 seconds =       0.05 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 12:59:29 2021
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 12:59:29 2021
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.70 seconds =       0.03 minutes
+	system time =       3.21 seconds =       0.05 minutes
+	total time  =          5 seconds =       0.08 minutes
+    ODC-12 Energy.........................................................................PASSED
+
+    Psi4 stopped on: Wednesday, 07 July 2021 12:59PM
+    Psi4 wall time for execution: 0:00:05.08
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dct11/CMakeLists.txt
+++ b/tests/dct11/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dct11 "psi;noc1;dct")

--- a/tests/dct11/input.dat
+++ b/tests/dct11/input.dat
@@ -1,0 +1,20 @@
+#! Restricted DF-DCT ODC-12 energies with linearly dependent basis functions
+
+molecule { 
+o 
+h 1 1.0 
+h 1 1.0 2 104.5
+}
+
+set {
+  basis 'aug-cc-pvtz'
+  dct_type df
+  s_tolerance 1e-3
+}
+
+dct_energy = energy('dct')
+
+compare_values(-76.348218880997010, variable("DCT TOTAL ENERGY"), 8, "ODC-12 Energy")
+
+clean()
+

--- a/tests/dct11/output.ref
+++ b/tests/dct11/output.ref
@@ -1,0 +1,450 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.4rc3.dev55 
+
+                         Git: Rev {lindep2} 9e87a7b dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 07 July 2021 01:02PM
+
+    Process ID: 44427
+    Host:       dhcp189-161.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Restricted DF-DCT ODC-12 energies with linearly dependent basis functions
+
+molecule { 
+o 
+h 1 1.0 
+h 1 1.0 2 104.5
+}
+
+set {
+  basis 'aug-cc-pvtz'
+  dct_type df
+  s_tolerance 1e-3
+}
+
+dct_energy = energy('dct')
+
+compare_values(-76.348218880997010, variable("DCT TOTAL ENERGY"), 8, "ODC-12 Energy")
+
+clean()
+
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 13:02:16 2021
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   331 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    40 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVTZ
+    Blend: AUG-CC-PVTZ
+    Number of shells: 32
+    Number of basis functions: 92
+    Number of Cartesian functions: 105
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              32
+      Number of primitives:             52
+      Number of atomic orbitals:       105
+      Number of basis functions:        92
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 18305562 doubles for integral storage.
+  We computed 139656 shell quartets total.
+  Whereas there are 139656 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.7031430406E-04.
+  Reciprocal condition number of the overlap matrix is 6.5187445034E-05.
+    Using canonical orthogonalization.
+  Overall, 2 of 92 possible MOs eliminated.
+
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        35      34 
+     A2        12      12 
+     B1        18      18 
+     B2        27      26 
+   -------------------------
+    Total      92      90
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.42760744012462   -7.54276e+01   0.00000e+00 
+   @RHF iter   1:   -75.96791498676515   -5.40308e-01   9.71328e-03 DIIS
+   @RHF iter   2:   -76.01905245608665   -5.11375e-02   6.93296e-03 DIIS
+   @RHF iter   3:   -76.05383094228139   -3.47785e-02   4.74063e-04 DIIS
+   @RHF iter   4:   -76.05428070537540   -4.49763e-04   1.23315e-04 DIIS
+   @RHF iter   5:   -76.05431480420393   -3.40988e-05   2.89328e-05 DIIS
+   @RHF iter   6:   -76.05431774205061   -2.93785e-06   6.31625e-06 DIIS
+   @RHF iter   7:   -76.05431789208677   -1.50036e-07   1.10264e-06 DIIS
+   @RHF iter   8:   -76.05431789601485   -3.92808e-09   1.98000e-07 DIIS
+   @RHF iter   9:   -76.05431789611971   -1.04862e-10   5.23692e-08 DIIS
+   @RHF iter  10:   -76.05431789612697   -7.26175e-12   7.56316e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.574682     2A1    -1.332641     1B2    -0.695068  
+       3A1    -0.576711     1B1    -0.507036  
+
+    Virtual:                                                              
+
+       4A1     0.031200     2B2     0.048894     5A1     0.150605  
+       2B1     0.160628     6A1     0.180475     3B2     0.196269  
+       4B2     0.225590     7A1     0.244782     1A2     0.264979  
+       3B1     0.298581     8A1     0.330602     5B2     0.364377  
+       6B2     0.492179     9A1     0.517046     7B2     0.657094  
+      10A1     0.664456     2A2     0.723335    11A1     0.725561  
+       4B1     0.733131    12A1     0.818787     5B1     0.841961  
+       8B2     0.909385     3A2     0.917459     6B1     0.923577  
+      13A1     0.953914     9B2     0.956346    14A1     0.987638  
+      10B2     1.031456     7B1     1.076247    11B2     1.101768  
+      15A1     1.152702     4A2     1.166051    16A1     1.275250  
+       5A2     1.496299    17A1     1.546608     8B1     1.561344  
+      12B2     1.630981    13B2     1.934406    18A1     2.075239  
+      14B2     2.113686    19A1     2.145861     9B1     2.257493  
+       6A2     2.306390    20A1     2.348273    10B1     2.411255  
+      21A1     2.440297    15B2     2.442838    11B1     2.705182  
+      22A1     2.724759    16B2     2.801573     7A2     2.862078  
+      17B2     3.580306    23A1     3.673220     8A2     3.984737  
+      12B1     4.040379    24A1     4.102957    18B2     4.135529  
+      13B1     4.266657    25A1     4.295032    19B2     4.321157  
+       9A2     4.358605    14B1     4.374066    26A1     4.394251  
+      20B2     4.651435    21B2     4.945488    27A1     5.041694  
+      10A2     5.046326    22B2     5.134520    15B1     5.397070  
+      28A1     5.436373    29A1     5.890942    23B2     6.027986  
+      16B1     6.696943    30A1     6.823737    17B1     7.077974  
+      24B2     7.203909    11A2     7.212395    18B1     7.230793  
+      31A1     7.305938    12A2     7.355273    32A1     7.419110  
+      25B2     7.711481    33A1     7.831059    26B2     8.469944  
+      34A1    14.531513  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @RHF Final Energy:   -76.05431789612697
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.3392908243878878
+    Two-Electron Energy =                  37.4835073636935192
+    Total Energy =                        -76.0543178961269888
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.0191
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2248
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7943     Total:     0.7943
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0189     Total:     2.0189
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 13:02:18 2021
+Module time:
+	user time   =       1.53 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       1.53 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+  Constructing Basis Sets for DCT...
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVTZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_DCT
+    atoms 1   entry O          line   264 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-ri.gbs 
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   286 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 13:02:18 2021
+
+
+
+	***********************************************************************************
+	*                             Density Cumulant Theory                             *
+	*                by Alexander Sokolov, Andy Simmonett, and Xiao Wang              *
+	***********************************************************************************
+
+
+	                  ************************************************
+	                  *         Density Fitting Module in DCT        *
+	                  *                by Xiao Wang                  *
+	                  ************************************************
+
+	 => Sizing <=
+
+	  Memory   =         500 MB
+	  Threads  =           1
+	  nn       =          92
+	  nQ       =         198
+
+	 => Primary Basis <=
+
+  Basis Set: AUG-CC-PVTZ
+    Blend: AUG-CC-PVTZ
+    Number of shells: 32
+    Number of basis functions: 92
+    Number of Cartesian functions: 105
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+	 => Auxiliary Basis <=
+
+  Basis Set: (AUG-CC-PVTZ AUX)
+    Blend: AUG-CC-PVTZ-RI
+    Number of shells: 56
+    Number of basis functions: 198
+    Number of Cartesian functions: 246
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+	 => Memory Requirement <=
+
+	Minimum Memory required                 :     51.35 MB 
+	Memory available                        :    500.00 MB 
+
+
+
+	Transforming two-electron integrals (transformation type: restricted)...
+	Computing MP2 amplitude guess...
+
+	*Total Hartree-Fock energy        =  -76.054317896126975
+	 Total MP2 correlation energy     =   -0.286004754570921
+	*Total MP2 energy                 =  -76.340322650697900
+
+	DCT Functional:    		 ODC-12
+	DCT Type:          		 DF
+	Algorithm:          		 SIMULTANEOUS
+	AO-Basis Integrals: 		 NONE
+
+	*=================================================================================*
+	* Cycle   Max Orb Grad    RMS Lambda Error   delta E        Total Energy     DIIS *
+	*---------------------------------------------------------------------------------*
+	* 1        2.734e-02         6.603e-04     -1.944e-03    -76.342267070983311      *
+	* 2        6.387e-03         1.802e-04     -1.863e-02    -76.360901682433905      *
+	* 3        2.730e-03         6.314e-05      1.132e-02    -76.349578675574747      *
+	* 4        1.343e-03         2.702e-05      4.141e-04    -76.349164611884945      *
+	* 5        9.918e-04         1.333e-05      6.642e-04    -76.348500404288160  S   *
+	* 6        6.011e-04         6.356e-06      1.023e-04    -76.348398060003603  S   *
+	* 7        4.291e-04         3.672e-06      1.331e-04    -76.348264921227525  S   *
+	* 8        2.882e-04         1.927e-06      4.174e-07    -76.348264503872528  S/E *
+	* 9        1.097e-06         6.732e-08      4.528e-05    -76.348219225398225  S/E *
+	* 10       3.150e-07         2.141e-08      2.614e-07    -76.348218964005383  S/E *
+	* 11       8.602e-08         3.681e-09      1.016e-07    -76.348218862359587  S/E *
+	* 12       3.282e-08         1.219e-09     -2.546e-08    -76.348218887819812  S/E *
+	* 13       7.071e-09         4.180e-10      9.880e-09    -76.348218877939658  S/E *
+	* 14       1.791e-09         9.422e-11     -1.617e-09    -76.348218879556896  S/E *
+	* 15       9.730e-10         3.429e-11     -1.083e-09    -76.348218880639891  S/E *
+	* 16       3.729e-10         1.008e-11     -2.433e-10    -76.348218880883152  S/E *
+	* 17       8.771e-11         3.495e-12     -1.139e-10    -76.348218880997010  S/E *
+	*=================================================================================*
+
+	*DF-ODC-12 SCF Energy                                 =     -75.745528583700974
+	*DF-ODC-12 Lambda Energy                              =      -0.602690297296038
+	*DF-ODC-12 Total Energy                               =     -76.348218880997010
+
+	Orbital occupations:
+		Doubly occupied orbitals
+		   1A1       1.9995     2A1       1.9787     1B1       1.9624     3A1       1.9579  
+		   1B2       1.9559  
+
+		Virtual orbitals
+		   2B2       0.0132     4A1       0.0112     5A1       0.0071     6A1       0.0054  
+		   2B1       0.0053     3B2       0.0052     4B2       0.0051     3B1       0.0049  
+		   7A1       0.0041     4B1       0.0037     5B2       0.0034     8A1       0.0032  
+		   5B1       0.0031     6B2       0.0031     9A1       0.0029    10A1       0.0028  
+		  11A1       0.0028     7B2       0.0024     1A2       0.0024    12A1       0.0023  
+		   6B1       0.0023     7B1       0.0022    13A1       0.0020     8B1       0.0019  
+		   2A2       0.0019    14A1       0.0019    15A1       0.0019     9B1       0.0019  
+		  16A1       0.0018    10B1       0.0017     3A2       0.0017    17A1       0.0017  
+		  18A1       0.0017     8B2       0.0016     9B2       0.0016    19A1       0.0014  
+		  20A1       0.0013    10B2       0.0012    21A1       0.0011     4A2       0.0011  
+		  11B1       0.0011    11B2       0.0011    22A1       0.0010    23A1       0.0007  
+		  24A1       0.0007    12B1       0.0007    12B2       0.0007    13B2       0.0006  
+		   5A2       0.0006    25A1       0.0006     6A2       0.0005    26A1       0.0005  
+		  14B2       0.0004    13B1       0.0004    14B1       0.0004    15B2       0.0004  
+		  27A1       0.0003    16B2       0.0003    28A1       0.0003    17B2       0.0003  
+		  29A1       0.0003    30A1       0.0003    18B2       0.0003    31A1       0.0003  
+		  19B2       0.0003    15B1       0.0003    32A1       0.0003     7A2       0.0003  
+		  20B2       0.0002    33A1       0.0002     8A2       0.0002    21B2       0.0002  
+		   9A2       0.0002    16B1       0.0002    22B2       0.0002    23B2       0.0002  
+		  10A2       0.0002    24B2       0.0002    25B2       0.0002    17B1       0.0002  
+		  26B2       0.0001    18B1       0.0001    11A2       0.0001    12A2       0.0001  
+		  34A1       0.0001  
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 13:02:40 2021
+Module time:
+	user time   =      16.86 seconds =       0.28 minutes
+	system time =       2.51 seconds =       0.04 minutes
+	total time  =         22 seconds =       0.37 minutes
+Total time:
+	user time   =      18.48 seconds =       0.31 minutes
+	system time =       2.61 seconds =       0.04 minutes
+	total time  =         24 seconds =       0.40 minutes
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Wed Jul  7 13:02:40 2021
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Wed Jul  7 13:02:40 2021
+Module time:
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      18.48 seconds =       0.31 minutes
+	system time =       2.61 seconds =       0.04 minutes
+	total time  =         24 seconds =       0.40 minutes
+    ODC-12 Energy.........................................................................PASSED
+
+    Psi4 stopped on: Wednesday, 07 July 2021 01:02PM
+    Psi4 wall time for execution: 0:00:23.53
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This fixes Example 2 of #2231. DF-DCT no longer segfaults in the presence of linear dependencies.

Even with this merged in, #2231 should stay open until I've had a chance to do some more thorough testing of the module. This is, once again, a stand-alone bugfix.

## Questions
- [x] Test case added! ~~It would be good for me to write a test case for everything I check as part of #2231. Should this live in ctests or pytests? I'm not clear on test best practices at this point in Psi development, since we want to mover over to pytests eventually. Even then, _right now_ is a bad time to write the test since #2232 will change the reference output.~~

## Checklist
- [x] `ctest -R dct` passes

## Status
- [x] Ready for review
- [x] Ready for merge
