### PR TITLE
Allow `matrix` Comparison

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -482,9 +482,8 @@ void export_mints(py::module& m) {
         .def("clone", &Matrix::clone, "Creates exact copy of the matrix and returns it")
         .def_property("name", py::cpp_function(&Matrix::name), py::cpp_function(&Matrix::set_name),
                       "The name of the Matrix. Used in printing.")
-
-        // def("set_name", &Matrix::set_name, "docstring").
-        // def("name", &Matrix::name, py::return_value_policy::copy, "docstring").
+        .def("is_approx_equal", &Matrix::is_approx_equal, "Is this approximately equal to other matrix within tolerance?",
+             "other"_a, "tol"_a = 1e-10)
         .def("print_out", &Matrix::print_out, "Prints the matrix to the output file")
         .def("print_atom_vector", &Matrix::print_atom_vector, "RMRoutfile"_a = "outfile",
              "Print the matrix with atom labels, assuming it is an natom X 3 tensor")

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -316,6 +316,30 @@ SharedMatrix Matrix::clone() const {
     return temp;
 }
 
+bool Matrix::is_approx_equal(const Matrix& other, double tol) const {
+    auto result = name_ == other.name();
+    result = result && nirrep_ == other.nirrep();
+    result = result && rowspi_ == other.rowspi();
+    result = result && colspi_ == other.colspi();
+    result = result && symmetry_ == other.symmetry();
+    result = result && numpy_shape_ == other.numpy_shape();
+    if (!result) {
+        return false;
+    }
+    for (int h = 0; h < nirrep_; ++h) {
+        auto my_pointer = get_pointer(h);
+        auto other_pointer = other.get_pointer(h);
+        for (int m = 0; m < rowspi_[h] * colspi_[h ^ symmetry_]; ++m) {
+            if (std::abs(*my_pointer - *other_pointer) > tol) {
+                return false;
+            }
+            my_pointer++;
+            other_pointer++;
+        }
+    }
+    return true;
+}
+
 void Matrix::copy(const Matrix *cp) {
     // Make sure we are the same size as cp
     bool same = true;

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -271,6 +271,8 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     void copy(const Matrix* cp);
     /** @} */
 
+    bool is_approx_equal(const Matrix& other, double tol = 1e-10) const;
+
     /**
     ** For a matrix of 3D vectors (ncol==3), rotate a set of points around an
     ** arbitrary axis.  Vectors are the rows of the matrix.
@@ -1121,7 +1123,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * Adds accessability to the matrix shape for numpy
      */
     void set_numpy_shape(std::vector<int> shape) { numpy_shape_ = shape; }
-    std::vector<int> numpy_shape() { return numpy_shape_; }
+    const std::vector<int> numpy_shape() const { return numpy_shape_; }
 
     /**
      * Rotates columns i and j in irrep h, by an angle theta

--- a/tests/pytests/test_matrix.py
+++ b/tests/pytests/test_matrix.py
@@ -224,3 +224,11 @@ def test_doublets(adl, adr, Ga, bdl, bdr, Gb, at, bt):
     block_checks = []
     for blk_idx in range(res.nirrep()):
         assert compare_arrays(expected[blk_idx], res_blocks[blk_idx], 8, f"Block[{blk_idx}]")
+
+def test_approx_equal():
+    a = build_random_mat(Dimension([5]), Dimension([5]))
+    a.name = "Test Matrix"
+    b = a.clone()
+    assert a.is_approx_equal(b)
+    b.identity()
+    assert not a.is_approx_equal(b)


### PR DESCRIPTION
## Description
Provides and exposes a `matrix` method to check if two matrices are the same, within a given tolerance. This may allow for some simplifying of the test infrastructure, but I don't know the test infrastructure nearly well enough to say.

## Checklist
- [x] `test_matrix.py` passes

## Status
- [x] Ready for review
- [x] Ready for merge
