### PR TITLE
fix scf-coverage ref after phi_ao sph correction

### DIFF
--- a/external/upstream/ambit/CMakeLists.txt
+++ b/external/upstream/ambit/CMakeLists.txt
@@ -27,7 +27,7 @@ if(${ENABLE_ambit})
         ExternalProject_Add(ambit_external
             DEPENDS lapack_external
                     hdf5_external
-            URL https://github.com/jturney/ambit/archive/v0.4.1.tar.gz
+            URL https://github.com/jturney/ambit/archive/v0.5.1.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external
-        URL https://github.com/pybind/pybind11/archive/v2.6.2.tar.gz
+        URL https://github.com/pybind/pybind11/archive/v2.7.0.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
 
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCElemental/archive/v0.19.0.tar.gz
+        URL https://github.com/MolSSI/QCElemental/archive/v0.21.0.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${Python_EXECUTABLE} setup.py build

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -167,6 +167,29 @@ class BasisSet(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def allclose(self, other, atol: float=1.e-8, verbose: int=1):
+        """Equality test. Sorts the coefficients so handles different shell orderings. Print any failed exp/coeff differences if verbose > 1."""
+        sc, se = (list(t) for t in zip(*sorted(zip(self.uoriginal_coefficients, self.uexponents))))
+        oc, oe = (list(t) for t in zip(*sorted(zip(other.uoriginal_coefficients, other.uexponents))))
+
+        if isinstance(other, self.__class__):
+            if ((self.name == other.name) and
+                (self.puream == other.puream) and
+                (self.PYnao == other.PYnao) and
+                (self.PYnbf == other.PYnbf) and
+                (self.n_prim_per_shell == other.n_prim_per_shell) and
+                (all(abs(isc - ioc) < atol for isc, ioc in zip(sc, oc))) and
+                (all(abs(ise - ioe) < atol for ise, ioe in zip(se, oe)))):
+                return True
+            else:
+                if verbose > 1:
+                    print("")
+                    for idx in range(len(sc)):
+                        if not((abs(sc[idx] - oc[idx]) < atol) and (abs(se[idx] - oe[idx]) < atol)):
+                            print(f"{sc[idx]:20.12f} {oc[idx]:20.12f}\t\t{sc[idx] - oc[idx]:8.1E}\t\t\t{se[idx]:20.12f} {oe[idx]:20.12f}\t\t{se[idx] - oe[idx]:8.1E}")
+                return False
+        return False
+
 
     # <<< Methods for Construction >>>
 

--- a/psi4/share/psi4/basis/primitives/diff_gbs.py
+++ b/psi4/share/psi4/basis/primitives/diff_gbs.py
@@ -111,7 +111,8 @@ for el in elements:
             rdict = {bname: ''.join(refcontents)}
             bs, msg, ecp = qcdb.BasisSet.construct(parser, mol, 'BASIS', None, bdict, False)
             rbs, rmsg, recp = qcdb.BasisSet.construct(parser, mol, 'BASIS', None, rdict, False)
-            if bs == rbs:
+            #if bs.allclose(rbs, verbose=2):   # see changed coeff/exp
+            if bs.allclose(rbs):  # one line per BS
                 print('{:3}'.format(el.lower()), end='')
             else:
                 print(bcolors.WARNING + '{:3}'.format(el.upper()) + bcolors.ENDC, end='')

--- a/tests/scf-coverage/input.dat
+++ b/tests/scf-coverage/input.dat
@@ -41,7 +41,7 @@ set perturb_with sphere
 set theta_points 10
 set phi_points 10
 scf_e = energy("SCF")
-compare_values(-76.00108612517847, scf_e, 6, "Water Perturn Spherical RHF") #TEST
+compare_values(-76.04926605031216, scf_e, 6, "Water Perturb Spherical RHF") #TEST
 
 # Try out UHF NOS
 molecule water_anion {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] #2210 revealed that an early test case had fallen prey to `phi_ao`'s Cartesian-only usefulness
- [x] mild enhancement to `diff_gbs` utility script so it can compare out-of-order basis sets
- [x] bump a few dep from-source-build versions

## Status
- [x] Ready for review
- [x] Ready for merge
