### PR TITLE
Expose reset_subspace to C++ for plugins

### DIFF
--- a/psi4/src/psi4/libdiis/diismanager.cc
+++ b/psi4/src/psi4/libdiis/diismanager.cc
@@ -62,6 +62,10 @@ void DIISManager::delete_diis_file() {
     pydiis.attr("delete_diis_file")();
 }
 
+void DIISManager::reset_subspace() {
+    pydiis.attr("reset_subspace")();
+}
+
 DIISManager::~DIISManager() {
 }
 

--- a/psi4/src/psi4/libdiis/diismanager.h
+++ b/psi4/src/psi4/libdiis/diismanager.h
@@ -89,6 +89,8 @@ class PSI_API DIISManager {
     };
 
     void delete_diis_file();
+
+    void reset_subspace();
     /// The number of vectors currently in the subspace
     int subspace_size();
 


### PR DESCRIPTION
## Description
Per @fevangelista request, this PR allows Forte to compile with master Psi, almost. That also requires a Forte PR.

## Todos
- [x] Exposes `reset_subspace` to C++

## Status
- [x] Ready for review
- [x] Ready for merge
