### PR TITLE
Remove Unnecessary, Buggy `dct` Convergence Metric

### DIFF
--- a/psi4/src/psi4/dct/dct.h
+++ b/psi4/src/psi4/dct/dct.h
@@ -288,8 +288,6 @@ class DCTSolver : public Wavefunction {
     bool orbitalsDone_;
     /// Controls convergence of the density cumulant updates
     bool cumulantDone_;
-    /// Controls convergence of the idempotent one-particle density
-    bool densityConverged_;
     /// Controls convergence of the DCT energy
     bool energyConverged_;
     /// Whether the user requested the DCT functional that is variationally orbitally-optimized

--- a/psi4/src/psi4/dct/dct_compute_RHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_RHF.cc
@@ -51,7 +51,6 @@ namespace dct {
 double DCTSolver::compute_energy_RHF() {
     orbitalsDone_ = false;
     cumulantDone_ = false;
-    densityConverged_ = false;
     energyConverged_ = false;
     initialize_orbitals_from_reference_U();
 
@@ -94,7 +93,7 @@ double DCTSolver::compute_energy_RHF() {
     }
 
     // If not converged -> Break
-    if (!orbitalsDone_ || !cumulantDone_ || !densityConverged_)
+    if (!orbitalsDone_ || !cumulantDone_)
         throw ConvergenceError<int>("DCT", maxiter_, cumulant_threshold_, cumulant_convergence_, __FILE__, __LINE__);
 
     std::string prefix = options_.get_str("DCT_TYPE") == "DF" ? "DF-" : " ";
@@ -147,7 +146,7 @@ void DCTSolver::run_simult_dct_RHF() {
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);
 
-    while ((!orbitalsDone_ || !cumulantDone_ || !densityConverged_ || !energyConverged_) && cycle++ < maxiter_) {
+    while ((!orbitalsDone_ || !cumulantDone_ || !energyConverged_) && cycle++ < maxiter_) {
         std::string diisString;
         // Save the old energy
         old_total_energy_ = new_total_energy_;
@@ -157,15 +156,13 @@ void DCTSolver::run_simult_dct_RHF() {
         if (options_.get_str("DCT_TYPE") == "DF" && options_.get_str("AO_BASIS") == "NONE") {
             build_DF_tensors_RHF();
 
-            auto mo_h = std::make_shared<Matrix>("MO-based H", nirrep_, nmopi_, nmopi_);
-            mo_h->copy(so_h_);
+            auto mo_h = so_h_.clone();
             mo_h->transform(Ca_);
 
             moFa_->copy(mo_h);
             moFa_->add(mo_gbarGamma_A_);
             // Back-transform the Fock matrix to the SO basis: F_so = (Ct)^-1 F_mo C^-1 = (C^-1)t F_mo C^-1
-            auto Ca_inverse = std::make_shared<Matrix>("Ca_ inverse", nirrep_, nmopi_, nsopi_);
-            Ca_inverse->copy(Ca_);
+            auto Ca_inverse = Ca_->clone();
             Ca_inverse->general_invert();
             Fa_->copy(moFa_);
             Fa_->transform(Ca_inverse);
@@ -254,8 +251,8 @@ void DCTSolver::run_simult_dct_RHF() {
         }
         // Transform two-electron integrals to the MO basis using new orbitals, build denominators
         transform_integrals_RHF();
-        // Update SCF density (Kappa) and check its RMS
-        densityConverged_ = update_scf_density_RHF() < orbitals_threshold_;
+        // Update SCF density (Kappa)
+        update_scf_density_RHF();
         // If we've performed enough lambda updates since the last orbitals
         // update, reset the counter so another SCF update is performed
         outfile->Printf("\t* %-3d   %12.3e      %12.3e   %12.3e  %21.15f  %-3s *\n", cycle, orbitals_convergence_,

--- a/psi4/src/psi4/dct/dct_compute_UHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_UHF.cc
@@ -48,7 +48,6 @@ namespace dct {
 double DCTSolver::compute_energy_UHF() {
     orbitalsDone_ = false;
     cumulantDone_ = false;
-    densityConverged_ = false;
     energyConverged_ = false;
     initialize_orbitals_from_reference_U();
 
@@ -95,7 +94,7 @@ double DCTSolver::compute_energy_UHF() {
     }
 
     // If not converged -> Break
-    if (!orbitalsDone_ || !cumulantDone_ || !densityConverged_)
+    if (!orbitalsDone_ || !cumulantDone_)
         throw ConvergenceError<int>("DCT", maxiter_, cumulant_threshold_, cumulant_convergence_, __FILE__, __LINE__);
 
     std::string prefix = options_.get_str("DCT_TYPE") == "DF" ? "DF-" : " ";
@@ -276,10 +275,9 @@ void DCTSolver::run_twostep_dct_orbital_updates() {
     // Update the orbitals
     int nSCFCycles = 0;
     // Reset the booleans that control the convergence
-    densityConverged_ = false;
     energyConverged_ = false;
     outfile->Printf("\tOrbital Updates\n");
-    while ((!densityConverged_ || !orbitalsDone_ || !energyConverged_) && (nSCFCycles++ < maxiter_)) {
+    while ((!orbitalsDone_ || !energyConverged_) && (nSCFCycles++ < maxiter_)) {
         std::string diisString;
         // Copy core hamiltonian into the Fock matrix array: F = H
         Fa_->copy(so_h_);
@@ -317,7 +315,7 @@ void DCTSolver::run_twostep_dct_orbital_updates() {
         // Make sure that the orbital phase is retained
         correct_mo_phases(false);
         // Update SCF density (Kappa) and check its RMS
-        densityConverged_ = update_scf_density() < orbitals_threshold_;
+        update_scf_density();
         // Compute the DCT energy
         new_total_energy_ = scf_energy_ + lambda_energy_;
         // Check convergence of the total DCT energy
@@ -361,7 +359,7 @@ void DCTSolver::run_simult_dct() {
     global_dpd_->buf4_close(&Laa);
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);
-    while ((!orbitalsDone_ || !cumulantDone_ || !densityConverged_ || !energyConverged_) && cycle++ < maxiter_) {
+    while ((!orbitalsDone_ || !cumulantDone_ || !energyConverged_) && cycle++ < maxiter_) {
         std::string diisString;
         // Save the old energy
         old_total_energy_ = new_total_energy_;
@@ -483,7 +481,7 @@ void DCTSolver::run_simult_dct() {
         // Transform two-electron integrals to the MO basis using new orbitals, build denominators
         transform_integrals();
         // Update SCF density (Kappa) and check its RMS
-        densityConverged_ = update_scf_density() < orbitals_threshold_;
+        update_scf_density();
         // If we've performed enough lambda updates since the last orbitals
         // update, reset the counter so another SCF update is performed
         outfile->Printf("\t* %-3d   %12.3e      %12.3e   %12.3e  %21.15f  %-3s *\n", cycle, orbitals_convergence_,

--- a/psi4/src/psi4/dct/dct_oo_RHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_RHF.cc
@@ -82,7 +82,7 @@ void DCTSolver::run_simult_dct_oo_RHF() {
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);
 
-    while ((!orbitalsDone_ || !cumulantDone_ || !densityConverged_ || !energyConverged_) && cycle++ < maxiter_) {
+    while ((!orbitalsDone_ || !cumulantDone_ || !energyConverged_) && cycle++ < maxiter_) {
         std::string diisString;
         compute_SO_tau_R();
 
@@ -185,8 +185,8 @@ void DCTSolver::run_simult_dct_oo_RHF() {
         }
         // Transform two-electron integrals to the MO basis using new orbitals, build denominators
         transform_integrals_RHF();
-        // Update SCF density (Kappa) and check its RMS
-        densityConverged_ = update_scf_density_RHF() < orbitals_threshold_;
+        // Update SCF density (Kappa)
+        update_scf_density_RHF();
         // If we've performed enough lambda updates since the last orbitals
         // update, reset the counter so another SCF update is performed
         outfile->Printf("\t* %-3d   %12.3e      %12.3e   %12.3e  %21.15f  %-3s *\n", cycle, orbitals_convergence_,

--- a/psi4/src/psi4/dct/dct_oo_UHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_UHF.cc
@@ -75,7 +75,7 @@ void DCTSolver::run_simult_dct_oo() {
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);
 
-    while ((!orbitalsDone_ || !cumulantDone_ || !densityConverged_ || !energyConverged_) && cycle++ < maxiter_) {
+    while ((!orbitalsDone_ || !cumulantDone_ || !energyConverged_) && cycle++ < maxiter_) {
         std::string diisString;
         compute_SO_tau_U();
 
@@ -174,8 +174,8 @@ void DCTSolver::run_simult_dct_oo() {
         }
         // Transform two-electron integrals to the MO basis using new orbitals, build denominators
         transform_integrals();
-        // Update SCF density (Kappa) and check its RMS
-        densityConverged_ = update_scf_density() < orbitals_threshold_;
+        // Update SCF density (Kappa)
+        update_scf_density();
         // If we've performed enough lambda updates since the last orbitals
         // update, reset the counter so another SCF update is performed
         outfile->Printf("\t* %-3d   %12.3e      %12.3e   %12.3e  %21.15f  %-3s *\n", cycle, orbitals_convergence_,

--- a/psi4/src/psi4/dct/dct_qc.cc
+++ b/psi4/src/psi4/dct/dct_qc.cc
@@ -90,7 +90,7 @@ void DCTSolver::run_qc_dct() {
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);
 
-    while ((!orbitalsDone_ || !cumulantDone_ || !energyConverged_ || !densityConverged_) && cycle++ < maxiter_) {
+    while ((!orbitalsDone_ || !cumulantDone_ || !energyConverged_) && cycle++ < maxiter_) {
         std::string diisString;
         // Compute the generalized Fock matrix and orbital gradient in the MO basis
         compute_orbital_gradient();
@@ -178,7 +178,7 @@ void DCTSolver::run_qc_dct() {
 
             if (orbital_idp_ != 0) {
                 // Update the density
-                densityConverged_ = update_scf_density() < orbitals_threshold_;
+                update_scf_density();
                 // Transform two-electron integrals to the MO basis using new orbitals, build denominators
                 // TODO: Transform_integrals shouldn't call build denominators for the QC alogorithm
                 transform_integrals();
@@ -196,7 +196,7 @@ void DCTSolver::run_qc_dct() {
             "\n");
     }
 
-    if (!orbitalsDone_ || !cumulantDone_ || !densityConverged_ || !energyConverged_)
+    if (!orbitalsDone_ || !cumulantDone_ || !energyConverged_)
         throw ConvergenceError<int>("DCT", maxiter_, cumulant_threshold_, cumulant_convergence_, __FILE__, __LINE__);
 }
 


### PR DESCRIPTION
## Description
This PR removes some convergence checks in the `dct` module that are redundant (when formulated correctly) and currently not implemented correctly.

In the current `dct` code, my threaded computations with near linear dependencies were taking a variable number of iterations to converge, due to the condition `update_scf_density_RHF() < orbitals_threshold_` being false. That check is _intended_ to enforce convergence of the orbitals, which change iteration-to-iteration. `update_SCF_density_RHF` returns a measure of how much the reference density changed but does not treat it with an orthogonalizer, so in the near linearly-dependent case, numerical noise leads to the computation proceeding even after all other convergence metrics are flat.

Given the choice between fixing the check or removing it, this PR removes it.
* In the case where orbitals are optimized to _satisfy a commutator equation_, all of our orbital convergence metrics are motivated by SCF. We already have the SCF check for small orbital residual elsewhere in the code. We don't check that the absolute change in the density is small in the SCF case, so we shouldn't check it here,  either.
* In the case where orbitals are optimized to _minimize the energy_, there is no theoretical justification for this check. We have existing checks that the residual of the orbital gradient is small.

## Todos
- [x] Removes an unnecessary, buggy `dct` convergence metric

## Checklist
- [x] `dct` tests still pass

## Status
- [x] Ready for review
- [x] Ready for merge
