### PR TITLE
Update CMake fork of Libint2, c. 2019 -> c. 2022

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@ jobs:
   timeoutInMinutes: 120
   variables:
     CTEST_OUTPUT_ON_FAILURE: 1
-    MKL_CBWR: AVX
+    MKL_CBWR: AUTO
   strategy:
     maxParallel: 8
     matrix:
@@ -86,7 +86,7 @@ jobs:
         -n p4env \
         python=$PYTHON_VER \
         psi4/label/dev::gau2grid \
-        psi4/label/dev::libint2=2.6.0=h2fe1556_13 \
+        psi4/label/testing::libint2=*=h2fe1556_15 \
         psi4/label/dev::libxc=5 \
         psi4/label/dev::ambit \
         psi4/label/dev::chemps2 \
@@ -108,7 +108,6 @@ jobs:
         networkx \
         pytest \
         eigen \
-        mpfr \
         pytest-xdist \
         msgpack-python \
         conda-forge::qcelemental \

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -129,9 +129,8 @@ jobs:
                         psi4/label/dev::dftd3 ^
                         psi4/label/dev::gcp ^
                         conda-forge::gau2grid ^
-                        psi4/label/dev::libint2=2.6.0=h2e52968_5 ^
                         conda-forge::libxc ^
-                        conda-forge::mpfr ^
+                        psi4/label/testing::libint2=*=h2e52968_4 ^
                         conda-forge::mpmath ^
                         conda-forge::msgpack-python ^
                         conda-forge::qcelemental ^
@@ -185,8 +184,9 @@ jobs:
                 -DCMAKE_CXX_FLAGS="/arch:AVX" ^
                 -DMAX_AM_ERI=!MAX_AM_ERI! ^
                 -DPython_EXECUTABLE="C:/tools/miniconda3/python.exe" ^
-                -DMPFR_ROOT="C:/tools/miniconda3/Library" ^
-                -DEigen_ROOT="C:/tools/miniconda3/Library" ^
+                -DEigen3_ROOT="C:/tools/miniconda3/Library" ^
+                -DBOOST_ROOT="C:/tools/miniconda3/Library" ^
+                -DMultiprecision_ROOT="C:/tools/miniconda3/Library" ^
                 -DBUILD_Libint2_GENERATOR=OFF ^
                 -DCMAKE_INSIST_FIND_PACKAGE_gau2grid=ON ^
                 -DCMAKE_INSIST_FIND_PACKAGE_Libint2=ON ^

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #    - pint (runtime only; e.g., `conda install pint -c conda-forge`)
 #    - pydantic >=1.0 (runtime only; e.g., `conda install pydantic -c conda-forge`)
 #    - msgpack-python (runtime only; e.g., `conda install msgpack-python`)
-#    - mpfr (for Libint2; e.g., `conda install mpfr`))
 #    - Eigen (for Libint2; e.g., `conda install eigen`)
 #    - SciPy (runtime only; e.g., `conda install scipy`)
 
