### PR TITLE
Fix bug in MemDFJK afflicting TDDFT

### DIFF
--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -770,7 +770,7 @@ std::pair<size_t, size_t> DFHelper::Qshell_blocks_for_transform(const size_t mem
             tmpbs = 0;
         }
     }
-    // returns pair(largest buffer size, largest block size)
+
     return std::make_pair(largest, block_size);
 }
 std::tuple<size_t, size_t> DFHelper::Qshell_blocks_for_JK_build(std::vector<std::pair<size_t, size_t>>& b,
@@ -826,7 +826,7 @@ std::tuple<size_t, size_t> DFHelper::Qshell_blocks_for_JK_build(std::vector<std:
             count = total_AO_buffer = tmpbs = 0;
         }
     }
-    // returns tuple(largest AO buffer size, largest Q block size)
+
     return std::make_tuple(largest, block_size);
 }
 
@@ -3010,6 +3010,9 @@ void DFHelper::compute_JK(std::vector<SharedMatrix> Cleft, std::vector<SharedMat
     // 1. we could predict the blocks used, write them to different files, and improve IO, otherwise
     // the strided disk reads for the AOs will result in a definite loss to DiskDFJK in the disk-bound realm
     // 2. we could allocate the buffers only once, instead of every time compute_JK() is called
+
+    // Each element of Qsteps specifies the endpoints of a batch of auxiliary shells.
+    // We'll treat all (PN|Q) for Q in this batch at once.
     std::vector<std::pair<size_t, size_t>> Qsteps;
     std::tuple<size_t, size_t> info = Qshell_blocks_for_JK_build(Qsteps, max_nocc, lr_symmetric);
     size_t tots = std::get<0>(info);
@@ -3039,7 +3042,6 @@ void DFHelper::compute_JK(std::vector<SharedMatrix> Cleft, std::vector<SharedMat
     size_t Ktmp_size = (!max_nocc ? totsb * 1 : totsb * max_nocc);
     Ktmp_size = std::max(Ktmp_size * nbf_, nthreads_ * naux_);  // max necessary
     Ktmp_size = std::max(Ktmp_size, nbf_ * nbf_); 
-    Ktmp_size = std::max(Ktmp_size, nthreads_ * naux_);
     T1 = std::make_unique<double[]>(Ktmp_size);
     double* T1p = T1.get();
 
@@ -3070,14 +3072,15 @@ void DFHelper::compute_JK(std::vector<SharedMatrix> Cleft, std::vector<SharedMat
         M1p = m1Ppq_.get();
     }
 
-    // transform in steps (blocks of Q)
-    for (size_t j = 0, bcount = 0; j < Qsteps.size(); j++) {
+    // Transform a single batch of integrals
+    size_t bcount = 0;
+    for (const auto& Qstep :Qsteps) {
         // Qshell step info
-        size_t start = std::get<0>(Qsteps[j]);
-        size_t stop = std::get<1>(Qsteps[j]);
-        size_t begin = Qshell_aggs_[start];
-        size_t end = Qshell_aggs_[stop + 1] - 1;
-        size_t block_size = end - begin + 1;
+        auto start = std::get<0>(Qstep);
+        auto stop = std::get<1>(Qstep);
+        auto begin = Qshell_aggs_[start];
+        auto end = Qshell_aggs_[stop + 1] - 1;
+        auto block_size = end - begin + 1;
 
         // get AO chunk according to directive
         timer_on("DFH: Grabbing AOs");
@@ -3177,7 +3180,7 @@ void DFHelper::fill(double* b, size_t count, double value) {
         b[i] = value;
     }
 }
-void DFHelper::compute_J(std::vector<SharedMatrix> D, std::vector<SharedMatrix> J, double* Mp, double* T1p, double* T2p,
+void DFHelper::compute_J(const std::vector<SharedMatrix> D, std::vector<SharedMatrix> J, double* Mp, double* T1p, double* T2p,
                          std::vector<std::vector<double>>& D_buffers, size_t bcount, size_t block_size) {
     for (size_t i = 0; i < J.size(); i++) {
         // grab orbital spaces
@@ -3185,6 +3188,7 @@ void DFHelper::compute_J(std::vector<SharedMatrix> D, std::vector<SharedMatrix> 
         double* Jp = J[i]->pointer()[0];
 
         // initialize Tmp (pQ)
+        // TODO: Make T1p a std::vector, so we don't need to know the length.
         fill(T1p, nthreads_ * naux_, 0.0);
 
 #pragma omp parallel for schedule(guided) num_threads(nthreads_)
@@ -3379,7 +3383,7 @@ void DFHelper::compute_wK(std::vector<SharedMatrix> Cleft, std::vector<SharedMat
             first_transform_pQq(nocc, bcount, block_size, wMp, T2p, Crp, C_buffers);
 
             // compute wK
-            C_DGEMM('N', 'T', nbf_, nbf_, nocc * block_size, 1.0, T2p, nocc * block_size, T1p, nocc * block_size, 1.0,
+            C_DGEMM('N', 'T', nbf_, nbf_, nocc * block_size, 1.0, T1p, nocc * block_size, T2p, nocc * block_size, 1.0,
                     wKp, nbf_);
         }
         bcount += block_size;

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -47,6 +47,9 @@ class Matrix;
 class ERISieve;
 class TwoBodyAOInt;
 
+// COMMON VARIABLE NAMES
+// lr_symmetric: Are the two C matrices in our J/K-esque contraction equal?
+
 class PSI_API DFHelper {
    public:
     DFHelper(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> aux);
@@ -410,6 +413,7 @@ class PSI_API DFHelper {
     // => generalized blocking <=
     std::pair<size_t, size_t> pshell_blocks_for_AO_build(const size_t mem, size_t symm,
                                                          std::vector<std::pair<size_t, size_t>>& b);
+    // returns pair(largest buffer size, largest block size)
     std::pair<size_t, size_t> Qshell_blocks_for_transform(const size_t mem, size_t wtmp, size_t wfinal,
                                                           std::vector<std::pair<size_t, size_t>>& b);
     void metric_contraction_blocking(std::vector<std::pair<size_t, size_t>>& steps, size_t blocking_index,
@@ -483,7 +487,10 @@ class PSI_API DFHelper {
                      std::pair<size_t, size_t> a3);
     void get_tensor_(std::string file, double* b, const size_t start1, const size_t stop1, const size_t start2,
                      const size_t stop2);
+    // Write to `file` from `Mp`, starting at position `start` in `file` and reading length `size`.
+    // The file is opened in mode `op`.
     void put_tensor_AO(std::string file, double* Mp, size_t size, size_t start, std::string op);
+    // Read from `file` into `Mp`, starting at position `start` in `file` and reading length `size`
     void get_tensor_AO(std::string file, double* Mp, size_t size, size_t start);
 
     // => internal handlers for FILE IO <=
@@ -511,7 +518,12 @@ class PSI_API DFHelper {
                     std::vector<SharedMatrix> J, std::vector<SharedMatrix> K, size_t max_nocc, bool do_J, bool do_K,
                     bool do_wK, bool lr_symmetric);
     void compute_D(std::vector<SharedMatrix> D, std::vector<SharedMatrix> Cleft, std::vector<SharedMatrix> Cright);
-    void compute_J(std::vector<SharedMatrix> D, std::vector<SharedMatrix> J, double* Mp, double* T1p, double* T2p,
+    // D   : Density matrices are read from here
+    // J   : Coulomb matrices are written to here
+    // M1p : Intermediate populated now for wK later.
+    // T1p : Temporary matrix
+    // T2p : Temporary matrix
+    void compute_J(const std::vector<SharedMatrix> D, std::vector<SharedMatrix> J, double* Mp, double* T1p, double* T2p,
                    std::vector<std::vector<double>>& D_buffers, size_t bcount, size_t block_size);
     void compute_J_symm(std::vector<SharedMatrix> D, std::vector<SharedMatrix> J, double* Mp, double* T1p, double* T2p,
                         std::vector<std::vector<double>>& D_buffers, size_t bcount, size_t block_size);
@@ -519,6 +531,7 @@ class PSI_API DFHelper {
     void compute_K(std::vector<SharedMatrix> Cleft, std::vector<SharedMatrix> Cright, std::vector<SharedMatrix> K,
                    double* Tp, double* Jtmp, double* Mp, size_t bcount, size_t block_size,
                    std::vector<std::vector<double>>& C_buffers, bool lr_symmetric);
+    // returns tuple(largest AO buffer size, largest Q block size)
     std::tuple<size_t, size_t> Qshell_blocks_for_JK_build(std::vector<std::pair<size_t, size_t>>& b, size_t max_nocc,
                                                           bool lr_symmetric);
     void compute_wK(std::vector<SharedMatrix> Cleft, std::vector<SharedMatrix> Cright, std::vector<SharedMatrix> wK,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,7 +101,7 @@ foreach(test_name adc1 adc2 aediis-1 aediis-2
                   options1 cubeprop-esp dft-smoke scf-hess1 scf-hess2 scf-hess3 scf-hess4 scf-hess5 scf-freq1 dft-jk scf-coverage
                   dft-custom-dhdf dft-custom-hybrid dft-custom-mgga dft-custom-gga
                   pywrap-bfs pywrap-align pywrap-align-chiral mints12 cc-module
-                  tdscf-1 tdscf-2 tdscf-3 tdscf-4 tdscf-5
+                  tdscf-1 tdscf-2 tdscf-3 tdscf-4 tdscf-5 tdscf-6
                   basis-ecp dft-pruning freq-masses sapt9 sapt10 sapt11 scf-uhf-grad-nobeta
 )
     add_subdirectory(${test_name})

--- a/tests/tdscf-6/CMakeLists.txt
+++ b/tests/tdscf-6/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(tdscf-6 "psi;quicktests;tdscf")

--- a/tests/tdscf-6/input.dat
+++ b/tests/tdscf-6/input.dat
@@ -1,0 +1,40 @@
+#! td-camb3lyp with DiskDF and method/basis specification
+from psi4.driver.procrouting.response.scf_response import tdscf_excitations
+
+memory 280 mb
+
+molecule h2o {
+O
+H 1 r
+H 1 r 2 a
+
+r=0.958
+a=104.5
+
+symmetry c1
+}
+
+set {
+    scf_type disk_df
+    e_convergence 8
+    d_convergence 8
+    save_jk true
+    basis def2-SVP
+}
+
+ref = 0.283463
+string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
+string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
+
+wfn = psi4.energy("cam-b3lyp", return_wfn=True, molecule=h2o)[1]
+res = tdscf_excitations(wfn, states=1, tda=True)
+print(wfn.variables())
+
+compare_values(ref, wfn.variable(string), 4, string)
+
+set scf_type mem_df
+
+wfn = psi4.energy("cam-b3lyp", return_wfn=True, molecule=h2o)[1]
+res = tdscf_excitations(wfn, states=1, tda=True)
+
+compare_values(ref, wfn.variable(string), 4, string)

--- a/tests/tdscf-6/input.dat
+++ b/tests/tdscf-6/input.dat
@@ -24,7 +24,6 @@ set {
 
 ref = 0.283463
 string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
-string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
 
 wfn = psi4.energy("cam-b3lyp", return_wfn=True, molecule=h2o)[1]
 res = tdscf_excitations(wfn, states=1, tda=True)

--- a/tests/tdscf-6/output.ref
+++ b/tests/tdscf-6/output.ref
@@ -67,7 +67,6 @@ set {
 
 ref = 0.283463
 string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
-string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
 
 wfn = psi4.energy("cam-b3lyp", return_wfn=True, molecule=h2o)[1]
 res = tdscf_excitations(wfn, states=1, tda=True)

--- a/tests/tdscf-6/output.ref
+++ b/tests/tdscf-6/output.ref
@@ -1,0 +1,732 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.6a1.dev45 
+
+                         Git: Rev {master} 2e3b0f2 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Thursday, 10 February 2022 03:39PM
+
+    Process ID: 31647
+    Host:       dhcp189-153.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! td-camb3lyp with DiskDF and method/basis specification
+from psi4.driver.procrouting.response.scf_response import tdscf_excitations
+
+memory 280 mb
+
+molecule h2o {
+O
+H 1 r
+H 1 r 2 a
+
+r=0.958
+a=104.5
+
+symmetry c1
+}
+
+set {
+    scf_type disk_df
+    e_convergence 8
+    d_convergence 8
+    save_jk true
+    basis def2-SVP
+}
+
+ref = 0.283463
+string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
+string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
+
+wfn = psi4.energy("cam-b3lyp", return_wfn=True, molecule=h2o)[1]
+res = tdscf_excitations(wfn, states=1, tda=True)
+print(wfn.variables())
+
+compare_values(ref, wfn.variable(string), 4, string)
+
+set scf_type mem_df
+
+wfn = psi4.energy("cam-b3lyp", return_wfn=True, molecule=h2o)[1]
+res = tdscf_excitations(wfn, states=1, tda=True)
+
+compare_values(ref, wfn.variable(string), 4, string)
+--------------------------------------------------------------------------
+
+  Memory set to 267.029 MiB by Python driver.
+
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-153.emerson.emory.edu
+*** at Thu Feb 10 15:39:02 2022
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    267 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065638538108    15.994914619570
+         H            0.000000000000    -0.757480611647     0.520865616165     1.007825032230
+         H            0.000000000000     0.757480611647     0.520865616165     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.37692  B =     14.57600  C =      9.51176 [cm^-1]
+  Rotational constants: A = 820739.39651  B = 436977.44416  C = 285155.28473 [MHz]
+  Nuclear repulsion =    9.187333574704981
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => LibXC <=
+
+    Version 5.1.5
+    S. Lehtola, C. Steigemann, M. J. Oliveira, and M. A. Marques, SoftwareX 7, 1 (2018) (10.1016/j.softx.2017.11.002)
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004) (10.1016/j.cplett.2004.06.011)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for B88 functional - erf [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_CAM_B3LYP:  1.00E-14 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           NONE
+    Nuclear Scheme         =       TREUTLER
+
+    Blocking Scheme        =         OCTREE
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             75
+    Spherical Points       =            302
+    Total Points           =          66186
+    Total Blocks           =            553
+    Max Points             =            255
+    Max Functions          =             24
+    Weights Tolerance      =       1.00E-15
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:              153
+    Algorithm:                Core
+    Integral Cache:           NONE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (DEF2-SVP AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Cached 100.0% of DFT collocation blocks in 0.046 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 3.7586553523E-02.
+  Reciprocal condition number of the overlap matrix is 9.7948418071E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -75.96686470860365   -7.59669e+01   0.00000e+00 
+   @DF-RKS iter   1:   -76.20148342915417   -2.34619e-01   2.43937e-02 DIIS
+   @DF-RKS iter   2:   -76.17589780043996    2.55856e-02   2.74605e-02 DIIS
+   @DF-RKS iter   3:   -76.32971418457153   -1.53816e-01   4.95859e-04 DIIS
+   @DF-RKS iter   4:   -76.32977996490725   -6.57803e-05   1.40139e-04 DIIS
+   @DF-RKS iter   5:   -76.32978482532044   -4.86041e-06   2.18588e-05 DIIS
+   @DF-RKS iter   6:   -76.32978496172510   -1.36405e-07   1.46511e-06 DIIS
+   @DF-RKS iter   7:   -76.32978496393514   -2.21004e-09   2.68910e-07 DIIS
+   @DF-RKS iter   8:   -76.32978496400901   -7.38680e-11   2.37192e-08 DIIS
+   @DF-RKS iter   9:   -76.32978496400946   -4.54747e-13   1.62146e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   Electrons on quadrature grid:
+      Ntotal   =   10.0000002369 ; deviation = 2.369e-07 
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -19.189782     2A     -1.060491     3A     -0.584855  
+       4A     -0.434089     5A     -0.361518  
+
+    Virtual:                                                              
+
+       6A      0.094001     7A      0.173681     8A      0.629996  
+       9A      0.690198    10A      0.984881    11A      0.989896  
+      12A      1.070370    13A      1.157203    14A      1.415757  
+      15A      1.480732    16A      1.622122    17A      1.859615  
+      18A      2.296688    19A      2.337991    20A      3.039647  
+      21A      3.089664    22A      3.270486    23A      3.581052  
+      24A      3.898864  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RKS Final Energy:   -76.32978496400946
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873335747049811
+    One-Electron Energy =                -123.1023942421548156
+    Two-Electron Energy =                  44.4154516829815691
+    DFT Exchange-Correlation Energy =      -6.8301759795411927
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -76.3297849640094626
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9763
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.1835
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.7928     Total:     0.7928
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.0151     Total:     2.0151
+
+
+*** tstop() called on dhcp189-153.emerson.emory.edu at Thu Feb 10 15:39:05 2022
+Module time:
+	user time   =       2.29 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =       2.29 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+
+         ---------------------------------------------------------
+                         TDSCF excitation energies                
+                 by Andrew M. James and Daniel G. A. Smith        
+         ---------------------------------------------------------
+
+  ==> Options <==
+
+     Residual threshold  : 1.0000e-04
+     Initial guess       : denominators
+     Reference           : RHF
+     Solver type         : TDA (Davidson)
+
+
+  ==> Requested Excitations <==
+
+      1 singlet states with A symmetry
+
+
+  ==> Seeking the lowest 1 singlet states with A symmetry
+
+                         Generalized Davidson Solver                         
+                               By Ruhee Dcunha                               
+
+  ==> Options <==
+
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-04
+    Max number of expansion vectors = 200  
+
+  => Iterations <=
+                           Max[D[value]]     Max[|R|]   # vectors
+  DavidsonSolver iter   1:   2.85457e-01  5.81643e-02      4      
+  DavidsonSolver iter   2:   1.92901e-03  9.81755e-03      5      
+  DavidsonSolver iter   3:   6.49658e-05  5.41803e-04      6      
+  DavidsonSolver iter   4:   2.13822e-07  3.79297e-05      7      Converged
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********  Length-gauge rotatory strengths are **NOT** gauge-origin invariant  **********
+******************************************************************************************
+
+                                    Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
+     #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
+    ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
+     1        A->A (1 A)       0.28346         7.71343        -76.04632        0.0179          0.1293         -0.0000         -0.0000        
+
+
+
+Contributing excitations
+Only contributions with coefficients > 1.00e-01 will be printed:
+
+Excited State    1 (1 A):   0.28346 au   160.74 nm f = 0.0179
+  Sums of squares: Xssq =  1.000000e+00
+     5 ->  6    0.998965 (99.793%)
+
+    TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY..........................PASSED
+
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-153.emerson.emory.edu
+*** at Thu Feb 10 15:39:07 2022
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   130 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    267 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065638538108    15.994914619570
+         H            0.000000000000    -0.757480611647     0.520865616165     1.007825032230
+         H            0.000000000000     0.757480611647     0.520865616165     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.37692  B =     14.57600  C =      9.51176 [cm^-1]
+  Rotational constants: A = 820739.39651  B = 436977.44416  C = 285155.28473 [MHz]
+  Nuclear repulsion =    9.187333574704981
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is MEM_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> DFT Potential <==
+
+   => LibXC <=
+
+    Version 5.1.5
+    S. Lehtola, C. Steigemann, M. J. Oliveira, and M. A. Marques, SoftwareX 7, 1 (2018) (10.1016/j.softx.2017.11.002)
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004) (10.1016/j.cplett.2004.06.011)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for B88 functional - erf [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_CAM_B3LYP:  1.00E-14 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           NONE
+    Nuclear Scheme         =       TREUTLER
+
+    Blocking Scheme        =         OCTREE
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             75
+    Spherical Points       =            302
+    Total Points           =          66186
+    Total Blocks           =            553
+    Max Points             =            255
+    Max Functions          =             24
+    Weights Tolerance      =       1.00E-15
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.150 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                  Yes
+    Omega:                3.300E-01
+    OpenMP threads:               1
+    Memory [MiB]:               153
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (DEF2-SVP AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Cached 100.0% of DFT collocation blocks in 0.046 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 3.7586553523E-02.
+  Reciprocal condition number of the overlap matrix is 9.7948418071E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -75.96686470860524   -7.59669e+01   0.00000e+00 
+   @DF-RKS iter   1:   -76.20148342915220   -2.34619e-01   2.43937e-02 DIIS
+   @DF-RKS iter   2:   -76.17589780043848    2.55856e-02   2.74605e-02 DIIS
+   @DF-RKS iter   3:   -76.32971418456872   -1.53816e-01   4.95859e-04 DIIS
+   @DF-RKS iter   4:   -76.32977996490450   -6.57803e-05   1.40139e-04 DIIS
+   @DF-RKS iter   5:   -76.32978482531766   -4.86041e-06   2.18588e-05 DIIS
+   @DF-RKS iter   6:   -76.32978496172220   -1.36405e-07   1.46511e-06 DIIS
+   @DF-RKS iter   7:   -76.32978496393233   -2.21013e-09   2.68910e-07 DIIS
+   @DF-RKS iter   8:   -76.32978496400614   -7.38112e-11   2.37192e-08 DIIS
+   @DF-RKS iter   9:   -76.32978496400669   -5.54223e-13   1.62146e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   Electrons on quadrature grid:
+      Ntotal   =   10.0000002369 ; deviation = 2.369e-07 
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -19.189782     2A     -1.060491     3A     -0.584855  
+       4A     -0.434089     5A     -0.361518  
+
+    Virtual:                                                              
+
+       6A      0.094001     7A      0.173681     8A      0.629996  
+       9A      0.690198    10A      0.984881    11A      0.989896  
+      12A      1.070370    13A      1.157203    14A      1.415757  
+      15A      1.480732    16A      1.622122    17A      1.859615  
+      18A      2.296688    19A      2.337991    20A      3.039647  
+      21A      3.089664    22A      3.270486    23A      3.581052  
+      24A      3.898864  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RKS Final Energy:   -76.32978496400669
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873335747049811
+    One-Electron Energy =                -123.1023942421458059
+    Two-Electron Energy =                  44.4154516829742008
+    DFT Exchange-Correlation Energy =      -6.8301759795400541
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -76.3297849640066772
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9763
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.1835
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.7928     Total:     0.7928
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     2.0151     Total:     2.0151
+
+
+*** tstop() called on dhcp189-153.emerson.emory.edu at Thu Feb 10 15:39:09 2022
+Module time:
+	user time   =       2.20 seconds =       0.04 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       6.10 seconds =       0.10 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+
+         ---------------------------------------------------------
+                         TDSCF excitation energies                
+                 by Andrew M. James and Daniel G. A. Smith        
+         ---------------------------------------------------------
+
+  ==> Options <==
+
+     Residual threshold  : 1.0000e-04
+     Initial guess       : denominators
+     Reference           : RHF
+     Solver type         : TDA (Davidson)
+
+
+  ==> Requested Excitations <==
+
+      1 singlet states with A symmetry
+
+
+  ==> Seeking the lowest 1 singlet states with A symmetry
+
+                         Generalized Davidson Solver                         
+                               By Ruhee Dcunha                               
+
+  ==> Options <==
+
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-04
+    Max number of expansion vectors = 200  
+
+  => Iterations <=
+                           Max[D[value]]     Max[|R|]   # vectors
+  DavidsonSolver iter   1:   2.85457e-01  5.81643e-02      4      
+  DavidsonSolver iter   2:   1.92901e-03  9.81755e-03      5      
+  DavidsonSolver iter   3:   6.49658e-05  5.41803e-04      6      
+  DavidsonSolver iter   4:   2.13822e-07  3.79297e-05      7      Converged
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********  Length-gauge rotatory strengths are **NOT** gauge-origin invariant  **********
+******************************************************************************************
+
+                                    Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
+     #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
+    ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
+     1        A->A (1 A)       0.28346         7.71343        -76.04632        0.0179          0.1293         -0.0000         -0.0000        
+
+
+
+Contributing excitations
+Only contributions with coefficients > 1.00e-01 will be printed:
+
+Excited State    1 (1 A):   0.28346 au   160.74 nm f = 0.0179
+  Sums of squares: Xssq =  1.000000e+00
+     5 ->  6    0.998965 (99.793%)
+
+    TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY..........................PASSED
+
+    Psi4 stopped on: Thursday, 10 February 2022 03:39PM
+    Psi4 wall time for execution: 0:00:08.85
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This PR fixes a bug introduced in #1749, where `MemDFJK` handling of range-separated functional was incorrect in the asymmetric case. This incorrect handling lead to incorrect TD-DFT excitation spectra for range-separated functionals when `MemDFJK` was used. This PR hence closes #2431. In the symmetric case, either swapping the contraction order had no effect, or it was corrected by a hermitivitize call later on, so no error was observed.

I strongly recommend backporting this PR (or at least the two characters needed to fix the bug). The rest of the PR other than those two characters is tests and commenting. Credit to @hokru for tag-team debugging. 

## Checklist
- [x] Tests added for newly working features

## Status
- [x] Ready for review
- [x] Ready for merge
