### PR TITLE
Deprecate `Wavefunction.density_fitted`

### DIFF
--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -370,6 +370,9 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     void set_reference_wavefunction(const std::shared_ptr<Wavefunction> wfn);
 
     /// Returns whether this wavefunction was obtained using density fitting or not
+    PSI_DEPRECATED(
+        "Using `Wavefunction.density_fitted` is deprecated for lack of use and will be removed in Psi4 1.7. "
+        "If you need an analogue of this, create a Wavefunction subclass.")
     bool density_fitted() const { return density_fitted_; }
 
     /// Returns the print level


### PR DESCRIPTION
## Description
Deprecating more legacy code. This boolean is always false in Psi, is only ever used in the Derivative code (but is still always false) where there are other ways to specify this information, and it's a holdover from pre-`scfgrad` days. To oblivion with it.

## Status
- [x] Ready for review
- [x] Ready for merge
