### PR TITLE
Fix MCSCF Final CI Energy Mismatch

### DIFF
--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -365,6 +365,7 @@ def mcscf_solver(ref_wfn):
 
         # Retransform intragrals and update CI coeffs., OPDM, and TPDM
         ciwfn.transform_mcscf_integrals(approx_integrals_only)
+        ciwfn.set_print(1)
         nci_iter = ciwfn.diag_h(abs(ediff) * 1.e-2, orb_grad_rms * 1.e-3)
 
         ciwfn.form_opdm()

--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -170,6 +170,8 @@ def mcscf_solver(ref_wfn):
 
         current_energy = ciwfn.variable("MCSCF TOTAL ENERGY")
 
+        ciwfn.reset_ci_H0block()
+
         orb_grad_rms = mcscf_obj.gradient_rms()
         ediff = current_energy - eold
 
@@ -366,6 +368,7 @@ def mcscf_solver(ref_wfn):
         # Retransform intragrals and update CI coeffs., OPDM, and TPDM
         ciwfn.transform_mcscf_integrals(approx_integrals_only)
         ciwfn.set_print(1)
+        ciwfn.set_ci_guess("H0_BLOCK")
         nci_iter = ciwfn.diag_h(abs(ediff) * 1.e-2, orb_grad_rms * 1.e-3)
 
         ciwfn.form_opdm()

--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -367,8 +367,6 @@ def mcscf_solver(ref_wfn):
         ciwfn.transform_mcscf_integrals(approx_integrals_only)
         nci_iter = ciwfn.diag_h(abs(ediff) * 1.e-2, orb_grad_rms * 1.e-3)
 
-        ciwfn.set_ci_guess("DFILE")
-
         ciwfn.form_opdm()
         ciwfn.form_tpdm()
 

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -554,6 +554,7 @@ void export_wavefunction(py::module& m) {
         .def("compute_state_transfer", &detci::CIWavefunction::compute_state_transfer, "docstring")
         .def("sigma", py_ci_sigma, "docstring")
         .def("sigma", py_ci_int_sigma, "docstring")
+        .def("reset_ci_H0block", &detci::CIWavefunction::reset_ci_H0block, "docstring")
         .def("cleanup_ci", &detci::CIWavefunction::cleanup_ci, "docstring")
         .def("cleanup_dpd", &detci::CIWavefunction::cleanup_dpd, "docstring")
         .def("set_ci_guess", &detci::CIWavefunction::set_ci_guess, "docstring");

--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -443,6 +443,14 @@ SharedMatrix CIWavefunction::get_tpdm(const std::string& spin, bool symmetrize) 
     }
 }
 
+void CIWavefunction::reset_ci_H0block() {
+    // Free H0block
+    H0block_free();
+
+    // initialize H0block
+    H0block_init(CIblks_->vectlen);
+}
+
 /*
 ** cleanup(): Free any allocated memory that wasn't already freed elsewhere
 */

--- a/psi4/src/psi4/detci/ciwave.h
+++ b/psi4/src/psi4/detci/ciwave.h
@@ -280,6 +280,8 @@ class CIWavefunction : public Wavefunction {
      */
     void cleanup_dpd();
 
+    void reset_ci_H0block();
+
     /**
      * Sets the diag_h guess option. !Expert option.
      * @param guess CI Guess: (UNIT, H0_BLOCK, or DFLIE)


### PR DESCRIPTION
## Description
Fix the mismatch for this issue on the forum [http://forum.psicode.org/t/slight-mismatching-of-casscf-between-total-mcscf-energy-and-mcscf-root-0-energy/1693/4](url). A more efficient way to obtain the CI coefficients would be a direct transformation (without solving the CI again) based on this paper [https://doi.org/10.1063/1.479573](url).

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
