### PR TITLE
fix docs warnings

### DIFF
--- a/doc/sphinxman/source/basissets.rst
+++ b/doc/sphinxman/source/basissets.rst
@@ -181,7 +181,7 @@ input.
 Should needed elements be missing from the best
 auxiliary basis or should the orbital basis be unknown to |PSIfour|,
 the auxiliary basis will fall back on `def2 quad-zeta fitting bases
-<https://github.com/psi4/psi4/blob/master/psi4/driver/qcdb/libmintsbasisset.py#L762>`_.
+:source:`psi4/driver/qcdb/libmintsbasisset.py#L762`.
 Note that if |mints__basis| is known to be larger than quad-zeta,
 |PSIfour| *will not* attempt to fall back on the def2 fitting bases.
 

--- a/doc/sphinxman/source/build_planning.rst
+++ b/doc/sphinxman/source/build_planning.rst
@@ -50,8 +50,7 @@ Planning: how to configure Psi4 and invoke CMake
 ------------------------------------------------
 
 |PSIfour| is built through CMake. An abbreviated build guide can be found
-`within the source itself
-<https://github.com/psi4/psi4/blob/master/CMakeLists.txt#L22>`_.
+:source:`within the source itself <CMakeLists.txt#L22>` .
 
 CMake does a good job scanning your computer to locate libraries, header
 files, and executables needed for compilation. So it's very possible that
@@ -210,17 +209,15 @@ that software for |PSIfour| and any notes and warnings pertaining to it.
 The following are also required for |PSIfour|, but if not detected, the
 build system will automatically download and build.
 
-* :ref:`gau2grid <cmake:gau2grid>` |w---w| :ref:`[what is gau2grid?] <sec:gau2grid>` `[gau2grid min version] <https://github.com/psi4/psi4/blob/master/external/upstream/gau2grid/CMakeLists.txt#L1>`_
+* :ref:`gau2grid <cmake:gau2grid>` |w---w| :ref:`[what is gau2grid?] <sec:gau2grid>` :source:`[gau2grid min version] <external/upstream/gau2grid/CMakeLists.txt#L1>`
 
-* :ref:`Libint <cmake:libint>` |w---w| :ref:`[what is Libint?] <sec:libint>` `[Libint min version] <https://github.com/psi4/psi4/blob/master/external/upstream/libint/CMakeLists.txt#L1>`_ (Libint2 as of Nov 2020; added by v1.4)
+* :ref:`Libint <cmake:libint>` |w---w| :ref:`[what is Libint?] <sec:libint>` :source:`[Libint min version] <external/upstream/libint/CMakeLists.txt#L1>` (Libint2 as of Nov 2020; added by v1.4)
 
   * Eigen https://eigen.tuxfamily.org/index.php?title=Main_Page
   * MPFR https://www.mpfr.org/
 
-* :ref:`Libxc <cmake:libxc>` |w---w| :ref:`[what is Libxc?] <sec:libxc>` `[Libxc min version] <https://github.com/psi4/psi4/blob/master/external/upstream/libxc/CMakeLists.txt#L1>`_
-
-* pybind11 |w---w| `[what is Pybind11?] <https://pybind11.readthedocs.io/en/stable/>`_ `[Pybind11 min version] <https://github.com/psi4/psi4/blob/master/external/upstream/pybind11/CMakeLists.txt#L1>`_
-
+* :ref:`Libxc <cmake:libxc>` |w---w| :ref:`[what is Libxc?] <sec:libxc>` :source:`[Libxc min version] <external/upstream/libxc/CMakeLists.txt#L1>`
+* pybind11 |w---w| `[what is Pybind11?] <https://pybind11.readthedocs.io/en/stable/>`_ :source:`[Pybind11 min version] <external/upstream/pybind11/CMakeLists.txt#L1>`
 * QCElemental |w---w| `[what is QCElemental?] <https://qcelemental.readthedocs.io/en/latest/>`_
 
 * QCEngine |w---w| `[what is QCEngine?] <https://qcengine.readthedocs.io/en/latest/>`_ (March 2019; added by v1.4)
@@ -269,11 +266,11 @@ are available pre-built from conda.
   * Perl (for some auto-documentation scripts) https://www.perl.org/
   * nbsphinx (for converting Jupyter notebooks) http://nbsphinx.readthedocs.io/en/jupyter-theme/
   * sphinx-psi-theme https://github.com/psi4/sphinx-psi-theme
