### PR TITLE
Move SCF-DIIS to Python

### DIFF
--- a/psi4/driver/procrouting/scf_proc/__init__.py
+++ b/psi4/driver/procrouting/scf_proc/__init__.py
@@ -27,7 +27,7 @@
 #
 
 """
-A helper folder for auxiliary SCF funcitons and iterations.
+A helper folder for auxiliary SCF functions and iterations.
 """
 
-from . import scf_iterator
+from . import scf_iterator, subclass_methods

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -76,7 +76,7 @@ def scf_compute_energy(self):
 
         # reset the DIIS & JK objects in prep for DIRECT
         if self.initialized_diis_manager_:
-            self.diis_manager().reset_subspace()
+            self.diis_manager_.reset_subspace()
         self.initialize_jk(self.memory_jk_)
     else:
         self.initialize()

--- a/psi4/driver/procrouting/scf_proc/subclass_methods.py
+++ b/psi4/driver/procrouting/scf_proc/subclass_methods.py
@@ -1,0 +1,88 @@
+import math
+
+from psi4 import core
+
+# Aliases for less typing. Sadly, can't `from psi4.core.X import Y` them
+StoragePolicy = core.DIISManager.StoragePolicy
+RemovalPolicy = core.DIISManager.RemovalPolicy
+
+def _RHF_orbital_gradient(self, save_fock: bool, max_diis_vectors: int) -> float:
+    gradient = self.form_FDSmSDF(self.Fa(), self.Da())
+
+    if save_fock:
+        if not self.initialized_diis_manager_:
+            storage_policy = StoragePolicy.InCore if self.scf_type() == "DIRECT" else StoragePolicy.OnDisk
+            self.diis_manager_ = core.DIISManager(max_diis_vectors, "HF DIIS vector", RemovalPolicy.LargestError, storage_policy)
+            self.diis_manager_.set_error_vector_size(gradient)
+            self.diis_manager_.set_vector_size(self.Fa())
+            self.initialized_diis_manager_ = True
+        
+        self.diis_manager_.add_entry(gradient, self.Fa())
+
+    if self.options().get_bool("DIIS_RMS_ERROR"):
+        return gradient.rms()
+    else:
+        return gradient.absmax()
+
+def _UHF_orbital_gradient(self, save_fock: bool, max_diis_vectors: int) -> float:
+    gradient_a = self.form_FDSmSDF(self.Fa(), self.Da());
+    gradient_b = self.form_FDSmSDF(self.Fb(), self.Db());
+
+    if save_fock:
+        if not self.initialized_diis_manager_:
+            self.diis_manager_ = core.DIISManager(max_diis_vectors, "HF DIIS vector", RemovalPolicy.LargestError,
+                                                          StoragePolicy.OnDisk)
+            self.diis_manager_.set_error_vector_size(gradient_a, gradient_b)
+            self.diis_manager_.set_vector_size(self.Fa(), self.Fb())
+            self.initialized_diis_manager_ = True
+
+        self.diis_manager_.add_entry(gradient_a, gradient_b, self.Fa(), self.Fb())
+
+    if self.options().get_bool("DIIS_RMS_ERROR"):
+        return math.sqrt(0.5 * (gradient_a.rms() ** 2 + gradient_b.rms() ** 2))
+    else:
+        return max(gradient_a.absmax(), gradient_b.absmax())
+
+def _ROHF_orbital_gradient(self, save_fock: bool, max_diis_vectors: int) -> float:
+    # Only the inact-act, inact-vir, and act-vir rotations are non-redundant
+    dim_zero = core.Dimension(self.nirrep(), "Zero Dim")
+    noccpi = self.doccpi() + self.soccpi()
+    row_slice = core.Slice(dim_zero, noccpi)
+    col_slice = core.Slice(self.doccpi(), self.nmopi())
+    MOgradient = self.moFeff().get_block(row_slice, col_slice)
+
+    # Zero the active-active block
+    for h in range(MOgradient.nirrep()):
+        socc = self.soccpi()[h]
+        docc = self.doccpi()[h]
+
+        MOgradient.nph[h][docc:docc+socc, 0:socc] = 0
+
+    # Grab inact-act and act-vir orbs
+    # Ct is (nmo x nmo), not the (nso x nmo) you would expect
+    row_slice = core.Slice(dim_zero, self.nmopi())
+    col_slice = core.Slice(dim_zero, noccpi)
+    Cia = self.Ct().get_block(row_slice, col_slice)
+    col_slice = core.Slice(self.doccpi(), self.nmopi())
+    Cav = self.Ct().get_block(row_slice, col_slice)
+
+    # Back transform MOgradient
+    gradient = core.triplet(Cia, MOgradient, Cav, False, False, True);
+
+    if save_fock:
+        if not self.initialized_diis_manager_:
+            self.diis_manager_ = core.DIISManager(max_diis_vectors, "HF DIIS vector", RemovalPolicy.LargestError, StoragePolicy.OnDisk)
+            self.diis_manager_.set_error_vector_size(gradient)
+            self.diis_manager_.set_vector_size(self.soFeff())
+            self.initialized_diis_manager_ = True
+
+        self.diis_manager_.add_entry(gradient, self.soFeff())
+
+    if self.options().get_bool("DIIS_RMS_ERROR"):
+        return gradient.rms()
+    else:
+        return gradient.absmax()
+
+core.RHF.compute_orbital_gradient = _RHF_orbital_gradient
+core.UHF.compute_orbital_gradient = core.CUHF.compute_orbital_gradient = _UHF_orbital_gradient
+core.ROHF.compute_orbital_gradient = _ROHF_orbital_gradient

--- a/psi4/src/export_diis.cc
+++ b/psi4/src/export_diis.cc
@@ -33,10 +33,42 @@
 
 using namespace psi;
 namespace py = pybind11;
