### PR TITLE
Docs fix

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -826,7 +826,7 @@ def _validate_diis(self):
 
     Raises
     ------
-    ValidationError
+    psi4.driver.p4util.exceptions.ValidationError
         If any of DIIS options don't play well together.
 
     Returns


### PR DESCRIPTION
## Description
Humor the Sphinx by specifying _exactly_ what error is raised by a function that was promoted to a Wavefunction method in the A/EDIIS PR.

## Status
- [x] Ready for review
- [x] Ready for merge
