### PR TITLE
Fix fractional occupation with symmetry

### DIFF
--- a/psi4/src/psi4/libscf_solver/frac.cc
+++ b/psi4/src/psi4/libscf_solver/frac.cc
@@ -204,7 +204,6 @@ void HF::frac_helper(bool denom) {
         int nso = Ca_->rowspi()[h];
         int nmo = Ca_->colspi()[h];
 
-        // And I say all that to say this:
         C_DSCAL(nso, std::sqrt(val), &Cp[0][j], nmo);
     }
 }

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -340,6 +340,7 @@ class HF : public Wavefunction {
 
     /// Renormalize orbitals to 1.0 before saving
     void frac_renormalize();
+    void frac_helper(bool denom);
 
     /// Formation of H is the same regardless of RHF, ROHF, UHF
     // Temporarily converting to virtual function for testing embedding

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   fcidump
                   fd-freq-energy fd-freq-energy-large fd-freq-gradient
                   fd-freq-gradient-large fd-gradient freq-isotope1 freq-isotope2 fnocc1 fnocc2
-                  fnocc3 fnocc4 fnocc5 fnocc6 frac frac-ip-fitting frac-traverse ghosts gibbs
+                  fnocc3 fnocc4 fnocc5 fnocc6 frac frac-ip-fitting frac-sym frac-traverse ghosts gibbs
                   lccd-grad1 lccd-grad2 matrix1 mbis-1 mbis-2 mbis-3 mbis-4 mbis-5 mbis-6 mcscf1 mcscf2 mcscf3
                   mints1 mints2 mints3 mints4 mints5 mints6 mints8 mints-benchmark mints-helper
                   mints9 mints10 mints15 molden1 molden2 mom mom-h2o-3 mom-h2o-4

--- a/tests/frac-sym/CMakeLists.txt
+++ b/tests/frac-sym/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(frac-sym "psi;misc;scf;frac")

--- a/tests/frac-sym/input.dat
+++ b/tests/frac-sym/input.dat
@@ -10,6 +10,7 @@ set scf_type direct
 set df_scf_guess false
 set reference uhf
 set basis sto-6g
+set e_convergence 8
 
 computed_energy = energy('scf')
 

--- a/tests/frac-sym/input.dat
+++ b/tests/frac-sym/input.dat
@@ -1,0 +1,16 @@
+molecule {
+0 2
+F
+}
+
+set frac_occ [ +3, +4, +5, -3, -4, -5 ]
+set frac_val [ 1.0, 1.0, 1.0, 6.666666666666666e-01, 6.666666666666666e-01, 6.666666666666666e-01 ]
+set frac_start 1
+set scf_type direct
+set df_scf_guess false
+set reference uhf
+set basis sto-6g
+
+computed_energy = energy('scf')
+
+compare_values(-98.6343474374526465, computed_energy, 8, "Fractional occupation energy")  #TEST


### PR DESCRIPTION
## Description
Closes #1673. This PR fixes an indexing error causing the wrong orbitals to be scaled during fractional occupation, when there are multiple irreps.

Now that the SCF module has its correctness errors fixed, I can get to some convergence improvements.

## Todos
- [x] Fixed a bug causing incorrect energies during fractional occupation for systems with point group symmetry

## Checklist
- [x] Tests added for any newly working features
- [x] frac tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
