### PR TITLE
damping_convergence not damping_threshold

### DIFF
--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -570,7 +570,7 @@ Damping [Off by Default]
     "damping" can be activated by setting the
     |scf__damping_percentage| keyword to a nonzero percent. Damping is
     turned off when the DIIS error is smaller than
-    |scf__damping_threshold|.
+    |scf__damping_convergence|.
 Level shifting [Off by default]
     A commonly used alternative to damping is to use level shifting,
     which decreases the mixing of occupied and unoccupied orbitals in


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Looks like there was a mistake in the added note on damping in #2225 that wasn't caught by the CI; this PR rectifies the referenced keyword.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
