### PR TITLE
OCC: Don't reset orbitals

### DIFF
--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -597,8 +597,6 @@ void OCCWave::mem_release() {
         delete oo_pairidxAA;
         delete vv_pairidxAA;
 
-        // Ca_.reset();
-        C_ref_[SpinType::Alpha].reset();
         Hso.reset();
         Tso.reset();
         Vso.reset();
@@ -628,10 +626,6 @@ void OCCWave::mem_release() {
             t1B.reset();
         }
 
-        Ca_.reset();
-        Cb_.reset();
-        C_ref_[SpinType::Alpha].reset();
-        C_ref_[SpinType::Beta].reset();
         Hso.reset();
         Tso.reset();
         Vso.reset();


### PR DESCRIPTION
## Description
Fix [a bug reported on the forums](http://forum.psicode.org/t/cubeprop-mp2-wfn/2228). That traces back to the orbitals getting wiped off OCC wavefunctions due to overzealous memory resets. Thanks to smart pointers, this is completely unnecessary. Offensive code removed.

This is a no-brainer bugfix, so 1.4 target appreciated.

## Status
- [x] Ready for review
- [x] Ready for merge