-  * See `["message" lines] <https://github.com/psi4/psi4/blob/master/doc/sphinxman/CMakeLists.txt>`_ for advice on obtaining docs dependencies
+  * See `["message" lines] :source:`doc/sphinxman/CMakeLists.txt` for advice on obtaining docs dependencies
 
 * Ambit |w---w| https://github.com/jturney/ambit
 
-* :ref:`CheMPS2 <cmake:chemps2>` |w---w| :ref:`[what is CheMPS2?] <sec:chemps2>` `[CheMPS2 min version] <https://github.com/psi4/psi4/blob/master/external/upstream/chemps2/CMakeLists.txt#L2>`_
+* :ref:`CheMPS2 <cmake:chemps2>` |w---w| :ref:`[what is CheMPS2?] <sec:chemps2>` :source:`[CheMPS2 min version] <external/upstream/chemps2/CMakeLists.txt#L2>`
 
   * HDF5 https://support.hdfgroup.org/HDF5/
   * zlib http://www.zlib.net/
@@ -282,11 +279,11 @@ are available pre-built from conda.
 
   * :ref:`Fortran Compiler <cmake:fortran>`
 
-* :ref:`dkh <cmake:dkh>` |w---w| :ref:`[what is dkh?] <sec:dkh>` `[dkh min version] <https://github.com/psi4/psi4/blob/master/external/upstream/dkh/CMakeLists.txt#L2>`_
+* :ref:`dkh <cmake:dkh>` |w---w| :ref:`[what is dkh?] <sec:dkh>` :source:`[dkh min version] <external/upstream/dkh/CMakeLists.txt#L2>`
 
   * :ref:`Fortran Compiler <cmake:fortran>`
 
-* :ref:`gdma <cmake:gdma>` |w---w| :ref:`[what is gdma?] <sec:gdma>` `[gdma min version] <https://github.com/psi4/psi4/blob/master/external/upstream/gdma/CMakeLists.txt#L2>`_
+* :ref:`gdma <cmake:gdma>` |w---w| :ref:`[what is gdma?] <sec:gdma>` :source:`[gdma min version] <external/upstream/gdma/CMakeLists.txt#L2>`
 
   * :ref:`Fortran Compiler <cmake:fortran>`
 
@@ -295,11 +292,11 @@ are available pre-built from conda.
   * :ref:`Fortran Compiler <cmake:fortran>`
   * zlib http://www.zlib.net/
 
-* :ref:`simint <cmake:simint>` |w---w| :ref:`[what is simint?] <sec:simint>` `[simint min version] <https://github.com/psi4/psi4/blob/master/external/upstream/simint/CMakeLists.txt#L2>`_
+* :ref:`simint <cmake:simint>` |w---w| :ref:`[what is simint?] <sec:simint>` :source:`[simint min version] <external/upstream/simint/CMakeLists.txt#L2>`
 
 Additionally, there are runtime-loaded capabilities:
 
-* :ref:`PylibEFP & libefp <cmake:libefp>` |w---w| :ref:`[what is LibEFP?] <sec:libefp>` `[LibEFP min version] <https://github.com/psi4/psi4/blob/master/external/upstream/libefp/CMakeLists.txt#L1>`_
+* :ref:`PylibEFP & libefp <cmake:libefp>` |w---w| :ref:`[what is LibEFP?] <sec:libefp>` :source:`[LibEFP min version] <external/upstream/libefp/CMakeLists.txt#L1>`
 
 * cfour |w---w| :ref:`[what is CFOUR?] <sec:cfour>`
 
@@ -449,7 +446,7 @@ The Mac and Windows packages have base ``MAX_AM_ERI=5`` and can run
 density-fitted.
 
 Details about angular momentum settings are available here
-https://github.com/psi4/psi4/blob/master/external/upstream/libint2/CMakeLists.txt
+:source:`external/upstream/libint2/CMakeLists.txt`
 .
 
 .. Since February 2019, the |PSIfour| conda package on Linux has been the
