### PR TITLE
try no xHost to broaden Windows build

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -9,7 +9,7 @@ jobs:
     variables:
       llvm.version: '11.0.0'
       mkl.version: '2019.1'
-      cmake.build_type: 'Release'
+      cmake.build_type: 'Debug'
       conda.build: false
       MKL_CBWR: AVX
       PYTHON_VERSION: '3.8'

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -9,7 +9,7 @@ jobs:
     variables:
       llvm.version: '11.0.0'
       mkl.version: '2019.1'
-      cmake.build_type: 'Debug'
+      cmake.build_type: 'Release'
       conda.build: false
       MKL_CBWR: AVX
       PYTHON_VERSION: '3.8'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,10 +142,10 @@ option_with_print(ENABLE_PLUGIN_TESTING "Test the plugin templates build and run
 option_with_print(ENABLE_CYTHONIZE "Compile each python file rather than plaintext (requires cython) !experimental!" OFF)
 if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
 option_with_flags(ENABLE_XHOST "Enables processor-specific optimization (with MSVC, it enables AVX2 instructions)" ON
-                  "-xHost" "-march=native" "/arch:AVX2")
+                  "-xHost" "-march=native" "/arch:AVX")
 else()
 option_with_flags(ENABLE_XHOST "Enables processor-specific optimization (with MSVC, it enables AVX2 instructions)" ON
-                  "-march=native" "-xHost" "/arch:AVX2")
+                  "-march=native" "-xHost" "/arch:AVX")
 endif()
 option_with_flags(ENABLE_CODE_COVERAGE "Enables details on code coverage" OFF
                   "-ftest-coverage")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
the Windows conda package isn't working for some computers. A report (http://forum.psicode.org/t/how-to-run-psi4-on-windows-10/2174/16) is that compiling with AVX _does_ work. The current situation should be building with AVX2 (https://github.com/psi4/psi4/blob/master/CMakeLists.txt#L145) and @kcpearce reports that the conda pkg still fails on his computer with AVX2 instructions, but this is worth a shot.

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
