### PR TITLE
fix fchk again

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -2051,7 +2051,8 @@ def fchk(wfn: core.Wavefunction, filename: str, *, debug: bool = False, strict_l
 
     # At this point we don't know the method name, so we try to search for it.
     # idea: get the method from the variable matching closely the 'current energy'
-    varlist = wfn.scalar_variables()
+    # for varlist, wfn is long-term and to allow from-file wfns. core is b/c some modules not storing in wfn yet
+    varlist = {**wfn.scalar_variables(), **core.scalar_variables()}
     current = varlist['CURRENT ENERGY']
 
     # delete problematic entries


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This works with both test_fchk_writer and #2400 (needed for independent run of fchk()). Thank goodness the fchk tester had a dfocc (comparatively old-style storage) case.

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
