### PR TITLE
Deprecate Built-In ADC

### DIFF
--- a/doc/sphinxman/source/adc.rst
+++ b/doc/sphinxman/source/adc.rst
@@ -314,6 +314,8 @@ Built-in ADC(2) code
              multiple roots are requested, due to an error in the Davidson solver,
              and is no longer maintained. It is slated for removal in Psi4 1.7.
              Use of the Psi interface to `adcc` instead is strongly recommended.
+             To use this code regardless, either do not have `adcc` installed, or
+             set `qc_module builtin`.
 
 The ADC code built into |PSIfour| is capable of ADC(2) computations
 of singlet excited states only.

--- a/doc/sphinxman/source/adc.rst
+++ b/doc/sphinxman/source/adc.rst
@@ -310,6 +310,11 @@ Built-in ADC(2) code
 .. codeauthor:: Masaaki Saitow
 .. sectionauthor:: Masaaki Saitow
 
+.. warning:: The built-in ADC(2) method may give incorrect results if
+             multiple roots are requested, due to an error in the Davidson solver,
+             and is no longer maintained. It is slated for removal in Psi4 1.7.
+             Use of the Psi interface to `adcc` instead is strongly recommended.
+
 The ADC code built into |PSIfour| is capable of ADC(2) computations
 of singlet excited states only.
 It makes use of the libtrans library for efficient and flexible

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1111,9 +1111,9 @@ def select_adc2(name, **kwargs):
     func = None
     if reference == 'RHF':
         if mtd_type == 'CONV':
-            if module == 'ADCC' and extras.addons("adcc"):
+            if module in {'ADCC', ''} and extras.addons("adcc"):
                 func = run_adcc
-            elif module in ['', 'BUILTIN']:
+            elif module in {'BUILTIN', ''}:
                 func = run_adc
 
     if reference == 'UHF':
@@ -3478,6 +3478,9 @@ def run_adc(name, **kwargs):
 
     # Ensure IWL files have been written
     proc_util.check_iwl_file_from_scf_type(core.get_global_option('SCF_TYPE'), ref_wfn)
+
+    warnings.warn("Using built-in `adc` module instead of add-on `adcc` interface is deprecated due "
+                  "to certain wrong results, and in 1.7, it will stop working.", category=FutureWarning)
 
     error_msg = ("\n\t\t\t\t!!!!! WARNING !!!!!\n" +
             "\t\tThe built-in ADC(2) method may give incorrect results if\n"

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3479,7 +3479,19 @@ def run_adc(name, **kwargs):
     # Ensure IWL files have been written
     proc_util.check_iwl_file_from_scf_type(core.get_global_option('SCF_TYPE'), ref_wfn)
 
-    return core.adc(ref_wfn)
+    error_msg = ("\n\t\t\t\t!!!!! WARNING !!!!!\n" +
+            "\t\tThe built-in ADC(2) method may give incorrect results if\n"
+        "\t\tmultiple roots are requested, due to an error in the Davidson solver,\n"
+        "\t\tand is no longer maintained. It is slated for removal in Psi4 1.7.\n"
+        "\t\tUse of the Psi interface to `adcc` instead is strongly recommended.\n")
+
+    core.print_out(error_msg)
+
+    wfn = core.adc(ref_wfn)
+
+    core.print_out(error_msg)
+
+    return wfn
 
 
 def run_adcc(name, **kwargs):

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -174,7 +174,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     /*- When several modules can compute the same methods and the default
     routing is not suitable, this targets a module. ``CCENERGY`` covers
     CCHBAR, etc. ``OCC`` covers OCC and DFOCC. -*/
-    options.add_str("QC_MODULE", "", "CCENERGY DETCI DFMP2 FNOCC OCC ADCC CCT3");
+    options.add_str("QC_MODULE", "", "CCENERGY DETCI DFMP2 FNOCC OCC ADCC CCT3 BUILTIN");
     /*- What algorithm to use for the SCF computation. See Table :ref:`SCF
     Convergence & Algorithm <table:conv_scf>` for default algorithm for
     different calculation types. -*/

--- a/tests/adc1/input.dat
+++ b/tests/adc1/input.dat
@@ -12,6 +12,7 @@ set {
     basis 6-31G**
     guess core
     roots_per_irrep [20]
+    qc_module builtin
 }
 
 ref_energy = -76.22243196371332 

--- a/tests/adc2/input.dat
+++ b/tests/adc2/input.dat
@@ -15,6 +15,7 @@ set {
     basis aug-cc-pvdz
     guess core
     roots_per_irrep [2]
+    qc_module builtin
 }
 
 ref_energy = -152.52670794053822


### PR DESCRIPTION
## Description
This PR deprecates Psi's built-in ADC module, per discussion on the January developer conference call, issue #1033, and my own investigation.

## Checklist
- [x] Tested ADC still runs, but with well-deserved warnings

## Status
- [x] Ready for review
- [ ] Ready for merge
