### PR TITLE
Silence sphinx warnings

### DIFF
--- a/tests/frac-sym/input.dat
+++ b/tests/frac-sym/input.dat
@@ -1,3 +1,5 @@
+#! Fractional occupation with symmetry
+
 molecule {
 0 2
 F

--- a/tests/fsapt-ext-abc/input.dat
+++ b/tests/fsapt-ext-abc/input.dat
@@ -1,3 +1,5 @@
+#! FSAPT with external charge on trimer
+
 memory 1 GB
 
 # water prism: https://science.sciencemag.org/content/sci/suppl/2012/05/16/336.6083.897.DC1/Perez_SM.pdf

--- a/tests/fsapt-ext-abc2/input.dat
+++ b/tests/fsapt-ext-abc2/input.dat
@@ -1,3 +1,5 @@
+#! FSAPT with external charge on dimer
+
 memory 1 GB
 
 # water prism: https://science.sciencemag.org/content/sci/suppl/2012/05/16/336.6083.897.DC1/Perez_SM.pdf

--- a/tests/mom-h2o-3/input.dat
+++ b/tests/mom-h2o-3/input.dat
@@ -1,4 +1,4 @@
-# MOM excitation from LUMO HOMO+3
+#! MOM excitation from LUMO HOMO+3
 
 ref_E = -74.2377159209776494
 

--- a/tests/mom-h2o-4/input.dat
+++ b/tests/mom-h2o-4/input.dat
@@ -1,4 +1,4 @@
-# MOM excitation from LUMO HOMO+4
+#! MOM excitation from LUMO HOMO+4
 
 ref_E = -55.7183072274117492
 

--- a/tests/scf-level-shift-cuhf/input.dat
+++ b/tests/scf-level-shift-cuhf/input.dat
@@ -1,3 +1,5 @@
+#! SCF level shift on a CUHF computation
+
 molecule {
 units bohr
 0 2

--- a/tests/scf-level-shift-rks/input.dat
+++ b/tests/scf-level-shift-rks/input.dat
@@ -1,3 +1,5 @@
+#! SCF level shift on an RKS computation
+
 memory 8 gb
 
 molecule {

--- a/tests/scf-level-shift-rohf/input.dat
+++ b/tests/scf-level-shift-rohf/input.dat
@@ -1,3 +1,5 @@
+#! SCF level shift on an ROHF computation
+
 molecule {
 units bohr
 0 2

--- a/tests/scf-level-shift-uhf/input.dat
+++ b/tests/scf-level-shift-uhf/input.dat
@@ -1,3 +1,5 @@
+#! SCF level shift on a UHF computation
+
 molecule {
 0 2
 O          1.14394        0.07535        0.00000

--- a/tests/scf-response3/input.dat
+++ b/tests/scf-response3/input.dat
@@ -1,4 +1,4 @@
-# UHF Dipole Polarizability Test
+#! UHF Dipole Polarizability Test
 
 molecule {
 1 2


### PR DESCRIPTION
## Description
This is an _attempt_ to get the docs working again by resolving "Undocumented input" warnings from Sphinx. Worst case scenario, Sphinx outputs are a little shorter. Best case scenario, there was some change in Sphinx that causes crashes when this warning occurs, and we can get docs working again.

## Status
- [x] Ready for review
- [x] Ready for merge