### PR TITLE
native_files field for qcschema

### DIFF
--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcelemental}))
     include(FindPythonModule)
-    find_python_module(qcelemental ATLEAST 0.23.0 QUIET)
+    find_python_module(qcelemental ATLEAST 0.24.0 QUIET)
 endif()
 
 if(${qcelemental_FOUND})
@@ -19,7 +19,7 @@ else()
 
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCElemental/archive/v0.23.0.tar.gz
+        URL https://github.com/MolSSI/QCElemental/archive/v0.24.0.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${Python_EXECUTABLE} setup.py build

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -415,8 +415,7 @@ def run_qcschema(input_data, clean=True):
             "version": __version__,
             "routine": "psi4.schema_runner.run_qcschema"
         })
-        if qcel.util.parse_version(qcel.__version__) >= qcel.util.parse_version("0.24.0"):
-            ret_data["native_files"]["input"] = json.dumps(json.loads(input_model.json()), indent=1)
+        ret_data["native_files"]["input"] = json.dumps(json.loads(input_model.json()), indent=1)
 
         exit_printing(start_time=start_time, success=True)
 
@@ -642,8 +641,7 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
         # binary "psi4.180.npy": Path(core.get_writer_file_prefix(wfn.molecule().name()) + ".180.npy"),
         "timer.dat": Path("timer.dat"),
     }
-    if qcel.util.parse_version(qcel.__version__) >= qcel.util.parse_version("0.24.0"):
-        json_data["native_files"] = {fl: flpath.read_text() for fl, flpath in files.items() if flpath.exists()}
+    json_data["native_files"] = {fl: flpath.read_text() for fl, flpath in files.items() if flpath.exists()}
 
     # Reset state
     _clean_psi_environ(clean)

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -40,6 +40,7 @@ import traceback
 import uuid
 import warnings
 from collections import defaultdict
+from pathlib import Path
 
 import numpy as np
 import qcelemental as qcel
@@ -414,6 +415,8 @@ def run_qcschema(input_data, clean=True):
             "version": __version__,
             "routine": "psi4.schema_runner.run_qcschema"
         })
+        if qcel.util.parse_version(qcel.__version__) >= qcel.util.parse_version("0.24.0"):
+            ret_data["native_files"]["input"] = json.dumps(json.loads(input_model.json()), indent=1)
 
         exit_printing(start_time=start_time, success=True)
 
@@ -632,6 +635,15 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
 
     if keep_wfn:
         json_data["wavefunction"] = _convert_wavefunction(wfn)
+
+    files = {
+        "psi4.grad": Path(core.get_writer_file_prefix(wfn.molecule().name()) + ".grad"),
+        "psi4.hess": Path(core.get_writer_file_prefix(wfn.molecule().name()) + ".hess"),
+        # binary "psi4.180.npy": Path(core.get_writer_file_prefix(wfn.molecule().name()) + ".180.npy"),
+        "timer.dat": Path("timer.dat"),
+    }
+    if qcel.util.parse_version(qcel.__version__) >= qcel.util.parse_version("0.24.0"):
+        json_data["native_files"] = {fl: flpath.read_text() for fl, flpath in files.items() if flpath.exists()}
 
     # Reset state
     _clean_psi_environ(clean)

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -639,7 +639,7 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
         "psi4.grad": Path(core.get_writer_file_prefix(wfn.molecule().name()) + ".grad"),
         "psi4.hess": Path(core.get_writer_file_prefix(wfn.molecule().name()) + ".hess"),
         # binary "psi4.180.npy": Path(core.get_writer_file_prefix(wfn.molecule().name()) + ".180.npy"),
-        "timer.dat": Path("timer.dat"),
+        "timer.dat": Path("timer.dat"),  # ok for `psi4 --qcschema` but no file collected for `qcengine.run_program(..., "psi4")`
     }
     json_data["native_files"] = {fl: flpath.read_text() for fl, flpath in files.items() if flpath.exists()}
 


### PR DESCRIPTION
## Description
In accordance with https://github.com/MolSSI/QCElemental/pull/275, return certain files in qcschema to be pruned down by user protocols. Bump qcel to 0.24.0 (and qcng to 0.23.0 once it's minted). Note that this can't handle the wfn file b/c binary. And it can't handle `timer.dat` b/c there's no fixed place it lands (I can get it to save calling schema_wrapper directly but not for QCEngine calling psi4).

## Checklist
- [x] Tests added for any new features -- tested at qcengine test_canonical_fields
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
