### PR TITLE
Make ENABLE_XHOST flag checks dependent on compiler brand.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,13 +141,20 @@ option_with_print(ENABLE_AUTO_BLAS "Enables CMake to auto-detect BLAS" ON)
 option_with_print(ENABLE_AUTO_LAPACK "Enables CMake to auto-detect LAPACK" ON)
 option_with_print(ENABLE_PLUGIN_TESTING "Test the plugin templates build and run" OFF)
 option_with_print(ENABLE_CYTHONIZE "Compile each python file rather than plaintext (requires cython) !experimental!" OFF)
+
+# Need to check things per compiler brand since they're different
 if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
-option_with_flags(ENABLE_XHOST "Enables processor-specific optimization (with MSVC, it enables AVX2 instructions)" ON
-                  "-xHost" "-march=native" "/arch:AVX")
-else()
-option_with_flags(ENABLE_XHOST "Enables processor-specific optimization (with MSVC, it enables AVX2 instructions)" ON
-                  "-march=native" "-xHost" "/arch:AVX")
+  option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON "-xHost")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+  option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON  "-march=native")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+  option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON  "-march=native")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES PGI)
+  option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON  "-tp host")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
+  option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON  "/arch:AVX2")
 endif()
+
 option_with_flags(ENABLE_CODE_COVERAGE "Enables details on code coverage" OFF
                   "-ftest-coverage")
 option_with_flags(ENABLE_BOUNDS_CHECK "Enables bounds check in Fortran" OFF


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR solves an issue with the use of the native optimization flags, which are different in various compilers and often get misinterpreted. It looks like the best solution is to first check the brand of the compiler, and then try whether the brand-specific flag(s) work.

Related issues https://gitlab.com/libxc/libxc/-/issues/361 and #2023


## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