@@ -274,6 +273,7 @@ ExternalProject_Add(psi4-core
               -DENABLE_OPENMP=${ENABLE_OPENMP}
               -DTargetLAPACK_DIR=${TargetLAPACK_DIR}
               -DTargetHDF5_DIR=${TargetHDF5_DIR}
+              -DEigen3_DIR=${Eigen3_DIR}
               -Dambit_DIR=${ambit_DIR}
               -DCheMPS2_DIR=${CheMPS2_DIR}
               -Ddkh_DIR=${dkh_DIR}

--- a/external/upstream/libint2/CMakeLists.txt
+++ b/external/upstream/libint2/CMakeLists.txt
@@ -6,6 +6,7 @@
 #   This is not the default, though it may become runtime selectable in future https://github.com/evaleev/libint/issues/190#issuecomment-691485225 .
 # * In order for any DF to work, need ENABLE_ERI3 and ENABLE_ERI2 >=0
 # * In order for gradient and Hessian tests to not segfault, need ENABLE_ERI and ENABLE_ERI3 and ENABLE_ERI2 =2
+# * (new c. Jan 2022) In order for Psi4 to at all work with a libint2 build for one-electron ints, need ENABLE_ONEBODY =2
 # * The `find_package(Libint2 ... COMPONENTS ...)` commands will check the above requirements met, provided the libint2
 #   was built with cmake+cmake, not libtool+cmake.
 # * Provided you know what you're doing wrt the above options and know what subset of Psi4 calculations you're targeting
@@ -24,17 +25,16 @@
 # * If ever use a libint2 with AM>7, edit the `init_spherical_harmonics` line in libmints/integral.cc
 # * In selecting AM values, before `grep`ing lots of basis set files, consult the guide at end of this file.
 
-
 # CHOOSE! `make export`
 #find_package(Libint2 CONFIG)
 # CHOOSE! pure cmake
-find_package(Libint2 CONFIG COMPONENTS gss "e${MAX_AM_ERI}" g2 h2 eri3_e4 eri3_g3 eri3_h3 eri2_e4 eri2_g3 eri2_h3)
+find_package(Libint2 CONFIG COMPONENTS gss CXX_ho impure_sh "eri_c4_d0_l${MAX_AM_ERI}" eri_c4_d1_l2 eri_c4_d2_l2 eri_c3_d0_l4 eri_c3_d1_l3 eri_c3_d2_l3 eri_c2_d0_l4 eri_c2_d1_l3 eri_c2_d2_l3 onebody_d0_l4 onebody_d1_l3 onebody_d2_l3)
 
 if(${Libint2_FOUND})
     # CHOOSE! `make export`
     #get_property(_loc TARGET Libint2::int2 PROPERTY LOCATION)
     # CHOOSE! pure cmake
-    get_property(_loc TARGET Libint2::cxx PROPERTY LOCATION)
+    get_property(_loc TARGET Libint2::int2 PROPERTY LOCATION)
     message(STATUS "${Cyan}Found Libint2 ${Libint2_MAX_AM_ERI}${ColourReset}: ${_loc} (found version ${Libint2_VERSION})")
     add_library(libint2_external INTERFACE)  # dummy
 else()
@@ -43,14 +43,6 @@ else()
     endif()
 
     include(ExternalProject)
-
-    if(${BUILD_SHARED_LIBS})
-        set(_a_only  OFF)
-        set(_so_only ON)
-    else()
-        set(_a_only  ON)
-        set(_so_only OFF)
-    endif()
 
     if(NOT ${BUILD_Libint2_GENERATOR})
         if (${MAX_AM_ERI} GREATER 5)
@@ -67,8 +59,8 @@ else()
             set(_url_am_src "1-0-0-0-0-0")  #    99  # LGTM_SRC bulids
         endif()
 
-        #set(_url_l2_tarball "https://github.com/loriab/libint/releases/download/v0.1/Libint2-export-${_url_am_src}_1.tgz")
-        set(_url_l2_tarball "https://github.com/loriab/libint/releases/download/v0.1/Libint2-export-5-4-3-6-5-4_mm4ob2.tgz")
+        #TODO set(_url_l2_tarball "https://github.com/loriab/libint/releases/download/v0.1/Libint2-export-${_url_am_src}_1.tgz")
+        set(_url_l2_tarball "https://github.com/loriab/libint/releases/download/v0.1/Libint2-export-5-4-3-6-5-4_mm4f12ob2.tgz")
 
         message(STATUS "Suitable Libint2 could not be located, ${Magenta}Building Libint2 ${_url_am_src}${ColourReset} instead.")
 
@@ -79,28 +71,33 @@ else()
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                       -DCMAKE_INSTALL_BINDIR=${CMAKE_INSTALL_BINDIR}
                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                        -DBOOST_ROOT=${BOOST_ROOT}
                        -DEigen3_DIR=${Eigen3_DIR}
-                       -DMPFR_ROOT=${MPFR_ROOT}
                        -DLIBINT2_SHGAUSS_ORDERING=gaussian
-                       -DBUILD_SHARED=${_so_only}
-                       -DBUILD_STATIC=${_a_only}
-                       -DENABLE_CXX11API=ON
+                       #-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                       -DBUILD_SHARED_LIBS=OFF
+                       -DREQUIRE_CXX_API=ON
+                       -DREQUIRE_CXX_API_COMPILED=OFF
                        -DENABLE_FORTRAN=OFF
                        -DENABLE_XHOST=${ENABLE_XHOST}
-                       -DBUILD_FPIC=${BUILD_FPIC}
             CMAKE_CACHE_ARGS -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
                              -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS})
 
     else()
         message(STATUS "Suitable Libint2 could not be located, ${Magenta}Building Libint2${ColourReset} from generator source instead.")
         message(WARNING "${Yellow}Libint2 generator source build requires Ninja (not Makefile) builder and Boost, Eigen, and MPFR dependencies. The build will be very long for non-trivial AM, and parallelism won't help for parts. Edit external/upstream/libint2/CMakeLists.txt for AM settings.${ColourReset}")