+using namespace pybind11::literals;
 
 void export_diis(py::module &m) {
-    py::class_<DIISManager, std::shared_ptr<DIISManager> >(m, "DIISManager", "docstring")
-        .def(py::init<>())
+    py::class_<DIISManager, std::shared_ptr<DIISManager> > diis(m, "DIISManager", "docstring");
+
+    py::enum_<DIISManager::StoragePolicy>(diis, "StoragePolicy")
+        .value("InCore", DIISManager::StoragePolicy::InCore)
+        .value("OnDisk", DIISManager::StoragePolicy::OnDisk);
+
+    py::enum_<DIISManager::RemovalPolicy>(diis, "RemovalPolicy")
+        .value("LargestError", DIISManager::RemovalPolicy::LargestError)
+        .value("OldestAdded", DIISManager::RemovalPolicy::OldestAdded);
+
+    diis.def(py::init<>())
+        .def(py::init<int, const std::string&, DIISManager::RemovalPolicy, DIISManager::StoragePolicy>(),
+                "max_vectors"_a, "name"_a, "removal_policy"_a = DIISManager::RemovalPolicy::LargestError, "storage_policy"_a = DIISManager::StoragePolicy::InCore)
+        .def("set_error_vector_size", [](DIISManager& diis, const SharedMatrix mat) {
+                diis.set_error_vector_size(1, DIISEntry::InputType::Matrix, mat.get());
+            })
+        .def("set_vector_size", [](DIISManager& diis, const SharedMatrix mat) {
+                diis.set_vector_size(1, DIISEntry::InputType::Matrix, mat.get());
+            })
+        .def("add_entry", [](DIISManager& diis, const SharedMatrix m1, const SharedMatrix m2) {
+                diis.add_entry(2, m1.get(), m2.get());
+            })
+        .def("set_error_vector_size", [](DIISManager& diis, const SharedMatrix m1, const SharedMatrix m2) {
+                diis.set_error_vector_size(2, DIISEntry::InputType::Matrix, m1.get(),  DIISEntry::InputType::Matrix, m2.get());
+            })
+        .def("set_vector_size", [](DIISManager& diis, const SharedMatrix m1, const SharedMatrix m2) {
+                diis.set_vector_size(2, DIISEntry::InputType::Matrix, m1.get(),  DIISEntry::InputType::Matrix, m2.get());
+             })
+        .def("add_entry", [](DIISManager& diis, const SharedMatrix m1, const SharedMatrix m2, const SharedMatrix m3, const SharedMatrix m4) {
+                diis.add_entry(4, m1.get(), m2.get(), m3.get(), m4.get());
+            })
         .def("reset_subspace", &DIISManager::reset_subspace, "docstring")
         .def("delete_diis_file", &DIISManager::delete_diis_file, "docstring");
+
+    py::class_<DIISEntry, std::shared_ptr<DIISEntry> > diis_entry(m, "DIISEntry", "docstring");
 }

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -204,6 +204,7 @@ void export_wavefunction(py::module& m) {
         .def("get_basisset", &Wavefunction::get_basisset, "Returns the requested auxiliary basis.")
         .def("set_basisset", &Wavefunction::set_basisset, "Sets the requested auxiliary basis.")
         .def("energy", &Wavefunction::energy, "Returns the Wavefunction's energy.")
+        .def("options", &Wavefunction::options, "Returns the Wavefunction's options object")
         .def("set_energy", &Wavefunction::set_energy,
              "Sets the Wavefunction's energy. Syncs with Wavefunction's QC variable ``CURRENT ENERGY``.")
         .def("gradient", &Wavefunction::gradient, "Returns the Wavefunction's gradient.")
@@ -333,6 +334,7 @@ void export_wavefunction(py::module& m) {
         .def("form_initial_F", &scf::HF::form_initial_F, "Forms the initial F matrix.")
         .def("form_H", &scf::HF::form_H, "Forms the core Hamiltonian")
         .def("form_Shalf", &scf::HF::form_Shalf, "Forms the S^1/2 matrix")
+        .def("form_FDSmSDF", &scf::HF::form_FDSmSDF, "Forms the residual of SCF theory")
         .def("guess", &scf::HF::guess, "Forms the guess (guarantees C, D, and E)")
         .def("initialize_gtfock_jk", &scf::HF::initialize_gtfock_jk, "Sets up a GTFock JK object")
         .def("onel_Hx", &scf::HF::onel_Hx, "One-electron Hessian-vector products.")
@@ -368,15 +370,16 @@ void export_wavefunction(py::module& m) {
         .def("compute_orbital_gradient", &scf::HF::compute_orbital_gradient, "docstring")
         .def("find_occupation", &scf::HF::find_occupation, "docstring")
         .def("diis", &scf::HF::diis, "docstring")
-        .def("diis_manager", &scf::HF::diis_manager, "docstring")
+        .def_property("diis_manager_", &scf::HF::diis_manager, &scf::HF::set_diis_manager, "The DIIS object.")
         .def_property("initialized_diis_manager_", &scf::HF::initialized_diis_manager,
-                      &scf::HF::set_initialized_diis_manager, "docstring")
+                      &scf::HF::set_initialized_diis_manager, "Has the DIIS object been initialized?")
         .def("damping_update", &scf::HF::damping_update, "docstring")
         .def("check_phases", &scf::HF::check_phases, "docstring")
         .def("print_orbitals", &scf::HF::print_orbitals, "docstring")
         .def("print_header", &scf::HF::print_header, "docstring")
         .def("get_energies", &scf::HF::get_energies, "docstring")
         .def("set_energies", &scf::HF::set_energies, "docstring")
+        .def("scf_type", &scf::HF::scf_type, "Return the value of scf_type_ used in the SCF computation.")
         .def("clear_external_potentials", &scf::HF::clear_external_potentials, "Clear private external_potentials list")
         .def("push_back_external_potential", &scf::HF::push_back_external_potential,
              "Add an external potential to the private external_potentials list", "V"_a)
@@ -410,9 +413,14 @@ void export_wavefunction(py::module& m) {
 
     py::class_<scf::ROHF, std::shared_ptr<scf::ROHF>, scf::HF>(m, "ROHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
+        .def("soFeff", &scf::ROHF::soFeff,
+             "Returns the effective Fock matrix in the orthogonalized SO basis. See libscf_solver/rohf.cc::form_C"
+             "for technical definition.")
         .def("moFeff", &scf::ROHF::moFeff, "docstring")
         .def("moFa", &scf::ROHF::moFa, "docstring")
         .def("moFb", &scf::ROHF::moFb, "docstring")
+        .def("Ct", &scf::ROHF::Ct,
+             "MO coefficients in the orthogonalized MO basis. Differs from the standard C matrix by an orthogonalizer matrix.")
         .def("c1_deep_copy", &scf::ROHF::c1_deep_copy,
              "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed "
              "BasisSet *basis*",

--- a/psi4/src/psi4/dct/dct_compute_RHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_RHF.cc
@@ -139,10 +139,10 @@ void DCTSolver::run_simult_dct_RHF() {
                            "Amplitude SF <OO|VV>");
     global_dpd_->buf4_init(&Lbb, PSIF_DCT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Amplitude <oo|vv>");
-    diisManager.set_error_vector_size(5, DIISEntry::Matrix, scf_error_a_.get(), DIISEntry::Matrix, scf_error_b_.get(),
-                                      DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);
-    diisManager.set_vector_size(5, DIISEntry::Matrix, Fa_.get(), DIISEntry::Matrix, Fb_.get(), DIISEntry::DPDBuf4, &Laa,
-                                DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);
+    diisManager.set_error_vector_size(5, DIISEntry::InputType::Matrix, scf_error_a_.get(), DIISEntry::InputType::Matrix, scf_error_b_.get(),
+                                      DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab, DIISEntry::InputType::DPDBuf4, &Lbb);
+    diisManager.set_vector_size(5, DIISEntry::InputType::Matrix, Fa_.get(), DIISEntry::InputType::Matrix, Fb_.get(), DIISEntry::InputType::DPDBuf4, &Laa,
+                                DIISEntry::InputType::DPDBuf4, &Lab, DIISEntry::InputType::DPDBuf4, &Lbb);
     global_dpd_->buf4_close(&Laa);
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);

--- a/psi4/src/psi4/dct/dct_compute_UHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_UHF.cc
@@ -176,11 +176,11 @@ int DCTSolver::run_twostep_dct_cumulant_updates() {
                            "Amplitude <Oo|Vv>");
     global_dpd_->buf4_init(&Lbb, PSIF_DCT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Amplitude <oo|vv>");
-    DIISManager lambdaDiisManager(maxdiis_, "DCT DIIS Amplitudes", DIISManager::LargestError, DIISManager::InCore);
+    DIISManager lambdaDiisManager(maxdiis_, "DCT DIIS Amplitudes", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
     if ((nalpha_ + nbeta_) > 1) {
-        lambdaDiisManager.set_error_vector_size(3, DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab,
-                                                DIISEntry::DPDBuf4, &Lbb);
-        lambdaDiisManager.set_vector_size(3, DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4,
+        lambdaDiisManager.set_error_vector_size(3, DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab,
+                                                DIISEntry::InputType::DPDBuf4, &Lbb);
+        lambdaDiisManager.set_vector_size(3, DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab, DIISEntry::InputType::DPDBuf4,
                                           &Lbb);
     }
     global_dpd_->buf4_close(&Laa);
@@ -267,11 +267,11 @@ void DCTSolver::run_twostep_dct_orbital_updates() {
     auto tmp = std::make_shared<Matrix>("temp", nirrep_, nsopi_, nsopi_);
 
     // Set up DIIS
-    DIISManager scfDiisManager(maxdiis_, "DCT DIIS Orbitals", DIISManager::LargestError, DIISManager::InCore);
+    DIISManager scfDiisManager(maxdiis_, "DCT DIIS Orbitals", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
     if ((nalpha_ + nbeta_) > 1) {
-        scfDiisManager.set_error_vector_size(2, DIISEntry::Matrix, scf_error_a_.get(), DIISEntry::Matrix,
+        scfDiisManager.set_error_vector_size(2, DIISEntry::InputType::Matrix, scf_error_a_.get(), DIISEntry::InputType::Matrix,
                                              scf_error_b_.get());
-        scfDiisManager.set_vector_size(2, DIISEntry::Matrix, Fa_.get(), DIISEntry::Matrix, Fb_.get());
+        scfDiisManager.set_vector_size(2, DIISEntry::InputType::Matrix, Fa_.get(), DIISEntry::InputType::Matrix, Fb_.get());
     }
     // Update the orbitals
     int nSCFCycles = 0;
@@ -354,10 +354,10 @@ void DCTSolver::run_simult_dct() {
                            "Amplitude <Oo|Vv>");
     global_dpd_->buf4_init(&Lbb, PSIF_DCT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Amplitude <oo|vv>");
-    diisManager.set_error_vector_size(5, DIISEntry::Matrix, scf_error_a_.get(), DIISEntry::Matrix, scf_error_b_.get(),
-                                      DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);
-    diisManager.set_vector_size(5, DIISEntry::Matrix, Fa_.get(), DIISEntry::Matrix, Fb_.get(), DIISEntry::DPDBuf4, &Laa,
-                                DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);
+    diisManager.set_error_vector_size(5, DIISEntry::InputType::Matrix, scf_error_a_.get(), DIISEntry::InputType::Matrix, scf_error_b_.get(),
+                                      DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab, DIISEntry::InputType::DPDBuf4, &Lbb);
+    diisManager.set_vector_size(5, DIISEntry::InputType::Matrix, Fa_.get(), DIISEntry::InputType::Matrix, Fb_.get(), DIISEntry::InputType::DPDBuf4, &Laa,
+                                DIISEntry::InputType::DPDBuf4, &Lab, DIISEntry::InputType::DPDBuf4, &Lbb);
     global_dpd_->buf4_close(&Laa);
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);

--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -107,10 +107,10 @@ void DCTSolver::dc06_response() {
         global_dpd_->file2_init(&zaa, PSIF_DCT_DPD, 0, ID('O'), ID('V'), "z <O|V>");
         global_dpd_->file2_init(&zbb, PSIF_DCT_DPD, 0, ID('o'), ID('v'), "z <o|v>");
         DIISManager diisManager(maxdiis_, "DCT DIIS orbital response vectors");
-        diisManager.set_error_vector_size(5, DIISEntry::DPDFile2, &zaa, DIISEntry::DPDFile2, &zbb, DIISEntry::DPDBuf4,
-                                          &Zaa, DIISEntry::DPDBuf4, &Zab, DIISEntry::DPDBuf4, &Zbb);
-        diisManager.set_vector_size(5, DIISEntry::DPDFile2, &zaa, DIISEntry::DPDFile2, &zbb, DIISEntry::DPDBuf4, &Zaa,
-                                    DIISEntry::DPDBuf4, &Zab, DIISEntry::DPDBuf4, &Zbb);
+        diisManager.set_error_vector_size(5, DIISEntry::InputType::DPDFile2, &zaa, DIISEntry::InputType::DPDFile2, &zbb, DIISEntry::InputType::DPDBuf4,
+                                          &Zaa, DIISEntry::InputType::DPDBuf4, &Zab, DIISEntry::InputType::DPDBuf4, &Zbb);
+        diisManager.set_vector_size(5, DIISEntry::InputType::DPDFile2, &zaa, DIISEntry::InputType::DPDFile2, &zbb, DIISEntry::InputType::DPDBuf4, &Zaa,
+                                    DIISEntry::InputType::DPDBuf4, &Zab, DIISEntry::InputType::DPDBuf4, &Zbb);
         global_dpd_->buf4_close(&Zaa);
         global_dpd_->buf4_close(&Zab);
         global_dpd_->buf4_close(&Zbb);
@@ -1117,9 +1117,9 @@ void DCTSolver::iterate_orbital_response() {
     dpdfile2 zaa, zbb, raa, rbb;
     global_dpd_->file2_init(&zaa, PSIF_DCT_DPD, 0, ID('O'), ID('V'), "z <O|V>");
     global_dpd_->file2_init(&zbb, PSIF_DCT_DPD, 0, ID('o'), ID('v'), "z <o|v>");
-    DIISManager ZiaDiisManager(maxdiis_, "DCT DIIS Orbital Z", DIISManager::LargestError, DIISManager::InCore);
-    ZiaDiisManager.set_error_vector_size(2, DIISEntry::DPDFile2, &zaa, DIISEntry::DPDFile2, &zbb);
-    ZiaDiisManager.set_vector_size(2, DIISEntry::DPDFile2, &zaa, DIISEntry::DPDFile2, &zbb);
+    DIISManager ZiaDiisManager(maxdiis_, "DCT DIIS Orbital Z", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
+    ZiaDiisManager.set_error_vector_size(2, DIISEntry::InputType::DPDFile2, &zaa, DIISEntry::InputType::DPDFile2, &zbb);
+    ZiaDiisManager.set_vector_size(2, DIISEntry::InputType::DPDFile2, &zaa, DIISEntry::InputType::DPDFile2, &zbb);
     global_dpd_->file2_close(&zaa);
     global_dpd_->file2_close(&zbb);
 
@@ -1912,9 +1912,9 @@ void DCTSolver::iterate_cumulant_response() {
     global_dpd_->buf4_init(&Zab, PSIF_DCT_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0, "Z <Oo|Vv>");
     global_dpd_->buf4_init(&Zbb, PSIF_DCT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Z <oo|vv>");
-    DIISManager ZDiisManager(maxdiis_, "DCT DIIS Z", DIISManager::LargestError, DIISManager::InCore);
-    ZDiisManager.set_error_vector_size(3, DIISEntry::DPDBuf4, &Zaa, DIISEntry::DPDBuf4, &Zab, DIISEntry::DPDBuf4, &Zbb);
-    ZDiisManager.set_vector_size(3, DIISEntry::DPDBuf4, &Zaa, DIISEntry::DPDBuf4, &Zab, DIISEntry::DPDBuf4, &Zbb);
+    DIISManager ZDiisManager(maxdiis_, "DCT DIIS Z", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
+    ZDiisManager.set_error_vector_size(3, DIISEntry::InputType::DPDBuf4, &Zaa, DIISEntry::InputType::DPDBuf4, &Zab, DIISEntry::InputType::DPDBuf4, &Zbb);
+    ZDiisManager.set_vector_size(3, DIISEntry::InputType::DPDBuf4, &Zaa, DIISEntry::InputType::DPDBuf4, &Zab, DIISEntry::InputType::DPDBuf4, &Zbb);
     global_dpd_->buf4_close(&Zaa);
     global_dpd_->buf4_close(&Zab);
     global_dpd_->buf4_close(&Zbb);

--- a/psi4/src/psi4/dct/dct_oo_RHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_RHF.cc
@@ -73,11 +73,11 @@ void DCTSolver::run_simult_dct_oo_RHF() {
                            "Amplitude SF <OO|VV>");
     global_dpd_->buf4_init(&Lbb, PSIF_DCT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Amplitude <oo|vv>");
-    diisManager.set_error_vector_size(5, DIISEntry::Matrix, orbital_gradient_a_.get(), DIISEntry::Matrix,
-                                      orbital_gradient_b_.get(), DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab,
-                                      DIISEntry::DPDBuf4, &Lbb);
-    diisManager.set_vector_size(5, DIISEntry::Matrix, Xtotal_a_.get(), DIISEntry::Matrix, Xtotal_b_.get(),
-                                DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);
+    diisManager.set_error_vector_size(5, DIISEntry::InputType::Matrix, orbital_gradient_a_.get(), DIISEntry::InputType::Matrix,
+                                      orbital_gradient_b_.get(), DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab,
+                                      DIISEntry::InputType::DPDBuf4, &Lbb);
+    diisManager.set_vector_size(5, DIISEntry::InputType::Matrix, Xtotal_a_.get(), DIISEntry::InputType::Matrix, Xtotal_b_.get(),
+                                DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab, DIISEntry::InputType::DPDBuf4, &Lbb);
     global_dpd_->buf4_close(&Laa);
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);

--- a/psi4/src/psi4/dct/dct_oo_UHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_UHF.cc
@@ -66,11 +66,11 @@ void DCTSolver::run_simult_dct_oo() {
                            "Amplitude <Oo|Vv>");
     global_dpd_->buf4_init(&Lbb, PSIF_DCT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Amplitude <oo|vv>");
-    diisManager.set_error_vector_size(5, DIISEntry::Matrix, orbital_gradient_a_.get(), DIISEntry::Matrix,
-                                      orbital_gradient_b_.get(), DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab,
-                                      DIISEntry::DPDBuf4, &Lbb);
-    diisManager.set_vector_size(5, DIISEntry::Matrix, Xtotal_a_.get(), DIISEntry::Matrix, Xtotal_b_.get(),
-                                DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);
+    diisManager.set_error_vector_size(5, DIISEntry::InputType::Matrix, orbital_gradient_a_.get(), DIISEntry::InputType::Matrix,
+                                      orbital_gradient_b_.get(), DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab,
+                                      DIISEntry::InputType::DPDBuf4, &Lbb);
+    diisManager.set_vector_size(5, DIISEntry::InputType::Matrix, Xtotal_a_.get(), DIISEntry::InputType::Matrix, Xtotal_b_.get(),
+                                DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab, DIISEntry::InputType::DPDBuf4, &Lbb);
     global_dpd_->buf4_close(&Laa);
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);

--- a/psi4/src/psi4/dct/dct_qc.cc
+++ b/psi4/src/psi4/dct/dct_qc.cc
@@ -81,11 +81,11 @@ void DCTSolver::run_qc_dct() {
                            "Amplitude <Oo|Vv>");
     global_dpd_->buf4_init(&Lbb, PSIF_DCT_DPD, 0, ID("[o>o]-"), ID("[v>v]-"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Amplitude <oo|vv>");
-    diisManager.set_error_vector_size(5, DIISEntry::Matrix, orbital_gradient_a_.get(), DIISEntry::Matrix,
-                                      orbital_gradient_b_.get(), DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab,
-                                      DIISEntry::DPDBuf4, &Lbb);
-    diisManager.set_vector_size(5, DIISEntry::Matrix, Xtotal_a_.get(), DIISEntry::Matrix, Xtotal_b_.get(),
-                                DIISEntry::DPDBuf4, &Laa, DIISEntry::DPDBuf4, &Lab, DIISEntry::DPDBuf4, &Lbb);
+    diisManager.set_error_vector_size(5, DIISEntry::InputType::Matrix, orbital_gradient_a_.get(), DIISEntry::InputType::Matrix,
+                                      orbital_gradient_b_.get(), DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab,
+                                      DIISEntry::InputType::DPDBuf4, &Lbb);
+    diisManager.set_vector_size(5, DIISEntry::InputType::Matrix, Xtotal_a_.get(), DIISEntry::InputType::Matrix, Xtotal_b_.get(),
+                                DIISEntry::InputType::DPDBuf4, &Laa, DIISEntry::InputType::DPDBuf4, &Lab, DIISEntry::InputType::DPDBuf4, &Lbb);
     global_dpd_->buf4_close(&Laa);
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);

--- a/psi4/src/psi4/dct/dct_tau_UHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_UHF.cc
@@ -719,12 +719,12 @@ void DCTSolver::build_tau_U() {
     bocc_d->copy(bocc_tau_);
     bvir_d->copy(bvir_tau_);
 
-    DIISManager diisManager(maxdiis_, "DCT DIIS Tau", DIISManager::LargestError, DIISManager::InCore);
+    DIISManager diisManager(maxdiis_, "DCT DIIS Tau", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
     if ((nalpha_ + nbeta_) > 1) {
-        diisManager.set_error_vector_size(4, DIISEntry::Matrix, &aocc_tau_, DIISEntry::Matrix, &bocc_tau_,
-                                          DIISEntry::Matrix, &avir_tau_, DIISEntry::Matrix, &bvir_tau_);
-        diisManager.set_vector_size(4, DIISEntry::Matrix, &aocc_tau_, DIISEntry::Matrix, &bocc_tau_, DIISEntry::Matrix,
-                                    &avir_tau_, DIISEntry::Matrix, &bvir_tau_);
+        diisManager.set_error_vector_size(4, DIISEntry::InputType::Matrix, &aocc_tau_, DIISEntry::InputType::Matrix, &bocc_tau_,
+                                          DIISEntry::InputType::Matrix, &avir_tau_, DIISEntry::InputType::Matrix, &bvir_tau_);
+        diisManager.set_vector_size(4, DIISEntry::InputType::Matrix, &aocc_tau_, DIISEntry::InputType::Matrix, &bocc_tau_, DIISEntry::InputType::Matrix,
+                                    &avir_tau_, DIISEntry::InputType::Matrix, &bvir_tau_);
     }
 
     auto aocc_r = std::make_shared<Matrix>("Residual (Alpha Occupied)", nirrep_, naoccpi_, naoccpi_);

--- a/psi4/src/psi4/dfocc/ccd_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccd_iterations.cc
@@ -58,9 +58,9 @@ void DFOCC::ccd_iterations() {
         std::shared_ptr<Matrix> T2(new Matrix("T2", naoccA * navirA, naoccA * navirA));
         if (reference_ == "RESTRICTED") {
             ccsdDiisManager = std::shared_ptr<DIISManager>(
-                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::LargestError, DIISManager::OnDisk));
-            ccsdDiisManager->set_error_vector_size(1, DIISEntry::Matrix, T2.get());
-            ccsdDiisManager->set_vector_size(1, DIISEntry::Matrix, T2.get());
+                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk));
+            ccsdDiisManager->set_error_vector_size(1, DIISEntry::InputType::Matrix, T2.get());
+            ccsdDiisManager->set_vector_size(1, DIISEntry::InputType::Matrix, T2.get());
         }
         T2.reset();
     }  // if diis true

--- a/psi4/src/psi4/dfocc/ccd_iterations_low.cc
+++ b/psi4/src/psi4/dfocc/ccd_iterations_low.cc
@@ -58,9 +58,9 @@ void DFOCC::ccd_iterations_low() {
         std::shared_ptr<Matrix> T2(new Matrix("T2", naoccA * navirA, naoccA * navirA));
         if (reference_ == "RESTRICTED") {
             ccsdDiisManager = std::shared_ptr<DIISManager>(
-                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::LargestError, DIISManager::OnDisk));
-            ccsdDiisManager->set_error_vector_size(1, DIISEntry::Matrix, T2.get());
-            ccsdDiisManager->set_vector_size(1, DIISEntry::Matrix, T2.get());
+                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk));
+            ccsdDiisManager->set_error_vector_size(1, DIISEntry::InputType::Matrix, T2.get());
+            ccsdDiisManager->set_vector_size(1, DIISEntry::InputType::Matrix, T2.get());
         }
         T2.reset();
     }  // if diis true

--- a/psi4/src/psi4/dfocc/ccdl_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccdl_iterations.cc
@@ -103,9 +103,9 @@ void DFOCC::ccdl_iterations() {
         std::shared_ptr<Matrix> L2(new Matrix("L2", naoccA * navirA, naoccA * navirA));
         if (reference_ == "RESTRICTED") {
             ccsdlDiisManager = std::shared_ptr<DIISManager>(
-                new DIISManager(cc_maxdiis_, "CCDL DIIS L2 Amps", DIISManager::LargestError, DIISManager::OnDisk));
-            ccsdlDiisManager->set_error_vector_size(1, DIISEntry::Matrix, L2.get());
-            ccsdlDiisManager->set_vector_size(1, DIISEntry::Matrix, L2.get());
+                new DIISManager(cc_maxdiis_, "CCDL DIIS L2 Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk));
+            ccsdlDiisManager->set_error_vector_size(1, DIISEntry::InputType::Matrix, L2.get());
+            ccsdlDiisManager->set_vector_size(1, DIISEntry::InputType::Matrix, L2.get());
         }
         L2.reset();
     }  // if diis true

--- a/psi4/src/psi4/dfocc/ccsd_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccsd_iterations.cc
@@ -62,9 +62,9 @@ void DFOCC::ccsd_iterations() {
         std::shared_ptr<Matrix> T1(new Matrix("T1", naoccA, navirA));
         if (reference_ == "RESTRICTED") {
             ccsdDiisManager = std::shared_ptr<DIISManager>(
-                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::LargestError, DIISManager::OnDisk));
-            ccsdDiisManager->set_error_vector_size(2, DIISEntry::Matrix, T2.get(), DIISEntry::Matrix, T1.get());
-            ccsdDiisManager->set_vector_size(2, DIISEntry::Matrix, T2.get(), DIISEntry::Matrix, T1.get());
+                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk));
+            ccsdDiisManager->set_error_vector_size(2, DIISEntry::InputType::Matrix, T2.get(), DIISEntry::InputType::Matrix, T1.get());
+            ccsdDiisManager->set_vector_size(2, DIISEntry::InputType::Matrix, T2.get(), DIISEntry::InputType::Matrix, T1.get());
         }
         T2.reset();
         T1.reset();

--- a/psi4/src/psi4/dfocc/ccsd_iterations_low.cc
+++ b/psi4/src/psi4/dfocc/ccsd_iterations_low.cc
@@ -62,9 +62,9 @@ void DFOCC::ccsd_iterations_low() {
         std::shared_ptr<Matrix> T1(new Matrix("T1", naoccA, navirA));
         if (reference_ == "RESTRICTED") {
             ccsdDiisManager = std::shared_ptr<DIISManager>(
-                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::LargestError, DIISManager::OnDisk));
-            ccsdDiisManager->set_error_vector_size(2, DIISEntry::Matrix, T2.get(), DIISEntry::Matrix, T1.get());
-            ccsdDiisManager->set_vector_size(2, DIISEntry::Matrix, T2.get(), DIISEntry::Matrix, T1.get());
+                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk));
+            ccsdDiisManager->set_error_vector_size(2, DIISEntry::InputType::Matrix, T2.get(), DIISEntry::InputType::Matrix, T1.get());
+            ccsdDiisManager->set_vector_size(2, DIISEntry::InputType::Matrix, T2.get(), DIISEntry::InputType::Matrix, T1.get());
         }
         T2.reset();
         T1.reset();

--- a/psi4/src/psi4/dfocc/ccsdl_iterations.cc
+++ b/psi4/src/psi4/dfocc/ccsdl_iterations.cc
@@ -120,9 +120,9 @@ void DFOCC::ccsdl_iterations() {
         std::shared_ptr<Matrix> L1(new Matrix("L1", naoccA, navirA));
         if (reference_ == "RESTRICTED") {
             ccsdlDiisManager = std::shared_ptr<DIISManager>(
-                new DIISManager(cc_maxdiis_, "CCSDL DIIS L Amps", DIISManager::LargestError, DIISManager::OnDisk));
-            ccsdlDiisManager->set_error_vector_size(2, DIISEntry::Matrix, L2.get(), DIISEntry::Matrix, L1.get());
-            ccsdlDiisManager->set_vector_size(2, DIISEntry::Matrix, L2.get(), DIISEntry::Matrix, L1.get());
+                new DIISManager(cc_maxdiis_, "CCSDL DIIS L Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk));
+            ccsdlDiisManager->set_error_vector_size(2, DIISEntry::InputType::Matrix, L2.get(), DIISEntry::InputType::Matrix, L1.get());
+            ccsdlDiisManager->set_vector_size(2, DIISEntry::InputType::Matrix, L2.get(), DIISEntry::InputType::Matrix, L1.get());
         }
         L2.reset();
         L1.reset();

--- a/psi4/src/psi4/dfocc/lccd_iterations.cc
+++ b/psi4/src/psi4/dfocc/lccd_iterations.cc
@@ -59,9 +59,9 @@ void DFOCC::lccd_iterations() {
         if (reference_ == "RESTRICTED") {
             std::shared_ptr<Matrix> T2(new Matrix("T2", naoccA * navirA, naoccA * navirA));
             ccsdDiisManager = std::shared_ptr<DIISManager>(
-                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::LargestError, DIISManager::OnDisk));
-            ccsdDiisManager->set_error_vector_size(1, DIISEntry::Matrix, T2.get());
-            ccsdDiisManager->set_vector_size(1, DIISEntry::Matrix, T2.get());
+                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk));
+            ccsdDiisManager->set_error_vector_size(1, DIISEntry::InputType::Matrix, T2.get());
+            ccsdDiisManager->set_vector_size(1, DIISEntry::InputType::Matrix, T2.get());
             T2.reset();
         }
 
@@ -71,11 +71,11 @@ void DFOCC::lccd_iterations() {
             std::shared_ptr<Matrix> T2BB(new Matrix("T2BB", ntri_anti_ijBB, ntri_anti_abBB));
             std::shared_ptr<Matrix> T2AB(new Matrix("T2AB", naoccA * naoccB, navirA * navirB));
             ccsdDiisManager = std::shared_ptr<DIISManager>(
-                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::LargestError, DIISManager::OnDisk));
-            ccsdDiisManager->set_error_vector_size(3, DIISEntry::Matrix, T2AA.get(), DIISEntry::Matrix, T2BB.get(),
-                                                   DIISEntry::Matrix, T2AB.get());
-            ccsdDiisManager->set_vector_size(3, DIISEntry::Matrix, T2AA.get(), DIISEntry::Matrix, T2BB.get(),
-                                             DIISEntry::Matrix, T2AB.get());
+                new DIISManager(cc_maxdiis_, "CCSD DIIS T Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk));
+            ccsdDiisManager->set_error_vector_size(3, DIISEntry::InputType::Matrix, T2AA.get(), DIISEntry::InputType::Matrix, T2BB.get(),
+                                                   DIISEntry::InputType::Matrix, T2AB.get());
+            ccsdDiisManager->set_vector_size(3, DIISEntry::InputType::Matrix, T2AA.get(), DIISEntry::InputType::Matrix, T2BB.get(),
+                                             DIISEntry::InputType::Matrix, T2AB.get());
             T2AA.reset();
             T2BB.reset();
             T2AB.reset();

--- a/psi4/src/psi4/dlpno/mp2.cc
+++ b/psi4/src/psi4/dlpno/mp2.cc
@@ -992,8 +992,8 @@ void DLPNOMP2::lmp2_iterations() {
     int iteration = 0, max_iteration = options_.get_int("DLPNO_MAXITER");
     double e_curr = 0.0, e_prev = 0.0, r_curr = 0.0;
     bool e_converged = false, r_converged = false;
-    auto diis = DIISManager(options_.get_int("DIIS_MAX_VECS"), "LMP2 DIIS", DIISManager::LargestError,
-                                              DIISManager::InCore);
+    auto diis = DIISManager(options_.get_int("DIIS_MAX_VECS"), "LMP2 DIIS", DIISManager::RemovalPolicy::LargestError,
+                                              DIISManager::StoragePolicy::InCore);
 
     while (!(e_converged && r_converged)) {
         // RMS of residual per LMO pair, for assessing convergence
@@ -1065,8 +1065,8 @@ void DLPNOMP2::lmp2_iterations() {
         auto R_iajb_flat = flatten_mats(R_iajb);
 
         if (iteration == 0) {
-            diis.set_error_vector_size(1, DIISEntry::Vector, R_iajb_flat.get());
-            diis.set_vector_size(1, DIISEntry::Vector, T_iajb_flat.get());
+            diis.set_error_vector_size(1, DIISEntry::InputType::Vector, R_iajb_flat.get());
+            diis.set_vector_size(1, DIISEntry::InputType::Vector, T_iajb_flat.get());
         }
 
         diis.add_entry(2, R_iajb_flat.get(), T_iajb_flat.get());

--- a/psi4/src/psi4/fisapt/fisapt.cc
+++ b/psi4/src/psi4/fisapt/fisapt.cc
@@ -4972,8 +4972,8 @@ void FISAPTSCF::compute_energy() {
     bool diised = false;
     auto Gsize = std::make_shared<Matrix>("Gsize", nmo, nmo);
     auto diis = std::make_shared<DIISManager>(max_diis_vectors, "FISAPT DIIS");
-    diis->set_error_vector_size(1, DIISEntry::Matrix, Gsize.get());
-    diis->set_vector_size(1, DIISEntry::Matrix, F.get());
+    diis->set_error_vector_size(1, DIISEntry::InputType::Matrix, Gsize.get());
+    diis->set_vector_size(1, DIISEntry::InputType::Matrix, F.get());
     Gsize.reset();
 
     // ==> Master Loop <== //

--- a/psi4/src/psi4/libdiis/diisentry.h
+++ b/psi4/src/psi4/libdiis/diisentry.h
@@ -58,7 +58,7 @@ class DIISEntry {
      *            set_size.. routines should be the number of elements to read.
      * Psio     - The PSIO object to use for I/O
      */
-    enum InputType { DPDBuf4, DPDFile2, Matrix, Vector, Pointer };
+    enum class InputType { DPDBuf4, DPDFile2, Matrix, Vector, Pointer };
     DIISEntry(std::string label, int ID, int count, int vectorSize, double *vector, int errorVectorSize,
               double *errorVector, std::shared_ptr<PSIO> psio);
     ~DIISEntry();

--- a/psi4/src/psi4/libdiis/diismanager.h
+++ b/psi4/src/psi4/libdiis/diismanager.h
@@ -52,16 +52,16 @@ class PSI_API DIISManager {
      * OnDisk - Stored on disk, and retrieved when required
      * InCore - Stored in memory throughout
      */
-    enum StoragePolicy { InCore, OnDisk };
+    enum class StoragePolicy { InCore, OnDisk };
     /**
      * @brief How vectors are removed from the subspace, when required
      *
      * LargestError - The vector corresponding to the largest error is removed
      * OldestFirst - A first-in-first-out policy is used
      */
-    enum RemovalPolicy { LargestError, OldestAdded };
+    enum class RemovalPolicy { LargestError, OldestAdded };
 
-    DIISManager(int maxSubspaceSize, const std::string& label, RemovalPolicy = LargestError, StoragePolicy = OnDisk);
+    DIISManager(int maxSubspaceSize, const std::string& label, RemovalPolicy = RemovalPolicy::LargestError, StoragePolicy = StoragePolicy::OnDisk);
     DIISManager() { _maxSubspaceSize = 0; }
     ~DIISManager();
 

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -390,28 +390,6 @@ double CUHF::compute_E() {
     return Etotal;
 }
 
-double CUHF::compute_orbital_gradient(bool save_diis, int max_diis_vectors) {
-    SharedMatrix grad_a = form_FDSmSDF(Fa_, Da_);
-    SharedMatrix grad_b = form_FDSmSDF(Fb_, Db_);
-
-    if (save_diis) {
-        if (initialized_diis_manager_ == false) {
-            diis_manager_ = std::make_shared<DIISManager>(max_diis_vectors, "HF DIIS vector", DIISManager::LargestError,
-                                                          DIISManager::OnDisk);
-            diis_manager_->set_error_vector_size(2, DIISEntry::Matrix, grad_a.get(), DIISEntry::Matrix, grad_b.get());
-            diis_manager_->set_vector_size(2, DIISEntry::Matrix, Fa_.get(), DIISEntry::Matrix, Fb_.get());
-            initialized_diis_manager_ = true;
-        }
-
-        diis_manager_->add_entry(4, grad_a.get(), grad_b.get(), Fa_.get(), Fb_.get());
-    }
-
-    if (options_.get_bool("DIIS_RMS_ERROR"))
-        return std::sqrt(0.5 * (std::pow(grad_a->rms(), 2) + std::pow(grad_b->rms(), 2)));
-    else
-        return std::max(grad_a->absmax(), grad_b->absmax());
-}
-
 bool CUHF::diis() { return diis_manager_->extrapolate(2, Fa_.get(), Fb_.get()); }
 
 bool CUHF::stability_analysis() {

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -94,7 +94,6 @@ class CUHF final : public HF {
 
     bool diis() override;
     void save_density_and_energy() override;
-    double compute_orbital_gradient(bool save_diis, int max_diis_vectors) override;
 
     void form_C(double shift = 0.0) override;
     void form_D() override;

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -223,9 +223,6 @@ class HF : public Wavefunction {
     /** Form Fia (for DIIS) **/
     virtual SharedMatrix form_Fia(SharedMatrix Fso, SharedMatrix Cso, int* noccpi);
 
-    /** Form X'(FDS - SDF)X (for DIIS) **/
-    virtual SharedMatrix form_FDSmSDF(SharedMatrix Fso, SharedMatrix Dso);
-
     /** Performs any operations required for a incoming guess **/
     virtual void format_guess();
 
@@ -272,6 +269,8 @@ class HF : public Wavefunction {
     /** Computes the initial energy. */
     virtual double compute_initial_E() { return 0.0; }
 
+    const std::string& scf_type() const { return scf_type_; }
+
     /// Check MO phases
     void check_phases();
 
@@ -286,8 +285,9 @@ class HF : public Wavefunction {
 
     /// The DIIS object
     std::shared_ptr<DIISManager> diis_manager() const { return diis_manager_; }
-    void set_initialized_diis_manager(bool tf) { initialized_diis_manager_ = tf; }
+    void set_diis_manager(std::shared_ptr<DIISManager> manager) { diis_manager_ = manager; }
     bool initialized_diis_manager() const { return initialized_diis_manager_; }
+    void set_initialized_diis_manager(bool tf) { initialized_diis_manager_ = tf; }
 
     /// The JK object (or null if it has been deleted)
     std::shared_ptr<JK> jk() const { return jk_; }
@@ -377,6 +377,9 @@ class HF : public Wavefunction {
 
     /** Forms the G matrix */
     virtual void form_G();
+
+    /** Form X'(FDS - SDF)X (for DIIS) **/
+    virtual SharedMatrix form_FDSmSDF(SharedMatrix Fso, SharedMatrix Dso);
 
     /** Rotates orbitals inplace C' = exp(U) C, U = antisymmetric matrix from x */
     void rotate_orbitals(SharedMatrix C, const SharedMatrix x);

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -238,33 +238,6 @@ void RHF::form_G() {
     }
 }
 
-double RHF::compute_orbital_gradient(bool save_fock, int max_diis_vectors) {
-    // Conventional DIIS (X'[FDS - SDF]X, where X levels things out)
-    SharedMatrix gradient = form_FDSmSDF(Fa_, Da_);
-
-    if (save_fock) {
-        if (initialized_diis_manager_ == false) {
-            if (scf_type_ == "DIRECT") {
-                diis_manager_ = std::make_shared<DIISManager>(max_diis_vectors, "HF DIIS vector",
-                                                              DIISManager::LargestError, DIISManager::InCore);
-            } else {
-                diis_manager_ = std::make_shared<DIISManager>(max_diis_vectors, "HF DIIS vector",
-                                                              DIISManager::LargestError, DIISManager::OnDisk);
-            }
-            diis_manager_->set_error_vector_size(1, DIISEntry::Matrix, gradient.get());
-            diis_manager_->set_vector_size(1, DIISEntry::Matrix, Fa_.get());
-            initialized_diis_manager_ = true;
-        }
-        diis_manager_->add_entry(2, gradient.get(), Fa_.get());
-    }
-
-    if (options_.get_bool("DIIS_RMS_ERROR")) {
-        return gradient->rms();
-    } else {
-        return gradient->absmax();
-    }
-}
-
 bool RHF::diis() { return diis_manager_->extrapolate(1, Fa_.get()); }
 
 void RHF::form_F() {

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -63,7 +63,6 @@ class RHF : public HF {
 
     bool diis() override;
     void save_density_and_energy() override;
-    double compute_orbital_gradient(bool save_fock, int max_diis_vectors) override;
 
     void form_C(double shift = 0.0) override;
     void form_D() override;

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -292,52 +292,6 @@ void ROHF::save_density_and_energy() {
     Dt_old_->copy(Dt_);
 }
 
-double ROHF::compute_orbital_gradient(bool save_diis, int max_diis_vectors) {
-    // Only the inact-act, inact-vir, and act-vir rotations are non-redundant
-    Dimension dim_zero = Dimension(nirrep_, "Zero Dim");
-    Dimension noccpi = doccpi_ + soccpi_;
-    Dimension virpi = nmopi_ - doccpi_;
-    Slice row_slice(dim_zero, noccpi);
-    Slice col_slice(doccpi_, doccpi_ + virpi);
-    SharedMatrix MOgradient = moFeff_->get_block(row_slice, col_slice);
-
-    // Zero out act-act part
-    for (size_t h = 0; h < nirrep_; h++) {
-        if (!soccpi_[h]) continue;
-
-        for (size_t i = 0; i < soccpi_[h]; i++) {
-            for (size_t j = 0; j < soccpi_[h]; j++) {
-                MOgradient->set(h, i + doccpi_[h], j, 0.0);
-            }
-        }
-    }
-
-    // Grab inact-act and act-vir orbs
-    // Ct_ is actuall (nmo x nmo)
-    SharedMatrix Cia = Ct_->get_block({dim_zero, nmopi_}, {dim_zero, noccpi});
-    SharedMatrix Cav = Ct_->get_block({dim_zero, nmopi_}, {doccpi_, doccpi_ + virpi});
-
-    // Back transform MOgradient
-    SharedMatrix gradient = linalg::triplet(Cia, MOgradient, Cav, false, false, true);
-
-    if (save_diis) {
-        if (initialized_diis_manager_ == false) {
-            diis_manager_ = std::make_shared<DIISManager>(max_diis_vectors, "HF DIIS vector", DIISManager::LargestError,
-                                                          DIISManager::OnDisk);
-            diis_manager_->set_error_vector_size(1, DIISEntry::Matrix, soFeff_.get());
-            diis_manager_->set_vector_size(1, DIISEntry::Matrix, soFeff_.get());
-            initialized_diis_manager_ = true;
-        }
-        diis_manager_->add_entry(2, gradient.get(), soFeff_.get());
-    }
-
-    if (options_.get_bool("DIIS_RMS_ERROR")) {
-        return gradient->rms();
-    } else {
-        return gradient->absmax();
-    }
-}
-
 bool ROHF::diis() { return diis_manager_->extrapolate(1, soFeff_.get()); }
 
 void ROHF::form_initial_F() {

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -71,13 +71,14 @@ class ROHF : public HF {
          std::shared_ptr<PSIO> psio);
     ~ROHF() override;
 
+    SharedMatrix soFeff() const { return soFeff_; }
     SharedMatrix moFeff() const { return moFeff_; }
     SharedMatrix moFa() const { return moFa_; }
     SharedMatrix moFb() const { return moFb_; }
+    SharedMatrix Ct() const {return Ct_; }
 
     bool diis() override;
     void save_density_and_energy() override;
-    double compute_orbital_gradient(bool save_diis, int max_diis_vectors) override;
 
     void form_C(double shift = 0.0) override;
     void form_D() override;

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -509,9 +509,9 @@ void SADGuess::get_uhf_atomic_density(std::shared_ptr<BasisSet> bas, std::shared
     int iteration = 0;
 
     // Setup DIIS
-    DIISManager diis_manager(6, "SAD DIIS", DIISManager::LargestError, DIISManager::InCore);
-    diis_manager.set_error_vector_size(2, DIISEntry::Matrix, gradient_a.get(), DIISEntry::Matrix, gradient_b.get());
-    diis_manager.set_vector_size(2, DIISEntry::Matrix, Fa.get(), DIISEntry::Matrix, Fb.get());
+    DIISManager diis_manager(6, "SAD DIIS", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
+    diis_manager.set_error_vector_size(2, DIISEntry::InputType::Matrix, gradient_a.get(), DIISEntry::InputType::Matrix, gradient_b.get());
+    diis_manager.set_vector_size(2, DIISEntry::InputType::Matrix, Fa.get(), DIISEntry::InputType::Matrix, Fb.get());
 
     // Setup JK
     std::unique_ptr<JK> jk;

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -1074,30 +1074,6 @@ int UHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter,
     return cphf_nfock_builds_;
 }
 
-double UHF::compute_orbital_gradient(bool save_fock, int max_diis_vectors) {
-    SharedMatrix gradient_a = form_FDSmSDF(Fa_, Da_);
-    SharedMatrix gradient_b = form_FDSmSDF(Fb_, Db_);
-
-    if (save_fock) {
-        if (initialized_diis_manager_ == false) {
-            diis_manager_ = std::make_shared<DIISManager>(max_diis_vectors, "HF DIIS vector", DIISManager::LargestError,
-                                                          DIISManager::OnDisk);
-            diis_manager_->set_error_vector_size(2, DIISEntry::Matrix, gradient_a.get(), DIISEntry::Matrix,
-                                                 gradient_b.get());
-            diis_manager_->set_vector_size(2, DIISEntry::Matrix, Fa_.get(), DIISEntry::Matrix, Fb_.get());
-            initialized_diis_manager_ = true;
-        }
-
-        diis_manager_->add_entry(4, gradient_a.get(), gradient_b.get(), Fa_.get(), Fb_.get());
-    }
-
-    if (options_.get_bool("DIIS_RMS_ERROR")) {
-        return std::sqrt(0.5 * (std::pow(gradient_a->rms(), 2) + std::pow(gradient_b->rms(), 2)));
-    } else {
-        return std::max(gradient_a->absmax(), gradient_b->absmax());
-    }
-}
-
 bool UHF::diis() { return diis_manager_->extrapolate(2, Fa_.get(), Fb_.get()); }
 
 bool UHF::stability_analysis() {

--- a/psi4/src/psi4/libscf_solver/uhf.h
+++ b/psi4/src/psi4/libscf_solver/uhf.h
@@ -71,7 +71,6 @@ class UHF : public HF {
 
     bool diis() override;
     void save_density_and_energy() override;
-    double compute_orbital_gradient(bool save_diis, int max_diis_vectors) override;
 
     void form_C(double shift = 0.0) override;
     void form_D() override;

--- a/psi4/src/psi4/occ/cepa_iterations.cc
+++ b/psi4/src/psi4/occ/cepa_iterations.cc
@@ -59,9 +59,9 @@ void OCCWave::cepa_iterations() {
             global_dpd_->buf4_init(&T, PSIF_OCC_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                                    "T2 <OO|VV>");
             t2DiisManager =
-                new DIISManager(maxdiis_, "CEPA DIIS T2 Amps", DIISManager::LargestError, DIISManager::OnDisk);
-            t2DiisManager->set_error_vector_size(1, DIISEntry::DPDBuf4, &T);
-            t2DiisManager->set_vector_size(1, DIISEntry::DPDBuf4, &T);
+                new DIISManager(maxdiis_, "CEPA DIIS T2 Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk);
+            t2DiisManager->set_error_vector_size(1, DIISEntry::InputType::DPDBuf4, &T);
+            t2DiisManager->set_vector_size(1, DIISEntry::InputType::DPDBuf4, &T);
             global_dpd_->buf4_close(&T);
             psio_->close(PSIF_OCC_DPD, 1);
         }
@@ -76,10 +76,10 @@ void OCCWave::cepa_iterations() {
             global_dpd_->buf4_init(&Tab, PSIF_OCC_DPD, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
                                    "T2 <Oo|Vv>");
             t2DiisManager =
-                new DIISManager(maxdiis_, "CEPA DIIS T2 Amps", DIISManager::LargestError, DIISManager::InCore);
-            t2DiisManager->set_error_vector_size(3, DIISEntry::DPDBuf4, &Taa, DIISEntry::DPDBuf4, &Tbb,
-                                                 DIISEntry::DPDBuf4, &Tab);
-            t2DiisManager->set_vector_size(3, DIISEntry::DPDBuf4, &Taa, DIISEntry::DPDBuf4, &Tbb, DIISEntry::DPDBuf4,
+                new DIISManager(maxdiis_, "CEPA DIIS T2 Amps", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
+            t2DiisManager->set_error_vector_size(3, DIISEntry::InputType::DPDBuf4, &Taa, DIISEntry::InputType::DPDBuf4, &Tbb,
+                                                 DIISEntry::InputType::DPDBuf4, &Tab);
+            t2DiisManager->set_vector_size(3, DIISEntry::InputType::DPDBuf4, &Taa, DIISEntry::InputType::DPDBuf4, &Tbb, DIISEntry::InputType::DPDBuf4,
                                            &Tab);
             global_dpd_->buf4_close(&Taa);
             global_dpd_->buf4_close(&Tbb);

--- a/psi4/src/psi4/occ/occ_iterations.cc
+++ b/psi4/src/psi4/occ/occ_iterations.cc
@@ -76,18 +76,18 @@ void OCCWave::occ_iterations() {
     // If diis?
     // if (nooA + nooB != 1) {
     if (do_diis_ == 1) {
-        orbitalDiis = new DIISManager(maxdiis_, "Orbital Optimized DIIS", DIISManager::LargestError, DIISManager::OnDisk);
+        orbitalDiis = new DIISManager(maxdiis_, "Orbital Optimized DIIS", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk);
         std::string tensor_name = (wfn_type_ == "OCEPA") ? "T2" : (wfn_type_ == "OMP2" ? "T" : "T2_1");
         if (reference_ == "RESTRICTED") {
             dpdbuf4 T;
             std::string temp1 = tensor_name + " <OO|VV>";
             global_dpd_->buf4_init(&T, PSIF_OCC_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0, temp1.c_str());
             if (wfn_type_ == "OMP2.5" || wfn_type_ == "OMP3") {
-                orbitalDiis->set_error_vector_size(3, DIISEntry::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::DPDBuf4, &T, DIISEntry::DPDBuf4, &T);
-                orbitalDiis->set_vector_size(3, DIISEntry::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::DPDBuf4, &T, DIISEntry::DPDBuf4, &T);
+                orbitalDiis->set_error_vector_size(3, DIISEntry::InputType::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::InputType::DPDBuf4, &T, DIISEntry::InputType::DPDBuf4, &T);
+                orbitalDiis->set_vector_size(3, DIISEntry::InputType::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::InputType::DPDBuf4, &T, DIISEntry::InputType::DPDBuf4, &T);
             } else {
-                orbitalDiis->set_error_vector_size(2, DIISEntry::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::DPDBuf4, &T);
-                orbitalDiis->set_vector_size(2, DIISEntry::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::DPDBuf4, &T);
+                orbitalDiis->set_error_vector_size(2, DIISEntry::InputType::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::InputType::DPDBuf4, &T);
+                orbitalDiis->set_vector_size(2, DIISEntry::InputType::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::InputType::DPDBuf4, &T);
             }
             global_dpd_->buf4_close(&T);
         } else if (reference_ == "UNRESTRICTED") {
@@ -104,15 +104,15 @@ void OCCWave::occ_iterations() {
             global_dpd_->buf4_init(&Tbb, PSIF_OCC_DPD, 0, ID("[o,o]"), ID("[v,v]"), ID("[o,o]"), ID("[v,v]"), 0,
                                temp1.c_str());
             if (wfn_type_ == "OMP2.5" || wfn_type_ == "OMP3") {
-                orbitalDiis->set_error_vector_size(8, DIISEntry::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::Vector, kappa_bar_[SpinType::Beta].get(),
-                                         DIISEntry::DPDBuf4, &Taa, DIISEntry::DPDBuf4, &Tab, DIISEntry::DPDBuf4, &Tbb, DIISEntry::DPDBuf4, &Taa, DIISEntry::DPDBuf4, &Tab, DIISEntry::DPDBuf4, &Tbb);
-                orbitalDiis->set_vector_size(8, DIISEntry::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::Vector, kappa_bar_[SpinType::Beta].get(),
-                                         DIISEntry::DPDBuf4, &Taa, DIISEntry::DPDBuf4, &Tab, DIISEntry::DPDBuf4, &Tbb, DIISEntry::DPDBuf4, &Taa, DIISEntry::DPDBuf4, &Tab, DIISEntry::DPDBuf4, &Tbb);
+                orbitalDiis->set_error_vector_size(8, DIISEntry::InputType::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::InputType::Vector, kappa_bar_[SpinType::Beta].get(),
+                                         DIISEntry::InputType::DPDBuf4, &Taa, DIISEntry::InputType::DPDBuf4, &Tab, DIISEntry::InputType::DPDBuf4, &Tbb, DIISEntry::InputType::DPDBuf4, &Taa, DIISEntry::InputType::DPDBuf4, &Tab, DIISEntry::InputType::DPDBuf4, &Tbb);
+                orbitalDiis->set_vector_size(8, DIISEntry::InputType::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::InputType::Vector, kappa_bar_[SpinType::Beta].get(),
+                                         DIISEntry::InputType::DPDBuf4, &Taa, DIISEntry::InputType::DPDBuf4, &Tab, DIISEntry::InputType::DPDBuf4, &Tbb, DIISEntry::InputType::DPDBuf4, &Taa, DIISEntry::InputType::DPDBuf4, &Tab, DIISEntry::InputType::DPDBuf4, &Tbb);
             } else {
-                orbitalDiis->set_error_vector_size(5, DIISEntry::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::Vector, kappa_bar_[SpinType::Beta].get(),
-                        DIISEntry::DPDBuf4, &Taa, DIISEntry::DPDBuf4, &Tab, DIISEntry::DPDBuf4, &Tbb);
-                orbitalDiis->set_vector_size(5, DIISEntry::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::Vector, kappa_bar_[SpinType::Beta].get(),
-                        DIISEntry::DPDBuf4, &Taa, DIISEntry::DPDBuf4, &Tab, DIISEntry::DPDBuf4, &Tbb);
+                orbitalDiis->set_error_vector_size(5, DIISEntry::InputType::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::InputType::Vector, kappa_bar_[SpinType::Beta].get(),
+                        DIISEntry::InputType::DPDBuf4, &Taa, DIISEntry::InputType::DPDBuf4, &Tab, DIISEntry::InputType::DPDBuf4, &Tbb);
+                orbitalDiis->set_vector_size(5, DIISEntry::InputType::Vector, kappa_bar_[SpinType::Alpha].get(), DIISEntry::InputType::Vector, kappa_bar_[SpinType::Beta].get(),
+                        DIISEntry::InputType::DPDBuf4, &Taa, DIISEntry::InputType::DPDBuf4, &Tab, DIISEntry::InputType::DPDBuf4, &Tbb);
             }
             global_dpd_->buf4_close(&Taa);
             global_dpd_->buf4_close(&Tab);


### PR DESCRIPTION
## Description
In preparation for some PRs adding EDIIS and ADIIS to Psi, this PR moves the `compute_orbital_gradient` functions, which call DIIS, to the Python layer.

There are multiple things going on:
- For pybinding, it was convenient to convert the enums in `libdiis` to _strongly typed enums_. This means the enums have their own scope, which changes how other functions had to call them. Every change in occ, dfocc, dct, fisapt, and libdiis is _solely_ due to this. This occupies commit one.
- Many other functions had to be pybound. In particular, it was necessary to convert `diis_manager` into a property. Old code would call `HF.diis_manager()`, but now they call `HF.diis_manager_`. We're not bothering to deprecate the old way of calling it. I'm not aware if there's a way to still support the old syntax. It might work if we change the property name to `diis_manager`? I haven't tested this.
- It is not possible to pybind a variadic, so I had to pybind every `set_error_vector_size` and `set_vector_size` and `add_entry` type combination that Python might use. Sad, but necessary.

And with that done, all four of the `compute_orbital_gradient` functions could finally be moved to the Python layer. `compute_orbital_gradient` is kept as a virtual function, C++ side, to signal that Psi expects such a function to exist. My tests indicate that if the function is defined C++ side, it still works, so this won't break any SCF subclasses defined in plugins.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] _Lots_ of pybind-ing involving DIIS
- [x] Alert! `HF.diis_manager()` has changed to `HF.diis_manager_`
- [x] `HF.compute_orbital_gradient` moved to the Python layer. C-side `compute_orbital_gradient` is still supported, but not used by the core Psi.

## Questions
- [ ] Who is responsible for updating the Great DFOCC Branch with the `libdiis` API change?
- [ ] How do we feel about the new functions I Pybind-ed over? Anything amiss?

## Checklist
- [x] `ctest -L scf` passes

## Status
- [x] Ready for review
- [ ] Let's discuss the two questions before merging this in, please.
