### PR TITLE
Fix 0 Frac Occupancy

### DIFF
--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -145,6 +145,9 @@ class HF : public Wavefunction {
 
     /// Frac started? (Same thing as frac_performed_)
     bool frac_performed_;
+    /// The orbitals _before_ scaling needed for Frac
+    SharedMatrix unscaled_Ca_;
+    SharedMatrix unscaled_Cb_;
 
     /// DIIS manager intiialized?
     bool initialized_diis_manager_;
@@ -340,7 +343,7 @@ class HF : public Wavefunction {
 
     /// Renormalize orbitals to 1.0 before saving
     void frac_renormalize();
-    void frac_helper(bool denom);
+    void frac_helper();
 
     /// Formation of H is the same regardless of RHF, ROHF, UHF
     // Temporarily converting to virtual function for testing embedding

--- a/tests/frac-traverse/CMakeLists.txt
+++ b/tests/frac-traverse/CMakeLists.txt
@@ -1,4 +1,4 @@
 include(TestingMacros)
 
-add_regression_test(frac-traverse "psi;misc")
+add_regression_test(frac-traverse "psi;misc;frac")
 set_tests_properties(frac-traverse PROPERTIES COST 100)


### PR DESCRIPTION
## Short Description
This PR reverts part of #2280 and restores the ability of `frac` to handle zero occupation number. At the cost of storing extra C matrices, this fixes a pre-#2280 bug in the handling of zero occupation number. Closes #2284.

## Long Description
The `frac` code is designed to allow SCF with fractional occupation numbers. Physically, this is an ensemble of Slater determinants, where the probabilities of a given orbital being occupied are uncorrelated. This is implemented by changing the C matrix from meaning "thing that contains orbitals" to "thing that produces the density", and incorporating the occupation numbers into the definition of the C matrix by multiplying by the occupation numbers. These are divided out after SCF to restore the original meaning of C.

Now, in the case of zero occupation number, multiplying by zero cannot be inverted, so the pre-#2280 code just left the orbitals. This is nonsense behavior, and #2280 banned the case of zero occupation number: the orbital should never have been included in `frac` in the first place if your use case was to describe a single ensemble. What I didn't realize was that there were legitimate use cases for this: if you had multiple ensembles and wanted to track what happens as the occupation number of one goes to zero. This is used by `frac_traverse`, so I broke the test. This slipped through the cracks because the test wasn't labeled as a frac test.

This PR allows frac to treat zero occupation number, and it corrects the previous pathological handling of the C matrix with zero occupation number by changing how we generate the restored C matrix: instead of inverting multiplication, we store the matrix where we never multiplied obitals by occupation numbers in the first place. This change keeps the symmetry fixes of #2280.

## Checklist
- [x] frac tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