+
+        if (MSVC)
+            message(FATAL_ERROR "${Red}Libint2 generator source build faulty on Windows.${ColourReset}")
+        endif()
+
         # NOTE: active AM settings below will pass few tests, as they're set for 1st row triple-zeta ene and double-zeta ene/grad/hess for both conv/df. Please edit for desired use.
 
         ExternalProject_Add(libint2_external
-            URL https://github.com/loriab/libint/archive/l2cmake.zip
+            URL https://github.com/loriab/libint/archive/new-cmake-harness-lab-rb1.zip
             CMAKE_ARGS -GNinja
                        -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -115,15 +112,15 @@ else()
                        -DBOOST_ROOT=${BOOST_ROOT}
                        -DEigen3_DIR=${Eigen3_DIR}
                        -DEigen3_ROOT=${Eigen3_ROOT}
-                       -DMPFR_ROOT=${MPFR_ROOT}
+                       -DMultiprecision_ROOT=${Multiprecision_ROOT}
                        -DERI3_PURE_SH=OFF
                        -DERI2_PURE_SH=OFF
                        -DLIBINT2_SHGAUSS_ORDERING=gaussian
                        -DLIBINT2_CARTGAUSS_ORDERING=standard
                        -DLIBINT2_SHELL_SET=standard
-                       -DBUILD_SHARED=${_so_only}
-                       -DBUILD_STATIC=${_a_only}
-                       -DENABLE_CXX11API=ON
+                       -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                       -DREQUIRE_CXX_API=ON
+                       -DREQUIRE_CXX_API_COMPILED=OFF
                        -DENABLE_FORTRAN=OFF
                        -DBUILD_TESTING=${BUILD_TESTING}
                        -DENABLE_XHOST=${ENABLE_XHOST}

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external
-        URL https://github.com/pybind/pybind11/archive/v2.7.0.tar.gz
+        URL https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -161,11 +161,12 @@ endif()
 
 # CHOOSE! this one for pure cmake libint2 library
 if(DEFINED ENV{LGTM_SRC})
-    find_package(Libint2 CONFIG REQUIRED COMPONENTS gss "e${MAX_AM_ERI}")
+    find_package(Libint2 CONFIG REQUIRED COMPONENTS gss "eri_c4_d0_l${MAX_AM_ERI}")
 else()
-    find_package(Libint2 CONFIG REQUIRED COMPONENTS gss "e${MAX_AM_ERI}" g2 h2 eri3_e4 eri3_g3 eri3_h3 eri2_e4 eri2_g3 eri2_h3)
+    find_package(Libint2 CONFIG REQUIRED COMPONENTS gss CXX_ho impure_sh "eri_c4_d0_l${MAX_AM_ERI}" eri_c4_d1_l2 eri_c4_d2_l2 eri_c3_d0_l4 eri_c3_d1_l3 eri_c3_d2_l3 eri_c2_d0_l4 eri_c2_d1_l3 eri_c2_d2_l3 onebody_d0_l4 onebody_d1_l3 onebody_d2_l3)
+
 endif()
-get_property(_loc TARGET Libint2::cxx PROPERTY LOCATION)
+get_property(_loc TARGET Libint2::int2 PROPERTY LOCATION)
 
 list(APPEND _addons ${_loc})
 message(STATUS "${Cyan}Using Libint2 ${Libint2_MAX_AM_ERI}${ColourReset}: ${_loc} (version ${Libint2_VERSION})")
@@ -222,9 +223,15 @@ endif()
 
 if(MSVC)
     # MSVC does not include <cmath> constants, unless _USE_MATH_DEFINES is defined.
-    add_definitions("/D_USE_MATH_DEFINES")
+    # _CRT_* to squash some getenv, strdup, strncpy, ctime, fopen warnings
+    add_compile_definitions(
+      _USE_MATH_DEFINES
+      _CRT_NONSTDC_NO_DEPRECATE
+      _CRT_NONSTDC_NO_WARNINGS
+      _CRT_SECURE_NO_WARNINGS
+      )
     # Set the exception handling model
-    add_definitions("/EHsc")
+    add_compile_options("/EHsc")
 endif()
 
 include_directories(include)

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -59,10 +59,15 @@ target_include_directories(l2export
   PRIVATE
     $<TARGET_PROPERTY:Libint2::cxx,INTERFACE_INCLUDE_DIRECTORIES>
   )
+target_link_libraries(
+  l2export
+  PRIVATE
+    pybind11::headers
+  )
 if(MSVC)
-  target_link_libraries(l2export
+  target_link_libraries(
+    l2export
     PRIVATE
-      pybind11::headers
       pybind11::windows_extras
     )
 endif()

--- a/psi4/src/psi4/libfock/CMakeLists.txt
+++ b/psi4/src/psi4/libfock/CMakeLists.txt
@@ -31,6 +31,7 @@ target_compile_definitions(fock
 target_link_libraries(fock
   PRIVATE
     gau2grid::gg
+    pybind11::headers
   )
 
 if(TARGET BrianQC::static_wrapper)

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -39,44 +39,51 @@ PRAGMA_WARNING_POP
 #include "onebody.h"
 #include "twobody.h"
 
+
+namespace psi {
+
 /*! \def INT_NCART(am)
     Gives the number of cartesian functions for an angular momentum.
 */
-#if !defined(INT_NCART)
-#define INT_NCART(am) ((am >= 0) ? ((((am) + 2) * ((am) + 1)) >> 1) : 0)
-#endif
+inline int INT_NCART(unsigned int am) {
+    return (am >= 0) ? ((((am) + 2) * ((am) + 1)) >> 1) : 0;
+}
+
 /*! \def INT_PURE(am)
     Gives the number of spherical functions for an angular momentum.
 */
-#if !defined(INT_NPURE)
-#define INT_NPURE(am) (2 * (am) + 1)
-#endif
+inline int INT_NPURE(unsigned int am) {
+    return 2 * (am) + 1;
+}
+
 /*! \def INT_NFUNC(pu,am)
     Gives the number of functions for an angular momentum based on pu.
 */
-#if !defined(INT_NFUNC)
-#define INT_NFUNC(pu, am) ((pu) ? INT_NPURE(am) : INT_NCART(am))
-#endif
+inline int INT_NFUNC(unsigned int pu, unsigned int am) {
+    return (pu) ? INT_NPURE(am) : INT_NCART(am);
+}
+
 /*! \def INT_CARTINDEX(am,i,j)
     Computes offset index for cartesian function.
 */
-#if !defined(INT_CARTINDEX)
-#define INT_CARTINDEX(am, i, j) (((i) == (am)) ? 0 : (((((am) - (i) + 1) * ((am) - (i))) >> 1) + (am) - (i) - (j)))
-#endif
+inline int INT_CARTINDEX(unsigned int am, int i, int j) {
+    return ((i) == (am)) ? 0 : (((((am) - (i) + 1) * ((am) - (i))) >> 1) + (am) - (i) - (j));
+}
+
 /*! \def INT_ICART(a, b, c)
     Given a, b, and c compute a cartesian offset.
 */
-#if !defined(INT_ICART)
-#define INT_ICART(a, b, c) (((((((a) + (b) + (c) + 1) << 1) - (a)) * ((a) + 1)) >> 1) - (b)-1)
-#endif
+inline int INT_ICART(int a, int b, int c) {
+    return ((((((a) + (b) + (c) + 1) << 1) - (a)) * ((a) + 1)) >> 1) - (b)-1;
+}
+
 /*! \def INT_IPURE(l, m)
     Given l and m compute a pure function offset.
 */
-#if !defined(INT_IPURE)
-#define INT_IPURE(l, m) ((l) + (m))
-#endif
+inline int INT_IPURE(int l, int m) {
+    return (l) + (m);
+}
 
-namespace psi {
 
 class BasisSet;
 class GaussianShell;

--- a/psi4/src/psi4/libqt/CMakeLists.txt
+++ b/psi4/src/psi4/libqt/CMakeLists.txt
@@ -23,7 +23,6 @@ list(APPEND sources
   solve_pep.cc
   timer.cc
   )
-add_definitions("-DFC_SYMBOL=${FC_SYMBOL}")
 
 if(WIN32)
   set(_has_dggsvd3 TRUE)
@@ -45,6 +44,7 @@ target_compile_definitions(qt
   PRIVATE
     $<$<BOOL:${_has_dggsvd3}>:LAPACK_HAS_DGGSVD3>
     $<$<BOOL:${_has_dggsvp3}>:LAPACK_HAS_DGGSVP3>
+    FC_SYMBOL=${FC_SYMBOL}
   )
 unset(_has_dggsvd3)
 unset(_has_dggsvp3)

--- a/tests/pytests/test_dft_blocking.py
+++ b/tests/pytests/test_dft_blocking.py
@@ -82,7 +82,8 @@ def test_dft_atomic_blocking():
     assert psi4.compare_values(xc_ref, xc_e, 7, "psi4numpy XC energy")
 
 
-def test_dft_block_schemes():
+@pytest.mark.parametrize("scheme", ["OCTREE", "NAIVE", "ATOMIC"])
+def test_dft_block_schemes(scheme):
     """all DFT_BLOCK_SCHEME should give same results and number
     of grid points. Water dimer with ghost atoms"""
 
@@ -106,17 +107,16 @@ def test_dft_block_schemes():
             "DFT_SPHERICAL_POINTS": 590,
             "DFT_RADIAL_POINTS": 85,
             "D_convergence": 1e-8,
+            "DFT_WEIGHTS_TOLERANCE": -1.0,
         }
     )
-    ref = {"XC GRID TOTAL POINTS": 293259, "DFT XC ENERGY": -9.218561399189895}
-    SCHEMES = ["OCTREE", "NAIVE", "ATOMIC"]
-    for S in SCHEMES:
-        psi4.set_options({"DFT_BLOCK_SCHEME": S})
-        e, wfn = psi4.energy("pbe/def2-SVPD", return_wfn=True)
-        P = psi4.variable("XC GRID TOTAL POINTS")
-        XC = wfn.variable("DFT XC ENERGY")
-        assert psi4.compare_integers(ref["XC GRID TOTAL POINTS"], P, f" {S} GRID POINTS:")
-        assert psi4.compare_values(ref["DFT XC ENERGY"], XC, f" {S} XC ENERGY:")
+    ref = {"XC GRID TOTAL POINTS": 300900, "DFT XC ENERGY": -9.218561399189895}
+    psi4.set_options({"DFT_BLOCK_SCHEME": scheme})
+    e, wfn = psi4.energy("pbe/def2-SVPD", return_wfn=True)
+    P = psi4.variable("XC GRID TOTAL POINTS")
+    XC = wfn.variable("DFT XC ENERGY")
+    assert psi4.compare_integers(ref["XC GRID TOTAL POINTS"], P, f" {scheme} GRID POINTS:")
+    assert psi4.compare_values(ref["DFT XC ENERGY"], XC, f" {scheme} XC ENERGY:")
 
 
 def test_dft_block_scheme_distantpoints():


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This corresponds to L2 at https://github.com/evaleev/libint/pull/233 .

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] switches psi4 to use a Libint2 forked from upstream in 2022, not in 2019
- [x] changes a couple cmake knobs and changes the required components to EFV's preferred syntax (`g5` -> `eri_c4_d1_l5`)
- [x] avoided grid points discrepancies that I had hit by implementing Holger's suggestion.
- [x] I and others have reported needing `pybind11::headers` in extra places, so adding those
- [x] The defines `INT_NCART` and `INT_CARTINDEX` in psi https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libmints/integral.h#L46-L64 are also in L2. They used to be `#define` in the current/2019 fork of L2, but now in L2 master, it’s an inline function. To avoid errors like the below, they're namespaced and inlined here now, too.


```
< namespace libint2 {
< inline int INT_NCART(int am) { return ((am + 2) * (am + 1)) >> 1; }
< }
< LIBINT_DEPRECATED("please use libint2::INT_NCART instead")
< inline int INT_NCART(int am) { return libint2::INT_NCART(am); }
---
> #define INT_NCART(am) ((((am)+2)*((am)+1))>>1)
```
With that situation (define in psi and inlined in L2), I get lots of
```
In file included from /psi/gits/hrw-pybind/psi4/src/psi4/libmints/integral.cc:28:
/psi/gits/libint2-efv/install-p01/include/libint2/cgshell_ordering.h:104:12: error: expected unqualified-id before 'int'
  104 | inline int INT_CARTINDEX(unsigned int am, int i, int j) {
      |            ^~~~~~~~~~~~~
```
I can fix the problem by renaming in psi to `INT_NCART_PSI` and `INT_CARTINDEX_PSI`. What's a cleaner solution than renaming? Should we inline? Or add to the `psi {}` namespace?

## Checklist
- [ ] ~Tests added for any new features~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge **SQUASH**
