### PR TITLE
Change `ccdensity` Keywords Around OPDM Relaxation

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3113,15 +3113,19 @@ def run_cc_property(name, **kwargs):
         if name == 'eom-ccsd':
             core.set_global_option('WFN', 'EOM_CCSD')
             core.set_global_option('DERTYPE', 'NONE')
-            core.set_global_option('ONEPDM', 'TRUE')
             core.cceom(ccwfn)
         elif name == 'eom-cc2':
             core.set_global_option('WFN', 'EOM_CC2')
             core.set_global_option('DERTYPE', 'NONE')
-            core.set_global_option('ONEPDM', 'TRUE')
             core.cceom(ccwfn)
         core.set_global_option('DERTYPE', 'NONE')
-        core.set_global_option('ONEPDM', 'TRUE')
+        if core.get_option('CCDENSITY', 'OPDM_RELAX') or n_two > 0:
+            # WARNING!!! A one-particle property computed _with_ a two-particle property will differ
+            # from a one-particle property computed by itself. There are no two-particle properties at
+            # present, so we can kick the issue further down the road.
+            core.set_global_option('OPDM_ONLY', 'FALSE')
+        else:
+            core.set_global_option('OPDM_ONLY', 'TRUE')
         core.cclambda(ccwfn)
         core.ccdensity(ccwfn)
 
@@ -3142,7 +3146,10 @@ def run_cc_property(name, **kwargs):
         else:
             raise ValidationError("""Unknown excited-state CC wave function.""")
         core.set_global_option('DERTYPE', 'NONE')
-        core.set_global_option('ONEPDM', 'TRUE')
+        if core.get_option('CCDENSITY', 'OPDM_RELAX'):
+            core.set_global_option('OPDM_ONLY', 'FALSE')
+        else:
+            core.set_global_option('OPDM_ONLY', 'TRUE')
         # Tight convergence unnecessary for transition properties
         core.set_local_option('CCLAMBDA', 'R_CONVERGENCE', 1e-4)
         core.set_local_option('CCEOM', 'R_CONVERGENCE', 1e-4)

