### PR TITLE
split mbis oeprop

### DIFF
--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -319,7 +319,7 @@ class PopulationAnalysisCalc : public Prop {
     /// Compute Lowdin Charges
     std::tuple<SharedStdVector, SharedStdVector, SharedStdVector> compute_lowdin_charges(bool print_output = false);
     /// Compute MBIS Multipoles (doi:10.1021/acs.jctc.6b00456)
-    std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> compute_mbis_multipoles(bool print_output = false);
+    std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> compute_mbis_multipoles(bool free_atom_volumes = false, bool print_output = false);
     /// Compute Mayer Bond Indices (non-orthogoal basis)
     std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedVector> compute_mayer_indices(bool print_output = false);
     /// Compute Wiberg Bond Indices using Lowdin Orbitals (symmetrically orthogonal basis)
@@ -415,7 +415,7 @@ class PSI_API OEProp : public TaskListComputer {
     /// Compute Lowdin Charges
     void compute_lowdin_charges();
     /// Compute MBIS Multipoles (doi:10.1021/acs.jctc.6b00456)
-    void compute_mbis_multipoles();
+    void compute_mbis_multipoles(bool free_atom_volumes = false);
     /// Compute Mayer Bond Indices (non-orthogoal basis)
     void compute_mayer_indices();
     /// Compute Wiberg Bond Indices using Lowdin Orbitals (symmetrically orthogonal basis)

--- a/tests/mbis-1/input.dat
+++ b/tests/mbis-1/input.dat
@@ -76,7 +76,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', "MBIS_VOLUME_RATIOS", title='H20 SCF')
+oeprop(wfn, 'MBIS_CHARGES', title='H20 SCF')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')
@@ -85,7 +85,6 @@ quadrupoles = wfn.array_variable('MBIS QUADRUPOLES')
 octupoles = wfn.array_variable('MBIS OCTUPOLES')
 avols = wfn.array_variable('MBIS RADIAL MOMENTS <R^3>')
 vwidths = wfn.array_variable('MBIS VALENCE WIDTHS')
-vratios = wfn.array_variable('MBIS VOLUME RATIOS')
 
 compare_matrices(charges_ref, charges, 5, "MBIS Charges")             #TEST
 compare_matrices(dipoles_ref, dipoles, 5, "MBIS Dipoles")             #TEST
@@ -93,4 +92,8 @@ compare_matrices(quadrupoles_ref, quadrupoles, 5, "MBIS Quadrupoles") #TEST
 compare_matrices(octupoles_ref, octupoles, 5, "MBIS Octupoles")       #TEST
 compare_matrices(avols_ref, avols, 5, "MBIS Radial Moments <r^3>")    #TEST
 compare_matrices(vwidths_ref, vwidths, 5, "MBIS Valence Widths")      #TEST
-compare_matrices(vratios_ref, vratios, 5, "MBIS Volume Ratios")      #TEST
+
+oeprop(wfn, "MBIS_VOLUME_RATIOS", title='H20 SCF')
+
+vratios = wfn.array_variable('MBIS VOLUME RATIOS')
+compare_matrices(vratios_ref, vratios, 5, "MBIS Volume Ratios")       #TEST

--- a/tests/mbis-1/input.dat
+++ b/tests/mbis-1/input.dat
@@ -76,7 +76,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='H20 SCF')
+oeprop(wfn, 'MBIS_CHARGES', "MBIS_VOLUME_RATIOS", title='H20 SCF')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')

--- a/tests/mbis-1/output.ref
+++ b/tests/mbis-1/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.5a1.dev48 
 
-                         Git: Rev {exp_vol} 3e7263c dirty
+                         Git: Rev {mbis_sep} 701fc30 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 25 January 2021 06:27PM
+    Psi4 started on: Thursday, 30 September 2021 10:20AM
 
-    Process ID: 238117
-    Host:       ds5
-    PSIDATADIR: /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4
+    Process ID: 14675
+    Host:       psinet
+    PSIDATADIR: /psi/gits/hrw-mbis/objdir39d/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -83,6 +83,12 @@ avols_ref = psi4.Matrix.from_list([ # TEST
  [ 1.50946513],   #TEST
  [ 1.50946513]])  #TEST
 
+vratios_ref = psi4.Matrix.from_list([
+[1.339537], 
+[0.206664],
+[0.206664]])
+
+
 # Reference Valence Widths From Horton
 # O 0.40355537630901217
 # H 0.35780574579137503
@@ -129,22 +135,27 @@ compare_matrices(quadrupoles_ref, quadrupoles, 5, "MBIS Quadrupoles") #TEST
 compare_matrices(octupoles_ref, octupoles, 5, "MBIS Octupoles")       #TEST
 compare_matrices(avols_ref, avols, 5, "MBIS Radial Moments <r^3>")    #TEST
 compare_matrices(vwidths_ref, vwidths, 5, "MBIS Valence Widths")      #TEST
+
+oeprop(wfn, "MBIS_VOLUME_RATIOS", title='H20 SCF')
+
+vratios = wfn.array_variable('MBIS VOLUME RATIOS')
+compare_matrices(vratios_ref, vratios, 5, "MBIS Volume Ratios")       #TEST
 --------------------------------------------------------------------------
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-*** tstart() called on ds5
-*** at Mon Jan 25 18:27:12 2021
+*** tstart() called on psinet
+*** at Thu Sep 30 10:20:48 2021
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -196,7 +207,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
@@ -206,8 +217,8 @@ Scratch directory: /scratch/jiang/
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -230,7 +241,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: (CC-PVDZ AUX)
     Blend: CC-PVDZ-JKFIT
     Number of shells: 42
-    Number of basis function: 116
+    Number of basis functions: 116
     Number of Cartesian functions: 131
     Spherical Harmonics?: true
     Max angular momentum: 3
@@ -255,17 +266,17 @@ Scratch directory: /scratch/jiang/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -75.45137243475268   -7.54514e+01   0.00000e+00 
-   @DF-RHF iter   1:   -75.94580099112714   -4.94429e-01   1.74038e-02 DIIS
-   @DF-RHF iter   2:   -75.99964867099831   -5.38477e-02   1.04495e-02 DIIS
-   @DF-RHF iter   3:   -76.02091630759966   -2.12676e-02   9.59211e-04 DIIS
-   @DF-RHF iter   4:   -76.02136941091693   -4.53103e-04   2.41284e-04 DIIS
-   @DF-RHF iter   5:   -76.02139623764272   -2.68267e-05   4.32356e-05 DIIS
-   @DF-RHF iter   6:   -76.02139743202831   -1.19439e-06   6.70672e-06 DIIS
-   @DF-RHF iter   7:   -76.02139746368687   -3.16586e-08   1.07122e-06 DIIS
-   @DF-RHF iter   8:   -76.02139746459460   -9.07733e-10   2.63034e-07 DIIS
-   @DF-RHF iter   9:   -76.02139746465662   -6.20162e-11   4.16358e-08 DIIS
-   @DF-RHF iter  10:   -76.02139746465794   -1.32161e-12   3.60702e-09 DIIS
+   @DF-RHF iter SAD:   -75.45137243475165   -7.54514e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.94580099112629   -4.94429e-01   1.74038e-02 DIIS
+   @DF-RHF iter   2:   -75.99964867099743   -5.38477e-02   1.04495e-02 DIIS
+   @DF-RHF iter   3:   -76.02091630759874   -2.12676e-02   9.59211e-04 DIIS
+   @DF-RHF iter   4:   -76.02136941091615   -4.53103e-04   2.41284e-04 DIIS
+   @DF-RHF iter   5:   -76.02139623764188   -2.68267e-05   4.32356e-05 DIIS
+   @DF-RHF iter   6:   -76.02139743202738   -1.19439e-06   6.70672e-06 DIIS
+   @DF-RHF iter   7:   -76.02139746368603   -3.16586e-08   1.07122e-06 DIIS
+   @DF-RHF iter   8:   -76.02139746459368   -9.07647e-10   2.63034e-07 DIIS
+   @DF-RHF iter   9:   -76.02139746465578   -6.21014e-11   4.16358e-08 DIIS
+   @DF-RHF iter  10:   -76.02139746465700   -1.22213e-12   3.60702e-09 DIIS
   Energy and wave function converged.
 
 
@@ -293,14 +304,14 @@ Scratch directory: /scratch/jiang/
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -76.02139746465794
+  @DF-RHF Final Energy:   -76.02139746465700
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8014655645673745
-    One-Electron Energy =                -122.4453031892467294
-    Two-Electron Energy =                  37.6224401600214122
-    Total Energy =                        -76.0213974646579373
+    One-Electron Energy =                -122.4453031892455925
+    Two-Electron Energy =                  37.6224401600212133
+    Total Energy =                        -76.0213974646569994
 
 Computation Completed
 
@@ -313,27 +324,532 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.0191
 
   Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:    -0.1945
+     X:     0.0000      Y:     0.0000      Z:    -0.1945
 
   Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     0.8246     Total:     0.8246
+     X:     0.0000      Y:     0.0000      Z:     0.8246     Total:     0.8246
 
   Dipole Moment: [D]
-     X:     0.0000      Y:    -0.0000      Z:     2.0958     Total:     2.0958
+     X:     0.0000      Y:     0.0000      Z:     2.0958     Total:     2.0958
 
 
-*** tstop() called on ds5 at Mon Jan 25 18:27:13 2021
+*** tstop() called on psinet at Thu Sep 30 10:20:48 2021
 Module time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.28 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.28 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+  Computing free-atom volumes
+  Running 2 free-atom UHF computations
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:20:48 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000     0.000000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 8
+  Nalpha       = 5
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 6
+    Number of basis functions: 14
+    Number of Cartesian functions: 15
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 24
+    Number of basis functions: 70
+    Number of Cartesian functions: 81
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.8857646190E-01.
+  Reciprocal condition number of the overlap matrix is 1.1034928328E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       2       2       2       0
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        2       2       1       1       1       0
+     B2u        2       2       1       0       0       1
+     B3u        2       2       1       0       0       1
+   -------------------------------------------------------
+    Total      14      14       5       3       3       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:   -72.12802286185405   -7.21280e+01   2.84048e-01 DIIS
+   @DF-UHF iter   2:   -74.66452517342852   -2.53650e+00   9.12873e-02 DIIS
+   @DF-UHF iter   3:   -74.79165567759856   -1.27131e-01   5.46578e-03 DIIS
+   @DF-UHF iter   4:   -74.79215563395239   -4.99956e-04   7.99998e-04 DIIS
+   @DF-UHF iter   5:   -74.79216699520872   -1.13613e-05   2.69695e-04 DIIS
+   @DF-UHF iter   6:   -74.79216969694662   -2.70174e-06   9.23535e-05 DIIS
+   @DF-UHF iter   7:   -74.79217005185782   -3.54911e-07   7.34857e-06 DIIS
+   @DF-UHF iter   8:   -74.79217005342693   -1.56911e-09   8.73652e-07 DIIS
+   @DF-UHF iter   9:   -74.79217005344404   -1.71099e-11   1.02051e-07 DIIS
+   @DF-UHF iter  10:   -74.79217005344435   -3.12639e-13   7.70082e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.366027994E-03
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.004366028E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.701965     2Ag    -1.407506     1B2u   -0.695884  
+       1B3u   -0.695884     1B1u   -0.599260  
+
+    Alpha Virtual:                                                        
+
+       2B2u    1.066348     2B3u    1.066348     2B1u    1.127173  
+       3Ag     1.325684     1B1g    2.767298     4Ag     2.767298  
+       1B3g    2.833965     1B2g    2.833965     5Ag     2.857514  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.622973     2Ag    -1.071404     1B1u   -0.512548  
+
+    Beta Virtual:                                                         
+
+       1B2u    0.132630     1B3u    0.132630     2B1u    1.171734  
+       2B2u    1.289033     2B3u    1.289033     3Ag     1.428639  
+       4Ag     2.958029     1B3g    2.969262     1B2g    2.969262  
+       1B1g    3.008345     5Ag     3.008345  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    1,    1 ]
+
+  @DF-UHF Final Energy:   -74.79217005344435
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -103.2769151451858534
+    Two-Electron Energy =                  28.4847450917414946
+    Total Energy =                        -74.7921700534443517
+
+  UHF NO Occupations:
+  HONO-2 :    2 Ag 1.9983866
+  HONO-1 :    1B3u 1.0000000
+  HONO-0 :    1B2u 1.0000000
+  LUNO+0 :    3 Ag 0.0016134
+  LUNO+1 :    2B1u 0.0005710
+  LUNO+2 :    4 Ag 0.0000002
+  LUNO+3 :    2B2u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:20:48 2021
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.41 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the O HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  8.00000 ( 8.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       O    8    8.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       O    8   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       O    8   -3.3414    0.0000   -0.0000   -3.3414    0.0000   -4.2036
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       O    8   -0.0000   -0.0000    0.0000   -0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       O    8   10.886456   19.661756   41.789365
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       O    8    0.380387
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:20:49 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 3
+    Number of basis functions: 5
+    Number of Cartesian functions: 5
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 9
+    Number of basis functions: 23
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 3.1513974851E-01.
+  Reciprocal condition number of the overlap matrix is 1.8704206965E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         2       2       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        1       1       0       0       0       0
+     B2u        1       1       0       0       0       0
+     B3u        1       1       0       0       0       0
+   -------------------------------------------------------
+    Total       5       5       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:    -0.49927840341958   -4.99278e-01   0.00000e+00 DIIS
+   @DF-UHF iter   2:    -0.49927840341958    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.499278  
+
+    Alpha Virtual:                                                        
+
+       2Ag     0.572446     1B1u    1.443081     1B2u    1.443081  
+       1B3u    1.443081  
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.073343     2Ag     0.753274     1B1u    1.573640  
+       1B2u    1.573640     1B3u    1.573640  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:    -0.49927840341958
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4992784034195830
+    Two-Electron Energy =                   0.0000000000000000
+    Total Energy =                         -0.4992784034195830
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+  LUNO+0 :    1B3u 0.0000000
+  LUNO+1 :    1B2u 0.0000000
+  LUNO+2 :    1B1u 0.0000000
+  LUNO+3 :    2 Ag 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:20:49 2021
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.62 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the H HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  1.00000 ( 1.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       H    1    1.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       H    1   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       H    1   -0.9909   -0.0000    0.0000   -0.9909   -0.0000   -0.9909
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       H    1    0.0000    0.0000   -0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000   -0.0000    0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       H    1    2.972557    7.303957   21.184330
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       H    1    0.499020
 
 Properties computed using the H20 SCF density matrix
 
@@ -352,37 +868,25 @@ Properties computed using the H20 SCF density matrix
    Center  Symbol  Z        X           Y           Z
       1       O    8    0.000000   -0.000000   -0.169807
       2       H    1   -0.000000   -0.030570    0.007963
-      3       H    1    0.000000    0.030570    0.007963
+      3       H    1   -0.000000    0.030570    0.007963
 
   MBIS Quadrupoles: [e a0^2]
    Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
-      1       O    8   -4.7047    0.0000    0.0000   -4.4913    0.0000   -4.6061
+      1       O    8   -4.7047    0.0000   -0.0000   -4.4913   -0.0000   -4.6061
       2       H    1   -0.2983    0.0000   -0.0000   -0.2880   -0.0017   -0.2837
-      3       H    1   -0.2983    0.0000    0.0000   -0.2880    0.0017   -0.2837
+      3       H    1   -0.2983    0.0000   -0.0000   -0.2880    0.0017   -0.2837
 
   MBIS Octupoles: [e a0^3]
    Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
-      1       O    8    0.0000   -0.0000   -0.1570    0.0000    0.0000    0.0000   -0.0000   -0.4565   -0.0000   -0.6499
+      1       O    8    0.0000    0.0000   -0.1570   -0.0000   -0.0000    0.0000   -0.0000   -0.4565    0.0000   -0.6499
       2       H    1   -0.0000   -0.0105    0.0009   -0.0000    0.0000   -0.0000   -0.0324   -0.0019   -0.0144   -0.0061
-      3       H    1    0.0000    0.0105    0.0009    0.0000    0.0000    0.0000    0.0324   -0.0019    0.0144   -0.0061
+      3       H    1    0.0000    0.0105    0.0009   -0.0000    0.0000   -0.0000    0.0324   -0.0019    0.0144   -0.0061
 
-  MBIS Radial Moments: [a0^2]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   13.802065
-      2       H    1    0.870057
-      3       H    1    0.870057
-
-  MBIS Radial Moments: [a0^3]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   26.337652
-      2       H    1    1.509465
-      3       H    1    1.509465
-
-  MBIS Radial Moments: [a0^4]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   59.340866
-      2       H    1    3.115289
-      3       H    1    3.115289
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       O    8   13.802065   26.337652   59.340866
+      2       H    1    0.870057    1.509465    3.115289
+      3       H    1    0.870057    1.509465    3.115289
 
   MBIS Valence Widths: [a0]
    Center  Symbol  Z     Width
@@ -396,7 +900,566 @@ Properties computed using the H20 SCF density matrix
     MBIS Radial Moments <r^3>.............................................................PASSED
     MBIS Valence Widths...................................................................PASSED
 
-    Psi4 stopped on: Monday, 25 January 2021 06:27PM
-    Psi4 wall time for execution: 0:00:01.33
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+  Computing free-atom volumes
+  Running 2 free-atom UHF computations
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:20:50 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000     0.000000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 8
+  Nalpha       = 5
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 6
+    Number of basis functions: 14
+    Number of Cartesian functions: 15
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 24
+    Number of basis functions: 70
+    Number of Cartesian functions: 81
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.8857646190E-01.
+  Reciprocal condition number of the overlap matrix is 1.1034928328E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       2       2       2       0
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        2       2       1       1       1       0
+     B2u        2       2       1       0       0       1
+     B3u        2       2       1       0       0       1
+   -------------------------------------------------------
+    Total      14      14       5       3       3       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:   -72.12802286185405   -7.21280e+01   2.84048e-01 DIIS
+   @DF-UHF iter   2:   -74.66452517342852   -2.53650e+00   9.12873e-02 DIIS
+   @DF-UHF iter   3:   -74.79165567759856   -1.27131e-01   5.46578e-03 DIIS
+   @DF-UHF iter   4:   -74.79215563395239   -4.99956e-04   7.99998e-04 DIIS
+   @DF-UHF iter   5:   -74.79216699520872   -1.13613e-05   2.69695e-04 DIIS
+   @DF-UHF iter   6:   -74.79216969694662   -2.70174e-06   9.23535e-05 DIIS
+   @DF-UHF iter   7:   -74.79217005185782   -3.54911e-07   7.34857e-06 DIIS
+   @DF-UHF iter   8:   -74.79217005342693   -1.56911e-09   8.73652e-07 DIIS
+   @DF-UHF iter   9:   -74.79217005344404   -1.71099e-11   1.02051e-07 DIIS
+   @DF-UHF iter  10:   -74.79217005344435   -3.12639e-13   7.70082e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.366027994E-03
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.004366028E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.701965     2Ag    -1.407506     1B2u   -0.695884  
+       1B3u   -0.695884     1B1u   -0.599260  
+
+    Alpha Virtual:                                                        
+
+       2B2u    1.066348     2B3u    1.066348     2B1u    1.127173  
+       3Ag     1.325684     1B1g    2.767298     4Ag     2.767298  
+       1B3g    2.833965     1B2g    2.833965     5Ag     2.857514  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.622973     2Ag    -1.071404     1B1u   -0.512548  
+
+    Beta Virtual:                                                         
+
+       1B2u    0.132630     1B3u    0.132630     2B1u    1.171734  
+       2B2u    1.289033     2B3u    1.289033     3Ag     1.428639  
+       4Ag     2.958029     1B3g    2.969262     1B2g    2.969262  
+       1B1g    3.008345     5Ag     3.008345  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    1,    1 ]
+
+  @DF-UHF Final Energy:   -74.79217005344435
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -103.2769151451858534
+    Two-Electron Energy =                  28.4847450917414946
+    Total Energy =                        -74.7921700534443517
+
+  UHF NO Occupations:
+  HONO-2 :    2 Ag 1.9983866
+  HONO-1 :    1B3u 1.0000000
+  HONO-0 :    1B2u 1.0000000
+  LUNO+0 :    3 Ag 0.0016134
+  LUNO+1 :    2B1u 0.0005710
+  LUNO+2 :    4 Ag 0.0000002
+  LUNO+3 :    2B2u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:20:50 2021
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.69 seconds =       0.03 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the O HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  8.00000 ( 8.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       O    8    8.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       O    8   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       O    8   -3.3414    0.0000   -0.0000   -3.3414    0.0000   -4.2036
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       O    8   -0.0000   -0.0000    0.0000   -0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       O    8   10.886456   19.661756   41.789365
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       O    8    0.380387
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:20:50 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 3
+    Number of basis functions: 5
+    Number of Cartesian functions: 5
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 9
+    Number of basis functions: 23
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 3.1513974851E-01.
+  Reciprocal condition number of the overlap matrix is 1.8704206965E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         2       2       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        1       1       0       0       0       0
+     B2u        1       1       0       0       0       0
+     B3u        1       1       0       0       0       0
+   -------------------------------------------------------
+    Total       5       5       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:    -0.49927840341958   -4.99278e-01   0.00000e+00 DIIS
+   @DF-UHF iter   2:    -0.49927840341958    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.499278  
+
+    Alpha Virtual:                                                        
+
+       2Ag     0.572446     1B1u    1.443081     1B2u    1.443081  
+       1B3u    1.443081  
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.073343     2Ag     0.753274     1B1u    1.573640  
+       1B2u    1.573640     1B3u    1.573640  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:    -0.49927840341958
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4992784034195830
+    Two-Electron Energy =                   0.0000000000000000
+    Total Energy =                         -0.4992784034195830
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+  LUNO+0 :    1B3u 0.0000000
+  LUNO+1 :    1B2u 0.0000000
+  LUNO+2 :    1B1u 0.0000000
+  LUNO+3 :    2 Ag 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:20:50 2021
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.90 seconds =       0.03 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the H HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  1.00000 ( 1.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       H    1    1.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       H    1   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       H    1   -0.9909   -0.0000    0.0000   -0.9909   -0.0000   -0.9909
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       H    1    0.0000    0.0000   -0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000   -0.0000    0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       H    1    2.972557    7.303957   21.184330
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       H    1    0.499020
+
+Properties computed using the H20 SCF density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number): 10.00000 (10.00000)
+  Difference:  0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       O    8    8.845724   -0.845724
+      2       H    1    0.577139    0.422861
+      3       H    1    0.577139    0.422861
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       O    8    0.000000   -0.000000   -0.169807
+      2       H    1   -0.000000   -0.030570    0.007963
+      3       H    1   -0.000000    0.030570    0.007963
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       O    8   -4.7047    0.0000   -0.0000   -4.4913   -0.0000   -4.6061
+      2       H    1   -0.2983    0.0000   -0.0000   -0.2880   -0.0017   -0.2837
+      3       H    1   -0.2983    0.0000   -0.0000   -0.2880    0.0017   -0.2837
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       O    8    0.0000    0.0000   -0.1570   -0.0000   -0.0000    0.0000   -0.0000   -0.4565    0.0000   -0.6499
+      2       H    1   -0.0000   -0.0105    0.0009   -0.0000    0.0000   -0.0000   -0.0324   -0.0019   -0.0144   -0.0061
+      3       H    1    0.0000    0.0105    0.0009   -0.0000    0.0000   -0.0000    0.0324   -0.0019    0.0144   -0.0061
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       O    8   13.802065   26.337652   59.340866
+      2       H    1    0.870057    1.509465    3.115289
+      3       H    1    0.870057    1.509465    3.115289
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       O    8    0.403553
+      2       H    1    0.357797
+      3       H    1    0.357797
+
+
+  MBIS Volume Ratios: 
+   Center  Symbol  Z     
+      1       O    8    1.339537
+      2       H    1    0.206664
+      3       H    1    0.206664
+    MBIS Volume Ratios....................................................................PASSED
+
+    Psi4 stopped on: Thursday, 30 September 2021 10:20AM
+    Psi4 wall time for execution: 0:00:02.93
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/mbis-2/input.dat
+++ b/tests/mbis-2/input.dat
@@ -83,7 +83,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='OH- SCF')
+oeprop(wfn, 'MBIS_CHARGES', "MBIS_VOLUME_RATIOS", title='OH- SCF')
 
 #NOTE: wfn.variable gives you the expanded, redundant atomic multipole arrays as numpy arrays; for flat, unique arrays, use wfn.array_variable
 charges = wfn.variable("MBIS CHARGES")

--- a/tests/mbis-2/output.ref
+++ b/tests/mbis-2/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.5a1.dev48 
 
-                         Git: Rev {exp_vol} 3e7263c dirty
+                         Git: Rev {mbis_sep} 701fc30 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 25 January 2021 06:28PM
+    Psi4 started on: Thursday, 30 September 2021 10:13AM
 
-    Process ID: 238153
-    Host:       ds5
-    PSIDATADIR: /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4
+    Process ID: 14481
+    Host:       psinet
+    PSIDATADIR: /psi/gits/hrw-mbis/objdir39d/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -103,6 +103,10 @@ vwidths_ref = np.array([  #TEST
  [0.4199382],             #TEST
  [0.4140744]])            #TEST
 
+vratios_ref = np.array([
+[1.568969],
+[0.457094]])
+
 molecule mol {
   -1 1
   O 0.0 0.0 0.0
@@ -122,7 +126,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='OH- SCF')
+oeprop(wfn, 'MBIS_CHARGES', "MBIS_VOLUME_RATIOS", title='OH- SCF')
 
 #NOTE: wfn.variable gives you the expanded, redundant atomic multipole arrays as numpy arrays; for flat, unique arrays, use wfn.array_variable
 charges = wfn.variable("MBIS CHARGES")
@@ -131,6 +135,7 @@ quadrupoles = wfn.variable("MBIS QUADRUPOLES")
 octupoles = wfn.variable("MBIS OCTUPOLES")
 avols = wfn.variable("MBIS RADIAL MOMENTS <R^3>")
 vwidths = wfn.variable("MBIS VALENCE WIDTHS")
+vratios = wfn.variable("MBIS VOLUME RATIOS")
 
 compare_values(charges_ref, charges, "MBIS Charges", atol=1.e-5)             #TEST
 compare_values(dipoles_ref, dipoles, "MBIS Dipoles", atol=1.e-5)             #TEST
@@ -138,22 +143,23 @@ compare_values(quadrupoles_ref, quadrupoles, "MBIS Quadrupoles", atol=1.e-5) #TE
 compare_values(octupoles_ref, octupoles, "MBIS Octupoles", atol=1.e-5)       #TEST
 compare_values(avols_ref, avols, "MBIS Radial Moments <r^3>", atol=1.e-5)    #TEST
 compare_values(vwidths_ref, vwidths, "MBIS Valence Widths", atol=1.e-5)      #TEST
+compare_values(vratios_ref, vratios, "MBIS Volume Ratios", atol=1.e-5)      #TEST
 --------------------------------------------------------------------------
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-*** tstart() called on ds5
-*** at Mon Jan 25 18:28:56 2021
+*** tstart() called on psinet
+*** at Thu Sep 30 10:13:47 2021
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry O          line   198 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2 entry H          line    22 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry H          line    22 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -204,7 +210,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 9
-    Number of basis function: 19
+    Number of basis functions: 19
     Number of Cartesian functions: 20
     Spherical Harmonics?: true
     Max angular momentum: 2
@@ -214,8 +220,8 @@ Scratch directory: /scratch/jiang/
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry O          line   221 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2 entry H          line    51 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry H          line    51 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -238,7 +244,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: (CC-PVDZ AUX)
     Blend: CC-PVDZ-JKFIT
     Number of shells: 33
-    Number of basis function: 93
+    Number of basis functions: 93
     Number of Cartesian functions: 106
     Spherical Harmonics?: true
     Max angular momentum: 3
@@ -263,17 +269,17 @@ Scratch directory: /scratch/jiang/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:   -74.63727338893389   -7.46373e+01   0.00000e+00 
-   @DF-RHF iter   1:   -75.16248376772840   -5.25210e-01   3.38206e-02 DIIS
-   @DF-RHF iter   2:   -75.27088408793018   -1.08400e-01   2.15939e-02 DIIS
-   @DF-RHF iter   3:   -75.32903542873741   -5.81513e-02   1.32509e-03 DIIS
-   @DF-RHF iter   4:   -75.32969112476715   -6.55696e-04   3.73381e-04 DIIS
-   @DF-RHF iter   5:   -75.32976360680892   -7.24820e-05   7.23711e-05 DIIS
-   @DF-RHF iter   6:   -75.32976671134368   -3.10453e-06   1.08451e-05 DIIS
-   @DF-RHF iter   7:   -75.32976676507242   -5.37287e-08   8.82377e-07 DIIS
-   @DF-RHF iter   8:   -75.32976676528813   -2.15707e-10   1.13853e-07 DIIS
-   @DF-RHF iter   9:   -75.32976676529088   -2.75691e-12   1.06213e-08 DIIS
-   @DF-RHF iter  10:   -75.32976676529094   -5.68434e-14   1.04873e-09 DIIS
+   @DF-RHF iter SAD:   -74.63727338893435   -7.46373e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.16248376772890   -5.25210e-01   3.38206e-02 DIIS
+   @DF-RHF iter   2:   -75.27088408793087   -1.08400e-01   2.15939e-02 DIIS
+   @DF-RHF iter   3:   -75.32903542873808   -5.81513e-02   1.32509e-03 DIIS
+   @DF-RHF iter   4:   -75.32969112476783   -6.55696e-04   3.73381e-04 DIIS
+   @DF-RHF iter   5:   -75.32976360680954   -7.24820e-05   7.23711e-05 DIIS
+   @DF-RHF iter   6:   -75.32976671134436   -3.10453e-06   1.08451e-05 DIIS
+   @DF-RHF iter   7:   -75.32976676507299   -5.37286e-08   8.82377e-07 DIIS
+   @DF-RHF iter   8:   -75.32976676528887   -2.15877e-10   1.13853e-07 DIIS
+   @DF-RHF iter   9:   -75.32976676529148   -2.61480e-12   1.06213e-08 DIIS
+   @DF-RHF iter  10:   -75.32976676529161   -1.27898e-13   1.04873e-09 DIIS
   Energy and wave function converged.
 
 
@@ -299,14 +305,14 @@ Scratch directory: /scratch/jiang/
               A 
     DOCC [     5 ]
 
-  @DF-RHF Final Energy:   -75.32976676529094
+  @DF-RHF Final Energy:   -75.32976676529161
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              4.2334176853600001
-    One-Electron Energy =                -116.9164032575289980
-    Two-Electron Energy =                  37.3532188068780684
-    Total Energy =                        -75.3297667652909411
+    One-Electron Energy =                -116.9164032575297369
+    Two-Electron Energy =                  37.3532188068781466
+    Total Energy =                        -75.3297667652915948
 
 Computation Completed
 
@@ -319,27 +325,1037 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.8897
 
   Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:    -1.6115
+     X:     0.0000      Y:     0.0000      Z:    -1.6115
 
   Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:     0.2782     Total:     0.2782
+     X:     0.0000      Y:     0.0000      Z:     0.2782     Total:     0.2782
 
   Dipole Moment: [D]
-     X:    -0.0000      Y:    -0.0000      Z:     0.7072     Total:     0.7072
+     X:     0.0000      Y:     0.0000      Z:     0.7072     Total:     0.7072
 
 
-*** tstop() called on ds5 at Mon Jan 25 18:28:56 2021
+*** tstop() called on psinet at Thu Sep 30 10:13:47 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
+	user time   =       0.26 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.18 seconds =       0.00 minutes
+	user time   =       0.26 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+  Computing free-atom volumes
+  Running 2 free-atom UHF computations
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:13:47 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 3
+    Number of basis functions: 5
+    Number of Cartesian functions: 5
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 9
+    Number of basis functions: 23
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 3.1513974851E-01.
+  Reciprocal condition number of the overlap matrix is 1.8704206965E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         2       2       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        1       1       0       0       0       0
+     B2u        1       1       0       0       0       0
+     B3u        1       1       0       0       0       0
+   -------------------------------------------------------
+    Total       5       5       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:    -0.49927840341958   -4.99278e-01   0.00000e+00 DIIS
+   @DF-UHF iter   2:    -0.49927840341958    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.499278  
+
+    Alpha Virtual:                                                        
+
+       2Ag     0.572446     1B1u    1.443081     1B2u    1.443081  
+       1B3u    1.443081  
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.073343     2Ag     0.753274     1B1u    1.573640  
+       1B2u    1.573640     1B3u    1.573640  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:    -0.49927840341958
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4992784034195830
+    Two-Electron Energy =                   0.0000000000000000
+    Total Energy =                         -0.4992784034195830
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+  LUNO+0 :    1B3u 0.0000000
+  LUNO+1 :    1B2u 0.0000000
+  LUNO+2 :    1B1u 0.0000000
+  LUNO+3 :    2 Ag 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:13:47 2021
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the H HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  1.00000 ( 1.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       H    1    1.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       H    1   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       H    1   -0.9909   -0.0000    0.0000   -0.9909   -0.0000   -0.9909
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       H    1    0.0000    0.0000   -0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000   -0.0000    0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       H    1    2.972557    7.303957   21.184330
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       H    1    0.499020
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:13:47 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000     0.000000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 8
+  Nalpha       = 5
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 6
+    Number of basis functions: 14
+    Number of Cartesian functions: 15
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 24
+    Number of basis functions: 70
+    Number of Cartesian functions: 81
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.8857646190E-01.
+  Reciprocal condition number of the overlap matrix is 1.1034928328E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       2       2       2       0
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        2       2       1       1       1       0
+     B2u        2       2       1       0       0       1
+     B3u        2       2       1       0       0       1
+   -------------------------------------------------------
+    Total      14      14       5       3       3       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:   -72.12802286185405   -7.21280e+01   2.84048e-01 DIIS
+   @DF-UHF iter   2:   -74.66452517342852   -2.53650e+00   9.12873e-02 DIIS
+   @DF-UHF iter   3:   -74.79165567759856   -1.27131e-01   5.46578e-03 DIIS
+   @DF-UHF iter   4:   -74.79215563395239   -4.99956e-04   7.99998e-04 DIIS
+   @DF-UHF iter   5:   -74.79216699520872   -1.13613e-05   2.69695e-04 DIIS
+   @DF-UHF iter   6:   -74.79216969694662   -2.70174e-06   9.23535e-05 DIIS
+   @DF-UHF iter   7:   -74.79217005185782   -3.54911e-07   7.34857e-06 DIIS
+   @DF-UHF iter   8:   -74.79217005342693   -1.56911e-09   8.73652e-07 DIIS
+   @DF-UHF iter   9:   -74.79217005344404   -1.71099e-11   1.02051e-07 DIIS
+   @DF-UHF iter  10:   -74.79217005344435   -3.12639e-13   7.70082e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.366027994E-03
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.004366028E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.701965     2Ag    -1.407506     1B2u   -0.695884  
+       1B3u   -0.695884     1B1u   -0.599260  
+
+    Alpha Virtual:                                                        
+
+       2B2u    1.066348     2B3u    1.066348     2B1u    1.127173  
+       3Ag     1.325684     1B1g    2.767298     4Ag     2.767298  
+       1B3g    2.833965     1B2g    2.833965     5Ag     2.857514  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.622973     2Ag    -1.071404     1B1u   -0.512548  
+
+    Beta Virtual:                                                         
+
+       1B2u    0.132630     1B3u    0.132630     2B1u    1.171734  
+       2B2u    1.289033     2B3u    1.289033     3Ag     1.428639  
+       4Ag     2.958029     1B3g    2.969262     1B2g    2.969262  
+       1B1g    3.008345     5Ag     3.008345  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    1,    1 ]
+
+  @DF-UHF Final Energy:   -74.79217005344435
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -103.2769151451858534
+    Two-Electron Energy =                  28.4847450917414946
+    Total Energy =                        -74.7921700534443517
+
+  UHF NO Occupations:
+  HONO-2 :    2 Ag 1.9983866
+  HONO-1 :    1B3u 1.0000000
+  HONO-0 :    1B2u 1.0000000
+  LUNO+0 :    3 Ag 0.0016134
+  LUNO+1 :    2B1u 0.0005710
+  LUNO+2 :    4 Ag 0.0000002
+  LUNO+3 :    2B2u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:13:47 2021
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.53 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the O HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  8.00000 ( 8.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       O    8    8.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       O    8   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       O    8   -3.3414    0.0000   -0.0000   -3.3414    0.0000   -4.2036
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       O    8   -0.0000   -0.0000    0.0000   -0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       O    8   10.886456   19.661756   41.789365
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       O    8    0.380387
+  Computing free-atom volumes
+  Running 2 free-atom UHF computations
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:13:47 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 3
+    Number of basis functions: 5
+    Number of Cartesian functions: 5
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 9
+    Number of basis functions: 23
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 3.1513974851E-01.
+  Reciprocal condition number of the overlap matrix is 1.8704206965E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         2       2       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        1       1       0       0       0       0
+     B2u        1       1       0       0       0       0
+     B3u        1       1       0       0       0       0
+   -------------------------------------------------------
+    Total       5       5       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:    -0.49927840341958   -4.99278e-01   0.00000e+00 DIIS
+   @DF-UHF iter   2:    -0.49927840341958    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.499278  
+
+    Alpha Virtual:                                                        
+
+       2Ag     0.572446     1B1u    1.443081     1B2u    1.443081  
+       1B3u    1.443081  
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.073343     2Ag     0.753274     1B1u    1.573640  
+       1B2u    1.573640     1B3u    1.573640  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:    -0.49927840341958
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4992784034195830
+    Two-Electron Energy =                   0.0000000000000000
+    Total Energy =                         -0.4992784034195830
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+  LUNO+0 :    1B3u 0.0000000
+  LUNO+1 :    1B2u 0.0000000
+  LUNO+2 :    1B1u 0.0000000
+  LUNO+3 :    2 Ag 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:13:48 2021
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the H HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  1.00000 ( 1.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       H    1    1.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       H    1   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       H    1   -0.9909   -0.0000    0.0000   -0.9909   -0.0000   -0.9909
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       H    1    0.0000    0.0000   -0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000   -0.0000    0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       H    1    2.972557    7.303957   21.184330
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       H    1    0.499020
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:13:48 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000     0.000000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 8
+  Nalpha       = 5
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 6
+    Number of basis functions: 14
+    Number of Cartesian functions: 15
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 24
+    Number of basis functions: 70
+    Number of Cartesian functions: 81
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.8857646190E-01.
+  Reciprocal condition number of the overlap matrix is 1.1034928328E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       2       2       2       0
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        2       2       1       1       1       0
+     B2u        2       2       1       0       0       1
+     B3u        2       2       1       0       0       1
+   -------------------------------------------------------
+    Total      14      14       5       3       3       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:   -72.12802286185405   -7.21280e+01   2.84048e-01 DIIS
+   @DF-UHF iter   2:   -74.66452517342852   -2.53650e+00   9.12873e-02 DIIS
+   @DF-UHF iter   3:   -74.79165567759856   -1.27131e-01   5.46578e-03 DIIS
+   @DF-UHF iter   4:   -74.79215563395239   -4.99956e-04   7.99998e-04 DIIS
+   @DF-UHF iter   5:   -74.79216699520872   -1.13613e-05   2.69695e-04 DIIS
+   @DF-UHF iter   6:   -74.79216969694662   -2.70174e-06   9.23535e-05 DIIS
+   @DF-UHF iter   7:   -74.79217005185782   -3.54911e-07   7.34857e-06 DIIS
+   @DF-UHF iter   8:   -74.79217005342693   -1.56911e-09   8.73652e-07 DIIS
+   @DF-UHF iter   9:   -74.79217005344404   -1.71099e-11   1.02051e-07 DIIS
+   @DF-UHF iter  10:   -74.79217005344435   -3.12639e-13   7.70082e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.366027994E-03
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.004366028E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.701965     2Ag    -1.407506     1B2u   -0.695884  
+       1B3u   -0.695884     1B1u   -0.599260  
+
+    Alpha Virtual:                                                        
+
+       2B2u    1.066348     2B3u    1.066348     2B1u    1.127173  
+       3Ag     1.325684     1B1g    2.767298     4Ag     2.767298  
+       1B3g    2.833965     1B2g    2.833965     5Ag     2.857514  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.622973     2Ag    -1.071404     1B1u   -0.512548  
+
+    Beta Virtual:                                                         
+
+       1B2u    0.132630     1B3u    0.132630     2B1u    1.171734  
+       2B2u    1.289033     2B3u    1.289033     3Ag     1.428639  
+       4Ag     2.958029     1B3g    2.969262     1B2g    2.969262  
+       1B1g    3.008345     5Ag     3.008345  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    1,    1 ]
+
+  @DF-UHF Final Energy:   -74.79217005344435
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -103.2769151451858534
+    Two-Electron Energy =                  28.4847450917414946
+    Total Energy =                        -74.7921700534443517
+
+  UHF NO Occupations:
+  HONO-2 :    2 Ag 1.9983866
+  HONO-1 :    1B3u 1.0000000
+  HONO-0 :    1B2u 1.0000000
+  LUNO+0 :    3 Ag 0.0016134
+  LUNO+1 :    2B1u 0.0005710
+  LUNO+2 :    4 Ag 0.0000002
+  LUNO+3 :    2B2u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:13:48 2021
+Module time:
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.89 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the O HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  8.00000 ( 8.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       O    8    8.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       O    8   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       O    8   -3.3414    0.0000   -0.0000   -3.3414    0.0000   -4.2036
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       O    8   -0.0000   -0.0000    0.0000   -0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       O    8   10.886456   19.661756   41.789365
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       O    8    0.380387
 
 Properties computed using the OH- SCF density matrix
 
@@ -356,45 +1372,42 @@ Properties computed using the OH- SCF density matrix
   MBIS Dipoles: [e a0]
    Center  Symbol  Z        X           Y           Z
       1       O    8   -0.000000   -0.000000   -0.100290
-      2       H    1   -0.000000    0.000000    0.016105
+      2       H    1    0.000000    0.000000    0.016105
 
   MBIS Quadrupoles: [e a0^2]
    Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
-      1       O    8   -5.3093    0.0000   -0.0000   -5.3093    0.0000   -4.9831
-      2       H    1   -0.5485    0.0000   -0.0000   -0.5485    0.0000   -0.5493
+      1       O    8   -5.3093   -0.0000    0.0000   -5.3093   -0.0000   -4.9831
+      2       H    1   -0.5485    0.0000   -0.0000   -0.5485   -0.0000   -0.5493
 
   MBIS Octupoles: [e a0^3]
    Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
-      1       O    8    0.0000    0.0000   -0.1945    0.0000    0.0000    0.0000    0.0000   -0.1945    0.0000   -1.0437
-      2       H    1   -0.0000    0.0000   -0.0020   -0.0000   -0.0000   -0.0000    0.0000   -0.0020    0.0000   -0.0023
+      1       O    8    0.0000    0.0000   -0.1945    0.0000   -0.0000   -0.0000   -0.0000   -0.1945    0.0000   -1.0437
+      2       H    1   -0.0000   -0.0000   -0.0020    0.0000    0.0000   -0.0000   -0.0000   -0.0020   -0.0000   -0.0023
 
-  MBIS Radial Moments: [a0^2]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   15.601620
-      2       H    1    1.646350
-
-  MBIS Radial Moments: [a0^3]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   30.848694
-      2       H    1    3.338597
-
-  MBIS Radial Moments: [a0^4]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   71.518969
-      2       H    1    8.026602
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       O    8   15.601620   30.848694   71.518969
+      2       H    1    1.646350    3.338597    8.026602
 
   MBIS Valence Widths: [a0]
    Center  Symbol  Z     Width
       1       O    8    0.419938
       2       H    1    0.414074
+
+
+  MBIS Volume Ratios: 
+   Center  Symbol  Z     
+      1       O    8    1.568969
+      2       H    1    0.457094
     MBIS Charges..........................................................................PASSED
     MBIS Dipoles..........................................................................PASSED
     MBIS Quadrupoles......................................................................PASSED
     MBIS Octupoles........................................................................PASSED
     MBIS Radial Moments <r^3>.............................................................PASSED
     MBIS Valence Widths...................................................................PASSED
+    MBIS Volume Ratios....................................................................PASSED
 
-    Psi4 stopped on: Monday, 25 January 2021 06:28PM
-    Psi4 wall time for execution: 0:00:00.68
+    Psi4 stopped on: Thursday, 30 September 2021 10:13AM
+    Psi4 wall time for execution: 0:00:01.53
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/mbis-3/input.dat
+++ b/tests/mbis-3/input.dat
@@ -62,7 +62,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='OH Radical SCF')
+oeprop(wfn, 'MBIS_VOLUME_RATIOS', title='OH Radical SCF')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')

--- a/tests/mbis-3/output.ref
+++ b/tests/mbis-3/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.5a1.dev48 
 
-                         Git: Rev {exp_vol} 3e7263c dirty
+                         Git: Rev {mbis_sep} 701fc30 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 25 January 2021 06:30PM
+    Psi4 started on: Thursday, 30 September 2021 10:20AM
 
-    Process ID: 238202
-    Host:       ds5
-    PSIDATADIR: /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4
+    Process ID: 14687
+    Host:       psinet
+    PSIDATADIR: /psi/gits/hrw-mbis/objdir39d/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -81,6 +81,10 @@ vwidths_ref = psi4.Matrix.from_list([  #TEST
  [0.39070772],    #TEST
  [0.35579084]])   #TEST
 
+vratios_ref = psi4.Matrix.from_list([  #TEST
+[1.139889],
+[0.211763]])
+
 molecule mol {
   0 2
   O 0.0 0.0 0.0
@@ -101,7 +105,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='OH Radical SCF')
+oeprop(wfn, 'MBIS_VOLUME_RATIOS', title='OH Radical SCF')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')
@@ -110,11 +114,13 @@ quadrupoles = wfn.array_variable('MBIS QUADRUPOLES')
 octupoles = wfn.array_variable('MBIS OCTUPOLES')
 avols = wfn.array_variable('MBIS RADIAL MOMENTS <R^3>')
 vwidths = wfn.array_variable('MBIS VALENCE WIDTHS')
+vratios = wfn.array_variable('MBIS VOLUME RATIOS')
 
 compare_matrices(charges_ref, charges, 5, "MBIS Charges")             #TEST
 compare_matrices(dipoles_ref, dipoles, 5, "MBIS Dipoles")             #TEST
 compare_matrices(avols_ref, avols, 5, "MBIS Radial Moments <r^3>")    #TEST
 compare_matrices(vwidths_ref, vwidths, 5, "MBIS Valence Widths")      #TEST
+compare_matrices(vratios, vratios, 5, "MBIS Volume Ratios")      #TEST
 
 # lands on different degenerate solutions due to high-symmetry wfn, so test stable values. (happens for molecular quadrupole, too, not just mbis.)
 compare_values(quadrupoles_ref.np[0, 5], quadrupoles.np[0, 5], 5, "MBIS Quadrupoles: ZZ of O") #TEST
@@ -123,20 +129,20 @@ compare_values(octupoles_ref.np[0, 9], octupoles.np[0, 9], 5, "MBIS Octupoles: Z
 compare_values(octupoles_ref.np[1, 9], octupoles.np[1, 9], 5, "MBIS Octupoles: ZZZ of H") #TEST
 --------------------------------------------------------------------------
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-*** tstart() called on ds5
-*** at Mon Jan 25 18:30:38 2021
+*** tstart() called on psinet
+*** at Thu Sep 30 10:20:55 2021
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry O          line   198 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2 entry H          line    22 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry H          line    22 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -187,7 +193,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 9
-    Number of basis function: 19
+    Number of basis functions: 19
     Number of Cartesian functions: 20
     Spherical Harmonics?: true
     Max angular momentum: 2
@@ -197,8 +203,8 @@ Scratch directory: /scratch/jiang/
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry O          line   221 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2 entry H          line    51 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2 entry H          line    51 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -221,7 +227,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: (CC-PVDZ AUX)
     Blend: CC-PVDZ-JKFIT
     Number of shells: 33
-    Number of basis function: 93
+    Number of basis functions: 93
     Number of Cartesian functions: 106
     Spherical Harmonics?: true
     Max angular momentum: 3
@@ -246,18 +252,18 @@ Scratch directory: /scratch/jiang/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-UHF iter SAD:   -74.63727338893389   -7.46373e+01   0.00000e+00 
-   @DF-UHF iter   1:   -75.37019015876535   -7.32917e-01   1.08751e-02 DIIS
-   @DF-UHF iter   2:   -75.38982038300738   -1.96302e-02   3.75405e-03 DIIS
-   @DF-UHF iter   3:   -75.39186957302307   -2.04919e-03   1.13211e-03 DIIS
-   @DF-UHF iter   4:   -75.39222890259296   -3.59330e-04   3.91575e-04 DIIS
-   @DF-UHF iter   5:   -75.39229045956361   -6.15570e-05   1.67750e-04 DIIS
-   @DF-UHF iter   6:   -75.39230826490481   -1.78053e-05   6.99524e-05 DIIS
-   @DF-UHF iter   7:   -75.39231257488093   -4.30998e-06   1.86310e-05 DIIS
-   @DF-UHF iter   8:   -75.39231285353594   -2.78655e-07   4.04152e-06 DIIS
-   @DF-UHF iter   9:   -75.39231286142504   -7.88910e-09   6.95681e-07 DIIS
-   @DF-UHF iter  10:   -75.39231286163519   -2.10150e-10   6.65174e-08 DIIS
-   @DF-UHF iter  11:   -75.39231286163692   -1.73372e-12   8.59548e-09 DIIS
+   @DF-UHF iter SAD:   -74.63727338893435   -7.46373e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.37019015876581   -7.32917e-01   1.08751e-02 DIIS
+   @DF-UHF iter   2:   -75.38982038300796   -1.96302e-02   3.75405e-03 DIIS
+   @DF-UHF iter   3:   -75.39186957302354   -2.04919e-03   1.13211e-03 DIIS
+   @DF-UHF iter   4:   -75.39222890259347   -3.59330e-04   3.91575e-04 DIIS
+   @DF-UHF iter   5:   -75.39229045956412   -6.15570e-05   1.67750e-04 DIIS
+   @DF-UHF iter   6:   -75.39230826490527   -1.78053e-05   6.99524e-05 DIIS
+   @DF-UHF iter   7:   -75.39231257488154   -4.30998e-06   1.86310e-05 DIIS
+   @DF-UHF iter   8:   -75.39231285353648   -2.78655e-07   4.04152e-06 DIIS
+   @DF-UHF iter   9:   -75.39231286142555   -7.88907e-09   6.95681e-07 DIIS
+   @DF-UHF iter  10:   -75.39231286163577   -2.10221e-10   6.65174e-08 DIIS
+   @DF-UHF iter  11:   -75.39231286163748   -1.70530e-12   8.59548e-09 DIIS
   Energy and wave function converged.
 
 
@@ -303,14 +309,14 @@ Scratch directory: /scratch/jiang/
     DOCC [     4 ]
     SOCC [     1 ]
 
-  @DF-UHF Final Energy:   -75.39231286163692
+  @DF-UHF Final Energy:   -75.39231286163748
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              4.2334176853600001
-    One-Electron Energy =                -112.5058729378287836
-    Two-Electron Energy =                  32.8801423908318569
-    Total Energy =                        -75.3923128616369240
+    One-Electron Energy =                -112.5058729378293947
+    Two-Electron Energy =                  32.8801423908319137
+    Total Energy =                        -75.3923128616374925
 
   UHF NO Occupations:
   HONO-2 :    3  A 1.9994099
@@ -333,27 +339,532 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.8897
 
   Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:    -1.1715
+     X:     0.0000      Y:    -0.0000      Z:    -1.1715
 
   Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:     0.7182     Total:     0.7182
+     X:     0.0000      Y:    -0.0000      Z:     0.7182     Total:     0.7182
 
   Dipole Moment: [D]
-     X:    -0.0000      Y:    -0.0000      Z:     1.8256     Total:     1.8256
+     X:     0.0000      Y:    -0.0000      Z:     1.8256     Total:     1.8256
 
 
-*** tstop() called on ds5 at Mon Jan 25 18:30:38 2021
+*** tstop() called on psinet at Thu Sep 30 10:20:55 2021
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.26 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.26 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+  Computing free-atom volumes
+  Running 2 free-atom UHF computations
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:20:55 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    22 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 3
+    Number of basis functions: 5
+    Number of Cartesian functions: 5
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    51 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 9
+    Number of basis functions: 23
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 3.1513974851E-01.
+  Reciprocal condition number of the overlap matrix is 1.8704206965E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         2       2       1       0       0       1
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        1       1       0       0       0       0
+     B2u        1       1       0       0       0       0
+     B3u        1       1       0       0       0       0
+   -------------------------------------------------------
+    Total       5       5       1       0       0       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:    -0.49927840341958   -4.99278e-01   0.00000e+00 DIIS
+   @DF-UHF iter   2:    -0.49927840341958    0.00000e+00   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.499278  
+
+    Alpha Virtual:                                                        
+
+       2Ag     0.572446     1B1u    1.443081     1B2u    1.443081  
+       1B3u    1.443081  
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.073343     2Ag     0.753274     1B1u    1.573640  
+       1B2u    1.573640     1B3u    1.573640  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:    -0.49927840341958
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4992784034195830
+    Two-Electron Energy =                   0.0000000000000000
+    Total Energy =                         -0.4992784034195830
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+  LUNO+0 :    1B3u 0.0000000
+  LUNO+1 :    1B2u 0.0000000
+  LUNO+2 :    1B1u 0.0000000
+  LUNO+3 :    2 Ag 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:20:55 2021
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.36 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the H HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  1.00000 ( 1.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       H    1    1.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       H    1   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       H    1   -0.9909   -0.0000    0.0000   -0.9909   -0.0000   -0.9909
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       H    1    0.0000    0.0000   -0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000   -0.0000    0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      [a0^5]      
+      1       H    1    2.972557    7.303957   21.184330   70.045429
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       H    1    0.499020
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:20:55 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000     0.000000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 8
+  Nalpha       = 5
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 6
+    Number of basis functions: 14
+    Number of Cartesian functions: 15
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 24
+    Number of basis functions: 70
+    Number of Cartesian functions: 81
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.8857646190E-01.
+  Reciprocal condition number of the overlap matrix is 1.1034928328E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       2       2       2       0
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        2       2       1       1       1       0
+     B2u        2       2       1       0       0       1
+     B3u        2       2       1       0       0       1
+   -------------------------------------------------------
+    Total      14      14       5       3       3       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:   -72.12802286185405   -7.21280e+01   2.84048e-01 DIIS
+   @DF-UHF iter   2:   -74.66452517342852   -2.53650e+00   9.12873e-02 DIIS
+   @DF-UHF iter   3:   -74.79165567759856   -1.27131e-01   5.46578e-03 DIIS
+   @DF-UHF iter   4:   -74.79215563395239   -4.99956e-04   7.99998e-04 DIIS
+   @DF-UHF iter   5:   -74.79216699520872   -1.13613e-05   2.69695e-04 DIIS
+   @DF-UHF iter   6:   -74.79216969694662   -2.70174e-06   9.23535e-05 DIIS
+   @DF-UHF iter   7:   -74.79217005185782   -3.54911e-07   7.34857e-06 DIIS
+   @DF-UHF iter   8:   -74.79217005342693   -1.56911e-09   8.73652e-07 DIIS
+   @DF-UHF iter   9:   -74.79217005344404   -1.71099e-11   1.02051e-07 DIIS
+   @DF-UHF iter  10:   -74.79217005344435   -3.12639e-13   7.70082e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.366027994E-03
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.004366028E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.701965     2Ag    -1.407506     1B2u   -0.695884  
+       1B3u   -0.695884     1B1u   -0.599260  
+
+    Alpha Virtual:                                                        
+
+       2B2u    1.066348     2B3u    1.066348     2B1u    1.127173  
+       3Ag     1.325684     1B1g    2.767298     4Ag     2.767298  
+       1B3g    2.833965     1B2g    2.833965     5Ag     2.857514  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.622973     2Ag    -1.071404     1B1u   -0.512548  
+
+    Beta Virtual:                                                         
+
+       1B2u    0.132630     1B3u    0.132630     2B1u    1.171734  
+       2B2u    1.289033     2B3u    1.289033     3Ag     1.428639  
+       4Ag     2.958029     1B3g    2.969262     1B2g    2.969262  
+       1B1g    3.008345     5Ag     3.008345  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    1,    1 ]
+
+  @DF-UHF Final Energy:   -74.79217005344435
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -103.2769151451858534
+    Two-Electron Energy =                  28.4847450917414946
+    Total Energy =                        -74.7921700534443517
+
+  UHF NO Occupations:
+  HONO-2 :    2 Ag 1.9983866
+  HONO-1 :    1B3u 1.0000000
+  HONO-0 :    1B2u 1.0000000
+  LUNO+0 :    3 Ag 0.0016134
+  LUNO+1 :    2B1u 0.0005710
+  LUNO+2 :    4 Ag 0.0000002
+  LUNO+3 :    2B2u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:20:55 2021
+Module time:
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the O HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  8.00000 ( 8.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       O    8    8.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       O    8   -0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       O    8   -3.3414    0.0000   -0.0000   -3.3414    0.0000   -4.2036
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       O    8   -0.0000   -0.0000    0.0000   -0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      [a0^5]      
+      1       O    8   10.886456   19.661756   41.789365   100.806153
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       O    8    0.380387
 
 Properties computed using the OH Radical SCF density matrix
 
@@ -369,53 +880,45 @@ Properties computed using the OH Radical SCF density matrix
 
   MBIS Dipoles: [e a0]
    Center  Symbol  Z        X           Y           Z
-      1       O    8    0.000000    0.000000   -0.057122
-      2       H    1   -0.000000   -0.000000    0.039653
+      1       O    8    0.000000   -0.000000   -0.057122
+      2       H    1   -0.000000    0.000000    0.039653
 
   MBIS Quadrupoles: [e a0^2]
    Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
-      1       O    8   -3.5825    0.0081    0.0000   -4.4188    0.0000   -4.1410
-      2       H    1   -0.2927    0.0003   -0.0000   -0.3225    0.0000   -0.2901
+      1       O    8   -4.3553   -0.2216   -0.0000   -3.6460    0.0000   -4.1410
+      2       H    1   -0.3202   -0.0079   -0.0000   -0.2949   -0.0000   -0.2901
 
   MBIS Octupoles: [e a0^3]
    Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
-      1       O    8    0.0000    0.0000   -0.0628   -0.0000   -0.0001   -0.0000    0.0000   -0.0543    0.0000   -0.4254
-      2       H    1   -0.0000    0.0000    0.0030    0.0000   -0.0002   -0.0000    0.0000    0.0192    0.0000    0.0440
+      1       O    8    0.0000    0.0000   -0.0550   -0.0000    0.0023   -0.0000   -0.0000   -0.0622   -0.0000   -0.4254
+      2       H    1   -0.0000    0.0000    0.0180    0.0000    0.0043   -0.0000   -0.0000    0.0043   -0.0000    0.0440
 
-  MBIS Radial Moments: [a0^2]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   12.142295
-      2       H    1    0.905265
-
-  MBIS Radial Moments: [a0^3]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   22.412224
-      2       H    1    1.546706
-
-  MBIS Radial Moments: [a0^4]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   48.673213
-      2       H    1    3.133232
-
-  MBIS Radial Moments: [a0^5]
-   Center  Symbol  Z     Rad Mo
-      1       O    8   120.451896
-      2       H    1    7.333765
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      [a0^5]      
+      1       O    8   12.142295   22.412224   48.673213   120.451896
+      2       H    1    0.905265    1.546706    3.133232    7.333765
 
   MBIS Valence Widths: [a0]
    Center  Symbol  Z     Width
       1       O    8    0.390708
       2       H    1    0.355791
+
+
+  MBIS Volume Ratios: 
+   Center  Symbol  Z     
+      1       O    8    1.139889
+      2       H    1    0.211763
     MBIS Charges..........................................................................PASSED
     MBIS Dipoles..........................................................................PASSED
     MBIS Radial Moments <r^3>.............................................................PASSED
     MBIS Valence Widths...................................................................PASSED
+    MBIS Volume Ratios....................................................................PASSED
     MBIS Quadrupoles: ZZ of O.............................................................PASSED
     MBIS Quadrupoles: ZZ of H.............................................................PASSED
     MBIS Octupoles: ZZZ of O..............................................................PASSED
     MBIS Octupoles: ZZZ of H..............................................................PASSED
 
-    Psi4 stopped on: Monday, 25 January 2021 06:30PM
-    Psi4 wall time for execution: 0:00:00.68
+    Psi4 stopped on: Thursday, 30 September 2021 10:20AM
+    Psi4 wall time for execution: 0:00:01.08
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/mbis-4/input.dat
+++ b/tests/mbis-4/input.dat
@@ -63,7 +63,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='NaCl SCF')
+oeprop(wfn, "MBIS_VOLUME_RATIOS", 'MBIS_CHARGES', title='NaCl SCF')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')

--- a/tests/mbis-4/output.ref
+++ b/tests/mbis-4/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.5a1.dev48 
 
-                         Git: Rev {exp_vol} 3e7263c dirty
+                         Git: Rev {mbis_sep} 701fc30 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 25 January 2021 06:31PM
+    Psi4 started on: Thursday, 30 September 2021 10:21AM
 
-    Process ID: 238241
-    Host:       ds5
-    PSIDATADIR: /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4
+    Process ID: 14699
+    Host:       psinet
+    PSIDATADIR: /psi/gits/hrw-mbis/objdir39d/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -82,6 +82,11 @@ vwidths_ref = psi4.Matrix.from_list([  #TEST
  [1.13464706],     #TEST
  [0.56829083]])    #TEST
 
+vratios_ref = psi4.Matrix.from_list([
+[0.088273],
+[1.490111]])
+
+
 molecule mol {
   0 1
   Na 0.00 0.00 0.00
@@ -101,7 +106,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='NaCl SCF')
+oeprop(wfn, "MBIS_VOLUME_RATIOS", 'MBIS_CHARGES', title='NaCl SCF')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')
@@ -110,6 +115,7 @@ quadrupoles = wfn.array_variable('MBIS QUADRUPOLES')
 octupoles = wfn.array_variable('MBIS OCTUPOLES')
 avols = wfn.array_variable('MBIS RADIAL MOMENTS <R^3>')
 vwidths = wfn.array_variable('MBIS VALENCE WIDTHS')
+vratios = wfn.array_variable('MBIS VOLUME RATIOS')
 
 
 compare_matrices(charges_ref, charges, 5, "MBIS Charges")             #TEST
@@ -118,22 +124,23 @@ compare_matrices(quadrupoles_ref, quadrupoles, 5, "MBIS Quadrupoles") #TEST
 compare_matrices(octupoles_ref, octupoles, 5, "MBIS Octupoles")       #TEST
 compare_matrices(avols_ref, avols, 5, "MBIS Radial Moments <r^3>")    #TEST
 compare_matrices(vwidths_ref, vwidths, 5, "MBIS Valence Widths")      #TEST
+compare_matrices(vratios_ref, vratios, 5, "MBIS Volume Ratios")      #TEST
 --------------------------------------------------------------------------
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-*** tstart() called on ds5
-*** at Mon Jan 25 18:31:53 2021
+*** tstart() called on psinet
+*** at Thu Sep 30 10:21:00 2021
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry NA         line   288 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2 entry CL         line   658 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1 entry NA         line   288 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry CL         line   658 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -184,7 +191,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 16
-    Number of basis function: 36
+    Number of basis functions: 36
     Number of Cartesian functions: 38
     Spherical Harmonics?: true
     Max angular momentum: 2
@@ -194,8 +201,8 @@ Scratch directory: /scratch/jiang/
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry NA         line   498 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2 entry CL         line   667 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1 entry NA         line   498 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry CL         line   667 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -218,7 +225,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: (CC-PVDZ AUX)
     Blend: CC-PVDZ-JKFIT + DEF2-UNIVERSAL-JKFIT
     Number of shells: 70
-    Number of basis function: 224
+    Number of basis functions: 224
     Number of Cartesian functions: 267
     Spherical Harmonics?: true
     Max angular momentum: 4
@@ -243,17 +250,17 @@ Scratch directory: /scratch/jiang/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -620.94148883010166   -6.20941e+02   0.00000e+00 
-   @DF-RHF iter   1:  -621.38771176641535   -4.46223e-01   6.97696e-03 DIIS
-   @DF-RHF iter   2:  -621.42850815194822   -4.07964e-02   2.82756e-03 DIIS
-   @DF-RHF iter   3:  -621.43354006965978   -5.03192e-03   2.04236e-04 DIIS
-   @DF-RHF iter   4:  -621.43361675137930   -7.66817e-05   5.31379e-05 DIIS
-   @DF-RHF iter   5:  -621.43362372643367   -6.97505e-06   9.60511e-06 DIIS
-   @DF-RHF iter   6:  -621.43362400375372   -2.77320e-07   3.19411e-06 DIIS
-   @DF-RHF iter   7:  -621.43362404931941   -4.55657e-08   5.24071e-07 DIIS
-   @DF-RHF iter   8:  -621.43362405026141   -9.42009e-10   7.94199e-08 DIIS
-   @DF-RHF iter   9:  -621.43362405027688   -1.54614e-11   1.13427e-08 DIIS
-   @DF-RHF iter  10:  -621.43362405027779   -9.09495e-13   1.33383e-09 DIIS
+   @DF-RHF iter SAD:  -620.94148883010337   -6.20941e+02   0.00000e+00 
+   @DF-RHF iter   1:  -621.38771176641831   -4.46223e-01   6.97696e-03 DIIS
+   @DF-RHF iter   2:  -621.42850815195084   -4.07964e-02   2.82756e-03 DIIS
+   @DF-RHF iter   3:  -621.43354006966263   -5.03192e-03   2.04236e-04 DIIS
+   @DF-RHF iter   4:  -621.43361675138192   -7.66817e-05   5.31379e-05 DIIS
+   @DF-RHF iter   5:  -621.43362372643651   -6.97505e-06   9.60511e-06 DIIS
+   @DF-RHF iter   6:  -621.43362400375702   -2.77321e-07   3.19411e-06 DIIS
+   @DF-RHF iter   7:  -621.43362404932202   -4.55650e-08   5.24071e-07 DIIS
+   @DF-RHF iter   8:  -621.43362405026380   -9.41782e-10   7.94199e-08 DIIS
+   @DF-RHF iter   9:  -621.43362405027938   -1.55751e-11   1.13427e-08 DIIS
+   @DF-RHF iter  10:  -621.43362405028040   -1.02318e-12   1.33383e-09 DIIS
   Energy and wave function converged.
 
 
@@ -285,14 +292,14 @@ Scratch directory: /scratch/jiang/
               A 
     DOCC [    14 ]
 
-  @DF-RHF Final Energy:  -621.43362405027779
+  @DF-RHF Final Energy:  -621.43362405028040
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             41.9305671166483052
-    One-Electron Energy =                -949.1924605667109063
-    Two-Electron Energy =                 285.8282693997848583
-    Total Energy =                       -621.4336240502777855
+    One-Electron Energy =                -949.1924605667162496
+    Two-Electron Energy =                 285.8282693997875867
+    Total Energy =                       -621.4336240502804003
 
 Computation Completed
 
@@ -305,27 +312,1073 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    75.8158
 
   Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:   -79.4880
+     X:     0.0000      Y:    -0.0000      Z:   -79.4880
 
   Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:    -3.6722     Total:     3.6722
+     X:     0.0000      Y:    -0.0000      Z:    -3.6722     Total:     3.6722
 
   Dipole Moment: [D]
-     X:    -0.0000      Y:    -0.0000      Z:    -9.3337     Total:     9.3337
+     X:     0.0000      Y:    -0.0000      Z:    -9.3337     Total:     9.3337
 
 
-*** tstop() called on ds5 at Mon Jan 25 18:31:53 2021
+*** tstop() called on psinet at Thu Sep 30 10:21:01 2021
 Module time:
-	user time   =       0.49 seconds =       0.01 minutes
+	user time   =       0.67 seconds =       0.01 minutes
 	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.49 seconds =       0.01 minutes
+	user time   =       0.67 seconds =       0.01 minutes
 	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+  Computing free-atom volumes
+  Running 2 free-atom UHF computations
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:21:01 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry CL         line   658 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         CL           0.000000000000     0.000000000000     0.000000000000    34.968852682000
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 17
+  Nalpha       = 9
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 8
+    Number of basis functions: 18
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry CL         line   667 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 36
+    Number of basis functions: 112
+    Number of Cartesian functions: 130
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.1173395933E-01.
+  Reciprocal condition number of the overlap matrix is 6.8304906759E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         6       6       3       3       3       0
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        3       3       2       2       2       0
+     B2u        3       3       2       2       2       0
+     B3u        3       3       2       1       1       1
+   -------------------------------------------------------
+    Total      18      18       9       8       8       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:  -456.56012886188489   -4.56560e+02   2.19878e-01 DIIS
+   @DF-UHF iter   2:  -459.42644521826645   -2.86632e+00   4.52744e-02 DIIS
+   @DF-UHF iter   3:  -459.47017090765826   -4.37257e-02   5.22457e-03 DIIS
+   @DF-UHF iter   4:  -459.47110711749417   -9.36210e-04   7.19092e-04 DIIS
+   @DF-UHF iter   5:  -459.47113850552978   -3.13880e-05   2.35823e-04 DIIS
+   @DF-UHF iter   6:  -459.47114273731495   -4.23179e-06   7.56554e-05 DIIS
+   @DF-UHF iter   7:  -459.47114328768669   -5.50372e-07   4.62619e-06 DIIS
+   @DF-UHF iter   8:  -459.47114328869094   -1.00425e-09   5.06068e-07 DIIS
+   @DF-UHF iter   9:  -459.47114328870464   -1.36993e-11   4.57884e-08 DIIS
+   @DF-UHF iter  10:  -459.47114328870481   -1.70530e-13   6.14093e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   5.665775161E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.556657752E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag  -104.884799     2Ag   -10.607799     1B3u   -8.093625  
+       1B1u   -8.067916     1B2u   -8.067916     3Ag    -1.131979  
+       2B3u   -0.574144     2B2u   -0.499452     2B1u   -0.499452  
+
+    Alpha Virtual:                                                        
+
+       3B3u    0.687981     3B2u    0.733040     3B1u    0.733040  
+       4Ag     0.782329     5Ag     0.889212     1B2g    0.904570  
+       1B1g    0.904570     1B3g    0.957600     6Ag     0.957600  
+
+    Beta Occupied:                                                        
+
+       1Ag  -104.873684     2Ag   -10.596477     1B2u   -8.062045  
+       1B1u   -8.062045     1B3u   -8.045256     3Ag    -1.011027  
+       2B2u   -0.475165     2B1u   -0.475165  
+
+    Beta Virtual:                                                         
+
+       2B3u   -0.033127     3B2u    0.742840     3B1u    0.742840  
+       3B3u    0.787588     4Ag     0.811477     1B3g    0.966456  
+       5Ag     0.966456     1B2g    1.000218     1B1g    1.000218  
+       6Ag     1.013713  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    2,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    1 ]
+
+  @DF-UHF Final Energy:  -459.47114328870481
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -634.9143395872708879
+    Two-Electron Energy =                 175.4431962985660789
+    Total Energy =                       -459.4711432887048090
+
+  UHF NO Occupations:
+  HONO-2 :    2B1u 1.9999654
+  HONO-1 :    3 Ag 1.9972333
+  HONO-0 :    2B3u 1.0000000
+  LUNO+0 :    4 Ag 0.0027667
+  LUNO+1 :    3B2u 0.0000346
+  LUNO+2 :    3B1u 0.0000346
+  LUNO+3 :    3B3u 0.0000008
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:21:01 2021
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.86 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the CL HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number): 17.00000 (17.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1      CL   17   17.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1      CL   17    0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1      CL   17   -7.9752    0.0000    0.0000   -9.6656    0.0000   -9.6656
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1      CL   17   -0.0000   -0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000    0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      CL   17   27.306403   62.890481   171.535930
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1      CL   17    0.520155
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:21:01 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry NA         line   288 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         NA           0.000000000000     0.000000000000     0.000000000000    22.989769282000
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 11
+  Nalpha       = 6
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 8
+    Number of basis functions: 18
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry NA         line   498 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 34
+    Number of basis functions: 112
+    Number of Cartesian functions: 137
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 4.3378783862E-02.
+  Reciprocal condition number of the overlap matrix is 2.2170251363E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         6       6       3       2       2       1
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        3       3       1       1       1       0
+     B2u        3       3       1       1       1       0
+     B3u        3       3       1       1       1       0
+   -------------------------------------------------------
+    Total      18      18       6       5       5       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:  -161.71551794824757   -1.61716e+02   4.92021e-02 DIIS
+   @DF-UHF iter   2:  -161.84249820578287   -1.26980e-01   7.73249e-03 DIIS
+   @DF-UHF iter   3:  -161.85156858075655   -9.07037e-03   1.87756e-03 DIIS
+   @DF-UHF iter   4:  -161.85298985299107   -1.42127e-03   4.12751e-04 DIIS
+   @DF-UHF iter   5:  -161.85306106587447   -7.12129e-05   1.73536e-05 DIIS
+   @DF-UHF iter   6:  -161.85306107952846   -1.36540e-08   7.49600e-07 DIIS
+   @DF-UHF iter   7:  -161.85306107954884   -2.03784e-11   9.36989e-08 DIIS
+   @DF-UHF iter   8:  -161.85306107954932   -4.83169e-13   6.60940e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.509622424E-05
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500450962E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -40.479504     2Ag    -2.800244     1B1u   -1.518832  
+       1B2u   -1.518832     1B3u   -1.518832     3Ag    -0.182136  
+
+    Alpha Virtual:                                                        
+
+       2B2u    0.023743     2B1u    0.023743     2B3u    0.023743  
+       4Ag     0.105547     3B3u    0.146121     3B2u    0.146121  
+       3B1u    0.146121     5Ag     0.254196     1B1g    0.254196  
+       1B2g    0.254196     1B3g    0.254196     6Ag     0.254196  
+
+    Beta Occupied:                                                        
+
+       1Ag   -40.477047     2Ag    -2.793525     1B1u   -1.516405  
+       1B2u   -1.516405     1B3u   -1.516405  
+
+    Beta Virtual:                                                         
+
+       3Ag     0.017520     2B2u    0.043768     2B3u    0.043768  
+       2B1u    0.043768     4Ag     0.143172     3B3u    0.179811  
+       3B2u    0.179811     3B1u    0.179811     5Ag     0.276980  
+       1B1g    0.276980     1B2g    0.276980     1B3g    0.276980  
+       6Ag     0.276980  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    1,    1 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:  -161.85306107954932
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -227.8679548334326057
+    Two-Electron Energy =                  66.0148937538832712
+    Total Energy =                       -161.8530610795493203
+
+  UHF NO Occupations:
+  HONO-2 :    1B3u 1.9999925
+  HONO-1 :    1B2u 1.9999925
+  HONO-0 :    3 Ag 1.0000000
+  LUNO+0 :    2B2u 0.0000075
+  LUNO+1 :    2B3u 0.0000075
+  LUNO+2 :    2B1u 0.0000075
+  LUNO+3 :    4 Ag 0.0000001
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:21:01 2021
+Module time:
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.32 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the NA HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number): 11.00000 (11.00000)
+  Difference:  0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1      NA   11   11.000000   -0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1      NA   11    0.000000   -0.000000   -0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1      NA   11   -9.0431   -0.0000    0.0000   -9.0431    0.0000   -9.0431
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1      NA   11   -0.0000    0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      NA   11   27.129157   124.450729   754.197310
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1      NA   11    1.231430
+  Computing free-atom volumes
+  Running 2 free-atom UHF computations
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:21:02 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry CL         line   658 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         CL           0.000000000000     0.000000000000     0.000000000000    34.968852682000
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 17
+  Nalpha       = 9
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 8
+    Number of basis functions: 18
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry CL         line   667 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 36
+    Number of basis functions: 112
+    Number of Cartesian functions: 130
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.1173395933E-01.
+  Reciprocal condition number of the overlap matrix is 6.8304906759E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         6       6       3       3       3       0
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        3       3       2       2       2       0
+     B2u        3       3       2       2       2       0
+     B3u        3       3       2       1       1       1
+   -------------------------------------------------------
+    Total      18      18       9       8       8       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:  -456.56012886188489   -4.56560e+02   2.19878e-01 DIIS
+   @DF-UHF iter   2:  -459.42644521826645   -2.86632e+00   4.52744e-02 DIIS
+   @DF-UHF iter   3:  -459.47017090765826   -4.37257e-02   5.22457e-03 DIIS
+   @DF-UHF iter   4:  -459.47110711749417   -9.36210e-04   7.19092e-04 DIIS
+   @DF-UHF iter   5:  -459.47113850552978   -3.13880e-05   2.35823e-04 DIIS
+   @DF-UHF iter   6:  -459.47114273731495   -4.23179e-06   7.56554e-05 DIIS
+   @DF-UHF iter   7:  -459.47114328768669   -5.50372e-07   4.62619e-06 DIIS
+   @DF-UHF iter   8:  -459.47114328869094   -1.00425e-09   5.06068e-07 DIIS
+   @DF-UHF iter   9:  -459.47114328870464   -1.36993e-11   4.57884e-08 DIIS
+   @DF-UHF iter  10:  -459.47114328870481   -1.70530e-13   6.14093e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   5.665775161E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.556657752E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag  -104.884799     2Ag   -10.607799     1B3u   -8.093625  
+       1B1u   -8.067916     1B2u   -8.067916     3Ag    -1.131979  
+       2B3u   -0.574144     2B2u   -0.499452     2B1u   -0.499452  
+
+    Alpha Virtual:                                                        
+
+       3B3u    0.687981     3B2u    0.733040     3B1u    0.733040  
+       4Ag     0.782329     5Ag     0.889212     1B2g    0.904570  
+       1B1g    0.904570     1B3g    0.957600     6Ag     0.957600  
+
+    Beta Occupied:                                                        
+
+       1Ag  -104.873684     2Ag   -10.596477     1B2u   -8.062045  
+       1B1u   -8.062045     1B3u   -8.045256     3Ag    -1.011027  
+       2B2u   -0.475165     2B1u   -0.475165  
+
+    Beta Virtual:                                                         
+
+       2B3u   -0.033127     3B2u    0.742840     3B1u    0.742840  
+       3B3u    0.787588     4Ag     0.811477     1B3g    0.966456  
+       5Ag     0.966456     1B2g    1.000218     1B1g    1.000218  
+       6Ag     1.013713  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    2,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    1 ]
+
+  @DF-UHF Final Energy:  -459.47114328870481
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -634.9143395872708879
+    Two-Electron Energy =                 175.4431962985660789
+    Total Energy =                       -459.4711432887048090
+
+  UHF NO Occupations:
+  HONO-2 :    2B1u 1.9999654
+  HONO-1 :    3 Ag 1.9972333
+  HONO-0 :    2B3u 1.0000000
+  LUNO+0 :    4 Ag 0.0027667
+  LUNO+1 :    3B2u 0.0000346
+  LUNO+2 :    3B1u 0.0000346
+  LUNO+3 :    3B3u 0.0000008
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:21:02 2021
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the CL HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number): 17.00000 (17.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1      CL   17   17.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1      CL   17    0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1      CL   17   -7.9752    0.0000    0.0000   -9.6656    0.0000   -9.6656
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1      CL   17   -0.0000   -0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000    0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      CL   17   27.306403   62.890481   171.535930
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1      CL   17    0.520155
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:21:02 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry NA         line   288 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         NA           0.000000000000     0.000000000000     0.000000000000    22.989769282000
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 11
+  Nalpha       = 6
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 8
+    Number of basis functions: 18
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry NA         line   498 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 34
+    Number of basis functions: 112
+    Number of Cartesian functions: 137
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 4.3378783862E-02.
+  Reciprocal condition number of the overlap matrix is 2.2170251363E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         6       6       3       2       2       1
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        3       3       1       1       1       0
+     B2u        3       3       1       1       1       0
+     B3u        3       3       1       1       1       0
+   -------------------------------------------------------
+    Total      18      18       6       5       5       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:  -161.71551794824757   -1.61716e+02   4.92021e-02 DIIS
+   @DF-UHF iter   2:  -161.84249820578287   -1.26980e-01   7.73249e-03 DIIS
+   @DF-UHF iter   3:  -161.85156858075655   -9.07037e-03   1.87756e-03 DIIS
+   @DF-UHF iter   4:  -161.85298985299107   -1.42127e-03   4.12751e-04 DIIS
+   @DF-UHF iter   5:  -161.85306106587447   -7.12129e-05   1.73536e-05 DIIS
+   @DF-UHF iter   6:  -161.85306107952846   -1.36540e-08   7.49600e-07 DIIS
+   @DF-UHF iter   7:  -161.85306107954884   -2.03784e-11   9.36989e-08 DIIS
+   @DF-UHF iter   8:  -161.85306107954932   -4.83169e-13   6.60940e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.509622424E-05
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500450962E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -40.479504     2Ag    -2.800244     1B1u   -1.518832  
+       1B2u   -1.518832     1B3u   -1.518832     3Ag    -0.182136  
+
+    Alpha Virtual:                                                        
+
+       2B2u    0.023743     2B1u    0.023743     2B3u    0.023743  
+       4Ag     0.105547     3B3u    0.146121     3B2u    0.146121  
+       3B1u    0.146121     5Ag     0.254196     1B1g    0.254196  
+       1B2g    0.254196     1B3g    0.254196     6Ag     0.254196  
+
+    Beta Occupied:                                                        
+
+       1Ag   -40.477047     2Ag    -2.793525     1B1u   -1.516405  
+       1B2u   -1.516405     1B3u   -1.516405  
+
+    Beta Virtual:                                                         
+
+       3Ag     0.017520     2B2u    0.043768     2B3u    0.043768  
+       2B1u    0.043768     4Ag     0.143172     3B3u    0.179811  
+       3B2u    0.179811     3B1u    0.179811     5Ag     0.276980  
+       1B1g    0.276980     1B2g    0.276980     1B3g    0.276980  
+       6Ag     0.276980  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    1,    1 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:  -161.85306107954932
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -227.8679548334326057
+    Two-Electron Energy =                  66.0148937538832712
+    Total Energy =                       -161.8530610795493203
+
+  UHF NO Occupations:
+  HONO-2 :    1B3u 1.9999925
+  HONO-1 :    1B2u 1.9999925
+  HONO-0 :    3 Ag 1.0000000
+  LUNO+0 :    2B2u 0.0000075
+  LUNO+1 :    2B3u 0.0000075
+  LUNO+2 :    2B1u 0.0000075
+  LUNO+3 :    4 Ag 0.0000001
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:21:02 2021
+Module time:
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.18 seconds =       0.04 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the NA HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number): 11.00000 (11.00000)
+  Difference:  0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1      NA   11   11.000000   -0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1      NA   11    0.000000   -0.000000   -0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1      NA   11   -9.0431   -0.0000    0.0000   -9.0431    0.0000   -9.0431
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1      NA   11   -0.0000    0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000    0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      NA   11   27.129157   124.450729   754.197310
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1      NA   11    1.231430
 
 Properties computed using the NaCl SCF density matrix
 