@@ -1656,8 +1653,7 @@ How to run a subset of tests
 CTest allows flexibly partitioned running of the test suite. In
 the examples below, *testname* are regex of :source:`test names <tests>`,
 and *testlabel* are regex of labels (*e.g.*, ``cc``, ``mints``,
-``libefp`` defined `[here, for example]
-<https://github.com/psi4/psi4/blob/master/tests/ci-property/CMakeLists.txt#L3>`_.
+``libefp`` defined :source:`[here, for example] <tests/ci-property/CMakeLists.txt#L3>` .
 
 * Run tests in parallel with ``-j`` flag. For maximum parallelism: :samp:`ctest -j\`getconf _NPROCESSORS_ONLN\`\ `
 * Run full test suite: ``ctest``

--- a/doc/sphinxman/source/conda.rst
+++ b/doc/sphinxman/source/conda.rst
@@ -67,7 +67,7 @@ distribution with same package manager `conda
 The |PSIfour| binary repository is at `Anaconda (formerly Binstar) <https://anaconda.org/psi4>`_.
 
 For commands to get a default installation, go to :ref:`sec:psi4conda`
-or the `psicode downloads page <https://psicode.org/installs/latest/>`_.
+or the :psicode:`psicode downloads page <installs/latest/>` .
 Users proficient with conda may prefer to consult :ref:`sec:condadetails`.
 For more flexibility and a detailed explanation, go to
 :ref:`sec:slowconda` and :ref:`sec:slowpsi4`.

--- a/doc/sphinxman/source/libint.rst
+++ b/doc/sphinxman/source/libint.rst
@@ -58,7 +58,7 @@ cannot build *without* Libint.
 .. note:: As of Nov 2020 or release v1.4, |PSIfour| uses Libint2, not Libint1.
    Compared to many other open-source QC codes, |PSIfour| requires a separate
    Libint compilation with a different integrals ordering. See notes at top of
-   https://github.com/psi4/psi4/blob/master/external/upstream/libint2/CMakeLists.txt
+   :source:`external/upstream/libint2/CMakeLists.txt` .
 
 Installation
 ~~~~~~~~~~~~

--- a/doc/sphinxman/source/manage_release.rst
+++ b/doc/sphinxman/source/manage_release.rst
@@ -112,7 +112,7 @@ Update copyright year
   - ``README.md``
   - ``tests/psitest.pl``
 
-* Also, in content of https://github.com/psi4/psi4/blob/master/doc/sphinxman/source/conf.py.in#L118
+* Also, in content of :source:`doc/sphinxman/source/conf.py.in#L130`
 
 
 Update samples

--- a/doc/sphinxman/source/manage_release.rst
+++ b/doc/sphinxman/source/manage_release.rst
@@ -136,7 +136,7 @@ Collect new authors
 Anticipate next release
 -----------------------
 
-* Bump version in ``codemeta.json``, https://github.com/psi4/psi4/blob/master/codemeta.json#L9
+* Bump version in ``codemeta.json``, :source:`codemeta.json#L9`
 * Add to branch list in ``azure-pipelines.yml``, :source:`azure-pipelines.yml`
 
 
@@ -431,7 +431,7 @@ Collect documentation snapshot
 ------------------------------
 
 * Documentation is built automatically by GHA from the latest psi4 master commit. It gets pushed to the psi4/psi4docs repository and thence served by netlify to a site independent of psicode.org. The netlify psicode.org site has a redirect so that psicode.org/psi4manual/master presents the psi4docs netlify content.
-* GHA controller is https://github.com/psi4/psi4/blob/master/.github/workflows/docs.yml
+* GHA controller is :source:`.github/workflows/docs.yml`
 * This setup works great for "latest" docs, but it won't build a nice copy on the tag because the tag commit is pushed before the tag itself, so the version shows up "undefined".
 * So, anytime after "Tag (pre)release" is over, navigate on psi4 GH to the tag commit (not the record commit) and retrigger the docs GHA. Download the artifact (zipped docs dir) at the end to a local computer.
 * In your hugo site clone, create a new directory under ``static/psi4manual``. Copy the zipped docs there, unpack, rearrange so that ``static/psi4manual/<new-tag>/index.html`` is present. Check in.

--- a/doc/sphinxman/source/psiapi.ipynb
+++ b/doc/sphinxman/source/psiapi.ipynb
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Psi4 is now able to be controlled directly from Python.  By default, Psi4 will print any output to the screen; this can be changed by giving a file name (with path if not in the current working directory) to the function `psi4.core.set_output_file()` [API](https://psicode.org/psi4manual/master/api/psi4.core.set_output_file \"Go to API\"), as a string:"
+    "Psi4 is now able to be controlled directly from Python.  By default, Psi4 will print any output to the screen; this can be changed by giving a file name (with path if not in the current working directory) to the function `psi4.core.set_output_file()` :psicode:`[API] <psi4manual/master/api/psi4.core.set_output_file>` , as a string:"
    ]
   },
   {
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Additionally, output may be suppressed by instead setting `psi4.core.be_quiet()` [API](https://psicode.org/psi4manual/master/api/psi4.core.be_quiet \"Go to API\")."
+    "Additionally, output may be suppressed by instead setting `psi4.core.be_quiet()` :psicode:`[API] <psi4manual/master/api/psi4.core.be_quiet>` ."
    ]
   },
   {
@@ -141,7 +141,7 @@
     "@DF-RHF Final Energy:     -76.02663273486682\n",
     "~~~\n",
     "\n",
-    "By default, the energy should be converged to about $1.0\\times 10^{-6}$, so agreement is only expected for about the first 6 digits after the decimal.  If the computation does not complete, there is probably a problem with the compilation or installation of the program (see the installation instructions in the main Psi4 manual section [Compiling and Installing from Source](https://psicode.org/psi4manual/master/build_planning.html \"Go to Psi4 Manual\")).\n",
+    "By default, the energy should be converged to about $1.0\\times 10^{-6}$, so agreement is only expected for about the first 6 digits after the decimal.  If the computation does not complete, there is probably a problem with the compilation or installation of the program (see the installation instructions in the main Psi4 manual section :psicode:`[Compiling and Installing from Source] <psi4manual/master/build_planning.html>` .\n",
     "\n",
     "This very simple input is sufficient to run the requested information.  Notice we didn't tell the program some otherwise useful information like the charge of the molecule (0, it's neutral), the spin multiplicity (1 for a closed-shell molecule with all electrons paired), or the reference wavefunction to use (restricted Hartree-Fock, or RHF, is usually appropriate for a closed-shell molecule).  The program correctly guessed all of these options for us.  We can change the default behavior through additional keywords."
    ]
