### PR TITLE
disables wcombine option

### DIFF
--- a/doc/sphinxman/source/dft.rst
+++ b/doc/sphinxman/source/dft.rst
@@ -46,6 +46,8 @@ Both density functional theory and Hartree--Fock theory are controlled
 through the SCF module, and the :ref:`SCF Introduction <sec:scfintro>`
 section is also relevant here.
 
+.. note:: Starting version 1.5, the |scf__wcombine| option is temporarily disabled.
+
 .. note:: Starting version 1.4 (tag v1.4a1 in the development repository), |PSIfour| uses an updated and extended (to 104 elements) set
           of Bragg-Slater radii. This leads to minimal deviations in absolute energies (1E-06 au) and
           relative energies (below 0.002 kcal/mol for S22), depending also on the applied grid, compared

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -31,6 +31,7 @@
 
 #include "psi4/psi4-dec.h"
 #include <psi4/libmints/typedefs.h>
+#include "psi4/libpsi4util/exception.h"
 
 #include <map>
 #include <list>
@@ -143,8 +144,14 @@ class PSI_API DFHelper {
     ///
     /// Do we calculate omega exchange and regular hf exchange together?
     /// @param wcombine boolean: all exchange in one matrix
-    ///
-    void set_wcombine(bool wcombine) {wcombine_ = wcombine;}
+    /// TODO: re-enable after all bugs are fixed.
+    // void set_wcombine(bool wcombine) {wcombine_ = wcombine;}
+    void set_wcombine(bool wcombine) {
+        if (wcombine) {
+            throw PSIEXCEPTION("JK: wcombine option is currently not available.");
+        }
+        wcombine_ = wcombine;
+    }
     bool get_wcombine() { return wcombine_; }
 
     ///

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -107,7 +107,8 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
 
     } else if (jk_type == "MEM_DF") {
         MemDFJK* jk = new MemDFJK(primary, auxiliary);
-        jk->set_wcombine(true);
+        // TODO: re-enable after fixing all bugs
+        jk->set_wcombine(false);
         _set_dfjk_options<MemDFJK>(jk, options);
         if (options["WCOMBINE"].has_changed()) { jk->set_wcombine(options.get_bool("WCOMBINE")); }
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1671,9 +1671,11 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
         /*- combine omega exchange and Hartree--Fock exchange into
               one matrix for efficiency?
-            Default is True for MemDFJK
-              (itself the default for |globals__scf_type| DF),
-            False otherwise as not yet implemented. -*/
+              Disabled until fixed.-*/
+            //NOTE: Re-enable with below doc string:
+            // Default is True for MemDFJK
+            //   (itself the default for |globals__scf_type| DF),
+            // False otherwise as not yet implemented. -*/
         options.add_bool("WCOMBINE", false);
     }
     if (name == "CPHF" || options.read_globals()) {


### PR DESCRIPTION
Reports indicate that the in-core `MemDF+wcombine` algorithm is not working correctly.
This PR disables the options. MemDF does not longer turn the option on automatically and users setting the option directly will get an exception error. A note is added to the DFT manual.

Issues: #2351 #2279 
Related: #2283 

## Status
- [x] Ready for review
- [x] Ready for merge
