### PR TITLE
Fix SCF memory leak and `Vector::gemv`

### DIFF
--- a/psi4/src/psi4/libmints/vector.cc
+++ b/psi4/src/psi4/libmints/vector.cc
@@ -231,7 +231,7 @@ void Vector::gemv(bool transa, double alpha, Matrix *A, Vector *X, double beta) 
     char trans = transa ? 't' : 'n';
 
     for (int h = 0; h < nirrep_; ++h) {
-        C_DGEMV(trans, A->rowspi(h), A->colspi(h), alpha, A->get_pointer(h), A->rowspi(h), &(X->vector_[h][0]), 1, beta,
+        C_DGEMV(trans, A->rowspi(h), A->colspi(h), alpha, A->get_pointer(h), A->colspi(h), &(X->vector_[h][0]), 1, beta,
                 &(vector_[h][0]), 1);
     }
 }


### PR DESCRIPTION
## Description
First, this PR cleans up some manual memory management in `libscf_solver`, including a memory leak of an `nao`-by-`nso` matrix created once per call to the SCF code.

During the course of fixing that, I uncovered a correctness error in `libmints`: the `dgemv` function was using rows rather than cols for an argument. The original choice was correct in Fortran-style indexing but not C-style indexing and disagreed with every other `C_DGEMV` call in Psi. It didn't cause any issues because `Vector::dgemv` is almost never used in Psi. The one other time I found it used was for a Hermitian matrix, which of course won't have problems.

## Questions
- [x] Jet, please double-check my claim of a bug in `libmints`.

## Checklist
- [x] Quick tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
