### PR TITLE
Fix DIIS memory leak

### DIFF
--- a/psi4/src/psi4/dlpno/mp2.cc
+++ b/psi4/src/psi4/dlpno/mp2.cc
@@ -992,8 +992,8 @@ void DLPNOMP2::lmp2_iterations() {
     int iteration = 0, max_iteration = options_.get_int("DLPNO_MAXITER");
     double e_curr = 0.0, e_prev = 0.0, r_curr = 0.0;
     bool e_converged = false, r_converged = false;
-    auto diis = DIISManager(options_.get_int("DIIS_MAX_VECS"), "LMP2 DIIS", DIISManager::RemovalPolicy::LargestError,
-                                              DIISManager::StoragePolicy::InCore);
+    DIISManager diis(options_.get_int("DIIS_MAX_VECS"), "LMP2 DIIS", DIISManager::RemovalPolicy::LargestError,
+                                       DIISManager::StoragePolicy::InCore);
 
     while (!(e_converged && r_converged)) {
         // RMS of residual per LMO pair, for assessing convergence

--- a/psi4/src/psi4/libdiis/diisentry.cc
+++ b/psi4/src/psi4/libdiis/diisentry.cc
@@ -39,12 +39,12 @@ PRAGMA_WARNING_POP
 
 namespace psi {
 
-DIISEntry::DIISEntry(std::string label, int ID, int orderAdded, std::unique_ptr<std::vector<double>> errorVector,
-                     std::unique_ptr<std::vector<double>> vector, std::shared_ptr<PSIO> psio)
-    : _vectorSize(static_cast<int>(vector->size())),
-      _errorVectorSize(static_cast<int>(errorVector->size())),
-      _vector(*vector.release()),
-      _errorVector(*errorVector.release()),
+DIISEntry::DIISEntry(std::string label, int ID, int orderAdded, std::vector<double> errorVector,
+                     std::vector<double> vector, std::shared_ptr<PSIO> psio)
+    : _vectorSize(static_cast<int>(vector.size())),
+      _errorVectorSize(static_cast<int>(errorVector.size())),
+      _vector(std::move(vector)),
+      _errorVector(std::move(errorVector)),
       _ID(ID),
       _orderAdded(orderAdded),
       _label(label),
@@ -103,11 +103,11 @@ void DIISEntry::read_error_vector_from_disk() {
 }
 
 void DIISEntry::free_vector_memory() {
-    _vector = std::vector<double>(0);
+    _vector.clear();
 }
 
 void DIISEntry::free_error_vector_memory() {
-    _errorVector = std::vector<double>(0);
+    _errorVector.clear();
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libdiis/diisentry.h
+++ b/psi4/src/psi4/libdiis/diisentry.h
@@ -59,8 +59,8 @@ class DIISEntry {
      * Psio     - The PSIO object to use for I/O
      */
     enum class InputType { DPDBuf4, DPDFile2, Matrix, Vector, Pointer };
-    DIISEntry(std::string label, int ID, int count, std::unique_ptr<std::vector<double>> vector,
-              std::unique_ptr<std::vector<double>> errorVector, std::shared_ptr<PSIO> psio);
+    DIISEntry(std::string label, int ID, int count, std::vector<double> vector,
+              std::vector<double> errorVector, std::shared_ptr<PSIO> psio);
     /// Whether the dot product of this entry's and the nth entry's error vector is known
     bool dot_is_known_with(int n) { return _knownDotProducts[n]; }
     /// The dot product of this entry's and the nth entry's error vectors
@@ -77,7 +77,7 @@ class DIISEntry {
     /// Marks the dot product with vector n as invalid
     void invalidate_dot(int n) { _knownDotProducts[n] = false; }
     /// Set the vector
-    void set_vector(std::unique_ptr<std::vector<double>> vec) { _vector = *vec.release(); }
+    void set_vector(std::vector<double> vec) { _vector = std::move(vec); }
     /// Put this vector entry on disk and free the memory
     void dump_vector_to_disk();
     /// Allocate vector memory and read from disk

--- a/psi4/src/psi4/libdiis/diismanager.cc
+++ b/psi4/src/psi4/libdiis/diismanager.cc
@@ -204,13 +204,13 @@ bool DIISManager::add_entry(int numQuantities, ...) {
     double *array;
     va_list args;
     va_start(args, numQuantities);
-    auto errorVector = std::make_unique<std::vector<double>>(_errorVectorSize);
-    auto paramVector = std::make_unique<std::vector<double>>(_vectorSize);
-    double *arrayPtr = errorVector->data();
+    auto errorVector = std::vector<double>(_errorVectorSize);
+    auto paramVector = std::vector<double>(_vectorSize);
+    double *arrayPtr = errorVector.data();
     for (int i = 0; i < numQuantities; ++i) {
         DIISEntry::InputType type = _componentTypes[i];
         // If we've filled the error vector, start filling the vector
-        if (i == _numErrorVectorComponents) arrayPtr = paramVector->data();
+        if (i == _numErrorVectorComponents) arrayPtr = paramVector.data();
         switch (type) {
             case DIISEntry::InputType::Pointer:
                 array = va_arg(args, double *);


### PR DESCRIPTION
## Description
This PR fixes a memory leak which I inadvertently introduced myself when refactoring `libdiis`.

What I was _trying_ to do was take heap memory and move it into the stack. You can't actually do that. So when I released my `std::vector` from the smart pointer and saved it to a class variable, the memory was _not_ cleared on object delete because it was still heap memory and not stack memory. _Mea culpa_.

## Checklist
- [x] Quick tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