@@ -515,7 +515,7 @@
     "     2     -257.418674031273       -0.016265984132       -0.016265984132\n",
     "~~~\n",
     "\n",
-    "And that's it!  The only remaining part of the example is a little table of the different `R` values and the CP-corrected CCSD(T) energies, converted from atomic units (Hartree) to kcal mol$^{-1}$ by multiplying by the automatically-defined conversion factor `psi4.constants.hartree2kcalmol`. Psi4 provides several built-in physical constants and conversion factors, as described in the Psi4 manual section [Physical Constants](http://psicode.org/psi4manual/master/psithoninput.html#sec-physicalconstants \"Go to Manual\").  The table can be printed either to the screen, by using standard [Python `print()` syntax](https://docs.python.org/3/whatsnew/3.0.html#print-is-a-function \"Python Documentation\"), or to the designated output file `output.dat` using Psi4's built-in function ``psi4.core.print_out()`` [API](https://psicode.org/psi4manual/master/api/psi4.core.print_out \"API Details\") (C style printing).  \n",
+    "And that's it!  The only remaining part of the example is a little table of the different `R` values and the CP-corrected CCSD(T) energies, converted from atomic units (Hartree) to kcal mol$^{-1}$ by multiplying by the automatically-defined conversion factor `psi4.constants.hartree2kcalmol`. Psi4 provides several built-in physical constants and conversion factors, as described in the Psi4 manual section [Physical Constants](http://psicode.org/psi4manual/master/psithoninput.html#sec-physicalconstants \"Go to Manual\").  The table can be printed either to the screen, by using standard [Python `print()` syntax](https://docs.python.org/3/whatsnew/3.0.html#print-is-a-function \"Python Documentation\"), or to the designated output file `output.dat` using Psi4's built-in function ``psi4.core.print_out()`` :psicode:`[API] <psi4manual/master/api/psi4.core.print_out>` (C style printing).  \n",
     "\n",
     "As we've seen so far, the combination of Psi4 and Python creates a unique, interactive approach to quantum chemistry.  The next section will explore this synergistic relationship in greater detail, describing how even very complex tasks can be done very easily with Psi4."
    ]


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
I think whoever brought up the new "warnings" in the sphinx log was on the right track. We do have the treat-warnings-as-errors flag on. It's the treat-broken-links-as-errors flag that we can't enable yet. Between that and the 9800 PR in the newest sphinx changelog released 17 Jan https://www.sphinx-doc.org/en/master/changes.html#release-4-4-0-released-jan-17-2022, I bet that's what's causing our docsbuild fail. Hopefully I haven't added any new syntax errors.

- [x] Ready for review
- [ ] Ready for merge