@@ -342,45 +1395,42 @@ Properties computed using the NaCl SCF density matrix
   MBIS Dipoles: [e a0]
    Center  Symbol  Z        X           Y           Z
       1      NA   11   -0.000000   -0.000000   -0.009806
-      2      CL   17   -0.000000   -0.000000    0.642357
+      2      CL   17    0.000000   -0.000000    0.642357
 
   MBIS Quadrupoles: [e a0^2]
    Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
       1      NA   11   -2.3499    0.0000    0.0000   -2.3499    0.0000   -2.2898
-      2      CL   17   -11.8920   -0.0000    0.0000   -11.8920    0.0000   -12.0798
+      2      CL   17   -11.8920    0.0000    0.0000   -11.8920    0.0000   -12.0798
 
   MBIS Octupoles: [e a0^3]
    Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
       1      NA   11   -0.0000    0.0000   -0.0256   -0.0000    0.0000   -0.0000   -0.0000   -0.0256    0.0000   -0.0592
       2      CL   17   -0.0000   -0.0000    2.2570   -0.0000   -0.0000   -0.0000   -0.0000    2.2570   -0.0000    4.5695
 
-  MBIS Radial Moments: [a0^2]
-   Center  Symbol  Z     Rad Mo
-      1      NA   11    6.989657
-      2      CL   17   35.863782
-
-  MBIS Radial Moments: [a0^3]
-   Center  Symbol  Z     Rad Mo
-      1      NA   11   10.985663
-      2      CL   17   93.713824
-
-  MBIS Radial Moments: [a0^4]
-   Center  Symbol  Z     Rad Mo
-      1      NA   11   33.141116
-      2      CL   17   296.832754
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      NA   11    6.989657   10.985663   33.141116
+      2      CL   17   35.863782   93.713824   296.832754
 
   MBIS Valence Widths: [a0]
    Center  Symbol  Z     Width
       1      NA   11    1.134647
       2      CL   17    0.568291
