### PR TITLE
Silence Compiler Warning

### DIFF
--- a/psi4/src/psi4/dlpno/mp2.h
+++ b/psi4/src/psi4/dlpno/mp2.h
@@ -181,7 +181,7 @@ class DLPNOMP2 : public Wavefunction {
     DLPNOMP2(SharedWavefunction ref_wfn, Options& options);
     ~DLPNOMP2() override;
 
-    double compute_energy();
+    double compute_energy() override;
 };
 
 }  // namespace dlpno


### PR DESCRIPTION
## Description
Make the below warning go away:
```
In file included from /Users/jonathonmisiewicz/psi4/psi4/src/psi4/dlpno/mp2.cc:29:
/Users/jonathonmisiewicz/psi4/psi4/src/psi4/dlpno/mp2.h:184:12: warning: 'compute_energy' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    double compute_energy();
           ^
/Users/jonathonmisiewicz/psi4/psi4/src/psi4/libmints/wavefunction.h:323:20: note: overridden virtual function is here
    virtual double compute_energy() {
```

## Status
- [x] Ready for review
- [x] Ready for merge
