### PR TITLE
Deprecate unused Deriv types

### DIFF
--- a/psi4/src/psi4/libmints/deriv.h
+++ b/psi4/src/psi4/libmints/deriv.h
@@ -55,16 +55,15 @@ class CdSalcList;
 // SCFandDF:    Correlated methods using DF (no reference contribution)
 // Correlated:  Correlated methods that write RDMs and Lagrangian to disk
 enum class DerivCalcType { Default,
-    PSI_DEPRECATED(
+    SCF PSI_DEPRECATED(
         "DerivCalcType::SCF is planned for removal in 1.7, due to lack of use and "
         "being superseded by the scfgrad library. Contact developers if you need "
-        "this ability.")
-      SCF,
-    PSI_DEPRECATED(
+        "this ability."),
+    SCFandDF PSI_DEPRECATED(
         "DerivCalcType::SCFandDF is planned for removal in 1.7, due to lack of use "
-        "and being superseded by the compute_df method. Contact devvelopers if you "
-        "need this ability.")
-      SCFandDF, Correlated };
+        "and being superseded by the compute_df method. Contact developers if you "
+        "need this ability."),
+    Correlated };
 
 class PSI_API Deriv {
     const std::shared_ptr<Wavefunction> wfn_;

--- a/psi4/src/psi4/libmints/deriv.h
+++ b/psi4/src/psi4/libmints/deriv.h
@@ -54,7 +54,17 @@ class CdSalcList;
 // SCF:         SCF methods
 // SCFandDF:    Correlated methods using DF (no reference contribution)
 // Correlated:  Correlated methods that write RDMs and Lagrangian to disk
-enum class DerivCalcType { Default, SCF, SCFandDF, Correlated };
+enum class DerivCalcType { Default,
+    PSI_DEPRECATED(
+        "DerivCalcType::SCF is planned for removal in 1.7, due to lack of use and "
+        "being superseded by the scfgrad library. Contact developers if you need "
+        "this ability.")
+      SCF,
+    PSI_DEPRECATED(
+        "DerivCalcType::SCFandDF is planned for removal in 1.7, due to lack of use "
+        "and being superseded by the compute_df method. Contact devvelopers if you "
+        "need this ability.")
+      SCFandDF, Correlated };
 
 class PSI_API Deriv {
     const std::shared_ptr<Wavefunction> wfn_;


### PR DESCRIPTION
## Description
Deprecates ways of calling derivatives that are, as best as I can tell, artifacts of legacy code that were never removed.

If anybody downstream of us needs these, we're giving them a chance to prevent us. Otherwise, less code, less problems.

## Status
- [x] Ready for review
- [x] Ready for merge