+
+
+  MBIS Volume Ratios: 
+   Center  Symbol  Z     
+      1      NA   11    0.088273
+      2      CL   17    1.490111
     MBIS Charges..........................................................................PASSED
     MBIS Dipoles..........................................................................PASSED
     MBIS Quadrupoles......................................................................PASSED
     MBIS Octupoles........................................................................PASSED
     MBIS Radial Moments <r^3>.............................................................PASSED
     MBIS Valence Widths...................................................................PASSED
+    MBIS Volume Ratios....................................................................PASSED
 
-    Psi4 stopped on: Monday, 25 January 2021 06:31PM
-    Psi4 wall time for execution: 0:00:03.80
+    Psi4 stopped on: Thursday, 30 September 2021 10:21AM
+    Psi4 wall time for execution: 0:00:05.26
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/mbis-5/input.dat
+++ b/tests/mbis-5/input.dat
@@ -61,7 +61,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='ZnO SCF')
+oeprop(wfn, 'MBIS_VOLUME_RATIOS', title='ZnO SCF')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')

--- a/tests/mbis-5/output.ref
+++ b/tests/mbis-5/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.5a1.dev48 
 
-                         Git: Rev {exp_vol} 3e7263c dirty
+                         Git: Rev {mbis_sep} 701fc30 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 25 January 2021 06:33PM
+    Psi4 started on: Thursday, 30 September 2021 10:21AM
 
