### PR TITLE
Add pb11 dependency to modules that use DIIS

### DIFF
--- a/psi4/src/psi4/cc/CMakeLists.txt
+++ b/psi4/src/psi4/cc/CMakeLists.txt
@@ -1,7 +1,5 @@
 psi4_add_module(bin cc "")
 
-target_link_libraries(cc PUBLIC pybind11::headers)
-
 # FIXME Remove once done
 list(APPEND _Clang_debug_flags
   "-Wall"

--- a/psi4/src/psi4/cc/CMakeLists.txt
+++ b/psi4/src/psi4/cc/CMakeLists.txt
@@ -1,5 +1,7 @@
 psi4_add_module(bin cc "")
 
+target_link_libraries(cc PUBLIC pybind11::headers)
+
 # FIXME Remove once done
 list(APPEND _Clang_debug_flags
   "-Wall"

--- a/psi4/src/psi4/dct/CMakeLists.txt
+++ b/psi4/src/psi4/dct/CMakeLists.txt
@@ -50,4 +50,4 @@ endif ()
 
 psi4_add_module(bin dct sources)
 
-target_link_libraries(dct PUBLIC pybind11::headers)
+target_link_libraries(dct PUBLIC diis)

--- a/psi4/src/psi4/dct/CMakeLists.txt
+++ b/psi4/src/psi4/dct/CMakeLists.txt
@@ -49,3 +49,5 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 endif ()
 
 psi4_add_module(bin dct sources)
+
+target_link_libraries(dct PUBLIC pybind11::headers)

--- a/psi4/src/psi4/dfocc/CMakeLists.txt
+++ b/psi4/src/psi4/dfocc/CMakeLists.txt
@@ -106,4 +106,4 @@ list(APPEND sources
   )
 psi4_add_module(bin dfocc sources)
 
-target_link_libraries(dfocc PUBLIC pybind11::headers)
+target_link_libraries(dfocc PUBLIC diis)

--- a/psi4/src/psi4/dfocc/CMakeLists.txt
+++ b/psi4/src/psi4/dfocc/CMakeLists.txt
@@ -105,3 +105,5 @@ list(APPEND sources
   z_vector_pcg.cc
   )
 psi4_add_module(bin dfocc sources)
+
+target_link_libraries(dfocc PUBLIC pybind11::headers)

--- a/psi4/src/psi4/dlpno/CMakeLists.txt
+++ b/psi4/src/psi4/dlpno/CMakeLists.txt
@@ -5,4 +5,4 @@ list(APPEND sources
   )
 psi4_add_module(bin dlpno sources)
 
-target_link_libraries(dlpno PUBLIC pybind11::headers)
+target_link_libraries(dlpno PUBLIC diis)

--- a/psi4/src/psi4/dlpno/CMakeLists.txt
+++ b/psi4/src/psi4/dlpno/CMakeLists.txt
@@ -4,3 +4,5 @@ list(APPEND sources
   sparse.cc
   )
 psi4_add_module(bin dlpno sources)
+
+target_link_libraries(dlpno PUBLIC pybind11::headers)

--- a/psi4/src/psi4/fisapt/CMakeLists.txt
+++ b/psi4/src/psi4/fisapt/CMakeLists.txt
@@ -3,3 +3,5 @@ list(APPEND sources
   local2.cc
   )
 psi4_add_module(bin fisapt sources)
+
+target_link_libraries(fisapt PUBLIC pybind11::headers)

--- a/psi4/src/psi4/fisapt/CMakeLists.txt
+++ b/psi4/src/psi4/fisapt/CMakeLists.txt
@@ -4,4 +4,4 @@ list(APPEND sources
   )
 psi4_add_module(bin fisapt sources)
 
-target_link_libraries(fisapt PUBLIC pybind11::headers)
+target_link_libraries(fisapt PUBLIC diis)

--- a/psi4/src/psi4/libdiis/CMakeLists.txt
+++ b/psi4/src/psi4/libdiis/CMakeLists.txt
@@ -2,3 +2,5 @@ list(APPEND sources
   diismanager.cc
   )
 psi4_add_module(lib diis sources)
+
+target_link_libraries(diis PUBLIC pybind11::headers)

--- a/psi4/src/psi4/libscf_solver/CMakeLists.txt
+++ b/psi4/src/psi4/libscf_solver/CMakeLists.txt
@@ -14,7 +14,7 @@ if(ENABLE_GTFOCK)
     add_dependencies(scf_solver INTERFACE GTFockInt GTFockCInt)
 endif()
 
-target_link_libraries(scf_solver PUBLIC pybind11::headers)
+target_link_libraries(scf_solver PUBLIC diis)
 
 if(TARGET BrianQC::static_wrapper)
   target_compile_definitions(scf_solver

--- a/psi4/src/psi4/libscf_solver/CMakeLists.txt
+++ b/psi4/src/psi4/libscf_solver/CMakeLists.txt
@@ -14,6 +14,8 @@ if(ENABLE_GTFOCK)
     add_dependencies(scf_solver INTERFACE GTFockInt GTFockCInt)
 endif()
 
+target_link_libraries(scf_solver PUBLIC pybind11::headers)
+
 if(TARGET BrianQC::static_wrapper)
   target_compile_definitions(scf_solver
     PUBLIC

--- a/psi4/src/psi4/occ/CMakeLists.txt
+++ b/psi4/src/psi4/occ/CMakeLists.txt
@@ -55,4 +55,4 @@ list(APPEND sources
   )
 psi4_add_module(bin occ sources)
 
-target_link_libraries(occ PUBLIC pybind11::headers)
+target_link_libraries(occ PUBLIC diis)

--- a/psi4/src/psi4/occ/CMakeLists.txt
+++ b/psi4/src/psi4/occ/CMakeLists.txt
@@ -54,3 +54,5 @@ list(APPEND sources
   z_vector.cc
   )
 psi4_add_module(bin occ sources)
+
+target_link_libraries(occ PUBLIC pybind11::headers)

--- a/psi4/src/psi4/scfgrad/CMakeLists.txt
+++ b/psi4/src/psi4/scfgrad/CMakeLists.txt
@@ -17,7 +17,7 @@ if(TARGET BrianQC::static_wrapper)
     )
 endif()
 
-target_link_libraries(scfgrad PUBLIC pybind11::headers)
+target_link_libraries(scfgrad PUBLIC scf_solver)
 
 if(TARGET ECPINT::ecpint)
   target_link_libraries(scfgrad

--- a/psi4/src/psi4/scfgrad/CMakeLists.txt
+++ b/psi4/src/psi4/scfgrad/CMakeLists.txt
@@ -17,6 +17,8 @@ if(TARGET BrianQC::static_wrapper)
     )
 endif()
 
+target_link_libraries(scfgrad PUBLIC pybind11::headers)
+
 if(TARGET ECPINT::ecpint)
   target_link_libraries(scfgrad
     PUBLIC


### PR DESCRIPTION
## Description
When trying to build from source, I had problems with Pybind11 headers not being found.  This is most likely due to #2369 introducing new dependencies on PB11 being introduced that the build system is unaware of.  This PR fixes the problem on my Linux/ICPC setup, but I'm open to suggestions if there's a more up to date way of telling CMake about these new dependencies.


## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
