### PR TITLE
Lose `*` in `ccdensity`

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/MOInfo.h
+++ b/psi4/src/psi4/cc/ccdensity/MOInfo.h
@@ -46,49 +46,49 @@ struct MOInfo {
     int nmo;                         /* no. of molecular orbitals */
     int nso;                         /* no. of symmetry orbitals */
     int nactive;                     /* no. of active orbitals */
-    int *orbspi;                     /* no. of MOs per irrep */
-    int *clsdpi;                     /* no. of closed-shells per irrep excl. frdocc */
-    int *openpi;                     /* no. of open-shells per irrep */
-    int *uoccpi;                     /* no. of unoccupied orbitals per irrep excl. fruocc */
-    int *frdocc;                     /* no. of frozen core orbitals per irrep */
-    int *fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
+    Dimension orbspi;                /* no. of MOs per irrep */
+    Dimension clsdpi;                /* no. of closed-shells per irrep excl. frdocc */
+    Dimension openpi;                /* no. of open-shells per irrep */
+    Dimension uoccpi;                /* no. of unoccupied orbitals per irrep excl. fruocc */
+    Dimension frdocc;                /* no. of frozen core orbitals per irrep */
+    Dimension fruocc;                /* no. of frozen unoccupied orbitals per irrep */
     std::vector<std::string> labels; /* irrep labels */
     int nfzc;                        /* total no. of frozen core orbitals */
     int nfzv;                        /* total no. of frozen virtual orbitals */
     int nclsd;                       /* total no. of closd shells excl. frdocc */
     int nopen;                       /* total no. of open shells  */
     int nuocc;                       /* total no. of unoccupied shells excl. fruocc */
-    int *occ_sym;                    /* active occupied index symmetry */
-    int *aocc_sym;                   /* alpha active occupied index symmetry */
-    int *bocc_sym;                   /* beta active occupied index symmetry */
-    int *vir_sym;                    /* active virtual index symmetry */
-    int *avir_sym;                   /* alpha active virtual index symmetry */
-    int *bvir_sym;                   /* beta active virtual index symmetry */
+    std::vector<int> occ_sym;        /* active occupied index symmetry */
+    std::vector<int> aocc_sym;       /* alpha active occupied index symmetry */
+    std::vector<int> bocc_sym;       /* beta active occupied index symmetry */
+    std::vector<int> vir_sym;        /* active virtual index symmetry */
+    std::vector<int> avir_sym;       /* alpha active virtual index symmetry */
+    std::vector<int> bvir_sym;       /* beta active virtual index symmetry */
     int sym;                         /* symmetry of converged CCSD state */
-    int *occpi;                      /* no. of active occ. orbs. (incl. open) per irrep */
-    int *aoccpi;                     /* no. of alpha active occ. orbs. (incl. open) per irrep */
-    int *boccpi;                     /* no. of beta active occ. orbs. (incl. open) per irrep */
-    int *virtpi;                     /* no. of active virt. orbs. (incl. open) per irrep */
-    int *avirtpi;                    /* no. of alpha active virt. orbs. (incl. open) per irrep */
-    int *bvirtpi;                    /* no. of beta active virt. orbs. (incl. open) per irrep */
-    int *occ_off;                    /* occupied orbital offsets within each irrep */
-    int *aocc_off;                   /* alpha occupied orbital offsets within each irrep */
-    int *bocc_off;                   /* beta occupied orbital offsets within each irrep */
-    int *vir_off;                    /* virtual orbital offsets within each irrep */
-    int *avir_off;                   /* alpha virtual orbital offsets within each irrep */
-    int *bvir_off;                   /* beta virtual orbital offsets within each irrep */
-    int *cc_occ;                     /* QT->CC active occupied reordering array */
-    int *cc_aocc;                    /* QT->CC alpha active occupied reordering array */
-    int *cc_bocc;                    /* QT->CC beta active occupied reordering array */
-    int *cc_vir;                     /* QT->CC active virtiual reordering array */
-    int *cc_avir;                    /* QT->CC alpha active virtiual reordering array */
-    int *cc_bvir;                    /* QT->CC beta active virtiual reordering array */
-    int *qt_occ;                     /* CC->QT active occupied reordering array */
-    int *qt_aocc;                    /* CC->QT alpha active occupied reordering array */
-    int *qt_bocc;                    /* CC->QT beta active occupied reordering array */
-    int *qt_vir;                     /* CC->QT active virtiual reordering array */
-    int *qt_avir;                    /* CC->QT alpha active virtiual reordering array */
-    int *qt_bvir;                    /* CC->QT beta active virtiual reordering array */
+    Dimension occpi;                 /* no. of active occ. orbs. (incl. open) per irrep */
+    Dimension aoccpi;                /* no. of alpha active occ. orbs. (incl. open) per irrep */
+    Dimension boccpi;                /* no. of beta active occ. orbs. (incl. open) per irrep */
+    Dimension virtpi;                /* no. of active virt. orbs. (incl. open) per irrep */
+    Dimension avirtpi;               /* no. of alpha active virt. orbs. (incl. open) per irrep */
+    Dimension bvirtpi;               /* no. of beta active virt. orbs. (incl. open) per irrep */
+    Dimension occ_off;               /* occupied orbital offsets within each irrep */
+    Dimension aocc_off;              /* alpha occupied orbital offsets within each irrep */
+    Dimension bocc_off;              /* beta occupied orbital offsets within each irrep */
+    Dimension vir_off;               /* virtual orbital offsets within each irrep */
+    Dimension avir_off;              /* alpha virtual orbital offsets within each irrep */
+    Dimension bvir_off;              /* beta virtual orbital offsets within each irrep */
+    std::vector<int> cc_occ;         /* QT->CC active occupied reordering array */
+    std::vector<int> cc_aocc;        /* QT->CC alpha active occupied reordering array */
+    std::vector<int> cc_bocc;        /* QT->CC beta active occupied reordering array */
+    std::vector<int> cc_vir;         /* QT->CC active virtiual reordering array */
+    std::vector<int> cc_avir;        /* QT->CC alpha active virtiual reordering array */
+    std::vector<int> cc_bvir;        /* QT->CC beta active virtiual reordering array */
+    std::vector<int> qt_occ;         /* CC->QT active occupied reordering array */
+    std::vector<int> qt_aocc;        /* CC->QT alpha active occupied reordering array */
+    std::vector<int> qt_bocc;        /* CC->QT beta active occupied reordering array */
+    std::vector<int> qt_vir;         /* CC->QT active virtiual reordering array */
+    std::vector<int> qt_avir;        /* CC->QT alpha active virtiual reordering array */
+    std::vector<int> qt_bvir;        /* CC->QT beta active virtiual reordering array */
     double enuc;                     /* Nuclear repulsion energy */
     double escf;                     /* SCF energy from wfn */
     double eref;                     /* Reference energy */
@@ -106,8 +106,8 @@ struct MOInfo {
     double **rtd;                    /* <n|O|0> Right transition density */
     double **rtd_a;                  /* <n|O|0> Right transition alpha density */
     double **rtd_b;                  /* <n|O|0> Right transition beta density */
-    int *pitzer2qt;                  /* Pitzer to QT re-ordering array */
-    int *qt2pitzer;                  /* QT to Pitzer re-ordering array */
+    std::vector<int> pitzer2qt;      /* Pitzer to QT re-ordering array */
+    std::vector<int> qt2pitzer;      /* QT to Pitzer re-ordering array */
     double **scf_qt;                 /* SCF orbitals (QT ordering of MOs) */
     SharedMatrix Ca;                 /* SCF orbitals (standard ordering) */
     double ***L;

--- a/psi4/src/psi4/cc/ccdensity/build_A_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A_ROHF.cc
@@ -56,19 +56,17 @@ namespace ccdensity {
 void build_A_ROHF() {
     int h, nirreps, e, m, a, i, em, ai, E, M, A, I;
     int Esym, Msym, Asym, Isym;
-    int *virtpi, *openpi, *occpi, *occ_off, *vir_off;
-    int *qt_occ, *qt_vir; /* Spatial orbital translators */
     dpdfile2 fIJ, fij, fAB, fab, fIA, fia;
     dpdbuf4 Amat, Amat2, D, C;
 
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    openpi = moinfo.openpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& occpi = moinfo.occpi;
+    const auto& openpi = moinfo.openpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& qt_occ = moinfo.qt_occ;
+    const auto& qt_vir = moinfo.qt_vir;
 
     /* Two-electron integral contributions */
     global_dpd_->buf4_init(&D, PSIF_CC_DINTS, 0, 0, 5, 0, 5, 0, "D <ij|ab>");

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -163,9 +163,9 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
 
         std::vector<int *> spaces;
         spaces.push_back(moinfo.occpi);
-        spaces.push_back(moinfo.occ_sym);
+        spaces.push_back(moinfo.occ_sym.data());
         spaces.push_back(moinfo.virtpi);
-        spaces.push_back(moinfo.vir_sym);
+        spaces.push_back(moinfo.vir_sym.data());
         delete dpd_list[0];
         dpd_list[0] = new DPD(0, moinfo.nirreps, params.memory, 0, cachefiles, cachelist, nullptr, 2, spaces);
         dpd_set_default(0);
@@ -175,13 +175,13 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
 
         std::vector<int *> spaces;
         spaces.push_back(moinfo.aoccpi);
-        spaces.push_back(moinfo.aocc_sym);
+        spaces.push_back(moinfo.aocc_sym.data());
         spaces.push_back(moinfo.avirtpi);
-        spaces.push_back(moinfo.avir_sym);
+        spaces.push_back(moinfo.avir_sym.data());
         spaces.push_back(moinfo.boccpi);
-        spaces.push_back(moinfo.bocc_sym);
+        spaces.push_back(moinfo.bocc_sym.data());
         spaces.push_back(moinfo.bvirtpi);
-        spaces.push_back(moinfo.bvir_sym);
+        spaces.push_back(moinfo.bvir_sym.data());
         dpd_init(0, moinfo.nirreps, params.memory, 0, cachefiles, cachelist, nullptr, 4, spaces);
     }
 

--- a/psi4/src/psi4/cc/ccdensity/dump_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_RHF.cc
@@ -78,12 +78,11 @@ namespace ccdensity {
 
 void dump_RHF(struct iwlbuf *OutBuf, const struct RHO_Params& rho_params) {
     int nirreps, nmo, nfzv;
-    int *qt_occ, *qt_vir;
     int h, row, col, p, q, r, s;
     dpdbuf4 G;
 
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& qt_occ = moinfo.qt_occ.data();
+    const auto& qt_vir = moinfo.qt_vir.data();
     nirreps = moinfo.nirreps;
     nmo = moinfo.nmo;
     nfzv = moinfo.nfzv;

--- a/psi4/src/psi4/cc/ccdensity/dump_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_ROHF.cc
@@ -68,12 +68,11 @@ namespace ccdensity {
 
 void dump_ROHF(struct iwlbuf *OutBuf, const struct RHO_Params& rho_params) {
     int nirreps, nmo, nfzv;
-    int *qt_occ, *qt_vir;
     int h, row, col, p, q, r, s;
     dpdbuf4 G;
 
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& qt_occ = moinfo.qt_occ.data();
+    const auto& qt_vir = moinfo.qt_vir.data();
     nirreps = moinfo.nirreps;
     nmo = moinfo.nmo;
     nfzv = moinfo.nfzv;

--- a/psi4/src/psi4/cc/ccdensity/dump_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_UHF.cc
@@ -61,16 +61,14 @@ namespace ccdensity {
 
 void dump_UHF(struct iwlbuf *AA, struct iwlbuf *BB, struct iwlbuf *AB, const struct RHO_Params& rho_params) {
     int nirreps, nmo, h, row, col;
-    int *qt_aocc, *qt_avir;
-    int *qt_bocc, *qt_bvir;
     int p, q, r, s, P, Q, R, S, pr, qs;
     double value;
     dpdbuf4 G;
 
-    qt_aocc = moinfo.qt_aocc;
-    qt_avir = moinfo.qt_avir;
-    qt_bocc = moinfo.qt_bocc;
-    qt_bvir = moinfo.qt_bvir;
+    const auto& qt_aocc = moinfo.qt_aocc.data();
+    const auto& qt_avir = moinfo.qt_avir.data();
+    const auto& qt_bocc = moinfo.qt_bocc.data();
+    const auto& qt_bvir = moinfo.qt_bvir.data();
     nirreps = moinfo.nirreps;
     nmo = moinfo.nmo;
 

--- a/psi4/src/psi4/cc/ccdensity/ex_sort_td_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_sort_td_rohf.cc
@@ -46,9 +46,6 @@ namespace ccdensity {
 void ex_sort_td_rohf(char hand, int Tirrep) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *occpi, *virtpi, *occ_off, *vir_off;
-    int *occ_sym, *vir_sym, *openpi;
-    int *qt_occ, *qt_vir;
     double chksum, value;
     psio_address next;
     dpdfile2 D;
@@ -59,15 +56,15 @@ void ex_sort_td_rohf(char hand, int Tirrep) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
+    const auto& qt_occ = moinfo.qt_occ;
+    const auto& qt_vir = moinfo.qt_vir;
 
     // moinfo.ltd = block_matrix(nmo, nmo);
     double **gtd = block_matrix(nmo, nmo);

--- a/psi4/src/psi4/cc/ccdensity/ex_sort_td_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_sort_td_uhf.cc
@@ -45,12 +45,6 @@ namespace ccdensity {
 void ex_sort_td_uhf(char hand, int Tirrep) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *aoccpi, *avirtpi, *aocc_off, *avir_off;
-    int *boccpi, *bvirtpi, *bocc_off, *bvir_off;
-    int *aocc_sym, *avir_sym;
-    int *bocc_sym, *bvir_sym;
-    int *qt_aocc, *qt_avir;
-    int *qt_bocc, *qt_bvir;
     double chksum, value;
     dpdfile2 D;
 
@@ -60,20 +54,20 @@ void ex_sort_td_uhf(char hand, int Tirrep) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    aoccpi = moinfo.aoccpi;
-    avirtpi = moinfo.avirtpi;
-    boccpi = moinfo.boccpi;
-    bvirtpi = moinfo.bvirtpi;
-    aocc_off = moinfo.aocc_off;
-    avir_off = moinfo.avir_off;
-    bocc_off = moinfo.bocc_off;
-    bvir_off = moinfo.bvir_off;
-    aocc_sym = moinfo.aocc_sym;
-    avir_sym = moinfo.avir_sym;
-    qt_aocc = moinfo.qt_aocc;
-    qt_avir = moinfo.qt_avir;
-    qt_bocc = moinfo.qt_bocc;
-    qt_bvir = moinfo.qt_bvir;
+    const auto& aoccpi = moinfo.aoccpi;
+    const auto& avirtpi = moinfo.avirtpi;
+    const auto& boccpi = moinfo.boccpi;
+    const auto& bvirtpi = moinfo.bvirtpi;
+    const auto& aocc_off = moinfo.aocc_off;
+    const auto& avir_off = moinfo.avir_off;
+    const auto& bocc_off = moinfo.bocc_off;
+    const auto& bvir_off = moinfo.bvir_off;
+    const auto& aocc_sym = moinfo.aocc_sym;
+    const auto& avir_sym = moinfo.avir_sym;
+    const auto& qt_aocc = moinfo.qt_aocc;
+    const auto& qt_avir = moinfo.qt_avir;
+    const auto& qt_bocc = moinfo.qt_bocc;
+    const auto& qt_bvir = moinfo.qt_bvir;
 
     double **gtd_a = block_matrix(nmo, nmo);
     double **gtd_b = block_matrix(nmo, nmo);

--- a/psi4/src/psi4/cc/ccdensity/fold_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/fold_RHF.cc
@@ -72,10 +72,6 @@ void fold_RHF(const struct RHO_Params& rho_params) {
     int I, J, K, L, M, A, B;
     int IM, JM, MI, MJ, MK, ML, MA, MB;
     int Gi, Gj, Gk, Gl, Gm, Ga, Gb;
-    int *occpi, *virtpi;
-    int *occ_off, *vir_off;
-    int *occ_sym, *vir_sym;
-    int *openpi;
     dpdfile2 D, D1, D2, F;
     dpdbuf4 G, Aints, E, C, DInts, FInts, BInts, G1, G2;
     double one_energy = 0.0, two_energy = 0.0, total_two_energy = 0.0;
@@ -83,13 +79,13 @@ void fold_RHF(const struct RHO_Params& rho_params) {
     double this_energy;
 
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
 
     if (!params.aobasis && params.debug_) {
         outfile->Printf("\n\tEnergies re-computed from Fock-adjusted CC density:\n");

--- a/psi4/src/psi4/cc/ccdensity/fold_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/fold_ROHF.cc
@@ -72,10 +72,6 @@ void fold_ROHF(const struct RHO_Params& rho_params) {
     int I, J, K, L, M, A, B;
     int IM, JM, MI, MJ, MK, ML, MA, MB;
     int Gi, Gj, Gk, Gl, Gm, Ga, Gb;
-    int *occpi, *virtpi;
-    int *occ_off, *vir_off;
-    int *occ_sym, *vir_sym;
-    int *openpi;
     dpdfile2 D, D1, D2, F;
     dpdbuf4 G, Aints, E, C, DInts, FInts, BInts, G1, G2;
     double one_energy = 0.0, two_energy = 0.0, total_two_energy = 0.0;
@@ -83,13 +79,13 @@ void fold_ROHF(const struct RHO_Params& rho_params) {
     double this_energy;
 
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
 
     if (!params.aobasis && params.debug_) {
         outfile->Printf("\n\tEnergies re-computed from Fock-adjusted CC density:\n");

--- a/psi4/src/psi4/cc/ccdensity/fold_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/fold_UHF.cc
@@ -73,30 +73,24 @@ void fold_UHF(const struct RHO_Params& rho_params) {
     int I, J, K, L, M, A, B;
     int IM, JM, MI, MJ, MK, ML, MA, MB;
     int Gi, Gj, Gk, Gl, Gm, Ga, Gb;
-    int *aoccpi, *avirtpi;
-    int *boccpi, *bvirtpi;
-    int *aocc_off, *avir_off;
-    int *bocc_off, *bvir_off;
-    int *aocc_sym, *avir_sym;
-    int *bocc_sym, *bvir_sym;
     dpdfile2 D, D1, D2, F;
     dpdbuf4 G, Aints, E, C, DInts, FInts, BInts, G1, G2;
     double one_energy = 0.0, two_energy = 0.0, total_two_energy = 0.0;
     double this_energy;
 
     nirreps = moinfo.nirreps;
-    aoccpi = moinfo.aoccpi;
-    avirtpi = moinfo.avirtpi;
-    boccpi = moinfo.boccpi;
-    bvirtpi = moinfo.bvirtpi;
-    aocc_off = moinfo.aocc_off;
-    avir_off = moinfo.avir_off;
-    bocc_off = moinfo.bocc_off;
-    bvir_off = moinfo.bvir_off;
-    aocc_sym = moinfo.aocc_sym;
-    avir_sym = moinfo.avir_sym;
-    bocc_sym = moinfo.bocc_sym;
-    bvir_sym = moinfo.bvir_sym;
+    const auto& aoccpi = moinfo.aoccpi;
+    const auto& avirtpi = moinfo.avirtpi;
+    const auto& boccpi = moinfo.boccpi;
+    const auto& bvirtpi = moinfo.bvirtpi;
+    const auto& aocc_off = moinfo.aocc_off;
+    const auto& avir_off = moinfo.avir_off;
+    const auto& bocc_off = moinfo.bocc_off;
+    const auto& bvir_off = moinfo.bvir_off;
+    const auto& aocc_sym = moinfo.aocc_sym;
+    const auto& avir_sym = moinfo.avir_sym;
+    const auto& bocc_sym = moinfo.bocc_sym;
+    const auto& bvir_sym = moinfo.bvir_sym;
 
     if (params.debug_) {
         outfile->Printf("\n\tEnergies re-computed from Fock-adjusted CC density:\n");

--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -73,14 +73,10 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     else
         moinfo.escf = wfn->energy();
 
-    moinfo.orbspi = init_int_array(moinfo.nirreps);
-    moinfo.clsdpi = init_int_array(moinfo.nirreps);
-    moinfo.openpi = init_int_array(moinfo.nirreps);
-    for (int h = 0; h < moinfo.nirreps; ++h) {
-        moinfo.orbspi[h] = wfn->nmopi()[h];
-        moinfo.clsdpi[h] = wfn->doccpi()[h];
-        moinfo.openpi[h] = wfn->soccpi()[h];
-    }
+    moinfo.orbspi = wfn->nmopi();
+    moinfo.clsdpi = wfn->doccpi();
+    moinfo.openpi = wfn->soccpi();
+
     moinfo.Ca = wfn->Ca();
     scf_pitzer = wfn->Ca()->to_block_matrix();
 
@@ -88,76 +84,78 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     for (i = 0; i < moinfo.nirreps; ++i)
         for (j = 0; j < moinfo.openpi[i]; ++j) moinfo.sym = moinfo.sym ^ i;
 
+    auto temp = std::vector<int>(moinfo.nirreps);
+
     /* Get frozen and active orbital lookups from CC_INFO */
-    moinfo.frdocc = init_int_array(moinfo.nirreps);
-    moinfo.fruocc = init_int_array(moinfo.nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)moinfo.frdocc, sizeof(int) * moinfo.nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)moinfo.fruocc, sizeof(int) * moinfo.nirreps);
+    psio_read_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
+    moinfo.frdocc = Dimension(temp);
+    psio_read_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
+    moinfo.fruocc = Dimension(temp);
 
     psio_read_entry(PSIF_CC_INFO, "No. of Active Orbitals", (char *)&(nactive), sizeof(int));
     moinfo.nactive = nactive;
 
     if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
 
-        moinfo.occpi = init_int_array(moinfo.nirreps);
-        moinfo.virtpi = init_int_array(moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)moinfo.occpi, sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)moinfo.virtpi,
+        psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
+        moinfo.occpi = Dimension(temp);
+        psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
+        moinfo.virtpi = Dimension(temp);
 
-        moinfo.occ_sym = init_int_array(nactive);
-        moinfo.vir_sym = init_int_array(nactive);
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Symmetry", (char *)moinfo.occ_sym, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Symmetry", (char *)moinfo.vir_sym, sizeof(int) * nactive);
+        moinfo.occ_sym = std::vector<int>(nactive);
+        psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Symmetry", (char *)moinfo.occ_sym.data(), sizeof(int) * nactive);
+        moinfo.vir_sym = std::vector<int>(nactive);
+        psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Symmetry", (char *)moinfo.vir_sym.data(), sizeof(int) * nactive);
 
-        moinfo.occ_off = init_int_array(moinfo.nirreps);
-        moinfo.vir_off = init_int_array(moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Offsets", (char *)moinfo.occ_off, sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)moinfo.vir_off, sizeof(int) * moinfo.nirreps);
+        psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Offsets", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
+        moinfo.occ_off = Dimension(temp);
+        psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
+        moinfo.vir_off = Dimension(temp);
 
     } else if (params.ref == 2) { /** UHF **/
-        moinfo.aoccpi = init_int_array(moinfo.nirreps);
-        moinfo.boccpi = init_int_array(moinfo.nirreps);
-        moinfo.avirtpi = init_int_array(moinfo.nirreps);
-        moinfo.bvirtpi = init_int_array(moinfo.nirreps);
 
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)moinfo.aoccpi,
+        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)moinfo.boccpi,
+        moinfo.aoccpi = Dimension(temp);
+        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)moinfo.avirtpi,
+        moinfo.boccpi = Dimension(temp);
+        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)moinfo.bvirtpi,
+        moinfo.avirtpi = Dimension(temp);
+        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
+        moinfo.bvirtpi = Dimension(temp);
 
-        moinfo.aocc_sym = init_int_array(nactive);
-        moinfo.bocc_sym = init_int_array(nactive);
-        moinfo.avir_sym = init_int_array(nactive);
-        moinfo.bvir_sym = init_int_array(nactive);
+        moinfo.aocc_sym = std::vector<int>(nactive);;
+        moinfo.bocc_sym = std::vector<int>(nactive);;
+        moinfo.avir_sym = std::vector<int>(nactive);;
+        moinfo.bvir_sym = std::vector<int>(nactive);;
 
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orb Symmetry", (char *)moinfo.aocc_sym, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orb Symmetry", (char *)moinfo.bocc_sym, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orb Symmetry", (char *)moinfo.avir_sym, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orb Symmetry", (char *)moinfo.bvir_sym, sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orb Symmetry", (char *)moinfo.aocc_sym.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orb Symmetry", (char *)moinfo.bocc_sym.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orb Symmetry", (char *)moinfo.avir_sym.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orb Symmetry", (char *)moinfo.bvir_sym.data(), sizeof(int) * nactive);
 
-        moinfo.aocc_off = init_int_array(moinfo.nirreps);
-        moinfo.bocc_off = init_int_array(moinfo.nirreps);
-        moinfo.avir_off = init_int_array(moinfo.nirreps);
-        moinfo.bvir_off = init_int_array(moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orb Offsets", (char *)moinfo.aocc_off,
+        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orb Offsets", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orb Offsets", (char *)moinfo.bocc_off,
+        moinfo.aocc_off = Dimension(temp);
+        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orb Offsets", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orb Offsets", (char *)moinfo.avir_off,
+        moinfo.bocc_off = Dimension(temp);
+        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orb Offsets", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orb Offsets", (char *)moinfo.bvir_off,
+        moinfo.avir_off = Dimension(temp);
+        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orb Offsets", (char *)temp.data(),
                         sizeof(int) * moinfo.nirreps);
+        moinfo.bvir_off = Dimension(temp);
     }
 
     /* Compute spatial-orbital reordering arrays */
-    moinfo.pitzer2qt = init_int_array(moinfo.nmo);
-    moinfo.qt2pitzer = init_int_array(moinfo.nmo);
-    reorder_qt(moinfo.clsdpi, moinfo.openpi, moinfo.frdocc, moinfo.fruocc, moinfo.pitzer2qt, moinfo.orbspi,
+    moinfo.pitzer2qt = std::vector<int>(moinfo.nmo);
+    moinfo.qt2pitzer = std::vector<int>(moinfo.nmo);
+    reorder_qt(moinfo.clsdpi, moinfo.openpi, moinfo.frdocc, moinfo.fruocc, moinfo.pitzer2qt.data(), moinfo.orbspi,
                moinfo.nirreps);
     for (i = 0; i < moinfo.nmo; i++) {
         j = moinfo.pitzer2qt[i];
@@ -165,32 +163,27 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     }
 
     /* Adjust clsdpi array for frozen orbitals */
-    for (i = 0; i < moinfo.nirreps; i++) moinfo.clsdpi[i] -= moinfo.frdocc[i];
+    moinfo.clsdpi -= moinfo.frdocc;
 
-    moinfo.uoccpi = init_int_array(moinfo.nirreps);
-    for (i = 0; i < moinfo.nirreps; i++)
-        moinfo.uoccpi[i] = moinfo.orbspi[i] - moinfo.clsdpi[i] - moinfo.openpi[i] - moinfo.fruocc[i] - moinfo.frdocc[i];
+    moinfo.uoccpi = moinfo.orbspi - moinfo.clsdpi - moinfo.openpi - moinfo.fruocc - moinfo.frdocc;
 
-    moinfo.nfzc = moinfo.nfzv = moinfo.nclsd = moinfo.nopen = moinfo.nuocc = 0;
-    for (h = 0; h < moinfo.nirreps; h++) {
-        moinfo.nfzc += moinfo.frdocc[h];
-        moinfo.nfzv += moinfo.fruocc[h];
-        moinfo.nclsd += moinfo.clsdpi[h];
-        moinfo.nopen += moinfo.openpi[h];
-        moinfo.nuocc += moinfo.uoccpi[h];
-    }
+    moinfo.nfzc = moinfo.frdocc.sum();
+    moinfo.nfzv = moinfo.fruocc.sum();
+    moinfo.nclsd = moinfo.clsdpi.sum();
+    moinfo.nopen = moinfo.openpi.sum();
+    moinfo.nuocc = moinfo.uoccpi.sum();
 
     if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
 
         /* Get CC->QT and QT->CC active occupied and virtual reordering arrays */
-        moinfo.qt_occ = init_int_array(nactive);
-        moinfo.qt_vir = init_int_array(nactive);
-        moinfo.cc_occ = init_int_array(nactive);
-        moinfo.cc_vir = init_int_array(nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Active Occ Order", (char *)moinfo.qt_occ, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Active Virt Order", (char *)moinfo.qt_vir, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Active Occ Order", (char *)moinfo.cc_occ, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Active Virt Order", (char *)moinfo.cc_vir, sizeof(int) * nactive);
+        moinfo.qt_occ = std::vector<int>(nactive);
+        moinfo.qt_vir = std::vector<int>(nactive);
+        moinfo.cc_occ = std::vector<int>(nactive);
+        moinfo.cc_vir = std::vector<int>(nactive);
+        psio_read_entry(PSIF_CC_INFO, "CC->QT Active Occ Order", (char *)moinfo.qt_occ.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "CC->QT Active Virt Order", (char *)moinfo.qt_vir.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "QT->CC Active Occ Order", (char *)moinfo.cc_occ.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "QT->CC Active Virt Order", (char *)moinfo.cc_vir.data(), sizeof(int) * nactive);
 
         /* Sort SCF MOs to QT order */
         moinfo.scf_qt = block_matrix(moinfo.nmo, moinfo.nmo);
@@ -203,23 +196,23 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     } else if (params.ref == 2) { /** UHF **/
 
         /* Get CC->QT and QT->CC active occupied and virtual reordering arrays */
-        moinfo.qt_aocc = init_int_array(nactive);
-        moinfo.qt_bocc = init_int_array(nactive);
-        moinfo.qt_avir = init_int_array(nactive);
-        moinfo.qt_bvir = init_int_array(nactive);
-        moinfo.cc_aocc = init_int_array(nactive);
-        moinfo.cc_bocc = init_int_array(nactive);
-        moinfo.cc_avir = init_int_array(nactive);
-        moinfo.cc_bvir = init_int_array(nactive);
+        moinfo.qt_aocc = std::vector<int>(nactive);
+        moinfo.qt_bocc = std::vector<int>(nactive);
+        moinfo.qt_avir = std::vector<int>(nactive);
+        moinfo.qt_bvir = std::vector<int>(nactive);
+        moinfo.cc_aocc = std::vector<int>(nactive);
+        moinfo.cc_bocc = std::vector<int>(nactive);
+        moinfo.cc_avir = std::vector<int>(nactive);
+        moinfo.cc_bvir = std::vector<int>(nactive);
 
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Alpha Active Occ Order", (char *)moinfo.qt_aocc, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Beta Active Occ Order", (char *)moinfo.qt_bocc, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Alpha Active Virt Order", (char *)moinfo.qt_avir, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Beta Active Virt Order", (char *)moinfo.qt_bvir, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Alpha Active Occ Order", (char *)moinfo.cc_aocc, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Beta Active Occ Order", (char *)moinfo.cc_bocc, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Alpha Active Virt Order", (char *)moinfo.cc_avir, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Beta Active Virt Order", (char *)moinfo.cc_bvir, sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "CC->QT Alpha Active Occ Order", (char *)moinfo.qt_aocc.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "CC->QT Beta Active Occ Order", (char *)moinfo.qt_bocc.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "CC->QT Alpha Active Virt Order", (char *)moinfo.qt_avir.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "CC->QT Beta Active Virt Order", (char *)moinfo.qt_bvir.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "QT->CC Alpha Active Occ Order", (char *)moinfo.cc_aocc.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "QT->CC Beta Active Occ Order", (char *)moinfo.cc_bocc.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "QT->CC Alpha Active Virt Order", (char *)moinfo.cc_avir.data(), sizeof(int) * nactive);
+        psio_read_entry(PSIF_CC_INFO, "QT->CC Beta Active Virt Order", (char *)moinfo.cc_bvir.data(), sizeof(int) * nactive);
     }
 
     psio_read_entry(PSIF_CC_INFO, "Reference Energy", (char *)&(moinfo.eref), sizeof(double));
@@ -251,50 +244,8 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 
 /* Frees memory allocated in get_moinfo(). */
 void cleanup() {
-    int i;
-
-    free(moinfo.orbspi);
-    free(moinfo.clsdpi);
-    free(moinfo.openpi);
-    //  free(moinfo.uoccpi);
-    //  free(moinfo.fruocc);
-    //  free(moinfo.frdocc);
-
     if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
-        free(moinfo.occ_sym);
-        free(moinfo.vir_sym);
-        free(moinfo.occ_off);
-        free(moinfo.vir_off);
-        free(moinfo.occpi);
-        free(moinfo.virtpi);
-        free(moinfo.qt_occ);
-        free(moinfo.qt_vir);
-        free(moinfo.cc_occ);
-        free(moinfo.cc_vir);
-        free(moinfo.pitzer2qt);
-        free(moinfo.qt2pitzer);
         free_block(moinfo.scf_qt);
-    } else if (params.ref == 2) { /** UHF **/
-        free(moinfo.aocc_sym);
-        free(moinfo.bocc_sym);
-        free(moinfo.avir_sym);
-        free(moinfo.bvir_sym);
-        free(moinfo.aocc_off);
-        free(moinfo.bocc_off);
-        free(moinfo.avir_off);
-        free(moinfo.bvir_off);
-        free(moinfo.aoccpi);
-        free(moinfo.boccpi);
-        free(moinfo.avirtpi);
-        free(moinfo.bvirtpi);
-        free(moinfo.qt_aocc);
-        free(moinfo.qt_bocc);
-        free(moinfo.qt_avir);
-        free(moinfo.qt_bvir);
-        free(moinfo.cc_aocc);
-        free(moinfo.cc_bocc);
-        free(moinfo.cc_avir);
-        free(moinfo.cc_bvir);
     }
 }
 

--- a/psi4/src/psi4/cc/ccdensity/norm.cc
+++ b/psi4/src/psi4/cc/ccdensity/norm.cc
@@ -104,20 +104,19 @@ void scm_C1(dpdfile2 *CME, dpdfile2 *Cme, double a) {
 }
 
 void c_clean(dpdfile2 *CME, dpdfile2 *Cme, dpdbuf4 *CMNEF, dpdbuf4 *Cmnef, dpdbuf4 *CMnEf) {
-    int *occpi, *virtpi, *occ_off, *vir_off, *openpi, C_irr;
-    int nirreps, *occ_sym, *vir_sym;
+    int C_irr, nirreps;
     int mn, ef, m, n, e, f, h, M, N, E, F;
     int msym, nsym, esym, fsym;
 
     C_irr = CME->my_irrep;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
 
     global_dpd_->file2_mat_init(CME);
     global_dpd_->file2_mat_rd(CME);
@@ -196,21 +195,20 @@ void c_clean(dpdfile2 *CME, dpdfile2 *Cme, dpdbuf4 *CMNEF, dpdbuf4 *Cmnef, dpdbu
 }
 
 void c_cleanSS(dpdfile2 *CME, dpdfile2 *Cme) {
-    int *occpi, *virtpi, *occ_off, *vir_off, *openpi;
-    int nirreps, *occ_sym, *vir_sym;
+    int nirreps;
     int mn, ef, m, n, e, f;
     int h, M, N, E, F;
     int msym, nsym, esym, fsym, C_irr;
 
     C_irr = CME->my_irrep;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
 
     global_dpd_->file2_mat_init(CME);
     global_dpd_->file2_mat_rd(CME);
@@ -232,20 +230,19 @@ void c_cleanSS(dpdfile2 *CME, dpdfile2 *Cme) {
 }
 
 void c_clean_CIJAB(dpdbuf4 *CMNEF) {
-    int *occpi, *virtpi, *occ_off, *vir_off, *openpi, C_irr;
-    int nirreps, *occ_sym, *vir_sym;
+    int C_irr, nirreps;
     int mn, ef, m, n, e, f, h, M, N, E, F;
     int msym, nsym, esym, fsym;
 
     C_irr = CMNEF->file.my_irrep;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
 
     for (h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_init(CMNEF, h);

--- a/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
@@ -63,9 +63,6 @@ namespace ccdensity {
 void sortI_RHF() {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *occpi, *virtpi, *occ_off, *vir_off;
-    int *occ_sym, *vir_sym, *openpi;
-    int *qt_occ, *qt_vir;
     double **O, chksum, value;
     dpdfile2 D;
 
@@ -75,15 +72,15 @@ void sortI_RHF() {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
+    const auto& qt_occ = moinfo.qt_occ;
+    const auto& qt_vir = moinfo.qt_vir;
 
     O = block_matrix(nmo, nmo);
 

--- a/psi4/src/psi4/cc/ccdensity/sortI_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_ROHF.cc
@@ -56,9 +56,6 @@ namespace ccdensity {
 void sortI_ROHF() {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *occpi, *virtpi, *occ_off, *vir_off;
-    int *occ_sym, *vir_sym, *openpi;
-    int *qt_occ, *qt_vir;
     double **O, chksum, value;
     dpdfile2 D;
 
@@ -68,15 +65,15 @@ void sortI_ROHF() {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
+    const auto& qt_occ = moinfo.qt_occ;
+    const auto& qt_vir = moinfo.qt_vir;
 
     O = block_matrix(nmo, nmo);
 

--- a/psi4/src/psi4/cc/ccdensity/sortI_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_UHF.cc
@@ -56,12 +56,6 @@ namespace ccdensity {
 void sortI_UHF() {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *aoccpi, *avirtpi, *aocc_off, *avir_off;
-    int *boccpi, *bvirtpi, *bocc_off, *bvir_off;
-    int *aocc_sym, *avir_sym;
-    int *bocc_sym, *bvir_sym;
-    int *qt_aocc, *qt_avir;
-    int *qt_bocc, *qt_bvir;
     double **O_a, **O_b;
     double chksum, value;
     dpdfile2 D;
@@ -72,23 +66,23 @@ void sortI_UHF() {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    aoccpi = moinfo.aoccpi;
-    avirtpi = moinfo.avirtpi;
-    boccpi = moinfo.boccpi;
-    bvirtpi = moinfo.bvirtpi;
-    aocc_off = moinfo.aocc_off;
-    avir_off = moinfo.avir_off;
-    bocc_off = moinfo.bocc_off;
-    bvir_off = moinfo.bvir_off;
-    aocc_sym = moinfo.aocc_sym;
-    avir_sym = moinfo.avir_sym;
-    bocc_sym = moinfo.bocc_sym;
-    bvir_sym = moinfo.bvir_sym;
+    const auto& aoccpi = moinfo.aoccpi;
+    const auto& avirtpi = moinfo.avirtpi;
+    const auto& boccpi = moinfo.boccpi;
+    const auto& bvirtpi = moinfo.bvirtpi;
+    const auto& aocc_off = moinfo.aocc_off;
+    const auto& avir_off = moinfo.avir_off;
+    const auto& bocc_off = moinfo.bocc_off;
+    const auto& bvir_off = moinfo.bvir_off;
+    const auto& aocc_sym = moinfo.aocc_sym;
+    const auto& avir_sym = moinfo.avir_sym;
+    const auto& bocc_sym = moinfo.bocc_sym;
+    const auto& bvir_sym = moinfo.bvir_sym;
 
-    qt_aocc = moinfo.qt_aocc;
-    qt_avir = moinfo.qt_avir;
-    qt_bocc = moinfo.qt_bocc;
-    qt_bvir = moinfo.qt_bvir;
+    const auto& qt_aocc = moinfo.qt_aocc;
+    const auto& qt_avir = moinfo.qt_avir;
+    const auto& qt_bocc = moinfo.qt_bocc;
+    const auto& qt_bvir = moinfo.qt_bvir;
 
     O_a = block_matrix(nmo, nmo);
     O_b = block_matrix(nmo, nmo);

--- a/psi4/src/psi4/cc/ccdensity/sort_ltd_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_ltd_rohf.cc
@@ -44,9 +44,6 @@ namespace ccdensity {
 void sort_ltd_rohf(const struct TD_Params& S) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *occpi, *virtpi, *occ_off, *vir_off;
-    int *occ_sym, *vir_sym, *openpi;
-    int *qt_occ, *qt_vir;
     double chksum, value;
     psio_address next;
     dpdfile2 D;
@@ -57,15 +54,15 @@ void sort_ltd_rohf(const struct TD_Params& S) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
+    const auto& qt_occ = moinfo.qt_occ;
+    const auto& qt_vir = moinfo.qt_vir;
 
     moinfo.ltd = block_matrix(nmo, nmo);
 

--- a/psi4/src/psi4/cc/ccdensity/sort_ltd_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_ltd_uhf.cc
@@ -44,12 +44,6 @@ namespace ccdensity {
 void sort_ltd_uhf(const struct TD_Params& S) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *aoccpi, *avirtpi, *aocc_off, *avir_off;
-    int *boccpi, *bvirtpi, *bocc_off, *bvir_off;
-    int *aocc_sym, *avir_sym;
-    int *bocc_sym, *bvir_sym;
-    int *qt_aocc, *qt_avir;
-    int *qt_bocc, *qt_bvir;
     double chksum, value;
     dpdfile2 D;
 
@@ -59,20 +53,20 @@ void sort_ltd_uhf(const struct TD_Params& S) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    aoccpi = moinfo.aoccpi;
-    avirtpi = moinfo.avirtpi;
-    boccpi = moinfo.boccpi;
-    bvirtpi = moinfo.bvirtpi;
-    aocc_off = moinfo.aocc_off;
-    avir_off = moinfo.avir_off;
-    bocc_off = moinfo.bocc_off;
-    bvir_off = moinfo.bvir_off;
-    aocc_sym = moinfo.aocc_sym;
-    avir_sym = moinfo.avir_sym;
-    qt_aocc = moinfo.qt_aocc;
-    qt_avir = moinfo.qt_avir;
-    qt_bocc = moinfo.qt_bocc;
-    qt_bvir = moinfo.qt_bvir;
+    const auto& aoccpi = moinfo.aoccpi;
+    const auto& avirtpi = moinfo.avirtpi;
+    const auto& boccpi = moinfo.boccpi;
+    const auto& bvirtpi = moinfo.bvirtpi;
+    const auto& aocc_off = moinfo.aocc_off;
+    const auto& avir_off = moinfo.avir_off;
+    const auto& bocc_off = moinfo.bocc_off;
+    const auto& bvir_off = moinfo.bvir_off;
+    const auto& aocc_sym = moinfo.aocc_sym;
+    const auto& avir_sym = moinfo.avir_sym;
+    const auto& qt_aocc = moinfo.qt_aocc;
+    const auto& qt_avir = moinfo.qt_avir;
+    const auto& qt_bocc = moinfo.qt_bocc;
+    const auto& qt_bvir = moinfo.qt_bvir;
 
     moinfo.ltd_a = block_matrix(nmo, nmo);
     moinfo.ltd_b = block_matrix(nmo, nmo);

--- a/psi4/src/psi4/cc/ccdensity/sort_rtd_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_rtd_rohf.cc
@@ -44,9 +44,6 @@ namespace ccdensity {
 void sort_rtd_rohf(const struct TD_Params& S) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *occpi, *virtpi, *occ_off, *vir_off;
-    int *occ_sym, *vir_sym, *openpi;
-    int *qt_occ, *qt_vir;
     double chksum, value;
     dpdfile2 D;
 
@@ -56,15 +53,15 @@ void sort_rtd_rohf(const struct TD_Params& S) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
+    const auto& qt_occ = moinfo.qt_occ;
+    const auto& qt_vir = moinfo.qt_vir;
 
     moinfo.rtd = block_matrix(nmo, nmo);
 

--- a/psi4/src/psi4/cc/ccdensity/sort_rtd_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_rtd_uhf.cc
@@ -44,12 +44,6 @@ namespace ccdensity {
 void sort_rtd_uhf(const struct TD_Params& S) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *aoccpi, *avirtpi, *aocc_off, *avir_off;
-    int *boccpi, *bvirtpi, *bocc_off, *bvir_off;
-    int *aocc_sym, *avir_sym;
-    int *bocc_sym, *bvir_sym;
-    int *qt_aocc, *qt_avir;
-    int *qt_bocc, *qt_bvir;
     double chksum, value;
     dpdfile2 D;
 
@@ -59,23 +53,23 @@ void sort_rtd_uhf(const struct TD_Params& S) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    aoccpi = moinfo.aoccpi;
-    avirtpi = moinfo.avirtpi;
-    boccpi = moinfo.boccpi;
-    bvirtpi = moinfo.bvirtpi;
-    aocc_off = moinfo.aocc_off;
-    avir_off = moinfo.avir_off;
-    bocc_off = moinfo.bocc_off;
-    bvir_off = moinfo.bvir_off;
-    aocc_sym = moinfo.aocc_sym;
-    avir_sym = moinfo.avir_sym;
-    bocc_sym = moinfo.bocc_sym;
-    bvir_sym = moinfo.bvir_sym;
+    const auto& aoccpi = moinfo.aoccpi;
+    const auto& avirtpi = moinfo.avirtpi;
+    const auto& boccpi = moinfo.boccpi;
+    const auto& bvirtpi = moinfo.bvirtpi;
+    const auto& aocc_off = moinfo.aocc_off;
+    const auto& avir_off = moinfo.avir_off;
+    const auto& bocc_off = moinfo.bocc_off;
+    const auto& bvir_off = moinfo.bvir_off;
+    const auto& aocc_sym = moinfo.aocc_sym;
+    const auto& avir_sym = moinfo.avir_sym;
+    const auto& bocc_sym = moinfo.bocc_sym;
+    const auto& bvir_sym = moinfo.bvir_sym;
 
-    qt_aocc = moinfo.qt_aocc;
-    qt_avir = moinfo.qt_avir;
-    qt_bocc = moinfo.qt_bocc;
-    qt_bvir = moinfo.qt_bvir;
+    const auto& qt_aocc = moinfo.qt_aocc;
+    const auto& qt_avir = moinfo.qt_avir;
+    const auto& qt_bocc = moinfo.qt_bocc;
+    const auto& qt_bvir = moinfo.qt_bvir;
 
     moinfo.rtd_a = block_matrix(nmo, nmo);
     moinfo.rtd_b = block_matrix(nmo, nmo);

--- a/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
@@ -68,9 +68,6 @@ namespace ccdensity {
 void sortone_RHF(const struct RHO_Params& rho_params) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *occpi, *virtpi, *occ_off, *vir_off;
-    int *occ_sym, *vir_sym, *openpi;
-    int *qt_occ, *qt_vir;
     double **O, chksum, value;
     dpdfile2 D;
     psio_address next;
@@ -81,15 +78,15 @@ void sortone_RHF(const struct RHO_Params& rho_params) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
+    const auto& qt_occ = moinfo.qt_occ;
+    const auto& qt_vir = moinfo.qt_vir;
 
     /* O = block_matrix(nmo-nfzc,nmo-nfzc); */
     O = block_matrix(nmo - nfzv, nmo - nfzv);

--- a/psi4/src/psi4/cc/ccdensity/sortone_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_ROHF.cc
@@ -62,9 +62,6 @@ namespace ccdensity {
 void sortone_ROHF(const struct RHO_Params& rho_params) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *occpi, *virtpi, *occ_off, *vir_off;
-    int *occ_sym, *vir_sym, *openpi;
-    int *qt_occ, *qt_vir;
     double chksum, value;
     dpdfile2 D;
     psio_address next;
@@ -75,15 +72,15 @@ void sortone_ROHF(const struct RHO_Params& rho_params) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    occpi = moinfo.occpi;
-    virtpi = moinfo.virtpi;
-    occ_off = moinfo.occ_off;
-    vir_off = moinfo.vir_off;
-    occ_sym = moinfo.occ_sym;
-    vir_sym = moinfo.vir_sym;
-    openpi = moinfo.openpi;
-    qt_occ = moinfo.qt_occ;
-    qt_vir = moinfo.qt_vir;
+    const auto& occpi = moinfo.occpi;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& occ_off = moinfo.occ_off;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& occ_sym = moinfo.occ_sym;
+    const auto& vir_sym = moinfo.vir_sym;
+    const auto& openpi = moinfo.openpi;
+    const auto& qt_occ = moinfo.qt_occ;
+    const auto& qt_vir = moinfo.qt_vir;
 
     /* O = block_matrix(nmo-nfzc,nmo-nfzc); */
     double **O_a = block_matrix(nmo, nmo);

--- a/psi4/src/psi4/cc/ccdensity/sortone_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_UHF.cc
@@ -63,12 +63,6 @@ namespace ccdensity {
 void sortone_UHF(const struct RHO_Params& rho_params) {
     int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
     int row, col, i, j, I, J, a, b, A, B, p, q;
-    int *aoccpi, *avirtpi, *aocc_off, *avir_off;
-    int *boccpi, *bvirtpi, *bocc_off, *bvir_off;
-    int *aocc_sym, *avir_sym;
-    int *bocc_sym, *bvir_sym;
-    int *qt_aocc, *qt_avir;
-    int *qt_bocc, *qt_bvir;
     double **O_a, **O_b;
     double chksum, value;
     dpdfile2 D;
@@ -79,23 +73,23 @@ void sortone_UHF(const struct RHO_Params& rho_params) {
     nclsd = moinfo.nclsd;
     nopen = moinfo.nopen;
     nirreps = moinfo.nirreps;
-    aoccpi = moinfo.aoccpi;
-    avirtpi = moinfo.avirtpi;
-    boccpi = moinfo.boccpi;
-    bvirtpi = moinfo.bvirtpi;
-    aocc_off = moinfo.aocc_off;
-    avir_off = moinfo.avir_off;
-    bocc_off = moinfo.bocc_off;
-    bvir_off = moinfo.bvir_off;
-    aocc_sym = moinfo.aocc_sym;
-    avir_sym = moinfo.avir_sym;
-    bocc_sym = moinfo.bocc_sym;
-    bvir_sym = moinfo.bvir_sym;
+    const auto& aoccpi = moinfo.aoccpi;
+    const auto& avirtpi = moinfo.avirtpi;
+    const auto& boccpi = moinfo.boccpi;
+    const auto& bvirtpi = moinfo.bvirtpi;
+    const auto& aocc_off = moinfo.aocc_off;
+    const auto& avir_off = moinfo.avir_off;
+    const auto& bocc_off = moinfo.bocc_off;
+    const auto& bvir_off = moinfo.bvir_off;
+    const auto& aocc_sym = moinfo.aocc_sym;
+    const auto& avir_sym = moinfo.avir_sym;
+    const auto& bocc_sym = moinfo.bocc_sym;
+    const auto& bvir_sym = moinfo.bvir_sym;
 
-    qt_aocc = moinfo.qt_aocc;
-    qt_avir = moinfo.qt_avir;
-    qt_bocc = moinfo.qt_bocc;
-    qt_bvir = moinfo.qt_bvir;
+    const auto& qt_aocc = moinfo.qt_aocc;
+    const auto& qt_avir = moinfo.qt_avir;
+    const auto& qt_bocc = moinfo.qt_bocc;
+    const auto& qt_bvir = moinfo.qt_bvir;
 
     O_a = block_matrix(nmo, nmo);
     O_b = block_matrix(nmo, nmo);

--- a/psi4/src/psi4/cc/ccdensity/to_matrix.cc
+++ b/psi4/src/psi4/cc/ccdensity/to_matrix.cc
@@ -8,7 +8,6 @@ namespace psi {
 namespace ccdensity {
 
 SharedMatrix block_to_matrix(double ** block) {
-    moinfo.Ca->colspi().print();
     auto mat = std::make_shared<Matrix>("Matrix", moinfo.Ca->colspi(), moinfo.Ca->colspi());
     int mo_offset = 0;
 


### PR DESCRIPTION
## Description
This PR replaces several `int *` types in `ccdensity` with `Dimension` or `std::vector<int>` objects as appropriate. In addition to eliminating manual memory management and making the code more readable, easy access to `Dimension` objects will allow for a subsequent PR to construct `Matrix` objects directly, replacing the current `block_matrix` representation of objects.

This is PR 2 in an ongoing series to make `ccdensity` compatible with the standard `Matrix` and `Wavefunction` machinery used elsewhere in Psi. Obligatory @lothian notification.

## Checklist
- [x] `cc` tests still pass

## Status
- [x] Ready for review
- [ ] Ready for merge - to be explicit, Lori advised me **not** to merge until I had manually checked the `cc` tests, since those tests run by perl script
