### PR TITLE
Misc. testing changes

### DIFF
--- a/psi4/driver/p4util/testing.py
+++ b/psi4/driver/p4util/testing.py
@@ -81,6 +81,9 @@ def _mergedapis_compare_matrices(expected, computed, *args, **kwargs):
 
     qcdb.testing._merge_psi4_qcel_apis(args, kwargs)
 
+    if kwargs.pop("check_name", False):
+        compare(expected.name, computed.name, f'{expected.name} vs. {computed.name} name', quiet=True)
+
     compare(expected.nirrep(), computed.nirrep(), f'{expected.name} vs. {computed.name} irreps', quiet=True)
     compare(expected.symmetry(), computed.symmetry(), f'{expected.name} vs. {computed.name} symmetry', quiet=True)
     for irrep in range(expected.nirrep()):

--- a/psi4/driver/qcdb/testing.py
+++ b/psi4/driver/qcdb/testing.py
@@ -112,7 +112,7 @@ def _mergedapis_compare_recursive(expected, computed, *args, **kwargs):
             ' Use the new `qcel.testing.compare_recursive` API, being sure to convert positional arg `digits` decimal places to keyword arg `atol` literal absolute tolerance.'
         )
 
-    return qcel.testing.compare_molrecs(expected, computed, *args, **kwargs)
+    return qcel.testing.compare_recursive(expected, computed, *args, **kwargs)
 
 
 def _mergedapis_compare_molrecs(expected, computed, *args, **kwargs):

--- a/tests/pytests/test_testing.py
+++ b/tests/pytests/test_testing.py
@@ -31,6 +31,7 @@ _mats = {
     'dimvecnear': psi4.core.Vector.from_array([np.arange(4), np.array([0.0001, 1.0001, 2.0001]), np.arange(5)]),
     'dimvecdim': psi4.core.Vector.from_array([np.arange(4), np.arange(3)]),
     'dimmat': psi4.core.Matrix.from_array([np.arange(4).reshape(2, 2), np.zeros((0, 3)), np.arange(16).reshape(4, 4)]),
+    'dimmatnamed': psi4.core.Matrix.from_array([np.arange(4).reshape(2, 2), np.zeros((0, 3)), np.arange(16).reshape(4, 4)], "Name"),
     'dimmatshape': psi4.core.Matrix.from_array([np.arange(4).reshape(2, 2), np.ones((0, 3)), np.arange(16).reshape(2, 8)]),
     'dimmatdim': psi4.core.Matrix.from_array([np.arange(4).reshape(2, 2), np.ones((0, 3))]),
     'dimmatnear': psi4.core.Matrix.from_array([np.array([[0.0001, 1.0001], [2.0001, 3.0001]]), np.zeros((0, 3)), np.arange(16).reshape(4, 4)]),
@@ -38,7 +39,7 @@ _mats = {
 
 
 @pytest.mark.parametrize(
-    "fn,args,kwargs",
+    "fn, args, kwargs",
     [
         # scalar int
         (psi4.compare_integers, [1, 1, 'labeled'], {}),
@@ -76,6 +77,7 @@ _mats = {
         (psi4.compare_matrices, [_mats['dimmat'], _mats['dimmat'], 'labeled'], {}),
         (psi4.compare_matrices, [_mats['dimmat'], _mats['dimmatnear'], 2], {}),
         (psi4.compare_matrices, [_mats['dimmat'], _mats['dimmatnear']], {'atol': 0.001}),
+        (psi4.compare_matrices, [_mats['dimmat'], _mats['dimmatnamed']], {'check_name': False}),
 
         # dicts
         (psi4.compare_recursive, [_dcts['ell'], _dcts['ell'], 'labeled'], {}),
@@ -87,7 +89,7 @@ def test_psi4_compare_true(fn, args, kwargs):
 
 
 @pytest.mark.parametrize(
-    "fn,args,kwargs",
+    "fn, args, kwargs",
     [
         # scalar int
         (qcdb.compare_integers, [1, 1, 'labeled'], {}),
@@ -128,7 +130,7 @@ def test_qcdb_compare_true(fn, args, kwargs):
 
 
 @pytest.mark.parametrize(
-    "fn,args,kwargs",
+    "fn, args, kwargs",
     [
         # scalar int
         (psi4.compare_integers, [1, 2, 'labeled'], {}),
@@ -169,6 +171,7 @@ def test_qcdb_compare_true(fn, args, kwargs):
         (psi4.compare_matrices, [_mats['dimmat'], _mats['dimmatdim']], {}),
         (psi4.compare_matrices, [_mats['dimmat'], _mats['dimmatnear'], 6], {}),
         (psi4.compare_matrices, [_mats['dimmat'], _mats['dimmatnear']], {}),
+        (psi4.compare_matrices, [_mats['dimmat'], _mats['dimmatnamed']], {'check_name': True}),
 
         # dicts
         (psi4.compare_recursive, [_dcts['elll'], _dcts['ell']], {}),
@@ -180,7 +183,7 @@ def test_psi4_compare_raise(fn, args, kwargs):
 
 
 @pytest.mark.parametrize(
-    "fn,args,kwargs",
+    "fn, args, kwargs",
     [
         # scalar int
         (qcdb.compare_integers, [1, 2, 'labeled'], {}),


### PR DESCRIPTION
## Description
This PR fixes a bug found by Lori, and gives `compare_matrices` the ability to compare names. Although Lori and I were in talks about some other improvements to comparison functions, those would touch `qcelemental` so can't be included here.

This blocks some development on another branch, so I'd appreciate a fast review.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Fixes `compare_recursive` bug
- [x] Adds flag to `compare_matrices` so named can be checked

## Checklist
- [x] New tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