--- a/psi4/src/psi4/cc/ccdensity/CMakeLists.txt
+++ b/psi4/src/psi4/cc/ccdensity/CMakeLists.txt
@@ -104,6 +104,7 @@ target_sources(cc
     ${CMAKE_CURRENT_SOURCE_DIR}/td_print.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/td_setup.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/tdensity.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/to_matrix.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/transL.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/transdip.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/transp.cc

--- a/psi4/src/psi4/cc/ccdensity/MOInfo.h
+++ b/psi4/src/psi4/cc/ccdensity/MOInfo.h
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+#include "psi4/libmints/matrix.h"
 
 namespace psi {
 namespace ccdensity {
@@ -108,6 +109,7 @@ struct MOInfo {
     int *pitzer2qt;                  /* Pitzer to QT re-ordering array */
     int *qt2pitzer;                  /* QT to Pitzer re-ordering array */
     double **scf_qt;                 /* SCF orbitals (QT ordering of MOs) */
+    SharedMatrix Ca;                 /* SCF orbitals (standard ordering) */
     double ***L;
     double ***nabla;
     double ***dip;

--- a/psi4/src/psi4/cc/ccdensity/Params.h
+++ b/psi4/src/psi4/cc/ccdensity/Params.h
@@ -46,8 +46,8 @@ struct Params {
     int cachelev;
     int aobasis;
     int ref;
-    int onepdm;            /* produce ONLY the onepdm for properties */
-    int onepdm_grid_dump;  // dump the onepdm on a grid to a dx file
+    bool onepdm;            /* produce ONLY the onepdm for properties */
+    bool onepdm_grid_dump;  // dump the onepdm on a grid to a dx file
     int relax_opdm;
     int use_zeta;
     int calc_xi;

--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -81,6 +81,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         moinfo.clsdpi[h] = wfn->doccpi()[h];
         moinfo.openpi[h] = wfn->soccpi()[h];
     }
+    moinfo.Ca = wfn->Ca();
     scf_pitzer = wfn->Ca()->to_block_matrix();
 
     moinfo.sym = 0;

--- a/psi4/src/psi4/cc/ccdensity/get_params.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_params.cc
@@ -67,7 +67,7 @@ void get_params(Options& options) {
     if (options["ONEPDM_GRID_DUMP"].has_changed()) {
         outfile->Printf("\tWarning! ONEPDM_GRID_DUMP is deprecated and will be removed in 1.7. Use OPDM_GRID_DUMP instead.");
         if (not options["OPDM_GRID_DUMP"].has_changed()) {
-            params.onepdm = options.get_bool("ONEPDM_GRID_DUMP");
+            params.onepdm_grid_dump = options.get_bool("ONEPDM_GRID_DUMP");
         }
     }
 

--- a/psi4/src/psi4/cc/ccdensity/get_params.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_params.cc
@@ -51,24 +51,25 @@ namespace psi {
 namespace ccdensity {
 
 void get_params(Options& options) {
-    int errcod, tol;
-    std::string junk;
-
     params.wfn = options.get_str("WFN");
-
-    // junk = options.get_str("REFERENCE");
-    // if(junk == "RHF") params.ref = 0;
-    // else if(junk == "ROHF") params.ref = 1;
-    // else if(junk == "UHF") params.ref = 2;
-    // else {
-    //  printf("Invalid value of input keyword REFERENCE: %s\n", junk.c_str());
-    //  throw PsiException("ccdensity: error", __FILE__, __LINE__);
-    //}
 
     psio_read_entry(PSIF_CC_INFO, "Reference Wavefunction", (char*)&(params.ref), sizeof(int));
 
-    params.onepdm = options.get_bool("ONEPDM");
-    params.onepdm_grid_dump = options.get_bool("ONEPDM_GRID_DUMP");
+    params.onepdm = options.get_bool("OPDM_ONLY");
+    if (options["ONEPDM"].has_changed()) {
+        outfile->Printf("\tWarning! ONEPDM is deprecated and will be removed in 1.7. Use OPDM_ONLY instead.");
+        if (not options["OPDM_ONLY"].has_changed()) {
+            params.onepdm = options.get_bool("ONEPDM");
+        }
+    }
+
+    params.onepdm_grid_dump = options.get_bool("OPDM_GRID_DUMP");
+    if (options["ONEPDM_GRID_DUMP"].has_changed()) {
+        outfile->Printf("\tWarning! ONEPDM_GRID_DUMP is deprecated and will be removed in 1.7. Use OPDM_GRID_DUMP instead.");
+        if (not options["OPDM_GRID_DUMP"].has_changed()) {
+            params.onepdm = options.get_bool("ONEPDM_GRID_DUMP");
+        }
+    }
 
     params.calc_xi = options.get_bool("XI");
     if (params.calc_xi) {
@@ -108,7 +109,7 @@ void get_params(Options& options) {
 
     /*** determine DERTYPE from input */
     params.dertype = 0;
-    junk = options.get_str("DERTYPE");
+    std::string junk = options.get_str("DERTYPE");
     if (junk == "NONE")
         params.dertype = 0;
     else if (junk == "FIRST")

--- a/psi4/src/psi4/cc/ccdensity/to_matrix.cc
+++ b/psi4/src/psi4/cc/ccdensity/to_matrix.cc
@@ -1,0 +1,37 @@
+#include "psi4/libmints/matrix.h"
+
+#include "MOInfo.h"
+#define EXTERN
+#include "globals.h"
+
+namespace psi {
+namespace ccdensity {
+
+SharedMatrix block_to_matrix(double ** block) {
+    moinfo.Ca->colspi().print();
+    auto mat = std::make_shared<Matrix>("Matrix", moinfo.Ca->colspi(), moinfo.Ca->colspi());
+    int mo_offset = 0;
+
+    for (int h = 0; h < moinfo.Ca->nirrep(); h++) {
+        int nmo = moinfo.orbspi[h];
+        int nfv = moinfo.fruocc[h];
+        int nmor = nmo - nfv;
+        if (!nmo || !nmor) continue;
+
+        // Loop over QT, convert to Pitzer
+        double **matp = mat->pointer(h);
+        for (int i = 0; i < nmo; i++) { // nmor in original code, density matrix
+            for (int j = 0; j < nmo; j++) { // nmor in original code, density matrix
+                int I = moinfo.pitzer2qt[i + mo_offset];
+                int J = moinfo.pitzer2qt[j + mo_offset];
+                matp[i][j] = block[I][J];
+            }
+        }
+        mo_offset += nmo;
+    }
+
+    return mat;
+} 
+
+}
+}

--- a/psi4/src/psi4/libqt/dx_write.cc
+++ b/psi4/src/psi4/libqt/dx_write.cc
@@ -79,7 +79,7 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
     // Set up AO->SO transformation matrix (u)
     MintsHelper helper(basis, options, 0);
     SharedMatrix aotoso = helper.petite_list(true)->aotoso();
-    int *col_offset = new int[wfn->nirrep()];
+    auto col_offset = std::vector<int>(wfn->nirrep());
     col_offset[0] = 0;
     for (int h = 1; h < wfn->nirrep(); h++) col_offset[h] = col_offset[h - 1] + aotoso->coldim(h - 1);
 
@@ -87,7 +87,6 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
     for (int h = 0; h < wfn->nirrep(); h++)
         for (int j = 0; j < aotoso->coldim(h); j++)
             for (int i = 0; i < nao; i++) u[i][j + col_offset[h]] = aotoso->get(h, i, j);
-    delete[] col_offset;
 
     // Scan along Cartesian axes to determine dimensions of box
     molecule->print();
@@ -113,13 +112,29 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
 
     double b2a3 = pc_bohr2angstroms * pc_bohr2angstroms * pc_bohr2angstroms;
 
+    double cutoff = options.get_double("OPDM_GRID_CUTOFF");
+    if (options["ONEPDM_GRID_CUTOFF"].has_changed()) {
+        outfile->Printf("\tWarning! ONEPDM_GRID_CUTOFF is deprecated and will be removed in 1.7. Use OPDM_GRID_CUTOFF instead.");
+        if (not options["OPDM_GRID_CUTOFF"].has_changed()) {
+            cutoff = options.get_bool("ONEPDM_GRID_CUTOFF");
+        }
+    }
+
+    double step_size = options.get_double("OPDM_GRID_STEPSIZE");
+    if (options["ONEPDM_GRID_STEPSIZE"].has_changed()) {
+        outfile->Printf("\tWarning! ONEPDM_GRID_STEPSIZE is deprecated and will be removed in 1.7. Use OPDM_GRID_STEPSIZE instead.");
+        if (not options["OPDM_GRID_STEPSIZE"].has_changed()) {
+            step_size = options.get_bool("ONEPDM_GRID_STEPSIZE");
+        }
+    }
+
     do {
         xmin -= 0.1;
         compute_delta(delta, xmin / pc_bohr2angstroms, 0, 0);
         dens = 0.0;
         for (int i = 0; i < nmo; i++)
             for (int j = 0; j < nmo; j++) dens += delta[i][j] * D[i][j];
-    } while ((dens / b2a3) > options.get_double("ONEPDM_GRID_CUTOFF"));
+    } while ((dens / b2a3) > cutoff);
     outfile->Printf("  xmin = %8.6f (Angstrom);  density(xmin,0,0) (e/Ang^3) = %8.6e\n", xmin, dens);
 
     do {
@@ -128,7 +143,7 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
         dens = 0.0;
         for (int i = 0; i < nmo; i++)
             for (int j = 0; j < nmo; j++) dens += delta[i][j] * D[i][j];
-    } while ((dens / b2a3) > options.get_double("ONEPDM_GRID_CUTOFF"));
+    } while ((dens / b2a3) > cutoff);
     outfile->Printf("  xmax = %8.6f (Angstrom);   density(xmax,0,0) (e/Ang^3) = %8.6e\n", xmax, dens);
 
     do {
@@ -137,7 +152,7 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
         dens = 0.0;
         for (int i = 0; i < nmo; i++)
             for (int j = 0; j < nmo; j++) dens += delta[i][j] * D[i][j];
-    } while ((dens / b2a3) > options.get_double("ONEPDM_GRID_CUTOFF"));
+    } while ((dens / b2a3) > cutoff);
     outfile->Printf("  ymin = %8.6f (Angstrom);  density(0,ymin,0) (e/Ang^3) = %8.6e\n", ymin, dens);
 
     do {
@@ -146,7 +161,7 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
         dens = 0.0;
         for (int i = 0; i < nmo; i++)
             for (int j = 0; j < nmo; j++) dens += delta[i][j] * D[i][j];
-    } while ((dens / b2a3) > options.get_double("ONEPDM_GRID_CUTOFF"));
+    } while ((dens / b2a3) > cutoff);
     outfile->Printf("  ymax = %8.6f (Angstrom);   density(0,ymax,0) (e/Ang^3) = %8.6e\n", ymax, dens);
 
     do {
@@ -155,7 +170,7 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
         dens = 0.0;
         for (int i = 0; i < nmo; i++)
             for (int j = 0; j < nmo; j++) dens += delta[i][j] * D[i][j];
-    } while ((dens / b2a3) > options.get_double("ONEPDM_GRID_CUTOFF"));
+    } while ((dens / b2a3) > cutoff);
     outfile->Printf("  zmin = %8.6f (Angstrom);  density(0,0,zmin) (e/Ang^3) = %8.6e\n", zmin, dens);
 
     do {
@@ -164,7 +179,7 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
         dens = 0.0;
         for (int i = 0; i < nmo; i++)
             for (int j = 0; j < nmo; j++) dens += delta[i][j] * D[i][j];
-    } while ((dens / b2a3) > options.get_double("ONEPDM_GRID_CUTOFF"));
+    } while ((dens / b2a3) > cutoff);
     outfile->Printf("  zmax = %8.6f (Angstrom);   density(0,0,zmax) (e/Ang^3) = %8.6e\n", zmax, dens);
 
     // Compute density at the nuclei
@@ -182,7 +197,6 @@ void dx_write(std::shared_ptr<Wavefunction> wfn, Options &options, double **D) {
                         y * pc_bohr2angstroms, z * pc_bohr2angstroms, dens / b2a3);
     }
 
-    double step_size = options.get_double("ONEPDM_GRID_STEPSIZE");
     int xsteps = (int)((xmax - xmin) / step_size + 1);
     int ysteps = (int)((ymax - ymin) / step_size + 1);
     int zsteps = (int)((zmax - zmin) / step_size + 1);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1809,14 +1809,22 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_bool("XI", false);
         /*- Do use zeta?  -*/
         options.add_bool("ZETA", false);
-        /*- Do compute one-particle density matrix? -*/
+        /*- Deprecated and will be removed in 1.7. Use OPDM_ONLY. -*/
         options.add_bool("ONEPDM", false);
-        /*- Write one-particle density matrix on a grid to file opdm.dx -*/
+        /*- For internal use only! Compute the one-particle density matrix, but not the two-particle density matrix. -*/
+        options.add_bool("OPDM_ONLY", false);
+        /*- Deprecated and will be removed in 1.7. Use OPDM_GRID_DUMP. -*/
         options.add_bool("ONEPDM_GRID_DUMP", false);
-        /*- Cutoff (e/A^3) for printing one-particle density matrix values on a grid -*/
+        /*- Write one-particle density matrix on a grid to file opdm.dx -*/
+        options.add_bool("OPDM_GRID_DUMP", false);
+        /*- Deprecated and will be removed in 1.7. Use OPDM_GRID_CUTOFF. -*/
         options.add_double("ONEPDM_GRID_CUTOFF", 1.0e-30);
-        /*- Step size (Angstrom) for one-particle density matrix values on a grid -*/
+        /*- Cutoff (e/A^3) for printing one-particle density matrix values on a grid -*/
+        options.add_double("OPDM_GRID_CUTOFF", 1.0e-30);
+        /*- Deprecated and will be removed in 1.7. Use OPDM_GRID_STEPSIZE. -*/
         options.add_double("ONEPDM_GRID_STEPSIZE", 0.1);
+        /*- Step size (Angstrom) for one-particle density matrix values on a grid -*/
+        options.add_double("OPDM_GRID_STEPSIZE", 0.1);
         /*- Do write natural orbitals (molden) -*/
         options.add_bool("WRITE_NOS", false);
         /*- Reproducing energies from densities ? -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1811,7 +1811,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_bool("ZETA", false);
         /*- Deprecated and will be removed in 1.7. Use OPDM_ONLY. -*/
         options.add_bool("ONEPDM", false);
-        /*- For internal use only! Compute the one-particle density matrix, but not the two-particle density matrix. -*/
+        /*- For internal use only! Compute the one-particle density matrix, but not the two-particle density matrix. !expert -*/
         options.add_bool("OPDM_ONLY", false);
         /*- Deprecated and will be removed in 1.7. Use OPDM_GRID_DUMP. -*/
         options.add_bool("ONEPDM_GRID_DUMP", false);

--- a/tests/pytests/test_dipoles.py
+++ b/tests/pytests/test_dipoles.py
@@ -19,7 +19,8 @@ perturbation_strength = 0.001
     pytest.param({'name': 'olccd', 'options': {'cc_type': 'df', 'max_mograd_convergence': 6}, 'varname': 'DF-OLCCD'}, id='df-olccd ae'),
     pytest.param({'name': 'olccd', 'options': {'cc_type': 'df', 'freeze_core': 'true', 'max_mograd_convergence': 6}, 'varname': 'DF-OLCCD'}, id='df-olccd fc'),
     pytest.param({'name': 'dct', 'options': {'dct_type': 'df'}, 'varname': 'DCT'}, id='df-rdct'),
-    pytest.param({'name': 'dct', 'options': {'dct_type': 'df', 'reference': 'uhf'}, 'varname': 'DCT'}, id='df-udct')
+    pytest.param({'name': 'dct', 'options': {'dct_type': 'df', 'reference': 'uhf'}, 'varname': 'DCT'}, id='df-udct'),
+    pytest.param({'name': 'ccsd', 'options': {'opdm_relax': 'true'}, 'varname': 'CCSD'}, id='ccsd'),
     ]
 )
 def test_dipole(inp):
@@ -41,4 +42,4 @@ def test_dipole(inp):
     wfn = psi4.properties(inp['name'], properties=['dipole'], return_wfn=True)[1]
     analytic_dipole = wfn.variable(inp['varname'] + " DIPOLE")
 
-    assert compare_values(findif_dipole, analytic_dipole, 5, "analytic vs. findif dipole")
+    assert compare_values(findif_dipole, analytic_dipole, 5, "findif vs. analytic dipole")


### PR DESCRIPTION
## Description
Closes #2432.

This is PR 1 in an ongoing series to make `ccdensity` compatible with the standard `Matrix` and `Wavefunction` machinery used elsewhere in Psi. (That means I'll have a lot of PRs for you two to review. Let me know if there's another person from VA Tech you want to take the responsibility of reviewing my PRs.)

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Adds finite difference test on CCSD dipoles
- [x] Standardizes `onepdm` vs `opdm` in `ccdensity` keywords.
- [x] Corrects incorrect description of the `onepdm`/`opdm` keyword
- [x] Creates new `ccdensity` function to convert `** double` to `Matrix`
- [x] Adds `Ca` matrix to parameters, to begin phasing out the QT ordered `** double` representation of the orbitals    

## Checklist
- [x] Passes `cc` tests
- [x] Passes finite difference test on CCSD dipoles

## Status
- [x] Ready for review
- [x] Ready for merge
