### PR TITLE
c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #  <<<  Required build dependencies that Psi4 can't build itself  >>>
 #
 #    - CMake (e.g., `conda install cmake`)
-#    - C++ and C compilers (C++14 compliant)
+#    - C++ and C compilers (C++17 compliant)
 #    - BLAS/LAPACK (also runtime; e.g., `conda install mkl-devel`)
 #    - Python (also runtime; interpreter and headers; e.g., `conda install python`)
 #    - NumPy (also runtime; avoidable at buildtime if gau2grid pre-built; e.g., `conda install numpy`)
@@ -175,7 +175,7 @@ option_with_default(CMAKE_INSTALL_LIBDIR "Directory to which libraries installed
 option_with_default(PYMOD_INSTALL_LIBDIR "Location within CMAKE_INSTALL_LIBDIR to which python modules are installed" /)
 option_with_default(ENABLE_GENERIC "Enables mostly static linking of language libraries for shared library" OFF)
 option_with_default(CMAKE_INSTALL_MESSAGE "Specify verbosity of installation messages" LAZY)
-option_with_default(psi4_CXX_STANDARD "Specify C++ standard for core Psi4" 14)
+option_with_default(psi4_CXX_STANDARD "Specify C++ standard for core Psi4" 17)
 option_with_default(SIMINT_VECTOR "Vectorization type to use for simint (scalar sse avx avxfma micavx512)" avx)
 option_with_default(SPHINX_THEME "Theme for Sphinx documentation and extensions" sphinx_psi_theme)
 option_with_default(SPHINXMAN_STRICT "Turn warnings into errors for docs target sphinxman" OFF)

--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -59,12 +59,14 @@ macro(psi4_add_module binlib libname sources)
 
   # This provides OpenMP flags and access to BLAS/LAPACK headers
   target_link_libraries(${libname}
-    PRIVATE
+#    PRIVATE
+    PUBLIC
       tgt::lapack
     )
   if(MSVC)
     target_link_libraries(${libname}
-      PRIVATE
+#      PRIVATE
+      PUBLIC
         Libint2::cxx
       )
   endif()

--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -59,14 +59,12 @@ macro(psi4_add_module binlib libname sources)
 
   # This provides OpenMP flags and access to BLAS/LAPACK headers
   target_link_libraries(${libname}
-#    PRIVATE
-    PUBLIC
+    PRIVATE
       tgt::lapack
     )
   if(MSVC)
     target_link_libraries(${libname}
-#      PRIVATE
-      PUBLIC
+      PRIVATE
         Libint2::cxx
       )
   endif()

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -59,6 +59,13 @@ target_include_directories(l2export
   PRIVATE
     $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
   )
+if(MSVC)
+  target_link_libraries(l2export
+    PRIVATE
+      pybind11::headers
+      pybind11::windows_extras
+    )
+endif()
 target_link_libraries(core PRIVATE l2export)
 
 # set_target_properties(core

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -52,6 +52,11 @@ target_sources(core
     python_data_type.cc
   )
 
+# need to down-standard the Libint2 connection from c++17 for Intel as of 2021.4
+set_source_files_properties(
+  export_mints.cc
+  PROPERTIES COMPILE_OPTIONS "-std=c++14")
+
 # set_target_properties(core
    # PROPERTIES
      # implicit in pybind11_add_module

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -38,7 +38,6 @@ target_sources(core
     export_dpd.cc
     export_fock.cc
     export_functional.cc
-    export_mints.cc
     export_misc.cc
     export_oeprop.cc
     export_pcm.cc
@@ -53,9 +52,10 @@ target_sources(core
   )
 
 # need to down-standard the Libint2 connection from c++17 for Intel as of 2021.4
-set_source_files_properties(
-  export_mints.cc
-  PROPERTIES COMPILE_OPTIONS "-std=c++14")
+add_library(l2export OBJECT export_mints.cc)
+set_property(TARGET l2export PROPERTY CXX_STANDARD 14)
+set_property(TARGET l2export PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(core PRIVATE l2export)
 
 # set_target_properties(core
    # PROPERTIES
@@ -111,6 +111,11 @@ endif()
 
 target_include_directories(core
   INTERFACE
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+  )
+target_include_directories(l2export
+  PRIVATE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
   )

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(core
     export_dpd.cc
     export_fock.cc
     export_functional.cc
+    export_mints.cc # ~TMP
     export_misc.cc
     export_oeprop.cc
     export_pcm.cc
@@ -52,10 +53,15 @@ target_sources(core
   )
 
 # need to down-standard the Libint2 connection from c++17 for Intel as of 2021.4
-add_library(l2export OBJECT export_mints.cc)
-set_property(TARGET l2export PROPERTY CXX_STANDARD 14)
-set_property(TARGET l2export PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(core PRIVATE l2export)
+if (MSVC)
+    set_source_files_properties(export_mints.cc PROPERTIES COMPILE_OPTIONS "-std:c++14")
+else()
+    set_source_files_properties(export_mints.cc PROPERTIES COMPILE_OPTIONS "-std=c++14")
+endif()
+#TMP add_library(l2export OBJECT export_mints.cc)
+#TMP set_property(TARGET l2export PROPERTY CXX_STANDARD 14)
+#TMP set_property(TARGET l2export PROPERTY POSITION_INDEPENDENT_CODE ON)
+#TMP target_link_libraries(core PRIVATE l2export)
 
 # set_target_properties(core
    # PROPERTIES
@@ -114,11 +120,11 @@ target_include_directories(core
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
   )
-target_include_directories(l2export
-  PRIVATE
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
-  )
+#TMP target_include_directories(l2export
+#TMP   PRIVATE
+#TMP #    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+#TMP     $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+#TMP   )
 
 install(TARGETS core
         EXPORT "psi4Targets"

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -53,11 +53,11 @@ target_sources(core
   )
 
 # need to down-standard the Libint2 connection from c++17 for Intel as of 2021.4
-if (MSVC)
-    set_source_files_properties(export_mints.cc PROPERTIES COMPILE_OPTIONS "-std:c++14")
-else()
-    set_source_files_properties(export_mints.cc PROPERTIES COMPILE_OPTIONS "-std=c++14")
-endif()
+#OK if (MSVC)
+#OK     set_source_files_properties(export_mints.cc PROPERTIES COMPILE_OPTIONS "-std:c++14")
+#OK else()
+#OK     set_source_files_properties(export_mints.cc PROPERTIES COMPILE_OPTIONS "-std=c++14")
+#OK endif()
 #TMP add_library(l2export OBJECT export_mints.cc)
 #TMP set_property(TARGET l2export PROPERTY CXX_STANDARD 14)
 #TMP set_property(TARGET l2export PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -118,7 +118,7 @@ endif()
 target_include_directories(core
   INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+#TMP2    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
   )
 #TMP target_include_directories(l2export
 #TMP   PRIVATE

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -38,7 +38,6 @@ target_sources(core
     export_dpd.cc
     export_fock.cc
     export_functional.cc
-    export_mints.cc # ~TMP
     export_misc.cc
     export_oeprop.cc
     export_pcm.cc
@@ -53,15 +52,14 @@ target_sources(core
   )
 
 # need to down-standard the Libint2 connection from c++17 for Intel as of 2021.4
-#OK if (MSVC)
-#OK     set_source_files_properties(export_mints.cc PROPERTIES COMPILE_OPTIONS "-std:c++14")
-#OK else()
-#OK     set_source_files_properties(export_mints.cc PROPERTIES COMPILE_OPTIONS "-std=c++14")
-#OK endif()
-#TMP add_library(l2export OBJECT export_mints.cc)
-#TMP set_property(TARGET l2export PROPERTY CXX_STANDARD 14)
-#TMP set_property(TARGET l2export PROPERTY POSITION_INDEPENDENT_CODE ON)
-#TMP target_link_libraries(core PRIVATE l2export)
+add_library(l2export OBJECT export_mints.cc)
+set_property(TARGET l2export PROPERTY CXX_STANDARD 14)
+set_property(TARGET l2export PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(l2export
+  PRIVATE
+    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+  )
+target_link_libraries(core PRIVATE l2export)
 
 # set_target_properties(core
    # PROPERTIES
@@ -118,13 +116,8 @@ endif()
 target_include_directories(core
   INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-#TMP2    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
   )
-#TMP target_include_directories(l2export
-#TMP   PRIVATE
-#TMP #    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-#TMP     $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
-#TMP   )
 
 install(TARGETS core
         EXPORT "psi4Targets"

--- a/psi4/src/export_cubeprop.cc
+++ b/psi4/src/export_cubeprop.cc
@@ -26,7 +26,6 @@
  * @END LICENSE
  */
 
-#include <libint2/shell.h>
 #include "psi4/pybind11.h"
 
 #include "psi4/libcubeprop/cubeprop.h"

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -26,7 +26,6 @@
  * @END LICENSE
  */
 
-#include <libint2/shell.h>
 #include "psi4/pybind11.h"
 
 #include "psi4/libfock/jk.h"

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -26,7 +26,6 @@
  * @END LICENSE
  */
 
-#include <libint2/shell.h>
 #include "psi4/pybind11.h"
 #include "psi4/libfunctional/superfunctional.h"
 #include "psi4/libfunctional/functional.h"

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -31,7 +31,6 @@
 #include <pybind11/pytypes.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/operators.h>
-#include <libint2/shell.h>
 
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libmints/basisset.h"
@@ -52,7 +51,7 @@
 #include "psi4/libmints/sointegral_twobody.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libmints/multipolesymmetry.h"
-#include "psi4/libmints/eri.h"
+//#include "psi4/libmints/eri.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/3coverlap.h"
 #include "psi4/libmints/pseudospectral.h"
@@ -1258,13 +1257,13 @@ void export_mints(py::module& m) {
         .def("update_density", &TwoBodyAOInt::update_density,
                        "Update density matrix (c1 symmetry) for Density-matrix based integral screening");
 
-    py::class_<Libint2TwoElectronInt, std::shared_ptr<Libint2TwoElectronInt>>(m, "TwoElectronInt", pyTwoBodyAOInt,
-                                                                "Computes two-electron repulsion integrals")
-        .def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell), "Compute ERIs between 4 shells")
-        .def("shell_significant", compute_shell_significant(&TwoBodyAOInt::shell_significant),
-                       "Determines if the P,Q,R,S shell combination is significant");
-
-    py::class_<Libint2ERI, std::shared_ptr<Libint2ERI>>(m, "ERI", pyTwoBodyAOInt, "Computes normal two electron repulsion integrals");
+//    py::class_<Libint2TwoElectronInt, std::shared_ptr<Libint2TwoElectronInt>>(m, "TwoElectronInt", pyTwoBodyAOInt,
+//                                                                "Computes two-electron repulsion integrals")
+//        .def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell), "Compute ERIs between 4 shells")
+//        .def("shell_significant", compute_shell_significant(&TwoBodyAOInt::shell_significant),
+//                       "Determines if the P,Q,R,S shell combination is significant");
+//
+    //py::class_<Libint2ERI, std::shared_ptr<Libint2ERI>>(m, "ERI", pyTwoBodyAOInt, "Computes normal two electron repulsion integrals");
 #ifdef ENABLE_Libint1t
     py::class_<F12, std::shared_ptr<F12>>(m, "F12", pyTwoBodyAOInt, "Computes F12 electron repulsion integrals");
     py::class_<F12G12, std::shared_ptr<F12G12>>(m, "F12G12", pyTwoBodyAOInt,

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -51,7 +51,7 @@
 #include "psi4/libmints/sointegral_twobody.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libmints/multipolesymmetry.h"
-//#include "psi4/libmints/eri.h"
+#include "psi4/libmints/eri.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/3coverlap.h"
 #include "psi4/libmints/pseudospectral.h"
@@ -1257,13 +1257,13 @@ void export_mints(py::module& m) {
         .def("update_density", &TwoBodyAOInt::update_density,
                        "Update density matrix (c1 symmetry) for Density-matrix based integral screening");
 
-//    py::class_<Libint2TwoElectronInt, std::shared_ptr<Libint2TwoElectronInt>>(m, "TwoElectronInt", pyTwoBodyAOInt,
-//                                                                "Computes two-electron repulsion integrals")
-//        .def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell), "Compute ERIs between 4 shells")
-//        .def("shell_significant", compute_shell_significant(&TwoBodyAOInt::shell_significant),
-//                       "Determines if the P,Q,R,S shell combination is significant");
-//
-    //py::class_<Libint2ERI, std::shared_ptr<Libint2ERI>>(m, "ERI", pyTwoBodyAOInt, "Computes normal two electron repulsion integrals");
+    py::class_<Libint2TwoElectronInt, std::shared_ptr<Libint2TwoElectronInt>>(m, "TwoElectronInt", pyTwoBodyAOInt,
+                                                                "Computes two-electron repulsion integrals")
+        .def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell), "Compute ERIs between 4 shells")
+        .def("shell_significant", compute_shell_significant(&TwoBodyAOInt::shell_significant),
+                       "Determines if the P,Q,R,S shell combination is significant");
+
+    py::class_<Libint2ERI, std::shared_ptr<Libint2ERI>>(m, "ERI", pyTwoBodyAOInt, "Computes normal two electron repulsion integrals");
 #ifdef ENABLE_Libint1t
     py::class_<F12, std::shared_ptr<F12>>(m, "F12", pyTwoBodyAOInt, "Computes F12 electron repulsion integrals");
     py::class_<F12G12, std::shared_ptr<F12G12>>(m, "F12G12", pyTwoBodyAOInt,

--- a/psi4/src/export_pcm.cc
+++ b/psi4/src/export_pcm.cc
@@ -26,7 +26,6 @@
  * @END LICENSE
  */
 
-#include <libint2/shell.h>
 #include "psi4/pybind11.h"
 
 #include "psi4/libmints/basisset.h"

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -27,7 +27,6 @@
  */
 
 #include <string>
-#include <libint2/shell.h>
 
 #include "psi4/pybind11.h"
 

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -64,28 +64,28 @@ list(APPEND sources
   gaussquad.cc
   ecpint.cc
   orthog.cc
-  eri.cc      # ~TMP
-  eribase.cc  # ~TMP
-  integral.cc # ~TMP
+#  eri.cc      # ~TMP
+#  eribase.cc  # ~TMP
+#  integral.cc # ~TMP
   )
 
-if (MSVC)
-    set_source_files_properties(eri.cc eribase.cc integral.cc PROPERTIES COMPILE_OPTIONS "-std:c++14")
-else()
-    set_source_files_properties(eri.cc eribase.cc integral.cc PROPERTIES COMPILE_OPTIONS "-std=c++14")
-endif()
+#OK if (MSVC)
+#OK     set_source_files_properties(eri.cc eribase.cc integral.cc PROPERTIES COMPILE_OPTIONS "-std:c++14")
+#OK else()
+#OK     set_source_files_properties(eri.cc eribase.cc integral.cc PROPERTIES COMPILE_OPTIONS "-std=c++14")
+#OK endif()
 
-#TMP add_library(l2intf OBJECT eri.cc eribase.cc integral.cc)
-#TMP set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
-#TMP set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
-#TMP target_include_directories(l2intf
-#TMP   PRIVATE
-#TMP     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-#TMP     $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
-#TMP   )
+add_library(l2intf OBJECT eri.cc eribase.cc integral.cc)
+set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
+set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(l2intf
+  PRIVATE
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 
 psi4_add_module(lib mints sources)
-#TMP target_link_libraries(mints PRIVATE l2intf)
+target_link_libraries(mints PRIVATE l2intf)
 
 # Always linked-to external projects
 #target_link_libraries(l2intf

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -64,21 +64,34 @@ list(APPEND sources
   gaussquad.cc
   ecpint.cc
   orthog.cc
+  eri.cc      # ~TMP
+  eribase.cc  # ~TMP
+  integral.cc # ~TMP
   )
 
-add_library(l2intf OBJECT eri.cc eribase.cc integral.cc)
-set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
-set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(l2intf
-  PRIVATE
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
-  )
+if (MSVC)
+    set_source_files_properties(eri.cc eribase.cc integral.cc PROPERTIES COMPILE_OPTIONS "-std:c++14")
+else()
+    set_source_files_properties(eri.cc eribase.cc integral.cc PROPERTIES COMPILE_OPTIONS "-std=c++14")
+endif()
+
+#TMP add_library(l2intf OBJECT eri.cc eribase.cc integral.cc)
+#TMP set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
+#TMP set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
+#TMP target_include_directories(l2intf
+#TMP   PRIVATE
+#TMP     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+#TMP     $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+#TMP   )
 
 psi4_add_module(lib mints sources)
-target_link_libraries(mints PRIVATE l2intf)
+#TMP target_link_libraries(mints PRIVATE l2intf)
 
 # Always linked-to external projects
+#target_link_libraries(l2intf
+#  PUBLIC
+#    Libint2::cxx
+#  )
 target_link_libraries(mints
   PUBLIC
     Libint2::cxx

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -69,15 +69,16 @@ list(APPEND sources
 add_library(l2intf OBJECT eri.cc eribase.cc integral.cc)
 set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
 set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(l2intf
+  PRIVATE
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 
 psi4_add_module(lib mints sources)
 target_link_libraries(mints PRIVATE l2intf)
 
 # Always linked-to external projects
-target_link_libraries(l2intf
-  PUBLIC
-    Libint2::cxx
-  )
 target_link_libraries(mints
   PUBLIC
     Libint2::cxx

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -69,6 +69,12 @@ list(APPEND sources
   orthog.cc
   )
 
+# CXX_STANDARD property for targets, not files, hence the double flag
+set_source_files_properties(
+  eri.cc
+  eribase.cc
+  PROPERTIES COMPILE_OPTIONS "-std=c++14")
+
 psi4_add_module(lib mints sources)
 
 # Always linked-to external projects

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -24,13 +24,11 @@ list(APPEND sources
   electrostatic.cc
   wavefunction.cc
   irrep.cc
-  eribase.cc
   fjt.cc
   potentialint.cc
   chartab.cc
   corrtab.cc
   quadrupole.cc
-  eri.cc
   symop.cc
   benchmark.cc
   get_writer_file_prefix.cc
@@ -54,7 +52,6 @@ list(APPEND sources
   kinetic.cc
   tracelessquadrupole.cc
   pseudospectral.cc
-  integral.cc
   matrix.cc
   gshell.cc
   integraliter.cc
@@ -69,16 +66,18 @@ list(APPEND sources
   orthog.cc
   )
 
-# CXX_STANDARD property for targets, not files, hence the double flag
-set_source_files_properties(
-  eri.cc
-  eribase.cc
-  integral.cc
-  PROPERTIES COMPILE_OPTIONS "-std=c++14")
+add_library(l2intf OBJECT eri.cc eribase.cc integral.cc)
+set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
+set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 psi4_add_module(lib mints sources)
+target_link_libraries(mints PRIVATE l2intf)
 
 # Always linked-to external projects
+target_link_libraries(l2intf
+  PUBLIC
+    Libint2::cxx
+  )
 target_link_libraries(mints
   PUBLIC
     Libint2::cxx

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -73,6 +73,7 @@ list(APPEND sources
 set_source_files_properties(
   eri.cc
   eribase.cc
+  integral.cc
   PROPERTIES COMPILE_OPTIONS "-std=c++14")
 
 psi4_add_module(lib mints sources)

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -78,11 +78,22 @@ list(APPEND sources
 add_library(l2intf OBJECT eri.cc eribase.cc integral.cc)
 set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
 set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(l2intf
+#target_include_directories(l2intf
+#  PRIVATE
+#    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+#    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+#  )
+target_link_libraries(l2intf
   PRIVATE
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
+    tgt::lapack
   )
+#if(MSVC)
+  target_link_libraries(l2intf
+    PRIVATE
+      Libint2::cxx
+      )
+#endif()
+
 
 psi4_add_module(lib mints sources)
 target_link_libraries(mints PRIVATE l2intf)

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -64,45 +64,24 @@ list(APPEND sources
   gaussquad.cc
   ecpint.cc
   orthog.cc
-#  eri.cc      # ~TMP
-#  eribase.cc  # ~TMP
-#  integral.cc # ~TMP
   )
-
-#OK if (MSVC)
-#OK     set_source_files_properties(eri.cc eribase.cc integral.cc PROPERTIES COMPILE_OPTIONS "-std:c++14")
-#OK else()
-#OK     set_source_files_properties(eri.cc eribase.cc integral.cc PROPERTIES COMPILE_OPTIONS "-std=c++14")
-#OK endif()
 
 add_library(l2intf OBJECT eri.cc eribase.cc integral.cc)
 set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
 set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
-#target_include_directories(l2intf
-#  PRIVATE
-#    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-#    $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
-#  )
+# below are what l2intf files would ordinarily have gotten from psi4_add_module.
+# * first brings OpenMP headers
+# * second brings l2. Linux needs only headers, but Windows needs headers and linking, so slight overkill here
 target_link_libraries(l2intf
   PRIVATE
     tgt::lapack
+    Libint2::cxx
   )
-#if(MSVC)
-  target_link_libraries(l2intf
-    PRIVATE
-      Libint2::cxx
-      )
-#endif()
-
 
 psi4_add_module(lib mints sources)
 target_link_libraries(mints PRIVATE l2intf)
 
 # Always linked-to external projects
-#target_link_libraries(l2intf
-#  PUBLIC
-#    Libint2::cxx
-#  )
 target_link_libraries(mints
   PUBLIC
     Libint2::cxx
@@ -117,16 +96,16 @@ if(TARGET Libint::libint)
 endif()
 
 if(TARGET simint::simint)
-  target_sources(mints
+  target_sources(l2intf
     PRIVATE
       siminteri.cc
     )
   # Add USING_simint definition, which is not in simint::simint
-  target_compile_definitions(mints
+  target_compile_definitions(l2intf
     PUBLIC
       USING_simint
     )
-  target_link_libraries(mints
+  target_link_libraries(l2intf
     PUBLIC
       simint::simint
     )

--- a/psi4/src/psi4/libmints/eri.cc
+++ b/psi4/src/psi4/libmints/eri.cc
@@ -32,8 +32,8 @@
 #include "psi4/libmints/fjt.h"
 #include "psi4/libqt/qt.h"
 
-#include <libint2/engine.h>
 #include <libint2/shell.h>
+#include <libint2/engine.h>
 using namespace psi;
 
 /////////

--- a/psi4/src/psi4/libmints/eribase.cc
+++ b/psi4/src/psi4/libmints/eribase.cc
@@ -37,8 +37,8 @@
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-#include <libint2/engine.h>
 #include <libint2/shell.h>
+#include <libint2/engine.h>
 
 #include <algorithm>
 #include <memory>


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. --> @andysim's suggestion worked! Overcomes the bad combination of Intel icpc, c++17 standard, and Libint2 (water energy off by 50 Eh). I've only run smoke tests so far but will fix that tomorrow.

*EDIT* I removed some l2 headers among the export_* files that didn't seem to be necessary. And I reordered some l2 headers for consistency with the l2 convenience header. this'll need a little adaptation after #2388 merge, I expect.

## Checklist
- [ ] ~Tests added for any new features~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
