### PR TITLE
Modernize `libdiis` Pointers

### DIFF
--- a/psi4/src/psi4/libdiis/diisentry.cc
+++ b/psi4/src/psi4/libdiis/diisentry.cc
@@ -39,17 +39,17 @@ PRAGMA_WARNING_POP
 
 namespace psi {
 
-DIISEntry::DIISEntry(std::string label, int ID, int orderAdded, int errorVectorSize, double *errorVector,
-                     int vectorSize, double *vector, std::shared_ptr<PSIO> psio)
-    : _vectorSize(vectorSize),
-      _errorVectorSize(errorVectorSize),
-      _vector(vector),
-      _errorVector(errorVector),
+DIISEntry::DIISEntry(std::string label, int ID, int orderAdded, std::vector<double>& errorVector,
+                     std::vector<double>& vector, std::shared_ptr<PSIO> psio)
+    : _vectorSize(static_cast<int>(vector.size())),
+      _errorVectorSize(static_cast<int>(errorVector.size())),
+      _vector(std::move(vector)),
+      _errorVector(std::move(errorVector)),
       _ID(ID),
       _orderAdded(orderAdded),
       _label(label),
       _psio(psio) {
-    double sumSQ = C_DDOT(_errorVectorSize, _errorVector, 1, _errorVector, 1);
+    double sumSQ = C_DDOT(_errorVectorSize, _errorVector.data(), 1, _errorVector.data(), 1);
     _rmsError = sqrt(sumSQ / _errorVectorSize);
     _dotProducts[_ID] = sumSQ;
     _knownDotProducts[_ID] = true;
@@ -73,48 +73,44 @@ void DIISEntry::close_psi_file() {
 void DIISEntry::dump_vector_to_disk() {
     std::string label = _label + " vector";
     open_psi_file();
-    _psio->write_entry(PSIF_LIBDIIS, label.c_str(), (char *)_vector, _vectorSize * sizeof(double));
+    _psio->write_entry(PSIF_LIBDIIS, label.c_str(), (char *)_vector.data(), _vectorSize * sizeof(double));
     free_vector_memory();
 }
 
 void DIISEntry::read_vector_from_disk() {
-    if (_vector == nullptr) {
-        _vector = new double[_vectorSize];
+    if (_vector.empty()) {
+        _vector = std::vector<double>(_vectorSize);
         std::string label = _label + " vector";
         open_psi_file();
-        _psio->read_entry(PSIF_LIBDIIS, label.c_str(), (char *)_vector, _vectorSize * sizeof(double));
+        _psio->read_entry(PSIF_LIBDIIS, label.c_str(), (char *)_vector.data(), _vectorSize * sizeof(double));
     }
 }
 
 void DIISEntry::dump_error_vector_to_disk() {
     std::string label = _label + " error";
     open_psi_file();
-    _psio->write_entry(PSIF_LIBDIIS, label.c_str(), (char *)_errorVector, _errorVectorSize * sizeof(double));
+    _psio->write_entry(PSIF_LIBDIIS, label.c_str(), (char *)_errorVector.data(), _errorVectorSize * sizeof(double));
     free_error_vector_memory();
 }
 
 void DIISEntry::read_error_vector_from_disk() {
-    if (_errorVector == nullptr) {
-        _errorVector = new double[_errorVectorSize];
+    if (_errorVector.empty()) {
+        _errorVector = std::vector<double>(_errorVectorSize);
         std::string label = _label + " error";
         open_psi_file();
-        _psio->read_entry(PSIF_LIBDIIS, label.c_str(), (char *)_errorVector, _errorVectorSize * sizeof(double));
+        _psio->read_entry(PSIF_LIBDIIS, label.c_str(), (char *)_errorVector.data(), _errorVectorSize * sizeof(double));
     }
 }
 
 void DIISEntry::free_vector_memory() {
-    if (_vector) delete[] _vector;
-    _vector = nullptr;
+    _vector = std::vector<double>(0);
 }
 
 void DIISEntry::free_error_vector_memory() {
-    if (_errorVector) delete[] _errorVector;
-    _errorVector = nullptr;
+    _errorVector = std::vector<double>(0);
 }
 
 DIISEntry::~DIISEntry() {
-    if (_vector != nullptr) delete[] _vector;
-    if (_errorVector != nullptr) delete[] _errorVector;
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libdiis/diisentry.cc
+++ b/psi4/src/psi4/libdiis/diisentry.cc
@@ -39,17 +39,17 @@ PRAGMA_WARNING_POP
 
 namespace psi {
 
-DIISEntry::DIISEntry(std::string label, int ID, int orderAdded, std::vector<double>& errorVector,
-                     std::vector<double>& vector, std::shared_ptr<PSIO> psio)
-    : _vectorSize(static_cast<int>(vector.size())),
-      _errorVectorSize(static_cast<int>(errorVector.size())),
+DIISEntry::DIISEntry(std::string label, int ID, int orderAdded, std::unique_ptr<std::vector<double>> errorVector,
+                     std::unique_ptr<std::vector<double>> vector, std::shared_ptr<PSIO> psio)
+    : _vectorSize(static_cast<int>(vector->size())),
+      _errorVectorSize(static_cast<int>(errorVector->size())),
       _vector(std::move(vector)),
       _errorVector(std::move(errorVector)),
       _ID(ID),
       _orderAdded(orderAdded),
       _label(label),
       _psio(psio) {
-    double sumSQ = C_DDOT(_errorVectorSize, _errorVector.data(), 1, _errorVector.data(), 1);
+    double sumSQ = C_DDOT(_errorVectorSize, _errorVector->data(), 1, _errorVector->data(), 1);
     _rmsError = sqrt(sumSQ / _errorVectorSize);
     _dotProducts[_ID] = sumSQ;
     _knownDotProducts[_ID] = true;
@@ -73,41 +73,41 @@ void DIISEntry::close_psi_file() {
 void DIISEntry::dump_vector_to_disk() {
     std::string label = _label + " vector";
     open_psi_file();
-    _psio->write_entry(PSIF_LIBDIIS, label.c_str(), (char *)_vector.data(), _vectorSize * sizeof(double));
+    _psio->write_entry(PSIF_LIBDIIS, label.c_str(), (char *)_vector->data(), _vectorSize * sizeof(double));
     free_vector_memory();
 }
 
 void DIISEntry::read_vector_from_disk() {
-    if (_vector.empty()) {
-        _vector = std::vector<double>(_vectorSize);
+    if (_vector->empty()) {
+        _vector = std::make_unique<std::vector<double>>(_vectorSize);
         std::string label = _label + " vector";
         open_psi_file();
-        _psio->read_entry(PSIF_LIBDIIS, label.c_str(), (char *)_vector.data(), _vectorSize * sizeof(double));
+        _psio->read_entry(PSIF_LIBDIIS, label.c_str(), (char *)_vector->data(), _vectorSize * sizeof(double));
     }
 }
 
 void DIISEntry::dump_error_vector_to_disk() {
     std::string label = _label + " error";
     open_psi_file();
-    _psio->write_entry(PSIF_LIBDIIS, label.c_str(), (char *)_errorVector.data(), _errorVectorSize * sizeof(double));
+    _psio->write_entry(PSIF_LIBDIIS, label.c_str(), (char *)_errorVector->data(), _errorVectorSize * sizeof(double));
     free_error_vector_memory();
 }
 
 void DIISEntry::read_error_vector_from_disk() {
-    if (_errorVector.empty()) {
-        _errorVector = std::vector<double>(_errorVectorSize);
+    if (_errorVector->empty()) {
+        _errorVector = std::make_unique<std::vector<double>>(_errorVectorSize);
         std::string label = _label + " error";
         open_psi_file();
-        _psio->read_entry(PSIF_LIBDIIS, label.c_str(), (char *)_errorVector.data(), _errorVectorSize * sizeof(double));
+        _psio->read_entry(PSIF_LIBDIIS, label.c_str(), (char *)_errorVector->data(), _errorVectorSize * sizeof(double));
     }
 }
 
 void DIISEntry::free_vector_memory() {
-    _vector = std::vector<double>(0);
+    _vector = std::make_unique<std::vector<double>>();
 }
 
 void DIISEntry::free_error_vector_memory() {
-    _errorVector = std::vector<double>(0);
+    _errorVector = std::make_unique<std::vector<double>>();
 }
 
 DIISEntry::~DIISEntry() {

--- a/psi4/src/psi4/libdiis/diisentry.h
+++ b/psi4/src/psi4/libdiis/diisentry.h
@@ -61,7 +61,6 @@ class DIISEntry {
     enum class InputType { DPDBuf4, DPDFile2, Matrix, Vector, Pointer };
     DIISEntry(std::string label, int ID, int count, std::unique_ptr<std::vector<double>> vector,
               std::unique_ptr<std::vector<double>> errorVector, std::shared_ptr<PSIO> psio);
-    ~DIISEntry();
     /// Whether the dot product of this entry's and the nth entry's error vector is known
     bool dot_is_known_with(int n) { return _knownDotProducts[n]; }
     /// The dot product of this entry's and the nth entry's error vectors
@@ -78,7 +77,7 @@ class DIISEntry {
     /// Marks the dot product with vector n as invalid
     void invalidate_dot(int n) { _knownDotProducts[n] = false; }
     /// Set the vector
-    void set_vector(std::unique_ptr<std::vector<double>> vec) { _vector = std::move(vec); }
+    void set_vector(std::unique_ptr<std::vector<double>> vec) { _vector = *vec.release(); }
     /// Put this vector entry on disk and free the memory
     void dump_vector_to_disk();
     /// Allocate vector memory and read from disk
@@ -94,12 +93,12 @@ class DIISEntry {
     /// Returns the error vector
     const double *errorVector() {
         read_error_vector_from_disk();
-        return _errorVector->data();
+        return _errorVector.data();
     }
     /// Returns the vector
     const double *vector() {
         read_vector_from_disk();
-        return _vector->data();
+        return _vector.data();
     }
     /// Open the psi file, if needed.
     void open_psi_file();
@@ -122,9 +121,9 @@ class DIISEntry {
     /// The RMS error for this entry
     double _rmsError;
     /// The error vector
-    std::unique_ptr<std::vector<double>> _errorVector;
+    std::vector<double> _errorVector;
     /// The error vector
-    std::unique_ptr<std::vector<double>> _vector;
+    std::vector<double> _vector;
     /// The label used for disk storage
     std::string _label;
     /// PSIO object

--- a/psi4/src/psi4/libdiis/diisentry.h
+++ b/psi4/src/psi4/libdiis/diisentry.h
@@ -59,8 +59,8 @@ class DIISEntry {
      * Psio     - The PSIO object to use for I/O
      */
     enum class InputType { DPDBuf4, DPDFile2, Matrix, Vector, Pointer };
-    DIISEntry(std::string label, int ID, int count, std::vector<double>& vector,
-              std::vector<double>& errorVector, std::shared_ptr<PSIO> psio);
+    DIISEntry(std::string label, int ID, int count, std::unique_ptr<std::vector<double>> vector,
+              std::unique_ptr<std::vector<double>> errorVector, std::shared_ptr<PSIO> psio);
     ~DIISEntry();
     /// Whether the dot product of this entry's and the nth entry's error vector is known
     bool dot_is_known_with(int n) { return _knownDotProducts[n]; }
@@ -78,7 +78,7 @@ class DIISEntry {
     /// Marks the dot product with vector n as invalid
     void invalidate_dot(int n) { _knownDotProducts[n] = false; }
     /// Set the vector
-    void set_vector(std::vector<double>& vec) { _vector = std::move(vec); }
+    void set_vector(std::unique_ptr<std::vector<double>> vec) { _vector = std::move(vec); }
     /// Put this vector entry on disk and free the memory
     void dump_vector_to_disk();
     /// Allocate vector memory and read from disk
@@ -94,12 +94,12 @@ class DIISEntry {
     /// Returns the error vector
     const double *errorVector() {
         read_error_vector_from_disk();
-        return _errorVector.data();
+        return _errorVector->data();
     }
     /// Returns the vector
     const double *vector() {
         read_vector_from_disk();
-        return _vector.data();
+        return _vector->data();
     }
     /// Open the psi file, if needed.
     void open_psi_file();
@@ -122,9 +122,9 @@ class DIISEntry {
     /// The RMS error for this entry
     double _rmsError;
     /// The error vector
-    std::vector<double> _errorVector;
+    std::unique_ptr<std::vector<double>> _errorVector;
     /// The error vector
-    std::vector<double> _vector;
+    std::unique_ptr<std::vector<double>> _vector;
     /// The label used for disk storage
     std::string _label;
     /// PSIO object

--- a/psi4/src/psi4/libdiis/diisentry.h
+++ b/psi4/src/psi4/libdiis/diisentry.h
@@ -59,8 +59,8 @@ class DIISEntry {
      * Psio     - The PSIO object to use for I/O
      */
     enum class InputType { DPDBuf4, DPDFile2, Matrix, Vector, Pointer };
-    DIISEntry(std::string label, int ID, int count, int vectorSize, double *vector, int errorVectorSize,
-              double *errorVector, std::shared_ptr<PSIO> psio);
+    DIISEntry(std::string label, int ID, int count, std::vector<double>& vector,
+              std::vector<double>& errorVector, std::shared_ptr<PSIO> psio);
     ~DIISEntry();
     /// Whether the dot product of this entry's and the nth entry's error vector is known
     bool dot_is_known_with(int n) { return _knownDotProducts[n]; }
@@ -78,7 +78,7 @@ class DIISEntry {
     /// Marks the dot product with vector n as invalid
     void invalidate_dot(int n) { _knownDotProducts[n] = false; }
     /// Set the vector
-    void set_vector(double *vec) { _vector = vec; }
+    void set_vector(std::vector<double>& vec) { _vector = std::move(vec); }
     /// Put this vector entry on disk and free the memory
     void dump_vector_to_disk();
     /// Allocate vector memory and read from disk
@@ -94,12 +94,12 @@ class DIISEntry {
     /// Returns the error vector
     const double *errorVector() {
         read_error_vector_from_disk();
-        return _errorVector;
+        return _errorVector.data();
     }
     /// Returns the vector
     const double *vector() {
         read_vector_from_disk();
-        return _vector;
+        return _vector.data();
     }
     /// Open the psi file, if needed.
     void open_psi_file();
@@ -122,9 +122,9 @@ class DIISEntry {
     /// The RMS error for this entry
     double _rmsError;
     /// The error vector
-    double *_errorVector;
+    std::vector<double> _errorVector;
     /// The error vector
-    double *_vector;
+    std::vector<double> _vector;
     /// The label used for disk storage
     std::string _label;
     /// PSIO object

--- a/psi4/src/psi4/libdiis/diismanager.cc
+++ b/psi4/src/psi4/libdiis/diismanager.cc
@@ -278,7 +278,7 @@ bool DIISManager::add_entry(int numQuantities, ...) {
         _subspace[entryID].dump_error_vector_to_disk();
     }
 
-    // Make we don't know any inner products involving this new entry
+    // Clear all inner products with this entry that may be cached
     for (int i = 0; i < _subspace.size(); ++i)
         if (i != entryID) _subspace[i].invalidate_dot(entryID);
 

--- a/psi4/src/psi4/libdiis/diismanager.cc
+++ b/psi4/src/psi4/libdiis/diismanager.cc
@@ -204,13 +204,13 @@ bool DIISManager::add_entry(int numQuantities, ...) {
     double *array;
     va_list args;
     va_start(args, numQuantities);
-    auto errorVector = std::vector<double>(_errorVectorSize);
-    auto paramVector = std::vector<double>(_vectorSize);
-    double *arrayPtr = errorVector.data();
+    auto errorVector = std::make_unique<std::vector<double>>(_errorVectorSize);
+    auto paramVector = std::make_unique<std::vector<double>>(_vectorSize);
+    double *arrayPtr = errorVector->data();
     for (int i = 0; i < numQuantities; ++i) {
         DIISEntry::InputType type = _componentTypes[i];
         // If we've filled the error vector, start filling the vector
-        if (i == _numErrorVectorComponents) arrayPtr = paramVector.data();
+        if (i == _numErrorVectorComponents) arrayPtr = paramVector->data();
         switch (type) {
             case DIISEntry::InputType::Pointer:
                 array = va_arg(args, double *);
@@ -268,10 +268,10 @@ bool DIISManager::add_entry(int numQuantities, ...) {
 
     int entryID = get_next_entry_id();
     if (_subspace.size() < _maxSubspaceSize) {
-        _subspace.push_back(new DIISEntry(_label, entryID, _entryCount++, errorVector, paramVector, _psio));
+        _subspace.push_back(new DIISEntry(_label, entryID, _entryCount++, std::move(errorVector), std::move(paramVector), _psio));
     } else {
         delete _subspace[entryID];
-        _subspace[entryID] = new DIISEntry(_label, entryID, _entryCount++, errorVector, paramVector, _psio);
+        _subspace[entryID] = new DIISEntry(_label, entryID, _entryCount++, std::move(errorVector), std::move(paramVector), _psio);
     }
 
     if (_storagePolicy == StoragePolicy::OnDisk) {

--- a/psi4/src/psi4/libdiis/diismanager.cc
+++ b/psi4/src/psi4/libdiis/diismanager.cc
@@ -204,13 +204,13 @@ bool DIISManager::add_entry(int numQuantities, ...) {
     double *array;
     va_list args;
     va_start(args, numQuantities);
-    auto *errorVectorPtr = new double[_errorVectorSize];
-    auto *vectorPtr = new double[_vectorSize];
-    double *arrayPtr = errorVectorPtr;
+    auto errorVector = std::vector<double>(_errorVectorSize);
+    auto paramVector = std::vector<double>(_vectorSize);
+    double *arrayPtr = errorVector.data();
     for (int i = 0; i < numQuantities; ++i) {
         DIISEntry::InputType type = _componentTypes[i];
         // If we've filled the error vector, start filling the vector
-        if (i == _numErrorVectorComponents) arrayPtr = vectorPtr;
+        if (i == _numErrorVectorComponents) arrayPtr = paramVector.data();
         switch (type) {
             case DIISEntry::InputType::Pointer:
                 array = va_arg(args, double *);
@@ -268,12 +268,10 @@ bool DIISManager::add_entry(int numQuantities, ...) {
 
     int entryID = get_next_entry_id();
     if (_subspace.size() < _maxSubspaceSize) {
-        _subspace.push_back(new DIISEntry(_label, entryID, _entryCount++, _errorVectorSize, errorVectorPtr, _vectorSize,
-                                          vectorPtr, _psio));
+        _subspace.push_back(new DIISEntry(_label, entryID, _entryCount++, errorVector, paramVector, _psio));
     } else {
         delete _subspace[entryID];
-        _subspace[entryID] = new DIISEntry(_label, entryID, _entryCount++, _errorVectorSize, errorVectorPtr,
-                                           _vectorSize, vectorPtr, _psio);
+        _subspace[entryID] = new DIISEntry(_label, entryID, _entryCount++, errorVector, paramVector, _psio);
     }
 
     if (_storagePolicy == StoragePolicy::OnDisk) {

--- a/psi4/src/psi4/libdiis/diismanager.cc
+++ b/psi4/src/psi4/libdiis/diismanager.cc
@@ -521,7 +521,6 @@ void DIISManager::delete_diis_file() {
 }
 
 DIISManager::~DIISManager() {
-    _subspace.clear();
     if (_psio->open_check(PSIF_LIBDIIS)) _psio->close(PSIF_LIBDIIS, 1);
 }
 

--- a/psi4/src/psi4/libdiis/diismanager.h
+++ b/psi4/src/psi4/libdiis/diismanager.h
@@ -109,7 +109,7 @@ class PSI_API DIISManager {
     /// The counter that keeps track of how many entries have been added
     int _entryCount;
     /// The DIIS entries
-    std::vector<DIISEntry*> _subspace;
+    std::vector<std::shared_ptr<DIISEntry>> _subspace;
     /// The types used in building the vector and the error vector
     std::vector<DIISEntry::InputType> _componentTypes;
     /// The types used in the vector

--- a/psi4/src/psi4/libdiis/diismanager.h
+++ b/psi4/src/psi4/libdiis/diismanager.h
@@ -109,7 +109,7 @@ class PSI_API DIISManager {
     /// The counter that keeps track of how many entries have been added
     int _entryCount;
     /// The DIIS entries
-    std::vector<std::shared_ptr<DIISEntry>> _subspace;
+    std::vector<DIISEntry> _subspace;
     /// The types used in building the vector and the error vector
     std::vector<DIISEntry::InputType> _componentTypes;
     /// The types used in the vector


### PR DESCRIPTION
## Description
This PR gets rid of all `new` and `delete` calls within `libdiis`, replacing them with `std::unique_ptr` and `std::vector`.  

Per [recommendations](https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/), I use a `std::unique_ptr` to signify the caller (of the `DIISEntry` constructor) loses ownership of the object.

## Checklist
- [x] Quick tests still pass

## Status
- [x] Ready for review
- [x] Ready for merge **SQUASH**
