### PR TITLE
Pybind `Vector.clone()`

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -359,6 +359,8 @@ void export_mints(py::module& m) {
         .def("set", vector_setitem_2(&Vector::set), "Sets a single element value located at m in irrep h", "h"_a, "m"_a,
              "val"_a)
         .def("copy", vector_one(&Vector::copy), "Returns a copy of the matrix")
+        .def("clone", [](Vector& vec) {
+                std::shared_ptr<Vector> result = std::move(vec.clone()); return result; }, "Clone the vector")
         .def("print_out", &Vector::print_out, "Prints the vector to the output file")
         .def("scale", &Vector::scale, "Scales the elements of a vector by sc", "sc"_a)
         .def("dim", &Vector::dim, "Returns the dimensions of the vector per irrep h", "h"_a = 0)

--- a/tests/pytests/test_vector.py
+++ b/tests/pytests/test_vector.py
@@ -50,3 +50,9 @@ for group_size in [1, 2, 4, 8]:
 def test_constructors_w_symmetry(name, dim):
     v = Vector(name, dim)
     check_block_vec(v, dim.n(), dim, name)
+
+def test_clone():
+    dim = Dimension([1, 2, 3])
+    vec = Vector(dim)
+    copy = vec.clone()
+    assert copy.dimpi() == dim


### PR DESCRIPTION
## Description
This PR exposes `Vector.clone()` to the Python layer, a generally useful function and one I specifically need for PyDIIS. Sadly, positive LoC this time.

The cast to `shared_ptr` is necessary for the clone to be available Py-side because when we pybound `Vector`, we specified `std::shared_ptr<Vector>` as its holder type. I imagine this is an example of "[holder types must be applied consistently](https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html#std-shared-ptr.)." Let's not talk about how long it took for me to implicate holder types in my test originally failing.

## Todos
- [x] `Vector.clone` available on the Python layer

## Checklist
- [x] Tests added for any new features

## Status
- [x] Ready for review
- [x] Ready for merge