-    Process ID: 238280
-    Host:       ds5
-    PSIDATADIR: /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4
+    Process ID: 14711
+    Host:       psinet
+    PSIDATADIR: /psi/gits/hrw-mbis/objdir39d/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -81,6 +81,10 @@ vwidths_ref = psi4.Matrix.from_list([  #TEST
  [0.70558769],     #TEST
  [0.40965805]])    #TEST
 
+vratios_ref = psi4.Matrix.from_list([  #TEST
+[0.652824],
+[1.379211]])
+
 molecule mol {
   0 1
   Zn 0.00 0.00 0.00
@@ -100,7 +104,7 @@ set {
 }
 
 e, wfn = energy('hf/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='ZnO SCF')
+oeprop(wfn, 'MBIS_VOLUME_RATIOS', title='ZnO SCF')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')
@@ -109,6 +113,7 @@ quadrupoles = wfn.array_variable('MBIS QUADRUPOLES')
 octupoles = wfn.array_variable('MBIS OCTUPOLES')
 avols = wfn.array_variable('MBIS RADIAL MOMENTS <R^3>')
 vwidths = wfn.array_variable('MBIS VALENCE WIDTHS')
+vratios = wfn.array_variable('MBIS VOLUME RATIOS')
 
 compare_matrices(charges_ref, charges, 5, "MBIS Charges")             #TEST
 compare_matrices(dipoles_ref, dipoles, 5, "MBIS Dipoles")             #TEST
@@ -116,22 +121,23 @@ compare_matrices(quadrupoles_ref, quadrupoles, 5, "MBIS Quadrupoles") #TEST
 compare_matrices(octupoles_ref, octupoles, 5, "MBIS Octupoles")       #TEST
 compare_matrices(avols_ref, avols, 5, "MBIS Radial Moments <r^3>")    #TEST
 compare_matrices(vwidths_ref, vwidths, 5, "MBIS Valence Widths")      #TEST
+compare_matrices(vratios_ref, vratios, 5, "MBIS Volume Ratios")      #TEST
 --------------------------------------------------------------------------
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-Scratch directory: /scratch/jiang/
+Scratch directory: /tmp/
 
-*** tstart() called on ds5
-*** at Mon Jan 25 18:33:05 2021
+*** tstart() called on psinet
+*** at Thu Sep 30 10:21:09 2021
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry ZN         line  2599 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2 entry O          line   198 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1 entry ZN         line  2599 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -182,7 +188,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 21
-    Number of basis function: 57
+    Number of basis functions: 57
     Number of Cartesian functions: 64
     Spherical Harmonics?: true
     Max angular momentum: 3
@@ -192,8 +198,8 @@ Scratch directory: /scratch/jiang/
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1 entry ZN         line  2482 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2 entry O          line   221 file /theoryfs2/ds/jiang/p4dev/psi4/objdir-dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1 entry ZN         line  2482 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -216,7 +222,7 @@ Scratch directory: /scratch/jiang/
   Basis Set: (CC-PVDZ AUX)
     Blend: CC-PVDZ-JKFIT + DEF2-UNIVERSAL-JKFIT
     Number of shells: 82
-    Number of basis function: 334
+    Number of basis functions: 334
     Number of Cartesian functions: 458
     Spherical Harmonics?: true
     Max angular momentum: 6
@@ -241,27 +247,27 @@ Scratch directory: /scratch/jiang/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD: -1847.77161408234269   -1.84777e+03   0.00000e+00 
-   @DF-RHF iter   1: -1850.87609049515481   -3.10448e+00   5.72916e-02 DIIS
-   @DF-RHF iter   2: -1838.46215842313859    1.24139e+01   1.40361e-01 DIIS
-   @DF-RHF iter   3: -1852.43421241194756   -1.39721e+01   9.83153e-03 DIIS
-   @DF-RHF iter   4: -1852.49754686178358   -6.33344e-02   6.03970e-03 DIIS
-   @DF-RHF iter   5: -1852.54947160336178   -5.19247e-02   1.14660e-03 DIIS
-   @DF-RHF iter   6: -1852.55190694793964   -2.43534e-03   3.18082e-04 DIIS
-   @DF-RHF iter   7: -1852.55254927071746   -6.42323e-04   2.21833e-04 DIIS
-   @DF-RHF iter   8: -1852.55290923399116   -3.59963e-04   7.77789e-05 DIIS
-   @DF-RHF iter   9: -1852.55294037627550   -3.11423e-05   1.32232e-05 DIIS
-   @DF-RHF iter  10: -1852.55294118147140   -8.05196e-07   3.33117e-06 DIIS
-   @DF-RHF iter  11: -1852.55294121103589   -2.95645e-08   6.66047e-07 DIIS
-   @DF-RHF iter  12: -1852.55294121247243   -1.43655e-09   1.12395e-07 DIIS
-   @DF-RHF iter  13: -1852.55294121252723   -5.47971e-11   2.63013e-08 DIIS
-   @DF-RHF iter  14: -1852.55294121253132   -4.09273e-12   4.37780e-09 DIIS
-   @DF-RHF iter  15: -1852.55294121253041    9.09495e-13   1.34861e-09 DIIS
-   @DF-RHF iter  16: -1852.55294121253110   -6.82121e-13   4.57996e-10 DIIS
-   @DF-RHF iter  17: -1852.55294121253110    0.00000e+00   3.38686e-10 DIIS
-   @DF-RHF iter  18: -1852.55294121253155   -4.54747e-13   3.00345e-10 DIIS
-   @DF-RHF iter  19: -1852.55294121253087    6.82121e-13   1.88986e-10 DIIS
-   @DF-RHF iter  20: -1852.55294121253064    2.27374e-13   6.65977e-11 DIIS
+   @DF-RHF iter SAD: -1847.77161132918877   -1.84777e+03   0.00000e+00 
+   @DF-RHF iter   1: -1850.87609273312000   -3.10448e+00   5.72916e-02 DIIS
+   @DF-RHF iter   2: -1838.46253478142035    1.24136e+01   1.40360e-01 DIIS
+   @DF-RHF iter   3: -1852.43421229887781   -1.39717e+01   9.83157e-03 DIIS
+   @DF-RHF iter   4: -1852.49754568553954   -6.33334e-02   6.03976e-03 DIIS
+   @DF-RHF iter   5: -1852.54947159825429   -5.19259e-02   1.14658e-03 DIIS
+   @DF-RHF iter   6: -1852.55190691575535   -2.43532e-03   3.18088e-04 DIIS
+   @DF-RHF iter   7: -1852.55254926068505   -6.42345e-04   2.21836e-04 DIIS
+   @DF-RHF iter   8: -1852.55290923649727   -3.59976e-04   7.77770e-05 DIIS
+   @DF-RHF iter   9: -1852.55294037650447   -3.11400e-05   1.32230e-05 DIIS
+   @DF-RHF iter  10: -1852.55294118169581   -8.05191e-07   3.33113e-06 DIIS
+   @DF-RHF iter  11: -1852.55294121125939   -2.95636e-08   6.66045e-07 DIIS
+   @DF-RHF iter  12: -1852.55294121269299   -1.43359e-09   1.12395e-07 DIIS
+   @DF-RHF iter  13: -1852.55294121274869   -5.57066e-11   2.63033e-08 DIIS
+   @DF-RHF iter  14: -1852.55294121275074   -2.04636e-12   4.38637e-09 DIIS
+   @DF-RHF iter  15: -1852.55294121275210   -1.36424e-12   1.37280e-09 DIIS
+   @DF-RHF iter  16: -1852.55294121275278   -6.82121e-13   5.16299e-10 DIIS
+   @DF-RHF iter  17: -1852.55294121275256    2.27374e-13   4.05369e-10 DIIS
+   @DF-RHF iter  18: -1852.55294121275324   -6.82121e-13   3.54487e-10 DIIS
+   @DF-RHF iter  19: -1852.55294121275324    0.00000e+00   1.97356e-10 DIIS
+   @DF-RHF iter  20: -1852.55294121275438   -1.13687e-12   6.92376e-11 DIIS
   Energy and wave function converged.
 
 
@@ -300,14 +306,14 @@ Scratch directory: /scratch/jiang/
               A 
     DOCC [    19 ]
 
-  @DF-RHF Final Energy: -1852.55294121253064
+  @DF-RHF Final Energy: -1852.55294121275438
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             64.1426922024242430
-    One-Electron Energy =               -2715.3429115728408760
-    Two-Electron Energy =                 798.6472781578859212
-    Total Energy =                      -1852.5529412125306408
+    One-Electron Energy =               -2715.3429115738281325
+    Two-Electron Energy =                 798.6472781586494420
+    Total Energy =                      -1852.5529412127543765
 
 Computation Completed
 
@@ -329,18 +335,533 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:    -0.0000      Z:    -4.9493     Total:     4.9493
 
 
-*** tstop() called on ds5 at Mon Jan 25 18:33:10 2021
+*** tstop() called on psinet at Thu Sep 30 10:21:17 2021
 Module time:
-	user time   =       4.89 seconds =       0.08 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       6.91 seconds =       0.12 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 Total time:
-	user time   =       4.89 seconds =       0.08 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       6.91 seconds =       0.12 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
 
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+  Computing free-atom volumes
+  Running 2 free-atom UHF computations
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:21:17 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry ZN         line  2599 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         ZN           0.000000000000     0.000000000000     0.000000000000    63.929142010000
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 30
+  Nalpha       = 15
+  Nbeta        = 15
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 15
+    Number of basis functions: 43
+    Number of Cartesian functions: 49
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry ZN         line  2482 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 58
+    Number of basis functions: 264
+    Number of Cartesian functions: 377
+    Spherical Harmonics?: true
+    Max angular momentum: 6
+
+  Minimum eigenvalue in the overlap matrix is 5.9611041216E-03.
+  Reciprocal condition number of the overlap matrix is 2.3783429792E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        12      12       5       5       5       0
+     B1g        3       3       1       1       1       0
+     B2g        3       3       1       1       1       0
+     B3g        3       3       1       1       1       0
+     Au         1       1       0       0       0       0
+     B1u        7       7       2       2       2       0
+     B2u        7       7       2       2       2       0
+     B3u        7       7       3       3       3       0
+   -------------------------------------------------------
+    Total      43      43      15      15      15       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     5,    0,    0,    0,    0,    4,    3,    3 ]
+
+   @DF-RHF iter   1: -1731.97434335323760   -1.73197e+03   5.00748e-01 DIIS
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     6,    1,    1,    1,    0,    2,    2,    2 ]
+
+   @DF-RHF iter   2: -1707.96535884646323    2.40090e+01   8.79422e-01 DIIS
+   @DF-RHF iter   3: -1777.34058697268392   -6.93752e+01   1.12117e-01 DIIS
+   @DF-RHF iter   4: -1777.49596098669099   -1.55374e-01   8.61366e-02 DIIS
+   @DF-RHF iter   5: -1777.60268723161767   -1.06726e-01   7.17869e-02 DIIS
+   @DF-RHF iter   6: -1777.84647945462461   -2.43792e-01   8.08452e-04 DIIS
+   @DF-RHF iter   7: -1777.84651062103831   -3.11664e-05   1.09000e-03 DIIS
+   @DF-RHF iter   8: -1777.84656900261598   -5.83816e-05   1.08779e-05 DIIS
+   @DF-RHF iter   9: -1777.84656901306516   -1.04492e-08   1.17642e-06 DIIS
+   @DF-RHF iter  10: -1777.84656901335052   -2.85354e-10   6.02072e-07 DIIS
+   @DF-RHF iter  11: -1777.84656901337371   -2.31921e-11   2.15835e-08 DIIS
+   @DF-RHF iter  12: -1777.84656901337303    6.82121e-13   9.63857e-09 DIIS
+   @DF-RHF iter  13: -1777.84656901337348   -4.54747e-13   1.14891e-10 DIIS
+   @DF-RHF iter  14: -1777.84656901337303    4.54747e-13   1.91293e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag  -353.304089     2Ag   -44.361211     1B3u  -38.924348  
+       1B2u  -38.924348     1B1u  -38.924348     3Ag    -5.637292  
+       2B2u   -3.838880     2B3u   -3.838880     2B1u   -3.838880  
+       1B3g   -0.782006     4Ag    -0.782006     1B2g   -0.782006  
+       5Ag    -0.782006     1B1g   -0.782006     6Ag    -0.292337  
+
+    Virtual:                                                              
+
+       3B3u    0.054668     3B2u    0.054668     3B1u    0.054668  
+       7Ag     0.152668     4B2u    0.295070     4B3u    0.295070  
+       4B1u    0.295070     2B3g    0.735518     2B2g    0.735518  
+       8Ag     0.735518     9Ag     0.735518     2B1g    0.735518  
+       5B2u    1.471438     5B3u    1.471438     5B1u    1.471438  
+      10Ag     1.574379     3B3g    4.133214    11Ag     4.133214  
+       3B2g    4.133214     3B1g    4.133214    12Ag     4.133214  
+       6B1u    5.926076     6B2u    5.926076     7B1u    5.926076  
+       1Au     5.926076     6B3u    5.926076     7B2u    5.926076  
+       7B3u    5.926076  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     6,    1,    1,    1,    0,    2,    2,    2 ]
+
+  @DF-RHF Final Energy: -1777.84656901337303
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =               -2484.1038564794798731
+    Two-Electron Energy =                 706.2572874661068454
+    Total Energy =                      -1777.8465690133730277
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:21:21 2021
+Module time:
+	user time   =       4.18 seconds =       0.07 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      11.11 seconds =       0.19 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =         12 seconds =       0.20 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the ZN HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number): 30.00000 (30.00000)
+  Difference:  0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1      ZN   30   30.000000   -0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1      ZN   30    0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1      ZN   30   -11.6541   -0.0000    0.0000   -11.6541   -0.0000   -11.6541
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1      ZN   30   -0.0000    0.0000    0.0000    0.0000    0.0000    0.0000    0.0000    0.0000    0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      ZN   30   34.962441   97.181578   382.518695
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1      ZN   30    0.777947
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on psinet
+*** at Thu Sep 30 10:21:22 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry O          line   198 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000     0.000000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 8
+  Nalpha       = 5
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 6
+    Number of basis functions: 14
+    Number of Cartesian functions: 15
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry O          line   221 file /psi/gits/hrw-mbis/objdir39d/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 24
+    Number of basis functions: 70
+    Number of Cartesian functions: 81
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.8857646190E-01.
+  Reciprocal condition number of the overlap matrix is 1.1034928328E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         5       5       2       2       2       0
+     B1g        1       1       0       0       0       0
+     B2g        1       1       0       0       0       0
+     B3g        1       1       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        2       2       1       1       1       0
+     B2u        2       2       1       0       0       1
+     B3u        2       2       1       0       0       1
+   -------------------------------------------------------
+    Total      14      14       5       3       3       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:   -72.12802286185405   -7.21280e+01   2.84048e-01 DIIS
+   @DF-UHF iter   2:   -74.66452517342852   -2.53650e+00   9.12873e-02 DIIS
+   @DF-UHF iter   3:   -74.79165567759856   -1.27131e-01   5.46578e-03 DIIS
+   @DF-UHF iter   4:   -74.79215563395239   -4.99956e-04   7.99998e-04 DIIS
+   @DF-UHF iter   5:   -74.79216699520872   -1.13613e-05   2.69695e-04 DIIS
+   @DF-UHF iter   6:   -74.79216969694662   -2.70174e-06   9.23535e-05 DIIS
+   @DF-UHF iter   7:   -74.79217005185782   -3.54911e-07   7.34857e-06 DIIS
+   @DF-UHF iter   8:   -74.79217005342693   -1.56911e-09   8.73652e-07 DIIS
+   @DF-UHF iter   9:   -74.79217005344404   -1.71099e-11   1.02051e-07 DIIS
+   @DF-UHF iter  10:   -74.79217005344435   -3.12639e-13   7.70082e-09 DIIS
+   @DF-UHF iter  11:   -74.79217005344437   -1.42109e-14   7.01057e-10 DIIS
+   @DF-UHF iter  12:   -74.79217005344437    0.00000e+00   2.34723e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.366028124E-03
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.004366028E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.701965     2Ag    -1.407506     1B2u   -0.695884  
+       1B3u   -0.695884     1B1u   -0.599260  
+
+    Alpha Virtual:                                                        
+
+       2B2u    1.066348     2B3u    1.066348     2B1u    1.127173  
+       3Ag     1.325684     1B1g    2.767298     4Ag     2.767298  
+       1B3g    2.833965     1B2g    2.833965     5Ag     2.857514  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.622973     2Ag    -1.071404     1B1u   -0.512548  
+
+    Beta Virtual:                                                         
+
+       1B3u    0.132630     1B2u    0.132630     2B1u    1.171734  
+       2B2u    1.289033     2B3u    1.289033     3Ag     1.428639  
+       4Ag     2.958029     1B3g    2.969262     1B2g    2.969262  
+       1B1g    3.008345     5Ag     3.008345  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    1,    1 ]
+
+  @DF-UHF Final Energy:   -74.79217005344437
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -103.2769150246997043
+    Two-Electron Energy =                  28.4847449712553384
+    Total Energy =                        -74.7921700534443659
+
+  UHF NO Occupations:
+  HONO-2 :    2 Ag 1.9983866
+  HONO-1 :    1B2u 1.0000000
+  HONO-0 :    1B3u 1.0000000
+  LUNO+0 :    3 Ag 0.0016134
+  LUNO+1 :    2B1u 0.0005710
+  LUNO+2 :    4 Ag 0.0000002
+  LUNO+3 :    2B3u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on psinet at Thu Sep 30 10:21:22 2021
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      11.90 seconds =       0.20 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =         13 seconds =       0.22 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the O HF/CC-PVDZ density matrix
+
+  ==> Computing MBIS Charges <==
+
+  Electron Count from Grid (Expected Number):  8.00000 ( 8.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       O    8    8.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       O    8   -0.000000    0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       O    8   -3.3414   -0.0000   -0.0000   -3.3414    0.0000   -4.2036
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       O    8   -0.0000   -0.0000    0.0000   -0.0000   -0.0000    0.0000   -0.0000    0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       O    8   10.886456   19.661756   41.789365
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       O    8    0.380387
 
 Properties computed using the ZnO SCF density matrix
 
@@ -362,40 +883,37 @@ Properties computed using the ZnO SCF density matrix
   MBIS Quadrupoles: [e a0^2]
    Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
       1      ZN   30   -9.0711   -0.0000    0.0000   -9.0711    0.0000   -9.2090
-      2       O    8   -4.8427    0.0000   -0.0000   -4.8427   -0.0000   -4.0866
+      2       O    8   -4.8427   -0.0000   -0.0000   -4.8427   -0.0000   -4.0866
 
   MBIS Octupoles: [e a0^3]
    Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
-      1      ZN   30   -0.0000   -0.0000    0.4035   -0.0000    0.0000   -0.0000   -0.0000    0.4035   -0.0000    1.0825
+      1      ZN   30   -0.0000   -0.0000    0.4035   -0.0000   -0.0000   -0.0000   -0.0000    0.4035   -0.0000    1.0825
       2       O    8   -0.0000   -0.0000    0.4453   -0.0000    0.0000   -0.0000   -0.0000    0.4453   -0.0000    1.2430
 
-  MBIS Radial Moments: [a0^2]
-   Center  Symbol  Z     Rad Mo
-      1      ZN   30   27.351067
-      2       O    8   13.771977
-
-  MBIS Radial Moments: [a0^3]
-   Center  Symbol  Z     Rad Mo
-      1      ZN   30   63.442454
-      2       O    8   27.117717
-
-  MBIS Radial Moments: [a0^4]
-   Center  Symbol  Z     Rad Mo
-      1      ZN   30   213.782611
-      2       O    8   63.184116
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      ZN   30   27.351067   63.442454   213.782611
+      2       O    8   13.771977   27.117717   63.184116
 
   MBIS Valence Widths: [a0]
    Center  Symbol  Z     Width
       1      ZN   30    0.705588
       2       O    8    0.409658
+
+
+  MBIS Volume Ratios: 
+   Center  Symbol  Z     
+      1      ZN   30    0.652824
+      2       O    8    1.379211
     MBIS Charges..........................................................................PASSED
     MBIS Dipoles..........................................................................PASSED
     MBIS Quadrupoles......................................................................PASSED
     MBIS Octupoles........................................................................PASSED
     MBIS Radial Moments <r^3>.............................................................PASSED
     MBIS Valence Widths...................................................................PASSED
+    MBIS Volume Ratios....................................................................PASSED
 
-    Psi4 stopped on: Monday, 25 January 2021 06:33PM
-    Psi4 wall time for execution: 0:00:08.15
+    Psi4 stopped on: Thursday, 30 September 2021 10:21AM
+    Psi4 wall time for execution: 0:00:15.00
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/mbis-6/input.dat
+++ b/tests/mbis-6/input.dat
@@ -62,7 +62,7 @@ set {
 }
 
 e, wfn = energy('b3lyp/cc-pvdz', return_wfn=True)
-oeprop(wfn, 'MBIS_CHARGES', title='H20 DFT')
+oeprop(wfn, 'MBIS_VOLUME_RATIOS', title='H20 DFT')
 
 #NOTE: wfn.array_variable gives you flattened atomic multipole arrays; for expanded arrays, use wfn.variable
 charges = wfn.array_variable('MBIS CHARGES')


### PR DESCRIPTION
## Description
This is a start to addressing #2272 

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] `MBIS_CHARGES` and `MBIS_VOLUME_RATIOS` are now separate oeprop tasks to the user but still reusing code.
- [ ] `oeprop(wfn, "MBIS_VOLUME_RATIOS")` should be fine (indep oeprop fn), but `set scf_properties mbis_volume_ratios; energy("scf")` will still fail as #2272 reported because those are `OEProp` class instantiations called from proc.py, and the free atom volumes aren't available. The oeprop.cc code could exit gracefully when free atom volumes aren't available, but having different properties lists for the two calling routes isn't good.
- [ ] so why not add the loc from oeprop() to `OEProp`s in proc.py so that atom volumes are available? nice thought, but the fn that produces them itself calls oeprop() and energy() and descends into endless recursion. I haven't sought the logic that makes this all work together.
- [ ] add tests. probably some of the existing ones will break for only calling one mbis property but checking volrat.

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
