### PR TITLE
Migrate energy-based `cc` tests to new standard

### DIFF
--- a/tests/cc11/CMakeLists.txt
+++ b/tests/cc11/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc11 "psi;cc;autotest;noc1")
+add_regression_test(cc11 "psi;cc;noc1")

--- a/tests/cc11/input.dat
+++ b/tests/cc11/input.dat
@@ -1,6 +1,6 @@
 #! Frozen-core CCSD(ROHF)/cc-pVDZ on CN radical with disk-based AO algorithm
 
-molecule cn {
+molecule CN {
   0 2
   C
   N 1 R
@@ -18,3 +18,14 @@ set {
 }
 
 energy('ccsd')
+
+enuc   =  18.9152705091      #TEST
+escf   = -92.19555660616889  #TEST
+eccsd  =  -0.28134621116616  #TEST
+etotal = -92.47690281733487  #TEST
+
+compare_values(enuc, CN.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(escf, variable("SCF total energy"), 7, "SCF energy")               #TEST
+compare_values(eccsd, variable("CCSD correlation energy"), 7, "CCSD contribution")        #TEST
+compare_values(etotal, variable("Current energy"), 7, "Total energy")             #TEST
+

--- a/tests/cc11/output.ref
+++ b/tests/cc11/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev52 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 5948333 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 February 2022 12:31PM
 
-    Process ID:  12354
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 5962
+    Host:       dhcp189-242.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -30,7 +43,7 @@
 --------------------------------------------------------------------------
 #! Frozen-core CCSD(ROHF)/cc-pVDZ on CN radical with disk-based AO algorithm
 
-molecule cn {
+molecule CN {
   0 2
   C
   N 1 R
@@ -48,23 +61,37 @@ set {
 }
 
 energy('ccsd')
+
+enuc   =  18.9152705091      #TEST
+escf   = -92.19555660616889  #TEST
+eccsd  =  -0.28134621116616  #TEST
+etotal = -92.47690281733487  #TEST
+
+compare_values(enuc, CN.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(escf, variable("SCF total energy"), 7, "SCF energy")               #TEST
+compare_values(eccsd, variable("CCSD correlation energy"), 7, "CCSD contribution")        #TEST
+compare_values(etotal, variable("Current energy"), 7, "Total energy")             #TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:07 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:31:10 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line   130 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2 entry N          line   160 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1 entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry N          line   168 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              ROHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -78,14 +105,14 @@ energy('ccsd')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.632756417668    12.000000000000
-           N          0.000000000000     0.000000000000     0.542243582332    14.003074004780
+         C            0.000000000000     0.000000000000    -0.632756417661    12.000000000000
+         N            0.000000000000     0.000000000000     0.542243582339    14.003074004430
 
   Running in c2v symmetry.
 
   Rotational constants: A = ************  B =      1.88947  C =      1.88947 [cm^-1]
-  Rotational constants: A = ************  B =  56644.99264  C =  56644.99264 [MHz]
-  Nuclear repulsion =   18.915270434706379
+  Rotational constants: A = ************  B =  56644.99308  C =  56644.99308 [MHz]
+  Nuclear repulsion =   18.915270509055315
 
   Charge       = 0
   Multiplicity = 2
@@ -102,7 +129,7 @@ energy('ccsd')
   Guess Type is CORE.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -122,19 +149,6 @@ energy('ccsd')
        1     C     17s 4p 1d // 3s 2p 1d 
        2     N     17s 4p 1d // 3s 2p 1d 
 
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        14      14       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         6       6       0       0       0       0
-     B2         6       6       0       0       0       0
-   -------------------------------------------------------
-    Total      28      28       7       6       6       1
-   -------------------------------------------------------
-
   ==> Integral Setup <==
 
   Using in-core PK algorithm.
@@ -152,51 +166,69 @@ energy('ccsd')
   Using 165242 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 1.0795200227E-02.
-  Using Symmetric Orthogonalization.
+
+  Minimum eigenvalue in the overlap matrix is 1.0795200130E-02.
+  Reciprocal condition number of the overlap matrix is 3.4696262257E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        14      14       5       4       4       1
+     A2         2       2       0       0       0       0
+     B1         6       6       1       1       1       0
+     B2         6       6       1       1       1       0
+   -------------------------------------------------------
+    Total      28      28       7       6       6       1
+   -------------------------------------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @ROHF iter   1:   -83.19841367423672   -8.31984e+01   1.36243e-01 
-   @ROHF iter   2:   -84.13066745073203   -9.32254e-01   1.22587e-01 DIIS
-   @ROHF iter   3:   -91.56994102487474   -7.43927e+00   4.70362e-02 DIIS
-   @ROHF iter   4:   -92.11548468951898   -5.45544e-01   1.78041e-02 DIIS
-   @ROHF iter   5:   -92.17531716254766   -5.98325e-02   4.68871e-03 DIIS
-   @ROHF iter   6:   -92.18489693171705   -9.57977e-03   1.97972e-03 DIIS
-   @ROHF iter   7:   -92.18849213633595   -3.59520e-03   2.60041e-03 DIIS
-   @ROHF iter   8:   -92.19473815552820   -6.24602e-03   8.77748e-04 DIIS
-   @ROHF iter   9:   -92.19547838920766   -7.40234e-04   4.93687e-04 DIIS
-   @ROHF iter  10:   -92.19552604195411   -4.76527e-05   2.46913e-04 DIIS
-   @ROHF iter  11:   -92.19549304134887    3.30006e-05   2.65380e-04 DIIS
-   @ROHF iter  12:   -92.19555559553606   -6.25542e-05   2.76122e-05 DIIS
-   @ROHF iter  13:   -92.19555658870789   -9.93172e-07   5.25184e-06 DIIS
-   @ROHF iter  14:   -92.19555660604067   -1.73328e-08   4.11111e-07 DIIS
-   @ROHF iter  15:   -92.19555660616743   -1.26761e-10   4.25812e-08 DIIS
-   @ROHF iter  16:   -92.19555660616857   -1.13687e-12   1.47859e-08 DIIS
-   @ROHF iter  17:   -92.19555660616874   -1.70530e-13   1.94133e-09 DIIS
+   @ROHF iter   1:   -83.19841366691793   -8.31984e+01   1.36243e-01 DIIS
+   @ROHF iter   2:   -84.13066748215795   -9.32254e-01   1.22587e-01 DIIS
+   @ROHF iter   3:   -91.56994102831302   -7.43927e+00   4.70362e-02 DIIS
+   @ROHF iter   4:   -92.11548469143059   -5.45544e-01   1.78041e-02 DIIS
+   @ROHF iter   5:   -92.17531716350557   -5.98325e-02   4.68871e-03 DIIS
+   @ROHF iter   6:   -92.18489693259673   -9.57977e-03   1.97972e-03 DIIS
+   @ROHF iter   7:   -92.18849213731929   -3.59520e-03   2.60041e-03 DIIS
+   @ROHF iter   8:   -92.19473815654065   -6.24602e-03   8.77748e-04 DIIS
+   @ROHF iter   9:   -92.19547838997779   -7.40233e-04   4.93687e-04 DIIS
+   @ROHF iter  10:   -92.19552604266499   -4.76527e-05   2.46913e-04 DIIS
+   @ROHF iter  11:   -92.19549304213029    3.30005e-05   2.65380e-04 DIIS
+   @ROHF iter  12:   -92.19555559632072   -6.25542e-05   2.76122e-05 DIIS
+   @ROHF iter  13:   -92.19555658949103   -9.93170e-07   5.25184e-06 DIIS
+   @ROHF iter  14:   -92.19555660682389   -1.73329e-08   4.11111e-07 DIIS
+   @ROHF iter  15:   -92.19555660695059   -1.26704e-10   4.25812e-08 DIIS
+   @ROHF iter  16:   -92.19555660695161   -1.02318e-12   1.47859e-08 DIIS
+   @ROHF iter  17:   -92.19555660695193   -3.12639e-13   1.94133e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1A1   -15.636443     2A1   -11.359535     3A1    -1.246019  
-       4A1    -0.626091     1B2    -0.507352     1B1    -0.507352  
+       4A1    -0.626091     1B1    -0.507352     1B2    -0.507352  
 
     Singly Occupied:                                                      
 
@@ -204,62 +236,57 @@ energy('ccsd')
 
     Virtual:                                                              
 
-       2B2     0.177180     2B1     0.177180     6A1     0.384745  
-       3B2     0.655939     3B1     0.655939     7A1     0.699522  
-       8A1     0.869525     4B2     1.036480     4B1     1.036480  
-       9A1     1.044978    10A1     1.314443     1A2     1.314443  
+       2B1     0.177180     2B2     0.177180     6A1     0.384745  
+       3B1     0.655939     3B2     0.655939     7A1     0.699522  
+       8A1     0.869525     4B1     1.036480     4B2     1.036480  
+       9A1     1.044978     1A2     1.314443    10A1     1.314443  
        5B2     1.503400     5B1     1.503400    11A1     1.564388  
        2A2     2.160944    12A1     2.160944    13A1     2.254479  
-       6B2     2.677031     6B1     2.677031    14A1     3.095851  
+       6B1     2.677031     6B2     2.677031    14A1     3.095851  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     4,    0,    1,    1 ]
     SOCC [     1,    0,    0,    0 ]
 
-  Energy converged.
-
-  @ROHF Final Energy:   -92.19555660616874
+  @ROHF Final Energy:   -92.19555660695193
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             18.9152704347063789
-    One-Electron Energy =                -161.7960330478498747
-    Two-Electron Energy =                  50.6852060069747736
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -92.1955566061687364
+    Nuclear Repulsion Energy =             18.9152705090553148
+    One-Electron Energy =                -161.7960331960863130
+    Two-Electron Energy =                  50.6852060800790625
+    Total Energy =                        -92.1955566069519250
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.0016
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.8531
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.8546     Total:     0.8546
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -2.1723     Total:     2.1723
 
 
-*** tstop() called on psinet at Mon May 15 15:34:08 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:31:10 2022
 Module time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.29 seconds =       0.00 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.29 seconds =       0.00 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -273,19 +300,19 @@ Total time:
       Number of basis functions:        28
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  14    2    6    6 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 21245 non-zero two-electron integrals.
+      Computed 19125 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:08 2017
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:31:10 2022
 
 
 	Wfn Parameters:
@@ -310,7 +337,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	h = 0; memfree         = 65535717
 	h = 0; rows_per_bucket = 150
@@ -538,7 +565,7 @@ Total time:
 	h = 3; rows_left       = 0
 	h = 3; nbuckets        = 1
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -86.99980355850415
+	Frozen core energy     =    -86.99980359744599
 
 	Size of irrep 0 of <ab|cd> integrals:      0.024 (MW) /      0.190 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.008 (MW) /      0.065 (MB)
@@ -558,37 +585,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.001 (MW) /      0.006 (MB)
 	Total:                                     0.003 (MW) /      0.027 (MB)
 
-	Nuclear Rep. energy          =     18.91527043470638
-	SCF energy                   =    -92.19555660616874
-	One-electron energy          =    -41.78838189026769
-	Two-electron (AA) energy     =      4.35444610145822
-	Two-electron (BB) energy     =      2.81993504234642
-	Two-electron (AB) energy     =     10.50297726409215
-	Two-electron energy          =    -24.11102348237090
-	Reference energy             =    -92.19555660616867
+	Nuclear Rep. energy          =     18.91527050905531
+	SCF energy                   =    -92.19555660695193
+	One-electron energy          =    -41.78838195448308
+	Two-electron (AA) energy     =      4.35444610787181
+	Two-electron (BB) energy     =      2.81993504742303
+	Two-electron (AB) energy     =     10.50297728062693
+	Two-electron energy          =    -24.11102351856131
+	Reference energy             =    -92.19555660695198
 
-*** tstop() called on psinet at Mon May 15 15:34:08 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:31:10 2022
 Module time:
 	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.31 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:08 2017
-
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   18.915270434706379
-    SCF energy          (wfn)     =  -92.195556606168736
-    Reference energy    (file100) =  -92.195556606168665
+    Nuclear Rep. energy (wfn)     =   18.915270509055315
+    SCF energy          (wfn)     =  -92.195556606951925
+    Reference energy    (file100) =  -92.195556606951982
 
     Input parameters:
     -----------------
@@ -620,7 +643,7 @@ Total time:
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.269179851004609    0.000e+00    0.000149    0.000285    0.000285    0.000000
+     0        -0.269179849708670    0.000e+00    0.000149    0.000285    0.000285    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -629,9 +652,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -639,7 +662,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     1        -0.260049743208066    1.126e-01    0.021322    0.036268    0.051291    0.000000
+     1        -0.260049742490273    1.126e-01    0.021322    0.036268    0.051291    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -648,9 +671,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -658,7 +681,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     2        -0.273471781003956    4.425e-02    0.022424    0.039312    0.055595    0.000000
+     2        -0.273471780079956    4.425e-02    0.022424    0.039312    0.055595    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -667,9 +690,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -677,7 +700,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     3        -0.278680944482367    3.740e-02    0.031307    0.059226    0.083759    0.000000
+     3        -0.278680943511649    3.740e-02    0.031307    0.059226    0.083759    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -686,9 +709,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -696,7 +719,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     4        -0.280246896771345    2.028e-02    0.039560    0.077598    0.109741    0.000000
+     4        -0.280246895785423    2.028e-02    0.039560    0.077598    0.109741    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -705,9 +728,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -715,7 +738,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     5        -0.281100423809015    1.327e-02    0.047113    0.094888    0.134192    0.000000
+     5        -0.281100422820590    1.327e-02    0.047113    0.094888    0.134192    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -724,9 +747,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -734,7 +757,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     6        -0.281191506371711    6.489e-03    0.051599    0.104860    0.148295    0.000000
+     6        -0.281191505395348    6.489e-03    0.051599    0.104860    0.148295    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -743,9 +766,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -753,7 +776,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     7        -0.281353642911622    2.263e-03    0.053025    0.107956    0.152672    0.000000
+     7        -0.281353641932080    2.263e-03    0.053025    0.107956    0.152672    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -762,9 +785,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -772,7 +795,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     8        -0.281350107254411    9.333e-04    0.053545    0.109088    0.154274    0.000000
+     8        -0.281350106275696    9.333e-04    0.053545    0.109088    0.154274    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -781,9 +804,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -791,7 +814,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-     9        -0.281340552298407    3.892e-04    0.053573    0.109147    0.154358    0.000000
+     9        -0.281340551319949    3.892e-04    0.053573    0.109147    0.154358    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -800,9 +823,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -810,7 +833,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    10        -0.281347751505718    2.020e-04    0.053607    0.109226    0.154469    0.000000
+    10        -0.281347750527119    2.020e-04    0.053607    0.109226    0.154469    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -819,9 +842,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -829,7 +852,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    11        -0.281348399095056    1.081e-04    0.053656    0.109332    0.154618    0.000000
+    11        -0.281348398116397    1.081e-04    0.053656    0.109332    0.154618    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -838,9 +861,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -848,7 +871,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    12        -0.281347849959504    5.799e-05    0.053635    0.109285    0.154553    0.000000
+    12        -0.281347848980764    5.799e-05    0.053635    0.109285    0.154553    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -857,9 +880,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -867,7 +890,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    13        -0.281346948512423    1.696e-05    0.053640    0.109298    0.154571    0.000000
+    13        -0.281346947533715    1.696e-05    0.053640    0.109298    0.154571    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -876,9 +899,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -886,7 +909,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    14        -0.281345947608317    4.184e-06    0.053641    0.109299    0.154572    0.000000
+    14        -0.281345946629655    4.184e-06    0.053641    0.109299    0.154572    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -895,9 +918,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -905,7 +928,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    15        -0.281346156964851    1.689e-06    0.053642    0.109301    0.154575    0.000000
+    15        -0.281346155986175    1.689e-06    0.053642    0.109301    0.154575    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -914,9 +937,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -924,7 +947,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    16        -0.281346213542959    6.292e-07    0.053642    0.109301    0.154575    0.000000
+    16        -0.281346212564279    6.292e-07    0.053642    0.109301    0.154575    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -933,9 +956,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -943,7 +966,7 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    17        -0.281346233951457    1.348e-07    0.053642    0.109301    0.154575    0.000000
+    17        -0.281346232972775    1.348e-07    0.053642    0.109301    0.154575    0.000000
      F intermediates...complete
      T1 amplitudes  ...complete
      Wmbej          ...complete
@@ -952,9 +975,9 @@ Total time:
      <ij||ab> -> T2 ...complete
      F -> T2        ...complete
      Wmnij -> T2    ...complete
-     *** Processed 21245 SO integrals for <AB||CD> --> T2
-     *** Processed 21245 SO integrals for <ab||cd> --> T2
-     *** Processed 21245 SO integrals for <Ab|Cd> --> T2
+     *** Processed 19125 SO integrals for <AB||CD> --> T2
+     *** Processed 19125 SO integrals for <ab||cd> --> T2
+     *** Processed 19125 SO integrals for <Ab|Cd> --> T2
      <ab||cd> -> T2 ...complete
      Z -> T2        ...complete
      <ia||bc> -> T2 ...complete
@@ -962,88 +985,86 @@ Total time:
      Wmbej -> T2    ...complete
      <ia||jb> -> T2 ...complete
      T2 amplitudes  ...complete
-    18        -0.281346230592179    4.566e-08    0.053642    0.109301    0.154575    0.000000
+    18        -0.281346229613496    4.566e-08    0.053642    0.109301    0.154575    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              3  12         0.0347928651
-              4  17         0.0347928651
-              3  13         0.0251643291
-              4  18         0.0251643291
-              3  15         0.0246223230
-              4  20         0.0246223230
-              2   3         0.0133499209
-              1   1         0.0124981041
-              1   3        -0.0116022830
-              2   1        -0.0112154829
+              3  12         0.0347928650
+              4  17         0.0347928650
+              3  13         0.0251643290
+              4  18         0.0251643290
+              3  15         0.0246223229
+              4  20         0.0246223229
+              2   3         0.0133499208
+              1   1         0.0124981040
+              1   3        -0.0116022827
+              2   1        -0.0112154828
 
     Largest Tia Amplitudes:
-              1   9         0.2183704193
+              1   9         0.2183704194
               3  12        -0.0351079222
               4  17        -0.0351079222
               1   3         0.0266414873
-              1   1        -0.0203028485
-              3  14        -0.0182528916
-              4  19        -0.0182528916
-              1   0        -0.0121681969
-              3  15         0.0115238327
-              4  20         0.0115238327
+              1   1        -0.0203028484
+              3  14        -0.0182528915
+              4  19        -0.0182528915
+              1   0        -0.0121681968
+              3  15         0.0115238326
+              4  20         0.0115238326
 
     Largest TIJAB Amplitudes:
-      4   3  17  12        -0.0342900497
-      3   2  12   3         0.0185542834
-      4   2  17   3         0.0185542834
-      4   3  18  13        -0.0175746704
-      3   2  13   1        -0.0173835429
-      4   2  18   1        -0.0173835429
-      4   3  10   4        -0.0165174337
+      4   3  17  12        -0.0342900496
+      3   2  12   3         0.0185542833
+      4   2  17   3         0.0185542833
+      4   3  18  13        -0.0175746705
+      3   2  13   1        -0.0173835430
+      4   2  18   1        -0.0173835430
+      4   3  10   4        -0.0165174338
       3   1  12   3        -0.0139506516
       4   1  17   3        -0.0139506516
-      4   3  17  14        -0.0117309871
+      4   3  17  14        -0.0117309872
 
     Largest Tijab Amplitudes:
-      3   1  12   9        -0.0387366473
-      4   1  17   9        -0.0387366473
-      4   3  17  12        -0.0370606069
+      3   1  12   9        -0.0387366471
+      4   1  17   9        -0.0387366471
+      4   3  17  12        -0.0370606067
       3   1  12   3        -0.0147519713
       4   1  17   3        -0.0147519713
-      4   3  10   4        -0.0146978803
-      4   3  18  13        -0.0146429229
-      3   1  14   9        -0.0132843162
-      4   1  19   9        -0.0132843162
+      4   3  10   4        -0.0146978804
+      4   3  18  13        -0.0146429230
+      3   1  14   9        -0.0132843163
+      4   1  19   9        -0.0132843163
       4   3  19  14        -0.0129372539
 
     Largest TIjAb Amplitudes:
-      3   3  12  12        -0.1035151202
-      4   4  17  17        -0.1035151202
-      3   1  12   9        -0.0807438374
-      4   1  17   9        -0.0807438374
-      3   4  12  17        -0.0612217282
-      4   3  17  12        -0.0612217282
-      2   3  12   9        -0.0526891775
-      2   4  17   9        -0.0526891775
-      1   1  12  12        -0.0410871705
-      1   1  17  17        -0.0410871705
+      3   3  12  12        -0.1035151193
+      4   4  17  17        -0.1035151193
+      3   1  12   9        -0.0807438369
+      4   1  17   9        -0.0807438369
+      3   4  12  17        -0.0612217278
+      4   3  17  12        -0.0612217278
+      2   3  12   9        -0.0526891777
+      2   4  17   9        -0.0526891777
+      1   1  12  12        -0.0410871703
+      1   1  17  17        -0.0410871703
 
-    SCF energy       (wfn)                    =  -92.195556606168736
-    Reference energy (file100)                =  -92.195556606168665
+    SCF energy       (wfn)                    =  -92.195556606951925
+    Reference energy (file100)                =  -92.195556606951982
 
-    Opposite-spin CCSD correlation energy     =   -0.218409658997227
-    Same-spin CCSD correlation energy         =   -0.059007712605548
-    CCSD correlation energy                   =   -0.281346230592179
-      * CCSD total energy                     =  -92.476902836760843
+    Opposite-spin CCSD correlation energy     =   -0.218409658157156
+    Same-spin CCSD correlation energy         =   -0.059007712488864
+    Singles CCSD correlation energy           =   -0.003928858967476
+    CCSD correlation energy                   =   -0.281346229613496
+      * CCSD total energy                     =  -92.476902836565472
 
+    Nuclear repulsion energy..............................................................PASSED
+    SCF energy............................................................................PASSED
+    CCSD contribution.....................................................................PASSED
+    Total energy..........................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:09 2017
-Module time:
-	user time   =       0.72 seconds =       0.01 minutes
-	system time =       0.46 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.03 seconds =       0.02 minutes
-	system time =       0.54 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+    Psi4 stopped on: Monday, 14 February 2022 12:31PM
+    Psi4 wall time for execution: 0:00:02.55
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc19/output.ref
+++ b/tests/cc19/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:25PM
 
-    Process ID:  12564
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65766
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -43,28 +56,26 @@ set {
     omega = [0.05, 0.1, au]
 }
 
-property('ccsd', properties=['polarizability'])
+properties('ccsd', properties=['polarizability'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:17 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:37 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 3 entry F          line   220 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1 entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3 entry F          line   228 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -78,14 +89,14 @@ property('ccsd', properties=['polarizability'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O         -0.947809457408    -0.132934425181     0.000000000000    15.994914619560
-           H         -1.513924046286     1.610489987673     0.000000000000     1.007825032070
-           F          0.878279174340     0.026485523618     0.000000000000    18.998403224000
+         O           -0.947809455906    -0.132934425143     0.000000000000    15.994914619570
+         H           -1.513924044784     1.610489987711     0.000000000000     1.007825032230
+         F            0.878279175842     0.026485523656     0.000000000000    18.998403162730
 
   Running in cs symmetry.
 
   Rotational constants: A =     20.68749  B =      1.92124  C =      1.75798 [cm^-1]
-  Rotational constants: A = 620195.40405  B =  57597.45554  C =  52702.94118 [MHz]
+  Rotational constants: A = 620195.40382  B =  57597.45561  C =  52702.94124 [MHz]
   Nuclear repulsion =   46.780362058359806
 
   Charge       = 0
@@ -103,28 +114,17 @@ property('ccsd', properties=['polarizability'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 15
-    Number of basis function: 33
+    Number of basis functions: 33
     Number of Cartesian functions: 35
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A'        24      24       0       0       0       0
-     A"         9       9       0       0       0       0
-   -------------------------------------------------------
-    Total      33      33       9       9       9       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -143,43 +143,59 @@ property('ccsd', properties=['polarizability'])
   Using 315282 doubles for integral storage.
   We computed 7260 shell quartets total.
   Whereas there are 7260 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 1.1480368199E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 1.1480368199E-02.
+  Reciprocal condition number of the overlap matrix is 3.1300362044E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        24      24 
+     A"         9       9 
+   -------------------------
+    Total      33      33
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -176.46735633451576   -1.76467e+02   1.55847e-01 
-   @RHF iter   1:  -174.37904569912271    2.08831e+00   1.33080e-02 
-   @RHF iter   2:  -174.41426912926568   -3.52234e-02   4.00695e-03 DIIS
-   @RHF iter   3:  -174.41781988025582   -3.55075e-03   1.21325e-03 DIIS
-   @RHF iter   4:  -174.41836283366897   -5.42953e-04   3.37025e-04 DIIS
-   @RHF iter   5:  -174.41842730781701   -6.44741e-05   6.88587e-05 DIIS
-   @RHF iter   6:  -174.41843271973801   -5.41192e-06   1.68789e-05 DIIS
-   @RHF iter   7:  -174.41843299213383   -2.72396e-07   3.57882e-06 DIIS
-   @RHF iter   8:  -174.41843300140869   -9.27486e-09   7.45043e-07 DIIS
-   @RHF iter   9:  -174.41843300161429   -2.05603e-10   1.78380e-07 DIIS
-   @RHF iter  10:  -174.41843300162435   -1.00613e-11   2.53484e-08 DIIS
-   @RHF iter  11:  -174.41843300162446   -1.13687e-13   4.44891e-09 DIIS
-   @RHF iter  12:  -174.41843300162452   -5.68434e-14   7.75281e-10 DIIS
-   @RHF iter  13:  -174.41843300162458   -5.68434e-14   9.91441e-11 DIIS
+   @RHF iter SAD:  -175.71153508650366   -1.75712e+02   0.00000e+00 
+   @RHF iter   1:  -174.37900637995455    1.33253e+00   1.23779e-02 DIIS/ADIIS
+   @RHF iter   2:  -174.41628672542191   -3.72803e-02   2.97325e-03 DIIS/ADIIS
+   @RHF iter   3:  -174.41816198318293   -1.87526e-03   8.87545e-04 DIIS/ADIIS
+   @RHF iter   4:  -174.41840010823466   -2.38125e-04   3.13379e-04 DIIS/ADIIS
+   @RHF iter   5:  -174.41843041377791   -3.03055e-05   4.87270e-05 DIIS
+   @RHF iter   6:  -174.41843281428160   -2.40050e-06   1.28265e-05 DIIS
+   @RHF iter   7:  -174.41843299643415   -1.82153e-07   2.26423e-06 DIIS
+   @RHF iter   8:  -174.41843300144276   -5.00862e-09   6.05795e-07 DIIS
+   @RHF iter   9:  -174.41843300161108   -1.68313e-10   1.59552e-07 DIIS
+   @RHF iter  10:  -174.41843300162398   -1.29035e-11   2.92361e-08 DIIS
+   @RHF iter  11:  -174.41843300162469   -7.10543e-13   4.22907e-09 DIIS
+   @RHF iter  12:  -174.41843300162469    0.00000e+00   7.64167e-10 DIIS
+   @RHF iter  13:  -174.41843300162441    2.84217e-13   9.05641e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -202,49 +218,44 @@ property('ccsd', properties=['polarizability'])
              Ap   App 
     DOCC [     7,    2 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -174.41843300162458
+  @RHF Final Energy:  -174.41843300162441
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             46.7803620583598061
-    One-Electron Energy =                -334.7576923185317810
-    Two-Electron Energy =                 113.5588972585474039
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -174.4184330016245781
+    One-Electron Energy =                -334.7576923169988277
+    Two-Electron Energy =                 113.5588972570146211
+    Total Energy =                       -174.4184330016244076
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:    -1.1919      Y:     0.7854      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     1.1188      Y:    -0.1743      Z:     0.0000
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:    -0.0731      Y:     0.6110      Z:     0.0000     Total:     0.6154
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:    -0.1857      Y:     1.5531      Z:     0.0000     Total:     1.5642
 
 
-*** tstop() called on psinet at Mon May 15 15:34:18 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:39 2022
 Module time:
-	user time   =       0.54 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.01 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.54 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.01 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -258,19 +269,19 @@ Total time:
       Number of basis functions:        33
 
       Number of irreps:                  2
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  24    9 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 79998 non-zero two-electron integrals.
+      Computed 78700 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:18 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:39 2022
 
 
 	Wfn Parameters:
@@ -293,7 +304,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -344,24 +355,20 @@ Total time:
 	Total:                                     0.025 (MW) /      0.197 (MB)
 
 	Nuclear Rep. energy          =     46.78036205835981
-	SCF energy                   =   -174.41843300162458
-	One-electron energy          =   -334.75769231697097
-	Two-electron energy          =    113.55889725698680
-	Reference energy             =   -174.41843300162438
+	SCF energy                   =   -174.41843300162441
+	One-electron energy          =   -334.75769231730192
+	Two-electron energy          =    113.55889725731765
+	Reference energy             =   -174.41843300162446
 
-*** tstop() called on psinet at Mon May 15 15:34:18 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:39 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.18 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.73 seconds =       0.01 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:18 2017
-
+	user time   =       1.23 seconds =       0.02 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -369,8 +376,8 @@ Total time:
             **************************
 
     Nuclear Rep. energy (wfn)     =   46.780362058359806
-    SCF energy          (wfn)     = -174.418433001624578
-    Reference energy    (file100) = -174.418433001624379
+    SCF energy          (wfn)     = -174.418433001624408
+    Reference energy    (file100) = -174.418433001624464
 
     Input parameters:
     -----------------
@@ -398,38 +405,38 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3566362407158354
+MP2 correlation energy -0.3566362407166802
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.356636240715835    0.000e+00    0.000000    0.000000    0.000000    0.109615
-     1        -0.362752063085787    3.144e-02    0.004275    0.011894    0.011894    0.119295
-     2        -0.368196197132809    1.020e-02    0.004675    0.013297    0.013297    0.125545
-     3        -0.368909989044555    3.691e-03    0.005274    0.015965    0.015965    0.127551
-     4        -0.368843223251894    1.064e-03    0.005417    0.016790    0.016790    0.128058
-     5        -0.368847102128174    5.172e-04    0.005511    0.017384    0.017384    0.128207
-     6        -0.368845295155213    1.896e-04    0.005559    0.017671    0.017671    0.128212
-     7        -0.368842607501075    4.221e-05    0.005566    0.017712    0.017712    0.128200
-     8        -0.368842991733846    9.726e-06    0.005568    0.017722    0.017722    0.128199
-     9        -0.368843083958685    1.805e-06    0.005568    0.017722    0.017722    0.128199
-    10        -0.368843084636058    4.602e-07    0.005568    0.017723    0.017723    0.128198
-    11        -0.368843099038190    1.246e-07    0.005568    0.017723    0.017723    0.128198
-    12        -0.368843101814606    3.400e-08    0.005568    0.017723    0.017723    0.128198
-    13        -0.368843102644183    8.788e-09    0.005568    0.017723    0.017723    0.128198
+     0        -0.356636240716680    0.000e+00    0.000000    0.000000    0.000000    0.109615
+     1        -0.362752063086016    3.144e-02    0.004275    0.011894    0.011894    0.119295
+     2        -0.368196197130606    1.020e-02    0.004675    0.013297    0.013297    0.125545
+     3        -0.368909989044804    3.691e-03    0.005274    0.015965    0.015965    0.127551
+     4        -0.368843223250895    1.064e-03    0.005417    0.016790    0.016790    0.128058
+     5        -0.368847102127169    5.172e-04    0.005511    0.017384    0.017384    0.128207
+     6        -0.368845295154130    1.896e-04    0.005559    0.017671    0.017671    0.128212
+     7        -0.368842607499978    4.221e-05    0.005566    0.017712    0.017712    0.128200
+     8        -0.368842991732743    9.726e-06    0.005568    0.017722    0.017722    0.128199
+     9        -0.368843083957580    1.805e-06    0.005568    0.017722    0.017722    0.128199
+    10        -0.368843084634956    4.602e-07    0.005568    0.017723    0.017723    0.128198
+    11        -0.368843099037087    1.246e-07    0.005568    0.017723    0.017723    0.128198
+    12        -0.368843101813504    3.400e-08    0.005568    0.017723    0.017723    0.128198
+    13        -0.368843102643079    8.788e-09    0.005568    0.017723    0.017723    0.128198
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              6   0         0.0137313979
-              6   2        -0.0064752642
+              6   0         0.0137313982
+              6   2        -0.0064752643
               7  17        -0.0058546058
-              5   0        -0.0054830976
-              6   9         0.0050129177
-              3   1         0.0049539840
-              8  17        -0.0043004442
-              6   1        -0.0041980393
+              5   0        -0.0054830977
+              6   9         0.0050129178
+              3   1         0.0049539841
+              8  17        -0.0043004440
+              6   1        -0.0041980387
               4   9        -0.0039633123
               7  18         0.0038967922
 
@@ -437,40 +444,28 @@ MP2 correlation energy -0.3566362407158354
       8   8  17  17        -0.0347803136
       6   6   2   2        -0.0346572612
       6   6   0   0        -0.0242680490
-      6   6   0   2         0.0221026068
-      6   6   2   0         0.0221026068
+      6   6   0   2         0.0221026069
+      6   6   2   0         0.0221026069
       8   8  18  18        -0.0216499642
       7   7  18  18        -0.0211241947
       7   8  17  17        -0.0203462181
       8   7  17  17        -0.0203462181
       7   8  18  18         0.0189838363
 
-    SCF energy       (wfn)                    = -174.418433001624578
-    Reference energy (file100)                = -174.418433001624379
+    SCF energy       (wfn)                    = -174.418433001624408
+    Reference energy (file100)                = -174.418433001624464
 
-    Opposite-spin MP2 correlation energy      =   -0.260477904529497
-    Same-spin MP2 correlation energy          =   -0.096158336186339
-    MP2 correlation energy                    =   -0.356636240715835
-      * MP2 total energy                      = -174.775069242340209
+    Opposite-spin MP2 correlation energy      =   -0.260477904529681
+    Same-spin MP2 correlation energy          =   -0.096158336186999
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.356636240716680
+      * MP2 total energy                      = -174.775069242341146
 
-    Opposite-spin CCSD correlation energy     =   -0.280899925284155
-    Same-spin CCSD correlation energy         =   -0.087943177358421
-    CCSD correlation energy                   =   -0.368843102644183
-      * CCSD total energy                     = -174.787276104268557
-
-
-*** tstop() called on psinet at Mon May 15 15:34:19 2017
-Module time:
-	user time   =       0.28 seconds =       0.00 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.01 seconds =       0.02 minutes
-	system time =       0.41 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:19 2017
+    Opposite-spin CCSD correlation energy     =   -0.280899925283734
+    Same-spin CCSD correlation energy         =   -0.087943177359345
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.368843102643079
+      * CCSD total energy                     = -174.787276104267534
 
 
 			**************************
@@ -480,20 +475,6 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:19 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.03 seconds =       0.02 minutes
-	system time =       0.44 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:19 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
@@ -501,10 +482,10 @@ Total time:
 
 	Nuclear Rep. energy (wfn)     =   46.780362058359806
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -174.418433001624578
-	Reference energy    (CC_INFO) = -174.418433001624379
-	CCSD energy         (CC_INFO) =   -0.368843102644183
-	Total CCSD energy   (CC_INFO) = -174.787276104268557
+	SCF energy          (wfn)     = -174.418433001624408
+	Reference energy    (CC_INFO) = -174.418433001624464
+	CCSD energy         (CC_INFO) =   -0.368843102643079
+	Total CCSD energy   (CC_INFO) = -174.787276104267534
 
 	Input parameters:
 	-----------------
@@ -517,7 +498,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -530,28 +511,28 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.368917658546573    0.000e+00
-	   1        -0.364932522975126    1.124e-02
-	   2        -0.364255665894247    1.639e-03
-	   3        -0.364135867440903    9.744e-04
-	   4        -0.364111552219229    4.261e-04
-	   5        -0.364122022062910    1.761e-04
-	   6        -0.364124905762203    4.164e-05
-	   7        -0.364124461330676    9.123e-06
-	   8        -0.364124452934033    1.977e-06
-	   9        -0.364124473938754    5.096e-07
-	  10        -0.364124471206593    1.305e-07
-	  11        -0.364124470168711    3.649e-08
+	   0        -0.368917658547535    0.000e+00
+	   1        -0.364932522974435    1.124e-02
+	   2        -0.364255665893209    1.639e-03
+	   3        -0.364135867439815    9.744e-04
+	   4        -0.364111552218176    4.261e-04
+	   5        -0.364122022061905    1.761e-04
+	   6        -0.364124905761203    4.164e-05
+	   7        -0.364124461329678    9.123e-06
+	   8        -0.364124452933033    1.977e-06
+	   9        -0.364124473937755    5.096e-07
+	  10        -0.364124471205595    1.305e-07
+	  11        -0.364124470167711    3.649e-08
 
 	Largest LIA Amplitudes:
-	          6   0         0.0088889534
+	          6   0         0.0088889537
 	          6   9         0.0046230269
 	          6   2        -0.0043558320
 	          7  17        -0.0037331039
-	          3   1         0.0037156072
+	          3   1         0.0037156073
 	          4   9        -0.0037153618
-	          5   0        -0.0036782944
-	          6   1        -0.0029821785
+	          5   0        -0.0036782945
+	          6   1        -0.0029821779
 	          4   2        -0.0027873897
 	          3  10         0.0027698857
 
@@ -569,21 +550,7 @@ Total time:
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.92327310263
-
-*** tstop() called on psinet at Mon May 15 15:34:19 2017
-Module time:
-	user time   =       0.10 seconds =       0.00 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.13 seconds =       0.02 minutes
-	system time =       0.52 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:19 2017
-
+	Overlap <L|e^T> =        0.92327310262
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -617,1438 +584,266 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =    17
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.004973311842420  0.013266995929194 -0.000628781752650  0.005821270029714  0.000919567978388 -0.029199972126280 -0.045028399100612 -0.004470261442863  0.011877997660976
-    1  (  1) -0.009507235197464  0.012821706325685  0.003799126662321  0.002252865927780 -0.055209495109638 -0.024587025371539 -0.024606989745348  0.013427377489127  0.015081303210993
-    2  (  2)  0.017389558115329  0.090269894198308 -0.021790983039231  0.002273396073758 -0.116264596862988 -0.115462041463200 -0.161679143653204 -0.004382227235231  0.044152650113456
-    3  (  3) -0.045800490256982  0.102684016384516  0.004298149179332  0.100539443932642  0.370543586881213 -0.055770882127081 -0.078687877648935  0.007825357989142 -0.005958094935070
-    4  (  4) -0.010437720508760 -0.261361023414739  0.067136694654890  0.024410751781325  0.194687941602041  0.189213367030653 -0.016782925636869  0.030449297972074  0.042728748936538
-    5  (  5) -0.204520483232389 -0.650047613350719  0.223047478915112  0.041190532288830  0.240619423578978  0.137439279021831  0.171279245566327  0.016185016716197  0.121002567618253
-    6  (  6)  0.280902317075698 -0.160624493052628 -0.273839367320907  0.104387818057120  0.105984664365183 -0.191695563527139  0.108911766202185  0.343815605886466 -0.365957079247673
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0) -0.004053113693640 -0.001130746719724  0.002197040319962  0.015409285346725  0.020385399861541 -0.015317248885301  0.001807788770669 -0.017920595472896
-    1  (  1)  0.009120082216769  0.007242671494469  0.002352070818783  0.003227187191148  0.007274880671274 -0.006594278499476  0.000810229863832 -0.037744633186988
-    2  (  2)  0.003699393587894 -0.014491498350454  0.012365540077676  0.024534096582419  0.035400276246270 -0.027568218912894 -0.001277774119094 -0.041982803931276
-    3  (  3) -0.007020625904770 -0.030420086186411  0.005111711552617 -0.010981748828448 -0.029324107040543  0.031529857635973  0.023380127781762 -0.037504135613171
-    4  (  4)  0.028745091229054  0.004362974798288  0.043337123990437  0.007599994175588 -0.010124122330633 -0.015830192253859 -0.106395365799597 -0.053301540072473
-    5  (  5)  0.000191291817102  0.025549777277640 -0.058630833236202  0.035380012602342  0.052526050019725 -0.020071096582297  0.076201395794857 -0.101034119172717
-    6  (  6) -0.057417324803451  0.003770361171125  0.312155564894547 -0.019595345178414  0.032179561711377 -0.085712769628610 -0.091655662969562 -0.043614568508176
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  7)  0.002562166576807 -0.127624975977970 -0.006095786674696 -0.057070001911144 -0.023443205612938  0.016613258960547 -0.145264601529895
-    1  (  8) -0.188514280230697 -0.034959079109952  0.090846586736885  0.600224852290861 -0.049044165260568 -0.027854382028144  0.077976937344803
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     7
-	   Irrep: 1 row =     2	col =     2
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)    
-
-    0  (  0) -0.877967627777420  0.000313522193888 -0.019259885114899  0.021251632646677  0.017412558381543  0.034335407608122 -0.000238172067977
-    1  (  1)  0.000322608301162  0.947380586418926  0.024249733504118  0.009114321616672 -0.017152420036554 -0.038527066340585 -0.008117265825269
-    2  (  2) -0.019192337212076  0.024108802324622 -0.143587960734165 -0.609589206490408 -0.080850441455264 -0.015635633462251  0.017209818026148
-    3  (  3)  0.021307524418295  0.009065921973045 -0.609927216030257  0.011341171531789 -0.562777560041829 -1.130102822062630  0.098161002116198
-    4  (  4)  0.017437875196281 -0.016860670100679 -0.081233426405482 -0.564804896125210 -0.137787092580986  0.037141276598326 -0.832484571958425
-    5  (  5)  0.034336422207809 -0.038415705150775 -0.016763474874720 -1.132859634730820  0.035968686389409  0.264833058338794  0.457303575012885
-    6  (  6) -0.000330176196204 -0.008043840531136  0.016330711457037  0.098416114621239 -0.830420506786356  0.457130067031757  0.385470725689893
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1     
-                      (  7)              (  8)    
-
-    0  (  7) -0.227964898187105  0.899784121233827
-    1  (  8)  0.899333065983888  0.346847097589665
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    17	col =    17
-	   Irrep: 1 row =     7	col =     7
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.616069892967514  0.536999907051132  0.064570261876073 -0.021746949912215  0.311054630877884 -0.014988999172356  0.403937330087933  0.080677979873068  0.190208106487436
-    1  (  1)  0.539100056498500  1.121467176666122  0.501269943316699  0.076120073616633  1.006742706967197  0.003907518839866 -0.383146326015980 -0.474993266173842 -0.025427814708089
-    2  (  2)  0.061217021707060  0.499628876649819  1.154179761547648 -0.137928182230330 -0.495313577328702  0.318380781085109  0.413200746977780  0.157674454194196  0.163348441730534
-    3  (  3) -0.019662932181842  0.077523110716421 -0.139848581831140  0.935298042213261 -0.495168520230484 -0.312161918206477  0.553850138158494  0.050690221949374 -0.115705670984065
-    4  (  4)  0.310943231912307  1.007930671638337 -0.496792878828605 -0.496057332349846 -0.163289419911517  0.399873031900594  0.581449523537017 -0.151289222759749 -0.558580697485684
-    5  (  5) -0.016981854891896  0.004948048764029  0.318027411184786 -0.311334572285853  0.400040741651159 -0.163260855919412 -0.043209700057553 -0.714667048662647  0.807833175148293
-    6  (  6)  0.405126484890673 -0.384326977793836  0.412161084214212  0.554052652902597  0.580944240574859 -0.043533045765531 -0.738038189913143  0.085634839739873 -0.225430347568172
-    7  (  7)  0.084899534839490 -0.477102952332221  0.155861734152243  0.049692746203274 -0.151524749975406 -0.714700304975067  0.085653110388769  1.020372569509776  0.273203758137330
-    8  (  8)  0.184458527486884 -0.023781009109227  0.165473299991638 -0.114600831781650 -0.558632517834915  0.809040541017870 -0.225150367734434  0.272550659433537  0.714544346078435
-    9  (  9)  0.053140085566908 -0.342609131399199 -0.159311675949905  0.022341895172386 -0.065531666457998 -0.269706601792147 -0.158590290041005 -0.172377416642194  0.098583572112306
-   10  ( 10)  0.103318634513581  0.336891904621794 -0.211860379640696  0.028705977449278  0.219074363337613  0.147144167978190  0.232719520034013  0.268264154906963  0.208839112806111
-   11  ( 11) -0.186528320728562  0.153201146227153  0.313141523626848 -0.072865729142253 -0.113774903876919  0.278147399319758 -0.079792554944443 -0.195212219985063  0.186019861514634
-   12  ( 12)  0.151804562470358 -0.108110913589224  0.032295103397461 -0.162704962998097  0.020425035985354  0.192138610039775  0.222419633081503  0.130336458514042  0.009407451168273
-   13  ( 13)  0.121608980468146 -0.110977070036412  0.045709995700803 -0.051967255031559  0.089407073382377  0.164909440906524  0.397216369690126 -0.051479025562899 -0.182819729690421
-   14  ( 14) -0.078729676811471  0.035361204543485 -0.059248000570129  0.112066401729498 -0.064040771924537 -0.235871938611430 -0.273666216491852  0.082834082600926 -0.020031425337585
-   15  ( 15) -0.041387782348733  0.012446902025407 -0.027295301343405 -0.097753764879958  0.030026558446376 -0.090321793918168  0.019874335440583  0.116017714618137 -0.126972589824044
-   16  ( 16) -0.132346570961001 -0.061311035452504 -0.029455538314584  0.015897095654112  0.164187274367247  0.163025551532567  0.169577657089601  0.068368765349860  0.040151411900283
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0)  0.055450179392117  0.103885767798645 -0.191032843184630  0.152009876765510  0.121262205093579 -0.077396557926421 -0.039919053508787 -0.132668039484820
-    1  (  1) -0.341982473849641  0.338042385842803  0.154837698936008 -0.109646885589356 -0.112374874685011  0.036067541299657  0.012224215969489 -0.062173439974409
-    2  (  2) -0.161380436915024 -0.212525022100483  0.315178751222923  0.032643675793751  0.046296273705359 -0.060259188597452 -0.027924052357607 -0.029774347871232
-    3  (  3)  0.022756835482488  0.028917816386337 -0.072019929552326 -0.162829131148331 -0.051988133264688  0.111942009790346 -0.098152283948764  0.016121374057675
-    4  (  4) -0.065398587780161  0.219671416349890 -0.113855291654859  0.020875558658236  0.090234442225766 -0.064699443883862  0.030327734232098  0.164965146771565
-    5  (  5) -0.271645100740263  0.146334667900126  0.279031366705028  0.192410761999375  0.165180364781876 -0.236457911753675 -0.090839325876833  0.163445998890330
-    6  (  6) -0.158392571216451  0.232617546830461 -0.079904277525593  0.222795557006328  0.397833037393679 -0.274049556346732  0.020076568565887  0.169937762836561
-    7  (  7) -0.170682218930804  0.268852788924366 -0.195692655631564  0.130524483662373 -0.051165870753648  0.082798905111444  0.115829481611899  0.068470603637705
-    8  (  8)  0.096564774400488  0.208060530676641  0.185992253087719  0.009546396555858 -0.182917669130639 -0.020127532892393 -0.126885643557761  0.040301896445586
-    9  (  9)  1.091880727567183  0.618059189550919  0.064491178316712 -0.255127265298153  0.132183322659095  0.068956515747517 -0.080323214785157  0.053878904245493
-   10  ( 10)  0.618133427218445 -0.009840747270176 -0.012838874312395 -0.097969065788505  0.187597974236451 -0.202172218192305  0.021959943928511 -0.096709126143751
-   11  ( 11)  0.065903124056317 -0.012296213223463  0.598357018260281  0.059602437106646  0.013365498655057  0.114364469387417  0.827703714814267  0.048268697375430
-   12  ( 12) -0.255300845543071 -0.098147098302434  0.059580177286638  0.567724364588447  0.571908990688714  0.504236828319309 -0.162215368687543 -0.181543287290782
-   13  ( 13)  0.132327758451946  0.187460052134489  0.013164164091641  0.571973146707974 -0.024738561731473 -0.558762474457342  0.053196123755597 -0.396928116374631
-   14  ( 14)  0.068667391811317 -0.202141325825385  0.114385734772804  0.504185200524858 -0.558826822299864  0.386685477843097 -0.175467887973267  0.372361407623338
-   15  ( 15) -0.080419165584544  0.021930833178619  0.827828341049343 -0.162189801264600  0.053238745633504 -0.175544320290186 -0.303093580717976 -0.025810555425008
-   16  ( 16)  0.053860155724758 -0.096716021429481  0.048339421207062 -0.181761176256005 -0.397159003963126  0.372509037743437 -0.025797733506417 -0.684921057347845
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  ( 17)  0.996221771264783  0.634916601424197 -0.014362716631700  0.063989857296956 -0.042407746505357 -0.006245913013570 -0.058879619182910
-    1  ( 18)  0.635492231729560 -0.849574597065530 -0.222501748007869 -0.070695707728268 -0.044659773960079 -0.000858385134602  0.091968108784979
-    2  ( 19) -0.014244902761459 -0.222479167715568  1.390369489816779 -0.091171600676671  0.230379334026947 -0.056370061079158 -0.056296969685375
-    3  ( 20)  0.061641277916796 -0.072215991374838 -0.089669757728546  0.479776129624280 -0.001619307121868  0.050691341679409 -0.843378870070337
-    4  ( 21) -0.042015467261129 -0.044624154704664  0.230215986734831 -0.001665187241096  0.807122289756009  0.600336959720768  0.061822950945862
-    5  ( 22) -0.006217156495504 -0.000752286573163 -0.056429339022519  0.050647999718979  0.600335726118908 -0.657774788651645 -0.002451531484141
-    6  ( 23) -0.058260203196287  0.091274675691574 -0.056274995793599 -0.843437750772324  0.061822627544739 -0.002424678590389 -0.386375955817277
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =    17
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.005067718602564  0.012834536697544 -0.000479852203790  0.005722139901835  0.000833808063494 -0.028778886596557 -0.044364182938665 -0.004452517622785  0.011610939961986
-    1  (  1) -0.009366317446027  0.012436714707341  0.003619967651492  0.002506343633181 -0.054364550699127 -0.024231895654864 -0.024309365376734  0.013315051357911  0.015021310452867
-    2  (  2)  0.013031948627571  0.082073139548065 -0.016750891783679  0.005003053437323 -0.107195561546808 -0.115639730242379 -0.163350570683223 -0.004090408571947  0.044315107876541
-    3  (  3) -0.036519743525601  0.094411862150321  0.011079097248539  0.098683633129598  0.374242899840899 -0.057337396588682 -0.088127176408082 -0.006641022684211 -0.002221148233639
-    4  (  4) -0.000669699172297 -0.250491740261693  0.056329271904456  0.020699653792380  0.189174399877554  0.184564489543572 -0.035853071510271  0.034875430761882  0.027893872485003
-    5  (  5) -0.214156532952014 -0.615288665228072  0.215771246496457  0.046102431034999  0.224131841626969  0.112114948215021  0.150102522248763  0.016602833134623  0.122840663448393
-    6  (  6)  0.274003045126345 -0.143471801350555 -0.253398037809422  0.106851026797177  0.096788453036169 -0.178572747687712  0.102040610315496  0.332630496777572 -0.346310147475002
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0) -0.004029200957262 -0.000882760387815  0.002163389161852  0.015131943390767  0.019986233213130 -0.015021193015431  0.001769851076152 -0.017643335711180
-    1  (  1)  0.008928102950836  0.007088858124714  0.002274297322437  0.003234469739505  0.007168429052842 -0.006447748030626  0.000776633831882 -0.037286026575743
-    2  (  2)  0.001170842165988 -0.008217089214695  0.012153847196612  0.024134889946244  0.032866749918208 -0.025142667403114 -0.001212134116123 -0.040817148842220
-    3  (  3) -0.011819482888986 -0.019738644366216  0.003700824753808 -0.007133785910532 -0.023026708836451  0.026144977983316  0.022041055636282 -0.034121256234262
-    4  (  4)  0.022466660017059  0.007998429684758  0.041919351164413  0.007813392525530 -0.007265785085741 -0.016637369547836 -0.098013371195297 -0.048843349051825
-    5  (  5) -0.004397289983553  0.028748859918887 -0.050560469286309  0.032522695518845  0.047617334307217 -0.017989934308048  0.071203484599802 -0.093017155821178
-    6  (  6) -0.042123284623250  0.008732952171969  0.284856396785620 -0.018363970093690  0.031949856970873 -0.080004455070448 -0.086790220224973 -0.043344803159579
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  7)  0.001724783206465 -0.146102349699596 -0.011750241124796 -0.057277414548611 -0.020173503070547  0.015641770076300 -0.133391360672722
-    1  (  8) -0.182384400209359 -0.023648068007229  0.082951126731178  0.562127906578998 -0.042963631893791 -0.024859663227064  0.073688495864433
-
 	Computing Mu_X-Perturbed Wave Function (0.050 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.102741776085
-	   1         5.169883418578    2.839e-01
-	   2         6.160877936328    1.719e-01
-	   3         6.223230716565    5.812e-02
-	   4         6.272628653251    3.365e-02
-	   5         6.278541556312    5.661e-03
-	   6         6.276858694790    1.660e-03
-	   7         6.276945202619    4.790e-04
-	   8         6.276905276907    1.161e-04
-	   9         6.276885929518    2.881e-05
-	  10         6.276887747977    7.093e-06
-	  11         6.276891101576    1.786e-06
-	  12         6.276892442252    3.933e-07
+	   0         4.102741778610
+	   1         5.169883422159    2.839e-01
+	   2         6.160877942124    1.719e-01
+	   3         6.223230722702    5.812e-02
+	   4         6.272628659543    3.365e-02
+	   5         6.278541562624    5.661e-03
+	   6         6.276858701095    1.660e-03
+	   7         6.276945208924    4.790e-04
+	   8         6.276905283212    1.161e-04
+	   9         6.276885935823    2.881e-05
+	  10         6.276887754281    7.093e-06
+	  11         6.276891107881    1.786e-06
+	  12         6.276892448556    3.933e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 9.435e-08
 
 	Computing Mu_X-Perturbed Wave Function (-0.050 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.859955295007
-	   1         4.792972774751    2.394e-01
-	   2         5.543286042842    1.288e-01
-	   3         5.564274980638    3.367e-02
-	   4         5.579487464003    1.800e-02
-	   5         5.581833632943    2.837e-03
-	   6         5.581097667854    7.784e-04
-	   7         5.581122102056    1.972e-04
-	   8         5.581111111200    4.625e-05
-	   9         5.581102559581    1.172e-05
-	  10         5.581103519944    2.765e-06
-	  11         5.581104750052    6.203e-07
-	  12         5.581105207377    1.294e-07
+	   0         3.859955297200
+	   1         4.792972777741    2.394e-01
+	   2         5.543286047227    1.288e-01
+	   3         5.564274985148    3.367e-02
+	   4         5.579487468556    1.800e-02
+	   5         5.581833637506    2.837e-03
+	   6         5.581097672414    7.784e-04
+	   7         5.581122106616    1.972e-04
+	   8         5.581111115761    4.625e-05
+	   9         5.581102564141    1.172e-05
+	  10         5.581103524504    2.765e-06
+	  11         5.581104754612    6.203e-07
+	  12         5.581105211937    1.294e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 2.905e-08
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =    17
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003265067152215  0.002026492209092  0.005500435318608  0.008078622301941 -0.008658500881109  0.036459293961252 -0.029326652250391  0.007624907133575 -0.017230266414268
-    1  (  1)  0.019848975655178 -0.008568674096349 -0.035768118335382  0.039338967933431 -0.008739192142382  0.002236852315732  0.003842536150611 -0.006370808307973  0.006387188771100
-    2  (  2) -0.001311158102682  0.005996603930092 -0.012088378357483  0.063288593855735 -0.042686750248075  0.096527587997965 -0.064713284258089 -0.038913772194284  0.014267016211395
-    3  (  3) -0.069641434452875  0.057681873117421  0.132311010020041 -0.036249277341741  0.036248934686346  0.111143378691454 -0.091174493929596  0.097901000061833 -0.105673461585893
-    4  (  4)  0.434124623887635 -0.301640726175203 -0.258270584723773 -0.205811882736710 -0.089339728161504  0.039739513490021 -0.135462303940190  0.002375526322170 -0.043263965637082
-    5  (  5)  0.081173968533563  0.037394137923481 -0.122560942083237  0.305171944931175  0.078260777553523  0.027064995698868  0.046022990304452  0.193875689971875 -0.171790059938592
-    6  (  6) -0.474121713810952  0.141227640283344  0.441524301346367  0.264512324387944 -0.140054125878165 -0.132135738723399 -0.051997998775631 -0.032760210570508 -0.100063633119523
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0)  0.006013935012044  0.002206969220209 -0.014470075947404  0.001368309875554  0.002087239599490 -0.000365868142111 -0.003958916776740 -0.001873434717837
-    1  (  1) -0.035403072354536 -0.013826422633153 -0.010343466208206  0.017788524189129 -0.002520441967521  0.012986907297241  0.004538611831476 -0.001552742472357
-    2  (  2) -0.005745134984337 -0.006714974843583 -0.127066954751498  0.030070029489338  0.001125013323686  0.025517535242831  0.018059867151878 -0.002030574745858
-    3  (  3)  0.088384862569294  0.013343980191387  0.044104599203938 -0.013053883960181 -0.019339911467356 -0.028936077036821 -0.075177469099726 -0.012052012829741
-    4  (  4) -0.210300662230597  0.088714358597621  0.069888081915214 -0.172504610132785  0.167942817048368  0.026139419673214 -0.056730594878719  0.041941123068085
-    5  (  5)  0.040118833547159 -0.073298763846292  0.248063286831586  0.077429976518261 -0.092806173921398 -0.056087804592582 -0.059344073998483 -0.039436610747247
-    6  (  6) -0.161288525186688  0.166450983348397  0.144923762167849 -0.094775042270021  0.169918790080029  0.220638703768895 -0.015086442554775  0.082074773648405
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  7)  0.023731286269058  0.015034330755501 -0.273330752922172  0.037820426660388  0.284138842805450 -0.218153574225316 -0.012438921134731
-    1  (  8)  0.021668325834947  0.033987896894426 -0.356592806410255  0.086505819787761  0.103102147653207  0.310664447039769  0.006708929270897
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     7
-	   Irrep: 1 row =     2	col =     2
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)    
-
-    0  (  0) -0.026466323364559  0.000028319304914 -0.001006810306637 -0.003418731692119  0.036663472175781 -0.018334333792420  0.037935397785809
-    1  (  1)  0.000028904174656  0.132705286535538  0.004008345044156 -0.010613170205884  0.032674204290777 -0.013900441820930 -0.038334147025939
-    2  (  2) -0.001010822077971  0.003967468036571 -0.002590146822482  0.085957463458987 -0.499260024044765  0.196034713340721 -0.015724343702868
-    3  (  3) -0.003440122629553 -0.010318982830085  0.086228041588947 -0.148739686038090  0.111883116788756  0.082549353436752 -0.646716339039273
-    4  (  4)  0.036870064509150  0.032414924454826 -0.500220770355431  0.111669597456319 -0.258922049164252 -0.258637762864367  0.023570822312213
-    5  (  5) -0.018463661866320 -0.013983080919739  0.195754953301471  0.081901638937235 -0.256070472760282  0.202482702191796  0.274528565175939
-    6  (  6)  0.038006050342084 -0.038540981085222 -0.014408679735145 -0.644760562649152  0.014285517766164  0.275314735896220 -0.068476999092314
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1     
-                      (  7)              (  8)    
-
-    0  (  7)  0.018929182095807  0.062039276079498
-    1  (  8)  0.062346959056566  0.053081448921200
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    17	col =    17
-	   Irrep: 1 row =     7	col =     7
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -2.045993134873731 -0.095409898653600 -0.387594270642989 -0.505900146912186  0.172746641033111 -0.046910168040385 -0.084737755155653 -0.410360151963549 -0.382261890655703
-    1  (  1) -0.095231007303474  0.039819948857640 -0.291910351304723  0.063885771451590 -0.017162503817772  0.571287954038829 -0.394953952483411 -0.243045723102671  0.180443842009873
-    2  (  2) -0.382632249330553 -0.292847693911782 -1.382982378647373 -0.154259655960369  0.173864428021762 -0.295670794202406 -0.107123996346545 -0.385982188376388  0.028658840683595
-    3  (  3) -0.505410909881567  0.062390573871582 -0.154036310291531  0.982968534089393 -0.104512367175512  0.145166782117297  0.226696601336116  0.135831670563868  0.433133822599894
-    4  (  4)  0.169297759495862 -0.015832070255012  0.175669698448482 -0.103333610656524 -0.088624263975634  0.268908892217795 -0.031655422270763 -0.274623540930917  0.238460903427720
-    5  (  5) -0.049136629278740  0.571895176561835 -0.294649084124477  0.144292264858497  0.268065736642396 -0.004325047106725  0.145918393270318  0.372810273859943 -0.431016787132458
-    6  (  6) -0.087260279207009 -0.394385667800918 -0.105217644713437  0.228088087956054 -0.031697143408226  0.145949167135850 -0.298604551214604 -0.041713472364692 -0.051008501927155
-    7  (  7) -0.410914339621091 -0.243365268427750 -0.386858728731771  0.135833418297861 -0.274552066892956  0.373543891834519 -0.041506475789765 -0.451020585572335  0.170871627903158
-    8  (  8) -0.381821204572435  0.180205615072504  0.029084404500310  0.432574410104883  0.238320694111666 -0.431320613321923 -0.051272354410806  0.170589507033196 -0.675829352019599
-    9  (  9) -0.283473421710116  0.112050034408627  0.560595473087251 -0.245415063372486 -0.149264847460109  0.242302621470858 -0.157290698226683  0.100468128429887 -0.266025795313291
-   10  ( 10) -0.052116385440804  0.107624847200442  0.282558920287670  0.059943056512493 -0.062387825969278 -0.115486622660684  0.256555884017987 -0.163523915221471  0.290885113176895
-   11  ( 11)  0.000312513273045  0.155187941900449  0.100393094451125  0.020336020080190  0.127674754605018 -0.211106522265856  0.120135660107417  0.136023622283511 -0.462455224037365
-   12  ( 12) -0.040088912895174  0.048991874235690 -0.011811422909576  0.091257017452860  0.019784182970063  0.016868406587959 -0.000544174708051 -0.124924205510212 -0.058166887460757
-   13  ( 13) -0.009390682767169 -0.016745321738356  0.010403462867083  0.088355953809463 -0.051207257527814  0.168655348073088 -0.014606152117855 -0.074404615170129  0.046843317912933
-   14  ( 14) -0.073276112260004  0.057758888405722  0.174249113368945 -0.108526984756369  0.005873988347796 -0.115290133695343  0.046811486241008 -0.064124627762932  0.051346278871495
-   15  ( 15)  0.005779177395601 -0.060389355097241  0.012276575492417 -0.096153630668420  0.181712320706024  0.128331892268229  0.225366212207405  0.081713947674767 -0.144525489497557
-   16  ( 16) -0.060752757257594  0.018327091553227  0.019085185007204  0.030973177274899  0.012354348831073  0.069603475266508 -0.030006835141826  0.005552576291094 -0.060836699707616
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0) -0.285303582746393 -0.056294192160665 -0.000200687930218 -0.038024825027710 -0.012046819629200 -0.077012885660403  0.006033548694711 -0.061807525496149
-    1  (  1)  0.113071704196730  0.108778532345339  0.156184092789691  0.048684365197324 -0.016243813405120  0.058823369178344 -0.060407135004659  0.018519743013255
-    2  (  2)  0.562523645229237  0.285264478722674  0.101513510030167 -0.013175405914280  0.011768340960851  0.176049115365102  0.011615146885545  0.019552984614227
-    3  (  3) -0.243737456306168  0.060847590488087  0.019824546151347  0.091291375704035  0.089537547257186 -0.108209096483289 -0.096544747228456  0.031323007671123
-    4  (  4) -0.149018755824729 -0.062754456373360  0.127376600662541  0.020366865409553 -0.051674532870044  0.005753595837931  0.181922433672134  0.012276690572424
-    5  (  5)  0.240627721939884 -0.114767648002828 -0.211416289254032  0.015975616858924  0.169586883038260 -0.114607009513284  0.128525855676351  0.070097551806575
-    6  (  6) -0.156693567229655  0.256215700441591  0.120063103357279 -0.000003040389676 -0.014992046515823  0.046904705681064  0.225574226220870 -0.030177739023540
-    7  (  7)  0.100263606325596 -0.163703826662444  0.135989927625065 -0.124576096560582 -0.074129889564192 -0.064680677402394  0.081773026674468  0.005774218340390
-    8  (  8) -0.266668295925435  0.290777226339073 -0.462544053201063 -0.058743583333771  0.046629285110809  0.051624572732368 -0.144465149214115 -0.061087050064978
-    9  (  9) -0.925652707318708 -0.583660752355916 -0.155775235357423  0.445905510547533 -0.085223163401930  0.320909369856072 -0.139003830120683  0.030422261138610
-   10  ( 10) -0.583279755470617 -0.303453157039093  0.125949989442450  0.209539965251911 -0.039645500897526  0.087763726360968 -0.069331015366641  0.008115477198654
-   11  ( 11) -0.155376626940309  0.125927989282900 -0.104729836793845  0.011349449787087 -0.028985031796447  0.101545429706514  0.020786740802604 -0.071540693180168
-   12  ( 12)  0.446199204416227  0.209533527715715  0.010652562772003 -0.122763822621396  0.084004825690867 -0.060856238307855  0.055415498514065 -0.016323905923520
-   13  ( 13) -0.084813114367247 -0.039575228923184 -0.029630201276164  0.084050535539902  0.039685632988849 -0.042279600675479  0.024577846833790 -0.033021008737513
-   14  ( 14)  0.321789737507025  0.088054269353386  0.102052558884899 -0.060946364351172 -0.042213968647851  0.054671591708845 -0.027704713949390  0.044786029623289
-   15  ( 15) -0.139004434932276 -0.069324980587538  0.020862927433168  0.055283762920506  0.024483424096936 -0.027399434763095  0.027805312058636 -0.039717899136090
-   16  ( 16)  0.030710136385131  0.008185345443293 -0.071909346470965 -0.016262510423583 -0.033030270773791  0.044859369380168 -0.039589710603285 -0.008513189267103
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  ( 17)  0.063740436686834 -0.004787154508074  0.538538933439869 -0.009052843531209  0.210737581731213  0.068032599878639 -0.012686995100758
-    1  ( 18) -0.005077960748769 -0.059037803747914  0.228349904229210 -0.009206614582854  0.138527633914846  0.009964745684741  0.007455890177025
-    2  ( 19)  0.541597901122945  0.227776389588582 -1.147253894628681  0.026129576715585 -0.564507518878226 -0.149606564239045 -0.032515314853600
-    3  ( 20) -0.009580989251238 -0.009149486679310  0.025566850285476  0.093409480733594  0.029387857687170 -0.006908216669476 -0.071485607388481
-    4  ( 21)  0.208618544932732  0.139451761819383 -0.563840838338479  0.028663300088685 -0.100582743739006  0.005895697838307  0.010722959978135
-    5  ( 22)  0.067974194993357  0.008600203631037 -0.149010367735970 -0.006598982413936  0.005915244102597 -0.015400685691487  0.019226657028192
-    6  ( 23) -0.012651691467565  0.007379655026589 -0.032350130589990 -0.071504127733178  0.010703285254014  0.019026056021972  0.017499411133403
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =    17
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003751828875244  0.002066993521910  0.005646018523719  0.007971235352960 -0.008514547746194  0.035651407199236 -0.028594135193668  0.007405276527293 -0.016749550255979
-    1  (  1)  0.019502304040523 -0.008601083038433 -0.034986080726304  0.038437171228534 -0.008699374239570  0.002232591662416  0.003683855646166 -0.005845992541352  0.006431929732322
-    2  (  2)  0.005162322558812  0.005006091601700 -0.013651447640213  0.073108562117686 -0.037110502694364  0.099971679953210 -0.061818640904389 -0.030065850288973  0.009991736200864
-    3  (  3) -0.057916505621728  0.056341598633679  0.113645462083389 -0.051661279744271  0.032845238255008  0.115183118840799 -0.098236437619912  0.091663726075877 -0.108759469637960
-    4  (  4)  0.406321573590683 -0.279225795319112 -0.216702557125586 -0.194841625855345 -0.082000972364980  0.036206780650479 -0.131621874359774 -0.002941154857446 -0.038291774767926
-    5  (  5)  0.082666085704471  0.037170774751607 -0.109366104305027  0.306227368555721  0.055852393512460  0.029132834214226  0.047858698305321  0.191190362296867 -0.153017394069324
-    6  (  6) -0.458136442070611  0.106031150480337  0.393081188393353  0.249752536705643 -0.125320465454532 -0.124263776658658 -0.043393736784742 -0.030845035580441 -0.093961046813138
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0)  0.005798934978529  0.002143687367549 -0.014089335198481  0.001324299844750  0.002019868875779 -0.000354215696095 -0.003864986390855 -0.001821684258311
-    1  (  1) -0.034363827795974 -0.013298895705888 -0.010073948025801  0.017368630238864 -0.002386826220116  0.012568412345399  0.004482838074461 -0.001577091809586
-    2  (  2) -0.005900863534114 -0.005792364484342 -0.113458341680317  0.027244997206748  0.000391909756193  0.024110004459923  0.015153768321953 -0.000959743197843
-    3  (  3)  0.079557340675880  0.007706717681738  0.039901607106568 -0.010833609875429 -0.018472734672823 -0.026055254589983 -0.070732329632562 -0.011158996652328
-    4  (  4) -0.182787083526436  0.089427715986207  0.062916944018857 -0.160041676635648  0.153729637667921  0.025374508612108 -0.050608420481544  0.037499586551580
-    5  (  5)  0.040920622349544 -0.067223701668111  0.223222565090092  0.071193525531542 -0.081550793775845 -0.055819422855801 -0.053722239139885 -0.036812165791084
-    6  (  6) -0.179948389216996  0.155410883892581  0.129738152623862 -0.084750037649381  0.153208006748098  0.206079952934255 -0.014680354899951  0.075082232624937
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  7)  0.007727960051405  0.014188761911108 -0.254870847034818  0.036245861641137  0.257329582057483 -0.202509743936333 -0.011664708636642
-    1  (  8) -0.000813195416604  0.022554294061283 -0.332537774106676  0.079445887399926  0.088054726222404  0.285022367621264  0.005162037999851
 
 	Computing Mu_Y-Perturbed Wave Function (0.050 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.359153193042
-	   1         5.598361293767    3.880e-01
-	   2         7.210172501780    2.546e-01
-	   3         7.288570403500    6.955e-02
-	   4         7.375149872043    3.606e-02
-	   5         7.384722024024    5.193e-03
-	   6         7.384223731239    1.466e-03
-	   7         7.384480397181    2.971e-04
-	   8         7.384507872057    6.671e-05
-	   9         7.384497299411    1.959e-05
-	  10         7.384499671967    6.135e-06
-	  11         7.384503291959    1.864e-06
-	  12         7.384505044665    4.256e-07
+	   0         4.359153196529
+	   1         5.598361298936    3.880e-01
+	   2         7.210172510546    2.546e-01
+	   3         7.288570412365    6.955e-02
+	   4         7.375149881021    3.606e-02
+	   5         7.384722033033    5.193e-03
+	   6         7.384223740242    1.466e-03
+	   7         7.384480406185    2.971e-04
+	   8         7.384507881061    6.671e-05
+	   9         7.384497308415    1.959e-05
+	  10         7.384499680972    6.135e-06
+	  11         7.384503300963    1.864e-06
+	  12         7.384505053669    4.256e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 8.019e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.050 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.036471660558
-	   1         5.067027170751    3.128e-01
-	   2         6.144597775068    1.828e-01
-	   3         6.161141955549    3.976e-02
-	   4         6.188160937688    1.914e-02
-	   5         6.191772806087    2.638e-03
-	   6         6.191582051344    7.170e-04
-	   7         6.191669650157    1.346e-04
-	   8         6.191679689203    2.789e-05
-	   9         6.191675467560    7.395e-06
-	  10         6.191676143436    2.148e-06
-	  11         6.191677152401    6.026e-07
-	  12         6.191677634185    1.338e-07
+	   0         4.036471663562
+	   1         5.067027175028    3.128e-01
+	   2         6.144597781499    1.828e-01
+	   3         6.161141962013    3.976e-02
+	   4         6.188160944196    1.914e-02
+	   5         6.191772812608    2.638e-03
+	   6         6.191582057864    7.170e-04
+	   7         6.191669656677    1.346e-04
+	   8         6.191679695723    2.789e-05
+	   9         6.191675474080    7.395e-06
+	  10         6.191676149956    2.148e-06
+	  11         6.191677158921    6.026e-07
+	  12         6.191677640706    1.338e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 2.408e-08
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     7
-	   Irrep: 1 row =     2	col =    17
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  0) -0.010786265183144  0.051029121132170  0.002996763849739 -0.011801503115544  0.001272030820720  0.000196386846190  0.002982916046102
-    1  (  1) -0.058609640963270 -0.012417801314910 -0.003971620689219 -0.009080237811660 -0.000121215070459 -0.000228818864652 -0.009373425738771
-    2  (  2) -0.085132594501744  0.091652823097353  0.007546774391891 -0.142423359791749  0.006996619603860  0.002101811348346 -0.029373124781206
-    3  (  3)  0.122069258148396  0.223131785279761 -0.087332676023743  0.050632801243966  0.042739607387155 -0.018430049330312  0.086614058743774
-    4  (  4) -0.105541230675864  0.048893582187370  0.328998944712803  0.105191585386823 -0.242811441764458  0.170260494209224  0.054325780187217
-    5  (  5) -0.265882747768071  0.058275011878436 -0.023416331604461  0.339635908182997  0.103800327020429 -0.114058283212065  0.058690855476724
-    6  (  6)  0.007633857500139  0.022854049227207 -0.377212343584744  0.102347661597779  0.009619050796435  0.297095107100103 -0.012497514920931
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  7) -0.147346265517506  0.175457635393697 -0.221105865986270 -0.029899707009198  0.165686742393032  0.115361676403977 -0.008355394047083  0.328221796014218  0.292080655206068
-    1  (  8) -0.122245405560539  0.024589732049082 -0.167118519556619 -0.015807337638932 -0.058301108727541 -0.105293352874109 -0.203866490026683  0.286393949830171  0.189278200780844
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  7) -0.087279639847736 -0.126770988900312 -0.036329390570234 -0.242965090530464  0.132308970188284  0.116935047705630  0.002357403463405 -0.057494504536996
-    1  (  8) -0.205975410858357  0.286653615135548 -0.077914712510969 -0.007558681388675 -0.292258655312688 -0.145533516877255  0.007845998491586  0.090356336812698
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     2
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1     
-                      (  7)              (  8)    
-
-    0  (  0) -0.043819140181369  0.036074491951167
-    1  (  1) -0.036237068531700 -0.050415577455144
-    2  (  2)  0.528492370226786  0.015299710619496
-    3  (  3)  0.017518923619511 -0.564610204547300
-    4  (  4)  0.085812129312801 -0.070371782668820
-    5  (  5)  0.252364389877497  0.175800283642740
-    6  (  6)  0.061085593898950  0.095127660035001
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)    
-
-    0  (  7) -0.044067543892294 -0.036488078491946  0.528279520963148  0.018864796666208  0.085565437065040  0.252014784445039  0.060037559006935
-    1  (  8)  0.036063712094606 -0.050614499023038  0.015518778585002 -0.562528692062847 -0.071591764890120  0.175011603181084  0.095580342225146
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    17	col =     7
-	   Irrep: 1 row =     7	col =    17
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  0)  0.599480222444637  0.016859533434664 -0.049897396924280  0.100931992321173 -0.178820057695389 -0.093593822067295 -0.045840833373615
-    1  (  1) -0.102825062644488  0.497551654375298  0.079024430059592 -0.089810403907835  0.095840244352085  0.042979610010712  0.100107750054018
-    2  (  2)  0.313847375874909 -0.236133415515714  0.290305789540109  0.013432093218325  0.277632595704877  0.128347816687602 -0.035321860848130
-    3  (  3) -0.120186064621026 -0.088525193286422 -0.285710676647029 -0.049963609023862 -0.018526308466162 -0.010366645593084  0.045528954113686
-    4  (  4) -0.090166928005197  0.032050142733123 -0.030452275714624 -0.063250796602694 -0.035750237348326 -0.017833119271341 -0.132006242302645
-    5  (  5) -0.142691415524645  0.223913086808699  0.027094381023140  0.024338605924022  0.028535894302556  0.007226239356373 -0.162190336038922
-    6  (  6) -0.066933385246723  0.243769517259146  0.020035311286226  0.114101180100409 -0.012489851345781  0.011332261380418 -0.233889391977416
-    7  (  7) -0.672885351756081 -0.001881267801208 -0.095136222092223 -0.058176395722164 -0.061089446815740 -0.043316162321467  0.019390286464139
-    8  (  8) -0.435312399605479  0.058517097371420 -0.132087164095948 -0.111210778747092 -0.084785664597104  0.018714661714217  0.051077770966582
-    9  (  9)  0.039880967641781  0.175296984662262  0.139275550562713 -0.022188880266031  0.000377216624842 -0.012858606937540 -0.034561120442390
-   10  ( 10) -0.303210587603071 -0.514083864535284 -0.056475775929677  0.034965638385877 -0.040317053885205 -0.017962506851195  0.053786011903196
-   11  ( 11) -0.027239637605681  0.034828784234934  0.033426829747022 -0.018094121367506  0.017093937691801  0.004223484052252 -0.011996780527565
-   12  ( 12) -0.308711690655872 -0.002817985822889 -0.037619399642840 -0.077619866356188 -0.025848322659187  0.002876135041613 -0.007325116102266
-   13  ( 13) -0.122322909534018  0.113539161130551  0.014757220452077 -0.054033827004457  0.003700011797212 -0.003003782149483 -0.047911411994658
-   14  ( 14) -0.097844480434489 -0.119320090615277  0.001467167999597  0.047025034239875 -0.015029470496590  0.001307380616700  0.021961924745376
-   15  ( 15) -0.003252338995529  0.016436791178655  0.055709805192912 -0.009293573860402 -0.005810476770249 -0.019308137788336 -0.008191212687172
-   16  ( 16) -0.036707953659231  0.103754840414863 -0.016684655371398 -0.061363104748847 -0.002167501914420  0.001092629910883  0.026459157258590
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 17)  0.599729724796822 -0.100763044997049  0.312417498644213 -0.121527463741962 -0.089494866802933 -0.142965380633054 -0.068176811299970 -0.669349755030469 -0.432871097543217
-    1  ( 18)  0.016829691255097  0.498021176353259 -0.236000617824191 -0.088934550094707  0.031202345455259  0.223575626840272  0.243864850259255 -0.002331620184497  0.057733029620748
-    2  ( 19) -0.054552900240867  0.080128078195554  0.292430603697284 -0.284599987869487 -0.029522070318793  0.026959103270929  0.021940193228378 -0.096891945038095 -0.133499525770681
-    3  ( 20)  0.100253522171184 -0.090631183013606  0.011713957045895 -0.049730048298516 -0.062592805551904  0.025213226750359  0.114036593498515 -0.057494677157406 -0.110236213187370
-    4  ( 21) -0.179159024052453  0.095672908178934  0.278266560095751 -0.018388137436416 -0.036511169805779  0.029495232441701 -0.013242480280230 -0.061079729130703 -0.084477317549054
-    5  ( 22) -0.088933490318749  0.041952581209809  0.126034689140710 -0.011275748873422 -0.017323803323152  0.005886315562041  0.011658588522848 -0.043044407090452  0.018540705202664
-    6  ( 23) -0.046333914085307  0.100418803408813 -0.035362724685491  0.045416588335831 -0.131810180134045 -0.161950813236466 -0.233566785912366  0.019297085245182  0.050997307344278
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  ( 17)  0.039312615108447 -0.302032443665741 -0.027550294935800 -0.310784860130476 -0.123366344699992 -0.097420977774117 -0.003209928183805 -0.036830398019273
-    1  ( 18)  0.175567267566103 -0.512664071190351  0.034894695549286 -0.001894103503434  0.112588400025920 -0.120085800524745  0.016426825731778  0.104378228791495
-    2  ( 19)  0.136543328570788 -0.058279389709951  0.033933657083247 -0.037273212570074  0.015308466144542  0.001541196291270  0.056028919618144 -0.016762051778500
-    3  ( 20) -0.022563171568634  0.034710591396916 -0.018459749038852 -0.077422552415566 -0.052960741334943  0.046505103663057 -0.009331616241340 -0.060923921975890
-    4  ( 21)  0.001466076193959 -0.040032717264813  0.016917418953977 -0.025762346460130  0.003762250578566 -0.014972651118730 -0.005881505372504 -0.002207525976346
-    5  ( 22) -0.011996109684438 -0.017649877911749  0.004310226300310  0.002850355947905 -0.002885632287969  0.001316998750490 -0.019472836966745  0.001098266616166
-    6  ( 23) -0.034634146639722  0.053685024377128 -0.011937415333247 -0.007255949520686 -0.047576628375718  0.021896401358334 -0.008171802221400  0.026587486496662
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     7
-	   Irrep: 1 row =     2	col =    17
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  0) -0.010574314095683  0.049882978545122  0.002870330966735 -0.011532171460868  0.001238602598829  0.000191316089031  0.002921482491107
-    1  (  1) -0.057532452524585 -0.012065759248930 -0.003751148528909 -0.008827776374122 -0.000113560391374 -0.000227841169844 -0.009209133435533
-    2  (  2) -0.091814855038090  0.094917804724041  0.006288310960891 -0.126283019227595  0.007222028964977  0.002073910472135 -0.025512078631774
-    3  (  3)  0.120653889319174  0.226084849611754 -0.075300125208344  0.046643270206305  0.037421332704021 -0.017859191162973  0.081266935673681
-    4  (  4) -0.097956489392108  0.051351897149702  0.305754549991063  0.095382973436958 -0.220329096451480  0.158512880282495  0.049614437366158
-    5  (  5) -0.261619207985082  0.056084449894857 -0.025368373388091  0.308737234570638  0.097128785420262 -0.105014860102430  0.053434785260047
-    6  (  6)  0.008799396272402  0.018728768046646 -0.354955141247505  0.095669064713818 -0.001191012606816  0.271606540647270 -0.012344010113691
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  7) -0.150705574361930  0.171630195989760 -0.209599417391610 -0.025489164143659  0.149255370410132  0.112216774108593 -0.000397827210048  0.316622730650583  0.277369362242453
-    1  (  8) -0.130570763068830  0.009488512240525 -0.144994119658194 -0.007578049469341 -0.047607403703452 -0.095540393045053 -0.185243293387079  0.276777433572968  0.180273089892158
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  7) -0.076246695560918 -0.118379428340658 -0.031849281493620 -0.218889052864385  0.125994951072932  0.108535764483610  0.002831367609020 -0.051643750178160
-    1  (  8) -0.193081458944204  0.284637903909638 -0.070582554931437 -0.002932045787915 -0.271746148176880 -0.130119446798498  0.007304069162710  0.084713895677763
 
 	Computing Mu_Z-Perturbed Wave Function (0.050 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.430648845029
-	   1         2.910766986626    1.864e-01
-	   2         3.294611228010    1.238e-01
-	   3         3.368260906367    6.734e-02
-	   4         3.423879613846    3.077e-02
-	   5         3.424926249707    8.248e-03
-	   6         3.427469018463    2.201e-03
-	   7         3.427520606064    4.848e-04
-	   8         3.427494925843    1.290e-04
-	   9         3.427510568664    3.374e-05
-	  10         3.427513194771    1.209e-05
-	  11         3.427511658470    3.141e-06
-	  12         3.427510377965    9.024e-07
-	  13         3.427510388317    2.093e-07
+	   0         2.430648844635
+	   1         2.910766986017    1.864e-01
+	   2         3.294611226970    1.238e-01
+	   3         3.368260905015    6.734e-02
+	   4         3.423879612285    3.077e-02
+	   5         3.424926248141    8.248e-03
+	   6         3.427469016888    2.201e-03
+	   7         3.427520604489    4.848e-04
+	   8         3.427494924268    1.290e-04
+	   9         3.427510567089    3.374e-05
+	  10         3.427513193196    1.209e-05
+	  11         3.427511656895    3.141e-06
+	  12         3.427510376390    9.024e-07
+	  13         3.427510386742    2.093e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 5.389e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.050 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.319515965123
-	   1         2.745304657092    1.539e-01
-	   2         3.034510153733    8.730e-02
-	   3         3.051803953434    3.527e-02
-	   4         3.065551691425    1.340e-02
-	   5         3.065056389137    3.294e-03
-	   6         3.065551022902    8.083e-04
-	   7         3.065578753688    1.694e-04
-	   8         3.065568800559    4.034e-05
-	   9         3.065572210363    8.828e-06
-	  10         3.065572939573    2.796e-06
-	  11         3.065572838665    7.295e-07
-	  12         3.065572627738    2.091e-07
+	   0         2.319515964771
+	   1         2.745304656574    1.539e-01
+	   2         3.034510152940    8.730e-02
+	   3         3.051803952577    3.527e-02
+	   4         3.065551690530    1.340e-02
+	   5         3.065056388243    3.294e-03
+	   6         3.065551022007    8.083e-04
+	   7         3.065578752793    1.694e-04
+	   8         3.065568799664    4.034e-05
+	   9         3.065572209467    8.828e-06
+	  10         3.065572938677    2.796e-06
+	  11         3.065572837769    7.295e-07
+	  12         3.065572626843    2.091e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.685e-08
 
 	Computing <<Mu;Mu>_(0.050) tensor.
 
-                 CCSD Dipole Polarizability [(e^2 a0^2)/E_h]:
+                 CCSD Dipole Polarizability (Length Gauge) [(e^2 a0^2)/E_h]:
   -------------------------------------------------------------------------
    Evaluated at omega = 0.050000 E_h (911.27 nm, 1.361 eV, 10973.73 cm-1)
   -------------------------------------------------------------------------
 
                    0                     1                     2        
 
-    0      5.757358061611913    -1.826957728644778     0.000000000000000
-    1     -1.826957728644778     6.559981873969495     0.000000000000000
-    2      0.000000000000000     0.000000000000000     3.189441989719278
+    0      5.757358066510180    -1.826957734843812     0.000000000000000
+    1     -1.826957734843812     6.559981880984797     0.000000000000000
+    2      0.000000000000000     0.000000000000000     3.189441988537673
 
-	alpha_(0.050) =       5.168927308434 a.u.
-
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =    17
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.004973311842420  0.013266995929194 -0.000628781752650  0.005821270029714  0.000919567978388 -0.029199972126280 -0.045028399100612 -0.004470261442863  0.011877997660976
-    1  (  1) -0.009507235197464  0.012821706325685  0.003799126662321  0.002252865927780 -0.055209495109638 -0.024587025371539 -0.024606989745348  0.013427377489127  0.015081303210993
-    2  (  2)  0.017389558115329  0.090269894198308 -0.021790983039231  0.002273396073758 -0.116264596862988 -0.115462041463200 -0.161679143653204 -0.004382227235231  0.044152650113456
-    3  (  3) -0.045800490256982  0.102684016384516  0.004298149179332  0.100539443932642  0.370543586881213 -0.055770882127081 -0.078687877648935  0.007825357989142 -0.005958094935070
-    4  (  4) -0.010437720508760 -0.261361023414739  0.067136694654890  0.024410751781325  0.194687941602041  0.189213367030653 -0.016782925636869  0.030449297972074  0.042728748936538
-    5  (  5) -0.204520483232389 -0.650047613350719  0.223047478915112  0.041190532288830  0.240619423578978  0.137439279021831  0.171279245566327  0.016185016716197  0.121002567618253
-    6  (  6)  0.280902317075698 -0.160624493052628 -0.273839367320907  0.104387818057120  0.105984664365183 -0.191695563527139  0.108911766202185  0.343815605886466 -0.365957079247673
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0) -0.004053113693640 -0.001130746719724  0.002197040319962  0.015409285346725  0.020385399861541 -0.015317248885301  0.001807788770669 -0.017920595472896
-    1  (  1)  0.009120082216769  0.007242671494469  0.002352070818783  0.003227187191148  0.007274880671274 -0.006594278499476  0.000810229863832 -0.037744633186988
-    2  (  2)  0.003699393587894 -0.014491498350454  0.012365540077676  0.024534096582419  0.035400276246270 -0.027568218912894 -0.001277774119094 -0.041982803931276
-    3  (  3) -0.007020625904770 -0.030420086186411  0.005111711552617 -0.010981748828448 -0.029324107040543  0.031529857635973  0.023380127781762 -0.037504135613171
-    4  (  4)  0.028745091229054  0.004362974798288  0.043337123990437  0.007599994175588 -0.010124122330633 -0.015830192253859 -0.106395365799597 -0.053301540072473
-    5  (  5)  0.000191291817102  0.025549777277640 -0.058630833236202  0.035380012602342  0.052526050019725 -0.020071096582297  0.076201395794857 -0.101034119172717
-    6  (  6) -0.057417324803451  0.003770361171125  0.312155564894547 -0.019595345178414  0.032179561711377 -0.085712769628610 -0.091655662969562 -0.043614568508176
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  7)  0.002562166576807 -0.127624975977970 -0.006095786674696 -0.057070001911144 -0.023443205612938  0.016613258960547 -0.145264601529895
-    1  (  8) -0.188514280230697 -0.034959079109952  0.090846586736885  0.600224852290861 -0.049044165260568 -0.027854382028144  0.077976937344803
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     7
-	   Irrep: 1 row =     2	col =     2
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)    
-
-    0  (  0) -0.877967627777420  0.000313522193888 -0.019259885114899  0.021251632646677  0.017412558381543  0.034335407608122 -0.000238172067977
-    1  (  1)  0.000322608301162  0.947380586418926  0.024249733504118  0.009114321616672 -0.017152420036554 -0.038527066340585 -0.008117265825269
-    2  (  2) -0.019192337212076  0.024108802324622 -0.143587960734165 -0.609589206490408 -0.080850441455264 -0.015635633462251  0.017209818026148
-    3  (  3)  0.021307524418295  0.009065921973045 -0.609927216030257  0.011341171531789 -0.562777560041829 -1.130102822062630  0.098161002116198
-    4  (  4)  0.017437875196281 -0.016860670100679 -0.081233426405482 -0.564804896125210 -0.137787092580986  0.037141276598326 -0.832484571958425
-    5  (  5)  0.034336422207809 -0.038415705150775 -0.016763474874720 -1.132859634730820  0.035968686389409  0.264833058338794  0.457303575012885
-    6  (  6) -0.000330176196204 -0.008043840531136  0.016330711457037  0.098416114621239 -0.830420506786356  0.457130067031757  0.385470725689893
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1     
-                      (  7)              (  8)    
-
-    0  (  7) -0.227964898187105  0.899784121233827
-    1  (  8)  0.899333065983888  0.346847097589665
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    17	col =    17
-	   Irrep: 1 row =     7	col =     7
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.616069892967514  0.536999907051132  0.064570261876073 -0.021746949912215  0.311054630877884 -0.014988999172356  0.403937330087933  0.080677979873068  0.190208106487436
-    1  (  1)  0.539100056498500  1.121467176666122  0.501269943316699  0.076120073616633  1.006742706967197  0.003907518839866 -0.383146326015980 -0.474993266173842 -0.025427814708089
-    2  (  2)  0.061217021707060  0.499628876649819  1.154179761547648 -0.137928182230330 -0.495313577328702  0.318380781085109  0.413200746977780  0.157674454194196  0.163348441730534
-    3  (  3) -0.019662932181842  0.077523110716421 -0.139848581831140  0.935298042213261 -0.495168520230484 -0.312161918206477  0.553850138158494  0.050690221949374 -0.115705670984065
-    4  (  4)  0.310943231912307  1.007930671638337 -0.496792878828605 -0.496057332349846 -0.163289419911517  0.399873031900594  0.581449523537017 -0.151289222759749 -0.558580697485684
-    5  (  5) -0.016981854891896  0.004948048764029  0.318027411184786 -0.311334572285853  0.400040741651159 -0.163260855919412 -0.043209700057553 -0.714667048662647  0.807833175148293
-    6  (  6)  0.405126484890673 -0.384326977793836  0.412161084214212  0.554052652902597  0.580944240574859 -0.043533045765531 -0.738038189913143  0.085634839739873 -0.225430347568172
-    7  (  7)  0.084899534839490 -0.477102952332221  0.155861734152243  0.049692746203274 -0.151524749975406 -0.714700304975067  0.085653110388769  1.020372569509776  0.273203758137330
-    8  (  8)  0.184458527486884 -0.023781009109227  0.165473299991638 -0.114600831781650 -0.558632517834915  0.809040541017870 -0.225150367734434  0.272550659433537  0.714544346078435
-    9  (  9)  0.053140085566908 -0.342609131399199 -0.159311675949905  0.022341895172386 -0.065531666457998 -0.269706601792147 -0.158590290041005 -0.172377416642194  0.098583572112306
-   10  ( 10)  0.103318634513581  0.336891904621794 -0.211860379640696  0.028705977449278  0.219074363337613  0.147144167978190  0.232719520034013  0.268264154906963  0.208839112806111
-   11  ( 11) -0.186528320728562  0.153201146227153  0.313141523626848 -0.072865729142253 -0.113774903876919  0.278147399319758 -0.079792554944443 -0.195212219985063  0.186019861514634
-   12  ( 12)  0.151804562470358 -0.108110913589224  0.032295103397461 -0.162704962998097  0.020425035985354  0.192138610039775  0.222419633081503  0.130336458514042  0.009407451168273
-   13  ( 13)  0.121608980468146 -0.110977070036412  0.045709995700803 -0.051967255031559  0.089407073382377  0.164909440906524  0.397216369690126 -0.051479025562899 -0.182819729690421
-   14  ( 14) -0.078729676811471  0.035361204543485 -0.059248000570129  0.112066401729498 -0.064040771924537 -0.235871938611430 -0.273666216491852  0.082834082600926 -0.020031425337585
-   15  ( 15) -0.041387782348733  0.012446902025407 -0.027295301343405 -0.097753764879958  0.030026558446376 -0.090321793918168  0.019874335440583  0.116017714618137 -0.126972589824044
-   16  ( 16) -0.132346570961001 -0.061311035452504 -0.029455538314584  0.015897095654112  0.164187274367247  0.163025551532567  0.169577657089601  0.068368765349860  0.040151411900283
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0)  0.055450179392117  0.103885767798645 -0.191032843184630  0.152009876765510  0.121262205093579 -0.077396557926421 -0.039919053508787 -0.132668039484820
-    1  (  1) -0.341982473849641  0.338042385842803  0.154837698936008 -0.109646885589356 -0.112374874685011  0.036067541299657  0.012224215969489 -0.062173439974409
-    2  (  2) -0.161380436915024 -0.212525022100483  0.315178751222923  0.032643675793751  0.046296273705359 -0.060259188597452 -0.027924052357607 -0.029774347871232
-    3  (  3)  0.022756835482488  0.028917816386337 -0.072019929552326 -0.162829131148331 -0.051988133264688  0.111942009790346 -0.098152283948764  0.016121374057675
-    4  (  4) -0.065398587780161  0.219671416349890 -0.113855291654859  0.020875558658236  0.090234442225766 -0.064699443883862  0.030327734232098  0.164965146771565
-    5  (  5) -0.271645100740263  0.146334667900126  0.279031366705028  0.192410761999375  0.165180364781876 -0.236457911753675 -0.090839325876833  0.163445998890330
-    6  (  6) -0.158392571216451  0.232617546830461 -0.079904277525593  0.222795557006328  0.397833037393679 -0.274049556346732  0.020076568565887  0.169937762836561
-    7  (  7) -0.170682218930804  0.268852788924366 -0.195692655631564  0.130524483662373 -0.051165870753648  0.082798905111444  0.115829481611899  0.068470603637705
-    8  (  8)  0.096564774400488  0.208060530676641  0.185992253087719  0.009546396555858 -0.182917669130639 -0.020127532892393 -0.126885643557761  0.040301896445586
-    9  (  9)  1.091880727567183  0.618059189550919  0.064491178316712 -0.255127265298153  0.132183322659095  0.068956515747517 -0.080323214785157  0.053878904245493
-   10  ( 10)  0.618133427218445 -0.009840747270176 -0.012838874312395 -0.097969065788505  0.187597974236451 -0.202172218192305  0.021959943928511 -0.096709126143751
-   11  ( 11)  0.065903124056317 -0.012296213223463  0.598357018260281  0.059602437106646  0.013365498655057  0.114364469387417  0.827703714814267  0.048268697375430
-   12  ( 12) -0.255300845543071 -0.098147098302434  0.059580177286638  0.567724364588447  0.571908990688714  0.504236828319309 -0.162215368687543 -0.181543287290782
-   13  ( 13)  0.132327758451946  0.187460052134489  0.013164164091641  0.571973146707974 -0.024738561731473 -0.558762474457342  0.053196123755597 -0.396928116374631
-   14  ( 14)  0.068667391811317 -0.202141325825385  0.114385734772804  0.504185200524858 -0.558826822299864  0.386685477843097 -0.175467887973267  0.372361407623338
-   15  ( 15) -0.080419165584544  0.021930833178619  0.827828341049343 -0.162189801264600  0.053238745633504 -0.175544320290186 -0.303093580717976 -0.025810555425008
-   16  ( 16)  0.053860155724758 -0.096716021429481  0.048339421207062 -0.181761176256005 -0.397159003963126  0.372509037743437 -0.025797733506417 -0.684921057347845
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  ( 17)  0.996221771264783  0.634916601424197 -0.014362716631700  0.063989857296956 -0.042407746505357 -0.006245913013570 -0.058879619182910
-    1  ( 18)  0.635492231729560 -0.849574597065530 -0.222501748007869 -0.070695707728268 -0.044659773960079 -0.000858385134602  0.091968108784979
-    2  ( 19) -0.014244902761459 -0.222479167715568  1.390369489816779 -0.091171600676671  0.230379334026947 -0.056370061079158 -0.056296969685375
-    3  ( 20)  0.061641277916796 -0.072215991374838 -0.089669757728546  0.479776129624280 -0.001619307121868  0.050691341679409 -0.843378870070337
-    4  ( 21) -0.042015467261129 -0.044624154704664  0.230215986734831 -0.001665187241096  0.807122289756009  0.600336959720768  0.061822950945862
-    5  ( 22) -0.006217156495504 -0.000752286573163 -0.056429339022519  0.050647999718979  0.600335726118908 -0.657774788651645 -0.002451531484141
-    6  ( 23) -0.058260203196287  0.091274675691574 -0.056274995793599 -0.843437750772324  0.061822627544739 -0.002424678590389 -0.386375955817277
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =    17
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.005067718602564  0.012834536697544 -0.000479852203790  0.005722139901835  0.000833808063494 -0.028778886596557 -0.044364182938665 -0.004452517622785  0.011610939961986
-    1  (  1) -0.009366317446027  0.012436714707341  0.003619967651492  0.002506343633181 -0.054364550699127 -0.024231895654864 -0.024309365376734  0.013315051357911  0.015021310452867
-    2  (  2)  0.013031948627571  0.082073139548065 -0.016750891783679  0.005003053437323 -0.107195561546808 -0.115639730242379 -0.163350570683223 -0.004090408571947  0.044315107876541
-    3  (  3) -0.036519743525601  0.094411862150321  0.011079097248539  0.098683633129598  0.374242899840899 -0.057337396588682 -0.088127176408082 -0.006641022684211 -0.002221148233639
-    4  (  4) -0.000669699172297 -0.250491740261693  0.056329271904456  0.020699653792380  0.189174399877554  0.184564489543572 -0.035853071510271  0.034875430761882  0.027893872485003
-    5  (  5) -0.214156532952014 -0.615288665228072  0.215771246496457  0.046102431034999  0.224131841626969  0.112114948215021  0.150102522248763  0.016602833134623  0.122840663448393
-    6  (  6)  0.274003045126345 -0.143471801350555 -0.253398037809422  0.106851026797177  0.096788453036169 -0.178572747687712  0.102040610315496  0.332630496777572 -0.346310147475002
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0) -0.004029200957262 -0.000882760387815  0.002163389161852  0.015131943390767  0.019986233213130 -0.015021193015431  0.001769851076152 -0.017643335711180
-    1  (  1)  0.008928102950836  0.007088858124714  0.002274297322437  0.003234469739505  0.007168429052842 -0.006447748030626  0.000776633831882 -0.037286026575743
-    2  (  2)  0.001170842165988 -0.008217089214695  0.012153847196612  0.024134889946244  0.032866749918208 -0.025142667403114 -0.001212134116123 -0.040817148842220
-    3  (  3) -0.011819482888986 -0.019738644366216  0.003700824753808 -0.007133785910532 -0.023026708836451  0.026144977983316  0.022041055636282 -0.034121256234262
-    4  (  4)  0.022466660017059  0.007998429684758  0.041919351164413  0.007813392525530 -0.007265785085741 -0.016637369547836 -0.098013371195297 -0.048843349051825
-    5  (  5) -0.004397289983553  0.028748859918887 -0.050560469286309  0.032522695518845  0.047617334307217 -0.017989934308048  0.071203484599802 -0.093017155821178
-    6  (  6) -0.042123284623250  0.008732952171969  0.284856396785620 -0.018363970093690  0.031949856970873 -0.080004455070448 -0.086790220224973 -0.043344803159579
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  7)  0.001724783206465 -0.146102349699596 -0.011750241124796 -0.057277414548611 -0.020173503070547  0.015641770076300 -0.133391360672722
-    1  (  8) -0.182384400209359 -0.023648068007229  0.082951126731178  0.562127906578998 -0.042963631893791 -0.024859663227064  0.073688495864433
+	alpha_(0.050) =       5.168927312011 a.u.
 
 	Computing Mu_X-Perturbed Wave Function (0.100 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.239364342754
-	   1         5.388323875556    3.132e-01
-	   2         6.544443492171    2.031e-01
-	   3         6.658705497183    8.002e-02
-	   4         6.756016490872    4.857e-02
-	   5         6.766956904166    8.604e-03
-	   6         6.764283009192    2.620e-03
-	   7         6.764477673141    8.068e-04
-	   8         6.764392645841    1.967e-04
-	   9         6.764363254971    4.842e-05
-	  10         6.764365184926    1.235e-05
-	  11         6.764371056530    3.317e-06
-	  12         6.764373540339    7.462e-07
-	  13         6.764373736728    1.871e-07
+	   0         4.239364345485
+	   1         5.388323879520    3.132e-01
+	   2         6.544443498985    2.031e-01
+	   3         6.658705504618    8.002e-02
+	   4         6.756016498620    4.857e-02
+	   5         6.766956911943    8.604e-03
+	   6         6.764283016955    2.620e-03
+	   7         6.764477680904    8.068e-04
+	   8         6.764392653603    1.967e-04
+	   9         6.764363262734    4.842e-05
+	  10         6.764365192688    1.235e-05
+	  11         6.764371064292    3.317e-06
+	  12         6.764373548101    7.462e-07
+	  13         6.764373744490    1.871e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 6.361e-08
 
 	Computing Mu_X-Perturbed Wave Function (-0.100 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.751195555509
-	   1         4.628361481239    2.221e-01
-	   2         5.290727007996    1.134e-01
-	   3         5.303446455702    2.659e-02
-	   4         5.312382174023    1.370e-02
-	   5         5.314004529641    2.112e-03
-	   6         5.313496247869    5.636e-04
-	   7         5.313511124856    1.342e-04
-	   8         5.313504920705    3.063e-05
-	   9         5.313499103603    7.817e-06
-	  10         5.313499756035    1.828e-06
-	  11         5.313500536646    3.909e-07
+	   0         3.751195557566
+	   1         4.628361483997    2.221e-01
+	   2         5.290727011885    1.134e-01
+	   3         5.303446459672    2.659e-02
+	   4         5.312382178018    1.370e-02
+	   5         5.314004533643    2.112e-03
+	   6         5.313496251869    5.636e-04
+	   7         5.313511128856    1.342e-04
+	   8         5.313504924705    3.063e-05
+	   9         5.313499107602    7.817e-06
+	  10         5.313499760035    1.828e-06
+	  11         5.313500540645    3.909e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 7.900e-08
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =    17
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003265067152215  0.002026492209092  0.005500435318608  0.008078622301941 -0.008658500881109  0.036459293961252 -0.029326652250391  0.007624907133575 -0.017230266414268
-    1  (  1)  0.019848975655178 -0.008568674096349 -0.035768118335382  0.039338967933431 -0.008739192142382  0.002236852315732  0.003842536150611 -0.006370808307973  0.006387188771100
-    2  (  2) -0.001311158102682  0.005996603930092 -0.012088378357483  0.063288593855735 -0.042686750248075  0.096527587997965 -0.064713284258089 -0.038913772194284  0.014267016211395
-    3  (  3) -0.069641434452875  0.057681873117421  0.132311010020041 -0.036249277341741  0.036248934686346  0.111143378691454 -0.091174493929596  0.097901000061833 -0.105673461585893
-    4  (  4)  0.434124623887635 -0.301640726175203 -0.258270584723773 -0.205811882736710 -0.089339728161504  0.039739513490021 -0.135462303940190  0.002375526322170 -0.043263965637082
-    5  (  5)  0.081173968533563  0.037394137923481 -0.122560942083237  0.305171944931175  0.078260777553523  0.027064995698868  0.046022990304452  0.193875689971875 -0.171790059938592
-    6  (  6) -0.474121713810952  0.141227640283344  0.441524301346367  0.264512324387944 -0.140054125878165 -0.132135738723399 -0.051997998775631 -0.032760210570508 -0.100063633119523
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0)  0.006013935012044  0.002206969220209 -0.014470075947404  0.001368309875554  0.002087239599490 -0.000365868142111 -0.003958916776740 -0.001873434717837
-    1  (  1) -0.035403072354536 -0.013826422633153 -0.010343466208206  0.017788524189129 -0.002520441967521  0.012986907297241  0.004538611831476 -0.001552742472357
-    2  (  2) -0.005745134984337 -0.006714974843583 -0.127066954751498  0.030070029489338  0.001125013323686  0.025517535242831  0.018059867151878 -0.002030574745858
-    3  (  3)  0.088384862569294  0.013343980191387  0.044104599203938 -0.013053883960181 -0.019339911467356 -0.028936077036821 -0.075177469099726 -0.012052012829741
-    4  (  4) -0.210300662230597  0.088714358597621  0.069888081915214 -0.172504610132785  0.167942817048368  0.026139419673214 -0.056730594878719  0.041941123068085
-    5  (  5)  0.040118833547159 -0.073298763846292  0.248063286831586  0.077429976518261 -0.092806173921398 -0.056087804592582 -0.059344073998483 -0.039436610747247
-    6  (  6) -0.161288525186688  0.166450983348397  0.144923762167849 -0.094775042270021  0.169918790080029  0.220638703768895 -0.015086442554775  0.082074773648405
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  7)  0.023731286269058  0.015034330755501 -0.273330752922172  0.037820426660388  0.284138842805450 -0.218153574225316 -0.012438921134731
-    1  (  8)  0.021668325834947  0.033987896894426 -0.356592806410255  0.086505819787761  0.103102147653207  0.310664447039769  0.006708929270897
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     7
-	   Irrep: 1 row =     2	col =     2
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)    
-
-    0  (  0) -0.026466323364559  0.000028319304914 -0.001006810306637 -0.003418731692119  0.036663472175781 -0.018334333792420  0.037935397785809
-    1  (  1)  0.000028904174656  0.132705286535538  0.004008345044156 -0.010613170205884  0.032674204290777 -0.013900441820930 -0.038334147025939
-    2  (  2) -0.001010822077971  0.003967468036571 -0.002590146822482  0.085957463458987 -0.499260024044765  0.196034713340721 -0.015724343702868
-    3  (  3) -0.003440122629553 -0.010318982830085  0.086228041588947 -0.148739686038090  0.111883116788756  0.082549353436752 -0.646716339039273
-    4  (  4)  0.036870064509150  0.032414924454826 -0.500220770355431  0.111669597456319 -0.258922049164252 -0.258637762864367  0.023570822312213
-    5  (  5) -0.018463661866320 -0.013983080919739  0.195754953301471  0.081901638937235 -0.256070472760282  0.202482702191796  0.274528565175939
-    6  (  6)  0.038006050342084 -0.038540981085222 -0.014408679735145 -0.644760562649152  0.014285517766164  0.275314735896220 -0.068476999092314
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1     
-                      (  7)              (  8)    
-
-    0  (  7)  0.018929182095807  0.062039276079498
-    1  (  8)  0.062346959056566  0.053081448921200
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    17	col =    17
-	   Irrep: 1 row =     7	col =     7
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -2.045993134873731 -0.095409898653600 -0.387594270642989 -0.505900146912186  0.172746641033111 -0.046910168040385 -0.084737755155653 -0.410360151963549 -0.382261890655703
-    1  (  1) -0.095231007303474  0.039819948857640 -0.291910351304723  0.063885771451590 -0.017162503817772  0.571287954038829 -0.394953952483411 -0.243045723102671  0.180443842009873
-    2  (  2) -0.382632249330553 -0.292847693911782 -1.382982378647373 -0.154259655960369  0.173864428021762 -0.295670794202406 -0.107123996346545 -0.385982188376388  0.028658840683595
-    3  (  3) -0.505410909881567  0.062390573871582 -0.154036310291531  0.982968534089393 -0.104512367175512  0.145166782117297  0.226696601336116  0.135831670563868  0.433133822599894
-    4  (  4)  0.169297759495862 -0.015832070255012  0.175669698448482 -0.103333610656524 -0.088624263975634  0.268908892217795 -0.031655422270763 -0.274623540930917  0.238460903427720
-    5  (  5) -0.049136629278740  0.571895176561835 -0.294649084124477  0.144292264858497  0.268065736642396 -0.004325047106725  0.145918393270318  0.372810273859943 -0.431016787132458
-    6  (  6) -0.087260279207009 -0.394385667800918 -0.105217644713437  0.228088087956054 -0.031697143408226  0.145949167135850 -0.298604551214604 -0.041713472364692 -0.051008501927155
-    7  (  7) -0.410914339621091 -0.243365268427750 -0.386858728731771  0.135833418297861 -0.274552066892956  0.373543891834519 -0.041506475789765 -0.451020585572335  0.170871627903158
-    8  (  8) -0.381821204572435  0.180205615072504  0.029084404500310  0.432574410104883  0.238320694111666 -0.431320613321923 -0.051272354410806  0.170589507033196 -0.675829352019599
-    9  (  9) -0.283473421710116  0.112050034408627  0.560595473087251 -0.245415063372486 -0.149264847460109  0.242302621470858 -0.157290698226683  0.100468128429887 -0.266025795313291
-   10  ( 10) -0.052116385440804  0.107624847200442  0.282558920287670  0.059943056512493 -0.062387825969278 -0.115486622660684  0.256555884017987 -0.163523915221471  0.290885113176895
-   11  ( 11)  0.000312513273045  0.155187941900449  0.100393094451125  0.020336020080190  0.127674754605018 -0.211106522265856  0.120135660107417  0.136023622283511 -0.462455224037365
-   12  ( 12) -0.040088912895174  0.048991874235690 -0.011811422909576  0.091257017452860  0.019784182970063  0.016868406587959 -0.000544174708051 -0.124924205510212 -0.058166887460757
-   13  ( 13) -0.009390682767169 -0.016745321738356  0.010403462867083  0.088355953809463 -0.051207257527814  0.168655348073088 -0.014606152117855 -0.074404615170129  0.046843317912933
-   14  ( 14) -0.073276112260004  0.057758888405722  0.174249113368945 -0.108526984756369  0.005873988347796 -0.115290133695343  0.046811486241008 -0.064124627762932  0.051346278871495
-   15  ( 15)  0.005779177395601 -0.060389355097241  0.012276575492417 -0.096153630668420  0.181712320706024  0.128331892268229  0.225366212207405  0.081713947674767 -0.144525489497557
-   16  ( 16) -0.060752757257594  0.018327091553227  0.019085185007204  0.030973177274899  0.012354348831073  0.069603475266508 -0.030006835141826  0.005552576291094 -0.060836699707616
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0) -0.285303582746393 -0.056294192160665 -0.000200687930218 -0.038024825027710 -0.012046819629200 -0.077012885660403  0.006033548694711 -0.061807525496149
-    1  (  1)  0.113071704196730  0.108778532345339  0.156184092789691  0.048684365197324 -0.016243813405120  0.058823369178344 -0.060407135004659  0.018519743013255
-    2  (  2)  0.562523645229237  0.285264478722674  0.101513510030167 -0.013175405914280  0.011768340960851  0.176049115365102  0.011615146885545  0.019552984614227
-    3  (  3) -0.243737456306168  0.060847590488087  0.019824546151347  0.091291375704035  0.089537547257186 -0.108209096483289 -0.096544747228456  0.031323007671123
-    4  (  4) -0.149018755824729 -0.062754456373360  0.127376600662541  0.020366865409553 -0.051674532870044  0.005753595837931  0.181922433672134  0.012276690572424
-    5  (  5)  0.240627721939884 -0.114767648002828 -0.211416289254032  0.015975616858924  0.169586883038260 -0.114607009513284  0.128525855676351  0.070097551806575
-    6  (  6) -0.156693567229655  0.256215700441591  0.120063103357279 -0.000003040389676 -0.014992046515823  0.046904705681064  0.225574226220870 -0.030177739023540
-    7  (  7)  0.100263606325596 -0.163703826662444  0.135989927625065 -0.124576096560582 -0.074129889564192 -0.064680677402394  0.081773026674468  0.005774218340390
-    8  (  8) -0.266668295925435  0.290777226339073 -0.462544053201063 -0.058743583333771  0.046629285110809  0.051624572732368 -0.144465149214115 -0.061087050064978
-    9  (  9) -0.925652707318708 -0.583660752355916 -0.155775235357423  0.445905510547533 -0.085223163401930  0.320909369856072 -0.139003830120683  0.030422261138610
-   10  ( 10) -0.583279755470617 -0.303453157039093  0.125949989442450  0.209539965251911 -0.039645500897526  0.087763726360968 -0.069331015366641  0.008115477198654
-   11  ( 11) -0.155376626940309  0.125927989282900 -0.104729836793845  0.011349449787087 -0.028985031796447  0.101545429706514  0.020786740802604 -0.071540693180168
-   12  ( 12)  0.446199204416227  0.209533527715715  0.010652562772003 -0.122763822621396  0.084004825690867 -0.060856238307855  0.055415498514065 -0.016323905923520
-   13  ( 13) -0.084813114367247 -0.039575228923184 -0.029630201276164  0.084050535539902  0.039685632988849 -0.042279600675479  0.024577846833790 -0.033021008737513
-   14  ( 14)  0.321789737507025  0.088054269353386  0.102052558884899 -0.060946364351172 -0.042213968647851  0.054671591708845 -0.027704713949390  0.044786029623289
-   15  ( 15) -0.139004434932276 -0.069324980587538  0.020862927433168  0.055283762920506  0.024483424096936 -0.027399434763095  0.027805312058636 -0.039717899136090
-   16  ( 16)  0.030710136385131  0.008185345443293 -0.071909346470965 -0.016262510423583 -0.033030270773791  0.044859369380168 -0.039589710603285 -0.008513189267103
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  ( 17)  0.063740436686834 -0.004787154508074  0.538538933439869 -0.009052843531209  0.210737581731213  0.068032599878639 -0.012686995100758
-    1  ( 18) -0.005077960748769 -0.059037803747914  0.228349904229210 -0.009206614582854  0.138527633914846  0.009964745684741  0.007455890177025
-    2  ( 19)  0.541597901122945  0.227776389588582 -1.147253894628681  0.026129576715585 -0.564507518878226 -0.149606564239045 -0.032515314853600
-    3  ( 20) -0.009580989251238 -0.009149486679310  0.025566850285476  0.093409480733594  0.029387857687170 -0.006908216669476 -0.071485607388481
-    4  ( 21)  0.208618544932732  0.139451761819383 -0.563840838338479  0.028663300088685 -0.100582743739006  0.005895697838307  0.010722959978135
-    5  ( 22)  0.067974194993357  0.008600203631037 -0.149010367735970 -0.006598982413936  0.005915244102597 -0.015400685691487  0.019226657028192
-    6  ( 23) -0.012651691467565  0.007379655026589 -0.032350130589990 -0.071504127733178  0.010703285254014  0.019026056021972  0.017499411133403
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =    17
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003751828875244  0.002066993521910  0.005646018523719  0.007971235352960 -0.008514547746194  0.035651407199236 -0.028594135193668  0.007405276527293 -0.016749550255979
-    1  (  1)  0.019502304040523 -0.008601083038433 -0.034986080726304  0.038437171228534 -0.008699374239570  0.002232591662416  0.003683855646166 -0.005845992541352  0.006431929732322
-    2  (  2)  0.005162322558812  0.005006091601700 -0.013651447640213  0.073108562117686 -0.037110502694364  0.099971679953210 -0.061818640904389 -0.030065850288973  0.009991736200864
-    3  (  3) -0.057916505621728  0.056341598633679  0.113645462083389 -0.051661279744271  0.032845238255008  0.115183118840799 -0.098236437619912  0.091663726075877 -0.108759469637960
-    4  (  4)  0.406321573590683 -0.279225795319112 -0.216702557125586 -0.194841625855345 -0.082000972364980  0.036206780650479 -0.131621874359774 -0.002941154857446 -0.038291774767926
-    5  (  5)  0.082666085704471  0.037170774751607 -0.109366104305027  0.306227368555721  0.055852393512460  0.029132834214226  0.047858698305321  0.191190362296867 -0.153017394069324
-    6  (  6) -0.458136442070611  0.106031150480337  0.393081188393353  0.249752536705643 -0.125320465454532 -0.124263776658658 -0.043393736784742 -0.030845035580441 -0.093961046813138
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  0)  0.005798934978529  0.002143687367549 -0.014089335198481  0.001324299844750  0.002019868875779 -0.000354215696095 -0.003864986390855 -0.001821684258311
-    1  (  1) -0.034363827795974 -0.013298895705888 -0.010073948025801  0.017368630238864 -0.002386826220116  0.012568412345399  0.004482838074461 -0.001577091809586
-    2  (  2) -0.005900863534114 -0.005792364484342 -0.113458341680317  0.027244997206748  0.000391909756193  0.024110004459923  0.015153768321953 -0.000959743197843
-    3  (  3)  0.079557340675880  0.007706717681738  0.039901607106568 -0.010833609875429 -0.018472734672823 -0.026055254589983 -0.070732329632562 -0.011158996652328
-    4  (  4) -0.182787083526436  0.089427715986207  0.062916944018857 -0.160041676635648  0.153729637667921  0.025374508612108 -0.050608420481544  0.037499586551580
-    5  (  5)  0.040920622349544 -0.067223701668111  0.223222565090092  0.071193525531542 -0.081550793775845 -0.055819422855801 -0.053722239139885 -0.036812165791084
-    6  (  6) -0.179948389216996  0.155410883892581  0.129738152623862 -0.084750037649381  0.153208006748098  0.206079952934255 -0.014680354899951  0.075082232624937
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  7)  0.007727960051405  0.014188761911108 -0.254870847034818  0.036245861641137  0.257329582057483 -0.202509743936333 -0.011664708636642
-    1  (  8) -0.000813195416604  0.022554294061283 -0.332537774106676  0.079445887399926  0.088054726222404  0.285022367621264  0.005162037999851
 
 	Computing Mu_Y-Perturbed Wave Function (0.100 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.547271318278
-	   1         5.921487033670    4.387e-01
-	   2         7.955606301720    3.071e-01
-	   3         8.127348946816    9.742e-02
-	   4         8.298354925308    5.266e-02
-	   5         8.316124618855    7.806e-03
-	   6         8.315308366274    2.241e-03
-	   7         8.315808568047    4.746e-04
-	   8         8.315859954335    1.114e-04
-	   9         8.315842381058    3.446e-05
-	  10         8.315847505589    1.119e-05
-	  11         8.315855084192    3.554e-06
-	  12         8.315858807758    8.295e-07
-	  13         8.315859012542    1.631e-07
+	   0         4.547271322065
+	   1         5.921487039418    4.387e-01
+	   2         7.955606312306    3.071e-01
+	   3         8.127348957602    9.742e-02
+	   4         8.298354936276    5.266e-02
+	   5         8.316124629876    7.806e-03
+	   6         8.315308377284    2.241e-03
+	   7         8.315808579059    4.746e-04
+	   8         8.315859965347    1.114e-04
+	   9         8.315842392070    3.446e-05
+	  10         8.315847516601    1.119e-05
+	  11         8.315855095204    3.554e-06
+	  12         8.315858818770    8.295e-07
+	  13         8.315859023553    1.631e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.204e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.100 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.896429233425
-	   1         4.844813010776    2.843e-01
-	   2         5.749499447351    1.576e-01
-	   3         5.756135692230    3.131e-02
-	   4         5.772161890170    1.456e-02
-	   5         5.774571649670    1.971e-03
-	   6         5.774450259023    5.252e-04
-	   7         5.774506065345    9.531e-05
-	   8         5.774512644950    1.907e-05
-	   9         5.774509854834    4.813e-06
-	  10         5.774510249815    1.343e-06
-	  11         5.774510823065    3.624e-07
+	   0         3.896429236232
+	   1         4.844813014705    2.843e-01
+	   2         5.749499453000    1.576e-01
+	   3         5.756135697899    3.131e-02
+	   4         5.772161895868    1.456e-02
+	   5         5.774571655378    1.971e-03
+	   6         5.774450264730    5.252e-04
+	   7         5.774506071052    9.531e-05
+	   8         5.774512650657    1.907e-05
+	   9         5.774509860541    4.813e-06
+	  10         5.774510255522    1.343e-06
+	  11         5.774510828771    3.624e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 7.982e-08
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     7
-	   Irrep: 1 row =     2	col =    17
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  0) -0.010786265183144  0.051029121132170  0.002996763849739 -0.011801503115544  0.001272030820720  0.000196386846190  0.002982916046102
-    1  (  1) -0.058609640963270 -0.012417801314910 -0.003971620689219 -0.009080237811660 -0.000121215070459 -0.000228818864652 -0.009373425738771
-    2  (  2) -0.085132594501744  0.091652823097353  0.007546774391891 -0.142423359791749  0.006996619603860  0.002101811348346 -0.029373124781206
-    3  (  3)  0.122069258148396  0.223131785279761 -0.087332676023743  0.050632801243966  0.042739607387155 -0.018430049330312  0.086614058743774
-    4  (  4) -0.105541230675864  0.048893582187370  0.328998944712803  0.105191585386823 -0.242811441764458  0.170260494209224  0.054325780187217
-    5  (  5) -0.265882747768071  0.058275011878436 -0.023416331604461  0.339635908182997  0.103800327020429 -0.114058283212065  0.058690855476724
-    6  (  6)  0.007633857500139  0.022854049227207 -0.377212343584744  0.102347661597779  0.009619050796435  0.297095107100103 -0.012497514920931
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  7) -0.147346265517506  0.175457635393697 -0.221105865986270 -0.029899707009198  0.165686742393032  0.115361676403977 -0.008355394047083  0.328221796014218  0.292080655206068
-    1  (  8) -0.122245405560539  0.024589732049082 -0.167118519556619 -0.015807337638932 -0.058301108727541 -0.105293352874109 -0.203866490026683  0.286393949830171  0.189278200780844
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  7) -0.087279639847736 -0.126770988900312 -0.036329390570234 -0.242965090530464  0.132308970188284  0.116935047705630  0.002357403463405 -0.057494504536996
-    1  (  8) -0.205975410858357  0.286653615135548 -0.077914712510969 -0.007558681388675 -0.292258655312688 -0.145533516877255  0.007845998491586  0.090356336812698
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     2
-	   Irrep: 1 row =     2	col =     7
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1     
-                      (  7)              (  8)    
-
-    0  (  0) -0.043819140181369  0.036074491951167
-    1  (  1) -0.036237068531700 -0.050415577455144
-    2  (  2)  0.528492370226786  0.015299710619496
-    3  (  3)  0.017518923619511 -0.564610204547300
-    4  (  4)  0.085812129312801 -0.070371782668820
-    5  (  5)  0.252364389877497  0.175800283642740
-    6  (  6)  0.061085593898950  0.095127660035001
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)    
-
-    0  (  7) -0.044067543892294 -0.036488078491946  0.528279520963148  0.018864796666208  0.085565437065040  0.252014784445039  0.060037559006935
-    1  (  8)  0.036063712094606 -0.050614499023038  0.015518778585002 -0.562528692062847 -0.071591764890120  0.175011603181084  0.095580342225146
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    17	col =     7
-	   Irrep: 1 row =     7	col =    17
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  0)  0.599480222444637  0.016859533434664 -0.049897396924280  0.100931992321173 -0.178820057695389 -0.093593822067295 -0.045840833373615
-    1  (  1) -0.102825062644488  0.497551654375298  0.079024430059592 -0.089810403907835  0.095840244352085  0.042979610010712  0.100107750054018
-    2  (  2)  0.313847375874909 -0.236133415515714  0.290305789540109  0.013432093218325  0.277632595704877  0.128347816687602 -0.035321860848130
-    3  (  3) -0.120186064621026 -0.088525193286422 -0.285710676647029 -0.049963609023862 -0.018526308466162 -0.010366645593084  0.045528954113686
-    4  (  4) -0.090166928005197  0.032050142733123 -0.030452275714624 -0.063250796602694 -0.035750237348326 -0.017833119271341 -0.132006242302645
-    5  (  5) -0.142691415524645  0.223913086808699  0.027094381023140  0.024338605924022  0.028535894302556  0.007226239356373 -0.162190336038922
-    6  (  6) -0.066933385246723  0.243769517259146  0.020035311286226  0.114101180100409 -0.012489851345781  0.011332261380418 -0.233889391977416
-    7  (  7) -0.672885351756081 -0.001881267801208 -0.095136222092223 -0.058176395722164 -0.061089446815740 -0.043316162321467  0.019390286464139
-    8  (  8) -0.435312399605479  0.058517097371420 -0.132087164095948 -0.111210778747092 -0.084785664597104  0.018714661714217  0.051077770966582
-    9  (  9)  0.039880967641781  0.175296984662262  0.139275550562713 -0.022188880266031  0.000377216624842 -0.012858606937540 -0.034561120442390
-   10  ( 10) -0.303210587603071 -0.514083864535284 -0.056475775929677  0.034965638385877 -0.040317053885205 -0.017962506851195  0.053786011903196
-   11  ( 11) -0.027239637605681  0.034828784234934  0.033426829747022 -0.018094121367506  0.017093937691801  0.004223484052252 -0.011996780527565
-   12  ( 12) -0.308711690655872 -0.002817985822889 -0.037619399642840 -0.077619866356188 -0.025848322659187  0.002876135041613 -0.007325116102266
-   13  ( 13) -0.122322909534018  0.113539161130551  0.014757220452077 -0.054033827004457  0.003700011797212 -0.003003782149483 -0.047911411994658
-   14  ( 14) -0.097844480434489 -0.119320090615277  0.001467167999597  0.047025034239875 -0.015029470496590  0.001307380616700  0.021961924745376
-   15  ( 15) -0.003252338995529  0.016436791178655  0.055709805192912 -0.009293573860402 -0.005810476770249 -0.019308137788336 -0.008191212687172
-   16  ( 16) -0.036707953659231  0.103754840414863 -0.016684655371398 -0.061363104748847 -0.002167501914420  0.001092629910883  0.026459157258590
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 17)  0.599729724796822 -0.100763044997049  0.312417498644213 -0.121527463741962 -0.089494866802933 -0.142965380633054 -0.068176811299970 -0.669349755030469 -0.432871097543217
-    1  ( 18)  0.016829691255097  0.498021176353259 -0.236000617824191 -0.088934550094707  0.031202345455259  0.223575626840272  0.243864850259255 -0.002331620184497  0.057733029620748
-    2  ( 19) -0.054552900240867  0.080128078195554  0.292430603697284 -0.284599987869487 -0.029522070318793  0.026959103270929  0.021940193228378 -0.096891945038095 -0.133499525770681
-    3  ( 20)  0.100253522171184 -0.090631183013606  0.011713957045895 -0.049730048298516 -0.062592805551904  0.025213226750359  0.114036593498515 -0.057494677157406 -0.110236213187370
-    4  ( 21) -0.179159024052453  0.095672908178934  0.278266560095751 -0.018388137436416 -0.036511169805779  0.029495232441701 -0.013242480280230 -0.061079729130703 -0.084477317549054
-    5  ( 22) -0.088933490318749  0.041952581209809  0.126034689140710 -0.011275748873422 -0.017323803323152  0.005886315562041  0.011658588522848 -0.043044407090452  0.018540705202664
-    6  ( 23) -0.046333914085307  0.100418803408813 -0.035362724685491  0.045416588335831 -0.131810180134045 -0.161950813236466 -0.233566785912366  0.019297085245182  0.050997307344278
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  ( 17)  0.039312615108447 -0.302032443665741 -0.027550294935800 -0.310784860130476 -0.123366344699992 -0.097420977774117 -0.003209928183805 -0.036830398019273
-    1  ( 18)  0.175567267566103 -0.512664071190351  0.034894695549286 -0.001894103503434  0.112588400025920 -0.120085800524745  0.016426825731778  0.104378228791495
-    2  ( 19)  0.136543328570788 -0.058279389709951  0.033933657083247 -0.037273212570074  0.015308466144542  0.001541196291270  0.056028919618144 -0.016762051778500
-    3  ( 20) -0.022563171568634  0.034710591396916 -0.018459749038852 -0.077422552415566 -0.052960741334943  0.046505103663057 -0.009331616241340 -0.060923921975890
-    4  ( 21)  0.001466076193959 -0.040032717264813  0.016917418953977 -0.025762346460130  0.003762250578566 -0.014972651118730 -0.005881505372504 -0.002207525976346
-    5  ( 22) -0.011996109684438 -0.017649877911749  0.004310226300310  0.002850355947905 -0.002885632287969  0.001316998750490 -0.019472836966745  0.001098266616166
-    6  ( 23) -0.034634146639722  0.053685024377128 -0.011937415333247 -0.007255949520686 -0.047576628375718  0.021896401358334 -0.008171802221400  0.026587486496662
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     7	col =     7
-	   Irrep: 1 row =     2	col =    17
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6     
-                      ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)              ( 23)    
-
-    0  (  0) -0.010574314095683  0.049882978545122  0.002870330966735 -0.011532171460868  0.001238602598829  0.000191316089031  0.002921482491107
-    1  (  1) -0.057532452524585 -0.012065759248930 -0.003751148528909 -0.008827776374122 -0.000113560391374 -0.000227841169844 -0.009209133435533
-    2  (  2) -0.091814855038090  0.094917804724041  0.006288310960891 -0.126283019227595  0.007222028964977  0.002073910472135 -0.025512078631774
-    3  (  3)  0.120653889319174  0.226084849611754 -0.075300125208344  0.046643270206305  0.037421332704021 -0.017859191162973  0.081266935673681
-    4  (  4) -0.097956489392108  0.051351897149702  0.305754549991063  0.095382973436958 -0.220329096451480  0.158512880282495  0.049614437366158
-    5  (  5) -0.261619207985082  0.056084449894857 -0.025368373388091  0.308737234570638  0.097128785420262 -0.105014860102430  0.053434785260047
-    6  (  6)  0.008799396272402  0.018728768046646 -0.354955141247505  0.095669064713818 -0.001191012606816  0.271606540647270 -0.012344010113691
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  7) -0.150705574361930  0.171630195989760 -0.209599417391610 -0.025489164143659  0.149255370410132  0.112216774108593 -0.000397827210048  0.316622730650583  0.277369362242453
-    1  (  8) -0.130570763068830  0.009488512240525 -0.144994119658194 -0.007578049469341 -0.047607403703452 -0.095540393045053 -0.185243293387079  0.276777433572968  0.180273089892158
-
-                         9                 10                 11                 12                 13                 14                 15                 16     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)              ( 14)              ( 15)              ( 16)    
-
-    0  (  7) -0.076246695560918 -0.118379428340658 -0.031849281493620 -0.218889052864385  0.125994951072932  0.108535764483610  0.002831367609020 -0.051643750178160
-    1  (  8) -0.193081458944204  0.284637903909638 -0.070582554931437 -0.002932045787915 -0.271746148176880 -0.130119446798498  0.007304069162710  0.084713895677763
 
 	Computing Mu_Z-Perturbed Wave Function (0.100 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.491952408357
-	   1         3.005265093432    2.089e-01
-	   2         3.447580410955    1.520e-01
-	   3         3.607570766750    9.857e-02
-	   4         3.749752690145    5.306e-02
-	   5         3.762047683885    1.567e-02
-	   6         3.770518179333    4.401e-03
-	   7         3.770564047323    9.843e-04
-	   8         3.770526585314    2.817e-04
-	   9         3.770570733684    8.164e-05
-	  10         3.770575572885    3.073e-05
-	  11         3.770569487643    7.811e-06
-	  12         3.770565491039    2.258e-06
-	  13         3.770565692535    5.334e-07
-	  14         3.770566045098    1.429e-07
+	   0         2.491952407936
+	   1         3.005265092761    2.089e-01
+	   2         3.447580409786    1.520e-01
+	   3         3.607570764834    9.857e-02
+	   4         3.749752687545    5.306e-02
+	   5         3.762047681200    1.567e-02
+	   6         3.770518176605    4.401e-03
+	   7         3.770564044594    9.843e-04
+	   8         3.770526582586    2.817e-04
+	   9         3.770570730955    8.164e-05
+	  10         3.770575570156    3.073e-05
+	  11         3.770569484915    7.811e-06
+	  12         3.770565488311    2.258e-06
+	  13         3.770565689806    5.334e-07
+	  14         3.770566042369    1.429e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 3.454e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.100 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.268748028445
-	   1         2.671832391780    1.418e-01
-	   2         2.926184077353    7.510e-02
-	   3         2.934537175009    2.669e-02
-	   4         2.942376988781    9.551e-03
-	   5         2.941962075533    2.279e-03
-	   6         2.942227123828    5.402e-04
-	   7         2.942246445296    1.104e-04
-	   8         2.942239953142    2.513e-05
-	   9         2.942241780427    5.113e-06
-	  10         2.942242191985    1.513e-06
-	  11         2.942242185700    3.874e-07
-	  12         2.942242089042    1.103e-07
+	   0         2.268748028110
+	   1         2.671832391297    1.418e-01
+	   2         2.926184076650    7.510e-02
+	   3         2.934537174276    2.669e-02
+	   4         2.942376988027    9.551e-03
+	   5         2.941962074780    2.279e-03
+	   6         2.942227123075    5.402e-04
+	   7         2.942246444543    1.104e-04
+	   8         2.942239952388    2.513e-05
+	   9         2.942241779673    5.113e-06
+	  10         2.942242191232    1.513e-06
+	  11         2.942242184947    3.874e-07
+	  12         2.942242088289    1.103e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 2.463e-08
 
 	Computing <<Mu;Mu>_(0.100) tensor.
 
-                 CCSD Dipole Polarizability [(e^2 a0^2)/E_h]:
+                 CCSD Dipole Polarizability (Length Gauge) [(e^2 a0^2)/E_h]:
   -------------------------------------------------------------------------
    Evaluated at omega = 0.100000 E_h (455.63 nm, 2.721 eV, 21947.46 cm-1)
   -------------------------------------------------------------------------
 
                    0                     1                     2        
 
-    0      5.861609117933943    -1.963176975817169     0.000000000000000
-    1     -1.963176975817169     6.804320828088689     0.000000000000000
-    2      0.000000000000000     0.000000000000000     3.296071340680112
+    0      5.861609123244674    -1.963176982523587     0.000000000000000
+    1     -1.963176982523587     6.804320835644361     0.000000000000000
+    2      0.000000000000000     0.000000000000000     3.296071339013346
 
-	alpha_(0.100) =       5.320667095568 a.u.
+	alpha_(0.100) =       5.320667099301 a.u.
 
 	-------------------------------
 	      CCSD Polarizability
@@ -2059,14 +854,7 @@ Total time:
 	0.050   911.27         5.16893
 	0.100   455.63         5.32067
 
-*** tstop() called on psinet at Mon May 15 15:34:23 2017
-Module time:
-	user time   =       1.87 seconds =       0.03 minutes
-	system time =       1.76 seconds =       0.03 minutes
-	total time  =          4 seconds =       0.07 minutes
-Total time:
-	user time   =       3.00 seconds =       0.05 minutes
-	system time =       2.28 seconds =       0.04 minutes
-	total time  =          6 seconds =       0.10 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
+    Psi4 wall time for execution: 0:00:11.45
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc22/input.dat
+++ b/tests/cc22/input.dat
@@ -20,9 +20,9 @@ energy('eom-ccsd')
 escf = -38.904170464925                                                    #TEST
 eccsd = -38.98782404003                                                    #TEST
 eeom_ccsd = [ -38.7169665265, -38.6330680540]                              #TEST
-compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
-compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy")        #TEST
+compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy")     #TEST
 for root in range(1,3):                                                    #TEST
     ref = eeom_ccsd[root-1]                                                #TEST
-    val = variable("CC ROOT %d TOTAL ENERGY" % root)                   #TEST
+    val = variable("CC ROOT %d TOTAL ENERGY" % root)                       #TEST
     compare_values(ref, val, 7, "EOM-CCSD root %d" % root)                 #TEST

--- a/tests/cc28/output.ref
+++ b/tests/cc28/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:24PM
 
-    Process ID:  12672
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65718
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -44,27 +57,25 @@ set {
   basis cc-pVDZ
 }
 
-property('ccsd', properties=['rotation'])
+properties('ccsd', properties=['rotation'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:26 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:47 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 3-4 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1-2 entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3-4 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -78,16 +89,16 @@ property('ccsd', properties=['rotation'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000    -0.695000000000    -0.049338350190    15.994914619560
-           O          0.000000000000     0.695000000000    -0.049338350190    15.994914619560
-           H          0.388142264171    -0.895248563098     0.783035421467     1.007825032070
-           H         -0.388142264171     0.895248563098     0.783035421467     1.007825032070
+         O            0.000000000000    -0.695000000000    -0.049338350197    15.994914619570
+         O            0.000000000000     0.695000000000    -0.049338350197    15.994914619570
+         H            0.388142264171    -0.895248563098     0.783035421459     1.007825032230
+         H           -0.388142264171     0.895248563098     0.783035421459     1.007825032230
 
   Running in c2 symmetry.
 
   Rotational constants: A =     10.61423  B =      0.97044  C =      0.91566 [cm^-1]
-  Rotational constants: A = 318206.57462  B =  29093.19738  C =  27450.82444 [MHz]
-  Nuclear repulsion =   38.253968380680327
+  Rotational constants: A = 318206.57700  B =  29093.19760  C =  27450.82465 [MHz]
+  Nuclear repulsion =   38.253968531042538
 
   Charge       = 0
   Multiplicity = 1
@@ -104,28 +115,17 @@ property('ccsd', properties=['rotation'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 18
-    Number of basis function: 38
+    Number of basis functions: 38
     Number of Cartesian functions: 40
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         19      19       0       0       0       0
-     B         19      19       0       0       0       0
-   -------------------------------------------------------
-    Total      38      38       9       9       9       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -144,44 +144,60 @@ property('ccsd', properties=['rotation'])
   Using 549822 doubles for integral storage.
   We computed 14706 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.1870579153E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.1047221517E-02.
+  Reciprocal condition number of the overlap matrix is 8.7919776090E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+     B         19      19 
+   -------------------------
+    Total      38      38
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -150.83527118424107   -1.50835e+02   7.61669e-02 
-   @RHF iter   1:  -150.75300393196321    8.22673e-02   8.92814e-03 
-   @RHF iter   2:  -150.77674264680306   -2.37387e-02   2.23904e-03 DIIS
-   @RHF iter   3:  -150.77866726940414   -1.92462e-03   8.11583e-04 DIIS
-   @RHF iter   4:  -150.77908304190512   -4.15773e-04   3.09116e-04 DIIS
-   @RHF iter   5:  -150.77917159812228   -8.85562e-05   9.19744e-05 DIIS
-   @RHF iter   6:  -150.77918361494835   -1.20168e-05   1.37015e-05 DIIS
-   @RHF iter   7:  -150.77918386184558   -2.46897e-07   2.97198e-06 DIIS
-   @RHF iter   8:  -150.77918387199861   -1.01530e-08   5.75950e-07 DIIS
-   @RHF iter   9:  -150.77918387232640   -3.27788e-10   1.51394e-07 DIIS
-   @RHF iter  10:  -150.77918387235525   -2.88480e-11   4.48580e-08 DIIS
-   @RHF iter  11:  -150.77918387235843   -3.18323e-12   9.89275e-09 DIIS
-   @RHF iter  12:  -150.77918387235849   -5.68434e-14   1.77899e-09 DIIS
-   @RHF iter  13:  -150.77918387235860   -1.13687e-13   2.61634e-10 DIIS
-   @RHF iter  14:  -150.77918387235866   -5.68434e-14   6.83681e-11 DIIS
+   @RHF iter SAD:  -150.13109142562024   -1.50131e+02   0.00000e+00 
+   @RHF iter   1:  -150.72994418505689   -5.98853e-01   1.20798e-02 ADIIS/DIIS
+   @RHF iter   2:  -150.77474437542560   -4.48002e-02   3.93712e-03 ADIIS/DIIS
+   @RHF iter   3:  -150.77872862263547   -3.98425e-03   9.99210e-04 ADIIS/DIIS
+   @RHF iter   4:  -150.77914039140384   -4.11769e-04   2.79341e-04 ADIIS/DIIS
+   @RHF iter   5:  -150.77918120837066   -4.08170e-05   4.89524e-05 DIIS
+   @RHF iter   6:  -150.77918362626531   -2.41789e-06   1.25560e-05 DIIS
+   @RHF iter   7:  -150.77918384927895   -2.23014e-07   3.89300e-06 DIIS
+   @RHF iter   8:  -150.77918387131706   -2.20381e-08   8.16055e-07 DIIS
+   @RHF iter   9:  -150.77918387210650   -7.89441e-10   1.49865e-07 DIIS
+   @RHF iter  10:  -150.77918387212898   -2.24816e-11   3.10868e-08 DIIS
+   @RHF iter  11:  -150.77918387213006   -1.08002e-12   6.61624e-09 DIIS
+   @RHF iter  12:  -150.77918387213001    5.68434e-14   1.38474e-09 DIIS
+   @RHF iter  13:  -150.77918387213003   -2.84217e-14   3.05202e-10 DIIS
+   @RHF iter  14:  -150.77918387213003    0.00000e+00   6.31844e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -206,49 +222,44 @@ property('ccsd', properties=['rotation'])
               A     B 
     DOCC [     5,    4 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -150.77918387235866
+  @RHF Final Energy:  -150.77918387213003
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             38.2539683806803268
-    One-Electron Energy =                -284.0698921465231024
-    Two-Electron Energy =                  95.0367398934841106
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -150.7791838723586579
+    Nuclear Repulsion Energy =             38.2539685310425384
+    One-Electron Energy =                -284.0698924306753952
+    Two-Electron Energy =                  95.0367400275028018
+    Total Energy =                       -150.7791838721300337
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.2602
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.2074     Total:     1.2074
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on psinet at Mon May 15 15:34:26 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:48 2022
 Module time:
-	user time   =       0.56 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.17 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.56 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.17 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -262,19 +273,19 @@ Total time:
       Number of basis functions:        38
 
       Number of irreps:                  2
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  19   19 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 117651 non-zero two-electron integrals.
+      Computed 107467 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:27 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:49 2022
 
 
 	Wfn Parameters:
@@ -297,7 +308,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -333,7 +344,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -132.27484824295885
+	Frozen core energy     =   -132.27484829822760
 
 	Size of irrep 0 of <ab|cd> integrals:      0.177 (MW) /      1.418 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.176 (MW) /      1.411 (MB)
@@ -347,34 +358,30 @@ Total time:
 	Size of irrep 1 of tijab amplitudes:       0.010 (MW) /      0.081 (MB)
 	Total:                                     0.021 (MW) /      0.165 (MB)
 
-	Nuclear Rep. energy          =     38.25396838068033
-	SCF energy                   =   -150.77918387235866
-	One-electron energy          =   -101.99691957132262
-	Two-electron energy          =     45.23861556124283
-	Reference energy             =   -150.77918387235832
+	Nuclear Rep. energy          =     38.25396853104254
+	SCF energy                   =   -150.77918387213003
+	One-electron energy          =   -101.99691974243427
+	Two-electron energy          =     45.23861563748924
+	Reference energy             =   -150.77918387213009
 
-*** tstop() called on psinet at Mon May 15 15:34:27 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:49 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.22 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.74 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:27 2017
-
+	user time   =       1.43 seconds =       0.02 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   38.253968380680327
-    SCF energy          (wfn)     = -150.779183872358658
-    Reference energy    (file100) = -150.779183872358317
+    Nuclear Rep. energy (wfn)     =   38.253968531042538
+    SCF energy          (wfn)     = -150.779183872130034
+    Reference energy    (file100) = -150.779183872130091
 
     Input parameters:
     -----------------
@@ -402,80 +409,68 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3802563054135776
+MP2 correlation energy -0.3802563047354116
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.380256305413578    0.000e+00    0.000000    0.000000    0.000000    0.143419
-     1        -0.384252700187874    4.172e-02    0.006281    0.014957    0.014957    0.146642
-     2        -0.393202764715056    1.580e-02    0.007156    0.016728    0.016728    0.156356
-     3        -0.394603278060571    5.260e-03    0.008061    0.018516    0.018516    0.160181
-     4        -0.394657650140995    1.398e-03    0.008198    0.018646    0.018646    0.161027
-     5        -0.394690572780892    5.030e-04    0.008266    0.018685    0.018685    0.161216
-     6        -0.394682677587012    1.898e-04    0.008293    0.018687    0.018687    0.161210
-     7        -0.394679309090239    5.979e-05    0.008301    0.018685    0.018685    0.161200
-     8        -0.394679268692328    2.095e-05    0.008303    0.018684    0.018684    0.161198
-     9        -0.394678919666649    7.909e-06    0.008304    0.018684    0.018684    0.161197
-    10        -0.394679205950677    3.344e-06    0.008304    0.018684    0.018684    0.161197
-    11        -0.394679180598581    1.110e-06    0.008304    0.018684    0.018684    0.161197
-    12        -0.394679218514583    3.658e-07    0.008304    0.018684    0.018684    0.161197
-    13        -0.394679216815987    1.105e-07    0.008304    0.018684    0.018684    0.161197
-    14        -0.394679217139842    3.761e-08    0.008304    0.018684    0.018684    0.161197
+     0        -0.380256304735412    0.000e+00    0.000000    0.000000    0.000000    0.143419
+     1        -0.384252699668223    4.172e-02    0.006281    0.014957    0.014957    0.146642
+     2        -0.393202764097124    1.580e-02    0.007156    0.016728    0.016728    0.156356
+     3        -0.394603277393149    5.260e-03    0.008061    0.018516    0.018516    0.160181
+     4        -0.394657649472679    1.398e-03    0.008198    0.018646    0.018646    0.161027
+     5        -0.394690572111229    5.030e-04    0.008266    0.018685    0.018685    0.161216
+     6        -0.394682676918496    1.898e-04    0.008293    0.018687    0.018687    0.161210
+     7        -0.394679308421909    5.979e-05    0.008301    0.018685    0.018685    0.161200
+     8        -0.394679268023979    2.095e-05    0.008303    0.018684    0.018684    0.161198
+     9        -0.394678918998321    7.909e-06    0.008304    0.018684    0.018684    0.161197
+    10        -0.394679205282325    3.344e-06    0.008304    0.018684    0.018684    0.161197
+    11        -0.394679179930230    1.110e-06    0.008304    0.018684    0.018684    0.161197
+    12        -0.394679217846231    3.658e-07    0.008304    0.018684    0.018684    0.161197
+    13        -0.394679216147637    1.105e-07    0.008304    0.018684    0.018684    0.161197
+    14        -0.394679216471492    3.761e-08    0.008304    0.018684    0.018684    0.161197
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              5  14        -0.0102219508
-              6  14        -0.0088239731
-              2   7        -0.0082621868
+              5  14        -0.0102219502
+              6  14        -0.0088239726
+              2   7        -0.0082621866
               2   9        -0.0079565239
-              2   4         0.0077446885
-              1   8        -0.0067312261
+              2   4         0.0077446884
+              1   8        -0.0067312260
               1   0        -0.0066839179
-              5  17         0.0064483659
-              1   3         0.0061907936
+              5  17         0.0064483657
+              1   3         0.0061907935
               6  16         0.0061070737
 
     Largest TIjAb Amplitudes:
-      2   2  15  15        -0.0682113914
-      2   2  14  15         0.0337460441
-      2   2  15  14         0.0337460441
-      1   2  15  15         0.0313513362
-      2   1  15  15         0.0313513362
+      2   2  15  15        -0.0682113907
+      2   2  14  15         0.0337460429
+      2   2  15  14         0.0337460429
+      1   2  15  15         0.0313513360
+      2   1  15  15         0.0313513360
       1   1  15  15        -0.0311200776
-      3   3  17  17        -0.0224518738
-      3   3  15  15        -0.0219509770
-      1   1   1   1        -0.0213098149
-      2   2  14  14        -0.0200419752
+      3   3  17  17        -0.0224518731
+      3   3  15  15        -0.0219509771
+      1   1   1   1        -0.0213098148
+      2   2  14  14        -0.0200419741
 
-    SCF energy       (wfn)                    = -150.779183872358658
-    Reference energy (file100)                = -150.779183872358317
+    SCF energy       (wfn)                    = -150.779183872130034
+    Reference energy (file100)                = -150.779183872130091
 
-    Opposite-spin MP2 correlation energy      =   -0.282698987529233
-    Same-spin MP2 correlation energy          =   -0.097557317884345
-    MP2 correlation energy                    =   -0.380256305413578
-      * MP2 total energy                      = -151.159440177771899
+    Opposite-spin MP2 correlation energy      =   -0.282698986958674
+    Same-spin MP2 correlation energy          =   -0.097557317776737
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.380256304735412
+      * MP2 total energy                      = -151.159440176865502
 
-    Opposite-spin CCSD correlation energy     =   -0.309012025076525
-    Same-spin CCSD correlation energy         =   -0.085667192058186
-    CCSD correlation energy                   =   -0.394679217139842
-      * CCSD total energy                     = -151.173863089498155
-
-
-*** tstop() called on psinet at Mon May 15 15:34:27 2017
-Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.97 seconds =       0.02 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:27 2017
+    Opposite-spin CCSD correlation energy     =   -0.309012024407253
+    Same-spin CCSD correlation energy         =   -0.085667192064238
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.394679216471492
+      * CCSD total energy                     = -151.173863088601593
 
 
 			**************************
@@ -485,31 +480,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:27 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.99 seconds =       0.02 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:27 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -150.779183872358658
-	Reference energy    (CC_INFO) = -150.779183872358317
-	CCSD energy         (CC_INFO) =   -0.394679217139842
-	Total CCSD energy   (CC_INFO) = -151.173863089498155
+	SCF energy          (wfn)     = -150.779183872130034
+	Reference energy    (CC_INFO) = -150.779183872130091
+	CCSD energy         (CC_INFO) =   -0.394679216471492
+	Total CCSD energy   (CC_INFO) = -151.173863088601593
 
 	Input parameters:
 	-----------------
@@ -522,7 +503,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -535,61 +516,47 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.394689328362803    0.000e+00
-	   1        -0.387349439443058    8.453e-03
-	   2        -0.386490854407244    2.123e-03
-	   3        -0.386312161313732    7.361e-04
-	   4        -0.386313416829649    2.605e-04
-	   5        -0.386314866180862    1.091e-04
-	   6        -0.386314215971210    3.723e-05
-	   7        -0.386314814764021    1.254e-05
-	   8        -0.386314851181659    4.681e-06
-	   9        -0.386314800042682    1.965e-06
-	  10        -0.386314796346953    6.926e-07
-	  11        -0.386314796081828    2.227e-07
-	  12        -0.386314799376017    7.185e-08
+	   0        -0.394689327699558    0.000e+00
+	   1        -0.387349438881212    8.453e-03
+	   2        -0.386490853852970    2.123e-03
+	   3        -0.386312160763678    7.361e-04
+	   4        -0.386313416278935    2.605e-04
+	   5        -0.386314865630370    1.091e-04
+	   6        -0.386314215420689    3.723e-05
+	   7        -0.386314814213452    1.254e-05
+	   8        -0.386314850631096    4.681e-06
+	   9        -0.386314799492124    1.965e-06
+	  10        -0.386314795796394    6.926e-07
+	  11        -0.386314795531270    2.227e-07
+	  12        -0.386314798825459    7.185e-08
 
 	Largest LIA Amplitudes:
-	          5  14        -0.0081755319
-	          2   7        -0.0070086000
-	          2   4         0.0069941940
-	          6  14        -0.0069135321
+	          5  14        -0.0081755314
+	          2   7        -0.0070085998
+	          2   4         0.0069941939
+	          6  14        -0.0069135316
 	          2   9        -0.0068936801
-	          2   3        -0.0057514820
+	          2   3        -0.0057514819
 	          1   8        -0.0055703120
-	          6  16         0.0053757483
-	          1   3         0.0053611529
-	          5  17         0.0051475786
+	          6  16         0.0053757482
+	          1   3         0.0053611528
+	          5  17         0.0051475783
 
 	Largest LIjAb Amplitudes:
-	  2   2  15  15        -0.0651684494
-	  2   2  14  15         0.0321208391
-	  2   2  15  14         0.0321208391
-	  1   2  15  15         0.0299871938
-	  2   1  15  15         0.0299871938
-	  1   1  15  15        -0.0299054286
-	  3   3  17  17        -0.0223852882
+	  2   2  15  15        -0.0651684488
+	  2   2  14  15         0.0321208379
+	  2   2  15  14         0.0321208379
+	  1   2  15  15         0.0299871937
+	  2   1  15  15         0.0299871937
+	  1   1  15  15        -0.0299054287
+	  3   3  17  17        -0.0223852875
 	  3   3  15  15        -0.0208671939
-	  1   1   1   1        -0.0208322120
-	  2   2  14  14        -0.0191106860
+	  1   1   1   1        -0.0208322119
+	  2   2  14  14        -0.0191106850
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.89177805568
-
-*** tstop() called on psinet at Mon May 15 15:34:28 2017
-Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.07 seconds =       0.02 minutes
-	system time =       0.46 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:28 2017
-
+	Overlap <L|e^T> =        0.89177805643
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -623,2975 +590,275 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933722  0.015024519180330 -0.027415915569926 -0.162886507397837  0.113254822182090 -0.064023650931681  0.055316304980595  0.030988679956786  0.002674429417473
-    1  (  1)  0.215473680254297  0.146951879885489 -0.277734064030085  0.062883278347907  0.148483123915976  0.181595053380792  0.367001371843723  0.003086313328535  0.095386404339389
-    2  (  2) -0.028492499167409  0.000076506520594 -0.059221747197115  0.071711487991930  0.074053260083171  0.055563200913409 -0.046720222778264  0.241063526706415  0.098194384215300
-    3  (  3) -0.132536698935214 -0.177581639220038 -0.107360746511037 -0.032262815899196  0.006088751294663  0.053657437577803 -0.241466578728668 -0.131962062699382  0.577380042604848
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927831  0.060461893794975 -0.005615477646774 -0.003888920206542  0.016113135271294 -0.008672229740058
-    1  (  1) -0.037058680758832 -0.084686071934146 -0.145302623884171 -0.027760832624294 -0.054555858489397  0.022009727182522
-    2  (  2) -0.087315818129464  0.399047483163754 -0.041723099752478 -0.020041920189952 -0.040600995633867  0.007777357868478
-    3  (  3)  0.035307803556674 -0.050920479686551  0.165550414172817 -0.068091463340310 -0.144062340529064 -0.042051983076326
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356556 -0.081063517853361  0.006129432768990  0.163964563111026  0.188951419459744 -0.080047732466249  0.074988303081884  0.007836242506549 -0.044696302205991
-    1  (  5)  0.348085979138488  0.014814724303189 -0.054134117524102 -0.070406995762182  0.073423358836430 -0.343984245233746  0.389896180591091 -0.295068043464405  0.051928952938000
-    2  (  6)  0.021691230674308 -0.340003625622928 -0.038072452179291 -0.014533847126878 -0.084733391360480 -0.004556444515519  0.201335045135150  0.349717311230199 -0.082620936463626
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932768 -0.007485730843832 -0.029474818409047  0.032209758674479  0.014108652541198
-    1  (  5)  0.209382720135366  0.066996563725019 -0.203801631001161 -0.021994746468443  0.025790645299279
-    2  (  6) -0.188199132187478 -0.086167806666971 -0.070501884768040 -0.051440727873377 -0.127552190835525
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135256936427952 -0.625840722558221  0.189152953764112
-    1  (  1) -0.199003345368290 -0.037728544846467 -0.132520495485755
-    2  (  2)  0.054832391479849  0.126830338283563 -0.064813973138962
-    3  (  3)  0.614911888994771 -0.126366054397384 -0.081969716276970
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135588281064904 -0.198280199301267  0.054865352772196  0.616466856386244
-    1  (  5) -0.625018546427486 -0.037797728443036  0.128181522571229 -0.126284878377160
-    2  (  6)  0.187313400211737 -0.129941287514713 -0.067401170507903 -0.079868689249863
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904654705038447 -0.487501531810708 -0.228989288733664  0.577066731250213 -0.193646174785151 -0.103557394991757 -0.002763438454961 -0.002521717002670 -0.093924205114663
-    1  (  1) -0.150947783743718 -0.133094859243219 -0.684508017896886  0.231703815137259 -0.050781378856692 -0.177728773246253  0.233390917593619  0.124583633127435 -0.128535104851894
-    2  (  2)  0.012551305323021 -0.025827567013436  0.172781771766395 -0.235942566464277 -0.123537066136894 -0.206303367930766 -0.122018320537678 -0.114258781226498 -0.027597706889355
-    3  (  3) -0.420664931045178  0.000231270272020 -0.019477825760908 -0.199685770844492 -0.007136872649739  0.053913463253293 -0.291371052496433  0.275369617235929  0.504870072210317
-    4  (  4) -0.444539603269803 -0.097599370289466 -0.201272452095786 -0.112154803373139 -0.168808745749079  0.009504026587737 -0.073434229339344 -0.314806815881344  0.576722941605365
-    5  (  5) -0.139185904754597  0.035403106550569 -0.250195485899929 -0.395579082865144  0.287107722232791 -0.179415180449191  0.197379951884854  0.283342209415980 -0.108348043155478
-    6  (  6) -0.129871685517428 -0.067550419610088  0.181281711489601  0.198220043794417  0.101452024103282  0.004283894850388 -0.540069944377460  0.047097617764531 -0.240100013513811
-    7  (  7) -0.134001967409457 -0.177786015227937  0.066093354439321 -0.420139999558483  0.282303467947247 -0.347511589889067 -0.074355555279622 -0.307158876945279  0.001553207015969
-    8  (  8) -0.063375553143536 -0.086930415097253  0.269823860040624  0.018758493940939  0.093244023047550  0.136825056817826  0.153826640418330 -0.031539001153955  0.057539448326199
-    9  (  9)  0.014052174262802  0.032094357332924  0.006340699519412 -0.122579073435548  0.077124463374283 -0.029957160801606  0.027113970740793  0.089338289754764 -0.000820355507439
-   10  ( 10)  0.055395761167618 -0.144588618215807  0.060408759576408 -0.048569537009262 -0.074902296486310 -0.098511130754444  0.029332110695438 -0.193865792017111  0.085017383342046
-   11  ( 11) -0.167030257809343 -0.139664345575235  0.283530253423074  0.091891536336475 -0.065839803661809 -0.024334768581110 -0.227863951306873  0.001156424000013 -0.053369630727928
-   12  ( 12) -0.032033949703816  0.367089735753367  0.116673683387299  0.049313912170209  0.015062916039851 -0.072484718896620  0.058244376751757 -0.115278436137835 -0.152926398532996
-   13  ( 13)  0.015984312806398 -0.071111738375073  0.101621776382356 -0.105958849078010  0.126694141619647 -0.065028650120473 -0.035640566810681 -0.004391274841067 -0.060055094679329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128805534604310 -0.011795734826670 -0.146692960373073 -0.059406136241753 -0.018473798015716  0.062695275021725
-    1  (  1)  0.288596068552158  0.103250502413098  0.290163518419001  0.006271627172818  0.000646355178478 -0.002163096577325
-    2  (  2) -0.124851872316921 -0.010381368501732 -0.056466489774845 -0.103372365620093 -0.082252504329980  0.048795995956760
-    3  (  3)  0.041212898278569 -0.068182265272190 -0.078432164026115  0.150307548616515  0.179510662629566  0.040218002018582
-    4  (  4)  0.222712022333468  0.063990226659608 -0.051059235174083 -0.009318639929278  0.269446728734512  0.059353222373419
-    5  (  5) -0.030203406833989 -0.174843255002292  0.092722839796391  0.028249854916050 -0.095235014058556 -0.000991383838387
-    6  (  6)  0.000094761803154 -0.095079960743173 -0.236654935643855  0.077257506718755 -0.062658502435841 -0.003579147462098
-    7  (  7) -0.071378609117900  0.113105200937282 -0.125970626242898 -0.059319553016902  0.017191793320064  0.045132807261626
-    8  (  8) -0.578011070913822 -0.096069905578471  0.034320656007075  0.008138721285755  0.200651419362850 -0.180375510922630
-    9  (  9) -0.075902771217084  0.004486710274029  0.008101295703532  0.005145165116265  0.000289827785464 -0.012192146264032
-   10  ( 10) -0.010144747737863  0.093887289987194  0.012520076511424 -0.048321113777971  0.058051870190577  0.029305003899343
-   11  ( 11) -0.079269835922185 -0.056407934156687 -0.083742200501709 -0.007977653697296  0.003415198719749 -0.009408271568785
-   12  ( 12) -0.063275611050180  0.041793376814452 -0.018940005265603 -0.031801650730441 -0.042593625401080 -0.051280864509093
-   13  ( 13)  0.241520854870219  0.060862078761145 -0.029296437788834 -0.004750900896371 -0.057204357338164  0.050359098198299
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902577471790101 -0.152994814233932  0.011940868446238 -0.420469735951606 -0.445351803972144 -0.142848111796374 -0.124602559894107 -0.133617692414479 -0.065299458730887
-    1  ( 15) -0.489189301960896 -0.131612108164584 -0.025288909698489  0.001211401602831 -0.097261943563860  0.035660096811446 -0.068846931566771 -0.178298501436217 -0.088180423881717
-    2  ( 16) -0.227827617997529 -0.682850378114893  0.173952246738550 -0.020483992991400 -0.200004527333180 -0.249321074904762  0.178969609143401  0.064626594784378  0.271714608016049
-    3  ( 17)  0.575057386639545  0.230829261967287 -0.236382682328743 -0.198529656444012 -0.112446756030160 -0.393646604056964  0.196512471195115 -0.417308417772929  0.017911249870982
-    4  ( 18) -0.193966815668284 -0.049741581832494 -0.123803326018047 -0.006759114368933 -0.167461192854180  0.285673743205736  0.102864894892838  0.279649773106956  0.092613585551367
-    5  ( 19) -0.103888340402909 -0.178666472837949 -0.207303680724541  0.054793013222011  0.008829749698437 -0.180189218695024  0.005881767836415 -0.346673619263749  0.135673181192661
-    6  ( 20) -0.005617400724262  0.235632824287364 -0.121420590502094 -0.289718560202372 -0.074621425323949  0.197136569143931 -0.541291075958390 -0.074791673502324  0.151088111942487
-    7  ( 21) -0.003477648436861  0.126185493130263 -0.114691185797939  0.273163908100164 -0.312825492602440  0.283665229878294  0.047436733181861 -0.310264889604266 -0.030965201327066
-    8  ( 22) -0.094388926763113 -0.130129267650442 -0.029533862325104  0.507284500100960  0.577428087616617 -0.108467531924833 -0.239047428592559  0.001751737689504  0.057800769417835
-    9  ( 23) -0.126681312381856  0.286563029789873 -0.124985424909591  0.042080944242163  0.222642441182942 -0.031761654185862  0.002250692027285 -0.069986298385737 -0.578241171376628
-   10  ( 24) -0.012403694982205  0.104087344759352 -0.011491899195223 -0.071458529676245  0.067846175537785 -0.174556024843144 -0.093417663431561  0.108925443196115 -0.094625153118491
-   11  ( 25) -0.145228226846074  0.289308800594077 -0.056604451501567 -0.078531469167011 -0.050901538775644  0.092556450573324 -0.236272716312904 -0.125766764843619  0.035457518122494
-   12  ( 26) -0.059274992639949  0.006488412450235 -0.103071268094578  0.150081428168228 -0.009323154225402  0.028319582293784  0.076974794119920 -0.059324199727383  0.008195435055820
-   13  ( 27) -0.018186469303715  0.001053679134700 -0.081623732601015  0.178695228145613  0.269234242250905 -0.095169442617143 -0.062998987790228  0.017097346840232  0.200778292928657
-   14  ( 28)  0.062534322058022 -0.002015210189792  0.048801137289310  0.040037948587356  0.059153802159815 -0.000976778891690 -0.003575151518202  0.045136723643297 -0.180538253756990
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015166832979202  0.055523245443861 -0.169795016453231 -0.032694007010711  0.015135554657568
-    1  ( 15)  0.032433930913447 -0.144386795244130 -0.139383558038472  0.367373211677701 -0.070777740101340
-    2  ( 16)  0.006497257681786  0.060476801934772  0.284376377240629  0.117114356398064  0.102408347319320
-    3  ( 17) -0.124715086899730 -0.049178690374442  0.092903745535273  0.049474206000848 -0.106524456538078
-    4  ( 18)  0.078147667167246 -0.074392615750257 -0.066572272669959  0.015153155253219  0.127142438959372
-    5  ( 19) -0.030012583037432 -0.098494401766441 -0.024951261153980 -0.072692839393734 -0.065509018082234
-    6  ( 20)  0.028658039508268  0.029893706465370 -0.227872682646957  0.058375213717391 -0.035317071011158
-    7  ( 21)  0.087698228581465 -0.193877542561776  0.000977855687069 -0.115255270457925 -0.004253825014343
-    8  ( 22) -0.000487339716269  0.085213745940574 -0.052874146845015 -0.152776261278858 -0.059953850619275
-    9  ( 23) -0.075363605944822 -0.010276769755622 -0.080252178607551 -0.063424914028104  0.241145188807008
-   10  ( 24)  0.001283950926939  0.093581096956637 -0.056859346555054  0.041777245375248  0.060823791108896
-   11  ( 25)  0.008356132167143  0.012479675910490 -0.083678859924604 -0.018947435212012 -0.029236284374189
-   12  ( 26)  0.005134210870859 -0.048347394079564 -0.007965979077246 -0.031780813486509 -0.004717184227605
-   13  ( 27)  0.000267583079026  0.057994430769062  0.003313390407093 -0.042646534152268 -0.057198829179600
-   14  ( 28) -0.012275122252029  0.029301677774353 -0.009473927119427 -0.051324560742064  0.050296874415886
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027985845163524  0.023014187360132 -0.021972704031550 -0.165873801926668  0.108498472423258 -0.065984445208027  0.052062590549153  0.024196903336059  0.005438903859049
-    1  (  1)  0.207753127107100  0.133586320603852 -0.248299413759929  0.051273643702392  0.137929228974577  0.172516172497646  0.338774489321057  0.007044125107960  0.086225487021978
-    2  (  2) -0.030725656049538  0.008685648887429 -0.054637639636829  0.081853822913586  0.065569345836835  0.054412511875610 -0.037702150980267  0.220880057677829  0.092517419795625
-    3  (  3) -0.146518460272185 -0.151164938887178 -0.090922259280638 -0.041550491468836  0.008256552512676  0.048975234640781 -0.222433708697271 -0.123978061818464  0.551233631040567
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.030368262613337  0.051015148860635 -0.002942978202016 -0.003356964742137  0.014802517799284 -0.008083321576794
-    1  (  1) -0.024523434755722 -0.073734688873540 -0.129066247639439 -0.024037316988320 -0.050282994530055  0.020846450280793
-    2  (  2) -0.075512350010898  0.366500451453791 -0.036592830040889 -0.016303194972460 -0.036175560248337  0.005423684503349
-    3  (  3)  0.036874256227630 -0.046039513569074  0.147486358648951 -0.060664952434382 -0.127426669479233 -0.039293702180427
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.050111098767745 -0.071439421665737  0.010360806490423  0.164982511003502  0.190752518001675 -0.070698878333088  0.064144987593348  0.009940358823804 -0.039049299317426
-    1  (  5)  0.346512350212501  0.020770988494970 -0.054063126549543 -0.066267909254760  0.061286416729942 -0.328133338026467  0.364459716199746 -0.282333058508693  0.052379135180748
-    2  (  6)  0.014820841999600 -0.308332589554773 -0.036490920160057 -0.008185142851144 -0.077220105539055  0.001985069156781  0.191861505554810  0.331452106505361 -0.064661161962335
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002710313008904 -0.006054102061478 -0.023960364540744  0.028066673595848  0.012225337247005
-    1  (  5)  0.191683957013482  0.061055761849053 -0.180315991810041 -0.020020550401249  0.020756656682088
-    2  (  6) -0.171946012527152 -0.078984789269474 -0.060019327368985 -0.045058581991741 -0.117222830082063
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102367  0.008188589712238 -0.013790999932787 -0.066013267343718 -0.002979179364402  0.115067560152143 -0.029904774000613  0.075658337330170  0.005135342269607
-    1  (  1) -0.415137332088612  0.400791789518638  0.060626653167991 -0.009777722957358  0.182694524485337  0.107591424113208 -0.071470092116898  0.210805299972917 -0.029640655301118
-    2  (  2)  0.731004204598524 -0.977674938020298  0.030910735141458  0.126476447646258  0.160297857646348 -0.115254107794114  0.017919423470245  0.019160269758161  0.056677210805993
-    3  (  3) -0.052710934455993  0.190825342618791 -0.121683764296163  0.058318753384834 -0.051331848225805  0.122833340921044  0.176985596744925 -0.321410474763126  0.015752780623231
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449213 -0.003857954296836  0.001116934481339 -0.006268480889134  0.011819863965880  0.022338641059406
-    1  (  1)  0.026581167918673 -0.003242138995826  0.002209759168116 -0.126256065331472  0.064001666171840  0.019583311633874
-    2  (  2)  0.060541607763300 -0.048685401885040 -0.005324531906368 -0.077364982992393 -0.023160042352118 -0.131997334895640
-    3  (  3)  0.086532549077842 -0.501054912835391 -0.033953281830235 -0.045954160893793  0.007588765668993  0.026055365513597
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407912 -0.003874637131510  0.017573675069989 -0.250000468336212  0.193535227171946 -0.023949830014057 -0.006344215172658 -0.002637721142605  0.025018403626550
-    1  (  5) -0.061066900138163  0.119597101102996  0.077747477731553 -0.181802110874956 -0.105212352540628 -0.191650240311689 -0.067261595147718  0.101033231559081  0.034053487252843
-    2  (  6) -0.129779125650158  0.272168473286842  0.218088904973338 -0.105590817864474  0.170044089806057 -0.413895401404384 -0.204721805057715  0.193774792721808  0.022574107317577
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304093 -0.022619515940248  0.001370551331509 -0.019480287608800 -0.016611790333306
-    1  (  5) -0.015006262168537  0.018557640744956 -0.000086080146177 -0.193359672647776  0.037991057379314
-    2  (  6)  0.020942063740398 -0.276121820896825 -0.020375408054502  0.090755244706104  0.038585932807354
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234774577907340 -0.089732279705020 -0.029281742956361
-    1  (  1)  0.629390080925054  0.562262027181648  1.005710563308147
-    2  (  2) -1.016842846984442  0.324902404629239  0.759850922288994
-    3  (  3)  0.070893719957037 -1.217739132557560  0.544721303880524
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235500971090726  0.628370240889402 -1.016044908027706  0.070845813096372
-    1  (  5) -0.089243248615735  0.558584627490131  0.332507599415180 -1.220818260487312
-    2  (  6) -0.028235811673249  1.000885266991202  0.767552789658038  0.543389712941562
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.803905357707311  0.860151305623949  0.271118555223167  0.233708148806798 -0.124148512341266 -0.010189985719979 -0.092729991992268  0.016788100393524 -0.004472139404122
-    1  (  1)  0.401013317552785 -0.256123411395810  1.725791219363352  0.228118396767626 -0.017083610861014  0.077834475735907 -0.010518533714653  0.508387054745627  0.007264375748279
-    2  (  2) -0.011434548540222 -0.088441201305154 -0.217324498232303 -0.271194503786495 -0.847646840544961 -0.636979337168603  0.167111761738664  0.613015596421828  0.118261935906470
-    3  (  3)  0.794342002638844 -0.188454328702485  0.221782475708119 -0.127238173306152  0.529725618505773 -1.234283764404522  0.503702151908138 -0.716733332201490  0.003730822870913
-    4  (  4) -0.401751095605530  0.338386780155127  0.027671797889821 -1.521964962245091  0.118534592965411  0.737791613352609  0.133068399810627  0.089420490967805  0.037476970403516
-    5  (  5) -0.062520837577632  0.401075384901201 -0.021867941133996 -0.715225023398739 -1.272095248267951  0.501721901780299 -0.443609728635242 -0.893075231648048  0.592672369741993
-    6  (  6) -0.010948759647979  0.203401403085997 -0.137048639531909 -0.113085573900653 -0.481495532073518  0.549209906368458  1.454114297098583 -0.104970888423571 -0.037484874409079
-    7  (  7)  0.128092468229021  0.321831618555177  0.165224131524797  0.036717435980679  0.490326956687596  0.556704330756835 -0.028026211847655  0.572891503259545  0.836605248949509
-    8  (  8)  0.028465864758886 -0.067177326433747 -0.261754785397495 -0.132197496012203 -0.099654097906746  0.125238705338503 -0.191161571927307  0.152439549355924 -0.345598496796334
-    9  (  9) -0.117164319402284  0.677600502185656  0.057458896318824  0.132501237674075 -0.004191340015369 -0.154828563575337 -0.038564068532644 -0.121792891458522 -0.349263289014943
-   10  ( 10) -0.181067725106296 -0.111582528205458  0.370630400902865 -0.010089018109779  0.175901282392120 -0.187388709548550 -0.018929605786239  0.507571524880377 -0.113635665926862
-   11  ( 11) -0.014437537795246  0.015226015168940  0.010134165664067 -0.005687484322489 -0.031065375239781 -0.023280669169025  0.128114396256681 -0.039417737851753 -0.110919095427042
-   12  ( 12) -0.125387244214951 -0.096520270925362  0.052418676370702  0.258253736986353  0.005758304720891  0.145179803274614  0.116533683249985 -0.074529049368730  0.022120054046506
-   13  ( 13) -0.016488000528151 -0.002368207793552 -0.087940291197149 -0.101326196004400 -0.036322133241993  0.195270868050333 -0.010169719681932  0.009700577933052 -0.056276489205959
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020656609432377  0.055454072209206  0.016498557049920 -0.100308993019535  0.100625813513966  0.085817872313959
-    1  (  1) -0.158188828440892 -0.302238781900211 -0.003254305982647  0.141295167420039 -0.086817823645988 -0.004522680615623
-    2  (  2)  0.117165454504024 -0.174443278203503 -0.011196610388147 -0.263022208165445  0.005179209446380 -0.028790206529749
-    3  (  3)  0.116979728848069 -0.002675319824407 -0.011237305263780 -0.059042081886281 -0.019813165086942  0.041020820057734
-    4  (  4)  0.050773800974292 -0.220964030765936  0.039978161841657 -0.028484730886475  0.038490445524596 -0.072488415876946
-    5  (  5) -0.020335163069148  0.163705236926197 -0.082951181907163  0.111454733440593  0.037975682191325 -0.107211881409464
-    6  (  6)  0.021278303210848  0.388606221992998  0.114903933510215  0.018782318547525  0.008939872036282 -0.015881860003982
-    7  (  7)  0.297901981281024  0.033254178443727  0.094283496173084 -0.060148927068472  0.021415208569123  0.043129019365108
-    8  (  8)  1.538151946484423  0.255389759643583 -0.163313084569292 -0.034663525935373 -0.142139339830442 -0.045757092023972
-    9  (  9)  0.091430832784144 -0.031111059625587 -0.061979966203490 -0.058675516664175  0.760855141023917  0.950655107543621
-   10  ( 10) -0.067314640632537  0.211103496431705 -0.020600002397637  1.234404704927125 -0.163782714272567  0.167558660890032
-   11  ( 11)  0.163451473737101 -0.060117653273661  1.332809431049165  0.048636523249740 -0.084741416350187  0.093758422678353
-   12  ( 12)  0.205980882962949 -1.200907557972782 -0.135489991479292  0.365850977217349 -0.094087533161484  0.008716209829183
-   13  ( 13) -0.181608420628060 -0.041944770724578  0.112411453405729  0.222931004263492  0.995147424974585 -0.917645025950541
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802215088996775  0.405760421584725 -0.010733900270896  0.784358891338122 -0.394207392965882 -0.066264169418438 -0.011728371528151  0.124097516118103  0.033513743357673
-    1  ( 15)  0.861921835284117 -0.259204458699967 -0.086550258239887 -0.179795107884808  0.329776011755083  0.399732735512309  0.202064202046553  0.330247474290177 -0.071973209379633
-    2  ( 16)  0.271441185213391  1.724486207548469 -0.218690579375801  0.222063595490460  0.027363367055485 -0.018802165875844 -0.135942286119417  0.163478817004599 -0.262387665735325
-    3  ( 17)  0.233788075721826  0.228159112392323 -0.271808517288257 -0.127676513444271 -1.519379653938277 -0.715083891079223 -0.112821347158474  0.035818562511062 -0.131766468683948
-    4  ( 18) -0.125942009127172 -0.016377869393706 -0.848482111339688  0.528657771751293  0.118745113074898 -1.271710188107035 -0.481153570999942  0.489178297010484 -0.100424350070291
-    5  ( 19) -0.011383686031449  0.078456463460941 -0.635793437126757 -1.233395635082388  0.737239370475296  0.499509899398320  0.548401749031313  0.558608158361660  0.124417124384875
-    6  ( 20) -0.091600198761770 -0.011876741058319  0.166091401418705  0.503941587465969  0.132948669117964 -0.442842250160731  1.455104693311837 -0.028341475910627 -0.190421671161177
-    7  ( 21)  0.014484668680380  0.509841880180764  0.613581819059005 -0.716630577428902  0.088564900472140 -0.892493010440163 -0.105683628158844  0.572246502497319  0.150576148757988
-    8  ( 22) -0.004174841691802  0.006707441197859  0.117679460919548  0.003167625275269  0.038325446188084  0.593620463308946 -0.036920125090448  0.835670699131347 -0.345282330703187
-    9  ( 23) -0.021563101305077 -0.156910385371061  0.117862784231017  0.115137818805332  0.052266686740979 -0.022652444633787  0.020589348904606  0.298647561105740  1.538509254803363
-   10  ( 24)  0.054696247538136 -0.300097703279750 -0.172676310394845 -0.004641896342478 -0.221287943064927  0.163661856689034  0.386962565847225  0.033092208048157  0.254762225348227
-   11  ( 25)  0.016478682999148 -0.003215291424268 -0.011157986184847 -0.011249059510507  0.039826186982321 -0.082792260839707  0.114868621990364  0.094214542109994 -0.163392531748718
-   12  ( 26) -0.099187962393071  0.141022599136927 -0.262517149368207 -0.059517894129389 -0.028614490021954  0.111532524460300  0.018579534511371 -0.059825884600083 -0.034049798717724
-   13  ( 27)  0.100178973364377 -0.086693773226363  0.005242460985690 -0.019116004377611  0.037912677180169  0.037754205119466  0.008826283068401  0.021770019636588 -0.142635094936193
-   14  ( 28)  0.086046178690242 -0.004751133686046 -0.028259740203224  0.042085140978763 -0.073608902693740 -0.107703616275598 -0.016209845373183  0.044336724946126 -0.046193144798357
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124213386192449 -0.184278545140157 -0.014644622518974 -0.126520793888936 -0.015935131079309
-    1  ( 15)  0.686886555278534 -0.109848033830421  0.015362111474085 -0.096623860958170 -0.002352924370873
-    2  ( 16)  0.057186301356343  0.372235382538515  0.010223067022666  0.052308263466605 -0.088321026996929
-    3  ( 17)  0.131851542209598 -0.011114262485829 -0.005723853800875  0.259717639216932 -0.101579897082117
-    4  ( 18) -0.005059922073798  0.176651992942668 -0.031045371067554  0.004751602541209 -0.036357227754461
-    5  ( 19) -0.153490417120552 -0.188182144826061 -0.023327004528605  0.145116229576305  0.195544967130553
-    6  ( 20) -0.038669146951691 -0.018322940249549  0.128217963501523  0.116247317068486 -0.010270205632719
-    7  ( 21) -0.121953539167482  0.508071938672096 -0.039503068949602 -0.074854789377140  0.009741351292022
-    8  ( 22) -0.349749690454153 -0.113383122522557 -0.110884130170500  0.022231095142528 -0.056430507970696
-    9  ( 23)  0.091277604676359 -0.068457429261195  0.163395065823676  0.205703107124365 -0.181427144774973
-   10  ( 24) -0.031490205855113  0.210975767808687 -0.060264671053420 -1.201247115008903 -0.041832647583344
-   11  ( 25) -0.061996899999264 -0.020492208070431  1.332807012156678 -0.135544852791734  0.112408630541359
-   12  ( 26) -0.058492216122820  1.234353822395186  0.048637099519176  0.365843792888730  0.222948291565721
-   13  ( 27)  0.761203399339422 -0.163718232424674 -0.084746898323330 -0.094131030705851  0.995190420313834
-   14  ( 28)  0.951767639345761  0.167573997453096  0.093760237560500  0.008708090964824 -0.917567337282473
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.061311180916174  0.007305734568299 -0.008052219664717 -0.075102530727564 -0.012025728300826  0.120194347984132 -0.026978429199379  0.070594185419545  0.016866098796694
-    1  (  1) -0.395437998629573  0.330196709230486  0.066130411816170 -0.001067023889988  0.191861180999614  0.113171387281916 -0.066995383271923  0.184795229028717 -0.029348228197537
-    2  (  2)  0.660966524714688 -0.861759345962241  0.033160724552169  0.127992765938447  0.170396202948104 -0.110113865477816  0.014392237869005  0.010445707783194  0.039464659932571
-    3  (  3) -0.040562495552703  0.173681994330223 -0.115433716796164  0.022385853875221 -0.029920163821990  0.106927003887640  0.164647198946454 -0.308627589591936  0.016471750534187
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.008075638079590 -0.004204267894386  0.001154899751921 -0.004302816895310  0.010300593916071  0.018583143246493
-    1  (  1)  0.022690643093880 -0.003824240162369  0.002196370237793 -0.111717598339107  0.056937031147815  0.021691580964165
-    2  (  2)  0.053339405350156 -0.044029154336949 -0.004382948251621 -0.071322882171572 -0.023334611635533 -0.125689353624520
-    3  (  3)  0.084457325104192 -0.461707512764016 -0.028403124486066 -0.043179936610554  0.008421132991555  0.024339438305143
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.015528904780166  0.000197217067411  0.014784122441979 -0.260011500898602  0.207731584784046  0.001836258201294  0.003784871531686 -0.004554790492094  0.029260236327573
-    1  (  5) -0.073737732106898  0.115839519981911  0.060966183364281 -0.191025915776738 -0.133264060723011 -0.183947109340336 -0.057101924893026  0.090583425466175  0.027097942199573
-    2  (  6) -0.138800981815769  0.257932125792776  0.172076461805675 -0.086501722972202  0.167229357348261 -0.397280885922369 -0.200441282704850  0.184212067375292  0.012201121124777
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.007496948487326 -0.019701904142718  0.001114080790245 -0.016769294212535 -0.015066280094060
-    1  (  5) -0.008011152002189  0.019463303254064 -0.001255118747011 -0.171713762805812  0.033052309738105
-    2  (  6)  0.023624103497187 -0.246377111375438 -0.017324022231723  0.084529293370869  0.033771435710698
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521810 -0.064555152855140  0.195953381503072 -0.041248493404100 -0.011229686922116 -0.030149441468397 -0.052245051042501 -0.006640144591441 -0.060816046803631
-    1  (  1)  0.618380750339701 -0.527850820452496 -0.215416501468030 -0.157035437820985 -0.069798458053192  0.063297476854260 -0.224803808806343 -0.036770088857871 -0.093292414355443
-    2  (  2)  0.089963765220208  0.016694193855681 -0.049894217028076 -0.224500363636592  0.100545586935621 -0.339808932362450 -0.300486601784935  0.103978674940069  0.003854593986182
-    3  (  3) -0.017912540893906  0.240051544179780  0.016875920141057 -0.019658112757032  0.000950481978191  0.139486307895262 -0.307526295494270 -0.245045411721381  0.038982174459018
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151717 -0.053483299255780  0.001461399819934 -0.009996127160186  0.040844890766482
-    1  (  1)  0.010356156252335  0.045196494943183  0.123149462829323 -0.009608799091533 -0.092775098416549
-    2  (  2)  0.068261626755325 -0.266621644473693  0.090983468547795 -0.007824999539039 -0.015479677414577
-    3  (  3)  0.102991688131888  0.095940846129217  0.235195882789535  0.030438278876706  0.100331913639096
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065258  0.055002400477826 -0.190701615134343 -0.008587073556960 -0.137456634337705 -0.102685174742819 -0.038575707278164  0.049077773985899  0.038775520871487
-    1  (  5)  0.266426121061182  0.201904502527541 -0.404472747743455  0.112355452346296  0.244543383067954  0.203488255110552  0.093346083766350  0.046662175778563  0.162564534078684
-    2  (  6)  0.310200495971188  0.275860886663906 -0.334362481171667  0.111323203428020  0.107269573508102 -0.015396505983542 -0.485347827861579 -0.115211810541093 -0.189399381355345
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661090 -0.010182782856367  0.015536223735827  0.027148068637773  0.019304531582392 -0.012170541889266
-    1  (  5) -0.076359104752422  0.072719944885937 -0.105706045053709 -0.076791075572627 -0.095250630872874  0.044053081318693
-    2  (  6) -0.023401555368525 -0.060789750773992  0.233844071164900 -0.060200608258470 -0.022972229731698  0.078966373846361
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134471189810092 -0.662148890372047 -0.267935016272650 -0.078917516466181
-    1  (  1) -0.664666296417858 -0.209284545759600  0.147471348275627  0.068908444059693
-    2  (  2) -0.267133357861078  0.148425589757628  0.187317601361827  0.001813043081997
-    3  (  3) -0.077770523166389  0.066603013397195  0.004062962607311  0.013912155247960
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274832594154714 -0.278242094914337 -0.671654031070884
-    1  (  5) -0.278497836106856 -0.012090613996289 -0.010590433835922
-    2  (  6) -0.670432937770643 -0.009657203375264  0.097732024172777
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959652947297446 -0.408123531987619 -0.490401240559718  0.038728625501850 -0.077955850449253 -0.487356513384779 -0.107431647026833 -0.396098723270224 -0.237559090649423
-    1  (  1) -0.405287391353834 -1.324235803795144  0.174918474964920  0.249090286909362 -0.197882092638117 -0.317613216127917 -0.251158649784065 -0.030182262258926  0.632878894780051
-    2  (  2) -0.488736302126935  0.174537834055795  0.686802536569195  0.342698519390660 -0.009978504141441  0.483630953231146  0.287674546129727  0.302838065576003 -0.272076060390986
-    3  (  3)  0.037680750791132  0.250810425630217  0.345041313376114 -0.288921950854187  0.242065062379730 -0.302245036941519 -0.510968387365602  0.184732147500300 -0.217019518876341
-    4  (  4) -0.076474970371118 -0.199548330465758 -0.011318561820522  0.242358447418328 -0.131824013162052  0.385851083614353 -0.241519487350351 -0.375192533273711  0.062578612411423
-    5  (  5) -0.485852483425266 -0.318979280528763  0.484066634013452 -0.298903807168945  0.382610997345618 -0.557142551517131  0.333197792146470  0.111813059758365  0.019832041990218
-    6  (  6) -0.104965308815928 -0.251905850413101  0.289646445983294 -0.510970311703583 -0.243416542914288  0.333477452263820 -0.859910605182056 -0.040221092410560  0.015978091027429
-    7  (  7) -0.396757752587363 -0.028569556877251  0.303650553506904  0.181375877079299 -0.373315055601480  0.109082013495532 -0.042394080422644 -0.424453142205116 -0.165367340665863
-    8  (  8) -0.232577777980881  0.628634227410956 -0.273406823912260 -0.217896152168838  0.062014351681569  0.020854775327294  0.015643896438574 -0.165522517445198 -1.139943298332195
-    9  (  9)  0.005610937642159  0.056039778145227  0.162949812700519 -0.082447741081119  0.072872155386977 -0.108705187107976 -0.023485984994573  0.044747716600193 -0.147251711508816
-   10  ( 10) -0.006823140015079  0.054329319992068 -0.040599884295365  0.341771214889488 -0.179762239296878  0.323458315510083  0.128244534494253 -0.274646157662585 -0.052523948909135
-   11  ( 11)  0.095363270787347 -0.102111548012532  0.068440604874557 -0.163728434997447 -0.155636086105072  0.243236788181447 -0.456650415997544 -0.005317873159721 -0.049821847160301
-   12  ( 12) -0.031682366540900  0.049375813516575 -0.071598146179691  0.132087989337538 -0.108611785555417  0.096654485419413  0.079499450722417 -0.086710987234524 -0.054539911364394
-   13  ( 13) -0.055056204890153  0.125842892748373 -0.045965574230317 -0.019980233406050 -0.072417713564596 -0.032557591563818 -0.014098057188424 -0.073500277920932  0.566229267173414
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807525521233 -0.007359537343921  0.096092508733764 -0.031848083816976 -0.055774198983232
-    1  (  1)  0.055013732650586  0.054716326372634 -0.101499825852225  0.049505806235113  0.126450547357477
-    2  (  2)  0.163059205506462 -0.041368872819456  0.069581455596234 -0.071597196780245 -0.045866052228085
-    3  (  3) -0.081105673439869  0.339429555892824 -0.164728153643699  0.131959969199162 -0.019695233925696
-    4  (  4)  0.071393373180112 -0.177479194335969 -0.155859184366711 -0.108539407321582 -0.072773970413827
-    5  (  5) -0.105603312078912  0.324542336417266  0.243446189575733  0.096679109403979 -0.032469296833009
-    6  (  6) -0.022598073087572  0.128545265092418 -0.457503820510282  0.079428257782213 -0.014293355829964
-    7  (  7)  0.043846313691523 -0.277398721649818 -0.005217801799309 -0.086814141836653 -0.073528025181399
-    8  (  8) -0.147650558386801 -0.051824889211656 -0.049479655499448 -0.054623458198541  0.565538504830395
-    9  (  9)  0.072040995887839  0.045487481778711  0.010267944449755  0.009607395545283  0.026537979914876
-   10  ( 10)  0.047954867962304 -0.139047713471829 -0.006984668871374 -0.101926998608402 -0.021981627690416
-   11  ( 11)  0.010232694252591 -0.006895180981132 -0.093446496400997 -0.006456318199702  0.037416385414388
-   12  ( 12)  0.009698093521025 -0.101910194048616 -0.006447087285736  0.055515253338052  0.004586695913697
-   13  ( 13)  0.026517968105571 -0.022107111741401  0.037498264993835  0.004566515568409 -0.064482567891937
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532087829692590 -0.788053685787543 -0.217638660718255  0.182558741425794  0.602280863487480 -0.200093873579573  0.029411468157287 -0.008618444683726 -0.142345995339967
-    1  ( 15) -0.793296879907851 -0.320033252713587 -0.162598975061937  0.058726797579308  0.020874324465825 -0.223415350495464  0.107419199072046 -0.353928058476850 -0.096059896297266
-    2  ( 16) -0.212771964426018 -0.165330329981933 -1.296138478501883  0.042119030626054  0.273634363153676 -0.438879796251796 -0.121813090934943  0.097180424393402 -0.140937625938142
-    3  ( 17)  0.179954420872001  0.058841120068099  0.044127193653625  0.293105599186954  0.349356888645549  0.303438248695204  0.077097855045665  0.005877107547810  0.014045104825034
-    4  ( 18)  0.599465706125478  0.022235571238169  0.273958684833300  0.351252283018589  0.210835219511268  0.044587084733166 -0.439010194116289 -0.491004374063182 -0.399383595875341
-    5  ( 19) -0.200414126422892 -0.221453681940971 -0.440132544745164  0.305750504885625  0.044859550994933 -0.117462871785049 -0.191542019031430 -0.319736101009363 -0.359370857937598
-    6  ( 20)  0.032162128490710  0.105939422470881 -0.123876353123509  0.078981740858070 -0.440632986523098 -0.189872412172292 -1.110683989274872  0.246909463066168  0.255271007146821
-    7  ( 21) -0.008289240270486 -0.354493597801953  0.096614444377338  0.006342901738698 -0.491270269306688 -0.319008747377893  0.247402781703421 -1.005041339289935  0.329310525846416
-    8  ( 22) -0.142958112237992 -0.097022080380776 -0.141105576266035  0.015162721218605 -0.401346216586595 -0.359442000824708  0.255249867089681  0.329100137017210  0.052130295704472
-    9  ( 23) -0.219989065380246 -0.250001442433259  0.576446348372414  0.098959674886800 -0.020568115056174  0.097513800211121 -0.059902955848638  0.014734527114704  0.155046520151383
-   10  ( 24) -0.078950494727199  0.108193141402953  0.027256154227325  0.046487728394439  0.091306743849428  0.113368151054255 -0.170234459022064  0.302098295161987 -0.032847707963684
-   11  ( 25)  0.043326744721135  0.032363389826812 -0.179596320201807  0.107314642639449 -0.187556761581101 -0.097228134857404 -0.510755068400788 -0.080036249796903  0.081235508165591
-   12  ( 26) -0.068197976739272  0.217296898230263  0.162613838841638  0.182156526175457 -0.078640971248232 -0.138388418075592  0.046099139294747 -0.318339562890745 -0.094298996233422
-   13  ( 27)  0.012948053174444 -0.163156717261063  0.064963474472039  0.076423090075366 -0.116362948599962 -0.057051341709586  0.002572557321622  0.275506911037167 -0.101255941405055
-   14  ( 28)  0.072512090984942  0.116063474825340 -0.039414549057152 -0.060057426555201 -0.063414940103828 -0.039930823846179 -0.007406649447407  0.061654502640363  0.127196073453639
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223472856186329 -0.079380673330417  0.044417374907374 -0.069445497218023  0.011729893427506  0.073549727582157
-    1  ( 15) -0.252084318917961  0.107740778119089  0.032072824705649  0.217703434939331 -0.162976179330690  0.115649023646982
-    2  ( 16)  0.579843117285508  0.028377214599785 -0.180834874279503  0.163175611851648  0.065411291339360 -0.039948698368928
-    3  ( 17)  0.098340901452171  0.045586420024689  0.108734472684589  0.182606429974975  0.076964420692713 -0.060236205753191
-    4  ( 18) -0.021650833253368  0.091327714075519 -0.188512569919576 -0.078662641540956 -0.116896916359804 -0.063655160224489
-    5  ( 19)  0.097171540237316  0.112970498693947 -0.096626702578479 -0.138712839413244 -0.057497371163198 -0.039673289236737
-    6  ( 20) -0.058059330793309 -0.170134824525265 -0.511529953350571  0.046149842859018  0.002603003870208 -0.007423573904069
-    7  ( 21)  0.014906052329776  0.302176683769003 -0.080527272396977 -0.318411101425731  0.275449773181718  0.061692765706429
-    8  ( 22)  0.155151887383248 -0.033185457482074  0.080998651116857 -0.094073422563741 -0.101041326065027  0.127067437701733
-    9  ( 23) -1.153509668704953 -0.223849781573310  0.084925914720570 -0.000154347639825  0.401132279504920 -0.346054713026435
-   10  ( 24) -0.223987599390505 -0.015012978211180 -0.013160266761979  0.067286208797175 -0.009874035055601 -0.084312333246363
-   11  ( 25)  0.084246135649734 -0.012978110758481 -0.099616699055155  0.005046001111317 -0.012239544431652  0.023063802197493
-   12  ( 26)  0.000203295279175  0.067424132200542  0.005012434803368  0.014687484508398 -0.012600853145572 -0.022021985836775
-   13  ( 27)  0.401487062569274 -0.009674045048257 -0.012249675488475 -0.012688275802534 -0.008212565425852  0.091176394210094
-   14  ( 28) -0.346417777877478 -0.084403131898400  0.023147564232903 -0.022062212430037  0.091088265440255  0.040127117539344
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.056215178351152 -0.054500121667396  0.201919259029640 -0.031077763909936 -0.011710544057694 -0.013075909014488 -0.042346948279412 -0.000671828437196 -0.052291650303081
-    1  (  1)  0.580185861075070 -0.459972753550963 -0.203225407919285 -0.146383812782444 -0.059047716562576  0.052226205810320 -0.210466211727551 -0.032187370830551 -0.063260161926320
-    2  (  2)  0.093393180484024  0.013367709279037 -0.072500434249941 -0.188901437279491  0.080233214984548 -0.320461373590757 -0.281774578817969  0.095754681534406  0.009993938559280
-    3  (  3) -0.011005998081791  0.212772041115702  0.010016689572689 -0.008866167178549  0.020319327817077  0.122354072622868 -0.286521492942098 -0.227705666262959  0.024617052813042
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004784997903906 -0.045646414234079  0.000336480836015 -0.008910135175809  0.037229970153597
-    1  (  1)  0.012654368872761  0.038726052908772  0.110122851111890 -0.008163616811273 -0.088473965510977
-    2  (  2)  0.059858161464052 -0.242276960674044  0.080687949967586 -0.004783380239994 -0.010585828283984
-    3  (  3)  0.093190009318185  0.087625848503461  0.210676223786748  0.029310965958952  0.092669937835962
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.095387850613253  0.063707287574100 -0.166137684328990 -0.019021592214621 -0.149973759488072 -0.101204345446005 -0.031472575013395  0.053498473418115  0.042967624605644
-    1  (  5)  0.255913374070676  0.182084005619737 -0.358054750763435  0.117938321447881  0.215767330994835  0.198255946304696  0.082288395387947  0.046112464804605  0.145174585244920
-    2  (  6)  0.310255017179614  0.238379631063291 -0.293832075513331  0.096225461668115  0.113893652343842 -0.010350380964834 -0.451016712892298 -0.111857488193420 -0.191795345079325
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.073847868868730 -0.008654741577254  0.012693286586184  0.023668684482898  0.017789448554089 -0.009288640558542
-    1  (  5) -0.053437184229602  0.073043484124087 -0.095008049379703 -0.066955824244484 -0.087649072564987  0.040223509254852
-    2  (  6) -0.005363327558409 -0.054894453058810  0.206318088063038 -0.056446188259803 -0.025451705059660  0.074272028126644
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016118777276715  0.076689387067912 -0.125264792267216  0.007931013310243 -0.098301937535605 -0.089040062536404 -0.042653189503994  0.143650549015439  0.062698356849192
-    1  (  1) -0.038523460792185  0.325926212074859 -0.217436403108296  0.076210929079388  0.124956744969533  0.049869905306291 -0.256022567536762  0.049219148025195 -0.025163660677609
-    2  (  2) -0.015460259327551  0.182364499530160 -0.081021447104332  0.065186772706263  0.193628085224717  0.090709199284730 -0.144227288852921  0.007154481293501 -0.060483347873676
-    3  (  3) -0.069494321441892 -0.016013992178318  0.169506236224067 -0.050547669997776 -0.177140340538979 -0.181255025833254 -0.201077665225233 -0.109139777586648 -0.215083611892032
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159361864611553 -0.056476108299591  0.034334354535919 -0.068420323850581  0.100698715800710 -0.049820592017774
-    1  (  1) -0.121041364374110 -0.003994619377137  0.190684428167184  0.052070114913580 -0.189028662705231  0.205096915582739
-    2  (  2)  0.013836799939816 -0.073875918803127  0.147901928532528 -0.343158528114239  0.053056478393277  0.086736758175880
-    3  (  3)  0.065392768372835 -0.072388535495376  0.365788807268924  0.156911353062511  0.184439406968006 -0.043117455907297
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095080611028908 -0.132974666952799  0.233475927910159 -0.109077700761849 -0.033619328181732 -0.003336619392394 -0.079318686273405 -0.006541773193158 -0.188514066103895
-    1  (  5)  0.133180554197722 -0.220459497770329 -0.122961007604814 -0.144493780528946  0.034530325126924 -0.144382538755391  0.001565508478566  0.179104189145763 -0.084352671049966
-    2  (  6)  0.305369897772513 -0.245966510909103 -0.171589985467964 -0.288954965589224  0.048536799653887 -0.105233271021583 -0.400024803684130 -0.035818012706233 -0.066124321501172
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011358647742862  0.047842821118301  0.011877525445924 -0.012099889406653  0.055702357687980
-    1  (  5) -0.060987538430201 -0.100437160073963 -0.174976176295358 -0.033059202656663 -0.296249624542354
-    2  (  6)  0.156959926194242 -0.053853503787387  0.406665675932448 -0.026462885456157 -0.143060389345547
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.020948331780215 -0.037000670267279 -0.105734997905917
-    1  (  1)  0.298755038289142 -0.115783497652312 -0.255943993115305
-    2  (  2)  0.258964229852114  0.115813970118107  0.442412044617565
-    3  (  3)  0.060316341789483 -0.030010868082768 -0.068666118917160
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019390140524655 -0.299690928631304 -0.261296417524431 -0.060590155832357
-    1  (  5)  0.036741212649359  0.114946374260334 -0.116921045330832  0.032705566460932
-    2  (  6)  0.104633614556808  0.252457748482493 -0.444028842624352  0.069853026830576
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.140296000548941  0.063793548091722 -0.058836863345753  0.099797632735300 -0.059473750236872 -0.159752966024087  0.002202306295360 -0.046127151478856  0.008686217300582
-    1  (  1)  0.090587236946104  0.202094731400236 -0.091626540491885 -0.096660154944673  0.169987669208235  0.083846972629074 -0.508703907389636  0.818627210894803 -0.070854467170586
-    2  (  2) -0.023735454247632  0.355751040292653 -0.273793043205585  0.278993695315875  0.352285402581272 -0.196481260763437 -0.305054920124749  0.066457242289417 -0.201198646054354
-    3  (  3) -0.097017476571804 -0.245783387728730  0.317753409227420 -0.024031108885499  0.214358325616717  0.049557148749413  0.028895867231305  0.054175105918326  0.003063371175243
-    4  (  4)  0.057659363291957  0.180009048378845 -0.233469321765478 -0.045014824473403 -0.207816785622826 -0.114404967029762 -0.123373159567671  0.226999771613591  0.055473302709796
-    5  (  5)  0.215768085458356 -0.315007699227405  0.316911447049752 -0.120875322919003 -0.280165731589989 -0.294210130176689  0.216431927362601  0.200720331119460  0.064409972369138
-    6  (  6)  0.088219394313516 -0.148901192549512  0.366942172197605 -0.011961263536269 -0.214232535784278 -0.110039106542730  0.192575526682645  0.231316173793134 -0.059843368650861
-    7  (  7)  0.046870162228495  0.280136788176482 -0.370966800512151  0.110896450302908 -0.088815259647623  0.146578221115441  0.021177591015912 -0.399548191737565 -0.041055228430585
-    8  (  8)  0.213227988512466  0.108113812359640 -0.632322240865726 -0.072819843847120 -0.035043483782363 -0.162903981240538  0.072814806218845 -0.219110389566894  0.041093714767865
-    9  (  9) -0.053156633750092  0.091069486685611  0.087550589369359 -0.029257872540274  0.135924804171581 -0.072635818919112 -0.001672210695563 -0.447570021005955 -0.046032192367435
-   10  ( 10)  0.217391745861597 -0.434935321818996 -0.409624285133968 -0.322087632703751 -0.032771616999581  0.320492051563577 -0.022523093471372  0.286105139278087  0.028763138212429
-   11  ( 11) -0.043659941201166 -0.078800676739412  0.262193973369673 -0.331520925219487  0.435752308936291  0.063676676892902  0.247088083747518 -0.001843639279205 -0.140239374636342
-   12  ( 12)  0.056061677925681 -0.010922368476032 -0.131982397268853 -0.097477385521921 -0.065023592624631  0.000079901840696 -0.216859084997238  0.136693191532889 -0.129330891363361
-   13  ( 13)  0.037505625217839  0.225932746100622 -0.091672875965964 -0.251961099655879 -0.015143667161303 -0.284372812983916  0.108288291225116 -0.003814786573758  0.367489612278402
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222389083699479 -0.015701847872491  0.082266344272818  0.001672372375017 -0.060404378510596  0.093615396274298
-    1  (  1)  0.559861410768401 -0.123417067860221 -0.153694454214599  0.170286503198903  0.081015909094690 -0.084027887041359
-    2  (  2) -0.169381986858395 -0.033504697868342  0.408858223550610 -0.223464971359780 -0.074967373568669  0.314521774767947
-    3  (  3) -0.116774114128462 -0.019779952941058 -0.283276175027846  0.175022332731274 -0.285114822219635 -0.036573121425863
-    4  (  4)  0.005741360693619 -0.042278482484542 -0.326192071941439 -0.429131786152031 -0.082289054899632  0.119000835266722
-    5  (  5) -0.013423516821882 -0.050360130511676  0.120578150283481  0.018831052901201 -0.153514667633313 -0.076208440200590
-    6  (  6) -0.081285465733278 -0.326426729670571 -0.215182088716426 -0.111429746637352 -0.018999981867360 -0.098876299117681
-    7  (  7)  0.155079790707964  0.099172280525285 -0.073865926904635  0.027727508963580 -0.092673813156168  0.234558008794572
-    8  (  8) -0.037083267042728  0.221065800398389  0.033616402941938 -0.500355807294861  0.749397585446660 -0.380737037092872
-    9  (  9) -0.121630550509204  0.307683459605081  0.063120656742114  0.759405905070709 -0.291159195179390  0.157029303682124
-   10  ( 10)  0.436871717108233  0.180601040070661 -0.427730677617901  0.039372181815525 -0.043027348816400 -0.570244276025105
-   11  ( 11)  0.012751187293868  0.355844753947909  0.014496438271320  0.331024552563185 -0.082393693285337 -0.048306649791118
-   12  ( 12)  0.275276941650836 -0.041042458905035  0.197286719636261  0.114170289272117  0.271015602602994 -0.185041163126162
-   13  ( 13) -0.588129593629221  0.141947366107150  0.099713722453882 -0.418536994369331  0.225811581271459  0.209432602066484
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.136332502394749 -0.095222138145572  0.020696372205148  0.093373694133048 -0.056974308142222 -0.218258098512315 -0.091558195590398 -0.045265175415099 -0.214855115358215
-    1  ( 15) -0.061137877049954 -0.202683152555044 -0.353526070367366  0.245609552328630 -0.180792151363875  0.315264721907539  0.149352343873492 -0.279119121208994 -0.106650279203797
-    2  ( 16)  0.054253456260384  0.094536229676350  0.275971725667493 -0.315900310810875  0.233299003747364 -0.315660301871661 -0.365030241871778  0.369812512976113  0.630864749455945
-    3  ( 17) -0.098600083901755  0.096469822823265 -0.277744609477382  0.023898918383951  0.044551237411584  0.121369522278835  0.010579098206465 -0.111662852316239  0.072981135122258
-    4  ( 18)  0.060921788911548 -0.171978353243574 -0.351197784899122 -0.213711518455428  0.207005180664450  0.279437354230444  0.215133444220066  0.090996522066592  0.034929647170932
-    5  ( 19)  0.161660633493130 -0.086147001578259  0.195689249382698 -0.050176283005300  0.114394522154310  0.293305044762979  0.108948153725431 -0.145670645933351  0.162820061706685
-    6  ( 20) -0.004942089875663  0.509118270553805  0.304174363151756 -0.027002468121694  0.123566788587237 -0.216329634503875 -0.190901556459585 -0.021589313504464 -0.073912134438808
-    7  ( 21)  0.046993230195692 -0.818922464708344 -0.067253581692948 -0.053433234642341 -0.227360464707534 -0.200960848773183 -0.230456752354745  0.400368266822890  0.219888380010792
-    8  ( 22) -0.008868333291472  0.070609706397600  0.201053171865247 -0.001993849783014 -0.055528515803173 -0.064226552772344  0.060945769172458  0.040893491115762 -0.040944224757385
-    9  ( 23)  0.222786038895661 -0.561633840914994  0.169748965776544  0.115017537449362 -0.005573546521783  0.012627582158638  0.079154278361276 -0.154947348010045  0.034750692696974
-   10  ( 24)  0.015630982551661  0.122733671133923  0.033084396710116  0.019083471564733  0.043061905001054  0.050187384392659  0.326689569372421 -0.099489621768347 -0.221182165068758
-   11  ( 25) -0.081015154146910  0.154577286238188 -0.407152055810610  0.281922448284786  0.325678484340217 -0.120357443687716  0.214090639253691  0.074318472872393 -0.033055834005931
-   12  ( 26) -0.003249512574472 -0.168975826063273  0.223036074940092 -0.178070767857802  0.432212639749881 -0.017831109413890  0.111890446658268 -0.031105258460500  0.501232341526329
-   13  ( 27)  0.059498482257520 -0.080037812453612  0.074838091648859  0.286196263876844  0.080953764066314  0.153280498633729  0.018263066455704  0.093491079781028 -0.750780345808096
-   14  ( 28) -0.091986801414438  0.083237402768118 -0.314203504421854  0.035798057800126 -0.118724746257427  0.076125512668229  0.098802767682634 -0.234229258446955  0.382010330057379
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054026801537010 -0.218820809975915  0.045482454896222 -0.056632819987025 -0.041796404833871
-    1  ( 15) -0.090820830473810  0.435186758518917  0.078110332208467  0.010977263097060 -0.224939947084334
-    2  ( 16) -0.088777001237116  0.410390806874956 -0.264290446122590  0.132187376060689  0.093429765679898
-    3  ( 17)  0.030434516536175  0.322721358771669  0.333859520772307  0.097565914369066  0.253669917594512
-    4  ( 18) -0.135235063679589  0.032604670655654 -0.437326454525517  0.064866560796367  0.014517281425601
-    5  ( 19)  0.073849032459231 -0.320876459277713 -0.062467936536600 -0.000278605221466  0.283338683340820
-    6  ( 20)  0.001151706101316  0.022831078108233 -0.248046023125033  0.216907811426422 -0.108111489570171
-    7  ( 21)  0.447532183210635 -0.286158140267043  0.001132096492586 -0.136654666693855  0.003521629186189
-    8  ( 22)  0.045856367104241 -0.028375498001528  0.139997600919731  0.129405058825669 -0.366807076710427
-    9  ( 23)  0.122241483842522 -0.437156690687902 -0.011610251070627 -0.275564671574127  0.586949730800332
-   10  ( 24) -0.308306411893986 -0.180824927568002 -0.356081384430245  0.040953387261227 -0.142499615106930
-   11  ( 25) -0.063084289113014  0.427546671858030 -0.014764234377538 -0.197272035106405 -0.099641021649025
-   12  ( 26) -0.762622032277512 -0.039709598418365 -0.331137446404131 -0.114150945582963  0.418558199192024
-   13  ( 27)  0.291985642881177  0.043175007677671  0.082328218789908 -0.270976982031899 -0.226037881131796
-   14  ( 28) -0.156874264256314  0.569987759510643  0.048450546712728  0.184997500776559 -0.209541353443935
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.008672268005474 -0.071816194535536  0.120572303780740 -0.008736386948533  0.090252792742144  0.086454229305773  0.046146899467462 -0.146407744632766 -0.062154271469811
-    1  (  1)  0.044530650554382 -0.342983591098757  0.233064855218190 -0.079639227294600 -0.129059897680550 -0.051256268905796  0.266059661239060 -0.043200568193505  0.014515255717698
-    2  (  2)  0.007672537139116 -0.182340760590912  0.088050318770564 -0.062838707832560 -0.192033538812169 -0.096771324380559  0.155189348182056 -0.027104280043820  0.057717481416352
-    3  (  3)  0.079454923837834  0.018724046078348 -0.188001130869982  0.049496277469554  0.189935485868638  0.187316285213201  0.212647127834877  0.116734593328088  0.223092695439610
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163722632719569  0.058660940928931 -0.036548308903601  0.075038733758198 -0.102471305627703  0.049390669973433
-    1  (  1)  0.131305501461469  0.004016373834291 -0.198208657763960 -0.065716899528052  0.202185681278344 -0.212640127812522
-    2  (  2) -0.022010926908288  0.084188438316748 -0.151883145143248  0.372685279274918 -0.062662101833962 -0.084377242507503
-    3  (  3) -0.069858345399842  0.076704087124391 -0.378053214374412 -0.165596914244603 -0.189596095473444  0.044613058561591
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.086473379523630  0.139653083392103 -0.215536578934992  0.105983968648794  0.036562785737962 -0.000489435041183  0.079768216054257  0.008070571604873  0.198804995040747
-    1  (  5) -0.142240879073995  0.240288051362283  0.124338297451208  0.149100238302081 -0.037605369870500  0.148064173456833 -0.006146293340323 -0.190577775542559  0.091735166734718
-    2  (  6) -0.312358773620771  0.263851207058737  0.167890772334593  0.304312057068126 -0.049989467903632  0.096105061756251  0.419039438444607  0.027582241523162  0.067772655900023
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.013020057289959 -0.053664053281982 -0.013498948569214  0.012511641581690 -0.053151765112829
-    1  (  5)  0.066147191246195  0.098753011039216  0.179209452625180  0.033057282019118  0.305926873948798
-    2  (  6) -0.161446014830287  0.052105091472844 -0.420025223008533  0.024344041595381  0.149807786778790
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002292052292103 -0.001327689025616 -0.000248352651822 -0.007958119616395 -0.006332326100075 -0.018602233716078 -0.068879285117606 -0.007819744108382  0.006538352080528
-    1  (  1) -0.002764164951482  0.002219747844779 -0.018293151832046  0.029668233290951 -0.039848292773046 -0.022489745012599 -0.162281988584093 -0.020804504235237  0.019083175045330
-    2  (  2)  0.011217835122942  0.011598249376099 -0.016968466001430  0.008250037510452  0.006232273271203  0.008766677291356  0.010338243291246  0.010725726663582  0.004470553150490
-    3  (  3)  0.050562851864419  0.047527304873169 -0.078707468856859  0.000484758494289  0.025585059000142  0.011993586441405  0.049963781283816 -0.008029454242804  0.026864587292977
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006805334012411  0.003000362320125  0.002228041038775  0.000013471324712  0.003129940535122 -0.001748281527537
-    1  (  1) -0.013913717596782 -0.013715090430948 -0.022806809849796 -0.002206415430011 -0.006824605289546  0.005086150284378
-    2  (  2) -0.011033408042675  0.021897939524419 -0.000684908130867 -0.006441462755861 -0.002207402072499 -0.000019160522387
-    3  (  3) -0.030996252825106 -0.007986449014412  0.024562077320803 -0.006200249162119 -0.010690383251548 -0.011486173135261
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.008068643711801 -0.010525757489217 -0.001816581937117 -0.014852647204913 -0.016446444650488  0.051123908211810 -0.105303074579272 -0.010186396385183 -0.002604742010164
-    1  (  5) -0.024807027264739  0.041872241876180  0.005357408083720 -0.028564486604492 -0.031353252400087  0.040716482303662 -0.082357809569049 -0.022204595749264  0.028676826310240
-    2  (  6)  0.057433465116018 -0.072910653400306 -0.007950207598677 -0.045866077252412 -0.051478467074871  0.066399959025154 -0.120267838044194  0.002980749702426 -0.024762093508968
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000934050050601  0.000604010149742 -0.003646663045597  0.000033137801781  0.002019175758165
-    1  (  5)  0.015497094356084  0.002871076746167 -0.025548488367169 -0.001995117147543 -0.006447008967147
-    2  (  6) -0.009288606849912 -0.006735078994323 -0.016930923349150 -0.006239987724853 -0.010309885333920
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.002227369320302  0.043818240274751 -0.042792694201834
-    1  (  1)  0.035951925322998  0.375496620144894 -0.229128772085716
-    2  (  2)  0.031465150106786  0.208897138486076 -0.045237461242765
-    3  (  3)  0.099863658462809  0.215373395444406  0.414485555399891
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.002189605326646 -0.035984212952739 -0.031631892423161 -0.100220822826744
-    1  (  5) -0.043639031048182 -0.374942416866401 -0.208923047083238 -0.216564932229395
-    2  (  6)  0.042460266706280  0.228166292733403  0.044493925974872 -0.415175515862027
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.071562418349012  0.044643481706977  0.010719216935154 -0.107277200321351  0.107632875987832  0.021972908893023  0.087547602927583 -0.002431274801360  0.013111334250454
-    1  (  1)  0.001008369172372 -0.002277471774414  0.009696290175596  0.069946425880608 -0.211098825088912 -0.144763348099231 -0.839194198113659 -0.082764265216905  0.083969085740913
-    2  (  2)  0.048015739591381  0.034141832828957  0.005384996811850 -0.362121098795589  0.166978481952055 -0.200125629587742 -0.200206168196784 -0.048085285607237  0.015203276210723
-    3  (  3) -0.099891713665449 -0.066731401112082  0.191986572239756  0.037167781463831  0.149487286569619  0.091951393356016 -0.124705204882072 -0.114478601924820 -0.084740346074761
-    4  (  4) -0.098285756319308 -0.060256061915825  0.234091228077372  0.042524175756500  0.172705200231067  0.110408395238964 -0.184820371793580 -0.074533125764680 -0.084738680257431
-    5  (  5)  0.074321577193758  0.053246631192159 -0.354250883641741  0.039006455448223  0.144970439473129  0.061654645426165 -0.045166377189249 -0.085032946258587  0.173094046414712
-    6  (  6) -0.068632137123898 -0.078233206409420  0.700315021753110 -0.207546424794390 -0.389419114790676 -0.222243315034359  0.109406552334946  0.045456034210779 -0.343861545970210
-    7  (  7)  0.021714310649791  0.016342702277335  0.098426565374129  0.004050549717199  0.006933240550943  0.079040673905138  0.378109429127298  0.122757215698559 -0.057846791014967
-    8  (  8)  0.009573943840507  0.006109547001624 -0.063930902923820  0.085654067260524 -0.069741050462179  0.032415356083110  0.211725004915126  0.046999658275536 -0.044383134381218
-    9  (  9) -0.004997225889028 -0.003637221795087 -0.021313207566750  0.021715545991438 -0.030064296136495 -0.023365724311185 -0.129019001213584 -0.016405843088409 -0.007636609284437
-   10  ( 10)  0.003358299878380  0.005153653126746  0.010163923897300  0.013149007914750 -0.036797600687866 -0.001802908184499 -0.031118321508131 -0.158323944941481 -0.001398783490941
-   11  ( 11) -0.005208493259169 -0.005568960280890  0.129295087104337 -0.009017109251971  0.009418367237833  0.064439120521238  0.026493808367378 -0.021964026481690  0.285490675127642
-   12  ( 12)  0.022911837501423 -0.014007914409696 -0.005292696989716 -0.012615780901936  0.011192989138601  0.041928856881976 -0.003030455289266  0.141645112536952 -0.005078949468415
-   13  ( 13)  0.006239037546554  0.010350872609282  0.013056167681009 -0.012419271776311 -0.009172814340136 -0.014463827270794 -0.062671831203717 -0.024810755425260  0.013232298103210
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.002821607396533 -0.008465859280820  0.005159289345680  0.009709845024265 -0.000346373782913 -0.003018233888482
-    1  (  1) -0.016525471949901 -0.036788825827130 -0.132790124932168  0.012547146970870  0.013610564122464 -0.014252087123011
-    2  (  2) -0.056507969172448  0.026681136428703  0.044485854173457 -0.008310199956635 -0.009809983442187  0.003131041163706
-    3  (  3)  0.065651101550528 -0.083995833188288  0.024123445214815 -0.011519438681452  0.005292773005652  0.009769161567339
-    4  (  4)  0.036044829938597  0.066193934069216 -0.035808070841047  0.000422817753884  0.007345671878807  0.010223551993872
-    5  (  5)  0.148904113147734 -0.109316649106822 -0.041264792150269 -0.008287145921655  0.000171232625907  0.012797852216750
-    6  (  6) -0.267748006314630 -0.203497034729309  0.004883612400303 -0.039146263280695  0.017846525773098 -0.043283889035238
-    7  (  7) -0.072387866888447  0.141337300939965 -0.132217285722503  0.021714594277698 -0.014576886695933  0.003413824005883
-    8  (  8)  0.065339690335782  0.070423798619333  0.663640860855607  0.043614551269968  0.008449185324519 -0.017636514679536
-    9  (  9)  0.053339386688333  0.015600999572867  0.295866385656840  0.007120395428458  0.021727601519868 -0.010943405927509
-   10  ( 10)  0.043780471226243 -0.395594436897359  0.177336126578030  0.145585406236130 -0.046786318842793  0.019087048140991
-   11  ( 11) -0.612581867283905 -0.015866942037506  0.053557734560298 -0.384133426307945 -0.648991977678548  0.223358395217625
-   12  ( 12)  0.089911319093164 -0.149481392645256  0.148009805956002 -0.410952060560403  0.122608060580667 -0.053525355813637
-   13  ( 13) -0.016967411584222 -0.001119769665917  0.667550447149721  0.016648914439162 -0.049071885737672  0.011595566667332
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.071379476227380 -0.001048107345874 -0.047847319632163  0.099096803223456  0.097425878686372 -0.073274835283488  0.066530976398690 -0.021907365211120 -0.009610510160406
-    1  ( 15) -0.044751454337473  0.002521207190522 -0.033954962989568  0.066720162723388  0.060297503520731 -0.053255041277315  0.078110117153983 -0.016343490661387 -0.006169185301126
-    2  ( 16) -0.011042456445560 -0.009621220621098 -0.005657518819133 -0.191392639644068 -0.233688154054541  0.353809940518162 -0.699390838431378 -0.098400280608918  0.064019946546423
-    3  ( 17)  0.107818298388925 -0.070528263413636  0.362149050189104 -0.037315109632561 -0.042452655982496 -0.038896971283720  0.207385001016399 -0.003937722541105 -0.085745973487131
-    4  ( 18) -0.108164771682442  0.211569235735825 -0.166881810314745 -0.149344513666530 -0.172912627937214 -0.144860894329907  0.389029639178511 -0.006991735156648  0.069587103616937
-    5  ( 19) -0.022034901092728  0.144639335745209  0.200195290755521 -0.092056347474794 -0.110733861294271 -0.061361632097978  0.221627156390718 -0.079027892241888 -0.032657458030366
-    6  ( 20) -0.089133637566930  0.839810294649537  0.200388109318644  0.125542312773296  0.184497876865321  0.044991942130055 -0.109396315941662 -0.378036325170406 -0.212906193050279
-    7  ( 21)  0.002196867006824  0.082899756555975  0.048115279374916  0.114723407886649  0.074445800738012  0.084900756029246 -0.045297736151835 -0.122662484012257 -0.047092811787579
-    8  ( 22) -0.013013108526046 -0.083880968781675 -0.015106010061369  0.084648698834981  0.084842145668688 -0.173118220416505  0.343867943956616  0.057834630145787  0.044463085263394
-    9  ( 23)  0.002899038827224  0.016237402203798  0.056359737364791 -0.065867727287580 -0.036357062083617 -0.148332567483149  0.266717008386610  0.072257711902870 -0.065401118589657
-   10  ( 24)  0.008453034218761  0.036792496630374 -0.026643685782358  0.084175209377106 -0.066503904171434  0.109372833173203  0.203212961501276 -0.141160482906112 -0.070506928282105
-   11  ( 25) -0.005372433858294  0.132964341260406 -0.044450916757190 -0.024049494205707  0.035746907565715  0.041241296739167 -0.004906662564596  0.132215391095914 -0.663807503452023
-   12  ( 26) -0.009743703341659 -0.012547820945935  0.008267356406185  0.011523281572029 -0.000373189232647  0.008287799895073  0.039182879439333 -0.021754582044359 -0.043605958741618
-   13  ( 27)  0.000316984988558 -0.013620382001563  0.009757290310366 -0.005224660475905 -0.007370239991754 -0.000209579654671 -0.017764427460055  0.014597770330481 -0.008463776890616
-   14  ( 28)  0.003075987620069  0.014184203488029 -0.003152602515271 -0.009779432437690 -0.010217463081165 -0.012805369803199  0.043328580726749 -0.003405373560657  0.017681393118998
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.005093177831083 -0.003391694549732  0.004782174271812 -0.022986027625481 -0.006388300989623
-    1  ( 15)  0.003655760801056 -0.005146167609244  0.005618407889967  0.014027116916428 -0.010302793578385
-    2  ( 16)  0.021370860681958 -0.010099899127123 -0.129116414547005  0.005333934325137 -0.012983600372401
-    3  ( 17) -0.021869921491230 -0.013215154242643  0.009123077510949  0.012606640556921  0.012446334486325
-    4  ( 18)  0.030272655227353  0.036864268294435 -0.009498431522863 -0.011184920276992  0.009178466867281
-    5  ( 19)  0.023458599618802  0.001801666075823 -0.064552415401924 -0.041959427003810  0.014422120327278
-    6  ( 20)  0.129459521423828  0.031271354696917 -0.026491579555366  0.003035107017297  0.062712218110468
-    7  ( 21)  0.016586408114880  0.158363845858414  0.021959943871014 -0.141641861845629  0.024817685283350
-    8  ( 22)  0.007575307701155  0.001384055242024 -0.285443271693517  0.005092655839931 -0.013202283951991
-    9  ( 23) -0.053335131127380 -0.043784781244715  0.612431255767613 -0.089944266819985  0.016910855433428
-   10  ( 24) -0.015342744071877  0.395632766534517  0.015815980082040  0.149475926737218  0.001110117846160
-   11  ( 25) -0.295833476490493 -0.177314277208158 -0.053562169532047 -0.148004503342686 -0.667549178746814
-   12  ( 26) -0.007155741332045 -0.145584854877254  0.384139934668211  0.410953720693688 -0.016648203877508
-   13  ( 27) -0.021702025353791  0.046795922259450  0.648985546330551 -0.122609080566925  0.049062461275054
-   14  ( 28)  0.010942461108182 -0.019093069660341 -0.223364865933360  0.053520934540283 -0.011602401514689
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002861849195600  0.001750118343665 -0.000194150196746  0.008574693111016  0.006010353559076  0.019458325296912  0.072285446678870  0.008447728513642 -0.006619839911905
-    1  (  1)  0.001924861668391 -0.002087363110901  0.016971855467530 -0.027235173953934  0.038093280019961  0.023104905850605  0.165692788520465  0.021219005281025 -0.019010687091109
-    2  (  2) -0.012268940248648 -0.010883087952419  0.016276306732469 -0.008309931413768 -0.005837724525099 -0.009011561998791 -0.007091651398210 -0.010639721826082 -0.003897826849990
-    3  (  3) -0.055999657987489 -0.045440477856664  0.076835806171601 -0.000960169751802 -0.024603305635074 -0.014163811775193 -0.053505119974436  0.007641653146516 -0.022495845210930
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.007010768189510 -0.003146790661101 -0.002197659213555  0.000162653889535 -0.003167919380673  0.001716454351420
-    1  (  1)  0.014102241824718  0.014333573201717  0.027759720880070  0.002387194913826  0.006827488663716 -0.005333656372041
-    2  (  2)  0.010359867010522 -0.021409066244275  0.001741696980020  0.007351305093923  0.001924339705620  0.000068941706469
-    3  (  3)  0.028959184887726  0.008194597278714 -0.026966557516044  0.006362654301925  0.010940855488235  0.011462480717190
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.007841499731725  0.011260922827034  0.003550382080370  0.014025398893426  0.016144397742124 -0.052695970359654  0.108253401254700  0.010488497388985  0.002709659180314
-    1  (  5)  0.026329524563314 -0.037825007600228 -0.006030211425349  0.027406600793118  0.031382299209950 -0.043131173483671  0.084960450738463  0.021264528915956 -0.026601463642217
-    2  (  6) -0.060083641924427  0.072478494093869  0.010248933969103  0.046258741412677  0.052269824639874 -0.069243610281519  0.126398541619941 -0.001565657218680  0.022435245739888
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000994215031647 -0.000923363442840  0.004583185686911  0.000218320240713 -0.001898840213869
-    1  (  5) -0.015124923054324 -0.001842634557062  0.029618847414201  0.001149888101607  0.006797617275229
-    2  (  6)  0.007998426054028  0.006657968933295  0.021107111486180  0.005764289634517  0.010813449750819
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440295578  0.058098623160149  0.000062770556747 -0.132305009159640 -0.206845253888039  0.090151367716481 -0.021622993201594 -0.039361663017838  0.081041759541844
-    1  (  1) -0.058446002592380  0.108172168387664  0.020491566069365  0.029038345945864 -0.075256281089896  0.197244333760811 -0.268904698800666 -0.104165934684919  0.067340388337436
-    2  (  2) -0.015395531940670  0.065975044888454  0.020693241252052  0.145278172828453  0.156811977467562  0.026190455409852 -0.072791620600653 -0.106379132149941  0.008110007387648
-    3  (  3)  0.209889648220471  0.051262205346318 -0.016792464687913 -0.095510023534375  0.095336437810915 -0.289116526954887  0.245753636284379 -0.379261907424051  0.084194488967517
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922100176 -0.024147628250431  0.039515998201656  0.082736569420113 -0.047511948424278
-    1  (  1)  0.028213287461093  0.067760885411211  0.238885785807081 -0.125969164479721  0.177609465312030
-    2  (  2)  0.077606300081110 -0.045313543916729  0.093141189396734  0.365274041996183  0.093447143795063
-    3  (  3)  0.414915648100447  0.159852566418802 -0.273568285227129 -0.034618677637946  0.200919751819537
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102681987246 -0.069778483698172  0.053388820632188  0.227201022134288 -0.199230027457294  0.049687576281256 -0.168877445270922 -0.014461225328824 -0.006078045812767
-    1  (  5)  0.058029574787106 -0.323045692563540  0.030451397472045 -0.087822399116216 -0.049669665032498 -0.052839306746919 -0.277652121541254 -0.149775076383330  0.305937155270736
-    2  (  6) -0.084055275470360  0.046073375199282  0.190725804864304 -0.087557818530462 -0.137785527514680 -0.205465571554523 -0.198777590920686 -0.118276962990448 -0.298899363373293
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985616707  0.083163093490792  0.059838819851122  0.009394325001925 -0.030439464329862  0.004211858017360
-    1  (  5)  0.056299326992319 -0.068872084539630  0.330916524068169 -0.053769676104340 -0.184435947376539 -0.103868547783986
-    2  (  6)  0.066328790174113 -0.124449756312365  0.113043685745450  0.144452726551001  0.299204372306583 -0.043729255680800
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000260799328814  0.008294549411173  0.017065509132629 -0.120823023937813
-    1  (  1) -0.008496132195738  0.000459228916484  0.070584547130300 -0.263658986380405
-    2  (  2) -0.016577243382678 -0.069994423934547  0.000663995310113  0.516189373310167
-    3  (  3)  0.119940673155352  0.260382744777091 -0.515797578549303  0.000896332895375
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000443199065137  0.381921103277014 -0.143832380212943
-    1  (  5) -0.379434119923402 -0.000485247174065  0.057931042501930
-    2  (  6)  0.142702240195831 -0.057674062630535  0.001442186168114
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000910219825462  0.057456315494167  0.021764053721958 -0.110121259160946 -0.041147685420936  0.038875238468069 -0.013658833334326  0.027740409199842  0.095876697377004
-    1  (  1) -0.055345620113473 -0.000114715855223 -0.161082100743083  0.114708095623102 -0.226148458080404  0.429581554700213 -0.364780574441808 -0.339773267999994 -0.220533775015703
-    2  (  2) -0.020999461374251  0.161288340706678  0.000052922940143  0.056734674516634  0.008992634243539  0.218257664425439 -0.249333786109915 -0.218109894036319  0.109339937450952
-    3  (  3)  0.109919099247493 -0.115822425772584 -0.056019356072116  0.000740007124151  0.462857615716207  0.122607299860807  0.103870365958941  0.116250705982649  0.000233457087431
-    4  (  4)  0.040147971327435  0.225934656776577 -0.007773114553173 -0.462818557657105 -0.000780254100804  0.292874409688809 -0.009409004834406 -0.051882583984439 -0.039822167887863
-    5  (  5) -0.036335623982806 -0.431140334321554 -0.219015877156661 -0.122742718969562 -0.292837706512844 -0.000258433770030  0.380099535262126  0.122521034811976  0.042311772881298
-    6  (  6)  0.010512439729451  0.366117333062846  0.249486244286841 -0.103549874288531  0.008542366045705 -0.379118456110851 -0.000620782720873  0.110534560804533 -0.061985573678083
-    7  (  7) -0.028794952109144  0.339121669903044  0.216809050553033 -0.114099992926570  0.053090461678186 -0.122152835713476 -0.109887843536853 -0.000210775947309 -0.084672807581202
-    8  (  8) -0.095808229432329  0.221323464446135 -0.109106314769919 -0.000875257370226  0.038544677458879 -0.040538328330232  0.059775641070054  0.084700205529952  0.000410389282629
-    9  (  9)  0.014690106677676 -0.105287842105419 -0.107275604589342  0.218821764495376  0.309676781793525 -0.105240911833305 -0.129641828300340  0.117997785258370  0.042511311165967
-   10  ( 10) -0.029204608723917  0.107752356942562 -0.099755035690676  0.053525818789624  0.138310129135290  0.190113742094553 -0.089997971717103 -0.050367402099573 -0.205935350521398
-   11  ( 11) -0.155172680877926  0.443695988924904 -0.328777258004313 -0.218798389165188 -0.215176387418517  0.086665175787649 -0.081418632262697 -0.042686048369212  0.076994698914289
-   12  ( 12)  0.047142387853016  0.056370877736755 -0.091886939960935  0.290638653896334 -0.241910293173795 -0.247337059600416  0.042831064612679  0.092379405814653 -0.274155000199424
-   13  ( 13) -0.050389463609625  0.050328281605153 -0.290240848550854  0.162056910685561  0.213783629816238 -0.103688021030834 -0.033887129791453 -0.045587144670831  0.299790508083899
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015162318835378  0.029089770357077  0.157702855053245 -0.046156695205794  0.051381788523401
-    1  (  1)  0.106899842384160 -0.107201619393601 -0.445393414611343 -0.057067667076039 -0.050060002330133
-    2  (  2)  0.108853020442019  0.100191021225089  0.328545989364509  0.092698579065235  0.291502735972872
-    3  (  3) -0.218857915462394 -0.054792818652366  0.218936510995734 -0.287400527011265 -0.163296274870058
-    4  (  4) -0.309023998295357 -0.137542450097200  0.215093937212832  0.238284970616127 -0.213551426913738
-    5  (  5)  0.105674820499688 -0.189857437866345 -0.086867271133608  0.246374813737064  0.103858683965504
-    6  (  6)  0.128168668073169  0.089874262606371  0.081958190146060 -0.043636026349126  0.033207564087096
-    7  (  7) -0.118048268068595  0.049676493985730  0.043691990049327 -0.088880391954538  0.045560836827754
-    8  (  8) -0.043185963892521  0.206226573094588 -0.075243165625009  0.272590964413989 -0.299131513393744
-    9  (  9) -0.000077812655806  0.416515228460327  0.033604308335513 -1.079153036114418  0.144875292314574
-   10  ( 10) -0.417421688626605 -0.000158782170528 -0.288840596251926 -0.322135886975336 -0.291543524616041
-   11  ( 11) -0.033233098401296  0.288689216188738  0.000098607034113  0.357467165068052 -0.110234432421322
-   12  ( 12)  1.082588808808366  0.322578291119115 -0.357464370574866 -0.000001008980927 -0.002433258977456
-   13  ( 13) -0.144961978494652  0.291352746558436  0.110198259093452  0.002466771759163  0.000072101852768
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000153758293573  0.016209319744983  0.024928923087972 -0.062060534269405 -0.021458157317334  0.118593249827295 -0.004670228348363 -0.089096780060312  0.035341471454486
-    1  ( 15) -0.019055649311341  0.000070156580396  0.073747917872717 -0.220440654642185  0.117173683557053 -0.070042104700274 -0.194626599435631  0.297284852411648 -0.000292615006130
-    2  ( 16) -0.022586057176061 -0.073725573702120 -0.001109122528867 -0.015411803572941 -0.086529842282525 -0.104871288135925 -0.398741646254535 -0.436619148290803  0.174927780236032
-    3  ( 17)  0.059798965758570  0.223563288101711  0.017237453196908  0.001072539320884  0.251308090709605 -0.316070038507959  0.194803920922688  0.070654458314154 -0.376473484057802
-    4  ( 18)  0.020063419795573 -0.119039349150294  0.086800563385573 -0.251653936247919 -0.000335080469717  0.043024304110374  0.031731211566238  0.166597040990208  0.162561044012722
-    5  ( 19) -0.121124499928881  0.070386001406864  0.107113060109827  0.315446439196993 -0.043168772404524 -0.000861182223329  0.084799444582179  0.176705933397061 -0.191684805310528
-    6  ( 20)  0.000233561008252  0.194646689316488  0.399810731697972 -0.193912344319211 -0.032510952628099 -0.085522667102850  0.000316477106834  0.483153682293504 -0.288298405946303
-    7  ( 21)  0.086715012726146 -0.297226361723507  0.437406682983154 -0.070307665225876 -0.166617940082316 -0.177260527666885 -0.482840792819482 -0.000014363839073  0.098144550640997
-    8  ( 22) -0.034848855945224  0.000859202259418 -0.174080336964064  0.374333295775790 -0.160768014871922  0.191629536743281  0.289445575908438 -0.097019024591293 -0.000025631290485
-    9  ( 23) -0.146128458942654  0.053492838881233  0.324237370292126  0.062951581954808  0.055209150473504  0.064149761290883  0.152989513529253  0.139473999144980 -0.103718919883348
-   10  ( 24)  0.228943772976322 -0.607904766640644 -0.190620042117683 -0.232958068537229 -0.097307404470545  0.308161168755027 -0.021743402371769  0.163623966375628  0.316399909838170
-   11  ( 25) -0.113574180426266 -0.174427793656612  0.418995996828982  0.308337203800434 -0.075443225323578  0.339087150964693 -0.159463644137134 -0.028413073180430 -0.098871219189354
-   12  ( 26) -0.037424667616197 -0.021650461850134  0.117304488625228 -0.051902638546729  0.180454397108215  0.010740660434746  0.081519307880048 -0.155893098296170  0.070546741469611
-   13  ( 27)  0.017280095018033 -0.067254948221378  0.031223412816175 -0.363810241814661  0.387221887080941  0.012090141341438  0.015814975926527  0.054980917611015 -0.199339784775612
-   14  ( 28)  0.034098865585284  0.073619427458161 -0.020485113735762 -0.085856422394852  0.016811589946857 -0.112843996657195 -0.014113720389586  0.178007823037396  0.110352388623858
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147079246017605 -0.230634884307448  0.118016008570358  0.038157144686245 -0.016510467338390 -0.035555014319301
-    1  ( 15) -0.054535975317160  0.607948558454318  0.173873444004683  0.021413077698393  0.066607275071670 -0.073358775740227
-    2  ( 16) -0.323553306767810  0.191880318072800 -0.420431580468539 -0.118056258288723 -0.032680374421701  0.021063792747363
-    3  ( 17) -0.062647993315218  0.233296910361178 -0.309972235789264  0.052767888005775  0.365466873290423  0.086191647934482
-    4  ( 18) -0.056463254704659  0.097267542243260  0.076718792069295 -0.181006281549198 -0.388581954764126 -0.017033117994916
-    5  ( 19) -0.064619380121905 -0.308870128962105 -0.338018874162144 -0.010262168050506 -0.011437556312376  0.112357516914852
-    6  ( 20) -0.155382617184205  0.021349499009466  0.159407311408361 -0.081840985858683 -0.016551112467373  0.014159445477374
-    7  ( 21) -0.140537868334591 -0.163950016196429  0.028635642754641  0.155664270507489 -0.055628199109166 -0.178154241019464
-    8  ( 22)  0.103340924054087 -0.315438553689221  0.098505861498584 -0.070640699164670  0.199194337971902 -0.110183696097256
-    9  ( 23)  0.000686334470077 -0.100169676668856 -0.098205410096924  0.175395135170107 -0.218110756020923  0.228152281870970
-   10  ( 24)  0.099945574878784 -0.000096874526586  0.318471840137312 -0.225312238992057 -0.500004280228380 -0.463864297020155
-   11  ( 25)  0.099841601913638 -0.317761699333726 -0.000010561932173  0.325597818789670 -0.211905875369382 -0.064803783290132
-   12  ( 26) -0.174935630019299  0.225292248892597 -0.325705390203938 -0.000017197211890 -0.212072627171769  0.098012445882972
-   13  ( 27)  0.218628597680076  0.499556536377707  0.211864150062139  0.212027765026480  0.000008829396513 -0.140826209090944
-   14  ( 28) -0.228628348725032  0.463533897278190  0.064881803503368 -0.097950839624484  0.140879063665638 -0.000044304487925
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019783286607667 -0.054735513570492  0.001137513326844  0.126035313344694  0.202288256463714 -0.093711193698784  0.024984211933465  0.040225532534290 -0.083002910266348
-    1  (  1)  0.062354141555506 -0.120130295665511 -0.021767958766603 -0.030544877233675  0.074729404058403 -0.202914227757890  0.283260340106330  0.110010623472489 -0.075144553745797
-    2  (  2)  0.020071775922308 -0.073560405733831 -0.021169788457012 -0.145854094152842 -0.150911679145940 -0.033300463325012  0.073764757277366  0.114546085452080 -0.006653298048327
-    3  (  3) -0.203743032315313 -0.061501990395663  0.012053005442539  0.096810293782688 -0.111136074331669  0.295383183213123 -0.262971263743015  0.383085482761273 -0.093214800317935
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009993046060541  0.025513386759873 -0.042737152868896 -0.089318313022720  0.047451575644814
-    1  (  1) -0.030039490492705 -0.071945228341214 -0.250267584824113  0.142236309251859 -0.184637049012501
-    2  (  2) -0.082997800684343  0.054871780927271 -0.094796177478387 -0.401103665959789 -0.092927167756829
-    3  (  3) -0.430981237850907 -0.170811683530718  0.282618326899226  0.039486331856936 -0.208093563870180
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.010424637780811  0.070076242850132 -0.057204660728363 -0.211582689187883  0.193468115886375 -0.043909115910882  0.178375291391116  0.011291008522235  0.006135050327905
-    1  (  5) -0.063097235172986  0.334472528658100 -0.025536895021054  0.078253605984607  0.050626848674631  0.056751427025114  0.294768359886251  0.157483235119348 -0.310569420199796
-    2  (  6)  0.095244047527648 -0.044264155264159 -0.212560989845075  0.091390111204814  0.149038964321561  0.211765484927062  0.210419447669955  0.121083324679766  0.309642082152002
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068004772690589 -0.092578616035472 -0.065573414522003 -0.010233554080849  0.030163257483495 -0.003064448267094
-    1  (  5) -0.053600125816554  0.069934313107806 -0.342538885093587  0.056907033818697  0.186630070751322  0.106323577696440
-    2  (  6) -0.072821378442813  0.126275995801835 -0.117600527323037 -0.149377060250910 -0.309029921894478  0.046031658506232
-
 	Computing Mu_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.739010919382
-	   1         4.520929235738    2.276e-01
-	   2         5.121031229034    1.173e-01
-	   3         5.125308592358    2.402e-02
-	   4         5.132374421008    8.468e-03
-	   5         5.132793521432    2.443e-03
-	   6         5.132769979287    6.524e-04
-	   7         5.132850835814    2.565e-04
-	   8         5.132818230978    8.508e-05
-	   9         5.132812334554    3.206e-05
-	  10         5.132812816336    1.509e-05
-	  11         5.132814012586    4.967e-06
-	  12         5.132813587177    1.133e-06
-	  13         5.132813234078    2.887e-07
+	   0         3.739010908273
+	   1         4.520929219571    2.276e-01
+	   2         5.121031206027    1.173e-01
+	   3         5.125308569024    2.402e-02
+	   4         5.132374397538    8.468e-03
+	   5         5.132793497927    2.443e-03
+	   6         5.132769955784    6.524e-04
+	   7         5.132850812309    2.565e-04
+	   8         5.132818207473    8.508e-05
+	   9         5.132812311049    3.206e-05
+	  10         5.132812792831    1.509e-05
+	  11         5.132813989081    4.967e-06
+	  12         5.132813563673    1.133e-06
+	  13         5.132813210573    2.887e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 8.588e-08
 
 	Computing L_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.722946400558
-	   1         6.024122767537    3.513e-01
-	   2         7.454815312554    2.240e-01
-	   3         7.559107537364    6.642e-02
-	   4         7.624871320211    3.104e-02
-	   5         7.630515678881    1.259e-02
-	   6         7.633403635289    6.792e-03
-	   7         7.635513615316    3.225e-03
-	   8         7.635283923804    1.560e-03
-	   9         7.635375833194    5.610e-04
-	  10         7.635406760022    2.124e-04
-	  11         7.635450078813    7.327e-05
-	  12         7.635443176363    3.166e-05
-	  13         7.635435024908    1.108e-05
-	  14         7.635434026851    4.264e-06
-	  15         7.635433579332    1.783e-06
-	  16         7.635432943776    8.406e-07
-	  17         7.635432202106    3.938e-07
-	  18         7.635431837898    1.939e-07
-	  19         7.635431725077    1.127e-07
+	   0         4.722946376174
+	   1         6.024122738367    3.513e-01
+	   2         7.454815277547    2.240e-01
+	   3         7.559107501008    6.642e-02
+	   4         7.624871283075    3.104e-02
+	   5         7.630515641321    1.259e-02
+	   6         7.633403597512    6.792e-03
+	   7         7.635513577426    3.225e-03
+	   8         7.635283885907    1.560e-03
+	   9         7.635375795302    5.610e-04
+	  10         7.635406722129    2.124e-04
+	  11         7.635450040919    7.327e-05
+	  12         7.635443138469    3.166e-05
+	  13         7.635434987014    1.108e-05
+	  14         7.635433988957    4.264e-06
+	  15         7.635433541438    1.783e-06
+	  16         7.635432905882    8.406e-07
+	  17         7.635432164213    3.938e-07
+	  18         7.635431800004    1.939e-07
+	  19         7.635431687183    1.127e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.622e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.645398620022
-	   1         9.659808152696    4.018e-01
-	   2        11.615005914989    2.129e-01
-	   3        11.637193813275    3.626e-02
-	   4        11.663908789547    1.720e-02
-	   5        11.667179881679    4.385e-03
-	   6        11.666781408871    1.367e-03
-	   7        11.667034443218    5.965e-04
-	   8        11.667047499289    2.546e-04
-	   9        11.666987756875    8.151e-05
-	  10        11.666995899536    2.124e-05
-	  11        11.667011882211    7.018e-06
-	  12        11.667019858820    1.616e-06
-	  13        11.667020023130    4.656e-07
-	  14        11.667019579616    2.114e-07
+	   0         7.645398549495
+	   1         9.659808058898    4.018e-01
+	   2        11.615005783945    2.129e-01
+	   3        11.637193680028    3.626e-02
+	   4        11.663908655420    1.720e-02
+	   5        11.667179747364    4.385e-03
+	   6        11.666781274576    1.367e-03
+	   7        11.667034308905    5.965e-04
+	   8        11.667047364975    2.546e-04
+	   9        11.666987622565    8.151e-05
+	  10        11.666995765225    2.124e-05
+	  11        11.667011747899    7.018e-06
+	  12        11.667019724508    1.616e-06
+	  13        11.667019888818    4.656e-07
+	  14        11.667019445304    2.114e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.971e-08
 
 	Computing L_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.272324759103
-	   1         0.368789931001    1.006e-01
-	   2         0.487198135362    6.745e-02
-	   3         0.502195608797    2.229e-02
-	   4         0.506613283639    6.365e-03
-	   5         0.506403751608    2.193e-03
-	   6         0.506355987290    1.088e-03
-	   7         0.506501812829    6.706e-04
-	   8         0.506453404437    2.776e-04
-	   9         0.506467405616    6.190e-05
-	  10         0.506468514714    2.352e-05
-	  11         0.506467097397    7.735e-06
-	  12         0.506465181455    2.919e-06
-	  13         0.506464946784    8.567e-07
-	  14         0.506465184881    3.774e-07
-	  15         0.506465274194    1.462e-07
+	   0         0.272324755459
+	   1         0.368789925648    1.006e-01
+	   2         0.487198126753    6.745e-02
+	   3         0.502195599712    2.229e-02
+	   4         0.506613274410    6.365e-03
+	   5         0.506403742376    2.193e-03
+	   6         0.506355978058    1.088e-03
+	   7         0.506501803573    6.706e-04
+	   8         0.506453395185    2.776e-04
+	   9         0.506467396364    6.190e-05
+	  10         0.506468505462    2.352e-05
+	  11         0.506467088145    7.735e-06
+	  12         0.506465172203    2.919e-06
+	  13         0.506464937531    8.567e-07
+	  14         0.506465175629    3.774e-07
+	  15         0.506465264942    1.462e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 5.331e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.589662329918
-	   1         6.874619096155    3.050e-01
-	   2         7.928633620779    1.502e-01
-	   3         7.927595247869    2.448e-02
-	   4         7.935133159290    1.041e-02
-	   5         7.936327455526    2.530e-03
-	   6         7.936232181842    8.148e-04
-	   7         7.936306737618    3.309e-04
-	   8         7.936293515142    1.056e-04
-	   9         7.936274307357    3.199e-05
-	  10         7.936276283470    1.019e-05
-	  11         7.936280196390    3.815e-06
-	  12         7.936282307991    1.063e-06
-	  13         7.936282311571    3.664e-07
-	  14         7.936282094251    1.314e-07
+	   0         5.589662288333
+	   1         6.874619039465    3.050e-01
+	   2         7.928633545008    1.502e-01
+	   3         7.927595171869    2.448e-02
+	   4         7.935133083006    1.041e-02
+	   5         7.936327379191    2.530e-03
+	   6         7.936232105511    8.148e-04
+	   7         7.936306661285    3.309e-04
+	   8         7.936293438809    1.056e-04
+	   9         7.936274231024    3.199e-05
+	  10         7.936276207137    1.019e-05
+	  11         7.936280120058    3.815e-06
+	  12         7.936282231658    1.063e-06
+	  13         7.936282235238    3.664e-07
+	  14         7.936282017918    1.314e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.186e-08
 
 	Computing L_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.182431510872
-	   1         5.219804043197    3.102e-01
-	   2         6.347230545632    2.169e-01
-	   3         6.576926108023    9.235e-02
-	   4         6.676221690267    3.600e-02
-	   5         6.676646126208    1.323e-02
-	   6         6.679514955744    5.742e-03
-	   7         6.680633866564    2.070e-03
-	   8         6.679982733512    8.770e-04
-	   9         6.680026498080    2.992e-04
-	  10         6.680023395778    1.468e-04
-	  11         6.680011472250    6.537e-05
-	  12         6.679968184412    2.891e-05
-	  13         6.679962107707    9.692e-06
-	  14         6.679966914871    3.295e-06
-	  15         6.679969118640    1.139e-06
-	  16         6.679969807258    4.283e-07
-	  17         6.679969840736    1.324e-07
+	   0         4.182431487237
+	   1         5.219804015117    3.102e-01
+	   2         6.347230512855    2.169e-01
+	   3         6.576926073722    9.235e-02
+	   4         6.676221655443    3.600e-02
+	   5         6.676646091232    1.323e-02
+	   6         6.679514920786    5.742e-03
+	   7         6.680633831581    2.070e-03
+	   8         6.679982698511    8.770e-04
+	   9         6.680026463081    2.992e-04
+	  10         6.680023360778    1.468e-04
+	  11         6.680011437250    6.537e-05
+	  12         6.679968149412    2.891e-05
+	  13         6.679962072707    9.692e-06
+	  14         6.679966879871    3.295e-06
+	  15         6.679969083640    1.139e-06
+	  16         6.679969772258    4.283e-07
+	  17         6.679969805737    1.324e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 4.713e-08
 
 	Computing 1/2 <<Mu;L>>_(0.077) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933722  0.015024519180330 -0.027415915569926 -0.162886507397837  0.113254822182090 -0.064023650931681  0.055316304980595  0.030988679956786  0.002674429417473
-    1  (  1)  0.215473680254297  0.146951879885489 -0.277734064030085  0.062883278347907  0.148483123915976  0.181595053380792  0.367001371843723  0.003086313328535  0.095386404339389
-    2  (  2) -0.028492499167409  0.000076506520594 -0.059221747197115  0.071711487991930  0.074053260083171  0.055563200913409 -0.046720222778264  0.241063526706415  0.098194384215300
-    3  (  3) -0.132536698935214 -0.177581639220038 -0.107360746511037 -0.032262815899196  0.006088751294663  0.053657437577803 -0.241466578728668 -0.131962062699382  0.577380042604848
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927831  0.060461893794975 -0.005615477646774 -0.003888920206542  0.016113135271294 -0.008672229740058
-    1  (  1) -0.037058680758832 -0.084686071934146 -0.145302623884171 -0.027760832624294 -0.054555858489397  0.022009727182522
-    2  (  2) -0.087315818129464  0.399047483163754 -0.041723099752478 -0.020041920189952 -0.040600995633867  0.007777357868478
-    3  (  3)  0.035307803556674 -0.050920479686551  0.165550414172817 -0.068091463340310 -0.144062340529064 -0.042051983076326
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356556 -0.081063517853361  0.006129432768990  0.163964563111026  0.188951419459744 -0.080047732466249  0.074988303081884  0.007836242506549 -0.044696302205991
-    1  (  5)  0.348085979138488  0.014814724303189 -0.054134117524102 -0.070406995762182  0.073423358836430 -0.343984245233746  0.389896180591091 -0.295068043464405  0.051928952938000
-    2  (  6)  0.021691230674308 -0.340003625622928 -0.038072452179291 -0.014533847126878 -0.084733391360480 -0.004556444515519  0.201335045135150  0.349717311230199 -0.082620936463626
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932768 -0.007485730843832 -0.029474818409047  0.032209758674479  0.014108652541198
-    1  (  5)  0.209382720135366  0.066996563725019 -0.203801631001161 -0.021994746468443  0.025790645299279
-    2  (  6) -0.188199132187478 -0.086167806666971 -0.070501884768040 -0.051440727873377 -0.127552190835525
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135256936427952 -0.625840722558221  0.189152953764112
-    1  (  1) -0.199003345368290 -0.037728544846467 -0.132520495485755
-    2  (  2)  0.054832391479849  0.126830338283563 -0.064813973138962
-    3  (  3)  0.614911888994771 -0.126366054397384 -0.081969716276970
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135588281064904 -0.198280199301267  0.054865352772196  0.616466856386244
-    1  (  5) -0.625018546427486 -0.037797728443036  0.128181522571229 -0.126284878377160
-    2  (  6)  0.187313400211737 -0.129941287514713 -0.067401170507903 -0.079868689249863
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904654705038447 -0.487501531810708 -0.228989288733664  0.577066731250213 -0.193646174785151 -0.103557394991757 -0.002763438454961 -0.002521717002670 -0.093924205114663
-    1  (  1) -0.150947783743718 -0.133094859243219 -0.684508017896886  0.231703815137259 -0.050781378856692 -0.177728773246253  0.233390917593619  0.124583633127435 -0.128535104851894
-    2  (  2)  0.012551305323021 -0.025827567013436  0.172781771766395 -0.235942566464277 -0.123537066136894 -0.206303367930766 -0.122018320537678 -0.114258781226498 -0.027597706889355
-    3  (  3) -0.420664931045178  0.000231270272020 -0.019477825760908 -0.199685770844492 -0.007136872649739  0.053913463253293 -0.291371052496433  0.275369617235929  0.504870072210317
-    4  (  4) -0.444539603269803 -0.097599370289466 -0.201272452095786 -0.112154803373139 -0.168808745749079  0.009504026587737 -0.073434229339344 -0.314806815881344  0.576722941605365
-    5  (  5) -0.139185904754597  0.035403106550569 -0.250195485899929 -0.395579082865144  0.287107722232791 -0.179415180449191  0.197379951884854  0.283342209415980 -0.108348043155478
-    6  (  6) -0.129871685517428 -0.067550419610088  0.181281711489601  0.198220043794417  0.101452024103282  0.004283894850388 -0.540069944377460  0.047097617764531 -0.240100013513811
-    7  (  7) -0.134001967409457 -0.177786015227937  0.066093354439321 -0.420139999558483  0.282303467947247 -0.347511589889067 -0.074355555279622 -0.307158876945279  0.001553207015969
-    8  (  8) -0.063375553143536 -0.086930415097253  0.269823860040624  0.018758493940939  0.093244023047550  0.136825056817826  0.153826640418330 -0.031539001153955  0.057539448326199
-    9  (  9)  0.014052174262802  0.032094357332924  0.006340699519412 -0.122579073435548  0.077124463374283 -0.029957160801606  0.027113970740793  0.089338289754764 -0.000820355507439
-   10  ( 10)  0.055395761167618 -0.144588618215807  0.060408759576408 -0.048569537009262 -0.074902296486310 -0.098511130754444  0.029332110695438 -0.193865792017111  0.085017383342046
-   11  ( 11) -0.167030257809343 -0.139664345575235  0.283530253423074  0.091891536336475 -0.065839803661809 -0.024334768581110 -0.227863951306873  0.001156424000013 -0.053369630727928
-   12  ( 12) -0.032033949703816  0.367089735753367  0.116673683387299  0.049313912170209  0.015062916039851 -0.072484718896620  0.058244376751757 -0.115278436137835 -0.152926398532996
-   13  ( 13)  0.015984312806398 -0.071111738375073  0.101621776382356 -0.105958849078010  0.126694141619647 -0.065028650120473 -0.035640566810681 -0.004391274841067 -0.060055094679329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128805534604310 -0.011795734826670 -0.146692960373073 -0.059406136241753 -0.018473798015716  0.062695275021725
-    1  (  1)  0.288596068552158  0.103250502413098  0.290163518419001  0.006271627172818  0.000646355178478 -0.002163096577325
-    2  (  2) -0.124851872316921 -0.010381368501732 -0.056466489774845 -0.103372365620093 -0.082252504329980  0.048795995956760
-    3  (  3)  0.041212898278569 -0.068182265272190 -0.078432164026115  0.150307548616515  0.179510662629566  0.040218002018582
-    4  (  4)  0.222712022333468  0.063990226659608 -0.051059235174083 -0.009318639929278  0.269446728734512  0.059353222373419
-    5  (  5) -0.030203406833989 -0.174843255002292  0.092722839796391  0.028249854916050 -0.095235014058556 -0.000991383838387
-    6  (  6)  0.000094761803154 -0.095079960743173 -0.236654935643855  0.077257506718755 -0.062658502435841 -0.003579147462098
-    7  (  7) -0.071378609117900  0.113105200937282 -0.125970626242898 -0.059319553016902  0.017191793320064  0.045132807261626
-    8  (  8) -0.578011070913822 -0.096069905578471  0.034320656007075  0.008138721285755  0.200651419362850 -0.180375510922630
-    9  (  9) -0.075902771217084  0.004486710274029  0.008101295703532  0.005145165116265  0.000289827785464 -0.012192146264032
-   10  ( 10) -0.010144747737863  0.093887289987194  0.012520076511424 -0.048321113777971  0.058051870190577  0.029305003899343
-   11  ( 11) -0.079269835922185 -0.056407934156687 -0.083742200501709 -0.007977653697296  0.003415198719749 -0.009408271568785
-   12  ( 12) -0.063275611050180  0.041793376814452 -0.018940005265603 -0.031801650730441 -0.042593625401080 -0.051280864509093
-   13  ( 13)  0.241520854870219  0.060862078761145 -0.029296437788834 -0.004750900896371 -0.057204357338164  0.050359098198299
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902577471790101 -0.152994814233932  0.011940868446238 -0.420469735951606 -0.445351803972144 -0.142848111796374 -0.124602559894107 -0.133617692414479 -0.065299458730887
-    1  ( 15) -0.489189301960896 -0.131612108164584 -0.025288909698489  0.001211401602831 -0.097261943563860  0.035660096811446 -0.068846931566771 -0.178298501436217 -0.088180423881717
-    2  ( 16) -0.227827617997529 -0.682850378114893  0.173952246738550 -0.020483992991400 -0.200004527333180 -0.249321074904762  0.178969609143401  0.064626594784378  0.271714608016049
-    3  ( 17)  0.575057386639545  0.230829261967287 -0.236382682328743 -0.198529656444012 -0.112446756030160 -0.393646604056964  0.196512471195115 -0.417308417772929  0.017911249870982
-    4  ( 18) -0.193966815668284 -0.049741581832494 -0.123803326018047 -0.006759114368933 -0.167461192854180  0.285673743205736  0.102864894892838  0.279649773106956  0.092613585551367
-    5  ( 19) -0.103888340402909 -0.178666472837949 -0.207303680724541  0.054793013222011  0.008829749698437 -0.180189218695024  0.005881767836415 -0.346673619263749  0.135673181192661
-    6  ( 20) -0.005617400724262  0.235632824287364 -0.121420590502094 -0.289718560202372 -0.074621425323949  0.197136569143931 -0.541291075958390 -0.074791673502324  0.151088111942487
-    7  ( 21) -0.003477648436861  0.126185493130263 -0.114691185797939  0.273163908100164 -0.312825492602440  0.283665229878294  0.047436733181861 -0.310264889604266 -0.030965201327066
-    8  ( 22) -0.094388926763113 -0.130129267650442 -0.029533862325104  0.507284500100960  0.577428087616617 -0.108467531924833 -0.239047428592559  0.001751737689504  0.057800769417835
-    9  ( 23) -0.126681312381856  0.286563029789873 -0.124985424909591  0.042080944242163  0.222642441182942 -0.031761654185862  0.002250692027285 -0.069986298385737 -0.578241171376628
-   10  ( 24) -0.012403694982205  0.104087344759352 -0.011491899195223 -0.071458529676245  0.067846175537785 -0.174556024843144 -0.093417663431561  0.108925443196115 -0.094625153118491
-   11  ( 25) -0.145228226846074  0.289308800594077 -0.056604451501567 -0.078531469167011 -0.050901538775644  0.092556450573324 -0.236272716312904 -0.125766764843619  0.035457518122494
-   12  ( 26) -0.059274992639949  0.006488412450235 -0.103071268094578  0.150081428168228 -0.009323154225402  0.028319582293784  0.076974794119920 -0.059324199727383  0.008195435055820
-   13  ( 27) -0.018186469303715  0.001053679134700 -0.081623732601015  0.178695228145613  0.269234242250905 -0.095169442617143 -0.062998987790228  0.017097346840232  0.200778292928657
-   14  ( 28)  0.062534322058022 -0.002015210189792  0.048801137289310  0.040037948587356  0.059153802159815 -0.000976778891690 -0.003575151518202  0.045136723643297 -0.180538253756990
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015166832979202  0.055523245443861 -0.169795016453231 -0.032694007010711  0.015135554657568
-    1  ( 15)  0.032433930913447 -0.144386795244130 -0.139383558038472  0.367373211677701 -0.070777740101340
-    2  ( 16)  0.006497257681786  0.060476801934772  0.284376377240629  0.117114356398064  0.102408347319320
-    3  ( 17) -0.124715086899730 -0.049178690374442  0.092903745535273  0.049474206000848 -0.106524456538078
-    4  ( 18)  0.078147667167246 -0.074392615750257 -0.066572272669959  0.015153155253219  0.127142438959372
-    5  ( 19) -0.030012583037432 -0.098494401766441 -0.024951261153980 -0.072692839393734 -0.065509018082234
-    6  ( 20)  0.028658039508268  0.029893706465370 -0.227872682646957  0.058375213717391 -0.035317071011158
-    7  ( 21)  0.087698228581465 -0.193877542561776  0.000977855687069 -0.115255270457925 -0.004253825014343
-    8  ( 22) -0.000487339716269  0.085213745940574 -0.052874146845015 -0.152776261278858 -0.059953850619275
-    9  ( 23) -0.075363605944822 -0.010276769755622 -0.080252178607551 -0.063424914028104  0.241145188807008
-   10  ( 24)  0.001283950926939  0.093581096956637 -0.056859346555054  0.041777245375248  0.060823791108896
-   11  ( 25)  0.008356132167143  0.012479675910490 -0.083678859924604 -0.018947435212012 -0.029236284374189
-   12  ( 26)  0.005134210870859 -0.048347394079564 -0.007965979077246 -0.031780813486509 -0.004717184227605
-   13  ( 27)  0.000267583079026  0.057994430769062  0.003313390407093 -0.042646534152268 -0.057198829179600
-   14  ( 28) -0.012275122252029  0.029301677774353 -0.009473927119427 -0.051324560742064  0.050296874415886
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027985845163524  0.023014187360132 -0.021972704031550 -0.165873801926668  0.108498472423258 -0.065984445208027  0.052062590549153  0.024196903336059  0.005438903859049
-    1  (  1)  0.207753127107100  0.133586320603852 -0.248299413759929  0.051273643702392  0.137929228974577  0.172516172497646  0.338774489321057  0.007044125107960  0.086225487021978
-    2  (  2) -0.030725656049538  0.008685648887429 -0.054637639636829  0.081853822913586  0.065569345836835  0.054412511875610 -0.037702150980267  0.220880057677829  0.092517419795625
-    3  (  3) -0.146518460272185 -0.151164938887178 -0.090922259280638 -0.041550491468836  0.008256552512676  0.048975234640781 -0.222433708697271 -0.123978061818464  0.551233631040567
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.030368262613337  0.051015148860635 -0.002942978202016 -0.003356964742137  0.014802517799284 -0.008083321576794
-    1  (  1) -0.024523434755722 -0.073734688873540 -0.129066247639439 -0.024037316988320 -0.050282994530055  0.020846450280793
-    2  (  2) -0.075512350010898  0.366500451453791 -0.036592830040889 -0.016303194972460 -0.036175560248337  0.005423684503349
-    3  (  3)  0.036874256227630 -0.046039513569074  0.147486358648951 -0.060664952434382 -0.127426669479233 -0.039293702180427
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.050111098767745 -0.071439421665737  0.010360806490423  0.164982511003502  0.190752518001675 -0.070698878333088  0.064144987593348  0.009940358823804 -0.039049299317426
-    1  (  5)  0.346512350212501  0.020770988494970 -0.054063126549543 -0.066267909254760  0.061286416729942 -0.328133338026467  0.364459716199746 -0.282333058508693  0.052379135180748
-    2  (  6)  0.014820841999600 -0.308332589554773 -0.036490920160057 -0.008185142851144 -0.077220105539055  0.001985069156781  0.191861505554810  0.331452106505361 -0.064661161962335
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002710313008904 -0.006054102061478 -0.023960364540744  0.028066673595848  0.012225337247005
-    1  (  5)  0.191683957013482  0.061055761849053 -0.180315991810041 -0.020020550401249  0.020756656682088
-    2  (  6) -0.171946012527152 -0.078984789269474 -0.060019327368985 -0.045058581991741 -0.117222830082063
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102367  0.008188589712238 -0.013790999932787 -0.066013267343718 -0.002979179364402  0.115067560152143 -0.029904774000613  0.075658337330170  0.005135342269607
-    1  (  1) -0.415137332088612  0.400791789518638  0.060626653167991 -0.009777722957358  0.182694524485337  0.107591424113208 -0.071470092116898  0.210805299972917 -0.029640655301118
-    2  (  2)  0.731004204598524 -0.977674938020298  0.030910735141458  0.126476447646258  0.160297857646348 -0.115254107794114  0.017919423470245  0.019160269758161  0.056677210805993
-    3  (  3) -0.052710934455993  0.190825342618791 -0.121683764296163  0.058318753384834 -0.051331848225805  0.122833340921044  0.176985596744925 -0.321410474763126  0.015752780623231
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449213 -0.003857954296836  0.001116934481339 -0.006268480889134  0.011819863965880  0.022338641059406
-    1  (  1)  0.026581167918673 -0.003242138995826  0.002209759168116 -0.126256065331472  0.064001666171840  0.019583311633874
-    2  (  2)  0.060541607763300 -0.048685401885040 -0.005324531906368 -0.077364982992393 -0.023160042352118 -0.131997334895640
-    3  (  3)  0.086532549077842 -0.501054912835391 -0.033953281830235 -0.045954160893793  0.007588765668993  0.026055365513597
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407912 -0.003874637131510  0.017573675069989 -0.250000468336212  0.193535227171946 -0.023949830014057 -0.006344215172658 -0.002637721142605  0.025018403626550
-    1  (  5) -0.061066900138163  0.119597101102996  0.077747477731553 -0.181802110874956 -0.105212352540628 -0.191650240311689 -0.067261595147718  0.101033231559081  0.034053487252843
-    2  (  6) -0.129779125650158  0.272168473286842  0.218088904973338 -0.105590817864474  0.170044089806057 -0.413895401404384 -0.204721805057715  0.193774792721808  0.022574107317577
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304093 -0.022619515940248  0.001370551331509 -0.019480287608800 -0.016611790333306
-    1  (  5) -0.015006262168537  0.018557640744956 -0.000086080146177 -0.193359672647776  0.037991057379314
-    2  (  6)  0.020942063740398 -0.276121820896825 -0.020375408054502  0.090755244706104  0.038585932807354
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234774577907340 -0.089732279705020 -0.029281742956361
-    1  (  1)  0.629390080925054  0.562262027181648  1.005710563308147
-    2  (  2) -1.016842846984442  0.324902404629239  0.759850922288994
-    3  (  3)  0.070893719957037 -1.217739132557560  0.544721303880524
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235500971090726  0.628370240889402 -1.016044908027706  0.070845813096372
-    1  (  5) -0.089243248615735  0.558584627490131  0.332507599415180 -1.220818260487312
-    2  (  6) -0.028235811673249  1.000885266991202  0.767552789658038  0.543389712941562
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.803905357707311  0.860151305623949  0.271118555223167  0.233708148806798 -0.124148512341266 -0.010189985719979 -0.092729991992268  0.016788100393524 -0.004472139404122
-    1  (  1)  0.401013317552785 -0.256123411395810  1.725791219363352  0.228118396767626 -0.017083610861014  0.077834475735907 -0.010518533714653  0.508387054745627  0.007264375748279
-    2  (  2) -0.011434548540222 -0.088441201305154 -0.217324498232303 -0.271194503786495 -0.847646840544961 -0.636979337168603  0.167111761738664  0.613015596421828  0.118261935906470
-    3  (  3)  0.794342002638844 -0.188454328702485  0.221782475708119 -0.127238173306152  0.529725618505773 -1.234283764404522  0.503702151908138 -0.716733332201490  0.003730822870913
-    4  (  4) -0.401751095605530  0.338386780155127  0.027671797889821 -1.521964962245091  0.118534592965411  0.737791613352609  0.133068399810627  0.089420490967805  0.037476970403516
-    5  (  5) -0.062520837577632  0.401075384901201 -0.021867941133996 -0.715225023398739 -1.272095248267951  0.501721901780299 -0.443609728635242 -0.893075231648048  0.592672369741993
-    6  (  6) -0.010948759647979  0.203401403085997 -0.137048639531909 -0.113085573900653 -0.481495532073518  0.549209906368458  1.454114297098583 -0.104970888423571 -0.037484874409079
-    7  (  7)  0.128092468229021  0.321831618555177  0.165224131524797  0.036717435980679  0.490326956687596  0.556704330756835 -0.028026211847655  0.572891503259545  0.836605248949509
-    8  (  8)  0.028465864758886 -0.067177326433747 -0.261754785397495 -0.132197496012203 -0.099654097906746  0.125238705338503 -0.191161571927307  0.152439549355924 -0.345598496796334
-    9  (  9) -0.117164319402284  0.677600502185656  0.057458896318824  0.132501237674075 -0.004191340015369 -0.154828563575337 -0.038564068532644 -0.121792891458522 -0.349263289014943
-   10  ( 10) -0.181067725106296 -0.111582528205458  0.370630400902865 -0.010089018109779  0.175901282392120 -0.187388709548550 -0.018929605786239  0.507571524880377 -0.113635665926862
-   11  ( 11) -0.014437537795246  0.015226015168940  0.010134165664067 -0.005687484322489 -0.031065375239781 -0.023280669169025  0.128114396256681 -0.039417737851753 -0.110919095427042
-   12  ( 12) -0.125387244214951 -0.096520270925362  0.052418676370702  0.258253736986353  0.005758304720891  0.145179803274614  0.116533683249985 -0.074529049368730  0.022120054046506
-   13  ( 13) -0.016488000528151 -0.002368207793552 -0.087940291197149 -0.101326196004400 -0.036322133241993  0.195270868050333 -0.010169719681932  0.009700577933052 -0.056276489205959
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020656609432377  0.055454072209206  0.016498557049920 -0.100308993019535  0.100625813513966  0.085817872313959
-    1  (  1) -0.158188828440892 -0.302238781900211 -0.003254305982647  0.141295167420039 -0.086817823645988 -0.004522680615623
-    2  (  2)  0.117165454504024 -0.174443278203503 -0.011196610388147 -0.263022208165445  0.005179209446380 -0.028790206529749
-    3  (  3)  0.116979728848069 -0.002675319824407 -0.011237305263780 -0.059042081886281 -0.019813165086942  0.041020820057734
-    4  (  4)  0.050773800974292 -0.220964030765936  0.039978161841657 -0.028484730886475  0.038490445524596 -0.072488415876946
-    5  (  5) -0.020335163069148  0.163705236926197 -0.082951181907163  0.111454733440593  0.037975682191325 -0.107211881409464
-    6  (  6)  0.021278303210848  0.388606221992998  0.114903933510215  0.018782318547525  0.008939872036282 -0.015881860003982
-    7  (  7)  0.297901981281024  0.033254178443727  0.094283496173084 -0.060148927068472  0.021415208569123  0.043129019365108
-    8  (  8)  1.538151946484423  0.255389759643583 -0.163313084569292 -0.034663525935373 -0.142139339830442 -0.045757092023972
-    9  (  9)  0.091430832784144 -0.031111059625587 -0.061979966203490 -0.058675516664175  0.760855141023917  0.950655107543621
-   10  ( 10) -0.067314640632537  0.211103496431705 -0.020600002397637  1.234404704927125 -0.163782714272567  0.167558660890032
-   11  ( 11)  0.163451473737101 -0.060117653273661  1.332809431049165  0.048636523249740 -0.084741416350187  0.093758422678353
-   12  ( 12)  0.205980882962949 -1.200907557972782 -0.135489991479292  0.365850977217349 -0.094087533161484  0.008716209829183
-   13  ( 13) -0.181608420628060 -0.041944770724578  0.112411453405729  0.222931004263492  0.995147424974585 -0.917645025950541
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802215088996775  0.405760421584725 -0.010733900270896  0.784358891338122 -0.394207392965882 -0.066264169418438 -0.011728371528151  0.124097516118103  0.033513743357673
-    1  ( 15)  0.861921835284117 -0.259204458699967 -0.086550258239887 -0.179795107884808  0.329776011755083  0.399732735512309  0.202064202046553  0.330247474290177 -0.071973209379633
-    2  ( 16)  0.271441185213391  1.724486207548469 -0.218690579375801  0.222063595490460  0.027363367055485 -0.018802165875844 -0.135942286119417  0.163478817004599 -0.262387665735325
-    3  ( 17)  0.233788075721826  0.228159112392323 -0.271808517288257 -0.127676513444271 -1.519379653938277 -0.715083891079223 -0.112821347158474  0.035818562511062 -0.131766468683948
-    4  ( 18) -0.125942009127172 -0.016377869393706 -0.848482111339688  0.528657771751293  0.118745113074898 -1.271710188107035 -0.481153570999942  0.489178297010484 -0.100424350070291
-    5  ( 19) -0.011383686031449  0.078456463460941 -0.635793437126757 -1.233395635082388  0.737239370475296  0.499509899398320  0.548401749031313  0.558608158361660  0.124417124384875
-    6  ( 20) -0.091600198761770 -0.011876741058319  0.166091401418705  0.503941587465969  0.132948669117964 -0.442842250160731  1.455104693311837 -0.028341475910627 -0.190421671161177
-    7  ( 21)  0.014484668680380  0.509841880180764  0.613581819059005 -0.716630577428902  0.088564900472140 -0.892493010440163 -0.105683628158844  0.572246502497319  0.150576148757988
-    8  ( 22) -0.004174841691802  0.006707441197859  0.117679460919548  0.003167625275269  0.038325446188084  0.593620463308946 -0.036920125090448  0.835670699131347 -0.345282330703187
-    9  ( 23) -0.021563101305077 -0.156910385371061  0.117862784231017  0.115137818805332  0.052266686740979 -0.022652444633787  0.020589348904606  0.298647561105740  1.538509254803363
-   10  ( 24)  0.054696247538136 -0.300097703279750 -0.172676310394845 -0.004641896342478 -0.221287943064927  0.163661856689034  0.386962565847225  0.033092208048157  0.254762225348227
-   11  ( 25)  0.016478682999148 -0.003215291424268 -0.011157986184847 -0.011249059510507  0.039826186982321 -0.082792260839707  0.114868621990364  0.094214542109994 -0.163392531748718
-   12  ( 26) -0.099187962393071  0.141022599136927 -0.262517149368207 -0.059517894129389 -0.028614490021954  0.111532524460300  0.018579534511371 -0.059825884600083 -0.034049798717724
-   13  ( 27)  0.100178973364377 -0.086693773226363  0.005242460985690 -0.019116004377611  0.037912677180169  0.037754205119466  0.008826283068401  0.021770019636588 -0.142635094936193
-   14  ( 28)  0.086046178690242 -0.004751133686046 -0.028259740203224  0.042085140978763 -0.073608902693740 -0.107703616275598 -0.016209845373183  0.044336724946126 -0.046193144798357
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124213386192449 -0.184278545140157 -0.014644622518974 -0.126520793888936 -0.015935131079309
-    1  ( 15)  0.686886555278534 -0.109848033830421  0.015362111474085 -0.096623860958170 -0.002352924370873
-    2  ( 16)  0.057186301356343  0.372235382538515  0.010223067022666  0.052308263466605 -0.088321026996929
-    3  ( 17)  0.131851542209598 -0.011114262485829 -0.005723853800875  0.259717639216932 -0.101579897082117
-    4  ( 18) -0.005059922073798  0.176651992942668 -0.031045371067554  0.004751602541209 -0.036357227754461
-    5  ( 19) -0.153490417120552 -0.188182144826061 -0.023327004528605  0.145116229576305  0.195544967130553
-    6  ( 20) -0.038669146951691 -0.018322940249549  0.128217963501523  0.116247317068486 -0.010270205632719
-    7  ( 21) -0.121953539167482  0.508071938672096 -0.039503068949602 -0.074854789377140  0.009741351292022
-    8  ( 22) -0.349749690454153 -0.113383122522557 -0.110884130170500  0.022231095142528 -0.056430507970696
-    9  ( 23)  0.091277604676359 -0.068457429261195  0.163395065823676  0.205703107124365 -0.181427144774973
-   10  ( 24) -0.031490205855113  0.210975767808687 -0.060264671053420 -1.201247115008903 -0.041832647583344
-   11  ( 25) -0.061996899999264 -0.020492208070431  1.332807012156678 -0.135544852791734  0.112408630541359
-   12  ( 26) -0.058492216122820  1.234353822395186  0.048637099519176  0.365843792888730  0.222948291565721
-   13  ( 27)  0.761203399339422 -0.163718232424674 -0.084746898323330 -0.094131030705851  0.995190420313834
-   14  ( 28)  0.951767639345761  0.167573997453096  0.093760237560500  0.008708090964824 -0.917567337282473
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.061311180916174  0.007305734568299 -0.008052219664717 -0.075102530727564 -0.012025728300826  0.120194347984132 -0.026978429199379  0.070594185419545  0.016866098796694
-    1  (  1) -0.395437998629573  0.330196709230486  0.066130411816170 -0.001067023889988  0.191861180999614  0.113171387281916 -0.066995383271923  0.184795229028717 -0.029348228197537
-    2  (  2)  0.660966524714688 -0.861759345962241  0.033160724552169  0.127992765938447  0.170396202948104 -0.110113865477816  0.014392237869005  0.010445707783194  0.039464659932571
-    3  (  3) -0.040562495552703  0.173681994330223 -0.115433716796164  0.022385853875221 -0.029920163821990  0.106927003887640  0.164647198946454 -0.308627589591936  0.016471750534187
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.008075638079590 -0.004204267894386  0.001154899751921 -0.004302816895310  0.010300593916071  0.018583143246493
-    1  (  1)  0.022690643093880 -0.003824240162369  0.002196370237793 -0.111717598339107  0.056937031147815  0.021691580964165
-    2  (  2)  0.053339405350156 -0.044029154336949 -0.004382948251621 -0.071322882171572 -0.023334611635533 -0.125689353624520
-    3  (  3)  0.084457325104192 -0.461707512764016 -0.028403124486066 -0.043179936610554  0.008421132991555  0.024339438305143
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.015528904780166  0.000197217067411  0.014784122441979 -0.260011500898602  0.207731584784046  0.001836258201294  0.003784871531686 -0.004554790492094  0.029260236327573
-    1  (  5) -0.073737732106898  0.115839519981911  0.060966183364281 -0.191025915776738 -0.133264060723011 -0.183947109340336 -0.057101924893026  0.090583425466175  0.027097942199573
-    2  (  6) -0.138800981815769  0.257932125792776  0.172076461805675 -0.086501722972202  0.167229357348261 -0.397280885922369 -0.200441282704850  0.184212067375292  0.012201121124777
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.007496948487326 -0.019701904142718  0.001114080790245 -0.016769294212535 -0.015066280094060
-    1  (  5) -0.008011152002189  0.019463303254064 -0.001255118747011 -0.171713762805812  0.033052309738105
-    2  (  6)  0.023624103497187 -0.246377111375438 -0.017324022231723  0.084529293370869  0.033771435710698
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521810 -0.064555152855140  0.195953381503072 -0.041248493404100 -0.011229686922116 -0.030149441468397 -0.052245051042501 -0.006640144591441 -0.060816046803631
-    1  (  1)  0.618380750339701 -0.527850820452496 -0.215416501468030 -0.157035437820985 -0.069798458053192  0.063297476854260 -0.224803808806343 -0.036770088857871 -0.093292414355443
-    2  (  2)  0.089963765220208  0.016694193855681 -0.049894217028076 -0.224500363636592  0.100545586935621 -0.339808932362450 -0.300486601784935  0.103978674940069  0.003854593986182
-    3  (  3) -0.017912540893906  0.240051544179780  0.016875920141057 -0.019658112757032  0.000950481978191  0.139486307895262 -0.307526295494270 -0.245045411721381  0.038982174459018
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151717 -0.053483299255780  0.001461399819934 -0.009996127160186  0.040844890766482
-    1  (  1)  0.010356156252335  0.045196494943183  0.123149462829323 -0.009608799091533 -0.092775098416549
-    2  (  2)  0.068261626755325 -0.266621644473693  0.090983468547795 -0.007824999539039 -0.015479677414577
-    3  (  3)  0.102991688131888  0.095940846129217  0.235195882789535  0.030438278876706  0.100331913639096
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065258  0.055002400477826 -0.190701615134343 -0.008587073556960 -0.137456634337705 -0.102685174742819 -0.038575707278164  0.049077773985899  0.038775520871487
-    1  (  5)  0.266426121061182  0.201904502527541 -0.404472747743455  0.112355452346296  0.244543383067954  0.203488255110552  0.093346083766350  0.046662175778563  0.162564534078684
-    2  (  6)  0.310200495971188  0.275860886663906 -0.334362481171667  0.111323203428020  0.107269573508102 -0.015396505983542 -0.485347827861579 -0.115211810541093 -0.189399381355345
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661090 -0.010182782856367  0.015536223735827  0.027148068637773  0.019304531582392 -0.012170541889266
-    1  (  5) -0.076359104752422  0.072719944885937 -0.105706045053709 -0.076791075572627 -0.095250630872874  0.044053081318693
-    2  (  6) -0.023401555368525 -0.060789750773992  0.233844071164900 -0.060200608258470 -0.022972229731698  0.078966373846361
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134471189810092 -0.662148890372047 -0.267935016272650 -0.078917516466181
-    1  (  1) -0.664666296417858 -0.209284545759600  0.147471348275627  0.068908444059693
-    2  (  2) -0.267133357861078  0.148425589757628  0.187317601361827  0.001813043081997
-    3  (  3) -0.077770523166389  0.066603013397195  0.004062962607311  0.013912155247960
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274832594154714 -0.278242094914337 -0.671654031070884
-    1  (  5) -0.278497836106856 -0.012090613996289 -0.010590433835922
-    2  (  6) -0.670432937770643 -0.009657203375264  0.097732024172777
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959652947297446 -0.408123531987619 -0.490401240559718  0.038728625501850 -0.077955850449253 -0.487356513384779 -0.107431647026833 -0.396098723270224 -0.237559090649423
-    1  (  1) -0.405287391353834 -1.324235803795144  0.174918474964920  0.249090286909362 -0.197882092638117 -0.317613216127917 -0.251158649784065 -0.030182262258926  0.632878894780051
-    2  (  2) -0.488736302126935  0.174537834055795  0.686802536569195  0.342698519390660 -0.009978504141441  0.483630953231146  0.287674546129727  0.302838065576003 -0.272076060390986
-    3  (  3)  0.037680750791132  0.250810425630217  0.345041313376114 -0.288921950854187  0.242065062379730 -0.302245036941519 -0.510968387365602  0.184732147500300 -0.217019518876341
-    4  (  4) -0.076474970371118 -0.199548330465758 -0.011318561820522  0.242358447418328 -0.131824013162052  0.385851083614353 -0.241519487350351 -0.375192533273711  0.062578612411423
-    5  (  5) -0.485852483425266 -0.318979280528763  0.484066634013452 -0.298903807168945  0.382610997345618 -0.557142551517131  0.333197792146470  0.111813059758365  0.019832041990218
-    6  (  6) -0.104965308815928 -0.251905850413101  0.289646445983294 -0.510970311703583 -0.243416542914288  0.333477452263820 -0.859910605182056 -0.040221092410560  0.015978091027429
-    7  (  7) -0.396757752587363 -0.028569556877251  0.303650553506904  0.181375877079299 -0.373315055601480  0.109082013495532 -0.042394080422644 -0.424453142205116 -0.165367340665863
-    8  (  8) -0.232577777980881  0.628634227410956 -0.273406823912260 -0.217896152168838  0.062014351681569  0.020854775327294  0.015643896438574 -0.165522517445198 -1.139943298332195
-    9  (  9)  0.005610937642159  0.056039778145227  0.162949812700519 -0.082447741081119  0.072872155386977 -0.108705187107976 -0.023485984994573  0.044747716600193 -0.147251711508816
-   10  ( 10) -0.006823140015079  0.054329319992068 -0.040599884295365  0.341771214889488 -0.179762239296878  0.323458315510083  0.128244534494253 -0.274646157662585 -0.052523948909135
-   11  ( 11)  0.095363270787347 -0.102111548012532  0.068440604874557 -0.163728434997447 -0.155636086105072  0.243236788181447 -0.456650415997544 -0.005317873159721 -0.049821847160301
-   12  ( 12) -0.031682366540900  0.049375813516575 -0.071598146179691  0.132087989337538 -0.108611785555417  0.096654485419413  0.079499450722417 -0.086710987234524 -0.054539911364394
-   13  ( 13) -0.055056204890153  0.125842892748373 -0.045965574230317 -0.019980233406050 -0.072417713564596 -0.032557591563818 -0.014098057188424 -0.073500277920932  0.566229267173414
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807525521233 -0.007359537343921  0.096092508733764 -0.031848083816976 -0.055774198983232
-    1  (  1)  0.055013732650586  0.054716326372634 -0.101499825852225  0.049505806235113  0.126450547357477
-    2  (  2)  0.163059205506462 -0.041368872819456  0.069581455596234 -0.071597196780245 -0.045866052228085
-    3  (  3) -0.081105673439869  0.339429555892824 -0.164728153643699  0.131959969199162 -0.019695233925696
-    4  (  4)  0.071393373180112 -0.177479194335969 -0.155859184366711 -0.108539407321582 -0.072773970413827
-    5  (  5) -0.105603312078912  0.324542336417266  0.243446189575733  0.096679109403979 -0.032469296833009
-    6  (  6) -0.022598073087572  0.128545265092418 -0.457503820510282  0.079428257782213 -0.014293355829964
-    7  (  7)  0.043846313691523 -0.277398721649818 -0.005217801799309 -0.086814141836653 -0.073528025181399
-    8  (  8) -0.147650558386801 -0.051824889211656 -0.049479655499448 -0.054623458198541  0.565538504830395
-    9  (  9)  0.072040995887839  0.045487481778711  0.010267944449755  0.009607395545283  0.026537979914876
-   10  ( 10)  0.047954867962304 -0.139047713471829 -0.006984668871374 -0.101926998608402 -0.021981627690416
-   11  ( 11)  0.010232694252591 -0.006895180981132 -0.093446496400997 -0.006456318199702  0.037416385414388
-   12  ( 12)  0.009698093521025 -0.101910194048616 -0.006447087285736  0.055515253338052  0.004586695913697
-   13  ( 13)  0.026517968105571 -0.022107111741401  0.037498264993835  0.004566515568409 -0.064482567891937
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532087829692590 -0.788053685787543 -0.217638660718255  0.182558741425794  0.602280863487480 -0.200093873579573  0.029411468157287 -0.008618444683726 -0.142345995339967
-    1  ( 15) -0.793296879907851 -0.320033252713587 -0.162598975061937  0.058726797579308  0.020874324465825 -0.223415350495464  0.107419199072046 -0.353928058476850 -0.096059896297266
-    2  ( 16) -0.212771964426018 -0.165330329981933 -1.296138478501883  0.042119030626054  0.273634363153676 -0.438879796251796 -0.121813090934943  0.097180424393402 -0.140937625938142
-    3  ( 17)  0.179954420872001  0.058841120068099  0.044127193653625  0.293105599186954  0.349356888645549  0.303438248695204  0.077097855045665  0.005877107547810  0.014045104825034
-    4  ( 18)  0.599465706125478  0.022235571238169  0.273958684833300  0.351252283018589  0.210835219511268  0.044587084733166 -0.439010194116289 -0.491004374063182 -0.399383595875341
-    5  ( 19) -0.200414126422892 -0.221453681940971 -0.440132544745164  0.305750504885625  0.044859550994933 -0.117462871785049 -0.191542019031430 -0.319736101009363 -0.359370857937598
-    6  ( 20)  0.032162128490710  0.105939422470881 -0.123876353123509  0.078981740858070 -0.440632986523098 -0.189872412172292 -1.110683989274872  0.246909463066168  0.255271007146821
-    7  ( 21) -0.008289240270486 -0.354493597801953  0.096614444377338  0.006342901738698 -0.491270269306688 -0.319008747377893  0.247402781703421 -1.005041339289935  0.329310525846416
-    8  ( 22) -0.142958112237992 -0.097022080380776 -0.141105576266035  0.015162721218605 -0.401346216586595 -0.359442000824708  0.255249867089681  0.329100137017210  0.052130295704472
-    9  ( 23) -0.219989065380246 -0.250001442433259  0.576446348372414  0.098959674886800 -0.020568115056174  0.097513800211121 -0.059902955848638  0.014734527114704  0.155046520151383
-   10  ( 24) -0.078950494727199  0.108193141402953  0.027256154227325  0.046487728394439  0.091306743849428  0.113368151054255 -0.170234459022064  0.302098295161987 -0.032847707963684
-   11  ( 25)  0.043326744721135  0.032363389826812 -0.179596320201807  0.107314642639449 -0.187556761581101 -0.097228134857404 -0.510755068400788 -0.080036249796903  0.081235508165591
-   12  ( 26) -0.068197976739272  0.217296898230263  0.162613838841638  0.182156526175457 -0.078640971248232 -0.138388418075592  0.046099139294747 -0.318339562890745 -0.094298996233422
-   13  ( 27)  0.012948053174444 -0.163156717261063  0.064963474472039  0.076423090075366 -0.116362948599962 -0.057051341709586  0.002572557321622  0.275506911037167 -0.101255941405055
-   14  ( 28)  0.072512090984942  0.116063474825340 -0.039414549057152 -0.060057426555201 -0.063414940103828 -0.039930823846179 -0.007406649447407  0.061654502640363  0.127196073453639
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223472856186329 -0.079380673330417  0.044417374907374 -0.069445497218023  0.011729893427506  0.073549727582157
-    1  ( 15) -0.252084318917961  0.107740778119089  0.032072824705649  0.217703434939331 -0.162976179330690  0.115649023646982
-    2  ( 16)  0.579843117285508  0.028377214599785 -0.180834874279503  0.163175611851648  0.065411291339360 -0.039948698368928
-    3  ( 17)  0.098340901452171  0.045586420024689  0.108734472684589  0.182606429974975  0.076964420692713 -0.060236205753191
-    4  ( 18) -0.021650833253368  0.091327714075519 -0.188512569919576 -0.078662641540956 -0.116896916359804 -0.063655160224489
-    5  ( 19)  0.097171540237316  0.112970498693947 -0.096626702578479 -0.138712839413244 -0.057497371163198 -0.039673289236737
-    6  ( 20) -0.058059330793309 -0.170134824525265 -0.511529953350571  0.046149842859018  0.002603003870208 -0.007423573904069
-    7  ( 21)  0.014906052329776  0.302176683769003 -0.080527272396977 -0.318411101425731  0.275449773181718  0.061692765706429
-    8  ( 22)  0.155151887383248 -0.033185457482074  0.080998651116857 -0.094073422563741 -0.101041326065027  0.127067437701733
-    9  ( 23) -1.153509668704953 -0.223849781573310  0.084925914720570 -0.000154347639825  0.401132279504920 -0.346054713026435
-   10  ( 24) -0.223987599390505 -0.015012978211180 -0.013160266761979  0.067286208797175 -0.009874035055601 -0.084312333246363
-   11  ( 25)  0.084246135649734 -0.012978110758481 -0.099616699055155  0.005046001111317 -0.012239544431652  0.023063802197493
-   12  ( 26)  0.000203295279175  0.067424132200542  0.005012434803368  0.014687484508398 -0.012600853145572 -0.022021985836775
-   13  ( 27)  0.401487062569274 -0.009674045048257 -0.012249675488475 -0.012688275802534 -0.008212565425852  0.091176394210094
-   14  ( 28) -0.346417777877478 -0.084403131898400  0.023147564232903 -0.022062212430037  0.091088265440255  0.040127117539344
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.056215178351152 -0.054500121667396  0.201919259029640 -0.031077763909936 -0.011710544057694 -0.013075909014488 -0.042346948279412 -0.000671828437196 -0.052291650303081
-    1  (  1)  0.580185861075070 -0.459972753550963 -0.203225407919285 -0.146383812782444 -0.059047716562576  0.052226205810320 -0.210466211727551 -0.032187370830551 -0.063260161926320
-    2  (  2)  0.093393180484024  0.013367709279037 -0.072500434249941 -0.188901437279491  0.080233214984548 -0.320461373590757 -0.281774578817969  0.095754681534406  0.009993938559280
-    3  (  3) -0.011005998081791  0.212772041115702  0.010016689572689 -0.008866167178549  0.020319327817077  0.122354072622868 -0.286521492942098 -0.227705666262959  0.024617052813042
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004784997903906 -0.045646414234079  0.000336480836015 -0.008910135175809  0.037229970153597
-    1  (  1)  0.012654368872761  0.038726052908772  0.110122851111890 -0.008163616811273 -0.088473965510977
-    2  (  2)  0.059858161464052 -0.242276960674044  0.080687949967586 -0.004783380239994 -0.010585828283984
-    3  (  3)  0.093190009318185  0.087625848503461  0.210676223786748  0.029310965958952  0.092669937835962
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.095387850613253  0.063707287574100 -0.166137684328990 -0.019021592214621 -0.149973759488072 -0.101204345446005 -0.031472575013395  0.053498473418115  0.042967624605644
-    1  (  5)  0.255913374070676  0.182084005619737 -0.358054750763435  0.117938321447881  0.215767330994835  0.198255946304696  0.082288395387947  0.046112464804605  0.145174585244920
-    2  (  6)  0.310255017179614  0.238379631063291 -0.293832075513331  0.096225461668115  0.113893652343842 -0.010350380964834 -0.451016712892298 -0.111857488193420 -0.191795345079325
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.073847868868730 -0.008654741577254  0.012693286586184  0.023668684482898  0.017789448554089 -0.009288640558542
-    1  (  5) -0.053437184229602  0.073043484124087 -0.095008049379703 -0.066955824244484 -0.087649072564987  0.040223509254852
-    2  (  6) -0.005363327558409 -0.054894453058810  0.206318088063038 -0.056446188259803 -0.025451705059660  0.074272028126644
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.016118777276715 -0.076689387067912  0.125264792267216 -0.007931013310243  0.098301937535605  0.089040062536404  0.042653189503994 -0.143650549015439 -0.062698356849192
-    1  (  1)  0.038523460792185 -0.325926212074859  0.217436403108296 -0.076210929079388 -0.124956744969533 -0.049869905306291  0.256022567536762 -0.049219148025195  0.025163660677609
-    2  (  2)  0.015460259327551 -0.182364499530160  0.081021447104332 -0.065186772706263 -0.193628085224717 -0.090709199284730  0.144227288852921 -0.007154481293501  0.060483347873676
-    3  (  3)  0.069494321441892  0.016013992178318 -0.169506236224067  0.050547669997776  0.177140340538979  0.181255025833254  0.201077665225233  0.109139777586648  0.215083611892032
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.159361864611553  0.056476108299591 -0.034334354535919  0.068420323850581 -0.100698715800710  0.049820592017774
-    1  (  1)  0.121041364374110  0.003994619377137 -0.190684428167184 -0.052070114913580  0.189028662705231 -0.205096915582739
-    2  (  2) -0.013836799939816  0.073875918803127 -0.147901928532528  0.343158528114239 -0.053056478393277 -0.086736758175880
-    3  (  3) -0.065392768372835  0.072388535495376 -0.365788807268924 -0.156911353062511 -0.184439406968006  0.043117455907297
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.095080611028908  0.132974666952799 -0.233475927910159  0.109077700761849  0.033619328181732  0.003336619392394  0.079318686273405  0.006541773193158  0.188514066103895
-    1  (  5) -0.133180554197722  0.220459497770329  0.122961007604814  0.144493780528946 -0.034530325126924  0.144382538755391 -0.001565508478566 -0.179104189145763  0.084352671049966
-    2  (  6) -0.305369897772513  0.245966510909103  0.171589985467964  0.288954965589224 -0.048536799653887  0.105233271021583  0.400024803684130  0.035818012706233  0.066124321501172
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.011358647742862 -0.047842821118301 -0.011877525445924  0.012099889406653 -0.055702357687980
-    1  (  5)  0.060987538430201  0.100437160073963  0.174976176295358  0.033059202656663  0.296249624542354
-    2  (  6) -0.156959926194242  0.053853503787387 -0.406665675932448  0.026462885456157  0.143060389345547
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.020948331780215  0.037000670267279  0.105734997905917
-    1  (  1) -0.298755038289142  0.115783497652312  0.255943993115305
-    2  (  2) -0.258964229852114 -0.115813970118107 -0.442412044617565
-    3  (  3) -0.060316341789483  0.030010868082768  0.068666118917160
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019390140524655  0.299690928631304  0.261296417524431  0.060590155832357
-    1  (  5) -0.036741212649359 -0.114946374260334  0.116921045330832 -0.032705566460932
-    2  (  6) -0.104633614556808 -0.252457748482493  0.444028842624352 -0.069853026830576
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.140296000548941 -0.063793548091722  0.058836863345753 -0.099797632735300  0.059473750236872  0.159752966024087 -0.002202306295360  0.046127151478856 -0.008686217300582
-    1  (  1) -0.090587236946104 -0.202094731400236  0.091626540491885  0.096660154944673 -0.169987669208235 -0.083846972629074  0.508703907389636 -0.818627210894803  0.070854467170586
-    2  (  2)  0.023735454247632 -0.355751040292653  0.273793043205585 -0.278993695315875 -0.352285402581272  0.196481260763437  0.305054920124749 -0.066457242289417  0.201198646054354
-    3  (  3)  0.097017476571804  0.245783387728730 -0.317753409227420  0.024031108885499 -0.214358325616717 -0.049557148749413 -0.028895867231305 -0.054175105918326 -0.003063371175243
-    4  (  4) -0.057659363291957 -0.180009048378845  0.233469321765478  0.045014824473403  0.207816785622826  0.114404967029762  0.123373159567671 -0.226999771613591 -0.055473302709796
-    5  (  5) -0.215768085458356  0.315007699227405 -0.316911447049752  0.120875322919003  0.280165731589989  0.294210130176689 -0.216431927362601 -0.200720331119460 -0.064409972369138
-    6  (  6) -0.088219394313516  0.148901192549512 -0.366942172197605  0.011961263536269  0.214232535784278  0.110039106542730 -0.192575526682645 -0.231316173793134  0.059843368650861
-    7  (  7) -0.046870162228495 -0.280136788176482  0.370966800512151 -0.110896450302908  0.088815259647623 -0.146578221115441 -0.021177591015912  0.399548191737565  0.041055228430585
-    8  (  8) -0.213227988512466 -0.108113812359640  0.632322240865726  0.072819843847120  0.035043483782363  0.162903981240538 -0.072814806218845  0.219110389566894 -0.041093714767865
-    9  (  9)  0.053156633750092 -0.091069486685611 -0.087550589369359  0.029257872540274 -0.135924804171581  0.072635818919112  0.001672210695563  0.447570021005955  0.046032192367435
-   10  ( 10) -0.217391745861597  0.434935321818996  0.409624285133968  0.322087632703751  0.032771616999581 -0.320492051563577  0.022523093471372 -0.286105139278087 -0.028763138212429
-   11  ( 11)  0.043659941201166  0.078800676739412 -0.262193973369673  0.331520925219487 -0.435752308936291 -0.063676676892902 -0.247088083747518  0.001843639279205  0.140239374636342
-   12  ( 12) -0.056061677925681  0.010922368476032  0.131982397268853  0.097477385521921  0.065023592624631 -0.000079901840696  0.216859084997238 -0.136693191532889  0.129330891363361
-   13  ( 13) -0.037505625217839 -0.225932746100622  0.091672875965964  0.251961099655879  0.015143667161303  0.284372812983916 -0.108288291225116  0.003814786573758 -0.367489612278402
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222389083699479  0.015701847872491 -0.082266344272818 -0.001672372375017  0.060404378510596 -0.093615396274298
-    1  (  1) -0.559861410768401  0.123417067860221  0.153694454214599 -0.170286503198903 -0.081015909094690  0.084027887041359
-    2  (  2)  0.169381986858395  0.033504697868342 -0.408858223550610  0.223464971359780  0.074967373568669 -0.314521774767947
-    3  (  3)  0.116774114128462  0.019779952941058  0.283276175027846 -0.175022332731274  0.285114822219635  0.036573121425863
-    4  (  4) -0.005741360693619  0.042278482484542  0.326192071941439  0.429131786152031  0.082289054899632 -0.119000835266722
-    5  (  5)  0.013423516821882  0.050360130511676 -0.120578150283481 -0.018831052901201  0.153514667633313  0.076208440200590
-    6  (  6)  0.081285465733278  0.326426729670571  0.215182088716426  0.111429746637352  0.018999981867360  0.098876299117681
-    7  (  7) -0.155079790707964 -0.099172280525285  0.073865926904635 -0.027727508963580  0.092673813156168 -0.234558008794572
-    8  (  8)  0.037083267042728 -0.221065800398389 -0.033616402941938  0.500355807294861 -0.749397585446660  0.380737037092872
-    9  (  9)  0.121630550509204 -0.307683459605081 -0.063120656742114 -0.759405905070709  0.291159195179390 -0.157029303682124
-   10  ( 10) -0.436871717108233 -0.180601040070661  0.427730677617901 -0.039372181815525  0.043027348816400  0.570244276025105
-   11  ( 11) -0.012751187293868 -0.355844753947909 -0.014496438271320 -0.331024552563185  0.082393693285337  0.048306649791118
-   12  ( 12) -0.275276941650836  0.041042458905035 -0.197286719636261 -0.114170289272117 -0.271015602602994  0.185041163126162
-   13  ( 13)  0.588129593629221 -0.141947366107150 -0.099713722453882  0.418536994369331 -0.225811581271459 -0.209432602066484
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.136332502394749  0.095222138145572 -0.020696372205148 -0.093373694133048  0.056974308142222  0.218258098512315  0.091558195590398  0.045265175415099  0.214855115358215
-    1  ( 15)  0.061137877049954  0.202683152555044  0.353526070367366 -0.245609552328630  0.180792151363875 -0.315264721907539 -0.149352343873492  0.279119121208994  0.106650279203797
-    2  ( 16) -0.054253456260384 -0.094536229676350 -0.275971725667493  0.315900310810875 -0.233299003747364  0.315660301871661  0.365030241871778 -0.369812512976113 -0.630864749455945
-    3  ( 17)  0.098600083901755 -0.096469822823265  0.277744609477382 -0.023898918383951 -0.044551237411584 -0.121369522278835 -0.010579098206465  0.111662852316239 -0.072981135122258
-    4  ( 18) -0.060921788911548  0.171978353243574  0.351197784899122  0.213711518455428 -0.207005180664450 -0.279437354230444 -0.215133444220066 -0.090996522066592 -0.034929647170932
-    5  ( 19) -0.161660633493130  0.086147001578259 -0.195689249382698  0.050176283005300 -0.114394522154310 -0.293305044762979 -0.108948153725431  0.145670645933351 -0.162820061706685
-    6  ( 20)  0.004942089875663 -0.509118270553805 -0.304174363151756  0.027002468121694 -0.123566788587237  0.216329634503875  0.190901556459585  0.021589313504464  0.073912134438808
-    7  ( 21) -0.046993230195692  0.818922464708344  0.067253581692948  0.053433234642341  0.227360464707534  0.200960848773183  0.230456752354745 -0.400368266822890 -0.219888380010792
-    8  ( 22)  0.008868333291472 -0.070609706397600 -0.201053171865247  0.001993849783014  0.055528515803173  0.064226552772344 -0.060945769172458 -0.040893491115762  0.040944224757385
-    9  ( 23) -0.222786038895661  0.561633840914994 -0.169748965776544 -0.115017537449362  0.005573546521783 -0.012627582158638 -0.079154278361276  0.154947348010045 -0.034750692696974
-   10  ( 24) -0.015630982551661 -0.122733671133923 -0.033084396710116 -0.019083471564733 -0.043061905001054 -0.050187384392659 -0.326689569372421  0.099489621768347  0.221182165068758
-   11  ( 25)  0.081015154146910 -0.154577286238188  0.407152055810610 -0.281922448284786 -0.325678484340217  0.120357443687716 -0.214090639253691 -0.074318472872393  0.033055834005931
-   12  ( 26)  0.003249512574472  0.168975826063273 -0.223036074940092  0.178070767857802 -0.432212639749881  0.017831109413890 -0.111890446658268  0.031105258460500 -0.501232341526329
-   13  ( 27) -0.059498482257520  0.080037812453612 -0.074838091648859 -0.286196263876844 -0.080953764066314 -0.153280498633729 -0.018263066455704 -0.093491079781028  0.750780345808096
-   14  ( 28)  0.091986801414438 -0.083237402768118  0.314203504421854 -0.035798057800126  0.118724746257427 -0.076125512668229 -0.098802767682634  0.234229258446955 -0.382010330057379
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054026801537010  0.218820809975915 -0.045482454896222  0.056632819987025  0.041796404833871
-    1  ( 15)  0.090820830473810 -0.435186758518917 -0.078110332208467 -0.010977263097060  0.224939947084334
-    2  ( 16)  0.088777001237116 -0.410390806874956  0.264290446122590 -0.132187376060689 -0.093429765679898
-    3  ( 17) -0.030434516536175 -0.322721358771669 -0.333859520772307 -0.097565914369066 -0.253669917594512
-    4  ( 18)  0.135235063679589 -0.032604670655654  0.437326454525517 -0.064866560796367 -0.014517281425601
-    5  ( 19) -0.073849032459231  0.320876459277713  0.062467936536600  0.000278605221466 -0.283338683340820
-    6  ( 20) -0.001151706101316 -0.022831078108233  0.248046023125033 -0.216907811426422  0.108111489570171
-    7  ( 21) -0.447532183210635  0.286158140267043 -0.001132096492586  0.136654666693855 -0.003521629186189
-    8  ( 22) -0.045856367104241  0.028375498001528 -0.139997600919731 -0.129405058825669  0.366807076710427
-    9  ( 23) -0.122241483842522  0.437156690687902  0.011610251070627  0.275564671574127 -0.586949730800332
-   10  ( 24)  0.308306411893986  0.180824927568002  0.356081384430245 -0.040953387261227  0.142499615106930
-   11  ( 25)  0.063084289113014 -0.427546671858030  0.014764234377538  0.197272035106405  0.099641021649025
-   12  ( 26)  0.762622032277512  0.039709598418365  0.331137446404131  0.114150945582963 -0.418558199192024
-   13  ( 27) -0.291985642881177 -0.043175007677671 -0.082328218789908  0.270976982031899  0.226037881131796
-   14  ( 28)  0.156874264256314 -0.569987759510643 -0.048450546712728 -0.184997500776559  0.209541353443935
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.008672268005474  0.071816194535536 -0.120572303780740  0.008736386948533 -0.090252792742144 -0.086454229305773 -0.046146899467462  0.146407744632766  0.062154271469811
-    1  (  1) -0.044530650554382  0.342983591098757 -0.233064855218190  0.079639227294600  0.129059897680550  0.051256268905796 -0.266059661239060  0.043200568193505 -0.014515255717698
-    2  (  2) -0.007672537139116  0.182340760590912 -0.088050318770564  0.062838707832560  0.192033538812169  0.096771324380559 -0.155189348182056  0.027104280043820 -0.057717481416352
-    3  (  3) -0.079454923837834 -0.018724046078348  0.188001130869982 -0.049496277469554 -0.189935485868638 -0.187316285213201 -0.212647127834877 -0.116734593328088 -0.223092695439610
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.163722632719569 -0.058660940928931  0.036548308903601 -0.075038733758198  0.102471305627703 -0.049390669973433
-    1  (  1) -0.131305501461469 -0.004016373834291  0.198208657763960  0.065716899528052 -0.202185681278344  0.212640127812522
-    2  (  2)  0.022010926908288 -0.084188438316748  0.151883145143248 -0.372685279274918  0.062662101833962  0.084377242507503
-    3  (  3)  0.069858345399842 -0.076704087124391  0.378053214374412  0.165596914244603  0.189596095473444 -0.044613058561591
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.086473379523630 -0.139653083392103  0.215536578934992 -0.105983968648794 -0.036562785737962  0.000489435041183 -0.079768216054257 -0.008070571604873 -0.198804995040747
-    1  (  5)  0.142240879073995 -0.240288051362283 -0.124338297451208 -0.149100238302081  0.037605369870500 -0.148064173456833  0.006146293340323  0.190577775542559 -0.091735166734718
-    2  (  6)  0.312358773620771 -0.263851207058737 -0.167890772334593 -0.304312057068126  0.049989467903632 -0.096105061756251 -0.419039438444607 -0.027582241523162 -0.067772655900023
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.013020057289959  0.053664053281982  0.013498948569214 -0.012511641581690  0.053151765112829
-    1  (  5) -0.066147191246195 -0.098753011039216 -0.179209452625180 -0.033057282019118 -0.305926873948798
-    2  (  6)  0.161446014830287 -0.052105091472844  0.420025223008533 -0.024344041595381 -0.149807786778790
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002292052292103  0.001327689025616  0.000248352651822  0.007958119616395  0.006332326100075  0.018602233716078  0.068879285117606  0.007819744108382 -0.006538352080528
-    1  (  1)  0.002764164951482 -0.002219747844779  0.018293151832046 -0.029668233290951  0.039848292773046  0.022489745012599  0.162281988584093  0.020804504235237 -0.019083175045330
-    2  (  2) -0.011217835122942 -0.011598249376099  0.016968466001430 -0.008250037510452 -0.006232273271203 -0.008766677291356 -0.010338243291246 -0.010725726663582 -0.004470553150490
-    3  (  3) -0.050562851864419 -0.047527304873169  0.078707468856859 -0.000484758494289 -0.025585059000142 -0.011993586441405 -0.049963781283816  0.008029454242804 -0.026864587292977
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006805334012411 -0.003000362320125 -0.002228041038775 -0.000013471324712 -0.003129940535122  0.001748281527537
-    1  (  1)  0.013913717596782  0.013715090430948  0.022806809849796  0.002206415430011  0.006824605289546 -0.005086150284378
-    2  (  2)  0.011033408042675 -0.021897939524419  0.000684908130867  0.006441462755861  0.002207402072499  0.000019160522387
-    3  (  3)  0.030996252825106  0.007986449014412 -0.024562077320803  0.006200249162119  0.010690383251548  0.011486173135261
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.008068643711801  0.010525757489217  0.001816581937117  0.014852647204913  0.016446444650488 -0.051123908211810  0.105303074579272  0.010186396385183  0.002604742010164
-    1  (  5)  0.024807027264739 -0.041872241876180 -0.005357408083720  0.028564486604492  0.031353252400087 -0.040716482303662  0.082357809569049  0.022204595749264 -0.028676826310240
-    2  (  6) -0.057433465116018  0.072910653400306  0.007950207598677  0.045866077252412  0.051478467074871 -0.066399959025154  0.120267838044194 -0.002980749702426  0.024762093508968
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000934050050601 -0.000604010149742  0.003646663045597 -0.000033137801781 -0.002019175758165
-    1  (  5) -0.015497094356084 -0.002871076746167  0.025548488367169  0.001995117147543  0.006447008967147
-    2  (  6)  0.009288606849912  0.006735078994323  0.016930923349150  0.006239987724853  0.010309885333920
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.002227369320302 -0.043818240274751  0.042792694201834
-    1  (  1) -0.035951925322998 -0.375496620144894  0.229128772085716
-    2  (  2) -0.031465150106786 -0.208897138486076  0.045237461242765
-    3  (  3) -0.099863658462809 -0.215373395444406 -0.414485555399891
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.002189605326646  0.035984212952739  0.031631892423161  0.100220822826744
-    1  (  5)  0.043639031048182  0.374942416866401  0.208923047083238  0.216564932229395
-    2  (  6) -0.042460266706280 -0.228166292733403 -0.044493925974872  0.415175515862027
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.071562418349012 -0.044643481706977 -0.010719216935154  0.107277200321351 -0.107632875987832 -0.021972908893023 -0.087547602927583  0.002431274801360 -0.013111334250454
-    1  (  1) -0.001008369172372  0.002277471774414 -0.009696290175596 -0.069946425880608  0.211098825088912  0.144763348099231  0.839194198113659  0.082764265216905 -0.083969085740913
-    2  (  2) -0.048015739591381 -0.034141832828957 -0.005384996811850  0.362121098795589 -0.166978481952055  0.200125629587742  0.200206168196784  0.048085285607237 -0.015203276210723
-    3  (  3)  0.099891713665449  0.066731401112082 -0.191986572239756 -0.037167781463831 -0.149487286569619 -0.091951393356016  0.124705204882072  0.114478601924820  0.084740346074761
-    4  (  4)  0.098285756319308  0.060256061915825 -0.234091228077372 -0.042524175756500 -0.172705200231067 -0.110408395238964  0.184820371793580  0.074533125764680  0.084738680257431
-    5  (  5) -0.074321577193758 -0.053246631192159  0.354250883641741 -0.039006455448223 -0.144970439473129 -0.061654645426165  0.045166377189249  0.085032946258587 -0.173094046414712
-    6  (  6)  0.068632137123898  0.078233206409420 -0.700315021753110  0.207546424794390  0.389419114790676  0.222243315034359 -0.109406552334946 -0.045456034210779  0.343861545970210
-    7  (  7) -0.021714310649791 -0.016342702277335 -0.098426565374129 -0.004050549717199 -0.006933240550943 -0.079040673905138 -0.378109429127298 -0.122757215698559  0.057846791014967
-    8  (  8) -0.009573943840507 -0.006109547001624  0.063930902923820 -0.085654067260524  0.069741050462179 -0.032415356083110 -0.211725004915126 -0.046999658275536  0.044383134381218
-    9  (  9)  0.004997225889028  0.003637221795087  0.021313207566750 -0.021715545991438  0.030064296136495  0.023365724311185  0.129019001213584  0.016405843088409  0.007636609284437
-   10  ( 10) -0.003358299878380 -0.005153653126746 -0.010163923897300 -0.013149007914750  0.036797600687866  0.001802908184499  0.031118321508131  0.158323944941481  0.001398783490941
-   11  ( 11)  0.005208493259169  0.005568960280890 -0.129295087104337  0.009017109251971 -0.009418367237833 -0.064439120521238 -0.026493808367378  0.021964026481690 -0.285490675127642
-   12  ( 12) -0.022911837501423  0.014007914409696  0.005292696989716  0.012615780901936 -0.011192989138601 -0.041928856881976  0.003030455289266 -0.141645112536952  0.005078949468415
-   13  ( 13) -0.006239037546554 -0.010350872609282 -0.013056167681009  0.012419271776311  0.009172814340136  0.014463827270794  0.062671831203717  0.024810755425260 -0.013232298103210
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.002821607396533  0.008465859280820 -0.005159289345680 -0.009709845024265  0.000346373782913  0.003018233888482
-    1  (  1)  0.016525471949901  0.036788825827130  0.132790124932168 -0.012547146970870 -0.013610564122464  0.014252087123011
-    2  (  2)  0.056507969172448 -0.026681136428703 -0.044485854173457  0.008310199956635  0.009809983442187 -0.003131041163706
-    3  (  3) -0.065651101550528  0.083995833188288 -0.024123445214815  0.011519438681452 -0.005292773005652 -0.009769161567339
-    4  (  4) -0.036044829938597 -0.066193934069216  0.035808070841047 -0.000422817753884 -0.007345671878807 -0.010223551993872
-    5  (  5) -0.148904113147734  0.109316649106822  0.041264792150269  0.008287145921655 -0.000171232625907 -0.012797852216750
-    6  (  6)  0.267748006314630  0.203497034729309 -0.004883612400303  0.039146263280695 -0.017846525773098  0.043283889035238
-    7  (  7)  0.072387866888447 -0.141337300939965  0.132217285722503 -0.021714594277698  0.014576886695933 -0.003413824005883
-    8  (  8) -0.065339690335782 -0.070423798619333 -0.663640860855607 -0.043614551269968 -0.008449185324519  0.017636514679536
-    9  (  9) -0.053339386688333 -0.015600999572867 -0.295866385656840 -0.007120395428458 -0.021727601519868  0.010943405927509
-   10  ( 10) -0.043780471226243  0.395594436897359 -0.177336126578030 -0.145585406236130  0.046786318842793 -0.019087048140991
-   11  ( 11)  0.612581867283905  0.015866942037506 -0.053557734560298  0.384133426307945  0.648991977678548 -0.223358395217625
-   12  ( 12) -0.089911319093164  0.149481392645256 -0.148009805956002  0.410952060560403 -0.122608060580667  0.053525355813637
-   13  ( 13)  0.016967411584222  0.001119769665917 -0.667550447149721 -0.016648914439162  0.049071885737672 -0.011595566667332
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.071379476227380  0.001048107345874  0.047847319632163 -0.099096803223456 -0.097425878686372  0.073274835283488 -0.066530976398690  0.021907365211120  0.009610510160406
-    1  ( 15)  0.044751454337473 -0.002521207190522  0.033954962989568 -0.066720162723388 -0.060297503520731  0.053255041277315 -0.078110117153983  0.016343490661387  0.006169185301126
-    2  ( 16)  0.011042456445560  0.009621220621098  0.005657518819133  0.191392639644068  0.233688154054541 -0.353809940518162  0.699390838431378  0.098400280608918 -0.064019946546423
-    3  ( 17) -0.107818298388925  0.070528263413636 -0.362149050189104  0.037315109632561  0.042452655982496  0.038896971283720 -0.207385001016399  0.003937722541105  0.085745973487131
-    4  ( 18)  0.108164771682442 -0.211569235735825  0.166881810314745  0.149344513666530  0.172912627937214  0.144860894329907 -0.389029639178511  0.006991735156648 -0.069587103616937
-    5  ( 19)  0.022034901092728 -0.144639335745209 -0.200195290755521  0.092056347474794  0.110733861294271  0.061361632097978 -0.221627156390718  0.079027892241888  0.032657458030366
-    6  ( 20)  0.089133637566930 -0.839810294649537 -0.200388109318644 -0.125542312773296 -0.184497876865321 -0.044991942130055  0.109396315941662  0.378036325170406  0.212906193050279
-    7  ( 21) -0.002196867006824 -0.082899756555975 -0.048115279374916 -0.114723407886649 -0.074445800738012 -0.084900756029246  0.045297736151835  0.122662484012257  0.047092811787579
-    8  ( 22)  0.013013108526046  0.083880968781675  0.015106010061369 -0.084648698834981 -0.084842145668688  0.173118220416505 -0.343867943956616 -0.057834630145787 -0.044463085263394
-    9  ( 23) -0.002899038827224 -0.016237402203798 -0.056359737364791  0.065867727287580  0.036357062083617  0.148332567483149 -0.266717008386610 -0.072257711902870  0.065401118589657
-   10  ( 24) -0.008453034218761 -0.036792496630374  0.026643685782358 -0.084175209377106  0.066503904171434 -0.109372833173203 -0.203212961501276  0.141160482906112  0.070506928282105
-   11  ( 25)  0.005372433858294 -0.132964341260406  0.044450916757190  0.024049494205707 -0.035746907565715 -0.041241296739167  0.004906662564596 -0.132215391095914  0.663807503452023
-   12  ( 26)  0.009743703341659  0.012547820945935 -0.008267356406185 -0.011523281572029  0.000373189232647 -0.008287799895073 -0.039182879439333  0.021754582044359  0.043605958741618
-   13  ( 27) -0.000316984988558  0.013620382001563 -0.009757290310366  0.005224660475905  0.007370239991754  0.000209579654671  0.017764427460055 -0.014597770330481  0.008463776890616
-   14  ( 28) -0.003075987620069 -0.014184203488029  0.003152602515271  0.009779432437690  0.010217463081165  0.012805369803199 -0.043328580726749  0.003405373560657 -0.017681393118998
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.005093177831083  0.003391694549732 -0.004782174271812  0.022986027625481  0.006388300989623
-    1  ( 15) -0.003655760801056  0.005146167609244 -0.005618407889967 -0.014027116916428  0.010302793578385
-    2  ( 16) -0.021370860681958  0.010099899127123  0.129116414547005 -0.005333934325137  0.012983600372401
-    3  ( 17)  0.021869921491230  0.013215154242643 -0.009123077510949 -0.012606640556921 -0.012446334486325
-    4  ( 18) -0.030272655227353 -0.036864268294435  0.009498431522863  0.011184920276992 -0.009178466867281
-    5  ( 19) -0.023458599618802 -0.001801666075823  0.064552415401924  0.041959427003810 -0.014422120327278
-    6  ( 20) -0.129459521423828 -0.031271354696917  0.026491579555366 -0.003035107017297 -0.062712218110468
-    7  ( 21) -0.016586408114880 -0.158363845858414 -0.021959943871014  0.141641861845629 -0.024817685283350
-    8  ( 22) -0.007575307701155 -0.001384055242024  0.285443271693517 -0.005092655839931  0.013202283951991
-    9  ( 23)  0.053335131127380  0.043784781244715 -0.612431255767613  0.089944266819985 -0.016910855433428
-   10  ( 24)  0.015342744071877 -0.395632766534517 -0.015815980082040 -0.149475926737218 -0.001110117846160
-   11  ( 25)  0.295833476490493  0.177314277208158  0.053562169532047  0.148004503342686  0.667549178746814
-   12  ( 26)  0.007155741332045  0.145584854877254 -0.384139934668211 -0.410953720693688  0.016648203877508
-   13  ( 27)  0.021702025353791 -0.046795922259450 -0.648985546330551  0.122609080566925 -0.049062461275054
-   14  ( 28) -0.010942461108182  0.019093069660341  0.223364865933360 -0.053520934540283  0.011602401514689
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002861849195600 -0.001750118343665  0.000194150196746 -0.008574693111016 -0.006010353559076 -0.019458325296912 -0.072285446678870 -0.008447728513642  0.006619839911905
-    1  (  1) -0.001924861668391  0.002087363110901 -0.016971855467530  0.027235173953934 -0.038093280019961 -0.023104905850605 -0.165692788520465 -0.021219005281025  0.019010687091109
-    2  (  2)  0.012268940248648  0.010883087952419 -0.016276306732469  0.008309931413768  0.005837724525099  0.009011561998791  0.007091651398210  0.010639721826082  0.003897826849990
-    3  (  3)  0.055999657987489  0.045440477856664 -0.076835806171601  0.000960169751802  0.024603305635074  0.014163811775193  0.053505119974436 -0.007641653146516  0.022495845210930
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.007010768189510  0.003146790661101  0.002197659213555 -0.000162653889535  0.003167919380673 -0.001716454351420
-    1  (  1) -0.014102241824718 -0.014333573201717 -0.027759720880070 -0.002387194913826 -0.006827488663716  0.005333656372041
-    2  (  2) -0.010359867010522  0.021409066244275 -0.001741696980020 -0.007351305093923 -0.001924339705620 -0.000068941706469
-    3  (  3) -0.028959184887726 -0.008194597278714  0.026966557516044 -0.006362654301925 -0.010940855488235 -0.011462480717190
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.007841499731725 -0.011260922827034 -0.003550382080370 -0.014025398893426 -0.016144397742124  0.052695970359654 -0.108253401254700 -0.010488497388985 -0.002709659180314
-    1  (  5) -0.026329524563314  0.037825007600228  0.006030211425349 -0.027406600793118 -0.031382299209950  0.043131173483671 -0.084960450738463 -0.021264528915956  0.026601463642217
-    2  (  6)  0.060083641924427 -0.072478494093869 -0.010248933969103 -0.046258741412677 -0.052269824639874  0.069243610281519 -0.126398541619941  0.001565657218680 -0.022435245739888
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000994215031647  0.000923363442840 -0.004583185686911 -0.000218320240713  0.001898840213869
-    1  (  5)  0.015124923054324  0.001842634557062 -0.029618847414201 -0.001149888101607 -0.006797617275229
-    2  (  6) -0.007998426054028 -0.006657968933295 -0.021107111486180 -0.005764289634517 -0.010813449750819
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.022503440295578 -0.058098623160149 -0.000062770556747  0.132305009159640  0.206845253888039 -0.090151367716481  0.021622993201594  0.039361663017838 -0.081041759541844
-    1  (  1)  0.058446002592380 -0.108172168387664 -0.020491566069365 -0.029038345945864  0.075256281089896 -0.197244333760811  0.268904698800666  0.104165934684919 -0.067340388337436
-    2  (  2)  0.015395531940670 -0.065975044888454 -0.020693241252052 -0.145278172828453 -0.156811977467562 -0.026190455409852  0.072791620600653  0.106379132149941 -0.008110007387648
-    3  (  3) -0.209889648220471 -0.051262205346318  0.016792464687913  0.095510023534375 -0.095336437810915  0.289116526954887 -0.245753636284379  0.379261907424051 -0.084194488967517
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009235922100176  0.024147628250431 -0.039515998201656 -0.082736569420113  0.047511948424278
-    1  (  1) -0.028213287461093 -0.067760885411211 -0.238885785807081  0.125969164479721 -0.177609465312030
-    2  (  2) -0.077606300081110  0.045313543916729 -0.093141189396734 -0.365274041996183 -0.093447143795063
-    3  (  3) -0.414915648100447 -0.159852566418802  0.273568285227129  0.034618677637946 -0.200919751819537
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.016102681987246  0.069778483698172 -0.053388820632188 -0.227201022134288  0.199230027457294 -0.049687576281256  0.168877445270922  0.014461225328824  0.006078045812767
-    1  (  5) -0.058029574787106  0.323045692563540 -0.030451397472045  0.087822399116216  0.049669665032498  0.052839306746919  0.277652121541254  0.149775076383330 -0.305937155270736
-    2  (  6)  0.084055275470360 -0.046073375199282 -0.190725804864304  0.087557818530462  0.137785527514680  0.205465571554523  0.198777590920686  0.118276962990448  0.298899363373293
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.065173985616707 -0.083163093490792 -0.059838819851122 -0.009394325001925  0.030439464329862 -0.004211858017360
-    1  (  5) -0.056299326992319  0.068872084539630 -0.330916524068169  0.053769676104340  0.184435947376539  0.103868547783986
-    2  (  6) -0.066328790174113  0.124449756312365 -0.113043685745450 -0.144452726551001 -0.299204372306583  0.043729255680800
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.000260799328814 -0.008294549411173 -0.017065509132629  0.120823023937813
-    1  (  1)  0.008496132195738 -0.000459228916484 -0.070584547130300  0.263658986380405
-    2  (  2)  0.016577243382678  0.069994423934547 -0.000663995310113 -0.516189373310167
-    3  (  3) -0.119940673155352 -0.260382744777091  0.515797578549303 -0.000896332895375
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.000443199065137 -0.381921103277014  0.143832380212943
-    1  (  5)  0.379434119923402  0.000485247174065 -0.057931042501930
-    2  (  6) -0.142702240195831  0.057674062630535 -0.001442186168114
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000910219825462 -0.057456315494167 -0.021764053721958  0.110121259160946  0.041147685420936 -0.038875238468069  0.013658833334326 -0.027740409199842 -0.095876697377004
-    1  (  1)  0.055345620113473  0.000114715855223  0.161082100743083 -0.114708095623102  0.226148458080404 -0.429581554700213  0.364780574441808  0.339773267999994  0.220533775015703
-    2  (  2)  0.020999461374251 -0.161288340706678 -0.000052922940143 -0.056734674516634 -0.008992634243539 -0.218257664425439  0.249333786109915  0.218109894036319 -0.109339937450952
-    3  (  3) -0.109919099247493  0.115822425772584  0.056019356072116 -0.000740007124151 -0.462857615716207 -0.122607299860807 -0.103870365958941 -0.116250705982649 -0.000233457087431
-    4  (  4) -0.040147971327435 -0.225934656776577  0.007773114553173  0.462818557657105  0.000780254100804 -0.292874409688809  0.009409004834406  0.051882583984439  0.039822167887863
-    5  (  5)  0.036335623982806  0.431140334321554  0.219015877156661  0.122742718969562  0.292837706512844  0.000258433770030 -0.380099535262126 -0.122521034811976 -0.042311772881298
-    6  (  6) -0.010512439729451 -0.366117333062846 -0.249486244286841  0.103549874288531 -0.008542366045705  0.379118456110851  0.000620782720873 -0.110534560804533  0.061985573678083
-    7  (  7)  0.028794952109144 -0.339121669903044 -0.216809050553033  0.114099992926570 -0.053090461678186  0.122152835713476  0.109887843536853  0.000210775947309  0.084672807581202
-    8  (  8)  0.095808229432329 -0.221323464446135  0.109106314769919  0.000875257370226 -0.038544677458879  0.040538328330232 -0.059775641070054 -0.084700205529952 -0.000410389282629
-    9  (  9) -0.014690106677676  0.105287842105419  0.107275604589342 -0.218821764495376 -0.309676781793525  0.105240911833305  0.129641828300340 -0.117997785258370 -0.042511311165967
-   10  ( 10)  0.029204608723917 -0.107752356942562  0.099755035690676 -0.053525818789624 -0.138310129135290 -0.190113742094553  0.089997971717103  0.050367402099573  0.205935350521398
-   11  ( 11)  0.155172680877926 -0.443695988924904  0.328777258004313  0.218798389165188  0.215176387418517 -0.086665175787649  0.081418632262697  0.042686048369212 -0.076994698914289
-   12  ( 12) -0.047142387853016 -0.056370877736755  0.091886939960935 -0.290638653896334  0.241910293173795  0.247337059600416 -0.042831064612679 -0.092379405814653  0.274155000199424
-   13  ( 13)  0.050389463609625 -0.050328281605153  0.290240848550854 -0.162056910685561 -0.213783629816238  0.103688021030834  0.033887129791453  0.045587144670831 -0.299790508083899
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015162318835378 -0.029089770357077 -0.157702855053245  0.046156695205794 -0.051381788523401
-    1  (  1) -0.106899842384160  0.107201619393601  0.445393414611343  0.057067667076039  0.050060002330133
-    2  (  2) -0.108853020442019 -0.100191021225089 -0.328545989364509 -0.092698579065235 -0.291502735972872
-    3  (  3)  0.218857915462394  0.054792818652366 -0.218936510995734  0.287400527011265  0.163296274870058
-    4  (  4)  0.309023998295357  0.137542450097200 -0.215093937212832 -0.238284970616127  0.213551426913738
-    5  (  5) -0.105674820499688  0.189857437866345  0.086867271133608 -0.246374813737064 -0.103858683965504
-    6  (  6) -0.128168668073169 -0.089874262606371 -0.081958190146060  0.043636026349126 -0.033207564087096
-    7  (  7)  0.118048268068595 -0.049676493985730 -0.043691990049327  0.088880391954538 -0.045560836827754
-    8  (  8)  0.043185963892521 -0.206226573094588  0.075243165625009 -0.272590964413989  0.299131513393744
-    9  (  9)  0.000077812655806 -0.416515228460327 -0.033604308335513  1.079153036114418 -0.144875292314574
-   10  ( 10)  0.417421688626605  0.000158782170528  0.288840596251926  0.322135886975336  0.291543524616041
-   11  ( 11)  0.033233098401296 -0.288689216188738 -0.000098607034113 -0.357467165068052  0.110234432421322
-   12  ( 12) -1.082588808808366 -0.322578291119115  0.357464370574866  0.000001008980927  0.002433258977456
-   13  ( 13)  0.144961978494652 -0.291352746558436 -0.110198259093452 -0.002466771759163 -0.000072101852768
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000153758293573 -0.016209319744983 -0.024928923087972  0.062060534269405  0.021458157317334 -0.118593249827295  0.004670228348363  0.089096780060312 -0.035341471454486
-    1  ( 15)  0.019055649311341 -0.000070156580396 -0.073747917872717  0.220440654642185 -0.117173683557053  0.070042104700274  0.194626599435631 -0.297284852411648  0.000292615006130
-    2  ( 16)  0.022586057176061  0.073725573702120  0.001109122528867  0.015411803572941  0.086529842282525  0.104871288135925  0.398741646254535  0.436619148290803 -0.174927780236032
-    3  ( 17) -0.059798965758570 -0.223563288101711 -0.017237453196908 -0.001072539320884 -0.251308090709605  0.316070038507959 -0.194803920922688 -0.070654458314154  0.376473484057802
-    4  ( 18) -0.020063419795573  0.119039349150294 -0.086800563385573  0.251653936247919  0.000335080469717 -0.043024304110374 -0.031731211566238 -0.166597040990208 -0.162561044012722
-    5  ( 19)  0.121124499928881 -0.070386001406864 -0.107113060109827 -0.315446439196993  0.043168772404524  0.000861182223329 -0.084799444582179 -0.176705933397061  0.191684805310528
-    6  ( 20) -0.000233561008252 -0.194646689316488 -0.399810731697972  0.193912344319211  0.032510952628099  0.085522667102850 -0.000316477106834 -0.483153682293504  0.288298405946303
-    7  ( 21) -0.086715012726146  0.297226361723507 -0.437406682983154  0.070307665225876  0.166617940082316  0.177260527666885  0.482840792819482  0.000014363839073 -0.098144550640997
-    8  ( 22)  0.034848855945224 -0.000859202259418  0.174080336964064 -0.374333295775790  0.160768014871922 -0.191629536743281 -0.289445575908438  0.097019024591293  0.000025631290485
-    9  ( 23)  0.146128458942654 -0.053492838881233 -0.324237370292126 -0.062951581954808 -0.055209150473504 -0.064149761290883 -0.152989513529253 -0.139473999144980  0.103718919883348
-   10  ( 24) -0.228943772976322  0.607904766640644  0.190620042117683  0.232958068537229  0.097307404470545 -0.308161168755027  0.021743402371769 -0.163623966375628 -0.316399909838170
-   11  ( 25)  0.113574180426266  0.174427793656612 -0.418995996828982 -0.308337203800434  0.075443225323578 -0.339087150964693  0.159463644137134  0.028413073180430  0.098871219189354
-   12  ( 26)  0.037424667616197  0.021650461850134 -0.117304488625228  0.051902638546729 -0.180454397108215 -0.010740660434746 -0.081519307880048  0.155893098296170 -0.070546741469611
-   13  ( 27) -0.017280095018033  0.067254948221378 -0.031223412816175  0.363810241814661 -0.387221887080941 -0.012090141341438 -0.015814975926527 -0.054980917611015  0.199339784775612
-   14  ( 28) -0.034098865585284 -0.073619427458161  0.020485113735762  0.085856422394852 -0.016811589946857  0.112843996657195  0.014113720389586 -0.178007823037396 -0.110352388623858
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147079246017605  0.230634884307448 -0.118016008570358 -0.038157144686245  0.016510467338390  0.035555014319301
-    1  ( 15)  0.054535975317160 -0.607948558454318 -0.173873444004683 -0.021413077698393 -0.066607275071670  0.073358775740227
-    2  ( 16)  0.323553306767810 -0.191880318072800  0.420431580468539  0.118056258288723  0.032680374421701 -0.021063792747363
-    3  ( 17)  0.062647993315218 -0.233296910361178  0.309972235789264 -0.052767888005775 -0.365466873290423 -0.086191647934482
-    4  ( 18)  0.056463254704659 -0.097267542243260 -0.076718792069295  0.181006281549198  0.388581954764126  0.017033117994916
-    5  ( 19)  0.064619380121905  0.308870128962105  0.338018874162144  0.010262168050506  0.011437556312376 -0.112357516914852
-    6  ( 20)  0.155382617184205 -0.021349499009466 -0.159407311408361  0.081840985858683  0.016551112467373 -0.014159445477374
-    7  ( 21)  0.140537868334591  0.163950016196429 -0.028635642754641 -0.155664270507489  0.055628199109166  0.178154241019464
-    8  ( 22) -0.103340924054087  0.315438553689221 -0.098505861498584  0.070640699164670 -0.199194337971902  0.110183696097256
-    9  ( 23) -0.000686334470077  0.100169676668856  0.098205410096924 -0.175395135170107  0.218110756020923 -0.228152281870970
-   10  ( 24) -0.099945574878784  0.000096874526586 -0.318471840137312  0.225312238992057  0.500004280228380  0.463864297020155
-   11  ( 25) -0.099841601913638  0.317761699333726  0.000010561932173 -0.325597818789670  0.211905875369382  0.064803783290132
-   12  ( 26)  0.174935630019299 -0.225292248892597  0.325705390203938  0.000017197211890  0.212072627171769 -0.098012445882972
-   13  ( 27) -0.218628597680076 -0.499556536377707 -0.211864150062139 -0.212027765026480 -0.000008829396513  0.140826209090944
-   14  ( 28)  0.228628348725032 -0.463533897278190 -0.064881803503368  0.097950839624484 -0.140879063665638  0.000044304487925
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019783286607667  0.054735513570492 -0.001137513326844 -0.126035313344694 -0.202288256463714  0.093711193698784 -0.024984211933465 -0.040225532534290  0.083002910266348
-    1  (  1) -0.062354141555506  0.120130295665511  0.021767958766603  0.030544877233675 -0.074729404058403  0.202914227757890 -0.283260340106330 -0.110010623472489  0.075144553745797
-    2  (  2) -0.020071775922308  0.073560405733831  0.021169788457012  0.145854094152842  0.150911679145940  0.033300463325012 -0.073764757277366 -0.114546085452080  0.006653298048327
-    3  (  3)  0.203743032315313  0.061501990395663 -0.012053005442539 -0.096810293782688  0.111136074331669 -0.295383183213123  0.262971263743015 -0.383085482761273  0.093214800317935
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009993046060541 -0.025513386759873  0.042737152868896  0.089318313022720 -0.047451575644814
-    1  (  1)  0.030039490492705  0.071945228341214  0.250267584824113 -0.142236309251859  0.184637049012501
-    2  (  2)  0.082997800684343 -0.054871780927271  0.094796177478387  0.401103665959789  0.092927167756829
-    3  (  3)  0.430981237850907  0.170811683530718 -0.282618326899226 -0.039486331856936  0.208093563870180
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.010424637780811 -0.070076242850132  0.057204660728363  0.211582689187883 -0.193468115886375  0.043909115910882 -0.178375291391116 -0.011291008522235 -0.006135050327905
-    1  (  5)  0.063097235172986 -0.334472528658100  0.025536895021054 -0.078253605984607 -0.050626848674631 -0.056751427025114 -0.294768359886251 -0.157483235119348  0.310569420199796
-    2  (  6) -0.095244047527648  0.044264155264159  0.212560989845075 -0.091390111204814 -0.149038964321561 -0.211765484927062 -0.210419447669955 -0.121083324679766 -0.309642082152002
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.068004772690589  0.092578616035472  0.065573414522003  0.010233554080849 -0.030163257483495  0.003064448267094
-    1  (  5)  0.053600125816554 -0.069934313107806  0.342538885093587 -0.056907033818697 -0.186630070751322 -0.106323577696440
-    2  (  6)  0.072821378442813 -0.126275995801835  0.117600527323037  0.149377060250910  0.309029921894478 -0.046031658506232
-
 	Computing Mu_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.101618864838
-	   1         5.080397792918    3.006e-01
-	   2         6.075258971793    1.822e-01
-	   3         6.115748392715    5.160e-02
-	   4         6.151313996112    2.288e-02
-	   5         6.155032254645    9.186e-03
-	   6         6.155103569561    3.698e-03
-	   7         6.155774858373    1.976e-03
-	   8         6.155414265481    9.535e-04
-	   9         6.155402025550    4.865e-04
-	  10         6.155425698494    2.020e-04
-	  11         6.155414365254    5.309e-05
-	  12         6.155393975710    1.861e-05
-	  13         6.155387305686    7.113e-06
-	  14         6.155389104443    3.241e-06
-	  15         6.155391212533    1.345e-06
-	  16         6.155391849429    4.648e-07
-	  17         6.155391848479    1.848e-07
+	   0         4.101618856976
+	   1         5.080397781191    3.006e-01
+	   2         6.075258954360    1.822e-01
+	   3         6.115748374929    5.160e-02
+	   4         6.151313978276    2.288e-02
+	   5         6.155032236659    9.186e-03
+	   6         6.155103551583    3.698e-03
+	   7         6.155774840372    1.976e-03
+	   8         6.155414247480    9.535e-04
+	   9         6.155402007552    4.865e-04
+	  10         6.155425680494    2.020e-04
+	  11         6.155414347255    5.309e-05
+	  12         6.155393957711    1.861e-05
+	  13         6.155387287687    7.113e-06
+	  14         6.155389086444    3.241e-06
+	  15         6.155391194535    1.345e-06
+	  16         6.155391831430    4.648e-07
+	  17         6.155391830480    1.848e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 7.256e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.304588111405
-	   1         5.345782798937    2.666e-01
-	   2         6.209374436868    1.452e-01
-	   3         6.231670553455    3.186e-02
-	   4         6.247694756667    1.224e-02
-	   5         6.248317649342    3.720e-03
-	   6         6.248612236149    1.586e-03
-	   7         6.248889658728    5.960e-04
-	   8         6.248832366227    2.064e-04
-	   9         6.248828666637    5.649e-05
-	  10         6.248828898189    1.744e-05
-	  11         6.248832998727    4.961e-06
-	  12         6.248833649048    1.434e-06
-	  13         6.248833376716    4.342e-07
-	  14         6.248833248650    1.583e-07
+	   0         4.304588083989
+	   1         5.345782764811    2.666e-01
+	   2         6.209374393806    1.452e-01
+	   3         6.231670509381    3.186e-02
+	   4         6.247694712103    1.224e-02
+	   5         6.248317604688    3.720e-03
+	   6         6.248612191467    1.586e-03
+	   7         6.248889614032    5.960e-04
+	   8         6.248832321533    2.064e-04
+	   9         6.248828621944    5.649e-05
+	  10         6.248828853496    1.744e-05
+	  11         6.248832954034    4.961e-06
+	  12         6.248833604355    1.434e-06
+	  13         6.248833332023    4.342e-07
+	  14         6.248833203956    1.583e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 5.623e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.691521186394
-	   1        11.310618911700    5.243e-01
-	   2        14.526993318611    3.154e-01
-	   3        14.610704713062    6.752e-02
-	   4        14.705683974158    3.810e-02
-	   5        14.719950285182    1.324e-02
-	   6        14.719106438045    5.610e-03
-	   7        14.720732936609    3.343e-03
-	   8        14.721113464049    1.709e-03
-	   9        14.720711667707    5.843e-04
-	  10        14.720763513908    2.110e-04
-	  11        14.720956825423    9.982e-05
-	  12        14.721082786779    3.574e-05
-	  13        14.721069838637    1.292e-05
-	  14        14.721045580722    6.219e-06
-	  15        14.721032386159    2.974e-06
-	  16        14.721030461709    1.159e-06
-	  17        14.721030599321    3.438e-07
-	  18        14.721030540918    2.078e-07
-	  19        14.721030478419    1.106e-07
+	   0         8.691521114841
+	   1        11.310618815467    5.243e-01
+	   2        14.526993174367    3.154e-01
+	   3        14.610704563653    6.752e-02
+	   4        14.705683822630    3.810e-02
+	   5        14.719950133004    1.324e-02
+	   6        14.719106285898    5.610e-03
+	   7        14.720732784334    3.343e-03
+	   8        14.721113311746    1.709e-03
+	   9        14.720711515427    5.843e-04
+	  10        14.720763361626    2.110e-04
+	  11        14.720956673135    9.982e-05
+	  12        14.721082634486    3.574e-05
+	  13        14.721069686343    1.292e-05
+	  14        14.721045428429    6.219e-06
+	  15        14.721032233867    2.974e-06
+	  16        14.721030309417    1.159e-06
+	  17        14.721030447029    3.438e-07
+	  18        14.721030388626    2.078e-07
+	  19        14.721030326126    1.106e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 3.504e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.247473609141
-	   1         0.325008604454    7.587e-02
-	   2         0.394968129896    4.297e-02
-	   3         0.397900715940    9.986e-03
-	   4         0.398841397111    2.270e-03
-	   5         0.398756050063    5.310e-04
-	   6         0.398745958868    1.449e-04
-	   7         0.398754398416    5.621e-05
-	   8         0.398751277325    2.617e-05
-	   9         0.398752253625    8.251e-06
-	  10         0.398752447007    2.408e-06
-	  11         0.398752429608    7.049e-07
-	  12         0.398752308142    2.270e-07
+	   0         0.247473605648
+	   1         0.325008599469    7.587e-02
+	   2         0.394968122783    4.297e-02
+	   3         0.397900708685    9.986e-03
+	   4         0.398841389812    2.270e-03
+	   5         0.398756042767    5.310e-04
+	   6         0.398745951572    1.449e-04
+	   7         0.398754391119    5.621e-05
+	   8         0.398751270029    2.617e-05
+	   9         0.398752246329    8.251e-06
+	  10         0.398752439711    2.408e-06
+	  11         0.398752422312    7.049e-07
+	  12         0.398752300846    2.270e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 5.017e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.253972336487
-	   1         7.898888943880    3.989e-01
-	   2         9.620960091869    2.265e-01
-	   3         9.639820546880    4.893e-02
-	   4         9.676371348075    2.481e-02
-	   5         9.682172432848    8.187e-03
-	   6         9.681946894631    3.248e-03
-	   7         9.682407415495    1.660e-03
-	   8         9.682362688807    6.262e-04
-	   9         9.682261523028    2.144e-04
-	  10         9.682281242816    7.611e-05
-	  11         9.682312698154    3.356e-05
-	  12         9.682333307231    1.315e-05
-	  13         9.682330992934    6.023e-06
-	  14         9.682325777704    2.901e-06
-	  15         9.682322918632    1.391e-06
-	  16         9.682322703151    6.136e-07
-	  17         9.682322917604    2.665e-07
-	  18         9.682323040962    1.180e-07
+	   0         6.253972296305
+	   1         7.898888888113    3.989e-01
+	   2         9.620960012862    2.265e-01
+	   3         9.639820467435    4.893e-02
+	   4         9.676371268042    2.481e-02
+	   5         9.682172352670    8.187e-03
+	   6         9.681946814453    3.248e-03
+	   7         9.682407335305    1.660e-03
+	   8         9.682362608614    6.262e-04
+	   9         9.682261442841    2.144e-04
+	  10         9.682281162629    7.611e-05
+	  11         9.682312617966    3.356e-05
+	  12         9.682333227043    1.315e-05
+	  13         9.682330912746    6.023e-06
+	  14         9.682325697515    2.901e-06
+	  15         9.682322838443    1.391e-06
+	  16         9.682322622962    6.136e-07
+	  17         9.682322837416    2.665e-07
+	  18         9.682322960774    1.180e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.930e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.860227191252
-	   1         4.705081741617    2.330e-01
-	   2         5.385168215419    1.365e-01
-	   3         5.432836637884    4.047e-02
-	   4         5.452279953214    1.183e-02
-	   5         5.451216289877    3.137e-03
-	   6         5.451449340901    1.047e-03
-	   7         5.451588789628    3.198e-04
-	   8         5.451534694341    1.148e-04
-	   9         5.451540579044    2.980e-05
-	  10         5.451541178145    9.450e-06
-	  11         5.451541749057    3.019e-06
-	  12         5.451540944040    1.187e-06
-	  13         5.451540856253    3.992e-07
-	  14         5.451541028184    1.499e-07
+	   0         3.860227165123
+	   1         4.705081709515    2.330e-01
+	   2         5.385168175680    1.365e-01
+	   3         5.432836596356    4.047e-02
+	   4         5.452279911035    1.183e-02
+	   5         5.451216247674    3.137e-03
+	   6         5.451449298680    1.047e-03
+	   7         5.451588747398    3.198e-04
+	   8         5.451534652112    1.148e-04
+	   9         5.451540536814    2.980e-05
+	  10         5.451541135914    9.450e-06
+	  11         5.451541706826    3.019e-06
+	  12         5.451540901810    1.187e-06
+	  13         5.451540814023    3.992e-07
+	  14         5.451540985953    1.499e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 4.863e-08
 
@@ -3604,2990 +871,290 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.155734387286854    -0.064272428528526     0.000000000000000
-    1     -0.266268387193635    -0.012765731542412     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.127276956104331
+    0      0.155734386263887    -0.064272428033447     0.000000000000000
+    1     -0.266268386856247    -0.012765731183706     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.127276954213308
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.077) =  -76.93370 deg/[dm (g/cm^3)]
-
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933722  0.015024519180330 -0.027415915569926 -0.162886507397837  0.113254822182090 -0.064023650931681  0.055316304980595  0.030988679956786  0.002674429417473
-    1  (  1)  0.215473680254297  0.146951879885489 -0.277734064030085  0.062883278347907  0.148483123915976  0.181595053380792  0.367001371843723  0.003086313328535  0.095386404339389
-    2  (  2) -0.028492499167409  0.000076506520594 -0.059221747197115  0.071711487991930  0.074053260083171  0.055563200913409 -0.046720222778264  0.241063526706415  0.098194384215300
-    3  (  3) -0.132536698935214 -0.177581639220038 -0.107360746511037 -0.032262815899196  0.006088751294663  0.053657437577803 -0.241466578728668 -0.131962062699382  0.577380042604848
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927831  0.060461893794975 -0.005615477646774 -0.003888920206542  0.016113135271294 -0.008672229740058
-    1  (  1) -0.037058680758832 -0.084686071934146 -0.145302623884171 -0.027760832624294 -0.054555858489397  0.022009727182522
-    2  (  2) -0.087315818129464  0.399047483163754 -0.041723099752478 -0.020041920189952 -0.040600995633867  0.007777357868478
-    3  (  3)  0.035307803556674 -0.050920479686551  0.165550414172817 -0.068091463340310 -0.144062340529064 -0.042051983076326
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356556 -0.081063517853361  0.006129432768990  0.163964563111026  0.188951419459744 -0.080047732466249  0.074988303081884  0.007836242506549 -0.044696302205991
-    1  (  5)  0.348085979138488  0.014814724303189 -0.054134117524102 -0.070406995762182  0.073423358836430 -0.343984245233746  0.389896180591091 -0.295068043464405  0.051928952938000
-    2  (  6)  0.021691230674308 -0.340003625622928 -0.038072452179291 -0.014533847126878 -0.084733391360480 -0.004556444515519  0.201335045135150  0.349717311230199 -0.082620936463626
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932768 -0.007485730843832 -0.029474818409047  0.032209758674479  0.014108652541198
-    1  (  5)  0.209382720135366  0.066996563725019 -0.203801631001161 -0.021994746468443  0.025790645299279
-    2  (  6) -0.188199132187478 -0.086167806666971 -0.070501884768040 -0.051440727873377 -0.127552190835525
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135256936427952 -0.625840722558221  0.189152953764112
-    1  (  1) -0.199003345368290 -0.037728544846467 -0.132520495485755
-    2  (  2)  0.054832391479849  0.126830338283563 -0.064813973138962
-    3  (  3)  0.614911888994771 -0.126366054397384 -0.081969716276970
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135588281064904 -0.198280199301267  0.054865352772196  0.616466856386244
-    1  (  5) -0.625018546427486 -0.037797728443036  0.128181522571229 -0.126284878377160
-    2  (  6)  0.187313400211737 -0.129941287514713 -0.067401170507903 -0.079868689249863
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904654705038447 -0.487501531810708 -0.228989288733664  0.577066731250213 -0.193646174785151 -0.103557394991757 -0.002763438454961 -0.002521717002670 -0.093924205114663
-    1  (  1) -0.150947783743718 -0.133094859243219 -0.684508017896886  0.231703815137259 -0.050781378856692 -0.177728773246253  0.233390917593619  0.124583633127435 -0.128535104851894
-    2  (  2)  0.012551305323021 -0.025827567013436  0.172781771766395 -0.235942566464277 -0.123537066136894 -0.206303367930766 -0.122018320537678 -0.114258781226498 -0.027597706889355
-    3  (  3) -0.420664931045178  0.000231270272020 -0.019477825760908 -0.199685770844492 -0.007136872649739  0.053913463253293 -0.291371052496433  0.275369617235929  0.504870072210317
-    4  (  4) -0.444539603269803 -0.097599370289466 -0.201272452095786 -0.112154803373139 -0.168808745749079  0.009504026587737 -0.073434229339344 -0.314806815881344  0.576722941605365
-    5  (  5) -0.139185904754597  0.035403106550569 -0.250195485899929 -0.395579082865144  0.287107722232791 -0.179415180449191  0.197379951884854  0.283342209415980 -0.108348043155478
-    6  (  6) -0.129871685517428 -0.067550419610088  0.181281711489601  0.198220043794417  0.101452024103282  0.004283894850388 -0.540069944377460  0.047097617764531 -0.240100013513811
-    7  (  7) -0.134001967409457 -0.177786015227937  0.066093354439321 -0.420139999558483  0.282303467947247 -0.347511589889067 -0.074355555279622 -0.307158876945279  0.001553207015969
-    8  (  8) -0.063375553143536 -0.086930415097253  0.269823860040624  0.018758493940939  0.093244023047550  0.136825056817826  0.153826640418330 -0.031539001153955  0.057539448326199
-    9  (  9)  0.014052174262802  0.032094357332924  0.006340699519412 -0.122579073435548  0.077124463374283 -0.029957160801606  0.027113970740793  0.089338289754764 -0.000820355507439
-   10  ( 10)  0.055395761167618 -0.144588618215807  0.060408759576408 -0.048569537009262 -0.074902296486310 -0.098511130754444  0.029332110695438 -0.193865792017111  0.085017383342046
-   11  ( 11) -0.167030257809343 -0.139664345575235  0.283530253423074  0.091891536336475 -0.065839803661809 -0.024334768581110 -0.227863951306873  0.001156424000013 -0.053369630727928
-   12  ( 12) -0.032033949703816  0.367089735753367  0.116673683387299  0.049313912170209  0.015062916039851 -0.072484718896620  0.058244376751757 -0.115278436137835 -0.152926398532996
-   13  ( 13)  0.015984312806398 -0.071111738375073  0.101621776382356 -0.105958849078010  0.126694141619647 -0.065028650120473 -0.035640566810681 -0.004391274841067 -0.060055094679329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128805534604310 -0.011795734826670 -0.146692960373073 -0.059406136241753 -0.018473798015716  0.062695275021725
-    1  (  1)  0.288596068552158  0.103250502413098  0.290163518419001  0.006271627172818  0.000646355178478 -0.002163096577325
-    2  (  2) -0.124851872316921 -0.010381368501732 -0.056466489774845 -0.103372365620093 -0.082252504329980  0.048795995956760
-    3  (  3)  0.041212898278569 -0.068182265272190 -0.078432164026115  0.150307548616515  0.179510662629566  0.040218002018582
-    4  (  4)  0.222712022333468  0.063990226659608 -0.051059235174083 -0.009318639929278  0.269446728734512  0.059353222373419
-    5  (  5) -0.030203406833989 -0.174843255002292  0.092722839796391  0.028249854916050 -0.095235014058556 -0.000991383838387
-    6  (  6)  0.000094761803154 -0.095079960743173 -0.236654935643855  0.077257506718755 -0.062658502435841 -0.003579147462098
-    7  (  7) -0.071378609117900  0.113105200937282 -0.125970626242898 -0.059319553016902  0.017191793320064  0.045132807261626
-    8  (  8) -0.578011070913822 -0.096069905578471  0.034320656007075  0.008138721285755  0.200651419362850 -0.180375510922630
-    9  (  9) -0.075902771217084  0.004486710274029  0.008101295703532  0.005145165116265  0.000289827785464 -0.012192146264032
-   10  ( 10) -0.010144747737863  0.093887289987194  0.012520076511424 -0.048321113777971  0.058051870190577  0.029305003899343
-   11  ( 11) -0.079269835922185 -0.056407934156687 -0.083742200501709 -0.007977653697296  0.003415198719749 -0.009408271568785
-   12  ( 12) -0.063275611050180  0.041793376814452 -0.018940005265603 -0.031801650730441 -0.042593625401080 -0.051280864509093
-   13  ( 13)  0.241520854870219  0.060862078761145 -0.029296437788834 -0.004750900896371 -0.057204357338164  0.050359098198299
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902577471790101 -0.152994814233932  0.011940868446238 -0.420469735951606 -0.445351803972144 -0.142848111796374 -0.124602559894107 -0.133617692414479 -0.065299458730887
-    1  ( 15) -0.489189301960896 -0.131612108164584 -0.025288909698489  0.001211401602831 -0.097261943563860  0.035660096811446 -0.068846931566771 -0.178298501436217 -0.088180423881717
-    2  ( 16) -0.227827617997529 -0.682850378114893  0.173952246738550 -0.020483992991400 -0.200004527333180 -0.249321074904762  0.178969609143401  0.064626594784378  0.271714608016049
-    3  ( 17)  0.575057386639545  0.230829261967287 -0.236382682328743 -0.198529656444012 -0.112446756030160 -0.393646604056964  0.196512471195115 -0.417308417772929  0.017911249870982
-    4  ( 18) -0.193966815668284 -0.049741581832494 -0.123803326018047 -0.006759114368933 -0.167461192854180  0.285673743205736  0.102864894892838  0.279649773106956  0.092613585551367
-    5  ( 19) -0.103888340402909 -0.178666472837949 -0.207303680724541  0.054793013222011  0.008829749698437 -0.180189218695024  0.005881767836415 -0.346673619263749  0.135673181192661
-    6  ( 20) -0.005617400724262  0.235632824287364 -0.121420590502094 -0.289718560202372 -0.074621425323949  0.197136569143931 -0.541291075958390 -0.074791673502324  0.151088111942487
-    7  ( 21) -0.003477648436861  0.126185493130263 -0.114691185797939  0.273163908100164 -0.312825492602440  0.283665229878294  0.047436733181861 -0.310264889604266 -0.030965201327066
-    8  ( 22) -0.094388926763113 -0.130129267650442 -0.029533862325104  0.507284500100960  0.577428087616617 -0.108467531924833 -0.239047428592559  0.001751737689504  0.057800769417835
-    9  ( 23) -0.126681312381856  0.286563029789873 -0.124985424909591  0.042080944242163  0.222642441182942 -0.031761654185862  0.002250692027285 -0.069986298385737 -0.578241171376628
-   10  ( 24) -0.012403694982205  0.104087344759352 -0.011491899195223 -0.071458529676245  0.067846175537785 -0.174556024843144 -0.093417663431561  0.108925443196115 -0.094625153118491
-   11  ( 25) -0.145228226846074  0.289308800594077 -0.056604451501567 -0.078531469167011 -0.050901538775644  0.092556450573324 -0.236272716312904 -0.125766764843619  0.035457518122494
-   12  ( 26) -0.059274992639949  0.006488412450235 -0.103071268094578  0.150081428168228 -0.009323154225402  0.028319582293784  0.076974794119920 -0.059324199727383  0.008195435055820
-   13  ( 27) -0.018186469303715  0.001053679134700 -0.081623732601015  0.178695228145613  0.269234242250905 -0.095169442617143 -0.062998987790228  0.017097346840232  0.200778292928657
-   14  ( 28)  0.062534322058022 -0.002015210189792  0.048801137289310  0.040037948587356  0.059153802159815 -0.000976778891690 -0.003575151518202  0.045136723643297 -0.180538253756990
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015166832979202  0.055523245443861 -0.169795016453231 -0.032694007010711  0.015135554657568
-    1  ( 15)  0.032433930913447 -0.144386795244130 -0.139383558038472  0.367373211677701 -0.070777740101340
-    2  ( 16)  0.006497257681786  0.060476801934772  0.284376377240629  0.117114356398064  0.102408347319320
-    3  ( 17) -0.124715086899730 -0.049178690374442  0.092903745535273  0.049474206000848 -0.106524456538078
-    4  ( 18)  0.078147667167246 -0.074392615750257 -0.066572272669959  0.015153155253219  0.127142438959372
-    5  ( 19) -0.030012583037432 -0.098494401766441 -0.024951261153980 -0.072692839393734 -0.065509018082234
-    6  ( 20)  0.028658039508268  0.029893706465370 -0.227872682646957  0.058375213717391 -0.035317071011158
-    7  ( 21)  0.087698228581465 -0.193877542561776  0.000977855687069 -0.115255270457925 -0.004253825014343
-    8  ( 22) -0.000487339716269  0.085213745940574 -0.052874146845015 -0.152776261278858 -0.059953850619275
-    9  ( 23) -0.075363605944822 -0.010276769755622 -0.080252178607551 -0.063424914028104  0.241145188807008
-   10  ( 24)  0.001283950926939  0.093581096956637 -0.056859346555054  0.041777245375248  0.060823791108896
-   11  ( 25)  0.008356132167143  0.012479675910490 -0.083678859924604 -0.018947435212012 -0.029236284374189
-   12  ( 26)  0.005134210870859 -0.048347394079564 -0.007965979077246 -0.031780813486509 -0.004717184227605
-   13  ( 27)  0.000267583079026  0.057994430769062  0.003313390407093 -0.042646534152268 -0.057198829179600
-   14  ( 28) -0.012275122252029  0.029301677774353 -0.009473927119427 -0.051324560742064  0.050296874415886
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027985845163524  0.023014187360132 -0.021972704031550 -0.165873801926668  0.108498472423258 -0.065984445208027  0.052062590549153  0.024196903336059  0.005438903859049
-    1  (  1)  0.207753127107100  0.133586320603852 -0.248299413759929  0.051273643702392  0.137929228974577  0.172516172497646  0.338774489321057  0.007044125107960  0.086225487021978
-    2  (  2) -0.030725656049538  0.008685648887429 -0.054637639636829  0.081853822913586  0.065569345836835  0.054412511875610 -0.037702150980267  0.220880057677829  0.092517419795625
-    3  (  3) -0.146518460272185 -0.151164938887178 -0.090922259280638 -0.041550491468836  0.008256552512676  0.048975234640781 -0.222433708697271 -0.123978061818464  0.551233631040567
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.030368262613337  0.051015148860635 -0.002942978202016 -0.003356964742137  0.014802517799284 -0.008083321576794
-    1  (  1) -0.024523434755722 -0.073734688873540 -0.129066247639439 -0.024037316988320 -0.050282994530055  0.020846450280793
-    2  (  2) -0.075512350010898  0.366500451453791 -0.036592830040889 -0.016303194972460 -0.036175560248337  0.005423684503349
-    3  (  3)  0.036874256227630 -0.046039513569074  0.147486358648951 -0.060664952434382 -0.127426669479233 -0.039293702180427
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.050111098767745 -0.071439421665737  0.010360806490423  0.164982511003502  0.190752518001675 -0.070698878333088  0.064144987593348  0.009940358823804 -0.039049299317426
-    1  (  5)  0.346512350212501  0.020770988494970 -0.054063126549543 -0.066267909254760  0.061286416729942 -0.328133338026467  0.364459716199746 -0.282333058508693  0.052379135180748
-    2  (  6)  0.014820841999600 -0.308332589554773 -0.036490920160057 -0.008185142851144 -0.077220105539055  0.001985069156781  0.191861505554810  0.331452106505361 -0.064661161962335
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002710313008904 -0.006054102061478 -0.023960364540744  0.028066673595848  0.012225337247005
-    1  (  5)  0.191683957013482  0.061055761849053 -0.180315991810041 -0.020020550401249  0.020756656682088
-    2  (  6) -0.171946012527152 -0.078984789269474 -0.060019327368985 -0.045058581991741 -0.117222830082063
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102367  0.008188589712238 -0.013790999932787 -0.066013267343718 -0.002979179364402  0.115067560152143 -0.029904774000613  0.075658337330170  0.005135342269607
-    1  (  1) -0.415137332088612  0.400791789518638  0.060626653167991 -0.009777722957358  0.182694524485337  0.107591424113208 -0.071470092116898  0.210805299972917 -0.029640655301118
-    2  (  2)  0.731004204598524 -0.977674938020298  0.030910735141458  0.126476447646258  0.160297857646348 -0.115254107794114  0.017919423470245  0.019160269758161  0.056677210805993
-    3  (  3) -0.052710934455993  0.190825342618791 -0.121683764296163  0.058318753384834 -0.051331848225805  0.122833340921044  0.176985596744925 -0.321410474763126  0.015752780623231
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449213 -0.003857954296836  0.001116934481339 -0.006268480889134  0.011819863965880  0.022338641059406
-    1  (  1)  0.026581167918673 -0.003242138995826  0.002209759168116 -0.126256065331472  0.064001666171840  0.019583311633874
-    2  (  2)  0.060541607763300 -0.048685401885040 -0.005324531906368 -0.077364982992393 -0.023160042352118 -0.131997334895640
-    3  (  3)  0.086532549077842 -0.501054912835391 -0.033953281830235 -0.045954160893793  0.007588765668993  0.026055365513597
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407912 -0.003874637131510  0.017573675069989 -0.250000468336212  0.193535227171946 -0.023949830014057 -0.006344215172658 -0.002637721142605  0.025018403626550
-    1  (  5) -0.061066900138163  0.119597101102996  0.077747477731553 -0.181802110874956 -0.105212352540628 -0.191650240311689 -0.067261595147718  0.101033231559081  0.034053487252843
-    2  (  6) -0.129779125650158  0.272168473286842  0.218088904973338 -0.105590817864474  0.170044089806057 -0.413895401404384 -0.204721805057715  0.193774792721808  0.022574107317577
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304093 -0.022619515940248  0.001370551331509 -0.019480287608800 -0.016611790333306
-    1  (  5) -0.015006262168537  0.018557640744956 -0.000086080146177 -0.193359672647776  0.037991057379314
-    2  (  6)  0.020942063740398 -0.276121820896825 -0.020375408054502  0.090755244706104  0.038585932807354
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234774577907340 -0.089732279705020 -0.029281742956361
-    1  (  1)  0.629390080925054  0.562262027181648  1.005710563308147
-    2  (  2) -1.016842846984442  0.324902404629239  0.759850922288994
-    3  (  3)  0.070893719957037 -1.217739132557560  0.544721303880524
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235500971090726  0.628370240889402 -1.016044908027706  0.070845813096372
-    1  (  5) -0.089243248615735  0.558584627490131  0.332507599415180 -1.220818260487312
-    2  (  6) -0.028235811673249  1.000885266991202  0.767552789658038  0.543389712941562
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.803905357707311  0.860151305623949  0.271118555223167  0.233708148806798 -0.124148512341266 -0.010189985719979 -0.092729991992268  0.016788100393524 -0.004472139404122
-    1  (  1)  0.401013317552785 -0.256123411395810  1.725791219363352  0.228118396767626 -0.017083610861014  0.077834475735907 -0.010518533714653  0.508387054745627  0.007264375748279
-    2  (  2) -0.011434548540222 -0.088441201305154 -0.217324498232303 -0.271194503786495 -0.847646840544961 -0.636979337168603  0.167111761738664  0.613015596421828  0.118261935906470
-    3  (  3)  0.794342002638844 -0.188454328702485  0.221782475708119 -0.127238173306152  0.529725618505773 -1.234283764404522  0.503702151908138 -0.716733332201490  0.003730822870913
-    4  (  4) -0.401751095605530  0.338386780155127  0.027671797889821 -1.521964962245091  0.118534592965411  0.737791613352609  0.133068399810627  0.089420490967805  0.037476970403516
-    5  (  5) -0.062520837577632  0.401075384901201 -0.021867941133996 -0.715225023398739 -1.272095248267951  0.501721901780299 -0.443609728635242 -0.893075231648048  0.592672369741993
-    6  (  6) -0.010948759647979  0.203401403085997 -0.137048639531909 -0.113085573900653 -0.481495532073518  0.549209906368458  1.454114297098583 -0.104970888423571 -0.037484874409079
-    7  (  7)  0.128092468229021  0.321831618555177  0.165224131524797  0.036717435980679  0.490326956687596  0.556704330756835 -0.028026211847655  0.572891503259545  0.836605248949509
-    8  (  8)  0.028465864758886 -0.067177326433747 -0.261754785397495 -0.132197496012203 -0.099654097906746  0.125238705338503 -0.191161571927307  0.152439549355924 -0.345598496796334
-    9  (  9) -0.117164319402284  0.677600502185656  0.057458896318824  0.132501237674075 -0.004191340015369 -0.154828563575337 -0.038564068532644 -0.121792891458522 -0.349263289014943
-   10  ( 10) -0.181067725106296 -0.111582528205458  0.370630400902865 -0.010089018109779  0.175901282392120 -0.187388709548550 -0.018929605786239  0.507571524880377 -0.113635665926862
-   11  ( 11) -0.014437537795246  0.015226015168940  0.010134165664067 -0.005687484322489 -0.031065375239781 -0.023280669169025  0.128114396256681 -0.039417737851753 -0.110919095427042
-   12  ( 12) -0.125387244214951 -0.096520270925362  0.052418676370702  0.258253736986353  0.005758304720891  0.145179803274614  0.116533683249985 -0.074529049368730  0.022120054046506
-   13  ( 13) -0.016488000528151 -0.002368207793552 -0.087940291197149 -0.101326196004400 -0.036322133241993  0.195270868050333 -0.010169719681932  0.009700577933052 -0.056276489205959
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020656609432377  0.055454072209206  0.016498557049920 -0.100308993019535  0.100625813513966  0.085817872313959
-    1  (  1) -0.158188828440892 -0.302238781900211 -0.003254305982647  0.141295167420039 -0.086817823645988 -0.004522680615623
-    2  (  2)  0.117165454504024 -0.174443278203503 -0.011196610388147 -0.263022208165445  0.005179209446380 -0.028790206529749
-    3  (  3)  0.116979728848069 -0.002675319824407 -0.011237305263780 -0.059042081886281 -0.019813165086942  0.041020820057734
-    4  (  4)  0.050773800974292 -0.220964030765936  0.039978161841657 -0.028484730886475  0.038490445524596 -0.072488415876946
-    5  (  5) -0.020335163069148  0.163705236926197 -0.082951181907163  0.111454733440593  0.037975682191325 -0.107211881409464
-    6  (  6)  0.021278303210848  0.388606221992998  0.114903933510215  0.018782318547525  0.008939872036282 -0.015881860003982
-    7  (  7)  0.297901981281024  0.033254178443727  0.094283496173084 -0.060148927068472  0.021415208569123  0.043129019365108
-    8  (  8)  1.538151946484423  0.255389759643583 -0.163313084569292 -0.034663525935373 -0.142139339830442 -0.045757092023972
-    9  (  9)  0.091430832784144 -0.031111059625587 -0.061979966203490 -0.058675516664175  0.760855141023917  0.950655107543621
-   10  ( 10) -0.067314640632537  0.211103496431705 -0.020600002397637  1.234404704927125 -0.163782714272567  0.167558660890032
-   11  ( 11)  0.163451473737101 -0.060117653273661  1.332809431049165  0.048636523249740 -0.084741416350187  0.093758422678353
-   12  ( 12)  0.205980882962949 -1.200907557972782 -0.135489991479292  0.365850977217349 -0.094087533161484  0.008716209829183
-   13  ( 13) -0.181608420628060 -0.041944770724578  0.112411453405729  0.222931004263492  0.995147424974585 -0.917645025950541
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802215088996775  0.405760421584725 -0.010733900270896  0.784358891338122 -0.394207392965882 -0.066264169418438 -0.011728371528151  0.124097516118103  0.033513743357673
-    1  ( 15)  0.861921835284117 -0.259204458699967 -0.086550258239887 -0.179795107884808  0.329776011755083  0.399732735512309  0.202064202046553  0.330247474290177 -0.071973209379633
-    2  ( 16)  0.271441185213391  1.724486207548469 -0.218690579375801  0.222063595490460  0.027363367055485 -0.018802165875844 -0.135942286119417  0.163478817004599 -0.262387665735325
-    3  ( 17)  0.233788075721826  0.228159112392323 -0.271808517288257 -0.127676513444271 -1.519379653938277 -0.715083891079223 -0.112821347158474  0.035818562511062 -0.131766468683948
-    4  ( 18) -0.125942009127172 -0.016377869393706 -0.848482111339688  0.528657771751293  0.118745113074898 -1.271710188107035 -0.481153570999942  0.489178297010484 -0.100424350070291
-    5  ( 19) -0.011383686031449  0.078456463460941 -0.635793437126757 -1.233395635082388  0.737239370475296  0.499509899398320  0.548401749031313  0.558608158361660  0.124417124384875
-    6  ( 20) -0.091600198761770 -0.011876741058319  0.166091401418705  0.503941587465969  0.132948669117964 -0.442842250160731  1.455104693311837 -0.028341475910627 -0.190421671161177
-    7  ( 21)  0.014484668680380  0.509841880180764  0.613581819059005 -0.716630577428902  0.088564900472140 -0.892493010440163 -0.105683628158844  0.572246502497319  0.150576148757988
-    8  ( 22) -0.004174841691802  0.006707441197859  0.117679460919548  0.003167625275269  0.038325446188084  0.593620463308946 -0.036920125090448  0.835670699131347 -0.345282330703187
-    9  ( 23) -0.021563101305077 -0.156910385371061  0.117862784231017  0.115137818805332  0.052266686740979 -0.022652444633787  0.020589348904606  0.298647561105740  1.538509254803363
-   10  ( 24)  0.054696247538136 -0.300097703279750 -0.172676310394845 -0.004641896342478 -0.221287943064927  0.163661856689034  0.386962565847225  0.033092208048157  0.254762225348227
-   11  ( 25)  0.016478682999148 -0.003215291424268 -0.011157986184847 -0.011249059510507  0.039826186982321 -0.082792260839707  0.114868621990364  0.094214542109994 -0.163392531748718
-   12  ( 26) -0.099187962393071  0.141022599136927 -0.262517149368207 -0.059517894129389 -0.028614490021954  0.111532524460300  0.018579534511371 -0.059825884600083 -0.034049798717724
-   13  ( 27)  0.100178973364377 -0.086693773226363  0.005242460985690 -0.019116004377611  0.037912677180169  0.037754205119466  0.008826283068401  0.021770019636588 -0.142635094936193
-   14  ( 28)  0.086046178690242 -0.004751133686046 -0.028259740203224  0.042085140978763 -0.073608902693740 -0.107703616275598 -0.016209845373183  0.044336724946126 -0.046193144798357
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124213386192449 -0.184278545140157 -0.014644622518974 -0.126520793888936 -0.015935131079309
-    1  ( 15)  0.686886555278534 -0.109848033830421  0.015362111474085 -0.096623860958170 -0.002352924370873
-    2  ( 16)  0.057186301356343  0.372235382538515  0.010223067022666  0.052308263466605 -0.088321026996929
-    3  ( 17)  0.131851542209598 -0.011114262485829 -0.005723853800875  0.259717639216932 -0.101579897082117
-    4  ( 18) -0.005059922073798  0.176651992942668 -0.031045371067554  0.004751602541209 -0.036357227754461
-    5  ( 19) -0.153490417120552 -0.188182144826061 -0.023327004528605  0.145116229576305  0.195544967130553
-    6  ( 20) -0.038669146951691 -0.018322940249549  0.128217963501523  0.116247317068486 -0.010270205632719
-    7  ( 21) -0.121953539167482  0.508071938672096 -0.039503068949602 -0.074854789377140  0.009741351292022
-    8  ( 22) -0.349749690454153 -0.113383122522557 -0.110884130170500  0.022231095142528 -0.056430507970696
-    9  ( 23)  0.091277604676359 -0.068457429261195  0.163395065823676  0.205703107124365 -0.181427144774973
-   10  ( 24) -0.031490205855113  0.210975767808687 -0.060264671053420 -1.201247115008903 -0.041832647583344
-   11  ( 25) -0.061996899999264 -0.020492208070431  1.332807012156678 -0.135544852791734  0.112408630541359
-   12  ( 26) -0.058492216122820  1.234353822395186  0.048637099519176  0.365843792888730  0.222948291565721
-   13  ( 27)  0.761203399339422 -0.163718232424674 -0.084746898323330 -0.094131030705851  0.995190420313834
-   14  ( 28)  0.951767639345761  0.167573997453096  0.093760237560500  0.008708090964824 -0.917567337282473
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.061311180916174  0.007305734568299 -0.008052219664717 -0.075102530727564 -0.012025728300826  0.120194347984132 -0.026978429199379  0.070594185419545  0.016866098796694
-    1  (  1) -0.395437998629573  0.330196709230486  0.066130411816170 -0.001067023889988  0.191861180999614  0.113171387281916 -0.066995383271923  0.184795229028717 -0.029348228197537
-    2  (  2)  0.660966524714688 -0.861759345962241  0.033160724552169  0.127992765938447  0.170396202948104 -0.110113865477816  0.014392237869005  0.010445707783194  0.039464659932571
-    3  (  3) -0.040562495552703  0.173681994330223 -0.115433716796164  0.022385853875221 -0.029920163821990  0.106927003887640  0.164647198946454 -0.308627589591936  0.016471750534187
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.008075638079590 -0.004204267894386  0.001154899751921 -0.004302816895310  0.010300593916071  0.018583143246493
-    1  (  1)  0.022690643093880 -0.003824240162369  0.002196370237793 -0.111717598339107  0.056937031147815  0.021691580964165
-    2  (  2)  0.053339405350156 -0.044029154336949 -0.004382948251621 -0.071322882171572 -0.023334611635533 -0.125689353624520
-    3  (  3)  0.084457325104192 -0.461707512764016 -0.028403124486066 -0.043179936610554  0.008421132991555  0.024339438305143
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.015528904780166  0.000197217067411  0.014784122441979 -0.260011500898602  0.207731584784046  0.001836258201294  0.003784871531686 -0.004554790492094  0.029260236327573
-    1  (  5) -0.073737732106898  0.115839519981911  0.060966183364281 -0.191025915776738 -0.133264060723011 -0.183947109340336 -0.057101924893026  0.090583425466175  0.027097942199573
-    2  (  6) -0.138800981815769  0.257932125792776  0.172076461805675 -0.086501722972202  0.167229357348261 -0.397280885922369 -0.200441282704850  0.184212067375292  0.012201121124777
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.007496948487326 -0.019701904142718  0.001114080790245 -0.016769294212535 -0.015066280094060
-    1  (  5) -0.008011152002189  0.019463303254064 -0.001255118747011 -0.171713762805812  0.033052309738105
-    2  (  6)  0.023624103497187 -0.246377111375438 -0.017324022231723  0.084529293370869  0.033771435710698
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521810 -0.064555152855140  0.195953381503072 -0.041248493404100 -0.011229686922116 -0.030149441468397 -0.052245051042501 -0.006640144591441 -0.060816046803631
-    1  (  1)  0.618380750339701 -0.527850820452496 -0.215416501468030 -0.157035437820985 -0.069798458053192  0.063297476854260 -0.224803808806343 -0.036770088857871 -0.093292414355443
-    2  (  2)  0.089963765220208  0.016694193855681 -0.049894217028076 -0.224500363636592  0.100545586935621 -0.339808932362450 -0.300486601784935  0.103978674940069  0.003854593986182
-    3  (  3) -0.017912540893906  0.240051544179780  0.016875920141057 -0.019658112757032  0.000950481978191  0.139486307895262 -0.307526295494270 -0.245045411721381  0.038982174459018
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151717 -0.053483299255780  0.001461399819934 -0.009996127160186  0.040844890766482
-    1  (  1)  0.010356156252335  0.045196494943183  0.123149462829323 -0.009608799091533 -0.092775098416549
-    2  (  2)  0.068261626755325 -0.266621644473693  0.090983468547795 -0.007824999539039 -0.015479677414577
-    3  (  3)  0.102991688131888  0.095940846129217  0.235195882789535  0.030438278876706  0.100331913639096
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065258  0.055002400477826 -0.190701615134343 -0.008587073556960 -0.137456634337705 -0.102685174742819 -0.038575707278164  0.049077773985899  0.038775520871487
-    1  (  5)  0.266426121061182  0.201904502527541 -0.404472747743455  0.112355452346296  0.244543383067954  0.203488255110552  0.093346083766350  0.046662175778563  0.162564534078684
-    2  (  6)  0.310200495971188  0.275860886663906 -0.334362481171667  0.111323203428020  0.107269573508102 -0.015396505983542 -0.485347827861579 -0.115211810541093 -0.189399381355345
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661090 -0.010182782856367  0.015536223735827  0.027148068637773  0.019304531582392 -0.012170541889266
-    1  (  5) -0.076359104752422  0.072719944885937 -0.105706045053709 -0.076791075572627 -0.095250630872874  0.044053081318693
-    2  (  6) -0.023401555368525 -0.060789750773992  0.233844071164900 -0.060200608258470 -0.022972229731698  0.078966373846361
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134471189810092 -0.662148890372047 -0.267935016272650 -0.078917516466181
-    1  (  1) -0.664666296417858 -0.209284545759600  0.147471348275627  0.068908444059693
-    2  (  2) -0.267133357861078  0.148425589757628  0.187317601361827  0.001813043081997
-    3  (  3) -0.077770523166389  0.066603013397195  0.004062962607311  0.013912155247960
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274832594154714 -0.278242094914337 -0.671654031070884
-    1  (  5) -0.278497836106856 -0.012090613996289 -0.010590433835922
-    2  (  6) -0.670432937770643 -0.009657203375264  0.097732024172777
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959652947297446 -0.408123531987619 -0.490401240559718  0.038728625501850 -0.077955850449253 -0.487356513384779 -0.107431647026833 -0.396098723270224 -0.237559090649423
-    1  (  1) -0.405287391353834 -1.324235803795144  0.174918474964920  0.249090286909362 -0.197882092638117 -0.317613216127917 -0.251158649784065 -0.030182262258926  0.632878894780051
-    2  (  2) -0.488736302126935  0.174537834055795  0.686802536569195  0.342698519390660 -0.009978504141441  0.483630953231146  0.287674546129727  0.302838065576003 -0.272076060390986
-    3  (  3)  0.037680750791132  0.250810425630217  0.345041313376114 -0.288921950854187  0.242065062379730 -0.302245036941519 -0.510968387365602  0.184732147500300 -0.217019518876341
-    4  (  4) -0.076474970371118 -0.199548330465758 -0.011318561820522  0.242358447418328 -0.131824013162052  0.385851083614353 -0.241519487350351 -0.375192533273711  0.062578612411423
-    5  (  5) -0.485852483425266 -0.318979280528763  0.484066634013452 -0.298903807168945  0.382610997345618 -0.557142551517131  0.333197792146470  0.111813059758365  0.019832041990218
-    6  (  6) -0.104965308815928 -0.251905850413101  0.289646445983294 -0.510970311703583 -0.243416542914288  0.333477452263820 -0.859910605182056 -0.040221092410560  0.015978091027429
-    7  (  7) -0.396757752587363 -0.028569556877251  0.303650553506904  0.181375877079299 -0.373315055601480  0.109082013495532 -0.042394080422644 -0.424453142205116 -0.165367340665863
-    8  (  8) -0.232577777980881  0.628634227410956 -0.273406823912260 -0.217896152168838  0.062014351681569  0.020854775327294  0.015643896438574 -0.165522517445198 -1.139943298332195
-    9  (  9)  0.005610937642159  0.056039778145227  0.162949812700519 -0.082447741081119  0.072872155386977 -0.108705187107976 -0.023485984994573  0.044747716600193 -0.147251711508816
-   10  ( 10) -0.006823140015079  0.054329319992068 -0.040599884295365  0.341771214889488 -0.179762239296878  0.323458315510083  0.128244534494253 -0.274646157662585 -0.052523948909135
-   11  ( 11)  0.095363270787347 -0.102111548012532  0.068440604874557 -0.163728434997447 -0.155636086105072  0.243236788181447 -0.456650415997544 -0.005317873159721 -0.049821847160301
-   12  ( 12) -0.031682366540900  0.049375813516575 -0.071598146179691  0.132087989337538 -0.108611785555417  0.096654485419413  0.079499450722417 -0.086710987234524 -0.054539911364394
-   13  ( 13) -0.055056204890153  0.125842892748373 -0.045965574230317 -0.019980233406050 -0.072417713564596 -0.032557591563818 -0.014098057188424 -0.073500277920932  0.566229267173414
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807525521233 -0.007359537343921  0.096092508733764 -0.031848083816976 -0.055774198983232
-    1  (  1)  0.055013732650586  0.054716326372634 -0.101499825852225  0.049505806235113  0.126450547357477
-    2  (  2)  0.163059205506462 -0.041368872819456  0.069581455596234 -0.071597196780245 -0.045866052228085
-    3  (  3) -0.081105673439869  0.339429555892824 -0.164728153643699  0.131959969199162 -0.019695233925696
-    4  (  4)  0.071393373180112 -0.177479194335969 -0.155859184366711 -0.108539407321582 -0.072773970413827
-    5  (  5) -0.105603312078912  0.324542336417266  0.243446189575733  0.096679109403979 -0.032469296833009
-    6  (  6) -0.022598073087572  0.128545265092418 -0.457503820510282  0.079428257782213 -0.014293355829964
-    7  (  7)  0.043846313691523 -0.277398721649818 -0.005217801799309 -0.086814141836653 -0.073528025181399
-    8  (  8) -0.147650558386801 -0.051824889211656 -0.049479655499448 -0.054623458198541  0.565538504830395
-    9  (  9)  0.072040995887839  0.045487481778711  0.010267944449755  0.009607395545283  0.026537979914876
-   10  ( 10)  0.047954867962304 -0.139047713471829 -0.006984668871374 -0.101926998608402 -0.021981627690416
-   11  ( 11)  0.010232694252591 -0.006895180981132 -0.093446496400997 -0.006456318199702  0.037416385414388
-   12  ( 12)  0.009698093521025 -0.101910194048616 -0.006447087285736  0.055515253338052  0.004586695913697
-   13  ( 13)  0.026517968105571 -0.022107111741401  0.037498264993835  0.004566515568409 -0.064482567891937
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532087829692590 -0.788053685787543 -0.217638660718255  0.182558741425794  0.602280863487480 -0.200093873579573  0.029411468157287 -0.008618444683726 -0.142345995339967
-    1  ( 15) -0.793296879907851 -0.320033252713587 -0.162598975061937  0.058726797579308  0.020874324465825 -0.223415350495464  0.107419199072046 -0.353928058476850 -0.096059896297266
-    2  ( 16) -0.212771964426018 -0.165330329981933 -1.296138478501883  0.042119030626054  0.273634363153676 -0.438879796251796 -0.121813090934943  0.097180424393402 -0.140937625938142
-    3  ( 17)  0.179954420872001  0.058841120068099  0.044127193653625  0.293105599186954  0.349356888645549  0.303438248695204  0.077097855045665  0.005877107547810  0.014045104825034
-    4  ( 18)  0.599465706125478  0.022235571238169  0.273958684833300  0.351252283018589  0.210835219511268  0.044587084733166 -0.439010194116289 -0.491004374063182 -0.399383595875341
-    5  ( 19) -0.200414126422892 -0.221453681940971 -0.440132544745164  0.305750504885625  0.044859550994933 -0.117462871785049 -0.191542019031430 -0.319736101009363 -0.359370857937598
-    6  ( 20)  0.032162128490710  0.105939422470881 -0.123876353123509  0.078981740858070 -0.440632986523098 -0.189872412172292 -1.110683989274872  0.246909463066168  0.255271007146821
-    7  ( 21) -0.008289240270486 -0.354493597801953  0.096614444377338  0.006342901738698 -0.491270269306688 -0.319008747377893  0.247402781703421 -1.005041339289935  0.329310525846416
-    8  ( 22) -0.142958112237992 -0.097022080380776 -0.141105576266035  0.015162721218605 -0.401346216586595 -0.359442000824708  0.255249867089681  0.329100137017210  0.052130295704472
-    9  ( 23) -0.219989065380246 -0.250001442433259  0.576446348372414  0.098959674886800 -0.020568115056174  0.097513800211121 -0.059902955848638  0.014734527114704  0.155046520151383
-   10  ( 24) -0.078950494727199  0.108193141402953  0.027256154227325  0.046487728394439  0.091306743849428  0.113368151054255 -0.170234459022064  0.302098295161987 -0.032847707963684
-   11  ( 25)  0.043326744721135  0.032363389826812 -0.179596320201807  0.107314642639449 -0.187556761581101 -0.097228134857404 -0.510755068400788 -0.080036249796903  0.081235508165591
-   12  ( 26) -0.068197976739272  0.217296898230263  0.162613838841638  0.182156526175457 -0.078640971248232 -0.138388418075592  0.046099139294747 -0.318339562890745 -0.094298996233422
-   13  ( 27)  0.012948053174444 -0.163156717261063  0.064963474472039  0.076423090075366 -0.116362948599962 -0.057051341709586  0.002572557321622  0.275506911037167 -0.101255941405055
-   14  ( 28)  0.072512090984942  0.116063474825340 -0.039414549057152 -0.060057426555201 -0.063414940103828 -0.039930823846179 -0.007406649447407  0.061654502640363  0.127196073453639
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223472856186329 -0.079380673330417  0.044417374907374 -0.069445497218023  0.011729893427506  0.073549727582157
-    1  ( 15) -0.252084318917961  0.107740778119089  0.032072824705649  0.217703434939331 -0.162976179330690  0.115649023646982
-    2  ( 16)  0.579843117285508  0.028377214599785 -0.180834874279503  0.163175611851648  0.065411291339360 -0.039948698368928
-    3  ( 17)  0.098340901452171  0.045586420024689  0.108734472684589  0.182606429974975  0.076964420692713 -0.060236205753191
-    4  ( 18) -0.021650833253368  0.091327714075519 -0.188512569919576 -0.078662641540956 -0.116896916359804 -0.063655160224489
-    5  ( 19)  0.097171540237316  0.112970498693947 -0.096626702578479 -0.138712839413244 -0.057497371163198 -0.039673289236737
-    6  ( 20) -0.058059330793309 -0.170134824525265 -0.511529953350571  0.046149842859018  0.002603003870208 -0.007423573904069
-    7  ( 21)  0.014906052329776  0.302176683769003 -0.080527272396977 -0.318411101425731  0.275449773181718  0.061692765706429
-    8  ( 22)  0.155151887383248 -0.033185457482074  0.080998651116857 -0.094073422563741 -0.101041326065027  0.127067437701733
-    9  ( 23) -1.153509668704953 -0.223849781573310  0.084925914720570 -0.000154347639825  0.401132279504920 -0.346054713026435
-   10  ( 24) -0.223987599390505 -0.015012978211180 -0.013160266761979  0.067286208797175 -0.009874035055601 -0.084312333246363
-   11  ( 25)  0.084246135649734 -0.012978110758481 -0.099616699055155  0.005046001111317 -0.012239544431652  0.023063802197493
-   12  ( 26)  0.000203295279175  0.067424132200542  0.005012434803368  0.014687484508398 -0.012600853145572 -0.022021985836775
-   13  ( 27)  0.401487062569274 -0.009674045048257 -0.012249675488475 -0.012688275802534 -0.008212565425852  0.091176394210094
-   14  ( 28) -0.346417777877478 -0.084403131898400  0.023147564232903 -0.022062212430037  0.091088265440255  0.040127117539344
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.056215178351152 -0.054500121667396  0.201919259029640 -0.031077763909936 -0.011710544057694 -0.013075909014488 -0.042346948279412 -0.000671828437196 -0.052291650303081
-    1  (  1)  0.580185861075070 -0.459972753550963 -0.203225407919285 -0.146383812782444 -0.059047716562576  0.052226205810320 -0.210466211727551 -0.032187370830551 -0.063260161926320
-    2  (  2)  0.093393180484024  0.013367709279037 -0.072500434249941 -0.188901437279491  0.080233214984548 -0.320461373590757 -0.281774578817969  0.095754681534406  0.009993938559280
-    3  (  3) -0.011005998081791  0.212772041115702  0.010016689572689 -0.008866167178549  0.020319327817077  0.122354072622868 -0.286521492942098 -0.227705666262959  0.024617052813042
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004784997903906 -0.045646414234079  0.000336480836015 -0.008910135175809  0.037229970153597
-    1  (  1)  0.012654368872761  0.038726052908772  0.110122851111890 -0.008163616811273 -0.088473965510977
-    2  (  2)  0.059858161464052 -0.242276960674044  0.080687949967586 -0.004783380239994 -0.010585828283984
-    3  (  3)  0.093190009318185  0.087625848503461  0.210676223786748  0.029310965958952  0.092669937835962
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.095387850613253  0.063707287574100 -0.166137684328990 -0.019021592214621 -0.149973759488072 -0.101204345446005 -0.031472575013395  0.053498473418115  0.042967624605644
-    1  (  5)  0.255913374070676  0.182084005619737 -0.358054750763435  0.117938321447881  0.215767330994835  0.198255946304696  0.082288395387947  0.046112464804605  0.145174585244920
-    2  (  6)  0.310255017179614  0.238379631063291 -0.293832075513331  0.096225461668115  0.113893652343842 -0.010350380964834 -0.451016712892298 -0.111857488193420 -0.191795345079325
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.073847868868730 -0.008654741577254  0.012693286586184  0.023668684482898  0.017789448554089 -0.009288640558542
-    1  (  5) -0.053437184229602  0.073043484124087 -0.095008049379703 -0.066955824244484 -0.087649072564987  0.040223509254852
-    2  (  6) -0.005363327558409 -0.054894453058810  0.206318088063038 -0.056446188259803 -0.025451705059660  0.074272028126644
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016118777276715  0.076689387067912 -0.125264792267216  0.007931013310243 -0.098301937535605 -0.089040062536404 -0.042653189503994  0.143650549015439  0.062698356849192
-    1  (  1) -0.038523460792185  0.325926212074859 -0.217436403108296  0.076210929079388  0.124956744969533  0.049869905306291 -0.256022567536762  0.049219148025195 -0.025163660677609
-    2  (  2) -0.015460259327551  0.182364499530160 -0.081021447104332  0.065186772706263  0.193628085224717  0.090709199284730 -0.144227288852921  0.007154481293501 -0.060483347873676
-    3  (  3) -0.069494321441892 -0.016013992178318  0.169506236224067 -0.050547669997776 -0.177140340538979 -0.181255025833254 -0.201077665225233 -0.109139777586648 -0.215083611892032
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159361864611553 -0.056476108299591  0.034334354535919 -0.068420323850581  0.100698715800710 -0.049820592017774
-    1  (  1) -0.121041364374110 -0.003994619377137  0.190684428167184  0.052070114913580 -0.189028662705231  0.205096915582739
-    2  (  2)  0.013836799939816 -0.073875918803127  0.147901928532528 -0.343158528114239  0.053056478393277  0.086736758175880
-    3  (  3)  0.065392768372835 -0.072388535495376  0.365788807268924  0.156911353062511  0.184439406968006 -0.043117455907297
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095080611028908 -0.132974666952799  0.233475927910159 -0.109077700761849 -0.033619328181732 -0.003336619392394 -0.079318686273405 -0.006541773193158 -0.188514066103895
-    1  (  5)  0.133180554197722 -0.220459497770329 -0.122961007604814 -0.144493780528946  0.034530325126924 -0.144382538755391  0.001565508478566  0.179104189145763 -0.084352671049966
-    2  (  6)  0.305369897772513 -0.245966510909103 -0.171589985467964 -0.288954965589224  0.048536799653887 -0.105233271021583 -0.400024803684130 -0.035818012706233 -0.066124321501172
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011358647742862  0.047842821118301  0.011877525445924 -0.012099889406653  0.055702357687980
-    1  (  5) -0.060987538430201 -0.100437160073963 -0.174976176295358 -0.033059202656663 -0.296249624542354
-    2  (  6)  0.156959926194242 -0.053853503787387  0.406665675932448 -0.026462885456157 -0.143060389345547
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.020948331780215 -0.037000670267279 -0.105734997905917
-    1  (  1)  0.298755038289142 -0.115783497652312 -0.255943993115305
-    2  (  2)  0.258964229852114  0.115813970118107  0.442412044617565
-    3  (  3)  0.060316341789483 -0.030010868082768 -0.068666118917160
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019390140524655 -0.299690928631304 -0.261296417524431 -0.060590155832357
-    1  (  5)  0.036741212649359  0.114946374260334 -0.116921045330832  0.032705566460932
-    2  (  6)  0.104633614556808  0.252457748482493 -0.444028842624352  0.069853026830576
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.140296000548941  0.063793548091722 -0.058836863345753  0.099797632735300 -0.059473750236872 -0.159752966024087  0.002202306295360 -0.046127151478856  0.008686217300582
-    1  (  1)  0.090587236946104  0.202094731400236 -0.091626540491885 -0.096660154944673  0.169987669208235  0.083846972629074 -0.508703907389636  0.818627210894803 -0.070854467170586
-    2  (  2) -0.023735454247632  0.355751040292653 -0.273793043205585  0.278993695315875  0.352285402581272 -0.196481260763437 -0.305054920124749  0.066457242289417 -0.201198646054354
-    3  (  3) -0.097017476571804 -0.245783387728730  0.317753409227420 -0.024031108885499  0.214358325616717  0.049557148749413  0.028895867231305  0.054175105918326  0.003063371175243
-    4  (  4)  0.057659363291957  0.180009048378845 -0.233469321765478 -0.045014824473403 -0.207816785622826 -0.114404967029762 -0.123373159567671  0.226999771613591  0.055473302709796
-    5  (  5)  0.215768085458356 -0.315007699227405  0.316911447049752 -0.120875322919003 -0.280165731589989 -0.294210130176689  0.216431927362601  0.200720331119460  0.064409972369138
-    6  (  6)  0.088219394313516 -0.148901192549512  0.366942172197605 -0.011961263536269 -0.214232535784278 -0.110039106542730  0.192575526682645  0.231316173793134 -0.059843368650861
-    7  (  7)  0.046870162228495  0.280136788176482 -0.370966800512151  0.110896450302908 -0.088815259647623  0.146578221115441  0.021177591015912 -0.399548191737565 -0.041055228430585
-    8  (  8)  0.213227988512466  0.108113812359640 -0.632322240865726 -0.072819843847120 -0.035043483782363 -0.162903981240538  0.072814806218845 -0.219110389566894  0.041093714767865
-    9  (  9) -0.053156633750092  0.091069486685611  0.087550589369359 -0.029257872540274  0.135924804171581 -0.072635818919112 -0.001672210695563 -0.447570021005955 -0.046032192367435
-   10  ( 10)  0.217391745861597 -0.434935321818996 -0.409624285133968 -0.322087632703751 -0.032771616999581  0.320492051563577 -0.022523093471372  0.286105139278087  0.028763138212429
-   11  ( 11) -0.043659941201166 -0.078800676739412  0.262193973369673 -0.331520925219487  0.435752308936291  0.063676676892902  0.247088083747518 -0.001843639279205 -0.140239374636342
-   12  ( 12)  0.056061677925681 -0.010922368476032 -0.131982397268853 -0.097477385521921 -0.065023592624631  0.000079901840696 -0.216859084997238  0.136693191532889 -0.129330891363361
-   13  ( 13)  0.037505625217839  0.225932746100622 -0.091672875965964 -0.251961099655879 -0.015143667161303 -0.284372812983916  0.108288291225116 -0.003814786573758  0.367489612278402
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222389083699479 -0.015701847872491  0.082266344272818  0.001672372375017 -0.060404378510596  0.093615396274298
-    1  (  1)  0.559861410768401 -0.123417067860221 -0.153694454214599  0.170286503198903  0.081015909094690 -0.084027887041359
-    2  (  2) -0.169381986858395 -0.033504697868342  0.408858223550610 -0.223464971359780 -0.074967373568669  0.314521774767947
-    3  (  3) -0.116774114128462 -0.019779952941058 -0.283276175027846  0.175022332731274 -0.285114822219635 -0.036573121425863
-    4  (  4)  0.005741360693619 -0.042278482484542 -0.326192071941439 -0.429131786152031 -0.082289054899632  0.119000835266722
-    5  (  5) -0.013423516821882 -0.050360130511676  0.120578150283481  0.018831052901201 -0.153514667633313 -0.076208440200590
-    6  (  6) -0.081285465733278 -0.326426729670571 -0.215182088716426 -0.111429746637352 -0.018999981867360 -0.098876299117681
-    7  (  7)  0.155079790707964  0.099172280525285 -0.073865926904635  0.027727508963580 -0.092673813156168  0.234558008794572
-    8  (  8) -0.037083267042728  0.221065800398389  0.033616402941938 -0.500355807294861  0.749397585446660 -0.380737037092872
-    9  (  9) -0.121630550509204  0.307683459605081  0.063120656742114  0.759405905070709 -0.291159195179390  0.157029303682124
-   10  ( 10)  0.436871717108233  0.180601040070661 -0.427730677617901  0.039372181815525 -0.043027348816400 -0.570244276025105
-   11  ( 11)  0.012751187293868  0.355844753947909  0.014496438271320  0.331024552563185 -0.082393693285337 -0.048306649791118
-   12  ( 12)  0.275276941650836 -0.041042458905035  0.197286719636261  0.114170289272117  0.271015602602994 -0.185041163126162
-   13  ( 13) -0.588129593629221  0.141947366107150  0.099713722453882 -0.418536994369331  0.225811581271459  0.209432602066484
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.136332502394749 -0.095222138145572  0.020696372205148  0.093373694133048 -0.056974308142222 -0.218258098512315 -0.091558195590398 -0.045265175415099 -0.214855115358215
-    1  ( 15) -0.061137877049954 -0.202683152555044 -0.353526070367366  0.245609552328630 -0.180792151363875  0.315264721907539  0.149352343873492 -0.279119121208994 -0.106650279203797
-    2  ( 16)  0.054253456260384  0.094536229676350  0.275971725667493 -0.315900310810875  0.233299003747364 -0.315660301871661 -0.365030241871778  0.369812512976113  0.630864749455945
-    3  ( 17) -0.098600083901755  0.096469822823265 -0.277744609477382  0.023898918383951  0.044551237411584  0.121369522278835  0.010579098206465 -0.111662852316239  0.072981135122258
-    4  ( 18)  0.060921788911548 -0.171978353243574 -0.351197784899122 -0.213711518455428  0.207005180664450  0.279437354230444  0.215133444220066  0.090996522066592  0.034929647170932
-    5  ( 19)  0.161660633493130 -0.086147001578259  0.195689249382698 -0.050176283005300  0.114394522154310  0.293305044762979  0.108948153725431 -0.145670645933351  0.162820061706685
-    6  ( 20) -0.004942089875663  0.509118270553805  0.304174363151756 -0.027002468121694  0.123566788587237 -0.216329634503875 -0.190901556459585 -0.021589313504464 -0.073912134438808
-    7  ( 21)  0.046993230195692 -0.818922464708344 -0.067253581692948 -0.053433234642341 -0.227360464707534 -0.200960848773183 -0.230456752354745  0.400368266822890  0.219888380010792
-    8  ( 22) -0.008868333291472  0.070609706397600  0.201053171865247 -0.001993849783014 -0.055528515803173 -0.064226552772344  0.060945769172458  0.040893491115762 -0.040944224757385
-    9  ( 23)  0.222786038895661 -0.561633840914994  0.169748965776544  0.115017537449362 -0.005573546521783  0.012627582158638  0.079154278361276 -0.154947348010045  0.034750692696974
-   10  ( 24)  0.015630982551661  0.122733671133923  0.033084396710116  0.019083471564733  0.043061905001054  0.050187384392659  0.326689569372421 -0.099489621768347 -0.221182165068758
-   11  ( 25) -0.081015154146910  0.154577286238188 -0.407152055810610  0.281922448284786  0.325678484340217 -0.120357443687716  0.214090639253691  0.074318472872393 -0.033055834005931
-   12  ( 26) -0.003249512574472 -0.168975826063273  0.223036074940092 -0.178070767857802  0.432212639749881 -0.017831109413890  0.111890446658268 -0.031105258460500  0.501232341526329
-   13  ( 27)  0.059498482257520 -0.080037812453612  0.074838091648859  0.286196263876844  0.080953764066314  0.153280498633729  0.018263066455704  0.093491079781028 -0.750780345808096
-   14  ( 28) -0.091986801414438  0.083237402768118 -0.314203504421854  0.035798057800126 -0.118724746257427  0.076125512668229  0.098802767682634 -0.234229258446955  0.382010330057379
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054026801537010 -0.218820809975915  0.045482454896222 -0.056632819987025 -0.041796404833871
-    1  ( 15) -0.090820830473810  0.435186758518917  0.078110332208467  0.010977263097060 -0.224939947084334
-    2  ( 16) -0.088777001237116  0.410390806874956 -0.264290446122590  0.132187376060689  0.093429765679898
-    3  ( 17)  0.030434516536175  0.322721358771669  0.333859520772307  0.097565914369066  0.253669917594512
-    4  ( 18) -0.135235063679589  0.032604670655654 -0.437326454525517  0.064866560796367  0.014517281425601
-    5  ( 19)  0.073849032459231 -0.320876459277713 -0.062467936536600 -0.000278605221466  0.283338683340820
-    6  ( 20)  0.001151706101316  0.022831078108233 -0.248046023125033  0.216907811426422 -0.108111489570171
-    7  ( 21)  0.447532183210635 -0.286158140267043  0.001132096492586 -0.136654666693855  0.003521629186189
-    8  ( 22)  0.045856367104241 -0.028375498001528  0.139997600919731  0.129405058825669 -0.366807076710427
-    9  ( 23)  0.122241483842522 -0.437156690687902 -0.011610251070627 -0.275564671574127  0.586949730800332
-   10  ( 24) -0.308306411893986 -0.180824927568002 -0.356081384430245  0.040953387261227 -0.142499615106930
-   11  ( 25) -0.063084289113014  0.427546671858030 -0.014764234377538 -0.197272035106405 -0.099641021649025
-   12  ( 26) -0.762622032277512 -0.039709598418365 -0.331137446404131 -0.114150945582963  0.418558199192024
-   13  ( 27)  0.291985642881177  0.043175007677671  0.082328218789908 -0.270976982031899 -0.226037881131796
-   14  ( 28) -0.156874264256314  0.569987759510643  0.048450546712728  0.184997500776559 -0.209541353443935
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.008672268005474 -0.071816194535536  0.120572303780740 -0.008736386948533  0.090252792742144  0.086454229305773  0.046146899467462 -0.146407744632766 -0.062154271469811
-    1  (  1)  0.044530650554382 -0.342983591098757  0.233064855218190 -0.079639227294600 -0.129059897680550 -0.051256268905796  0.266059661239060 -0.043200568193505  0.014515255717698
-    2  (  2)  0.007672537139116 -0.182340760590912  0.088050318770564 -0.062838707832560 -0.192033538812169 -0.096771324380559  0.155189348182056 -0.027104280043820  0.057717481416352
-    3  (  3)  0.079454923837834  0.018724046078348 -0.188001130869982  0.049496277469554  0.189935485868638  0.187316285213201  0.212647127834877  0.116734593328088  0.223092695439610
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163722632719569  0.058660940928931 -0.036548308903601  0.075038733758198 -0.102471305627703  0.049390669973433
-    1  (  1)  0.131305501461469  0.004016373834291 -0.198208657763960 -0.065716899528052  0.202185681278344 -0.212640127812522
-    2  (  2) -0.022010926908288  0.084188438316748 -0.151883145143248  0.372685279274918 -0.062662101833962 -0.084377242507503
-    3  (  3) -0.069858345399842  0.076704087124391 -0.378053214374412 -0.165596914244603 -0.189596095473444  0.044613058561591
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.086473379523630  0.139653083392103 -0.215536578934992  0.105983968648794  0.036562785737962 -0.000489435041183  0.079768216054257  0.008070571604873  0.198804995040747
-    1  (  5) -0.142240879073995  0.240288051362283  0.124338297451208  0.149100238302081 -0.037605369870500  0.148064173456833 -0.006146293340323 -0.190577775542559  0.091735166734718
-    2  (  6) -0.312358773620771  0.263851207058737  0.167890772334593  0.304312057068126 -0.049989467903632  0.096105061756251  0.419039438444607  0.027582241523162  0.067772655900023
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.013020057289959 -0.053664053281982 -0.013498948569214  0.012511641581690 -0.053151765112829
-    1  (  5)  0.066147191246195  0.098753011039216  0.179209452625180  0.033057282019118  0.305926873948798
-    2  (  6) -0.161446014830287  0.052105091472844 -0.420025223008533  0.024344041595381  0.149807786778790
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002292052292103 -0.001327689025616 -0.000248352651822 -0.007958119616395 -0.006332326100075 -0.018602233716078 -0.068879285117606 -0.007819744108382  0.006538352080528
-    1  (  1) -0.002764164951482  0.002219747844779 -0.018293151832046  0.029668233290951 -0.039848292773046 -0.022489745012599 -0.162281988584093 -0.020804504235237  0.019083175045330
-    2  (  2)  0.011217835122942  0.011598249376099 -0.016968466001430  0.008250037510452  0.006232273271203  0.008766677291356  0.010338243291246  0.010725726663582  0.004470553150490
-    3  (  3)  0.050562851864419  0.047527304873169 -0.078707468856859  0.000484758494289  0.025585059000142  0.011993586441405  0.049963781283816 -0.008029454242804  0.026864587292977
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006805334012411  0.003000362320125  0.002228041038775  0.000013471324712  0.003129940535122 -0.001748281527537
-    1  (  1) -0.013913717596782 -0.013715090430948 -0.022806809849796 -0.002206415430011 -0.006824605289546  0.005086150284378
-    2  (  2) -0.011033408042675  0.021897939524419 -0.000684908130867 -0.006441462755861 -0.002207402072499 -0.000019160522387
-    3  (  3) -0.030996252825106 -0.007986449014412  0.024562077320803 -0.006200249162119 -0.010690383251548 -0.011486173135261
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.008068643711801 -0.010525757489217 -0.001816581937117 -0.014852647204913 -0.016446444650488  0.051123908211810 -0.105303074579272 -0.010186396385183 -0.002604742010164
-    1  (  5) -0.024807027264739  0.041872241876180  0.005357408083720 -0.028564486604492 -0.031353252400087  0.040716482303662 -0.082357809569049 -0.022204595749264  0.028676826310240
-    2  (  6)  0.057433465116018 -0.072910653400306 -0.007950207598677 -0.045866077252412 -0.051478467074871  0.066399959025154 -0.120267838044194  0.002980749702426 -0.024762093508968
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000934050050601  0.000604010149742 -0.003646663045597  0.000033137801781  0.002019175758165
-    1  (  5)  0.015497094356084  0.002871076746167 -0.025548488367169 -0.001995117147543 -0.006447008967147
-    2  (  6) -0.009288606849912 -0.006735078994323 -0.016930923349150 -0.006239987724853 -0.010309885333920
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.002227369320302  0.043818240274751 -0.042792694201834
-    1  (  1)  0.035951925322998  0.375496620144894 -0.229128772085716
-    2  (  2)  0.031465150106786  0.208897138486076 -0.045237461242765
-    3  (  3)  0.099863658462809  0.215373395444406  0.414485555399891
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.002189605326646 -0.035984212952739 -0.031631892423161 -0.100220822826744
-    1  (  5) -0.043639031048182 -0.374942416866401 -0.208923047083238 -0.216564932229395
-    2  (  6)  0.042460266706280  0.228166292733403  0.044493925974872 -0.415175515862027
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.071562418349012  0.044643481706977  0.010719216935154 -0.107277200321351  0.107632875987832  0.021972908893023  0.087547602927583 -0.002431274801360  0.013111334250454
-    1  (  1)  0.001008369172372 -0.002277471774414  0.009696290175596  0.069946425880608 -0.211098825088912 -0.144763348099231 -0.839194198113659 -0.082764265216905  0.083969085740913
-    2  (  2)  0.048015739591381  0.034141832828957  0.005384996811850 -0.362121098795589  0.166978481952055 -0.200125629587742 -0.200206168196784 -0.048085285607237  0.015203276210723
-    3  (  3) -0.099891713665449 -0.066731401112082  0.191986572239756  0.037167781463831  0.149487286569619  0.091951393356016 -0.124705204882072 -0.114478601924820 -0.084740346074761
-    4  (  4) -0.098285756319308 -0.060256061915825  0.234091228077372  0.042524175756500  0.172705200231067  0.110408395238964 -0.184820371793580 -0.074533125764680 -0.084738680257431
-    5  (  5)  0.074321577193758  0.053246631192159 -0.354250883641741  0.039006455448223  0.144970439473129  0.061654645426165 -0.045166377189249 -0.085032946258587  0.173094046414712
-    6  (  6) -0.068632137123898 -0.078233206409420  0.700315021753110 -0.207546424794390 -0.389419114790676 -0.222243315034359  0.109406552334946  0.045456034210779 -0.343861545970210
-    7  (  7)  0.021714310649791  0.016342702277335  0.098426565374129  0.004050549717199  0.006933240550943  0.079040673905138  0.378109429127298  0.122757215698559 -0.057846791014967
-    8  (  8)  0.009573943840507  0.006109547001624 -0.063930902923820  0.085654067260524 -0.069741050462179  0.032415356083110  0.211725004915126  0.046999658275536 -0.044383134381218
-    9  (  9) -0.004997225889028 -0.003637221795087 -0.021313207566750  0.021715545991438 -0.030064296136495 -0.023365724311185 -0.129019001213584 -0.016405843088409 -0.007636609284437
-   10  ( 10)  0.003358299878380  0.005153653126746  0.010163923897300  0.013149007914750 -0.036797600687866 -0.001802908184499 -0.031118321508131 -0.158323944941481 -0.001398783490941
-   11  ( 11) -0.005208493259169 -0.005568960280890  0.129295087104337 -0.009017109251971  0.009418367237833  0.064439120521238  0.026493808367378 -0.021964026481690  0.285490675127642
-   12  ( 12)  0.022911837501423 -0.014007914409696 -0.005292696989716 -0.012615780901936  0.011192989138601  0.041928856881976 -0.003030455289266  0.141645112536952 -0.005078949468415
-   13  ( 13)  0.006239037546554  0.010350872609282  0.013056167681009 -0.012419271776311 -0.009172814340136 -0.014463827270794 -0.062671831203717 -0.024810755425260  0.013232298103210
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.002821607396533 -0.008465859280820  0.005159289345680  0.009709845024265 -0.000346373782913 -0.003018233888482
-    1  (  1) -0.016525471949901 -0.036788825827130 -0.132790124932168  0.012547146970870  0.013610564122464 -0.014252087123011
-    2  (  2) -0.056507969172448  0.026681136428703  0.044485854173457 -0.008310199956635 -0.009809983442187  0.003131041163706
-    3  (  3)  0.065651101550528 -0.083995833188288  0.024123445214815 -0.011519438681452  0.005292773005652  0.009769161567339
-    4  (  4)  0.036044829938597  0.066193934069216 -0.035808070841047  0.000422817753884  0.007345671878807  0.010223551993872
-    5  (  5)  0.148904113147734 -0.109316649106822 -0.041264792150269 -0.008287145921655  0.000171232625907  0.012797852216750
-    6  (  6) -0.267748006314630 -0.203497034729309  0.004883612400303 -0.039146263280695  0.017846525773098 -0.043283889035238
-    7  (  7) -0.072387866888447  0.141337300939965 -0.132217285722503  0.021714594277698 -0.014576886695933  0.003413824005883
-    8  (  8)  0.065339690335782  0.070423798619333  0.663640860855607  0.043614551269968  0.008449185324519 -0.017636514679536
-    9  (  9)  0.053339386688333  0.015600999572867  0.295866385656840  0.007120395428458  0.021727601519868 -0.010943405927509
-   10  ( 10)  0.043780471226243 -0.395594436897359  0.177336126578030  0.145585406236130 -0.046786318842793  0.019087048140991
-   11  ( 11) -0.612581867283905 -0.015866942037506  0.053557734560298 -0.384133426307945 -0.648991977678548  0.223358395217625
-   12  ( 12)  0.089911319093164 -0.149481392645256  0.148009805956002 -0.410952060560403  0.122608060580667 -0.053525355813637
-   13  ( 13) -0.016967411584222 -0.001119769665917  0.667550447149721  0.016648914439162 -0.049071885737672  0.011595566667332
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.071379476227380 -0.001048107345874 -0.047847319632163  0.099096803223456  0.097425878686372 -0.073274835283488  0.066530976398690 -0.021907365211120 -0.009610510160406
-    1  ( 15) -0.044751454337473  0.002521207190522 -0.033954962989568  0.066720162723388  0.060297503520731 -0.053255041277315  0.078110117153983 -0.016343490661387 -0.006169185301126
-    2  ( 16) -0.011042456445560 -0.009621220621098 -0.005657518819133 -0.191392639644068 -0.233688154054541  0.353809940518162 -0.699390838431378 -0.098400280608918  0.064019946546423
-    3  ( 17)  0.107818298388925 -0.070528263413636  0.362149050189104 -0.037315109632561 -0.042452655982496 -0.038896971283720  0.207385001016399 -0.003937722541105 -0.085745973487131
-    4  ( 18) -0.108164771682442  0.211569235735825 -0.166881810314745 -0.149344513666530 -0.172912627937214 -0.144860894329907  0.389029639178511 -0.006991735156648  0.069587103616937
-    5  ( 19) -0.022034901092728  0.144639335745209  0.200195290755521 -0.092056347474794 -0.110733861294271 -0.061361632097978  0.221627156390718 -0.079027892241888 -0.032657458030366
-    6  ( 20) -0.089133637566930  0.839810294649537  0.200388109318644  0.125542312773296  0.184497876865321  0.044991942130055 -0.109396315941662 -0.378036325170406 -0.212906193050279
-    7  ( 21)  0.002196867006824  0.082899756555975  0.048115279374916  0.114723407886649  0.074445800738012  0.084900756029246 -0.045297736151835 -0.122662484012257 -0.047092811787579
-    8  ( 22) -0.013013108526046 -0.083880968781675 -0.015106010061369  0.084648698834981  0.084842145668688 -0.173118220416505  0.343867943956616  0.057834630145787  0.044463085263394
-    9  ( 23)  0.002899038827224  0.016237402203798  0.056359737364791 -0.065867727287580 -0.036357062083617 -0.148332567483149  0.266717008386610  0.072257711902870 -0.065401118589657
-   10  ( 24)  0.008453034218761  0.036792496630374 -0.026643685782358  0.084175209377106 -0.066503904171434  0.109372833173203  0.203212961501276 -0.141160482906112 -0.070506928282105
-   11  ( 25) -0.005372433858294  0.132964341260406 -0.044450916757190 -0.024049494205707  0.035746907565715  0.041241296739167 -0.004906662564596  0.132215391095914 -0.663807503452023
-   12  ( 26) -0.009743703341659 -0.012547820945935  0.008267356406185  0.011523281572029 -0.000373189232647  0.008287799895073  0.039182879439333 -0.021754582044359 -0.043605958741618
-   13  ( 27)  0.000316984988558 -0.013620382001563  0.009757290310366 -0.005224660475905 -0.007370239991754 -0.000209579654671 -0.017764427460055  0.014597770330481 -0.008463776890616
-   14  ( 28)  0.003075987620069  0.014184203488029 -0.003152602515271 -0.009779432437690 -0.010217463081165 -0.012805369803199  0.043328580726749 -0.003405373560657  0.017681393118998
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.005093177831083 -0.003391694549732  0.004782174271812 -0.022986027625481 -0.006388300989623
-    1  ( 15)  0.003655760801056 -0.005146167609244  0.005618407889967  0.014027116916428 -0.010302793578385
-    2  ( 16)  0.021370860681958 -0.010099899127123 -0.129116414547005  0.005333934325137 -0.012983600372401
-    3  ( 17) -0.021869921491230 -0.013215154242643  0.009123077510949  0.012606640556921  0.012446334486325
-    4  ( 18)  0.030272655227353  0.036864268294435 -0.009498431522863 -0.011184920276992  0.009178466867281
-    5  ( 19)  0.023458599618802  0.001801666075823 -0.064552415401924 -0.041959427003810  0.014422120327278
-    6  ( 20)  0.129459521423828  0.031271354696917 -0.026491579555366  0.003035107017297  0.062712218110468
-    7  ( 21)  0.016586408114880  0.158363845858414  0.021959943871014 -0.141641861845629  0.024817685283350
-    8  ( 22)  0.007575307701155  0.001384055242024 -0.285443271693517  0.005092655839931 -0.013202283951991
-    9  ( 23) -0.053335131127380 -0.043784781244715  0.612431255767613 -0.089944266819985  0.016910855433428
-   10  ( 24) -0.015342744071877  0.395632766534517  0.015815980082040  0.149475926737218  0.001110117846160
-   11  ( 25) -0.295833476490493 -0.177314277208158 -0.053562169532047 -0.148004503342686 -0.667549178746814
-   12  ( 26) -0.007155741332045 -0.145584854877254  0.384139934668211  0.410953720693688 -0.016648203877508
-   13  ( 27) -0.021702025353791  0.046795922259450  0.648985546330551 -0.122609080566925  0.049062461275054
-   14  ( 28)  0.010942461108182 -0.019093069660341 -0.223364865933360  0.053520934540283 -0.011602401514689
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002861849195600  0.001750118343665 -0.000194150196746  0.008574693111016  0.006010353559076  0.019458325296912  0.072285446678870  0.008447728513642 -0.006619839911905
-    1  (  1)  0.001924861668391 -0.002087363110901  0.016971855467530 -0.027235173953934  0.038093280019961  0.023104905850605  0.165692788520465  0.021219005281025 -0.019010687091109
-    2  (  2) -0.012268940248648 -0.010883087952419  0.016276306732469 -0.008309931413768 -0.005837724525099 -0.009011561998791 -0.007091651398210 -0.010639721826082 -0.003897826849990
-    3  (  3) -0.055999657987489 -0.045440477856664  0.076835806171601 -0.000960169751802 -0.024603305635074 -0.014163811775193 -0.053505119974436  0.007641653146516 -0.022495845210930
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.007010768189510 -0.003146790661101 -0.002197659213555  0.000162653889535 -0.003167919380673  0.001716454351420
-    1  (  1)  0.014102241824718  0.014333573201717  0.027759720880070  0.002387194913826  0.006827488663716 -0.005333656372041
-    2  (  2)  0.010359867010522 -0.021409066244275  0.001741696980020  0.007351305093923  0.001924339705620  0.000068941706469
-    3  (  3)  0.028959184887726  0.008194597278714 -0.026966557516044  0.006362654301925  0.010940855488235  0.011462480717190
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.007841499731725  0.011260922827034  0.003550382080370  0.014025398893426  0.016144397742124 -0.052695970359654  0.108253401254700  0.010488497388985  0.002709659180314
-    1  (  5)  0.026329524563314 -0.037825007600228 -0.006030211425349  0.027406600793118  0.031382299209950 -0.043131173483671  0.084960450738463  0.021264528915956 -0.026601463642217
-    2  (  6) -0.060083641924427  0.072478494093869  0.010248933969103  0.046258741412677  0.052269824639874 -0.069243610281519  0.126398541619941 -0.001565657218680  0.022435245739888
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000994215031647 -0.000923363442840  0.004583185686911  0.000218320240713 -0.001898840213869
-    1  (  5) -0.015124923054324 -0.001842634557062  0.029618847414201  0.001149888101607  0.006797617275229
-    2  (  6)  0.007998426054028  0.006657968933295  0.021107111486180  0.005764289634517  0.010813449750819
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440295578  0.058098623160149  0.000062770556747 -0.132305009159640 -0.206845253888039  0.090151367716481 -0.021622993201594 -0.039361663017838  0.081041759541844
-    1  (  1) -0.058446002592380  0.108172168387664  0.020491566069365  0.029038345945864 -0.075256281089896  0.197244333760811 -0.268904698800666 -0.104165934684919  0.067340388337436
-    2  (  2) -0.015395531940670  0.065975044888454  0.020693241252052  0.145278172828453  0.156811977467562  0.026190455409852 -0.072791620600653 -0.106379132149941  0.008110007387648
-    3  (  3)  0.209889648220471  0.051262205346318 -0.016792464687913 -0.095510023534375  0.095336437810915 -0.289116526954887  0.245753636284379 -0.379261907424051  0.084194488967517
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922100176 -0.024147628250431  0.039515998201656  0.082736569420113 -0.047511948424278
-    1  (  1)  0.028213287461093  0.067760885411211  0.238885785807081 -0.125969164479721  0.177609465312030
-    2  (  2)  0.077606300081110 -0.045313543916729  0.093141189396734  0.365274041996183  0.093447143795063
-    3  (  3)  0.414915648100447  0.159852566418802 -0.273568285227129 -0.034618677637946  0.200919751819537
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102681987246 -0.069778483698172  0.053388820632188  0.227201022134288 -0.199230027457294  0.049687576281256 -0.168877445270922 -0.014461225328824 -0.006078045812767
-    1  (  5)  0.058029574787106 -0.323045692563540  0.030451397472045 -0.087822399116216 -0.049669665032498 -0.052839306746919 -0.277652121541254 -0.149775076383330  0.305937155270736
-    2  (  6) -0.084055275470360  0.046073375199282  0.190725804864304 -0.087557818530462 -0.137785527514680 -0.205465571554523 -0.198777590920686 -0.118276962990448 -0.298899363373293
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985616707  0.083163093490792  0.059838819851122  0.009394325001925 -0.030439464329862  0.004211858017360
-    1  (  5)  0.056299326992319 -0.068872084539630  0.330916524068169 -0.053769676104340 -0.184435947376539 -0.103868547783986
-    2  (  6)  0.066328790174113 -0.124449756312365  0.113043685745450  0.144452726551001  0.299204372306583 -0.043729255680800
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000260799328814  0.008294549411173  0.017065509132629 -0.120823023937813
-    1  (  1) -0.008496132195738  0.000459228916484  0.070584547130300 -0.263658986380405
-    2  (  2) -0.016577243382678 -0.069994423934547  0.000663995310113  0.516189373310167
-    3  (  3)  0.119940673155352  0.260382744777091 -0.515797578549303  0.000896332895375
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000443199065137  0.381921103277014 -0.143832380212943
-    1  (  5) -0.379434119923402 -0.000485247174065  0.057931042501930
-    2  (  6)  0.142702240195831 -0.057674062630535  0.001442186168114
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000910219825462  0.057456315494167  0.021764053721958 -0.110121259160946 -0.041147685420936  0.038875238468069 -0.013658833334326  0.027740409199842  0.095876697377004
-    1  (  1) -0.055345620113473 -0.000114715855223 -0.161082100743083  0.114708095623102 -0.226148458080404  0.429581554700213 -0.364780574441808 -0.339773267999994 -0.220533775015703
-    2  (  2) -0.020999461374251  0.161288340706678  0.000052922940143  0.056734674516634  0.008992634243539  0.218257664425439 -0.249333786109915 -0.218109894036319  0.109339937450952
-    3  (  3)  0.109919099247493 -0.115822425772584 -0.056019356072116  0.000740007124151  0.462857615716207  0.122607299860807  0.103870365958941  0.116250705982649  0.000233457087431
-    4  (  4)  0.040147971327435  0.225934656776577 -0.007773114553173 -0.462818557657105 -0.000780254100804  0.292874409688809 -0.009409004834406 -0.051882583984439 -0.039822167887863
-    5  (  5) -0.036335623982806 -0.431140334321554 -0.219015877156661 -0.122742718969562 -0.292837706512844 -0.000258433770030  0.380099535262126  0.122521034811976  0.042311772881298
-    6  (  6)  0.010512439729451  0.366117333062846  0.249486244286841 -0.103549874288531  0.008542366045705 -0.379118456110851 -0.000620782720873  0.110534560804533 -0.061985573678083
-    7  (  7) -0.028794952109144  0.339121669903044  0.216809050553033 -0.114099992926570  0.053090461678186 -0.122152835713476 -0.109887843536853 -0.000210775947309 -0.084672807581202
-    8  (  8) -0.095808229432329  0.221323464446135 -0.109106314769919 -0.000875257370226  0.038544677458879 -0.040538328330232  0.059775641070054  0.084700205529952  0.000410389282629
-    9  (  9)  0.014690106677676 -0.105287842105419 -0.107275604589342  0.218821764495376  0.309676781793525 -0.105240911833305 -0.129641828300340  0.117997785258370  0.042511311165967
-   10  ( 10) -0.029204608723917  0.107752356942562 -0.099755035690676  0.053525818789624  0.138310129135290  0.190113742094553 -0.089997971717103 -0.050367402099573 -0.205935350521398
-   11  ( 11) -0.155172680877926  0.443695988924904 -0.328777258004313 -0.218798389165188 -0.215176387418517  0.086665175787649 -0.081418632262697 -0.042686048369212  0.076994698914289
-   12  ( 12)  0.047142387853016  0.056370877736755 -0.091886939960935  0.290638653896334 -0.241910293173795 -0.247337059600416  0.042831064612679  0.092379405814653 -0.274155000199424
-   13  ( 13) -0.050389463609625  0.050328281605153 -0.290240848550854  0.162056910685561  0.213783629816238 -0.103688021030834 -0.033887129791453 -0.045587144670831  0.299790508083899
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015162318835378  0.029089770357077  0.157702855053245 -0.046156695205794  0.051381788523401
-    1  (  1)  0.106899842384160 -0.107201619393601 -0.445393414611343 -0.057067667076039 -0.050060002330133
-    2  (  2)  0.108853020442019  0.100191021225089  0.328545989364509  0.092698579065235  0.291502735972872
-    3  (  3) -0.218857915462394 -0.054792818652366  0.218936510995734 -0.287400527011265 -0.163296274870058
-    4  (  4) -0.309023998295357 -0.137542450097200  0.215093937212832  0.238284970616127 -0.213551426913738
-    5  (  5)  0.105674820499688 -0.189857437866345 -0.086867271133608  0.246374813737064  0.103858683965504
-    6  (  6)  0.128168668073169  0.089874262606371  0.081958190146060 -0.043636026349126  0.033207564087096
-    7  (  7) -0.118048268068595  0.049676493985730  0.043691990049327 -0.088880391954538  0.045560836827754
-    8  (  8) -0.043185963892521  0.206226573094588 -0.075243165625009  0.272590964413989 -0.299131513393744
-    9  (  9) -0.000077812655806  0.416515228460327  0.033604308335513 -1.079153036114418  0.144875292314574
-   10  ( 10) -0.417421688626605 -0.000158782170528 -0.288840596251926 -0.322135886975336 -0.291543524616041
-   11  ( 11) -0.033233098401296  0.288689216188738  0.000098607034113  0.357467165068052 -0.110234432421322
-   12  ( 12)  1.082588808808366  0.322578291119115 -0.357464370574866 -0.000001008980927 -0.002433258977456
-   13  ( 13) -0.144961978494652  0.291352746558436  0.110198259093452  0.002466771759163  0.000072101852768
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000153758293573  0.016209319744983  0.024928923087972 -0.062060534269405 -0.021458157317334  0.118593249827295 -0.004670228348363 -0.089096780060312  0.035341471454486
-    1  ( 15) -0.019055649311341  0.000070156580396  0.073747917872717 -0.220440654642185  0.117173683557053 -0.070042104700274 -0.194626599435631  0.297284852411648 -0.000292615006130
-    2  ( 16) -0.022586057176061 -0.073725573702120 -0.001109122528867 -0.015411803572941 -0.086529842282525 -0.104871288135925 -0.398741646254535 -0.436619148290803  0.174927780236032
-    3  ( 17)  0.059798965758570  0.223563288101711  0.017237453196908  0.001072539320884  0.251308090709605 -0.316070038507959  0.194803920922688  0.070654458314154 -0.376473484057802
-    4  ( 18)  0.020063419795573 -0.119039349150294  0.086800563385573 -0.251653936247919 -0.000335080469717  0.043024304110374  0.031731211566238  0.166597040990208  0.162561044012722
-    5  ( 19) -0.121124499928881  0.070386001406864  0.107113060109827  0.315446439196993 -0.043168772404524 -0.000861182223329  0.084799444582179  0.176705933397061 -0.191684805310528
-    6  ( 20)  0.000233561008252  0.194646689316488  0.399810731697972 -0.193912344319211 -0.032510952628099 -0.085522667102850  0.000316477106834  0.483153682293504 -0.288298405946303
-    7  ( 21)  0.086715012726146 -0.297226361723507  0.437406682983154 -0.070307665225876 -0.166617940082316 -0.177260527666885 -0.482840792819482 -0.000014363839073  0.098144550640997
-    8  ( 22) -0.034848855945224  0.000859202259418 -0.174080336964064  0.374333295775790 -0.160768014871922  0.191629536743281  0.289445575908438 -0.097019024591293 -0.000025631290485
-    9  ( 23) -0.146128458942654  0.053492838881233  0.324237370292126  0.062951581954808  0.055209150473504  0.064149761290883  0.152989513529253  0.139473999144980 -0.103718919883348
-   10  ( 24)  0.228943772976322 -0.607904766640644 -0.190620042117683 -0.232958068537229 -0.097307404470545  0.308161168755027 -0.021743402371769  0.163623966375628  0.316399909838170
-   11  ( 25) -0.113574180426266 -0.174427793656612  0.418995996828982  0.308337203800434 -0.075443225323578  0.339087150964693 -0.159463644137134 -0.028413073180430 -0.098871219189354
-   12  ( 26) -0.037424667616197 -0.021650461850134  0.117304488625228 -0.051902638546729  0.180454397108215  0.010740660434746  0.081519307880048 -0.155893098296170  0.070546741469611
-   13  ( 27)  0.017280095018033 -0.067254948221378  0.031223412816175 -0.363810241814661  0.387221887080941  0.012090141341438  0.015814975926527  0.054980917611015 -0.199339784775612
-   14  ( 28)  0.034098865585284  0.073619427458161 -0.020485113735762 -0.085856422394852  0.016811589946857 -0.112843996657195 -0.014113720389586  0.178007823037396  0.110352388623858
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147079246017605 -0.230634884307448  0.118016008570358  0.038157144686245 -0.016510467338390 -0.035555014319301
-    1  ( 15) -0.054535975317160  0.607948558454318  0.173873444004683  0.021413077698393  0.066607275071670 -0.073358775740227
-    2  ( 16) -0.323553306767810  0.191880318072800 -0.420431580468539 -0.118056258288723 -0.032680374421701  0.021063792747363
-    3  ( 17) -0.062647993315218  0.233296910361178 -0.309972235789264  0.052767888005775  0.365466873290423  0.086191647934482
-    4  ( 18) -0.056463254704659  0.097267542243260  0.076718792069295 -0.181006281549198 -0.388581954764126 -0.017033117994916
-    5  ( 19) -0.064619380121905 -0.308870128962105 -0.338018874162144 -0.010262168050506 -0.011437556312376  0.112357516914852
-    6  ( 20) -0.155382617184205  0.021349499009466  0.159407311408361 -0.081840985858683 -0.016551112467373  0.014159445477374
-    7  ( 21) -0.140537868334591 -0.163950016196429  0.028635642754641  0.155664270507489 -0.055628199109166 -0.178154241019464
-    8  ( 22)  0.103340924054087 -0.315438553689221  0.098505861498584 -0.070640699164670  0.199194337971902 -0.110183696097256
-    9  ( 23)  0.000686334470077 -0.100169676668856 -0.098205410096924  0.175395135170107 -0.218110756020923  0.228152281870970
-   10  ( 24)  0.099945574878784 -0.000096874526586  0.318471840137312 -0.225312238992057 -0.500004280228380 -0.463864297020155
-   11  ( 25)  0.099841601913638 -0.317761699333726 -0.000010561932173  0.325597818789670 -0.211905875369382 -0.064803783290132
-   12  ( 26) -0.174935630019299  0.225292248892597 -0.325705390203938 -0.000017197211890 -0.212072627171769  0.098012445882972
-   13  ( 27)  0.218628597680076  0.499556536377707  0.211864150062139  0.212027765026480  0.000008829396513 -0.140826209090944
-   14  ( 28) -0.228628348725032  0.463533897278190  0.064881803503368 -0.097950839624484  0.140879063665638 -0.000044304487925
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019783286607667 -0.054735513570492  0.001137513326844  0.126035313344694  0.202288256463714 -0.093711193698784  0.024984211933465  0.040225532534290 -0.083002910266348
-    1  (  1)  0.062354141555506 -0.120130295665511 -0.021767958766603 -0.030544877233675  0.074729404058403 -0.202914227757890  0.283260340106330  0.110010623472489 -0.075144553745797
-    2  (  2)  0.020071775922308 -0.073560405733831 -0.021169788457012 -0.145854094152842 -0.150911679145940 -0.033300463325012  0.073764757277366  0.114546085452080 -0.006653298048327
-    3  (  3) -0.203743032315313 -0.061501990395663  0.012053005442539  0.096810293782688 -0.111136074331669  0.295383183213123 -0.262971263743015  0.383085482761273 -0.093214800317935
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009993046060541  0.025513386759873 -0.042737152868896 -0.089318313022720  0.047451575644814
-    1  (  1) -0.030039490492705 -0.071945228341214 -0.250267584824113  0.142236309251859 -0.184637049012501
-    2  (  2) -0.082997800684343  0.054871780927271 -0.094796177478387 -0.401103665959789 -0.092927167756829
-    3  (  3) -0.430981237850907 -0.170811683530718  0.282618326899226  0.039486331856936 -0.208093563870180
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.010424637780811  0.070076242850132 -0.057204660728363 -0.211582689187883  0.193468115886375 -0.043909115910882  0.178375291391116  0.011291008522235  0.006135050327905
-    1  (  5) -0.063097235172986  0.334472528658100 -0.025536895021054  0.078253605984607  0.050626848674631  0.056751427025114  0.294768359886251  0.157483235119348 -0.310569420199796
-    2  (  6)  0.095244047527648 -0.044264155264159 -0.212560989845075  0.091390111204814  0.149038964321561  0.211765484927062  0.210419447669955  0.121083324679766  0.309642082152002
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068004772690589 -0.092578616035472 -0.065573414522003 -0.010233554080849  0.030163257483495 -0.003064448267094
-    1  (  5) -0.053600125816554  0.069934313107806 -0.342538885093587  0.056907033818697  0.186630070751322  0.106323577696440
-    2  (  6) -0.072821378442813  0.126275995801835 -0.117600527323037 -0.149377060250910 -0.309029921894478  0.046031658506232
+	[alpha]_(0.077) =  -76.93369 deg/[dm (g/cm^3)]
 
 	Computing Mu_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.636110668357
-	   1         4.368226284645    2.102e-01
-	   2         4.889420903742    1.034e-01
-	   3         4.890699547019    1.950e-02
-	   4         4.895139853950    6.508e-03
-	   5         4.895380616762    1.736e-03
-	   6         4.895369410772    4.222e-04
-	   7         4.895420519453    1.505e-04
-	   8         4.895404611369    4.379e-05
-	   9         4.895401381090    1.349e-05
-	  10         4.895401628895    6.158e-06
-	  11         4.895402448686    2.470e-06
-	  12         4.895402380861    5.904e-07
-	  13         4.895402218579    1.388e-07
+	   0         3.636110656490
+	   1         4.368226267565    2.102e-01
+	   2         4.889420880054    1.034e-01
+	   3         4.890699523087    1.950e-02
+	   4         4.895139829915    6.508e-03
+	   5         4.895380592705    1.736e-03
+	   6         4.895369386717    4.222e-04
+	   7         4.895420495396    1.505e-04
+	   8         4.895404587312    4.379e-05
+	   9         4.895401357033    1.349e-05
+	  10         4.895401604839    6.158e-06
+	  11         4.895402424629    2.470e-06
+	  12         4.895402356805    5.904e-07
+	  13         4.895402194523    1.388e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 3.859e-08
 
 	Computing L_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.885887798223
-	   1         6.300799558550    3.908e-01
-	   2         8.042166065694    2.648e-01
-	   3         8.232912105131    9.042e-02
-	   4         8.350320778069    4.596e-02
-	   5         8.364772803545    2.108e-02
-	   6         8.372862035149    1.249e-02
-	   7         8.378389890312    6.798e-03
-	   8         8.378550012013    3.868e-03
-	   9         8.379102617453    1.584e-03
-	  10         8.379275351597    6.450e-04
-	  11         8.379414488305    2.450e-04
-	  12         8.379366543529    1.190e-04
-	  13         8.379331429029    4.495e-05
-	  14         8.379328483312    1.921e-05
-	  15         8.379326771845    8.922e-06
-	  16         8.379322805446    4.483e-06
-	  17         8.379318119181    2.125e-06
-	  18         8.379316087222    1.156e-06
-	  19         8.379314883363    7.830e-07
-	  20         8.379314708863    4.153e-07
-	  21         8.379314711965    2.045e-07
+	   0         4.885887775380
+	   1         6.300799532190    3.908e-01
+	   2         8.042166037384    2.648e-01
+	   3         8.232912076853    9.042e-02
+	   4         8.350320749645    4.596e-02
+	   5         8.364772774436    2.108e-02
+	   6         8.372862005542    1.249e-02
+	   7         8.378389860408    6.798e-03
+	   8         8.378549982024    3.868e-03
+	   9         8.379102587476    1.584e-03
+	  10         8.379275321614    6.450e-04
+	  11         8.379414458325    2.450e-04
+	  12         8.379366513547    1.190e-04
+	  13         8.379331399047    4.495e-05
+	  14         8.379328453329    1.921e-05
+	  15         8.379326741862    8.922e-06
+	  16         8.379322775463    4.483e-06
+	  17         8.379318089198    2.125e-06
+	  18         8.379316057239    1.156e-06
+	  19         8.379314853381    7.830e-07
+	  20         8.379314678881    4.153e-07
+	  21         8.379314681983    2.045e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 9.286e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.358053133969
-	   1         9.221758751009    3.716e-01
-	   2        10.916162414058    1.897e-01
-	   3        10.931084970640    3.056e-02
-	   4        10.949681819319    1.383e-02
-	   5        10.951925675500    3.260e-03
-	   6        10.951642793660    9.463e-04
-	   7        10.951803234039    3.750e-04
-	   8        10.951808654077    1.508e-04
-	   9        10.951773522031    4.901e-05
-	  10        10.951778420642    1.253e-05
-	  11        10.951787168341    3.945e-06
-	  12        10.951791281519    8.117e-07
-	  13        10.951791392512    2.025e-07
+	   0         7.358053064122
+	   1         9.221758658583    3.716e-01
+	   2        10.916162287664    1.897e-01
+	   3        10.931084842543    3.056e-02
+	   4        10.949681690565    1.383e-02
+	   5        10.951925546614    3.260e-03
+	   6        10.951642664788    9.463e-04
+	   7        10.951803105157    3.750e-04
+	   8        10.951808525194    1.508e-04
+	   9        10.951773393151    4.901e-05
+	  10        10.951778291761    1.253e-05
+	  11        10.951787039460    3.945e-06
+	  12        10.951791152638    8.117e-07
+	  13        10.951791263630    2.025e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 8.616e-08
 
 	Computing L_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.282042748553
-	   1         0.386817673143    1.123e-01
-	   2         0.532364391281    8.038e-02
-	   3         0.561332353462    3.134e-02
-	   4         0.569946752418    1.006e-02
-	   5         0.569815402843    4.207e-03
-	   6         0.569779007180    2.516e-03
-	   7         0.570316010619    1.671e-03
-	   8         0.570192080649    6.621e-04
-	   9         0.570236097443    1.629e-04
-	  10         0.570238721845    7.212e-05
-	  11         0.570232531172    2.578e-05
-	  12         0.570224809883    1.110e-05
-	  13         0.570223911595    4.308e-06
-	  14         0.570225663737    2.231e-06
-	  15         0.570226248114    7.956e-07
-	  16         0.570226367605    3.005e-07
-	  17         0.570226320527    1.207e-07
+	   0         0.282042744862
+	   1         0.386817667667    1.123e-01
+	   2         0.532364382026    8.038e-02
+	   3         0.561332343521    3.134e-02
+	   4         0.569946742269    1.006e-02
+	   5         0.569815392669    4.207e-03
+	   6         0.569778996991    2.516e-03
+	   7         0.570316000357    1.671e-03
+	   8         0.570192070394    6.621e-04
+	   9         0.570236087186    1.629e-04
+	  10         0.570238711588    7.212e-05
+	  11         0.570232520915    2.578e-05
+	  12         0.570224799626    1.110e-05
+	  13         0.570223901338    4.308e-06
+	  14         0.570225653480    2.231e-06
+	  15         0.570226237857    7.956e-07
+	  16         0.570226357348    3.005e-07
+	  17         0.570226310270    1.207e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 4.113e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.404411435098
-	   1         6.598966157981    2.821e-01
-	   2         7.515826384066    1.333e-01
-	   3         7.513416753353    2.023e-02
-	   4         7.518023839766    8.199e-03
-	   5         7.518815832612    1.834e-03
-	   6         7.518752444754    5.596e-04
-	   7         7.518801461297    2.130e-04
-	   8         7.518793851915    6.505e-05
-	   9         7.518781943512    1.891e-05
-	  10         7.518783061288    5.849e-06
-	  11         7.518785231726    2.143e-06
-	  12         7.518786370509    5.634e-07
-	  13         7.518786385811    1.849e-07
+	   0         5.404411393401
+	   1         6.598966101537    2.821e-01
+	   2         7.515826310042    1.333e-01
+	   3         7.513416679168    2.023e-02
+	   4         7.518023765374    8.199e-03
+	   5         7.518815758184    1.834e-03
+	   6         7.518752370328    5.596e-04
+	   7         7.518801386869    2.130e-04
+	   8         7.518793777488    6.505e-05
+	   9         7.518781869085    1.891e-05
+	  10         7.518782986861    5.849e-06
+	  11         7.518785157299    2.143e-06
+	  12         7.518786296081    5.634e-07
+	  13         7.518786311384    1.849e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 6.421e-08
 
 	Computing L_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.306076661937
-	   1         5.427542221295    3.475e-01
-	   2         6.784160994647    2.603e-01
-	   3         7.225526995626    1.323e-01
-	   4         7.434836022172    6.019e-02
-	   5         7.450407010962    2.621e-02
-	   6         7.462308887900    1.252e-02
-	   7         7.466061663196    4.987e-03
-	   8         7.464335791544    2.351e-03
-	   9         7.464570512193    9.851e-04
-	  10         7.464580776560    5.391e-04
-	  11         7.464536286719    2.304e-04
-	  12         7.464350737213    9.836e-05
-	  13         7.464331459579    3.332e-05
-	  14         7.464350251041    1.192e-05
-	  15         7.464356939271    4.310e-06
-	  16         7.464358257010    1.778e-06
-	  17         7.464357579835    5.880e-07
-	  18         7.464357400200    2.086e-07
+	   0         4.306076639543
+	   1         5.427542195490    3.475e-01
+	   2         6.784160966895    2.603e-01
+	   3         7.225526971506    1.323e-01
+	   4         7.434836000683    6.019e-02
+	   5         7.450406990027    2.621e-02
+	   6         7.462308867495    1.252e-02
+	   7         7.466061642807    4.987e-03
+	   8         7.464335771084    2.351e-03
+	   9         7.464570491751    9.851e-04
+	  10         7.464580756118    5.391e-04
+	  11         7.464536266278    2.304e-04
+	  12         7.464350716773    9.836e-05
+	  13         7.464331439140    3.332e-05
+	  14         7.464350230602    1.192e-05
+	  15         7.464356918831    4.310e-06
+	  16         7.464358236571    1.778e-06
+	  17         7.464357559395    5.880e-07
+	  18         7.464357379760    2.086e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 8.619e-08
 
 	Computing 1/2 <<Mu;L>>_(0.128) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933722  0.015024519180330 -0.027415915569926 -0.162886507397837  0.113254822182090 -0.064023650931681  0.055316304980595  0.030988679956786  0.002674429417473
-    1  (  1)  0.215473680254297  0.146951879885489 -0.277734064030085  0.062883278347907  0.148483123915976  0.181595053380792  0.367001371843723  0.003086313328535  0.095386404339389
-    2  (  2) -0.028492499167409  0.000076506520594 -0.059221747197115  0.071711487991930  0.074053260083171  0.055563200913409 -0.046720222778264  0.241063526706415  0.098194384215300
-    3  (  3) -0.132536698935214 -0.177581639220038 -0.107360746511037 -0.032262815899196  0.006088751294663  0.053657437577803 -0.241466578728668 -0.131962062699382  0.577380042604848
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927831  0.060461893794975 -0.005615477646774 -0.003888920206542  0.016113135271294 -0.008672229740058
-    1  (  1) -0.037058680758832 -0.084686071934146 -0.145302623884171 -0.027760832624294 -0.054555858489397  0.022009727182522
-    2  (  2) -0.087315818129464  0.399047483163754 -0.041723099752478 -0.020041920189952 -0.040600995633867  0.007777357868478
-    3  (  3)  0.035307803556674 -0.050920479686551  0.165550414172817 -0.068091463340310 -0.144062340529064 -0.042051983076326
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356556 -0.081063517853361  0.006129432768990  0.163964563111026  0.188951419459744 -0.080047732466249  0.074988303081884  0.007836242506549 -0.044696302205991
-    1  (  5)  0.348085979138488  0.014814724303189 -0.054134117524102 -0.070406995762182  0.073423358836430 -0.343984245233746  0.389896180591091 -0.295068043464405  0.051928952938000
-    2  (  6)  0.021691230674308 -0.340003625622928 -0.038072452179291 -0.014533847126878 -0.084733391360480 -0.004556444515519  0.201335045135150  0.349717311230199 -0.082620936463626
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932768 -0.007485730843832 -0.029474818409047  0.032209758674479  0.014108652541198
-    1  (  5)  0.209382720135366  0.066996563725019 -0.203801631001161 -0.021994746468443  0.025790645299279
-    2  (  6) -0.188199132187478 -0.086167806666971 -0.070501884768040 -0.051440727873377 -0.127552190835525
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135256936427952 -0.625840722558221  0.189152953764112
-    1  (  1) -0.199003345368290 -0.037728544846467 -0.132520495485755
-    2  (  2)  0.054832391479849  0.126830338283563 -0.064813973138962
-    3  (  3)  0.614911888994771 -0.126366054397384 -0.081969716276970
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135588281064904 -0.198280199301267  0.054865352772196  0.616466856386244
-    1  (  5) -0.625018546427486 -0.037797728443036  0.128181522571229 -0.126284878377160
-    2  (  6)  0.187313400211737 -0.129941287514713 -0.067401170507903 -0.079868689249863
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904654705038447 -0.487501531810708 -0.228989288733664  0.577066731250213 -0.193646174785151 -0.103557394991757 -0.002763438454961 -0.002521717002670 -0.093924205114663
-    1  (  1) -0.150947783743718 -0.133094859243219 -0.684508017896886  0.231703815137259 -0.050781378856692 -0.177728773246253  0.233390917593619  0.124583633127435 -0.128535104851894
-    2  (  2)  0.012551305323021 -0.025827567013436  0.172781771766395 -0.235942566464277 -0.123537066136894 -0.206303367930766 -0.122018320537678 -0.114258781226498 -0.027597706889355
-    3  (  3) -0.420664931045178  0.000231270272020 -0.019477825760908 -0.199685770844492 -0.007136872649739  0.053913463253293 -0.291371052496433  0.275369617235929  0.504870072210317
-    4  (  4) -0.444539603269803 -0.097599370289466 -0.201272452095786 -0.112154803373139 -0.168808745749079  0.009504026587737 -0.073434229339344 -0.314806815881344  0.576722941605365
-    5  (  5) -0.139185904754597  0.035403106550569 -0.250195485899929 -0.395579082865144  0.287107722232791 -0.179415180449191  0.197379951884854  0.283342209415980 -0.108348043155478
-    6  (  6) -0.129871685517428 -0.067550419610088  0.181281711489601  0.198220043794417  0.101452024103282  0.004283894850388 -0.540069944377460  0.047097617764531 -0.240100013513811
-    7  (  7) -0.134001967409457 -0.177786015227937  0.066093354439321 -0.420139999558483  0.282303467947247 -0.347511589889067 -0.074355555279622 -0.307158876945279  0.001553207015969
-    8  (  8) -0.063375553143536 -0.086930415097253  0.269823860040624  0.018758493940939  0.093244023047550  0.136825056817826  0.153826640418330 -0.031539001153955  0.057539448326199
-    9  (  9)  0.014052174262802  0.032094357332924  0.006340699519412 -0.122579073435548  0.077124463374283 -0.029957160801606  0.027113970740793  0.089338289754764 -0.000820355507439
-   10  ( 10)  0.055395761167618 -0.144588618215807  0.060408759576408 -0.048569537009262 -0.074902296486310 -0.098511130754444  0.029332110695438 -0.193865792017111  0.085017383342046
-   11  ( 11) -0.167030257809343 -0.139664345575235  0.283530253423074  0.091891536336475 -0.065839803661809 -0.024334768581110 -0.227863951306873  0.001156424000013 -0.053369630727928
-   12  ( 12) -0.032033949703816  0.367089735753367  0.116673683387299  0.049313912170209  0.015062916039851 -0.072484718896620  0.058244376751757 -0.115278436137835 -0.152926398532996
-   13  ( 13)  0.015984312806398 -0.071111738375073  0.101621776382356 -0.105958849078010  0.126694141619647 -0.065028650120473 -0.035640566810681 -0.004391274841067 -0.060055094679329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128805534604310 -0.011795734826670 -0.146692960373073 -0.059406136241753 -0.018473798015716  0.062695275021725
-    1  (  1)  0.288596068552158  0.103250502413098  0.290163518419001  0.006271627172818  0.000646355178478 -0.002163096577325
-    2  (  2) -0.124851872316921 -0.010381368501732 -0.056466489774845 -0.103372365620093 -0.082252504329980  0.048795995956760
-    3  (  3)  0.041212898278569 -0.068182265272190 -0.078432164026115  0.150307548616515  0.179510662629566  0.040218002018582
-    4  (  4)  0.222712022333468  0.063990226659608 -0.051059235174083 -0.009318639929278  0.269446728734512  0.059353222373419
-    5  (  5) -0.030203406833989 -0.174843255002292  0.092722839796391  0.028249854916050 -0.095235014058556 -0.000991383838387
-    6  (  6)  0.000094761803154 -0.095079960743173 -0.236654935643855  0.077257506718755 -0.062658502435841 -0.003579147462098
-    7  (  7) -0.071378609117900  0.113105200937282 -0.125970626242898 -0.059319553016902  0.017191793320064  0.045132807261626
-    8  (  8) -0.578011070913822 -0.096069905578471  0.034320656007075  0.008138721285755  0.200651419362850 -0.180375510922630
-    9  (  9) -0.075902771217084  0.004486710274029  0.008101295703532  0.005145165116265  0.000289827785464 -0.012192146264032
-   10  ( 10) -0.010144747737863  0.093887289987194  0.012520076511424 -0.048321113777971  0.058051870190577  0.029305003899343
-   11  ( 11) -0.079269835922185 -0.056407934156687 -0.083742200501709 -0.007977653697296  0.003415198719749 -0.009408271568785
-   12  ( 12) -0.063275611050180  0.041793376814452 -0.018940005265603 -0.031801650730441 -0.042593625401080 -0.051280864509093
-   13  ( 13)  0.241520854870219  0.060862078761145 -0.029296437788834 -0.004750900896371 -0.057204357338164  0.050359098198299
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902577471790101 -0.152994814233932  0.011940868446238 -0.420469735951606 -0.445351803972144 -0.142848111796374 -0.124602559894107 -0.133617692414479 -0.065299458730887
-    1  ( 15) -0.489189301960896 -0.131612108164584 -0.025288909698489  0.001211401602831 -0.097261943563860  0.035660096811446 -0.068846931566771 -0.178298501436217 -0.088180423881717
-    2  ( 16) -0.227827617997529 -0.682850378114893  0.173952246738550 -0.020483992991400 -0.200004527333180 -0.249321074904762  0.178969609143401  0.064626594784378  0.271714608016049
-    3  ( 17)  0.575057386639545  0.230829261967287 -0.236382682328743 -0.198529656444012 -0.112446756030160 -0.393646604056964  0.196512471195115 -0.417308417772929  0.017911249870982
-    4  ( 18) -0.193966815668284 -0.049741581832494 -0.123803326018047 -0.006759114368933 -0.167461192854180  0.285673743205736  0.102864894892838  0.279649773106956  0.092613585551367
-    5  ( 19) -0.103888340402909 -0.178666472837949 -0.207303680724541  0.054793013222011  0.008829749698437 -0.180189218695024  0.005881767836415 -0.346673619263749  0.135673181192661
-    6  ( 20) -0.005617400724262  0.235632824287364 -0.121420590502094 -0.289718560202372 -0.074621425323949  0.197136569143931 -0.541291075958390 -0.074791673502324  0.151088111942487
-    7  ( 21) -0.003477648436861  0.126185493130263 -0.114691185797939  0.273163908100164 -0.312825492602440  0.283665229878294  0.047436733181861 -0.310264889604266 -0.030965201327066
-    8  ( 22) -0.094388926763113 -0.130129267650442 -0.029533862325104  0.507284500100960  0.577428087616617 -0.108467531924833 -0.239047428592559  0.001751737689504  0.057800769417835
-    9  ( 23) -0.126681312381856  0.286563029789873 -0.124985424909591  0.042080944242163  0.222642441182942 -0.031761654185862  0.002250692027285 -0.069986298385737 -0.578241171376628
-   10  ( 24) -0.012403694982205  0.104087344759352 -0.011491899195223 -0.071458529676245  0.067846175537785 -0.174556024843144 -0.093417663431561  0.108925443196115 -0.094625153118491
-   11  ( 25) -0.145228226846074  0.289308800594077 -0.056604451501567 -0.078531469167011 -0.050901538775644  0.092556450573324 -0.236272716312904 -0.125766764843619  0.035457518122494
-   12  ( 26) -0.059274992639949  0.006488412450235 -0.103071268094578  0.150081428168228 -0.009323154225402  0.028319582293784  0.076974794119920 -0.059324199727383  0.008195435055820
-   13  ( 27) -0.018186469303715  0.001053679134700 -0.081623732601015  0.178695228145613  0.269234242250905 -0.095169442617143 -0.062998987790228  0.017097346840232  0.200778292928657
-   14  ( 28)  0.062534322058022 -0.002015210189792  0.048801137289310  0.040037948587356  0.059153802159815 -0.000976778891690 -0.003575151518202  0.045136723643297 -0.180538253756990
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015166832979202  0.055523245443861 -0.169795016453231 -0.032694007010711  0.015135554657568
-    1  ( 15)  0.032433930913447 -0.144386795244130 -0.139383558038472  0.367373211677701 -0.070777740101340
-    2  ( 16)  0.006497257681786  0.060476801934772  0.284376377240629  0.117114356398064  0.102408347319320
-    3  ( 17) -0.124715086899730 -0.049178690374442  0.092903745535273  0.049474206000848 -0.106524456538078
-    4  ( 18)  0.078147667167246 -0.074392615750257 -0.066572272669959  0.015153155253219  0.127142438959372
-    5  ( 19) -0.030012583037432 -0.098494401766441 -0.024951261153980 -0.072692839393734 -0.065509018082234
-    6  ( 20)  0.028658039508268  0.029893706465370 -0.227872682646957  0.058375213717391 -0.035317071011158
-    7  ( 21)  0.087698228581465 -0.193877542561776  0.000977855687069 -0.115255270457925 -0.004253825014343
-    8  ( 22) -0.000487339716269  0.085213745940574 -0.052874146845015 -0.152776261278858 -0.059953850619275
-    9  ( 23) -0.075363605944822 -0.010276769755622 -0.080252178607551 -0.063424914028104  0.241145188807008
-   10  ( 24)  0.001283950926939  0.093581096956637 -0.056859346555054  0.041777245375248  0.060823791108896
-   11  ( 25)  0.008356132167143  0.012479675910490 -0.083678859924604 -0.018947435212012 -0.029236284374189
-   12  ( 26)  0.005134210870859 -0.048347394079564 -0.007965979077246 -0.031780813486509 -0.004717184227605
-   13  ( 27)  0.000267583079026  0.057994430769062  0.003313390407093 -0.042646534152268 -0.057198829179600
-   14  ( 28) -0.012275122252029  0.029301677774353 -0.009473927119427 -0.051324560742064  0.050296874415886
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027985845163524  0.023014187360132 -0.021972704031550 -0.165873801926668  0.108498472423258 -0.065984445208027  0.052062590549153  0.024196903336059  0.005438903859049
-    1  (  1)  0.207753127107100  0.133586320603852 -0.248299413759929  0.051273643702392  0.137929228974577  0.172516172497646  0.338774489321057  0.007044125107960  0.086225487021978
-    2  (  2) -0.030725656049538  0.008685648887429 -0.054637639636829  0.081853822913586  0.065569345836835  0.054412511875610 -0.037702150980267  0.220880057677829  0.092517419795625
-    3  (  3) -0.146518460272185 -0.151164938887178 -0.090922259280638 -0.041550491468836  0.008256552512676  0.048975234640781 -0.222433708697271 -0.123978061818464  0.551233631040567
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.030368262613337  0.051015148860635 -0.002942978202016 -0.003356964742137  0.014802517799284 -0.008083321576794
-    1  (  1) -0.024523434755722 -0.073734688873540 -0.129066247639439 -0.024037316988320 -0.050282994530055  0.020846450280793
-    2  (  2) -0.075512350010898  0.366500451453791 -0.036592830040889 -0.016303194972460 -0.036175560248337  0.005423684503349
-    3  (  3)  0.036874256227630 -0.046039513569074  0.147486358648951 -0.060664952434382 -0.127426669479233 -0.039293702180427
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.050111098767745 -0.071439421665737  0.010360806490423  0.164982511003502  0.190752518001675 -0.070698878333088  0.064144987593348  0.009940358823804 -0.039049299317426
-    1  (  5)  0.346512350212501  0.020770988494970 -0.054063126549543 -0.066267909254760  0.061286416729942 -0.328133338026467  0.364459716199746 -0.282333058508693  0.052379135180748
-    2  (  6)  0.014820841999600 -0.308332589554773 -0.036490920160057 -0.008185142851144 -0.077220105539055  0.001985069156781  0.191861505554810  0.331452106505361 -0.064661161962335
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002710313008904 -0.006054102061478 -0.023960364540744  0.028066673595848  0.012225337247005
-    1  (  5)  0.191683957013482  0.061055761849053 -0.180315991810041 -0.020020550401249  0.020756656682088
-    2  (  6) -0.171946012527152 -0.078984789269474 -0.060019327368985 -0.045058581991741 -0.117222830082063
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102367  0.008188589712238 -0.013790999932787 -0.066013267343718 -0.002979179364402  0.115067560152143 -0.029904774000613  0.075658337330170  0.005135342269607
-    1  (  1) -0.415137332088612  0.400791789518638  0.060626653167991 -0.009777722957358  0.182694524485337  0.107591424113208 -0.071470092116898  0.210805299972917 -0.029640655301118
-    2  (  2)  0.731004204598524 -0.977674938020298  0.030910735141458  0.126476447646258  0.160297857646348 -0.115254107794114  0.017919423470245  0.019160269758161  0.056677210805993
-    3  (  3) -0.052710934455993  0.190825342618791 -0.121683764296163  0.058318753384834 -0.051331848225805  0.122833340921044  0.176985596744925 -0.321410474763126  0.015752780623231
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449213 -0.003857954296836  0.001116934481339 -0.006268480889134  0.011819863965880  0.022338641059406
-    1  (  1)  0.026581167918673 -0.003242138995826  0.002209759168116 -0.126256065331472  0.064001666171840  0.019583311633874
-    2  (  2)  0.060541607763300 -0.048685401885040 -0.005324531906368 -0.077364982992393 -0.023160042352118 -0.131997334895640
-    3  (  3)  0.086532549077842 -0.501054912835391 -0.033953281830235 -0.045954160893793  0.007588765668993  0.026055365513597
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407912 -0.003874637131510  0.017573675069989 -0.250000468336212  0.193535227171946 -0.023949830014057 -0.006344215172658 -0.002637721142605  0.025018403626550
-    1  (  5) -0.061066900138163  0.119597101102996  0.077747477731553 -0.181802110874956 -0.105212352540628 -0.191650240311689 -0.067261595147718  0.101033231559081  0.034053487252843
-    2  (  6) -0.129779125650158  0.272168473286842  0.218088904973338 -0.105590817864474  0.170044089806057 -0.413895401404384 -0.204721805057715  0.193774792721808  0.022574107317577
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304093 -0.022619515940248  0.001370551331509 -0.019480287608800 -0.016611790333306
-    1  (  5) -0.015006262168537  0.018557640744956 -0.000086080146177 -0.193359672647776  0.037991057379314
-    2  (  6)  0.020942063740398 -0.276121820896825 -0.020375408054502  0.090755244706104  0.038585932807354
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234774577907340 -0.089732279705020 -0.029281742956361
-    1  (  1)  0.629390080925054  0.562262027181648  1.005710563308147
-    2  (  2) -1.016842846984442  0.324902404629239  0.759850922288994
-    3  (  3)  0.070893719957037 -1.217739132557560  0.544721303880524
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235500971090726  0.628370240889402 -1.016044908027706  0.070845813096372
-    1  (  5) -0.089243248615735  0.558584627490131  0.332507599415180 -1.220818260487312
-    2  (  6) -0.028235811673249  1.000885266991202  0.767552789658038  0.543389712941562
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.803905357707311  0.860151305623949  0.271118555223167  0.233708148806798 -0.124148512341266 -0.010189985719979 -0.092729991992268  0.016788100393524 -0.004472139404122
-    1  (  1)  0.401013317552785 -0.256123411395810  1.725791219363352  0.228118396767626 -0.017083610861014  0.077834475735907 -0.010518533714653  0.508387054745627  0.007264375748279
-    2  (  2) -0.011434548540222 -0.088441201305154 -0.217324498232303 -0.271194503786495 -0.847646840544961 -0.636979337168603  0.167111761738664  0.613015596421828  0.118261935906470
-    3  (  3)  0.794342002638844 -0.188454328702485  0.221782475708119 -0.127238173306152  0.529725618505773 -1.234283764404522  0.503702151908138 -0.716733332201490  0.003730822870913
-    4  (  4) -0.401751095605530  0.338386780155127  0.027671797889821 -1.521964962245091  0.118534592965411  0.737791613352609  0.133068399810627  0.089420490967805  0.037476970403516
-    5  (  5) -0.062520837577632  0.401075384901201 -0.021867941133996 -0.715225023398739 -1.272095248267951  0.501721901780299 -0.443609728635242 -0.893075231648048  0.592672369741993
-    6  (  6) -0.010948759647979  0.203401403085997 -0.137048639531909 -0.113085573900653 -0.481495532073518  0.549209906368458  1.454114297098583 -0.104970888423571 -0.037484874409079
-    7  (  7)  0.128092468229021  0.321831618555177  0.165224131524797  0.036717435980679  0.490326956687596  0.556704330756835 -0.028026211847655  0.572891503259545  0.836605248949509
-    8  (  8)  0.028465864758886 -0.067177326433747 -0.261754785397495 -0.132197496012203 -0.099654097906746  0.125238705338503 -0.191161571927307  0.152439549355924 -0.345598496796334
-    9  (  9) -0.117164319402284  0.677600502185656  0.057458896318824  0.132501237674075 -0.004191340015369 -0.154828563575337 -0.038564068532644 -0.121792891458522 -0.349263289014943
-   10  ( 10) -0.181067725106296 -0.111582528205458  0.370630400902865 -0.010089018109779  0.175901282392120 -0.187388709548550 -0.018929605786239  0.507571524880377 -0.113635665926862
-   11  ( 11) -0.014437537795246  0.015226015168940  0.010134165664067 -0.005687484322489 -0.031065375239781 -0.023280669169025  0.128114396256681 -0.039417737851753 -0.110919095427042
-   12  ( 12) -0.125387244214951 -0.096520270925362  0.052418676370702  0.258253736986353  0.005758304720891  0.145179803274614  0.116533683249985 -0.074529049368730  0.022120054046506
-   13  ( 13) -0.016488000528151 -0.002368207793552 -0.087940291197149 -0.101326196004400 -0.036322133241993  0.195270868050333 -0.010169719681932  0.009700577933052 -0.056276489205959
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020656609432377  0.055454072209206  0.016498557049920 -0.100308993019535  0.100625813513966  0.085817872313959
-    1  (  1) -0.158188828440892 -0.302238781900211 -0.003254305982647  0.141295167420039 -0.086817823645988 -0.004522680615623
-    2  (  2)  0.117165454504024 -0.174443278203503 -0.011196610388147 -0.263022208165445  0.005179209446380 -0.028790206529749
-    3  (  3)  0.116979728848069 -0.002675319824407 -0.011237305263780 -0.059042081886281 -0.019813165086942  0.041020820057734
-    4  (  4)  0.050773800974292 -0.220964030765936  0.039978161841657 -0.028484730886475  0.038490445524596 -0.072488415876946
-    5  (  5) -0.020335163069148  0.163705236926197 -0.082951181907163  0.111454733440593  0.037975682191325 -0.107211881409464
-    6  (  6)  0.021278303210848  0.388606221992998  0.114903933510215  0.018782318547525  0.008939872036282 -0.015881860003982
-    7  (  7)  0.297901981281024  0.033254178443727  0.094283496173084 -0.060148927068472  0.021415208569123  0.043129019365108
-    8  (  8)  1.538151946484423  0.255389759643583 -0.163313084569292 -0.034663525935373 -0.142139339830442 -0.045757092023972
-    9  (  9)  0.091430832784144 -0.031111059625587 -0.061979966203490 -0.058675516664175  0.760855141023917  0.950655107543621
-   10  ( 10) -0.067314640632537  0.211103496431705 -0.020600002397637  1.234404704927125 -0.163782714272567  0.167558660890032
-   11  ( 11)  0.163451473737101 -0.060117653273661  1.332809431049165  0.048636523249740 -0.084741416350187  0.093758422678353
-   12  ( 12)  0.205980882962949 -1.200907557972782 -0.135489991479292  0.365850977217349 -0.094087533161484  0.008716209829183
-   13  ( 13) -0.181608420628060 -0.041944770724578  0.112411453405729  0.222931004263492  0.995147424974585 -0.917645025950541
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802215088996775  0.405760421584725 -0.010733900270896  0.784358891338122 -0.394207392965882 -0.066264169418438 -0.011728371528151  0.124097516118103  0.033513743357673
-    1  ( 15)  0.861921835284117 -0.259204458699967 -0.086550258239887 -0.179795107884808  0.329776011755083  0.399732735512309  0.202064202046553  0.330247474290177 -0.071973209379633
-    2  ( 16)  0.271441185213391  1.724486207548469 -0.218690579375801  0.222063595490460  0.027363367055485 -0.018802165875844 -0.135942286119417  0.163478817004599 -0.262387665735325
-    3  ( 17)  0.233788075721826  0.228159112392323 -0.271808517288257 -0.127676513444271 -1.519379653938277 -0.715083891079223 -0.112821347158474  0.035818562511062 -0.131766468683948
-    4  ( 18) -0.125942009127172 -0.016377869393706 -0.848482111339688  0.528657771751293  0.118745113074898 -1.271710188107035 -0.481153570999942  0.489178297010484 -0.100424350070291
-    5  ( 19) -0.011383686031449  0.078456463460941 -0.635793437126757 -1.233395635082388  0.737239370475296  0.499509899398320  0.548401749031313  0.558608158361660  0.124417124384875
-    6  ( 20) -0.091600198761770 -0.011876741058319  0.166091401418705  0.503941587465969  0.132948669117964 -0.442842250160731  1.455104693311837 -0.028341475910627 -0.190421671161177
-    7  ( 21)  0.014484668680380  0.509841880180764  0.613581819059005 -0.716630577428902  0.088564900472140 -0.892493010440163 -0.105683628158844  0.572246502497319  0.150576148757988
-    8  ( 22) -0.004174841691802  0.006707441197859  0.117679460919548  0.003167625275269  0.038325446188084  0.593620463308946 -0.036920125090448  0.835670699131347 -0.345282330703187
-    9  ( 23) -0.021563101305077 -0.156910385371061  0.117862784231017  0.115137818805332  0.052266686740979 -0.022652444633787  0.020589348904606  0.298647561105740  1.538509254803363
-   10  ( 24)  0.054696247538136 -0.300097703279750 -0.172676310394845 -0.004641896342478 -0.221287943064927  0.163661856689034  0.386962565847225  0.033092208048157  0.254762225348227
-   11  ( 25)  0.016478682999148 -0.003215291424268 -0.011157986184847 -0.011249059510507  0.039826186982321 -0.082792260839707  0.114868621990364  0.094214542109994 -0.163392531748718
-   12  ( 26) -0.099187962393071  0.141022599136927 -0.262517149368207 -0.059517894129389 -0.028614490021954  0.111532524460300  0.018579534511371 -0.059825884600083 -0.034049798717724
-   13  ( 27)  0.100178973364377 -0.086693773226363  0.005242460985690 -0.019116004377611  0.037912677180169  0.037754205119466  0.008826283068401  0.021770019636588 -0.142635094936193
-   14  ( 28)  0.086046178690242 -0.004751133686046 -0.028259740203224  0.042085140978763 -0.073608902693740 -0.107703616275598 -0.016209845373183  0.044336724946126 -0.046193144798357
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124213386192449 -0.184278545140157 -0.014644622518974 -0.126520793888936 -0.015935131079309
-    1  ( 15)  0.686886555278534 -0.109848033830421  0.015362111474085 -0.096623860958170 -0.002352924370873
-    2  ( 16)  0.057186301356343  0.372235382538515  0.010223067022666  0.052308263466605 -0.088321026996929
-    3  ( 17)  0.131851542209598 -0.011114262485829 -0.005723853800875  0.259717639216932 -0.101579897082117
-    4  ( 18) -0.005059922073798  0.176651992942668 -0.031045371067554  0.004751602541209 -0.036357227754461
-    5  ( 19) -0.153490417120552 -0.188182144826061 -0.023327004528605  0.145116229576305  0.195544967130553
-    6  ( 20) -0.038669146951691 -0.018322940249549  0.128217963501523  0.116247317068486 -0.010270205632719
-    7  ( 21) -0.121953539167482  0.508071938672096 -0.039503068949602 -0.074854789377140  0.009741351292022
-    8  ( 22) -0.349749690454153 -0.113383122522557 -0.110884130170500  0.022231095142528 -0.056430507970696
-    9  ( 23)  0.091277604676359 -0.068457429261195  0.163395065823676  0.205703107124365 -0.181427144774973
-   10  ( 24) -0.031490205855113  0.210975767808687 -0.060264671053420 -1.201247115008903 -0.041832647583344
-   11  ( 25) -0.061996899999264 -0.020492208070431  1.332807012156678 -0.135544852791734  0.112408630541359
-   12  ( 26) -0.058492216122820  1.234353822395186  0.048637099519176  0.365843792888730  0.222948291565721
-   13  ( 27)  0.761203399339422 -0.163718232424674 -0.084746898323330 -0.094131030705851  0.995190420313834
-   14  ( 28)  0.951767639345761  0.167573997453096  0.093760237560500  0.008708090964824 -0.917567337282473
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.061311180916174  0.007305734568299 -0.008052219664717 -0.075102530727564 -0.012025728300826  0.120194347984132 -0.026978429199379  0.070594185419545  0.016866098796694
-    1  (  1) -0.395437998629573  0.330196709230486  0.066130411816170 -0.001067023889988  0.191861180999614  0.113171387281916 -0.066995383271923  0.184795229028717 -0.029348228197537
-    2  (  2)  0.660966524714688 -0.861759345962241  0.033160724552169  0.127992765938447  0.170396202948104 -0.110113865477816  0.014392237869005  0.010445707783194  0.039464659932571
-    3  (  3) -0.040562495552703  0.173681994330223 -0.115433716796164  0.022385853875221 -0.029920163821990  0.106927003887640  0.164647198946454 -0.308627589591936  0.016471750534187
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.008075638079590 -0.004204267894386  0.001154899751921 -0.004302816895310  0.010300593916071  0.018583143246493
-    1  (  1)  0.022690643093880 -0.003824240162369  0.002196370237793 -0.111717598339107  0.056937031147815  0.021691580964165
-    2  (  2)  0.053339405350156 -0.044029154336949 -0.004382948251621 -0.071322882171572 -0.023334611635533 -0.125689353624520
-    3  (  3)  0.084457325104192 -0.461707512764016 -0.028403124486066 -0.043179936610554  0.008421132991555  0.024339438305143
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.015528904780166  0.000197217067411  0.014784122441979 -0.260011500898602  0.207731584784046  0.001836258201294  0.003784871531686 -0.004554790492094  0.029260236327573
-    1  (  5) -0.073737732106898  0.115839519981911  0.060966183364281 -0.191025915776738 -0.133264060723011 -0.183947109340336 -0.057101924893026  0.090583425466175  0.027097942199573
-    2  (  6) -0.138800981815769  0.257932125792776  0.172076461805675 -0.086501722972202  0.167229357348261 -0.397280885922369 -0.200441282704850  0.184212067375292  0.012201121124777
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.007496948487326 -0.019701904142718  0.001114080790245 -0.016769294212535 -0.015066280094060
-    1  (  5) -0.008011152002189  0.019463303254064 -0.001255118747011 -0.171713762805812  0.033052309738105
-    2  (  6)  0.023624103497187 -0.246377111375438 -0.017324022231723  0.084529293370869  0.033771435710698
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521810 -0.064555152855140  0.195953381503072 -0.041248493404100 -0.011229686922116 -0.030149441468397 -0.052245051042501 -0.006640144591441 -0.060816046803631
-    1  (  1)  0.618380750339701 -0.527850820452496 -0.215416501468030 -0.157035437820985 -0.069798458053192  0.063297476854260 -0.224803808806343 -0.036770088857871 -0.093292414355443
-    2  (  2)  0.089963765220208  0.016694193855681 -0.049894217028076 -0.224500363636592  0.100545586935621 -0.339808932362450 -0.300486601784935  0.103978674940069  0.003854593986182
-    3  (  3) -0.017912540893906  0.240051544179780  0.016875920141057 -0.019658112757032  0.000950481978191  0.139486307895262 -0.307526295494270 -0.245045411721381  0.038982174459018
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151717 -0.053483299255780  0.001461399819934 -0.009996127160186  0.040844890766482
-    1  (  1)  0.010356156252335  0.045196494943183  0.123149462829323 -0.009608799091533 -0.092775098416549
-    2  (  2)  0.068261626755325 -0.266621644473693  0.090983468547795 -0.007824999539039 -0.015479677414577
-    3  (  3)  0.102991688131888  0.095940846129217  0.235195882789535  0.030438278876706  0.100331913639096
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065258  0.055002400477826 -0.190701615134343 -0.008587073556960 -0.137456634337705 -0.102685174742819 -0.038575707278164  0.049077773985899  0.038775520871487
-    1  (  5)  0.266426121061182  0.201904502527541 -0.404472747743455  0.112355452346296  0.244543383067954  0.203488255110552  0.093346083766350  0.046662175778563  0.162564534078684
-    2  (  6)  0.310200495971188  0.275860886663906 -0.334362481171667  0.111323203428020  0.107269573508102 -0.015396505983542 -0.485347827861579 -0.115211810541093 -0.189399381355345
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661090 -0.010182782856367  0.015536223735827  0.027148068637773  0.019304531582392 -0.012170541889266
-    1  (  5) -0.076359104752422  0.072719944885937 -0.105706045053709 -0.076791075572627 -0.095250630872874  0.044053081318693
-    2  (  6) -0.023401555368525 -0.060789750773992  0.233844071164900 -0.060200608258470 -0.022972229731698  0.078966373846361
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134471189810092 -0.662148890372047 -0.267935016272650 -0.078917516466181
-    1  (  1) -0.664666296417858 -0.209284545759600  0.147471348275627  0.068908444059693
-    2  (  2) -0.267133357861078  0.148425589757628  0.187317601361827  0.001813043081997
-    3  (  3) -0.077770523166389  0.066603013397195  0.004062962607311  0.013912155247960
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274832594154714 -0.278242094914337 -0.671654031070884
-    1  (  5) -0.278497836106856 -0.012090613996289 -0.010590433835922
-    2  (  6) -0.670432937770643 -0.009657203375264  0.097732024172777
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959652947297446 -0.408123531987619 -0.490401240559718  0.038728625501850 -0.077955850449253 -0.487356513384779 -0.107431647026833 -0.396098723270224 -0.237559090649423
-    1  (  1) -0.405287391353834 -1.324235803795144  0.174918474964920  0.249090286909362 -0.197882092638117 -0.317613216127917 -0.251158649784065 -0.030182262258926  0.632878894780051
-    2  (  2) -0.488736302126935  0.174537834055795  0.686802536569195  0.342698519390660 -0.009978504141441  0.483630953231146  0.287674546129727  0.302838065576003 -0.272076060390986
-    3  (  3)  0.037680750791132  0.250810425630217  0.345041313376114 -0.288921950854187  0.242065062379730 -0.302245036941519 -0.510968387365602  0.184732147500300 -0.217019518876341
-    4  (  4) -0.076474970371118 -0.199548330465758 -0.011318561820522  0.242358447418328 -0.131824013162052  0.385851083614353 -0.241519487350351 -0.375192533273711  0.062578612411423
-    5  (  5) -0.485852483425266 -0.318979280528763  0.484066634013452 -0.298903807168945  0.382610997345618 -0.557142551517131  0.333197792146470  0.111813059758365  0.019832041990218
-    6  (  6) -0.104965308815928 -0.251905850413101  0.289646445983294 -0.510970311703583 -0.243416542914288  0.333477452263820 -0.859910605182056 -0.040221092410560  0.015978091027429
-    7  (  7) -0.396757752587363 -0.028569556877251  0.303650553506904  0.181375877079299 -0.373315055601480  0.109082013495532 -0.042394080422644 -0.424453142205116 -0.165367340665863
-    8  (  8) -0.232577777980881  0.628634227410956 -0.273406823912260 -0.217896152168838  0.062014351681569  0.020854775327294  0.015643896438574 -0.165522517445198 -1.139943298332195
-    9  (  9)  0.005610937642159  0.056039778145227  0.162949812700519 -0.082447741081119  0.072872155386977 -0.108705187107976 -0.023485984994573  0.044747716600193 -0.147251711508816
-   10  ( 10) -0.006823140015079  0.054329319992068 -0.040599884295365  0.341771214889488 -0.179762239296878  0.323458315510083  0.128244534494253 -0.274646157662585 -0.052523948909135
-   11  ( 11)  0.095363270787347 -0.102111548012532  0.068440604874557 -0.163728434997447 -0.155636086105072  0.243236788181447 -0.456650415997544 -0.005317873159721 -0.049821847160301
-   12  ( 12) -0.031682366540900  0.049375813516575 -0.071598146179691  0.132087989337538 -0.108611785555417  0.096654485419413  0.079499450722417 -0.086710987234524 -0.054539911364394
-   13  ( 13) -0.055056204890153  0.125842892748373 -0.045965574230317 -0.019980233406050 -0.072417713564596 -0.032557591563818 -0.014098057188424 -0.073500277920932  0.566229267173414
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807525521233 -0.007359537343921  0.096092508733764 -0.031848083816976 -0.055774198983232
-    1  (  1)  0.055013732650586  0.054716326372634 -0.101499825852225  0.049505806235113  0.126450547357477
-    2  (  2)  0.163059205506462 -0.041368872819456  0.069581455596234 -0.071597196780245 -0.045866052228085
-    3  (  3) -0.081105673439869  0.339429555892824 -0.164728153643699  0.131959969199162 -0.019695233925696
-    4  (  4)  0.071393373180112 -0.177479194335969 -0.155859184366711 -0.108539407321582 -0.072773970413827
-    5  (  5) -0.105603312078912  0.324542336417266  0.243446189575733  0.096679109403979 -0.032469296833009
-    6  (  6) -0.022598073087572  0.128545265092418 -0.457503820510282  0.079428257782213 -0.014293355829964
-    7  (  7)  0.043846313691523 -0.277398721649818 -0.005217801799309 -0.086814141836653 -0.073528025181399
-    8  (  8) -0.147650558386801 -0.051824889211656 -0.049479655499448 -0.054623458198541  0.565538504830395
-    9  (  9)  0.072040995887839  0.045487481778711  0.010267944449755  0.009607395545283  0.026537979914876
-   10  ( 10)  0.047954867962304 -0.139047713471829 -0.006984668871374 -0.101926998608402 -0.021981627690416
-   11  ( 11)  0.010232694252591 -0.006895180981132 -0.093446496400997 -0.006456318199702  0.037416385414388
-   12  ( 12)  0.009698093521025 -0.101910194048616 -0.006447087285736  0.055515253338052  0.004586695913697
-   13  ( 13)  0.026517968105571 -0.022107111741401  0.037498264993835  0.004566515568409 -0.064482567891937
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532087829692590 -0.788053685787543 -0.217638660718255  0.182558741425794  0.602280863487480 -0.200093873579573  0.029411468157287 -0.008618444683726 -0.142345995339967
-    1  ( 15) -0.793296879907851 -0.320033252713587 -0.162598975061937  0.058726797579308  0.020874324465825 -0.223415350495464  0.107419199072046 -0.353928058476850 -0.096059896297266
-    2  ( 16) -0.212771964426018 -0.165330329981933 -1.296138478501883  0.042119030626054  0.273634363153676 -0.438879796251796 -0.121813090934943  0.097180424393402 -0.140937625938142
-    3  ( 17)  0.179954420872001  0.058841120068099  0.044127193653625  0.293105599186954  0.349356888645549  0.303438248695204  0.077097855045665  0.005877107547810  0.014045104825034
-    4  ( 18)  0.599465706125478  0.022235571238169  0.273958684833300  0.351252283018589  0.210835219511268  0.044587084733166 -0.439010194116289 -0.491004374063182 -0.399383595875341
-    5  ( 19) -0.200414126422892 -0.221453681940971 -0.440132544745164  0.305750504885625  0.044859550994933 -0.117462871785049 -0.191542019031430 -0.319736101009363 -0.359370857937598
-    6  ( 20)  0.032162128490710  0.105939422470881 -0.123876353123509  0.078981740858070 -0.440632986523098 -0.189872412172292 -1.110683989274872  0.246909463066168  0.255271007146821
-    7  ( 21) -0.008289240270486 -0.354493597801953  0.096614444377338  0.006342901738698 -0.491270269306688 -0.319008747377893  0.247402781703421 -1.005041339289935  0.329310525846416
-    8  ( 22) -0.142958112237992 -0.097022080380776 -0.141105576266035  0.015162721218605 -0.401346216586595 -0.359442000824708  0.255249867089681  0.329100137017210  0.052130295704472
-    9  ( 23) -0.219989065380246 -0.250001442433259  0.576446348372414  0.098959674886800 -0.020568115056174  0.097513800211121 -0.059902955848638  0.014734527114704  0.155046520151383
-   10  ( 24) -0.078950494727199  0.108193141402953  0.027256154227325  0.046487728394439  0.091306743849428  0.113368151054255 -0.170234459022064  0.302098295161987 -0.032847707963684
-   11  ( 25)  0.043326744721135  0.032363389826812 -0.179596320201807  0.107314642639449 -0.187556761581101 -0.097228134857404 -0.510755068400788 -0.080036249796903  0.081235508165591
-   12  ( 26) -0.068197976739272  0.217296898230263  0.162613838841638  0.182156526175457 -0.078640971248232 -0.138388418075592  0.046099139294747 -0.318339562890745 -0.094298996233422
-   13  ( 27)  0.012948053174444 -0.163156717261063  0.064963474472039  0.076423090075366 -0.116362948599962 -0.057051341709586  0.002572557321622  0.275506911037167 -0.101255941405055
-   14  ( 28)  0.072512090984942  0.116063474825340 -0.039414549057152 -0.060057426555201 -0.063414940103828 -0.039930823846179 -0.007406649447407  0.061654502640363  0.127196073453639
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223472856186329 -0.079380673330417  0.044417374907374 -0.069445497218023  0.011729893427506  0.073549727582157
-    1  ( 15) -0.252084318917961  0.107740778119089  0.032072824705649  0.217703434939331 -0.162976179330690  0.115649023646982
-    2  ( 16)  0.579843117285508  0.028377214599785 -0.180834874279503  0.163175611851648  0.065411291339360 -0.039948698368928
-    3  ( 17)  0.098340901452171  0.045586420024689  0.108734472684589  0.182606429974975  0.076964420692713 -0.060236205753191
-    4  ( 18) -0.021650833253368  0.091327714075519 -0.188512569919576 -0.078662641540956 -0.116896916359804 -0.063655160224489
-    5  ( 19)  0.097171540237316  0.112970498693947 -0.096626702578479 -0.138712839413244 -0.057497371163198 -0.039673289236737
-    6  ( 20) -0.058059330793309 -0.170134824525265 -0.511529953350571  0.046149842859018  0.002603003870208 -0.007423573904069
-    7  ( 21)  0.014906052329776  0.302176683769003 -0.080527272396977 -0.318411101425731  0.275449773181718  0.061692765706429
-    8  ( 22)  0.155151887383248 -0.033185457482074  0.080998651116857 -0.094073422563741 -0.101041326065027  0.127067437701733
-    9  ( 23) -1.153509668704953 -0.223849781573310  0.084925914720570 -0.000154347639825  0.401132279504920 -0.346054713026435
-   10  ( 24) -0.223987599390505 -0.015012978211180 -0.013160266761979  0.067286208797175 -0.009874035055601 -0.084312333246363
-   11  ( 25)  0.084246135649734 -0.012978110758481 -0.099616699055155  0.005046001111317 -0.012239544431652  0.023063802197493
-   12  ( 26)  0.000203295279175  0.067424132200542  0.005012434803368  0.014687484508398 -0.012600853145572 -0.022021985836775
-   13  ( 27)  0.401487062569274 -0.009674045048257 -0.012249675488475 -0.012688275802534 -0.008212565425852  0.091176394210094
-   14  ( 28) -0.346417777877478 -0.084403131898400  0.023147564232903 -0.022062212430037  0.091088265440255  0.040127117539344
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.056215178351152 -0.054500121667396  0.201919259029640 -0.031077763909936 -0.011710544057694 -0.013075909014488 -0.042346948279412 -0.000671828437196 -0.052291650303081
-    1  (  1)  0.580185861075070 -0.459972753550963 -0.203225407919285 -0.146383812782444 -0.059047716562576  0.052226205810320 -0.210466211727551 -0.032187370830551 -0.063260161926320
-    2  (  2)  0.093393180484024  0.013367709279037 -0.072500434249941 -0.188901437279491  0.080233214984548 -0.320461373590757 -0.281774578817969  0.095754681534406  0.009993938559280
-    3  (  3) -0.011005998081791  0.212772041115702  0.010016689572689 -0.008866167178549  0.020319327817077  0.122354072622868 -0.286521492942098 -0.227705666262959  0.024617052813042
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004784997903906 -0.045646414234079  0.000336480836015 -0.008910135175809  0.037229970153597
-    1  (  1)  0.012654368872761  0.038726052908772  0.110122851111890 -0.008163616811273 -0.088473965510977
-    2  (  2)  0.059858161464052 -0.242276960674044  0.080687949967586 -0.004783380239994 -0.010585828283984
-    3  (  3)  0.093190009318185  0.087625848503461  0.210676223786748  0.029310965958952  0.092669937835962
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.095387850613253  0.063707287574100 -0.166137684328990 -0.019021592214621 -0.149973759488072 -0.101204345446005 -0.031472575013395  0.053498473418115  0.042967624605644
-    1  (  5)  0.255913374070676  0.182084005619737 -0.358054750763435  0.117938321447881  0.215767330994835  0.198255946304696  0.082288395387947  0.046112464804605  0.145174585244920
-    2  (  6)  0.310255017179614  0.238379631063291 -0.293832075513331  0.096225461668115  0.113893652343842 -0.010350380964834 -0.451016712892298 -0.111857488193420 -0.191795345079325
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.073847868868730 -0.008654741577254  0.012693286586184  0.023668684482898  0.017789448554089 -0.009288640558542
-    1  (  5) -0.053437184229602  0.073043484124087 -0.095008049379703 -0.066955824244484 -0.087649072564987  0.040223509254852
-    2  (  6) -0.005363327558409 -0.054894453058810  0.206318088063038 -0.056446188259803 -0.025451705059660  0.074272028126644
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.016118777276715 -0.076689387067912  0.125264792267216 -0.007931013310243  0.098301937535605  0.089040062536404  0.042653189503994 -0.143650549015439 -0.062698356849192
-    1  (  1)  0.038523460792185 -0.325926212074859  0.217436403108296 -0.076210929079388 -0.124956744969533 -0.049869905306291  0.256022567536762 -0.049219148025195  0.025163660677609
-    2  (  2)  0.015460259327551 -0.182364499530160  0.081021447104332 -0.065186772706263 -0.193628085224717 -0.090709199284730  0.144227288852921 -0.007154481293501  0.060483347873676
-    3  (  3)  0.069494321441892  0.016013992178318 -0.169506236224067  0.050547669997776  0.177140340538979  0.181255025833254  0.201077665225233  0.109139777586648  0.215083611892032
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.159361864611553  0.056476108299591 -0.034334354535919  0.068420323850581 -0.100698715800710  0.049820592017774
-    1  (  1)  0.121041364374110  0.003994619377137 -0.190684428167184 -0.052070114913580  0.189028662705231 -0.205096915582739
-    2  (  2) -0.013836799939816  0.073875918803127 -0.147901928532528  0.343158528114239 -0.053056478393277 -0.086736758175880
-    3  (  3) -0.065392768372835  0.072388535495376 -0.365788807268924 -0.156911353062511 -0.184439406968006  0.043117455907297
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.095080611028908  0.132974666952799 -0.233475927910159  0.109077700761849  0.033619328181732  0.003336619392394  0.079318686273405  0.006541773193158  0.188514066103895
-    1  (  5) -0.133180554197722  0.220459497770329  0.122961007604814  0.144493780528946 -0.034530325126924  0.144382538755391 -0.001565508478566 -0.179104189145763  0.084352671049966
-    2  (  6) -0.305369897772513  0.245966510909103  0.171589985467964  0.288954965589224 -0.048536799653887  0.105233271021583  0.400024803684130  0.035818012706233  0.066124321501172
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.011358647742862 -0.047842821118301 -0.011877525445924  0.012099889406653 -0.055702357687980
-    1  (  5)  0.060987538430201  0.100437160073963  0.174976176295358  0.033059202656663  0.296249624542354
-    2  (  6) -0.156959926194242  0.053853503787387 -0.406665675932448  0.026462885456157  0.143060389345547
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.020948331780215  0.037000670267279  0.105734997905917
-    1  (  1) -0.298755038289142  0.115783497652312  0.255943993115305
-    2  (  2) -0.258964229852114 -0.115813970118107 -0.442412044617565
-    3  (  3) -0.060316341789483  0.030010868082768  0.068666118917160
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019390140524655  0.299690928631304  0.261296417524431  0.060590155832357
-    1  (  5) -0.036741212649359 -0.114946374260334  0.116921045330832 -0.032705566460932
-    2  (  6) -0.104633614556808 -0.252457748482493  0.444028842624352 -0.069853026830576
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.140296000548941 -0.063793548091722  0.058836863345753 -0.099797632735300  0.059473750236872  0.159752966024087 -0.002202306295360  0.046127151478856 -0.008686217300582
-    1  (  1) -0.090587236946104 -0.202094731400236  0.091626540491885  0.096660154944673 -0.169987669208235 -0.083846972629074  0.508703907389636 -0.818627210894803  0.070854467170586
-    2  (  2)  0.023735454247632 -0.355751040292653  0.273793043205585 -0.278993695315875 -0.352285402581272  0.196481260763437  0.305054920124749 -0.066457242289417  0.201198646054354
-    3  (  3)  0.097017476571804  0.245783387728730 -0.317753409227420  0.024031108885499 -0.214358325616717 -0.049557148749413 -0.028895867231305 -0.054175105918326 -0.003063371175243
-    4  (  4) -0.057659363291957 -0.180009048378845  0.233469321765478  0.045014824473403  0.207816785622826  0.114404967029762  0.123373159567671 -0.226999771613591 -0.055473302709796
-    5  (  5) -0.215768085458356  0.315007699227405 -0.316911447049752  0.120875322919003  0.280165731589989  0.294210130176689 -0.216431927362601 -0.200720331119460 -0.064409972369138
-    6  (  6) -0.088219394313516  0.148901192549512 -0.366942172197605  0.011961263536269  0.214232535784278  0.110039106542730 -0.192575526682645 -0.231316173793134  0.059843368650861
-    7  (  7) -0.046870162228495 -0.280136788176482  0.370966800512151 -0.110896450302908  0.088815259647623 -0.146578221115441 -0.021177591015912  0.399548191737565  0.041055228430585
-    8  (  8) -0.213227988512466 -0.108113812359640  0.632322240865726  0.072819843847120  0.035043483782363  0.162903981240538 -0.072814806218845  0.219110389566894 -0.041093714767865
-    9  (  9)  0.053156633750092 -0.091069486685611 -0.087550589369359  0.029257872540274 -0.135924804171581  0.072635818919112  0.001672210695563  0.447570021005955  0.046032192367435
-   10  ( 10) -0.217391745861597  0.434935321818996  0.409624285133968  0.322087632703751  0.032771616999581 -0.320492051563577  0.022523093471372 -0.286105139278087 -0.028763138212429
-   11  ( 11)  0.043659941201166  0.078800676739412 -0.262193973369673  0.331520925219487 -0.435752308936291 -0.063676676892902 -0.247088083747518  0.001843639279205  0.140239374636342
-   12  ( 12) -0.056061677925681  0.010922368476032  0.131982397268853  0.097477385521921  0.065023592624631 -0.000079901840696  0.216859084997238 -0.136693191532889  0.129330891363361
-   13  ( 13) -0.037505625217839 -0.225932746100622  0.091672875965964  0.251961099655879  0.015143667161303  0.284372812983916 -0.108288291225116  0.003814786573758 -0.367489612278402
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222389083699479  0.015701847872491 -0.082266344272818 -0.001672372375017  0.060404378510596 -0.093615396274298
-    1  (  1) -0.559861410768401  0.123417067860221  0.153694454214599 -0.170286503198903 -0.081015909094690  0.084027887041359
-    2  (  2)  0.169381986858395  0.033504697868342 -0.408858223550610  0.223464971359780  0.074967373568669 -0.314521774767947
-    3  (  3)  0.116774114128462  0.019779952941058  0.283276175027846 -0.175022332731274  0.285114822219635  0.036573121425863
-    4  (  4) -0.005741360693619  0.042278482484542  0.326192071941439  0.429131786152031  0.082289054899632 -0.119000835266722
-    5  (  5)  0.013423516821882  0.050360130511676 -0.120578150283481 -0.018831052901201  0.153514667633313  0.076208440200590
-    6  (  6)  0.081285465733278  0.326426729670571  0.215182088716426  0.111429746637352  0.018999981867360  0.098876299117681
-    7  (  7) -0.155079790707964 -0.099172280525285  0.073865926904635 -0.027727508963580  0.092673813156168 -0.234558008794572
-    8  (  8)  0.037083267042728 -0.221065800398389 -0.033616402941938  0.500355807294861 -0.749397585446660  0.380737037092872
-    9  (  9)  0.121630550509204 -0.307683459605081 -0.063120656742114 -0.759405905070709  0.291159195179390 -0.157029303682124
-   10  ( 10) -0.436871717108233 -0.180601040070661  0.427730677617901 -0.039372181815525  0.043027348816400  0.570244276025105
-   11  ( 11) -0.012751187293868 -0.355844753947909 -0.014496438271320 -0.331024552563185  0.082393693285337  0.048306649791118
-   12  ( 12) -0.275276941650836  0.041042458905035 -0.197286719636261 -0.114170289272117 -0.271015602602994  0.185041163126162
-   13  ( 13)  0.588129593629221 -0.141947366107150 -0.099713722453882  0.418536994369331 -0.225811581271459 -0.209432602066484
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.136332502394749  0.095222138145572 -0.020696372205148 -0.093373694133048  0.056974308142222  0.218258098512315  0.091558195590398  0.045265175415099  0.214855115358215
-    1  ( 15)  0.061137877049954  0.202683152555044  0.353526070367366 -0.245609552328630  0.180792151363875 -0.315264721907539 -0.149352343873492  0.279119121208994  0.106650279203797
-    2  ( 16) -0.054253456260384 -0.094536229676350 -0.275971725667493  0.315900310810875 -0.233299003747364  0.315660301871661  0.365030241871778 -0.369812512976113 -0.630864749455945
-    3  ( 17)  0.098600083901755 -0.096469822823265  0.277744609477382 -0.023898918383951 -0.044551237411584 -0.121369522278835 -0.010579098206465  0.111662852316239 -0.072981135122258
-    4  ( 18) -0.060921788911548  0.171978353243574  0.351197784899122  0.213711518455428 -0.207005180664450 -0.279437354230444 -0.215133444220066 -0.090996522066592 -0.034929647170932
-    5  ( 19) -0.161660633493130  0.086147001578259 -0.195689249382698  0.050176283005300 -0.114394522154310 -0.293305044762979 -0.108948153725431  0.145670645933351 -0.162820061706685
-    6  ( 20)  0.004942089875663 -0.509118270553805 -0.304174363151756  0.027002468121694 -0.123566788587237  0.216329634503875  0.190901556459585  0.021589313504464  0.073912134438808
-    7  ( 21) -0.046993230195692  0.818922464708344  0.067253581692948  0.053433234642341  0.227360464707534  0.200960848773183  0.230456752354745 -0.400368266822890 -0.219888380010792
-    8  ( 22)  0.008868333291472 -0.070609706397600 -0.201053171865247  0.001993849783014  0.055528515803173  0.064226552772344 -0.060945769172458 -0.040893491115762  0.040944224757385
-    9  ( 23) -0.222786038895661  0.561633840914994 -0.169748965776544 -0.115017537449362  0.005573546521783 -0.012627582158638 -0.079154278361276  0.154947348010045 -0.034750692696974
-   10  ( 24) -0.015630982551661 -0.122733671133923 -0.033084396710116 -0.019083471564733 -0.043061905001054 -0.050187384392659 -0.326689569372421  0.099489621768347  0.221182165068758
-   11  ( 25)  0.081015154146910 -0.154577286238188  0.407152055810610 -0.281922448284786 -0.325678484340217  0.120357443687716 -0.214090639253691 -0.074318472872393  0.033055834005931
-   12  ( 26)  0.003249512574472  0.168975826063273 -0.223036074940092  0.178070767857802 -0.432212639749881  0.017831109413890 -0.111890446658268  0.031105258460500 -0.501232341526329
-   13  ( 27) -0.059498482257520  0.080037812453612 -0.074838091648859 -0.286196263876844 -0.080953764066314 -0.153280498633729 -0.018263066455704 -0.093491079781028  0.750780345808096
-   14  ( 28)  0.091986801414438 -0.083237402768118  0.314203504421854 -0.035798057800126  0.118724746257427 -0.076125512668229 -0.098802767682634  0.234229258446955 -0.382010330057379
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054026801537010  0.218820809975915 -0.045482454896222  0.056632819987025  0.041796404833871
-    1  ( 15)  0.090820830473810 -0.435186758518917 -0.078110332208467 -0.010977263097060  0.224939947084334
-    2  ( 16)  0.088777001237116 -0.410390806874956  0.264290446122590 -0.132187376060689 -0.093429765679898
-    3  ( 17) -0.030434516536175 -0.322721358771669 -0.333859520772307 -0.097565914369066 -0.253669917594512
-    4  ( 18)  0.135235063679589 -0.032604670655654  0.437326454525517 -0.064866560796367 -0.014517281425601
-    5  ( 19) -0.073849032459231  0.320876459277713  0.062467936536600  0.000278605221466 -0.283338683340820
-    6  ( 20) -0.001151706101316 -0.022831078108233  0.248046023125033 -0.216907811426422  0.108111489570171
-    7  ( 21) -0.447532183210635  0.286158140267043 -0.001132096492586  0.136654666693855 -0.003521629186189
-    8  ( 22) -0.045856367104241  0.028375498001528 -0.139997600919731 -0.129405058825669  0.366807076710427
-    9  ( 23) -0.122241483842522  0.437156690687902  0.011610251070627  0.275564671574127 -0.586949730800332
-   10  ( 24)  0.308306411893986  0.180824927568002  0.356081384430245 -0.040953387261227  0.142499615106930
-   11  ( 25)  0.063084289113014 -0.427546671858030  0.014764234377538  0.197272035106405  0.099641021649025
-   12  ( 26)  0.762622032277512  0.039709598418365  0.331137446404131  0.114150945582963 -0.418558199192024
-   13  ( 27) -0.291985642881177 -0.043175007677671 -0.082328218789908  0.270976982031899  0.226037881131796
-   14  ( 28)  0.156874264256314 -0.569987759510643 -0.048450546712728 -0.184997500776559  0.209541353443935
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.008672268005474  0.071816194535536 -0.120572303780740  0.008736386948533 -0.090252792742144 -0.086454229305773 -0.046146899467462  0.146407744632766  0.062154271469811
-    1  (  1) -0.044530650554382  0.342983591098757 -0.233064855218190  0.079639227294600  0.129059897680550  0.051256268905796 -0.266059661239060  0.043200568193505 -0.014515255717698
-    2  (  2) -0.007672537139116  0.182340760590912 -0.088050318770564  0.062838707832560  0.192033538812169  0.096771324380559 -0.155189348182056  0.027104280043820 -0.057717481416352
-    3  (  3) -0.079454923837834 -0.018724046078348  0.188001130869982 -0.049496277469554 -0.189935485868638 -0.187316285213201 -0.212647127834877 -0.116734593328088 -0.223092695439610
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.163722632719569 -0.058660940928931  0.036548308903601 -0.075038733758198  0.102471305627703 -0.049390669973433
-    1  (  1) -0.131305501461469 -0.004016373834291  0.198208657763960  0.065716899528052 -0.202185681278344  0.212640127812522
-    2  (  2)  0.022010926908288 -0.084188438316748  0.151883145143248 -0.372685279274918  0.062662101833962  0.084377242507503
-    3  (  3)  0.069858345399842 -0.076704087124391  0.378053214374412  0.165596914244603  0.189596095473444 -0.044613058561591
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.086473379523630 -0.139653083392103  0.215536578934992 -0.105983968648794 -0.036562785737962  0.000489435041183 -0.079768216054257 -0.008070571604873 -0.198804995040747
-    1  (  5)  0.142240879073995 -0.240288051362283 -0.124338297451208 -0.149100238302081  0.037605369870500 -0.148064173456833  0.006146293340323  0.190577775542559 -0.091735166734718
-    2  (  6)  0.312358773620771 -0.263851207058737 -0.167890772334593 -0.304312057068126  0.049989467903632 -0.096105061756251 -0.419039438444607 -0.027582241523162 -0.067772655900023
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.013020057289959  0.053664053281982  0.013498948569214 -0.012511641581690  0.053151765112829
-    1  (  5) -0.066147191246195 -0.098753011039216 -0.179209452625180 -0.033057282019118 -0.305926873948798
-    2  (  6)  0.161446014830287 -0.052105091472844  0.420025223008533 -0.024344041595381 -0.149807786778790
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002292052292103  0.001327689025616  0.000248352651822  0.007958119616395  0.006332326100075  0.018602233716078  0.068879285117606  0.007819744108382 -0.006538352080528
-    1  (  1)  0.002764164951482 -0.002219747844779  0.018293151832046 -0.029668233290951  0.039848292773046  0.022489745012599  0.162281988584093  0.020804504235237 -0.019083175045330
-    2  (  2) -0.011217835122942 -0.011598249376099  0.016968466001430 -0.008250037510452 -0.006232273271203 -0.008766677291356 -0.010338243291246 -0.010725726663582 -0.004470553150490
-    3  (  3) -0.050562851864419 -0.047527304873169  0.078707468856859 -0.000484758494289 -0.025585059000142 -0.011993586441405 -0.049963781283816  0.008029454242804 -0.026864587292977
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006805334012411 -0.003000362320125 -0.002228041038775 -0.000013471324712 -0.003129940535122  0.001748281527537
-    1  (  1)  0.013913717596782  0.013715090430948  0.022806809849796  0.002206415430011  0.006824605289546 -0.005086150284378
-    2  (  2)  0.011033408042675 -0.021897939524419  0.000684908130867  0.006441462755861  0.002207402072499  0.000019160522387
-    3  (  3)  0.030996252825106  0.007986449014412 -0.024562077320803  0.006200249162119  0.010690383251548  0.011486173135261
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.008068643711801  0.010525757489217  0.001816581937117  0.014852647204913  0.016446444650488 -0.051123908211810  0.105303074579272  0.010186396385183  0.002604742010164
-    1  (  5)  0.024807027264739 -0.041872241876180 -0.005357408083720  0.028564486604492  0.031353252400087 -0.040716482303662  0.082357809569049  0.022204595749264 -0.028676826310240
-    2  (  6) -0.057433465116018  0.072910653400306  0.007950207598677  0.045866077252412  0.051478467074871 -0.066399959025154  0.120267838044194 -0.002980749702426  0.024762093508968
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000934050050601 -0.000604010149742  0.003646663045597 -0.000033137801781 -0.002019175758165
-    1  (  5) -0.015497094356084 -0.002871076746167  0.025548488367169  0.001995117147543  0.006447008967147
-    2  (  6)  0.009288606849912  0.006735078994323  0.016930923349150  0.006239987724853  0.010309885333920
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.002227369320302 -0.043818240274751  0.042792694201834
-    1  (  1) -0.035951925322998 -0.375496620144894  0.229128772085716
-    2  (  2) -0.031465150106786 -0.208897138486076  0.045237461242765
-    3  (  3) -0.099863658462809 -0.215373395444406 -0.414485555399891
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.002189605326646  0.035984212952739  0.031631892423161  0.100220822826744
-    1  (  5)  0.043639031048182  0.374942416866401  0.208923047083238  0.216564932229395
-    2  (  6) -0.042460266706280 -0.228166292733403 -0.044493925974872  0.415175515862027
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.071562418349012 -0.044643481706977 -0.010719216935154  0.107277200321351 -0.107632875987832 -0.021972908893023 -0.087547602927583  0.002431274801360 -0.013111334250454
-    1  (  1) -0.001008369172372  0.002277471774414 -0.009696290175596 -0.069946425880608  0.211098825088912  0.144763348099231  0.839194198113659  0.082764265216905 -0.083969085740913
-    2  (  2) -0.048015739591381 -0.034141832828957 -0.005384996811850  0.362121098795589 -0.166978481952055  0.200125629587742  0.200206168196784  0.048085285607237 -0.015203276210723
-    3  (  3)  0.099891713665449  0.066731401112082 -0.191986572239756 -0.037167781463831 -0.149487286569619 -0.091951393356016  0.124705204882072  0.114478601924820  0.084740346074761
-    4  (  4)  0.098285756319308  0.060256061915825 -0.234091228077372 -0.042524175756500 -0.172705200231067 -0.110408395238964  0.184820371793580  0.074533125764680  0.084738680257431
-    5  (  5) -0.074321577193758 -0.053246631192159  0.354250883641741 -0.039006455448223 -0.144970439473129 -0.061654645426165  0.045166377189249  0.085032946258587 -0.173094046414712
-    6  (  6)  0.068632137123898  0.078233206409420 -0.700315021753110  0.207546424794390  0.389419114790676  0.222243315034359 -0.109406552334946 -0.045456034210779  0.343861545970210
-    7  (  7) -0.021714310649791 -0.016342702277335 -0.098426565374129 -0.004050549717199 -0.006933240550943 -0.079040673905138 -0.378109429127298 -0.122757215698559  0.057846791014967
-    8  (  8) -0.009573943840507 -0.006109547001624  0.063930902923820 -0.085654067260524  0.069741050462179 -0.032415356083110 -0.211725004915126 -0.046999658275536  0.044383134381218
-    9  (  9)  0.004997225889028  0.003637221795087  0.021313207566750 -0.021715545991438  0.030064296136495  0.023365724311185  0.129019001213584  0.016405843088409  0.007636609284437
-   10  ( 10) -0.003358299878380 -0.005153653126746 -0.010163923897300 -0.013149007914750  0.036797600687866  0.001802908184499  0.031118321508131  0.158323944941481  0.001398783490941
-   11  ( 11)  0.005208493259169  0.005568960280890 -0.129295087104337  0.009017109251971 -0.009418367237833 -0.064439120521238 -0.026493808367378  0.021964026481690 -0.285490675127642
-   12  ( 12) -0.022911837501423  0.014007914409696  0.005292696989716  0.012615780901936 -0.011192989138601 -0.041928856881976  0.003030455289266 -0.141645112536952  0.005078949468415
-   13  ( 13) -0.006239037546554 -0.010350872609282 -0.013056167681009  0.012419271776311  0.009172814340136  0.014463827270794  0.062671831203717  0.024810755425260 -0.013232298103210
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.002821607396533  0.008465859280820 -0.005159289345680 -0.009709845024265  0.000346373782913  0.003018233888482
-    1  (  1)  0.016525471949901  0.036788825827130  0.132790124932168 -0.012547146970870 -0.013610564122464  0.014252087123011
-    2  (  2)  0.056507969172448 -0.026681136428703 -0.044485854173457  0.008310199956635  0.009809983442187 -0.003131041163706
-    3  (  3) -0.065651101550528  0.083995833188288 -0.024123445214815  0.011519438681452 -0.005292773005652 -0.009769161567339
-    4  (  4) -0.036044829938597 -0.066193934069216  0.035808070841047 -0.000422817753884 -0.007345671878807 -0.010223551993872
-    5  (  5) -0.148904113147734  0.109316649106822  0.041264792150269  0.008287145921655 -0.000171232625907 -0.012797852216750
-    6  (  6)  0.267748006314630  0.203497034729309 -0.004883612400303  0.039146263280695 -0.017846525773098  0.043283889035238
-    7  (  7)  0.072387866888447 -0.141337300939965  0.132217285722503 -0.021714594277698  0.014576886695933 -0.003413824005883
-    8  (  8) -0.065339690335782 -0.070423798619333 -0.663640860855607 -0.043614551269968 -0.008449185324519  0.017636514679536
-    9  (  9) -0.053339386688333 -0.015600999572867 -0.295866385656840 -0.007120395428458 -0.021727601519868  0.010943405927509
-   10  ( 10) -0.043780471226243  0.395594436897359 -0.177336126578030 -0.145585406236130  0.046786318842793 -0.019087048140991
-   11  ( 11)  0.612581867283905  0.015866942037506 -0.053557734560298  0.384133426307945  0.648991977678548 -0.223358395217625
-   12  ( 12) -0.089911319093164  0.149481392645256 -0.148009805956002  0.410952060560403 -0.122608060580667  0.053525355813637
-   13  ( 13)  0.016967411584222  0.001119769665917 -0.667550447149721 -0.016648914439162  0.049071885737672 -0.011595566667332
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.071379476227380  0.001048107345874  0.047847319632163 -0.099096803223456 -0.097425878686372  0.073274835283488 -0.066530976398690  0.021907365211120  0.009610510160406
-    1  ( 15)  0.044751454337473 -0.002521207190522  0.033954962989568 -0.066720162723388 -0.060297503520731  0.053255041277315 -0.078110117153983  0.016343490661387  0.006169185301126
-    2  ( 16)  0.011042456445560  0.009621220621098  0.005657518819133  0.191392639644068  0.233688154054541 -0.353809940518162  0.699390838431378  0.098400280608918 -0.064019946546423
-    3  ( 17) -0.107818298388925  0.070528263413636 -0.362149050189104  0.037315109632561  0.042452655982496  0.038896971283720 -0.207385001016399  0.003937722541105  0.085745973487131
-    4  ( 18)  0.108164771682442 -0.211569235735825  0.166881810314745  0.149344513666530  0.172912627937214  0.144860894329907 -0.389029639178511  0.006991735156648 -0.069587103616937
-    5  ( 19)  0.022034901092728 -0.144639335745209 -0.200195290755521  0.092056347474794  0.110733861294271  0.061361632097978 -0.221627156390718  0.079027892241888  0.032657458030366
-    6  ( 20)  0.089133637566930 -0.839810294649537 -0.200388109318644 -0.125542312773296 -0.184497876865321 -0.044991942130055  0.109396315941662  0.378036325170406  0.212906193050279
-    7  ( 21) -0.002196867006824 -0.082899756555975 -0.048115279374916 -0.114723407886649 -0.074445800738012 -0.084900756029246  0.045297736151835  0.122662484012257  0.047092811787579
-    8  ( 22)  0.013013108526046  0.083880968781675  0.015106010061369 -0.084648698834981 -0.084842145668688  0.173118220416505 -0.343867943956616 -0.057834630145787 -0.044463085263394
-    9  ( 23) -0.002899038827224 -0.016237402203798 -0.056359737364791  0.065867727287580  0.036357062083617  0.148332567483149 -0.266717008386610 -0.072257711902870  0.065401118589657
-   10  ( 24) -0.008453034218761 -0.036792496630374  0.026643685782358 -0.084175209377106  0.066503904171434 -0.109372833173203 -0.203212961501276  0.141160482906112  0.070506928282105
-   11  ( 25)  0.005372433858294 -0.132964341260406  0.044450916757190  0.024049494205707 -0.035746907565715 -0.041241296739167  0.004906662564596 -0.132215391095914  0.663807503452023
-   12  ( 26)  0.009743703341659  0.012547820945935 -0.008267356406185 -0.011523281572029  0.000373189232647 -0.008287799895073 -0.039182879439333  0.021754582044359  0.043605958741618
-   13  ( 27) -0.000316984988558  0.013620382001563 -0.009757290310366  0.005224660475905  0.007370239991754  0.000209579654671  0.017764427460055 -0.014597770330481  0.008463776890616
-   14  ( 28) -0.003075987620069 -0.014184203488029  0.003152602515271  0.009779432437690  0.010217463081165  0.012805369803199 -0.043328580726749  0.003405373560657 -0.017681393118998
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.005093177831083  0.003391694549732 -0.004782174271812  0.022986027625481  0.006388300989623
-    1  ( 15) -0.003655760801056  0.005146167609244 -0.005618407889967 -0.014027116916428  0.010302793578385
-    2  ( 16) -0.021370860681958  0.010099899127123  0.129116414547005 -0.005333934325137  0.012983600372401
-    3  ( 17)  0.021869921491230  0.013215154242643 -0.009123077510949 -0.012606640556921 -0.012446334486325
-    4  ( 18) -0.030272655227353 -0.036864268294435  0.009498431522863  0.011184920276992 -0.009178466867281
-    5  ( 19) -0.023458599618802 -0.001801666075823  0.064552415401924  0.041959427003810 -0.014422120327278
-    6  ( 20) -0.129459521423828 -0.031271354696917  0.026491579555366 -0.003035107017297 -0.062712218110468
-    7  ( 21) -0.016586408114880 -0.158363845858414 -0.021959943871014  0.141641861845629 -0.024817685283350
-    8  ( 22) -0.007575307701155 -0.001384055242024  0.285443271693517 -0.005092655839931  0.013202283951991
-    9  ( 23)  0.053335131127380  0.043784781244715 -0.612431255767613  0.089944266819985 -0.016910855433428
-   10  ( 24)  0.015342744071877 -0.395632766534517 -0.015815980082040 -0.149475926737218 -0.001110117846160
-   11  ( 25)  0.295833476490493  0.177314277208158  0.053562169532047  0.148004503342686  0.667549178746814
-   12  ( 26)  0.007155741332045  0.145584854877254 -0.384139934668211 -0.410953720693688  0.016648203877508
-   13  ( 27)  0.021702025353791 -0.046795922259450 -0.648985546330551  0.122609080566925 -0.049062461275054
-   14  ( 28) -0.010942461108182  0.019093069660341  0.223364865933360 -0.053520934540283  0.011602401514689
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002861849195600 -0.001750118343665  0.000194150196746 -0.008574693111016 -0.006010353559076 -0.019458325296912 -0.072285446678870 -0.008447728513642  0.006619839911905
-    1  (  1) -0.001924861668391  0.002087363110901 -0.016971855467530  0.027235173953934 -0.038093280019961 -0.023104905850605 -0.165692788520465 -0.021219005281025  0.019010687091109
-    2  (  2)  0.012268940248648  0.010883087952419 -0.016276306732469  0.008309931413768  0.005837724525099  0.009011561998791  0.007091651398210  0.010639721826082  0.003897826849990
-    3  (  3)  0.055999657987489  0.045440477856664 -0.076835806171601  0.000960169751802  0.024603305635074  0.014163811775193  0.053505119974436 -0.007641653146516  0.022495845210930
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.007010768189510  0.003146790661101  0.002197659213555 -0.000162653889535  0.003167919380673 -0.001716454351420
-    1  (  1) -0.014102241824718 -0.014333573201717 -0.027759720880070 -0.002387194913826 -0.006827488663716  0.005333656372041
-    2  (  2) -0.010359867010522  0.021409066244275 -0.001741696980020 -0.007351305093923 -0.001924339705620 -0.000068941706469
-    3  (  3) -0.028959184887726 -0.008194597278714  0.026966557516044 -0.006362654301925 -0.010940855488235 -0.011462480717190
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.007841499731725 -0.011260922827034 -0.003550382080370 -0.014025398893426 -0.016144397742124  0.052695970359654 -0.108253401254700 -0.010488497388985 -0.002709659180314
-    1  (  5) -0.026329524563314  0.037825007600228  0.006030211425349 -0.027406600793118 -0.031382299209950  0.043131173483671 -0.084960450738463 -0.021264528915956  0.026601463642217
-    2  (  6)  0.060083641924427 -0.072478494093869 -0.010248933969103 -0.046258741412677 -0.052269824639874  0.069243610281519 -0.126398541619941  0.001565657218680 -0.022435245739888
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000994215031647  0.000923363442840 -0.004583185686911 -0.000218320240713  0.001898840213869
-    1  (  5)  0.015124923054324  0.001842634557062 -0.029618847414201 -0.001149888101607 -0.006797617275229
-    2  (  6) -0.007998426054028 -0.006657968933295 -0.021107111486180 -0.005764289634517 -0.010813449750819
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.022503440295578 -0.058098623160149 -0.000062770556747  0.132305009159640  0.206845253888039 -0.090151367716481  0.021622993201594  0.039361663017838 -0.081041759541844
-    1  (  1)  0.058446002592380 -0.108172168387664 -0.020491566069365 -0.029038345945864  0.075256281089896 -0.197244333760811  0.268904698800666  0.104165934684919 -0.067340388337436
-    2  (  2)  0.015395531940670 -0.065975044888454 -0.020693241252052 -0.145278172828453 -0.156811977467562 -0.026190455409852  0.072791620600653  0.106379132149941 -0.008110007387648
-    3  (  3) -0.209889648220471 -0.051262205346318  0.016792464687913  0.095510023534375 -0.095336437810915  0.289116526954887 -0.245753636284379  0.379261907424051 -0.084194488967517
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009235922100176  0.024147628250431 -0.039515998201656 -0.082736569420113  0.047511948424278
-    1  (  1) -0.028213287461093 -0.067760885411211 -0.238885785807081  0.125969164479721 -0.177609465312030
-    2  (  2) -0.077606300081110  0.045313543916729 -0.093141189396734 -0.365274041996183 -0.093447143795063
-    3  (  3) -0.414915648100447 -0.159852566418802  0.273568285227129  0.034618677637946 -0.200919751819537
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.016102681987246  0.069778483698172 -0.053388820632188 -0.227201022134288  0.199230027457294 -0.049687576281256  0.168877445270922  0.014461225328824  0.006078045812767
-    1  (  5) -0.058029574787106  0.323045692563540 -0.030451397472045  0.087822399116216  0.049669665032498  0.052839306746919  0.277652121541254  0.149775076383330 -0.305937155270736
-    2  (  6)  0.084055275470360 -0.046073375199282 -0.190725804864304  0.087557818530462  0.137785527514680  0.205465571554523  0.198777590920686  0.118276962990448  0.298899363373293
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.065173985616707 -0.083163093490792 -0.059838819851122 -0.009394325001925  0.030439464329862 -0.004211858017360
-    1  (  5) -0.056299326992319  0.068872084539630 -0.330916524068169  0.053769676104340  0.184435947376539  0.103868547783986
-    2  (  6) -0.066328790174113  0.124449756312365 -0.113043685745450 -0.144452726551001 -0.299204372306583  0.043729255680800
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.000260799328814 -0.008294549411173 -0.017065509132629  0.120823023937813
-    1  (  1)  0.008496132195738 -0.000459228916484 -0.070584547130300  0.263658986380405
-    2  (  2)  0.016577243382678  0.069994423934547 -0.000663995310113 -0.516189373310167
-    3  (  3) -0.119940673155352 -0.260382744777091  0.515797578549303 -0.000896332895375
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.000443199065137 -0.381921103277014  0.143832380212943
-    1  (  5)  0.379434119923402  0.000485247174065 -0.057931042501930
-    2  (  6) -0.142702240195831  0.057674062630535 -0.001442186168114
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000910219825462 -0.057456315494167 -0.021764053721958  0.110121259160946  0.041147685420936 -0.038875238468069  0.013658833334326 -0.027740409199842 -0.095876697377004
-    1  (  1)  0.055345620113473  0.000114715855223  0.161082100743083 -0.114708095623102  0.226148458080404 -0.429581554700213  0.364780574441808  0.339773267999994  0.220533775015703
-    2  (  2)  0.020999461374251 -0.161288340706678 -0.000052922940143 -0.056734674516634 -0.008992634243539 -0.218257664425439  0.249333786109915  0.218109894036319 -0.109339937450952
-    3  (  3) -0.109919099247493  0.115822425772584  0.056019356072116 -0.000740007124151 -0.462857615716207 -0.122607299860807 -0.103870365958941 -0.116250705982649 -0.000233457087431
-    4  (  4) -0.040147971327435 -0.225934656776577  0.007773114553173  0.462818557657105  0.000780254100804 -0.292874409688809  0.009409004834406  0.051882583984439  0.039822167887863
-    5  (  5)  0.036335623982806  0.431140334321554  0.219015877156661  0.122742718969562  0.292837706512844  0.000258433770030 -0.380099535262126 -0.122521034811976 -0.042311772881298
-    6  (  6) -0.010512439729451 -0.366117333062846 -0.249486244286841  0.103549874288531 -0.008542366045705  0.379118456110851  0.000620782720873 -0.110534560804533  0.061985573678083
-    7  (  7)  0.028794952109144 -0.339121669903044 -0.216809050553033  0.114099992926570 -0.053090461678186  0.122152835713476  0.109887843536853  0.000210775947309  0.084672807581202
-    8  (  8)  0.095808229432329 -0.221323464446135  0.109106314769919  0.000875257370226 -0.038544677458879  0.040538328330232 -0.059775641070054 -0.084700205529952 -0.000410389282629
-    9  (  9) -0.014690106677676  0.105287842105419  0.107275604589342 -0.218821764495376 -0.309676781793525  0.105240911833305  0.129641828300340 -0.117997785258370 -0.042511311165967
-   10  ( 10)  0.029204608723917 -0.107752356942562  0.099755035690676 -0.053525818789624 -0.138310129135290 -0.190113742094553  0.089997971717103  0.050367402099573  0.205935350521398
-   11  ( 11)  0.155172680877926 -0.443695988924904  0.328777258004313  0.218798389165188  0.215176387418517 -0.086665175787649  0.081418632262697  0.042686048369212 -0.076994698914289
-   12  ( 12) -0.047142387853016 -0.056370877736755  0.091886939960935 -0.290638653896334  0.241910293173795  0.247337059600416 -0.042831064612679 -0.092379405814653  0.274155000199424
-   13  ( 13)  0.050389463609625 -0.050328281605153  0.290240848550854 -0.162056910685561 -0.213783629816238  0.103688021030834  0.033887129791453  0.045587144670831 -0.299790508083899
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015162318835378 -0.029089770357077 -0.157702855053245  0.046156695205794 -0.051381788523401
-    1  (  1) -0.106899842384160  0.107201619393601  0.445393414611343  0.057067667076039  0.050060002330133
-    2  (  2) -0.108853020442019 -0.100191021225089 -0.328545989364509 -0.092698579065235 -0.291502735972872
-    3  (  3)  0.218857915462394  0.054792818652366 -0.218936510995734  0.287400527011265  0.163296274870058
-    4  (  4)  0.309023998295357  0.137542450097200 -0.215093937212832 -0.238284970616127  0.213551426913738
-    5  (  5) -0.105674820499688  0.189857437866345  0.086867271133608 -0.246374813737064 -0.103858683965504
-    6  (  6) -0.128168668073169 -0.089874262606371 -0.081958190146060  0.043636026349126 -0.033207564087096
-    7  (  7)  0.118048268068595 -0.049676493985730 -0.043691990049327  0.088880391954538 -0.045560836827754
-    8  (  8)  0.043185963892521 -0.206226573094588  0.075243165625009 -0.272590964413989  0.299131513393744
-    9  (  9)  0.000077812655806 -0.416515228460327 -0.033604308335513  1.079153036114418 -0.144875292314574
-   10  ( 10)  0.417421688626605  0.000158782170528  0.288840596251926  0.322135886975336  0.291543524616041
-   11  ( 11)  0.033233098401296 -0.288689216188738 -0.000098607034113 -0.357467165068052  0.110234432421322
-   12  ( 12) -1.082588808808366 -0.322578291119115  0.357464370574866  0.000001008980927  0.002433258977456
-   13  ( 13)  0.144961978494652 -0.291352746558436 -0.110198259093452 -0.002466771759163 -0.000072101852768
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000153758293573 -0.016209319744983 -0.024928923087972  0.062060534269405  0.021458157317334 -0.118593249827295  0.004670228348363  0.089096780060312 -0.035341471454486
-    1  ( 15)  0.019055649311341 -0.000070156580396 -0.073747917872717  0.220440654642185 -0.117173683557053  0.070042104700274  0.194626599435631 -0.297284852411648  0.000292615006130
-    2  ( 16)  0.022586057176061  0.073725573702120  0.001109122528867  0.015411803572941  0.086529842282525  0.104871288135925  0.398741646254535  0.436619148290803 -0.174927780236032
-    3  ( 17) -0.059798965758570 -0.223563288101711 -0.017237453196908 -0.001072539320884 -0.251308090709605  0.316070038507959 -0.194803920922688 -0.070654458314154  0.376473484057802
-    4  ( 18) -0.020063419795573  0.119039349150294 -0.086800563385573  0.251653936247919  0.000335080469717 -0.043024304110374 -0.031731211566238 -0.166597040990208 -0.162561044012722
-    5  ( 19)  0.121124499928881 -0.070386001406864 -0.107113060109827 -0.315446439196993  0.043168772404524  0.000861182223329 -0.084799444582179 -0.176705933397061  0.191684805310528
-    6  ( 20) -0.000233561008252 -0.194646689316488 -0.399810731697972  0.193912344319211  0.032510952628099  0.085522667102850 -0.000316477106834 -0.483153682293504  0.288298405946303
-    7  ( 21) -0.086715012726146  0.297226361723507 -0.437406682983154  0.070307665225876  0.166617940082316  0.177260527666885  0.482840792819482  0.000014363839073 -0.098144550640997
-    8  ( 22)  0.034848855945224 -0.000859202259418  0.174080336964064 -0.374333295775790  0.160768014871922 -0.191629536743281 -0.289445575908438  0.097019024591293  0.000025631290485
-    9  ( 23)  0.146128458942654 -0.053492838881233 -0.324237370292126 -0.062951581954808 -0.055209150473504 -0.064149761290883 -0.152989513529253 -0.139473999144980  0.103718919883348
-   10  ( 24) -0.228943772976322  0.607904766640644  0.190620042117683  0.232958068537229  0.097307404470545 -0.308161168755027  0.021743402371769 -0.163623966375628 -0.316399909838170
-   11  ( 25)  0.113574180426266  0.174427793656612 -0.418995996828982 -0.308337203800434  0.075443225323578 -0.339087150964693  0.159463644137134  0.028413073180430  0.098871219189354
-   12  ( 26)  0.037424667616197  0.021650461850134 -0.117304488625228  0.051902638546729 -0.180454397108215 -0.010740660434746 -0.081519307880048  0.155893098296170 -0.070546741469611
-   13  ( 27) -0.017280095018033  0.067254948221378 -0.031223412816175  0.363810241814661 -0.387221887080941 -0.012090141341438 -0.015814975926527 -0.054980917611015  0.199339784775612
-   14  ( 28) -0.034098865585284 -0.073619427458161  0.020485113735762  0.085856422394852 -0.016811589946857  0.112843996657195  0.014113720389586 -0.178007823037396 -0.110352388623858
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147079246017605  0.230634884307448 -0.118016008570358 -0.038157144686245  0.016510467338390  0.035555014319301
-    1  ( 15)  0.054535975317160 -0.607948558454318 -0.173873444004683 -0.021413077698393 -0.066607275071670  0.073358775740227
-    2  ( 16)  0.323553306767810 -0.191880318072800  0.420431580468539  0.118056258288723  0.032680374421701 -0.021063792747363
-    3  ( 17)  0.062647993315218 -0.233296910361178  0.309972235789264 -0.052767888005775 -0.365466873290423 -0.086191647934482
-    4  ( 18)  0.056463254704659 -0.097267542243260 -0.076718792069295  0.181006281549198  0.388581954764126  0.017033117994916
-    5  ( 19)  0.064619380121905  0.308870128962105  0.338018874162144  0.010262168050506  0.011437556312376 -0.112357516914852
-    6  ( 20)  0.155382617184205 -0.021349499009466 -0.159407311408361  0.081840985858683  0.016551112467373 -0.014159445477374
-    7  ( 21)  0.140537868334591  0.163950016196429 -0.028635642754641 -0.155664270507489  0.055628199109166  0.178154241019464
-    8  ( 22) -0.103340924054087  0.315438553689221 -0.098505861498584  0.070640699164670 -0.199194337971902  0.110183696097256
-    9  ( 23) -0.000686334470077  0.100169676668856  0.098205410096924 -0.175395135170107  0.218110756020923 -0.228152281870970
-   10  ( 24) -0.099945574878784  0.000096874526586 -0.318471840137312  0.225312238992057  0.500004280228380  0.463864297020155
-   11  ( 25) -0.099841601913638  0.317761699333726  0.000010561932173 -0.325597818789670  0.211905875369382  0.064803783290132
-   12  ( 26)  0.174935630019299 -0.225292248892597  0.325705390203938  0.000017197211890  0.212072627171769 -0.098012445882972
-   13  ( 27) -0.218628597680076 -0.499556536377707 -0.211864150062139 -0.212027765026480 -0.000008829396513  0.140826209090944
-   14  ( 28)  0.228628348725032 -0.463533897278190 -0.064881803503368  0.097950839624484 -0.140879063665638  0.000044304487925
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019783286607667  0.054735513570492 -0.001137513326844 -0.126035313344694 -0.202288256463714  0.093711193698784 -0.024984211933465 -0.040225532534290  0.083002910266348
-    1  (  1) -0.062354141555506  0.120130295665511  0.021767958766603  0.030544877233675 -0.074729404058403  0.202914227757890 -0.283260340106330 -0.110010623472489  0.075144553745797
-    2  (  2) -0.020071775922308  0.073560405733831  0.021169788457012  0.145854094152842  0.150911679145940  0.033300463325012 -0.073764757277366 -0.114546085452080  0.006653298048327
-    3  (  3)  0.203743032315313  0.061501990395663 -0.012053005442539 -0.096810293782688  0.111136074331669 -0.295383183213123  0.262971263743015 -0.383085482761273  0.093214800317935
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009993046060541 -0.025513386759873  0.042737152868896  0.089318313022720 -0.047451575644814
-    1  (  1)  0.030039490492705  0.071945228341214  0.250267584824113 -0.142236309251859  0.184637049012501
-    2  (  2)  0.082997800684343 -0.054871780927271  0.094796177478387  0.401103665959789  0.092927167756829
-    3  (  3)  0.430981237850907  0.170811683530718 -0.282618326899226 -0.039486331856936  0.208093563870180
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.010424637780811 -0.070076242850132  0.057204660728363  0.211582689187883 -0.193468115886375  0.043909115910882 -0.178375291391116 -0.011291008522235 -0.006135050327905
-    1  (  5)  0.063097235172986 -0.334472528658100  0.025536895021054 -0.078253605984607 -0.050626848674631 -0.056751427025114 -0.294768359886251 -0.157483235119348  0.310569420199796
-    2  (  6) -0.095244047527648  0.044264155264159  0.212560989845075 -0.091390111204814 -0.149038964321561 -0.211765484927062 -0.210419447669955 -0.121083324679766 -0.309642082152002
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.068004772690589  0.092578616035472  0.065573414522003  0.010233554080849 -0.030163257483495  0.003064448267094
-    1  (  5)  0.053600125816554 -0.069934313107806  0.342538885093587 -0.056907033818697 -0.186630070751322 -0.106323577696440
-    2  (  6)  0.072821378442813 -0.126275995801835  0.117600527323037  0.149377060250910  0.309029921894478 -0.046031658506232
-
 	Computing Mu_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.242119405908
-	   1         5.307094955381    3.345e-01
-	   2         6.521009476069    2.157e-01
-	   3         6.601281990060    7.069e-02
-	   4         6.669276267924    3.494e-02
-	   5         6.679268498525    1.631e-02
-	   6         6.680326558391    7.806e-03
-	   7         6.682482706679    4.653e-03
-	   8         6.681707531269    2.567e-03
-	   9         6.681844151154    1.420e-03
-	  10         6.681966937524    5.795e-04
-	  11         6.681901115777    1.657e-04
-	  12         6.681815232587    7.367e-05
-	  13         6.681790190236    3.318e-05
-	  14         6.681808395025    1.602e-05
-	  15         6.681820850128    6.436e-06
-	  16         6.681823531031    2.433e-06
-	  17         6.681823063423    1.142e-06
-	  18         6.681822671691    4.072e-07
-	  19         6.681822589852    2.036e-07
-	  20         6.681822583737    1.103e-07
+	   0         4.242119399568
+	   1         5.307094946001    3.345e-01
+	   2         6.521009463011    2.157e-01
+	   3         6.601281977359    7.069e-02
+	   4         6.669276255800    3.494e-02
+	   5         6.679268486245    1.631e-02
+	   6         6.680326546148    7.806e-03
+	   7         6.682482694400    4.653e-03
+	   8         6.681707518976    2.567e-03
+	   9         6.681844138867    1.420e-03
+	  10         6.681966925233    5.795e-04
+	  11         6.681901103485    1.657e-04
+	  12         6.681815220294    7.367e-05
+	  13         6.681790177943    3.318e-05
+	  14         6.681808382734    1.602e-05
+	  15         6.681820837837    6.436e-06
+	  16         6.681823518740    2.433e-06
+	  17         6.681823051132    1.142e-06
+	  18         6.681822659400    4.072e-07
+	  19         6.681822577561    2.036e-07
+	  20         6.681822571446    1.103e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 6.012e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.186353174575
-	   1         5.161662249853    2.464e-01
-	   2         5.911282308196    1.283e-01
-	   3         5.925539350942    2.616e-02
-	   4         5.936395644564    9.560e-03
-	   5         5.936746794681    2.701e-03
-	   6         5.936919744496    1.071e-03
-	   7         5.937087711463    3.837e-04
-	   8         5.937053206948    1.239e-04
-	   9         5.937049895812    3.210e-05
-	  10         5.937049911317    9.401e-06
-	  11         5.937052151043    2.569e-06
-	  12         5.937052553433    6.391e-07
-	  13         5.937052431420    1.689e-07
+	   0         4.186353146522
+	   1         5.161662214812    2.464e-01
+	   2         5.911282264327    1.283e-01
+	   3         5.925539306283    2.616e-02
+	   4         5.936395599532    9.560e-03
+	   5         5.936746749591    2.701e-03
+	   6         5.936919699390    1.071e-03
+	   7         5.937087666348    3.837e-04
+	   8         5.937053161834    1.239e-04
+	   9         5.937049850698    3.210e-05
+	  10         5.937049866203    9.401e-06
+	  11         5.937052105930    2.569e-06
+	  12         5.937052508319    6.391e-07
+	  13         5.937052386307    1.689e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 5.936e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.109852245780
-	   1        11.996094164114    5.792e-01
-	   2        15.885441719522    3.652e-01
-	   3        16.023216375027    8.692e-02
-	   4        16.179551532135    5.264e-02
-	   5        16.206987755722    2.098e-02
-	   6        16.206820423197    1.024e-02
-	   7        16.210754110999    6.830e-03
-	   8        16.212355026029    3.850e-03
-	   9        16.211538639947    1.508e-03
-	  10        16.211672503870    6.766e-04
-	  11        16.212315740792    3.489e-04
-	  12        16.212731813566    1.227e-04
-	  13        16.212683561887    4.413e-05
-	  14        16.212592478485    2.285e-05
-	  15        16.212540145687    1.201e-05
-	  16        16.212528556487    4.777e-06
-	  17        16.212529894076    1.559e-06
-	  18        16.212529351885    1.012e-06
-	  19        16.212529245694    5.627e-07
-	  20        16.212529125626    2.204e-07
-	  21        16.212529165569    1.362e-07
+	   0         9.109852174480
+	   1        11.996094068191    5.792e-01
+	   2        15.885441572889    3.652e-01
+	   3        16.023216221479    8.692e-02
+	   4        16.179551375957    5.264e-02
+	   5        16.206987598543    2.098e-02
+	   6        16.206820266042    1.024e-02
+	   7        16.210753953540    6.830e-03
+	   8        16.212354868463    3.850e-03
+	   9        16.211538482420    1.508e-03
+	  10        16.211672346338    6.766e-04
+	  11        16.212315583251    3.489e-04
+	  12        16.212731656006    1.227e-04
+	  13        16.212683404327    4.413e-05
+	  14        16.212592320930    2.285e-05
+	  15        16.212539988134    1.201e-05
+	  16        16.212528398933    4.777e-06
+	  17        16.212529736522    1.559e-06
+	  18        16.212529194332    1.012e-06
+	  19        16.212529088141    5.627e-07
+	  20        16.212528968073    2.204e-07
+	  21        16.212529008016    1.362e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 5.973e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.240468652596
-	   1         0.313209498607    7.007e-02
-	   2         0.373709169912    3.781e-02
-	   3         0.375556448030    8.058e-03
-	   4         0.376178493697    1.738e-03
-	   5         0.376116640072    3.791e-04
-	   6         0.376110557795    9.190e-05
-	   7         0.376115037296    2.692e-05
-	   8         0.376113650642    1.018e-05
-	   9         0.376113956866    3.897e-06
-	  10         0.376114068619    1.311e-06
-	  11         0.376114080967    3.969e-07
-	  12         0.376114023250    1.211e-07
+	   0         0.240468649153
+	   1         0.313209493736    7.007e-02
+	   2         0.373709163166    3.781e-02
+	   3         0.375556441186    8.058e-03
+	   4         0.376178486822    1.738e-03
+	   5         0.376116633199    3.791e-04
+	   6         0.376110550923    9.190e-05
+	   7         0.376115030424    2.692e-05
+	   8         0.376113643770    1.018e-05
+	   9         0.376113949994    3.897e-06
+	  10         0.376114061747    1.311e-06
+	  11         0.376114074094    3.969e-07
+	  12         0.376114016378    1.211e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 2.604e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.515692693021
-	   1         8.318755770261    4.415e-01
-	   2        10.402192731893    2.645e-01
-	   3        10.443322126040    6.468e-02
-	   4        10.509134679451    3.527e-02
-	   5        10.520754933699    1.316e-02
-	   6        10.520775549563    5.741e-03
-	   7        10.521931785908    3.215e-03
-	   8        10.521951372108    1.306e-03
-	   9        10.521762506639    4.749e-04
-	  10        10.521820877025    1.886e-04
-	  11        10.521897644864    9.992e-05
-	  12        10.521959772194    5.220e-05
-	  13        10.521945651686    2.883e-05
-	  14        10.521920907158    1.518e-05
-	  15        10.521908886768    7.526e-06
-	  16        10.521909105232    3.140e-06
-	  17        10.521910400114    1.312e-06
-	  18        10.521910934898    6.234e-07
-	  19        10.521911098491    2.888e-07
-	  20        10.521911105352    1.072e-07
+	   0         6.515692653853
+	   1         8.318755715780    4.415e-01
+	   2        10.402192653836    2.645e-01
+	   3        10.443322047730    6.468e-02
+	   4        10.509134600652    3.527e-02
+	   5        10.520754854726    1.316e-02
+	   6        10.520775470582    5.741e-03
+	   7        10.521931706908    3.215e-03
+	   8        10.521951293099    1.306e-03
+	   9        10.521762427641    4.749e-04
+	  10        10.521820798029    1.886e-04
+	  11        10.521897565871    9.992e-05
+	  12        10.521959693204    5.220e-05
+	  13        10.521945572693    2.883e-05
+	  14        10.521920828162    1.518e-05
+	  15        10.521908807772    7.526e-06
+	  16        10.521909026235    3.140e-06
+	  17        10.521910321117    1.312e-06
+	  18        10.521910855900    6.234e-07
+	  19        10.521911019493    2.888e-07
+	  20        10.521911026355    1.072e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 5.868e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.767770310162
-	   1         4.563532570790    2.151e-01
-	   2         5.153334063442    1.198e-01
-	   3         5.184426428959    3.270e-02
-	   4         5.197264648557    8.990e-03
-	   5         5.196483205714    2.257e-03
-	   6         5.196637604176    7.071e-04
-	   7         5.196727224056    2.123e-04
-	   8         5.196698716543    7.458e-05
-	   9         5.196703243792    1.972e-05
-	  10         5.196703963306    6.251e-06
-	  11         5.196704370202    1.959e-06
-	  12         5.196703950793    7.478e-07
-	  13         5.196703918192    2.229e-07
+	   0         3.767770283491
+	   1         4.563532537926    2.151e-01
+	   2         5.153334023020    1.198e-01
+	   3         5.184426387138    3.270e-02
+	   4         5.197264606240    8.990e-03
+	   5         5.196483163389    2.257e-03
+	   6         5.196637561838    7.071e-04
+	   7         5.196727181712    2.123e-04
+	   8         5.196698674199    7.458e-05
+	   9         5.196703201448    1.972e-05
+	  10         5.196703920961    6.251e-06
+	  11         5.196704327858    1.959e-06
+	  12         5.196703908449    7.478e-07
+	  13         5.196703875848    2.229e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 7.279e-08
 
@@ -6600,12 +1167,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.273204709350883    -0.118930581327424     0.000000000000000
-    1     -0.474438445773736    -0.025397024055254     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.221410014996711
+    0      0.273204707761102    -0.118930580636346     0.000000000000000
+    1     -0.474438446130291    -0.025397023393736     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.221410011414567
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) = -214.73318 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -214.73317 deg/[dm (g/cm^3)]
 
    ------------------------------------------
        CCSD Length-Gauge Optical Rotation
@@ -6613,17 +1180,10 @@ Total time:
        Omega           alpha
     E_h      nm   deg/[dm (g/cm^3)]
    -----   ------ ------------------
-   0.077   589.00       -76.93370
-   0.128   355.00      -214.73318
+   0.077   589.00       -76.93369
+   0.128   355.00      -214.73317
 
-*** tstop() called on psinet at Mon May 15 15:34:36 2017
-Module time:
-	user time   =       4.08 seconds =       0.07 minutes
-	system time =       4.00 seconds =       0.07 minutes
-	total time  =          8 seconds =       0.13 minutes
-Total time:
-	user time   =       5.15 seconds =       0.09 minutes
-	system time =       4.46 seconds =       0.07 minutes
-	total time  =         10 seconds =       0.17 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
+    Psi4 wall time for execution: 0:00:21.60
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc30/output.ref
+++ b/tests/cc30/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:25PM
 
-    Process ID:  12735
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65742
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -51,28 +64,26 @@ set {
   basis STO-3G
 }
 
-property('ccsd',properties=['rotation'])
+properties('ccsd',properties=['rotation'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:34 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:21 2022
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-3  entry C          line    60 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 4    entry O          line    80 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 5-10 entry H          line    18 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1-3  entry C          line    61 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 4    entry O          line    81 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 5-10 entry H          line    19 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -86,22 +97,22 @@ property('ccsd',properties=['rotation'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.210991841737     0.047663662717     0.483960886619    12.000000000000
-           C         -0.960965312103     0.688519555303    -0.115848688934    12.000000000000
-           C          1.558206749694     0.047460114159    -0.180267436891    12.000000000000
-           O         -0.815251456906    -0.734986972268    -0.138532905591    15.994914619560
-           H          0.223550547304    -0.045637654519     1.567373484970     1.007825032070
-           H         -1.759483315918     1.063259112311     0.516330435381     1.007825032070
-           H         -0.862256972568     1.177986074652    -1.079897880020     1.007825032070
-           H          2.088617117792    -0.883541600456     0.026321487274     1.007825032070
-           H          2.169362364888     0.872235726981     0.192209317060     1.007825032070
-           H          1.455347299576     0.149768052462    -1.260354487995     1.007825032070
+         C            0.210991841728     0.047663662711     0.483960886619    12.000000000000
+         C           -0.960965312112     0.688519555297    -0.115848688934    12.000000000000
+         C            1.558206749685     0.047460114153    -0.180267436891    12.000000000000
+         O           -0.815251456915    -0.734986972274    -0.138532905591    15.994914619570
+         H            0.223550547295    -0.045637654525     1.567373484970     1.007825032230
+         H           -1.759483315927     1.063259112305     0.516330435381     1.007825032230
+         H           -0.862256972577     1.177986074646    -1.079897880020     1.007825032230
+         H            2.088617117783    -0.883541600462     0.026321487274     1.007825032230
+         H            2.169362364879     0.872235726975     0.192209317060     1.007825032230
+         H            1.455347299567     0.149768052456    -1.260354487995     1.007825032230
 
   Running in c1 symmetry.
 
   Rotational constants: A =      0.60799  B =      0.22239  C =      0.19815 [cm^-1]
-  Rotational constants: A =  18226.99774  B =   6666.95622  C =   5940.33276 [MHz]
-  Nuclear repulsion =  124.788534121263865
+  Rotational constants: A =  18226.99788  B =   6666.95627  C =   5940.33280 [MHz]
+  Nuclear repulsion =  124.788534611761449
 
   Charge       = 0
   Multiplicity = 1
@@ -118,27 +129,17 @@ property('ccsd',properties=['rotation'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 18
-    Number of basis function: 26
+    Number of basis functions: 26
     Number of Cartesian functions: 26
     Spherical Harmonics?: true
     Max angular momentum: 1
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         26      26       0       0       0       0
-   -------------------------------------------------------
-    Total      26      26      16      16      16       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -157,45 +158,59 @@ property('ccsd',properties=['rotation'])
   Using 123552 doubles for integral storage.
   We computed 14355 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.0902507179E-01.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.0902506889E-01.
+  Reciprocal condition number of the overlap matrix is 8.4122044079E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         26      26 
+   -------------------------
+    Total      26      26
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -189.14691005126650   -1.89147e+02   1.09501e-01 
-   @RHF iter   1:  -189.43036886409882   -2.83459e-01   1.10564e-02 
-   @RHF iter   2:  -189.50510750165620   -7.47386e-02   3.37004e-03 DIIS
-   @RHF iter   3:  -189.51246555575443   -7.35805e-03   1.05795e-03 DIIS
-   @RHF iter   4:  -189.51330985896300   -8.44303e-04   2.79860e-04 DIIS
-   @RHF iter   5:  -189.51340579507908   -9.59361e-05   9.48346e-05 DIIS
-   @RHF iter   6:  -189.51341658460973   -1.07895e-05   2.52558e-05 DIIS
-   @RHF iter   7:  -189.51341720881524   -6.24206e-07   5.08705e-06 DIIS
-   @RHF iter   8:  -189.51341723639678   -2.75815e-08   1.05884e-06 DIIS
-   @RHF iter   9:  -189.51341723745801   -1.06124e-09   3.08858e-07 DIIS
-   @RHF iter  10:  -189.51341723757079   -1.12777e-10   8.22657e-08 DIIS
-   @RHF iter  11:  -189.51341723757943   -8.64020e-12   1.90570e-08 DIIS
-   @RHF iter  12:  -189.51341723757997   -5.40012e-13   3.37648e-09 DIIS
-   @RHF iter  13:  -189.51341723757986    1.13687e-13   6.27883e-10 DIIS
-   @RHF iter  14:  -189.51341723758011   -2.55795e-13   1.53694e-10 DIIS
-   @RHF iter  15:  -189.51341723757997    1.42109e-13   4.68260e-11 DIIS
+   @RHF iter SAD:  -186.43072166022969   -1.86431e+02   0.00000e+00 
+   @RHF iter   1:  -189.43266126778431   -3.00194e+00   1.28222e-02 ADIIS/DIIS
+   @RHF iter   2:  -189.50256237003049   -6.99011e-02   5.10734e-03 ADIIS/DIIS
+   @RHF iter   3:  -189.51308752257810   -1.05252e-02   6.61403e-04 ADIIS/DIIS
+   @RHF iter   4:  -189.51341362083576   -3.26098e-04   6.54297e-05 DIIS
+   @RHF iter   5:  -189.51341710353671   -3.48270e-06   1.19638e-05 DIIS
+   @RHF iter   6:  -189.51341723375197   -1.30215e-07   1.91468e-06 DIIS
+   @RHF iter   7:  -189.51341723649421   -2.74224e-09   7.28366e-07 DIIS
+   @RHF iter   8:  -189.51341723702996   -5.35749e-10   2.37098e-07 DIIS
+   @RHF iter   9:  -189.51341723710055   -7.05995e-11   4.41139e-08 DIIS
+   @RHF iter  10:  -189.51341723710277   -2.21689e-12   7.00241e-09 DIIS
+   @RHF iter  11:  -189.51341723710271    5.68434e-14   1.79171e-09 DIIS
+   @RHF iter  12:  -189.51341723710263    8.52651e-14   4.46110e-10 DIIS
+   @RHF iter  13:  -189.51341723710271   -8.52651e-14   1.14588e-10 DIIS
+   @RHF iter  14:  -189.51341723710269    2.84217e-14   1.75058e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -217,49 +232,44 @@ property('ccsd',properties=['rotation'])
               A 
     DOCC [    16 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -189.51341723757997
+  @RHF Final Energy:  -189.51341723710269
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =            124.7885341212638650
-    One-Electron Energy =                -505.7302694793730211
-    Two-Electron Energy =                 191.4283181205291839
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -189.5134172375799722
+    Nuclear Repulsion Energy =            124.7885346117614489
+    One-Electron Energy =                -505.7302704013783909
+    Two-Electron Energy =                 191.4283185525142414
+    Total Energy =                       -189.5134172371026864
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     3.1039      Y:     2.1846      Z:    -0.0363
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:    -2.8119      Y:    -1.6853      Z:     0.1750
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.2920      Y:     0.4993      Z:     0.1387     Total:     0.5948
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.7422      Y:     1.2690      Z:     0.3525     Total:     1.5118
 
 
-*** tstop() called on psinet at Mon May 15 15:34:35 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:23 2022
 Module time:
-	user time   =       0.65 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.28 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.65 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.28 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -273,19 +283,19 @@ Total time:
       Number of basis functions:        26
 
       Number of irreps:                  1
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  26 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 61560 non-zero two-electron integrals.
+      Computed 60685 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:35 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:23 2022
 
 
 	Wfn Parameters:
@@ -307,7 +317,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -343,7 +353,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -209.07983613514418
+	Frozen core energy     =   -209.07983635006988
 
 	Size of irrep 0 of <ab|cd> integrals:      0.010 (MW) /      0.080 (MB)
 	Total:                                     0.010 (MW) /      0.080 (MB)
@@ -354,34 +364,30 @@ Total time:
 	Size of irrep 0 of tijab amplitudes:       0.014 (MW) /      0.115 (MB)
 	Total:                                     0.014 (MW) /      0.115 (MB)
 
-	Nuclear Rep. energy          =    124.78853412126387
-	SCF energy                   =   -189.51341723757997
-	One-electron energy          =   -194.60728307298822
-	Two-electron energy          =     89.38516784928819
-	Reference energy             =   -189.51341723758034
+	Nuclear Rep. energy          =    124.78853461176145
+	SCF energy                   =   -189.51341723710269
+	One-electron energy          =   -194.60728356878721
+	Two-electron energy          =     89.38516806999309
+	Reference energy             =   -189.51341723710254
 
-*** tstop() called on psinet at Mon May 15 15:34:35 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:23 2022
 Module time:
-	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.81 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:35 2017
-
+	user time   =       1.51 seconds =       0.03 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =  124.788534121263865
-    SCF energy          (wfn)     = -189.513417237579972
-    Reference energy    (file100) = -189.513417237580342
+    Nuclear Rep. energy (wfn)     =  124.788534611761449
+    SCF energy          (wfn)     = -189.513417237102686
+    Reference energy    (file100) = -189.513417237102544
 
     Input parameters:
     -----------------
@@ -409,81 +415,69 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.1984983537949022
+MP2 correlation energy -0.1984983521050313
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.198498353794902    0.000e+00    0.000000    0.000000    0.000000    0.124632
-     1        -0.237008933272351    7.197e-02    0.005013    0.019208    0.019208    0.149707
-     2        -0.254270371793138    2.556e-02    0.005982    0.022682    0.022682    0.163374
-     3        -0.255782956694381    5.592e-03    0.006458    0.025003    0.025003    0.165523
-     4        -0.256080298178184    1.875e-03    0.006481    0.025202    0.025202    0.166491
-     5        -0.256086467634576    4.302e-04    0.006487    0.025253    0.025253    0.166665
-     6        -0.256081473680009    9.732e-05    0.006489    0.025260    0.025260    0.166678
-     7        -0.256081021850376    2.919e-05    0.006488    0.025256    0.025256    0.166681
-     8        -0.256081381420836    1.108e-05    0.006488    0.025254    0.025254    0.166682
-     9        -0.256081421006700    3.133e-06    0.006488    0.025253    0.025253    0.166681
-    10        -0.256081359603313    1.163e-06    0.006488    0.025253    0.025253    0.166681
-    11        -0.256081358475880    4.447e-07    0.006488    0.025253    0.025253    0.166681
-    12        -0.256081369429196    1.783e-07    0.006488    0.025253    0.025253    0.166681
-    13        -0.256081379627737    5.451e-08    0.006488    0.025253    0.025253    0.166681
-    14        -0.256081381334090    1.813e-08    0.006488    0.025253    0.025253    0.166681
-    15        -0.256081380880501    6.961e-09    0.006488    0.025253    0.025253    0.166681
+     0        -0.198498352105031    0.000e+00    0.000000    0.000000    0.000000    0.124632
+     1        -0.237008931308751    7.197e-02    0.005013    0.019208    0.019208    0.149707
+     2        -0.254270369637538    2.556e-02    0.005982    0.022682    0.022682    0.163374
+     3        -0.255782954497087    5.592e-03    0.006458    0.025003    0.025003    0.165523
+     4        -0.256080295969144    1.875e-03    0.006481    0.025202    0.025202    0.166491
+     5        -0.256086465424992    4.302e-04    0.006487    0.025253    0.025253    0.166665
+     6        -0.256081471470671    9.732e-05    0.006489    0.025260    0.025260    0.166678
+     7        -0.256081019641028    2.919e-05    0.006488    0.025256    0.025256    0.166681
+     8        -0.256081379211469    1.108e-05    0.006488    0.025254    0.025254    0.166682
+     9        -0.256081418797327    3.133e-06    0.006488    0.025253    0.025253    0.166681
+    10        -0.256081357393936    1.163e-06    0.006488    0.025253    0.025253    0.166681
+    11        -0.256081356266501    4.447e-07    0.006488    0.025253    0.025253    0.166681
+    12        -0.256081367219822    1.783e-07    0.006488    0.025253    0.025253    0.166681
+    13        -0.256081377418367    5.451e-08    0.006488    0.025253    0.025253    0.166681
+    14        -0.256081379124717    1.813e-08    0.006488    0.025253    0.025253    0.166681
+    15        -0.256081378671129    6.961e-09    0.006488    0.025253    0.025253    0.166681
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-             11   2         0.0172860478
+             11   2         0.0172860477
              11   3        -0.0101252597
-              9   0         0.0093896207
-             11   5         0.0079607188
-             11   1        -0.0067478297
-              2   1         0.0067121219
-              4   2        -0.0059054293
-             10   1        -0.0053242037
-             10   2        -0.0053113232
-              4   1         0.0046921707
+              9   0         0.0093896208
+             11   5         0.0079607182
+             11   1        -0.0067478301
+              2   1         0.0067121218
+              4   2        -0.0059054292
+             10   1        -0.0053242035
+             10   2        -0.0053113229
+              4   1         0.0046921708
 
     Largest TIjAb Amplitudes:
-     10  10   0   0        -0.0729527920
-      9   9   0   0        -0.0599470174
-      6   6   6   6        -0.0458883504
-      9  10   0   1         0.0399836404
-     10   9   1   0         0.0399836404
-     10  10   1   1        -0.0353807714
-      9  10   1   0         0.0308742315
-     10   9   0   1         0.0308742315
-      8   8   2   2        -0.0255613060
-      9   9   1   1        -0.0225414535
+     10  10   0   0        -0.0729527916
+      9   9   0   0        -0.0599470167
+      6   6   6   6        -0.0458883494
+      9  10   0   1         0.0399836398
+     10   9   1   0         0.0399836398
+     10  10   1   1        -0.0353807705
+      9  10   1   0         0.0308742310
+     10   9   0   1         0.0308742310
+      8   8   2   2        -0.0255613056
+      9   9   1   1        -0.0225414532
 
-    SCF energy       (wfn)                    = -189.513417237579972
-    Reference energy (file100)                = -189.513417237580342
+    SCF energy       (wfn)                    = -189.513417237102686
+    Reference energy (file100)                = -189.513417237102544
 
-    Opposite-spin MP2 correlation energy      =   -0.172369086868551
-    Same-spin MP2 correlation energy          =   -0.026129266926351
-    MP2 correlation energy                    =   -0.198498353794902
-      * MP2 total energy                      = -189.711915591375231
+    Opposite-spin MP2 correlation energy      =   -0.172369085425351
+    Same-spin MP2 correlation energy          =   -0.026129266679681
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.198498352105031
+      * MP2 total energy                      = -189.711915589207564
 
-    Opposite-spin CCSD correlation energy     =   -0.233276064934856
-    Same-spin CCSD correlation energy         =   -0.022805315945626
-    CCSD correlation energy                   =   -0.256081380880501
-      * CCSD total energy                     = -189.769498618460830
-
-
-*** tstop() called on psinet at Mon May 15 15:34:35 2017
-Module time:
-	user time   =       0.22 seconds =       0.00 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.03 seconds =       0.02 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:35 2017
+    Opposite-spin CCSD correlation energy     =   -0.233276062832105
+    Same-spin CCSD correlation energy         =   -0.022805315839024
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.256081378671129
+      * CCSD total energy                     = -189.769498615773671
 
 
 			**************************
@@ -493,31 +487,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:35 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.04 seconds =       0.02 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:35 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =  124.788534121263865
+	Nuclear Rep. energy (wfn)     =  124.788534611761449
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -189.513417237579972
-	Reference energy    (CC_INFO) = -189.513417237580342
-	CCSD energy         (CC_INFO) =   -0.256081380880501
-	Total CCSD energy   (CC_INFO) = -189.769498618460830
+	SCF energy          (wfn)     = -189.513417237102686
+	Reference energy    (CC_INFO) = -189.513417237102544
+	CCSD energy         (CC_INFO) =   -0.256081378671129
+	Total CCSD energy   (CC_INFO) = -189.769498615773671
 
 	Input parameters:
 	-----------------
@@ -530,7 +510,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -543,61 +523,47 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.256237915146067    0.000e+00
-	   1        -0.252169339226238    1.810e-02
-	   2        -0.250666632448738    3.407e-03
-	   3        -0.250393618703240    1.323e-03
-	   4        -0.250341130499737    4.043e-04
-	   5        -0.250345489448306    1.111e-04
-	   6        -0.250347132052883    2.991e-05
-	   7        -0.250347367903609    8.505e-06
-	   8        -0.250347455571628    3.205e-06
-	   9        -0.250347484175278    1.342e-06
-	  10        -0.250347488134282    5.615e-07
-	  11        -0.250347483074131    2.263e-07
-	  12        -0.250347479746485    7.512e-08
+	   0        -0.256237912933552    0.000e+00
+	   1        -0.252169337111640    1.810e-02
+	   2        -0.250666630366034    3.407e-03
+	   3        -0.250393616625877    1.323e-03
+	   4        -0.250341128423953    4.043e-04
+	   5        -0.250345487372515    1.111e-04
+	   6        -0.250347129977033    2.991e-05
+	   7        -0.250347365827743    8.505e-06
+	   8        -0.250347453495757    3.205e-06
+	   9        -0.250347482099403    1.342e-06
+	  10        -0.250347486058407    5.615e-07
+	  11        -0.250347480998257    2.263e-07
+	  12        -0.250347477670610    7.512e-08
 
 	Largest LIA Amplitudes:
-	         11   2         0.0118111422
+	         11   2         0.0118111420
 	         11   3        -0.0069061034
-	         11   5         0.0053763874
-	          2   1         0.0052385543
-	         11   1        -0.0038870567
-	          0   1        -0.0037819862
-	          9   0         0.0036545358
-	          1   1         0.0034939138
+	         11   5         0.0053763870
+	          2   1         0.0052385542
+	         11   1        -0.0038870571
+	          0   1        -0.0037819861
+	          9   0         0.0036545359
+	          1   1         0.0034939137
 	          4   2        -0.0032795874
-	         11   4        -0.0027053346
+	         11   4        -0.0027053355
 
 	Largest LIjAb Amplitudes:
-	 10  10   0   0        -0.0698116835
-	  9   9   0   0        -0.0569655616
-	  6   6   6   6        -0.0455822736
-	  9  10   0   1         0.0384444666
-	 10   9   1   0         0.0384444666
-	 10  10   1   1        -0.0342780652
-	  9  10   1   0         0.0298886045
-	 10   9   0   1         0.0298886045
-	  8   8   2   2        -0.0251518867
-	  9   9   1   1        -0.0223865008
+	 10  10   0   0        -0.0698116831
+	  9   9   0   0        -0.0569655610
+	  6   6   6   6        -0.0455822726
+	  9  10   0   1         0.0384444660
+	 10   9   1   0         0.0384444660
+	 10  10   1   1        -0.0342780644
+	  9  10   1   0         0.0298886040
+	 10   9   0   1         0.0298886040
+	  8   8   2   2        -0.0251518864
+	  9   9   1   1        -0.0223865005
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.86083040552
-
-*** tstop() called on psinet at Mon May 15 15:34:35 2017
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.11 seconds =       0.02 minutes
-	system time =       0.41 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:35 2017
-
+	Overlap <L|e^T> =        0.86083040761
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -631,2419 +597,259 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008290776080582 -0.050801504097253  0.025635294562259 -0.003046442602711 -0.019839162173202 -0.042287718066775  0.002274291905087 -0.017250301075761 -0.063217582232324
-    1  (  1) -0.005656720485448  0.005906316890016 -0.013342327104385  0.062795095869537  0.034384806675368 -0.011824889654518 -0.010091423219065 -0.046942857543920 -0.048716688440686
-    2  (  2)  0.031253511604130  0.072637650556073 -0.014421891959526 -0.004213302445553  0.070727435854801 -0.065656867197555 -0.018370400388693 -0.002385908267158  0.006354255904041
-    3  (  3) -0.059832580241196 -0.053424480759820 -0.021451003825827 -0.018138018553495 -0.036100327164171  0.016134873511603  0.024740373136963  0.003793018506519 -0.167949395515151
-    4  (  4) -0.064204693944690 -0.131652862682136  0.117404639608972  0.157417127901485 -0.230036611567443  0.047515122725740  0.039984594404843  0.125482054176259 -0.256771627646738
-    5  (  5)  0.146085129938632  0.278398764610060 -0.159854012203638  0.282968510269086  0.101365891285813  0.356608825189021  0.125659431918166  0.044422988683829  0.166646852463301
-    6  (  6) -0.076564725597579  0.133650798922835 -0.020866614443156 -0.061441481951876  0.071232976830213 -0.204259413485531  0.443726141038863  0.031546384888620  0.054109942402284
-    7  (  7)  0.171392689665179  0.199512600411571 -0.417327799251045 -0.052763427688751  0.301472803852696  0.065491949787692 -0.090135905280205  0.243374803622146  0.087314234232365
-    8  (  8)  0.052750851527397  0.070024200557922 -0.379656051510646  0.506727880893360  0.456213741194719 -0.053888497905949  0.020349944072208  0.064388593842935 -0.270869373264179
-    9  (  9) -0.321512384290440  0.557302077819714  0.036935298894209  0.154840347992778  0.003043634782132  0.230873783877613  0.106477418838008  0.187200194326970 -0.093391131247138
-   10  ( 10) -0.965723013629727  0.203375174675727  0.231799200789465 -0.113515758170139  0.032657967963446 -0.147828874479423  0.019227710807050 -0.096617606939553  0.006766409668261
-   11  ( 11) -0.210596475192897  0.094976222444135 -0.072335244920971  0.290764752768263 -0.062314851229712  0.053607127427930  0.145285323049651  0.073900587412887 -0.326764941791807
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071285844130264
-    1  (  1)  0.010066343394199
-    2  (  2) -0.108617239028194
-    3  (  3) -0.063737900590760
-    4  (  4) -0.015793155353663
-    5  (  5)  0.238781543103224
-    6  (  6) -0.065357063243315
-    7  (  7)  0.120098496018758
-    8  (  8) -0.128051536292778
-    9  (  9)  0.179029916473930
-   10  ( 10) -0.084757737907666
-   11  ( 11)  0.159141561245499
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.230778688168130 -0.557039020018502  0.102231622004203 -0.365190061837505 -0.400431097899025 -0.011240783369823 -0.138486416116495  0.002452040812742 -0.004398637078623
-    1  (  1) -0.556776142920827 -2.040315056194718  0.915507378155102  1.014426942838368  0.734278848751725  0.048588577390964  0.281167270606351  0.301449170381432  0.094768863002394
-    2  (  2)  0.102191442528323  0.915686903851560  1.209547690777273 -0.958100119655737 -0.740471389480369 -0.004947182895568  0.495915674452131 -0.139783988312968  0.095073435804183
-    3  (  3) -0.364539165929170  1.014070571549057 -0.958316089423204 -0.283348551998825 -0.131889670325022 -1.271015261428147  0.039370973643206 -0.404136843612415 -0.596543898512850
-    4  (  4) -0.399870169082361  0.732987024839952 -0.742129335372324 -0.132056740778799  0.552809694709972  0.050609502973822 -0.485130318718432 -1.569135325660496 -0.955644372877197
-    5  (  5) -0.012067668711970  0.049395634351447 -0.004235997753528 -1.269867451709877  0.052501445594591  0.142961307435960 -0.243772741862524  0.815823088969846 -1.032660122676294
-    6  (  6) -0.138184751914924  0.281444487458849  0.496109632619357  0.039289252640444 -0.483545301414318 -0.244146373994899 -2.567548494258237  0.471042691193011  0.535768572608993
-    7  (  7)  0.002443724218529  0.302692867022601 -0.138498316501231 -0.403820450806263 -1.565811046199608  0.816611901103015  0.471628294535134 -1.688652935957108  0.671482803026688
-    8  (  8) -0.004344564384300  0.094578985136196  0.094798646138089 -0.597437555079113 -0.950266206536146 -1.030172101956222  0.534632090191761  0.669551052804072 -0.286047601971907
-    9  (  9)  0.321027459692546 -0.124494588251713 -0.355830352458176 -0.608802973418470 -0.402462352421951 -0.368076132570564 -1.240230517037675 -0.910561909620175  0.043652486559104
-   10  ( 10)  0.011815823949598 -0.051101513605038 -0.395397800969984  0.309598565761669  0.194737646185127  0.053604366895841 -0.879466474650196  0.757981021960396  0.138272602216670
-   11  ( 11)  0.159425836287601 -0.085783898744993 -0.370909602534729 -0.056636941516785 -0.307385996591224 -0.268976928323790 -0.442853482929670  0.013290639913097 -0.876205899626718
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.323082673575100  0.012827323300415  0.160383781034165
-    1  (  1) -0.126844464371028 -0.052604971080148 -0.086843133976977
-    2  (  2) -0.357788273401833 -0.396667921961515 -0.371902334820724
-    3  (  3) -0.612287607386654  0.306667669522199 -0.056656844524874
-    4  (  4) -0.405472668706639  0.195190062002348 -0.306615567899281
-    5  (  5) -0.367351821286147  0.055534904015428 -0.275720960811118
-    6  (  6) -1.243158670589035 -0.884111685009210 -0.446520521343404
-    7  (  7) -0.909610092856081  0.758960738026336  0.004121680213622
-    8  (  8)  0.044479614426162  0.142510706976164 -0.890141861038879
-    9  (  9)  0.430645603358394 -0.292573864178629 -0.177569371172063
-   10  ( 10) -0.297251468770778  0.639563517042984 -0.084252875076621
-   11  ( 11) -0.176313836183732 -0.086637188746477  1.226883274744448
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.555032728737771  0.712617672671401  0.419810286882489  0.050887754227596 -0.090842975445822 -0.470640518796941  0.705404320416024 -0.102097016449215  0.079849652538938
-    1  (  1)  0.712915390108471  0.338414908248977  0.746799463635505  0.289033465951793  0.281577689527702 -0.590080565321557 -1.163166129408219 -0.188838662213219  0.235465544716902
-    2  (  2)  0.420424419523684  0.746397208582966 -0.016153704953468 -0.358852287949201 -0.952285365412292  1.041198523267407 -0.387389024226280  0.231972398395418 -1.201681468114436
-    3  (  3)  0.052990374128029  0.287939592192507 -0.356997201476426 -0.860130940767887 -1.322600194001359 -0.190991097932252 -0.172427859143025  1.049268576710733  0.759838942947354
-    4  (  4) -0.091729674999201  0.281558404761801 -0.953826965790842 -1.321136801436185  1.452847715742109  0.019357804497789  0.219531843898996 -0.321163524474806  0.383368380154908
-    5  (  5) -0.468391179467906 -0.590920943851569  1.042843901419442 -0.190946364776948  0.019284064585406 -0.578157261908740  0.477982154885554  0.309192885886468  0.350343314103329
-    6  (  6)  0.705416628116867 -1.163498224121495 -0.385221267991331 -0.173426272959358  0.218834180811751  0.478203132617135 -2.784703127021582 -0.089827446409910  0.007438070857215
-    7  (  7) -0.100892718625019 -0.189193923309364  0.233172791358426  1.048794685120079 -0.321694154621351  0.309157324551256 -0.089653742381773 -3.228872513573496  0.508232911749822
-    8  (  8)  0.078189592702616  0.235740536359493 -1.205024775916881  0.762330717256039  0.383275686836382  0.348953623655193  0.008045450505770  0.508467502681986  0.472369144605263
-    9  (  9) -0.077760701800955  0.237396383481108 -0.096343734790574 -0.354923660187535 -0.984336588474142  1.335053740742370  0.269902452459777  0.319055275759352 -0.321749140962585
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.078162493766068
-    1  (  1)  0.238847682218727
-    2  (  2) -0.098903683747888
-    3  (  3) -0.354949509542455
-    4  (  4) -0.983822640646403
-    5  (  5)  1.333720211340158
-    6  (  6)  0.269441491786924
-    7  (  7)  0.318898660493929
-    8  (  8) -0.321196908799485
-    9  (  9) -0.198768714929451
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015331616498833 -0.019922018235360  0.024795453639952  0.001428994822442 -0.007662564632869 -0.030564864466354 -0.002998096035874 -0.014184257518557 -0.050369876521864
-    1  (  1)  0.002536892896206 -0.000724332833140 -0.010931820831771  0.061385329925525  0.034527384530112 -0.002930909394968 -0.006897041777642 -0.048924198461387 -0.045892788765523
-    2  (  2)  0.055930590988109  0.061668786229878 -0.009784880887058 -0.011292178101404  0.079575226023927 -0.052325708606337 -0.009086556132667 -0.001787844130138  0.008215255410943
-    3  (  3) -0.058532225277701 -0.048285500112225 -0.015912879350588  0.001479837376653 -0.030353501548890  0.023819914693463  0.021025260847826  0.014207102374829 -0.151577267379535
-    4  (  4) -0.056221687371934 -0.122358938171234  0.112292181821658  0.146881610350559 -0.213263741399596  0.056469707520368  0.037816511197979  0.118315319709634 -0.249164851234958
-    5  (  5)  0.125699079920792  0.245765102963436 -0.144688421941741  0.269480954167622  0.108175820650901  0.330495489462815  0.121717019021094  0.042981278927133  0.139107704893676
-    6  (  6) -0.090953864200081  0.138378038123711 -0.018999653387300 -0.059021477190613  0.070107383816014 -0.188422561576096  0.422479983427336  0.027031745312951  0.054392856003620
-    7  (  7)  0.157772366372595  0.187920697768143 -0.411777035755239 -0.046692805557951  0.283266431788380  0.074879967037488 -0.084103929184262  0.226658912465472  0.075512245279510
-    8  (  8)  0.054210291452992  0.062449071960101 -0.361963320103574  0.503001997291620  0.438083797101076 -0.063050427843078  0.017066076329137  0.069221757957400 -0.257467231990446
-    9  (  9) -0.273423536032774  0.529295983026682  0.033766766508851  0.151918529592259 -0.009418984940093  0.206571120107986  0.110624885223032  0.172829785443028 -0.101427788661059
-   10  ( 10) -0.861462052752320  0.172326691424178  0.212371997651326 -0.111218596621436  0.023269411258717 -0.143388725237391  0.039930804953421 -0.091843120858856  0.022422158283106
-   11  ( 11) -0.188670480611874  0.096820345118133 -0.066190773880029  0.287205832494666 -0.059420643781434  0.064429852032339  0.150091109571506  0.074231547885084 -0.343171650309577
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.057461514086606
-    1  (  1)  0.006963958755564
-    2  (  2) -0.098129328522494
-    3  (  3) -0.059012682268642
-    4  (  4) -0.004449861106028
-    5  (  5)  0.220945294639113
-    6  (  6) -0.063939488850868
-    7  (  7)  0.102360934503055
-    8  (  8) -0.118112557417407
-    9  (  9)  0.155151984964126
-   10  ( 10) -0.077691214009347
-   11  ( 11)  0.169304339523055
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007929033245727 -0.086776514026638 -0.041466992686244 -0.000624066975311 -0.013156595381987  0.043080477030762  0.042448060293463  0.012239880545527  0.029029915184304
-    1  (  1) -0.033878180177558  0.070173508648210  0.019230609095550 -0.003533880530575 -0.001550569267327 -0.001809299397526 -0.111518736659909 -0.001270571448457 -0.012934311690280
-    2  (  2)  0.053119512373320  0.091732793273830  0.021408607612661  0.032674571200622 -0.027446877387833  0.001428368203209  0.035760699595502 -0.016168017803360  0.076110316338229
-    3  (  3) -0.111768458659199  0.032123986864070  0.006283151908271 -0.033287020781358  0.043086093005307 -0.045344868585861  0.050504244775852 -0.018808552325982 -0.035145863401031
-    4  (  4) -0.008665305449844 -0.063452607411023 -0.029600165455924  0.047115677331559  0.019168666345381 -0.031501732622098  0.317766848542404 -0.025484653465158  0.136713668607013
-    5  (  5) -0.096942829349587  0.462416830630329  0.133842090994118  0.092985874350147 -0.099421870808029 -0.234587688959823 -0.217512036032000  0.115491679731730 -0.074046828271163
-    6  (  6)  0.147504151854231  0.176016277524490 -0.101374573515317 -0.288079277305196 -0.230919141922049  0.118478695990594  0.200039409574699  0.528080641738917 -0.150345125085143
-    7  (  7) -0.042669001755884  0.443406170499069  0.389143916519812  0.161315900065673 -0.044923622848274 -0.251217580401495  0.349139344106497 -0.313375744671926 -0.105308356658894
-    8  (  8) -0.090773283284028 -0.098945242676733  0.273219850231927 -0.153556988234685  0.012049248011756  0.153837601800696  0.096783765511278 -0.036655814574288 -0.158022323654812
-    9  (  9) -0.854099711852282 -0.117772176421944 -0.239016409160077 -0.177375733867881  0.100275769298913  0.252844583057920  0.226930144139075  0.153229528005110  0.127239027610851
-   10  ( 10)  0.395991653576375  0.538214267844356  0.096531314019954 -0.336382832184142  0.099895828912763  0.055956501178133 -0.146421756050995  0.134905206743007  0.024743642762261
-   11  ( 11)  0.048495982241480  0.204014858900645 -0.274325469868742  0.134595356909103  0.084519511625804 -0.191133538480751  0.069261639154394  0.103192119612584  0.176045180364651
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.028831087335228
-    1  (  1) -0.001371858337113
-    2  (  2)  0.086279641236700
-    3  (  3) -0.002619734805492
-    4  (  4) -0.021137684583830
-    5  (  5) -0.191430382947414
-    6  (  6) -0.264284919761669
-    7  (  7)  0.000269384690538
-    8  (  8)  0.116882729881709
-    9  (  9)  0.120074711434079
-   10  ( 10)  0.053632787996257
-   11  ( 11) -0.085463803953674
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.675541283858356 -0.292064021280293 -0.790025131233222  0.039304385342315 -0.142699371183327  0.268327500474091  0.055268589173706  0.193336176520280 -0.032498607183913
-    1  (  1) -0.292005367417511 -0.068094888399427 -0.091928539573230  0.129152126993159 -0.002672883933379  0.049262453691224  0.862140772831706 -0.434895002279636  0.030957963645570
-    2  (  2) -0.789447165009789 -0.092254483472880 -0.804853040833334  0.464036191543570  0.288328515691532 -0.782373392336952 -0.359658943728641 -0.388090328975242  0.068147997029207
-    3  (  3)  0.039444395620206  0.128939281409480  0.463903578747306 -0.241479807350799 -0.029257651091736  0.289330170364477 -0.078438871496667  0.246243716348015 -0.221624488999474
-    4  (  4) -0.142005033730652 -0.003441352982276  0.286700873937055 -0.029953661733414 -0.427750919311445 -0.225593242891832  0.001248695253401  0.308372097905189  0.608170303007273
-    5  (  5)  0.266046370608821  0.051710611539180 -0.778167579408912  0.290283723006215 -0.224453112864279 -0.369348441761130 -0.137527542499239  0.160088399589127  0.333141145250294
-    6  (  6)  0.055576665996038  0.861897091141550 -0.359382180614210 -0.079367338581182  0.001316960755447 -0.139592143084602 -0.236061692038733 -0.500995422630755 -0.152924823639678
-    7  (  7)  0.191190365321726 -0.433335934056497 -0.384226491533538  0.246895934047586  0.308256930114393  0.160145299200529 -0.499551364365546  0.169042466304747 -0.232433156817922
-    8  (  8) -0.032324733830521  0.030583581869279  0.067800595440523 -0.220839746025180  0.605132330733771  0.331428074510260 -0.152991449816876 -0.231671787208498 -0.624414674119492
-    9  (  9) -0.170133827289346  0.173802608390272  0.582650141434017 -0.560382911834174 -0.212565567455627  0.095754045184088 -0.282286783247438 -0.105642205052933 -0.000539730602912
-   10  ( 10)  0.052970874353821 -0.227531715435441 -0.648876828841383 -0.696767965643644 -0.268344000354012  0.568720278318329 -0.098598860256773  0.086269937526947 -0.081275470268861
-   11  ( 11)  0.025516552524119 -0.085059735579504 -0.121415959836865  0.018097922040376 -0.846374652520441 -0.307989344147049  0.044343294285023  0.231195949738532  0.168305572109582
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.171375974411067  0.055216931376792  0.025964207813788
-    1  (  1)  0.173220084938157 -0.230603891969826 -0.085840408679658
-    2  (  2)  0.586304150506699 -0.654210189691972 -0.122677885868631
-    3  (  3) -0.564217005061761 -0.698424845148049  0.018146779332832
-    4  (  4) -0.213592841407263 -0.268356081771837 -0.851093566817366
-    5  (  5)  0.095187708087751  0.569138844284334 -0.311815017332116
-    6  (  6) -0.283847446348569 -0.099361887898569  0.045327800607922
-    7  (  7) -0.106442929251796  0.084951820105520  0.232402123183799
-    8  (  8) -0.000679287280351 -0.083181582350312  0.174842773942352
-    9  (  9)  0.184137973286679  0.103441117955563 -0.011188766481418
-   10  ( 10)  0.107554052466808  0.106515041132340 -0.165743784884080
-   11  ( 11) -0.010550245981975 -0.165913802295303  0.859885805027657
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.229655435401251 -0.279601353643965 -0.085575827802352 -0.135048509105901 -0.463462610619003 -0.365248455770507 -0.039660777368333  0.191781963250870 -0.304572804139555
-    1  (  1) -0.279047925679444  0.077319987469585  0.204439247136492  0.070123615269243  0.055860395624731  0.138642318409271 -0.343207769076389 -0.182810883095464 -0.017999280994748
-    2  (  2) -0.085240959465133  0.204263364283089 -0.311156623733494  0.294688564065330  0.229669520218161 -0.281737981462645  0.137882893674030 -0.194668648298996  0.517507397185879
-    3  (  3) -0.137052652301458  0.068817803199155  0.294513347383327 -0.628744473812505  0.688526281107777  0.166771123104115  0.212803952843010 -0.269010206604892 -0.411620416751970
-    4  (  4) -0.461604619248266  0.055843287983042  0.230054478565236  0.688395074228786 -1.421511879446005  0.180495138052121 -0.177199847230662  0.268188410470329  0.119512289645345
-    5  (  5) -0.365099883123814  0.139122909294115 -0.282780063256330  0.166251175855828  0.181093271919847 -0.292775738602585 -0.240660983788926  0.305216197970317  0.235452232882587
-    6  (  6) -0.039141072198114 -0.342047900602042  0.138302509146164  0.211959339222516 -0.177087648441962 -0.240505624310098 -0.304304277829310 -0.910739369588832  0.202811323160239
-    7  (  7)  0.191443148224360 -0.183077517400336 -0.194209029769022 -0.269384260651775  0.268168725961981  0.305441092512858 -0.910852433205190  0.029633662055934 -0.204453968987965
-    8  (  8) -0.303246852232180 -0.018509744386768  0.519514080414653 -0.413340759430442  0.119384719254151  0.236362024043069  0.201991249845660 -0.204562219955504 -0.661555776893828
-    9  (  9) -0.300472910579648  0.170014354298783 -0.291259695102906  0.029160805834281  0.317264449488489 -0.326442124436524  0.007044557482429 -0.101763181058410  0.215338723709779
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301684802635884
-    1  (  1)  0.169719322346163
-    2  (  2) -0.289724655704096
-    3  (  3)  0.029002914588453
-    4  (  4)  0.316574855082561
-    5  (  5) -0.325796183326422
-    6  (  6)  0.007131791827115
-    7  (  7) -0.101918507704736
-    8  (  8)  0.215214193797303
-    9  (  9) -0.431317970778139
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009148490318064 -0.020309806158549 -0.015977532182931  0.004014783738387 -0.010489793112351  0.029667649783295  0.020232440585606  0.011223082041042  0.023312323786938
-    1  (  1) -0.044375857230131  0.052262766826166  0.015548487373741 -0.003662802577056 -0.002781875625079 -0.001383977859398 -0.098229640468489 -0.001043710758572 -0.010909270118946
-    2  (  2)  0.054181385020550  0.080128526478900  0.022828931876126  0.037487063410101 -0.042770056882922 -0.005218720540993  0.030479703829638 -0.014823518322437  0.065536667960166
-    3  (  3) -0.129996832535740  0.025539245172390 -0.001710767497197 -0.035208153932012  0.051497303033318 -0.033810939265315  0.041923713016432 -0.018028802137201 -0.031841589713416
-    4  (  4) -0.018797598258319 -0.055382521313148 -0.025678897036466  0.042677314096974  0.024119803445938 -0.028773903589126  0.288385579456642 -0.023957336001325  0.134022392012911
-    5  (  5) -0.085790126908808  0.402408359114006  0.110878458520312  0.084218998643581 -0.097302640260559 -0.211015098306590 -0.195826989075132  0.107508726926065 -0.059970385150068
-    6  (  6)  0.117117046001707  0.164907313314791 -0.092740522447941 -0.263892346037872 -0.208050086690414  0.121861415926763  0.180654068666643  0.487980567663863 -0.134813668081860
-    7  (  7) -0.052709991074355  0.381296251220592  0.349380237841959  0.145852911752160 -0.041346590279243 -0.220669429372274  0.328816279036270 -0.285726302429830 -0.093478286390337
-    8  (  8) -0.075491834851014 -0.090622807799606  0.261184981058617 -0.148637821570292  0.006281256453519  0.144842826611815  0.089811111402247 -0.036110485207390 -0.153520220179307
-    9  (  9) -0.696164148321021 -0.104910101886221 -0.203383144631185 -0.164870629493292  0.069977329160723  0.194202208543558  0.212076681930829  0.132693764051193  0.096725293429142
-   10  ( 10)  0.348175665954885  0.434442729860845  0.069207287013024 -0.311902381205193  0.086974667298470  0.051225223079379 -0.122216101880307  0.122874476488139  0.012079820457350
-   11  ( 11)  0.044712948857676  0.176004094735536 -0.255862724288287  0.126758826080010  0.078218473139894 -0.179984369340434  0.067110991111726  0.095360581673868  0.177561710091429
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.024402944617349
-    1  (  1) -0.001173348606223
-    2  (  2)  0.076484101898115
-    3  (  3)  0.001169431615315
-    4  (  4) -0.024935532887633
-    5  (  5) -0.174540155531575
-    6  (  6) -0.236517338782017
-    7  (  7)  0.008859575697215
-    8  (  8)  0.109927192293737
-    9  (  9)  0.089534068178409
-   10  ( 10)  0.043410237741554
-   11  ( 11) -0.093132968001143
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002170644752931 -0.022324956514099 -0.029394826211345  0.023309311068680 -0.000970852822634 -0.043511040680121  0.014013985960523  0.007860305508825 -0.031314125297178
-    1  (  1) -0.004975212184910 -0.009727238108985  0.081406434912428 -0.023252939392766  0.038928067463043 -0.010458408905981 -0.034913544836836  0.014265058471693  0.051735797486860
-    2  (  2)  0.017880176100707  0.015599348022774  0.096023531696764 -0.045237679689815 -0.002431886781376  0.077281603581543 -0.027482410098613 -0.002121837766367 -0.131596950090464
-    3  (  3) -0.033671282161329 -0.042247110815725  0.017614407066521  0.120482048147517 -0.071788669015437  0.100417130949899  0.026095439370731  0.024912292415628  0.128857994704884
-    4  (  4) -0.039094504869080  0.011586636873075 -0.201648756832533 -0.417167224027039  0.232183671922422 -0.365776066782585  0.000436512477144 -0.036487401941041 -0.092913589753420
-    5  (  5)  0.107020694538732  0.188165249192967  0.272788343236859 -0.444403017959699  0.118293552778212  0.528258782415562  0.125325642779073 -0.198753130098826  0.028672980278371
-    6  (  6)  0.121158671169740 -0.085565322151460  0.088586051783133  0.010298532059028 -0.107250216094850 -0.195698840050220  0.370534853760273  0.159194784952583 -0.016512860210084
-    7  (  7) -0.033804952616344 -0.168095045341921  0.398821112602689 -0.046726828449621 -0.030609711055064 -0.217531691733838 -0.115639511714214  0.399856930098400  0.150033235311716
-    8  (  8) -0.059559370905179  0.306305036465827 -0.595923646185890 -0.119277640805674 -0.722271918559490  0.001726267262613 -0.027179920353598 -0.211451038002310  0.148912062372910
-    9  (  9) -0.188866142842736  0.096789990486457  0.236442562527094  0.092757728041313  0.072651948101216 -0.016472461695526 -0.026914575117300  0.247244600184375  0.370870606832493
-   10  ( 10) -0.406957853798143  0.141958866881762 -0.085132936917023  0.102326296221874  0.017996095944708 -0.062553443565296 -0.105319900227601 -0.005069269037988  0.006423933602228
-   11  ( 11) -0.081915250147579  0.202583484157184 -0.282203343833431 -0.339304077428364  0.118298550150489 -0.126692826807318  0.005731143361727 -0.150166092159272 -0.134968415625333
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.038183979702674
-    1  (  1) -0.001758617329220
-    2  (  2) -0.002245458358924
-    3  (  3) -0.305015280585847
-    4  (  4) -0.011707659076193
-    5  (  5) -0.052479234679287
-    6  (  6)  0.143560462314116
-    7  (  7)  0.320971036748081
-    8  (  8)  0.148594551736844
-    9  (  9) -0.097500178466871
-   10  ( 10) -0.069870490871550
-   11  ( 11)  0.082515655756872
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.053221344681142 -0.117483147833985 -0.106139723247453 -0.495823955121092  0.391515874804455  0.212402958848530 -0.083769680573767 -0.039675371517883  0.058634274306531
-    1  (  1) -0.117410394687696 -0.001165915237512 -0.133100613626654 -0.630012634533085  0.317623482499555 -0.573984529169381  0.375575851008806  0.417091736224605 -0.210582306420709
-    2  (  2) -0.106116179316557 -0.133365754849436  0.099881677186242 -0.283389270168438  0.408842653260195  0.463415082290805 -0.094461635582511 -0.339728478273951 -0.187117729157411
-    3  (  3) -0.495487159854538 -0.630575218275538 -0.284210529100489 -0.394005207299682  0.243829412824131 -0.426368810438983  0.000017569224274 -0.316982847795332  1.182262387796268
-    4  (  4)  0.391977861689502  0.318458435778042  0.410524448216213  0.243871385545647 -0.262605821454379  0.313475558817429 -0.006238164976110  0.146232809940208 -0.404783357267945
-    5  (  5)  0.211677947989569 -0.572946112183618  0.465876094202739 -0.424891649228725  0.310576368667640  0.340119032966648 -0.103399884420596 -0.366027570904681  0.140243317389270
-    6  (  6) -0.083203642949521  0.374758513857944 -0.095474380553338 -0.000848431158077 -0.007011740191065 -0.103456952640946  0.035381526355376  0.100664517850410 -0.224617556800866
-    7  (  7) -0.039824177760467  0.417269525333673 -0.339848279473418 -0.316785009817077  0.144981956006953 -0.366591938133070  0.100487370214345  0.453363803566786 -0.284080848307595
-    8  (  8)  0.058454981179204 -0.209563433448112 -0.187086823104815  1.182437825563613 -0.401897920471953  0.141960153823608 -0.223791716105096 -0.283768269790238 -0.127258563076312
-    9  (  9)  0.176473367868989 -0.113695285962430 -0.191045562239273 -0.466077182834650  0.080353173846381 -0.392419296545826  0.139310719822578  0.097667658130615  0.260382741772322
-   10  ( 10)  0.087511748605763 -0.084525637542731 -0.451433812661641  0.087442027470754 -0.075301055147615  0.128254312442896  0.066832910809452  0.040269698765907  0.083963538620684
-   11  ( 11) -0.256000473516428  0.178934738319287  0.462669412659627  0.336070869572452 -0.226364820740552  0.220661186826050  0.015682276558009 -0.019696413835863 -0.320368477367524
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.177398660643495  0.088413661062507 -0.257047850800415
-    1  (  1) -0.114710761582569 -0.086001542477366  0.179468892454740
-    2  (  2) -0.191402905701337 -0.452554194931555  0.463985875678332
-    3  (  3) -0.467548510382317  0.086605995128391  0.336310348111395
-    4  (  4)  0.080907164839857 -0.077457000042675 -0.231693183962593
-    5  (  5) -0.391713702811823  0.124122145336547  0.233240659481206
-    6  (  6)  0.139727422139028  0.065972550943365  0.014736999139443
-    7  (  7)  0.097438431199858  0.039119593081805 -0.012607893852994
-    8  (  8)  0.258370481571402  0.084693167750785 -0.328679992068142
-    9  (  9) -0.027947875522173 -0.059452680730838  0.039102598209232
-   10  ( 10) -0.061112133253744 -0.042824028656813 -0.176907573001062
-   11  ( 11)  0.036269564126208 -0.174115037047438  0.046562990208638
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.221915567502623  0.240154969163816  0.089524025753548 -0.009891539023461 -0.105352264889997 -0.079728196437896 -0.186918344067447 -0.018609216798882 -0.150218987334760
-    1  (  1)  0.239595861160914  0.097635005536382 -0.020343203465831  0.252497393963625 -0.178770889626966  0.156659860903133  0.042031186852564 -0.226739274781765  0.050354579998016
-    2  (  2)  0.090047283413814 -0.021960432152020 -0.652704165096791 -0.484235858264924  0.265074532283746 -0.870240852693915  0.056963933090132  0.087593695232780 -0.397150344061483
-    3  (  3) -0.008304023565221  0.254514964099576 -0.488668744172267  0.243914942296862 -0.497430549408554 -0.651892044099941 -0.144949354151790  0.009197770416785  0.363155689203458
-    4  (  4) -0.105368055288416 -0.178968402377489  0.265813616023428 -0.498441236963999  0.117807978177016 -0.197938223960627  0.010977461550819  0.054866508200549 -0.633466747483980
-    5  (  5) -0.079092278611567  0.155211327907083 -0.870349858528248 -0.648891955877304 -0.198852995680930  0.056118287010249  0.077393750543525 -0.820063131904850 -0.522591293712200
-    6  (  6) -0.188319262904704  0.043235387216250  0.056704467242807 -0.145342612784415  0.011176054667898  0.077123788010048 -0.017043504447154 -0.229308594149143 -0.061253571825596
-    7  (  7) -0.017449220652026 -0.226052369590475  0.086398229140611  0.009988063298837  0.055257253277244 -0.820894010869112 -0.229107411788767  0.436891114659360  0.154693358924324
-    8  (  8) -0.147652836473568  0.050157233403955 -0.397985593672069  0.364902332737576 -0.632177325650741 -0.523669848989306 -0.060883358066048  0.155008994016302 -0.331322085722016
-    9  (  9) -0.012364053013731 -0.381902018882131  0.730234455154150  0.318717588976828  0.654372705810295  0.234910934996783  0.063436038641434  0.568676727219248  0.116095919775855
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010717409085818
-    1  (  1) -0.381606046587817
-    2  (  2)  0.729520232349256
-    3  (  3)  0.319801359646356
-    4  (  4)  0.655576694394483
-    5  (  5)  0.233766377042350
-    6  (  6)  0.063681628675817
-    7  (  7)  0.569047245691214
-    8  (  8)  0.115234955131862
-    9  (  9) -0.255200733989858
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006756611009239 -0.004812319108707 -0.015155246179453  0.018768861614548  0.003263846230316 -0.029956626691063  0.007768157616613  0.008654952545397 -0.024139771998296
-    1  (  1) -0.000276876655733 -0.007317152277636  0.067126401411285 -0.013873168496829  0.038395392580021 -0.004054864162186 -0.028032553908660  0.014238200673600  0.044802348000681
-    2  (  2)  0.034311733284435  0.014478380463186  0.079037871547464 -0.037480797351928  0.004455235189999  0.068266709703376 -0.020927095140560 -0.000590179941322 -0.116436689576599
-    3  (  3) -0.034781167081690 -0.039999835648210  0.017388947621558  0.117724049135840 -0.062309713575062  0.098214530429882  0.024529272430519  0.026637769905859  0.121592113448416
-    4  (  4) -0.036088452219928  0.018119725898309 -0.181397076074172 -0.381210957896193  0.211295234548894 -0.335046977567969 -0.001001209940803 -0.032788904430710 -0.087406508170972
-    5  (  5)  0.091932999121248  0.163472911292393  0.257039057929667 -0.406986018028708  0.108362880698111  0.483755223010107  0.114747171070721 -0.179816739697054  0.021814542430540
-    6  (  6)  0.102207313652244 -0.075273825473482  0.076700485775484  0.010389199522243 -0.095145363312679 -0.177269643268087  0.339312666537493  0.145893525857585 -0.013352577122472
-    7  (  7) -0.036776384387696 -0.162278963391709  0.362818814892890 -0.043460364327904 -0.026462409718549 -0.199351982461758 -0.104180059013018  0.364628559511404  0.137093791802520
-    8  (  8) -0.054133642075650  0.281937460317668 -0.549118750139198 -0.110766566728388 -0.665283649525633 -0.004014717984651 -0.026030812844979 -0.193249298632007  0.140185869779560
-    9  (  9) -0.149539825936769  0.083496187141563  0.222414359602469  0.086467924966290  0.058519767738283 -0.026610134648035 -0.023639345193443  0.224482305471681  0.335967535114734
-   10  ( 10) -0.342551768791105  0.115343806322270 -0.079695331214451  0.094078531732984  0.012984790263811 -0.052720281866277 -0.089289783188097 -0.003161584461577  0.011520822726607
-   11  ( 11) -0.067948144123858  0.170897803094304 -0.268478044795138 -0.331752793901224  0.110501398686606 -0.120431522039808  0.010421693063374 -0.142909196950524 -0.136584264097857
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.029945709624550
-    1  (  1) -0.003777838622564
-    2  (  2) -0.000494193391228
-    3  (  3) -0.283159255072162
-    4  (  4) -0.002056849846006
-    5  (  5) -0.055491249216550
-    6  (  6)  0.134241443599212
-    7  (  7)  0.294425347600366
-    8  (  8)  0.138732741810037
-    9  (  9) -0.100744739667680
-   10  ( 10) -0.062352827286650
-   11  ( 11)  0.087587602591740
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057027762100789  0.007489633887342 -0.036964189813796  0.021384352100284 -0.004867815775604 -0.032130235858782  0.019486973797962  0.000503926514732  0.024868986663351
-    1  (  1) -0.007883399599923  0.007529104506445  0.013216566770749 -0.001554286609489 -0.002481002458300 -0.003555137440754  0.020216878378801 -0.003435265519663 -0.003420680709423
-    2  (  2) -0.005061763911744 -0.024005030999464 -0.016920245291348  0.019760528227158  0.007759414271484 -0.029231812106945 -0.009559298232843  0.004745878981161  0.053662769962019
-    3  (  3) -0.011903086348447  0.106154395386531  0.048846797682958 -0.038122834717736  0.042076447151745 -0.017515736018254 -0.021695004377211 -0.017259669010754 -0.058953679400153
-    4  (  4)  0.086846706941042 -0.161257530089836 -0.037361255861875  0.089905419413410 -0.174437646387183  0.071028892880315  0.038811212273731  0.045200518155063  0.066894551440516
-    5  (  5) -0.295118954821928 -0.042171667688274 -0.057142717280935  0.095328920031059 -0.118376834610768  0.017202604507056  0.038088685926927  0.015413673756028  0.019970185142534
-    6  (  6)  0.061695197805604  0.041447416246154 -0.107874329349021  0.009310856499629  0.028327062477196  0.072556054900044 -0.031173831746629 -0.093673016450942 -0.096470656575707
-    7  (  7) -0.040164356283535 -0.019606328824315  0.022514162311588 -0.103095269177578  0.105738125414362 -0.000251323240260 -0.190667102998226  0.014251172141516 -0.042544347999407
-    8  (  8)  0.209747539729284  0.026225521984115  0.065411218317390 -0.108576414051802  0.195951046046893 -0.054935351774023  0.181062671358124 -0.048648601818055 -0.037403343457353
-    9  (  9) -0.029537922421234  0.045187174636289 -0.013381512217286  0.049426415359509 -0.003411235911782  0.045265306723710 -0.096457278821335 -0.006113492494935  0.044165814974043
-   10  ( 10) -0.026870929841946 -0.010513244846490  0.122411818973730 -0.066300236331789  0.074150921852319  0.175359501999903  0.025219490294838 -0.031299023505132  0.032770162927265
-   11  ( 11)  0.076638806040972  0.048660864910506  0.054798136469999  0.067410404189619 -0.096042680906718  0.030077767167195  0.040609376761651  0.003350033647470  0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007613623485115
-    1  (  1)  0.001053219582711
-    2  (  2) -0.054751844139672
-    3  (  3)  0.021588797011546
-    4  (  4)  0.069416579868176
-    5  (  5)  0.031311068013170
-    6  (  6) -0.060683491342485
-    7  (  7) -0.004937786560826
-    8  (  8) -0.055843386605960
-    9  (  9) -0.053258374332423
-   10  ( 10) -0.029326398375861
-   11  ( 11)  0.027904630917537
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000025015734507 -0.010198711087952 -0.006474775958448 -0.066946051563528  0.066550206967977  0.041188873125926 -0.023552914991952 -0.019202263160422  0.006942946197737
-    1  (  1)  0.010140605887652  0.000014394957877 -0.022996796061328  0.067092192493274 -0.063685673857393 -0.019093615376604  0.005525180617760  0.015031464830750 -0.005320182556269
-    2  (  2)  0.006534739001904  0.022969584694137 -0.000183457658640  0.211551326757209 -0.218187807438925 -0.104132114893528  0.065436658246811  0.042103919182146  0.012243831904844
-    3  (  3)  0.066304931943444 -0.066584833979085 -0.210703888875489  0.000394093515089  0.011258600581601  0.092530428436357  0.131881992071255 -0.026480578605083 -0.063346368194022
-    4  (  4) -0.065779542430873  0.062822415172501  0.216601239538476 -0.011617389043850 -0.000720555249011 -0.020159848057855 -0.073942431465134 -0.001119920964031 -0.016120241216710
-    5  (  5) -0.040846799691504  0.018979734118351  0.103125251405654 -0.092549855601907  0.021623501291584  0.000771447754999  0.234552119202209  0.000611164043666  0.101606719343242
-    6  (  6)  0.023326218450828 -0.005550385111505 -0.065252405074981 -0.131681855193961  0.073575257938565 -0.233645237851028 -0.000193851682480  0.255788429172446 -0.079072823032341
-    7  (  7)  0.019055068515462 -0.014786531642521 -0.041539856986611  0.026353850726780  0.001700683540838 -0.000445480591706 -0.255766070671258 -0.000118381893033  0.151562772366571
-    8  (  8) -0.006620321009197  0.005142966830662 -0.011245852682541  0.062510776113309  0.015648596901915 -0.102272652360209  0.078381794853266 -0.152302821501449  0.000094469957927
-    9  (  9) -0.045347281960025  0.040291069791943  0.085226922335689  0.018441757598111  0.027467525239214  0.004932928889320  0.020868912898856 -0.024483356625930 -0.224180460199113
-   10  ( 10) -0.020374790573784  0.028198954860440  0.010392111666997  0.120181326176130 -0.060512260831236 -0.109015894697222 -0.047153104465120 -0.043944046420833 -0.103069326885495
-   11  ( 11)  0.049408052352300 -0.045270280246414 -0.110185553685008 -0.041594160321979 -0.088273360930753  0.183934249639257 -0.003285919080508  0.178701510068243 -0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.045673042542890  0.020717466986083 -0.050844518832522
-    1  (  1) -0.040043621408487 -0.028287827625151  0.045457031631407
-    2  (  2) -0.084888848710605 -0.010052611398803  0.109898373773783
-    3  (  3) -0.018088362425205 -0.120534313520650  0.041770057803413
-    4  (  4) -0.026789230886550  0.060849702419905  0.088673365261613
-    5  (  5) -0.008004711197727  0.108432873838655 -0.185071361149962
-    6  (  6) -0.020116775504235  0.047889712574718  0.001523439225442
-    7  (  7)  0.023964360822185  0.043618854823263 -0.177454217319223
-    8  (  8)  0.226734396044438  0.102481459206944  0.008115223439087
-    9  (  9) -0.000423083368406 -0.309060226547434  0.090400550219427
-   10  ( 10)  0.308249178857435 -0.001017567434936 -0.330623886780632
-   11  ( 11) -0.090136758927266  0.334530610017321  0.000453348817603
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000379496190680 -0.036516557673727  0.022488411844201  0.041143099111719 -0.015151024607555  0.009820525598214  0.001328546168408 -0.002719718233480  0.079787685858295
-    1  (  1)  0.035173743352485  0.000509376348503 -0.021748140811100 -0.018984912310085 -0.002571720003760  0.101540537848848  0.014107119535580  0.020961802105584  0.100916916558314
-    2  (  2) -0.024420430259890  0.020833264343634 -0.000589210441902 -0.028690810435666  0.025063562199365  0.056845698692633  0.019362765266970  0.000534124800005  0.061230653902760
-    3  (  3) -0.039980341452345  0.019929624233720  0.028127725164783  0.000384377200086 -0.012223469426354 -0.007870420436516 -0.021500821930750  0.002985124038023 -0.055850425927213
-    4  (  4)  0.015033200445576  0.003096204403696 -0.023799943458502  0.011898049659739 -0.000036971633887  0.000277032322295  0.021239662546675 -0.005095064856192  0.060237805990277
-    5  (  5) -0.010708008535887 -0.101587409014600 -0.056660431011914  0.007350368054025  0.000126941263904  0.000065704202214 -0.008506831299188  0.011228150905342  0.011964202302477
-    6  (  6) -0.000469087338482 -0.014200163610075 -0.019097267233085  0.021632296910845 -0.021392214011008  0.008495741848254  0.000109627873962 -0.021812533614874 -0.020464844726232
-    7  (  7)  0.002889338898616 -0.020632474935553 -0.000453752095144 -0.002975803626006  0.005037506724376 -0.011335159213681  0.021733393798695 -0.000007087204356 -0.019955598928897
-    8  (  8) -0.081293710509515 -0.100918057466141 -0.060971767857812  0.055875536861090 -0.060631757745431 -0.011264467031019  0.020209151997608  0.020081495210629  0.000340983773767
-    9  (  9)  0.080516503167305 -0.106262951221757 -0.031461397073353 -0.007056184146683  0.022432192781915  0.017093833942137  0.097099983466552 -0.001349018368294  0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.079753101670227
-    1  (  1)  0.106710217482987
-    2  (  2)  0.031619499292907
-    3  (  3)  0.007164069356259
-    4  (  4) -0.022223903647397
-    5  (  5) -0.017462464724719
-    6  (  6) -0.096957045420818
-    7  (  7)  0.001243112172754
-    8  (  8) -0.004611313750592
-    9  (  9) -0.000252169760563
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055343853322395 -0.005338522209203  0.036325792187091 -0.020411379114398  0.005004472559017  0.030883540419705 -0.019693764112942 -0.000404480716013 -0.025396203204216
-    1  (  1)  0.006570683600848 -0.008768421568488 -0.011573795638563  0.000009175751903  0.002770565739659  0.004931208897901 -0.022163570789429  0.003290104656908  0.003254936700297
-    2  (  2)  0.001674419203277  0.021967102120902  0.025831824909554 -0.024758928994745 -0.009340908203812  0.034459015755376  0.010228225914487 -0.005919790861067 -0.058115699230390
-    3  (  3)  0.007779977639509 -0.106141218473434 -0.050482163293278  0.041812559908941 -0.042606909564863  0.016938249582167  0.022723831963497  0.018285942873731  0.061788101761112
-    4  (  4) -0.087397972334062  0.164590469335859  0.035983465272717 -0.095460926704216  0.183399304764373 -0.073380967092300 -0.038295030471351 -0.047026058194857 -0.066959437295317
-    5  (  5)  0.293750190777910  0.042648437038433  0.056404874075468 -0.100193237694056  0.123782490033077 -0.014652582564902 -0.036251400704161 -0.016769125982848 -0.023410414575794
-    6  (  6) -0.063526410041118 -0.042202406515953  0.107158367449000 -0.011222400592515 -0.032805848689894 -0.070775222023081  0.034269417179590  0.097599209765295  0.095048599779477
-    7  (  7)  0.039213631545190  0.016300797142278 -0.022834925899151  0.106699749704471 -0.109813770660251 -0.000567880224415  0.192962587636570 -0.013162275101134  0.042958800457043
-    8  (  8) -0.207671023275567 -0.021761663181296 -0.066317329893717  0.113575721461044 -0.208505431005016  0.053139089145086 -0.182387663583988  0.049317657695772  0.039898751560786
-    9  (  9)  0.031717525025615 -0.035452316963842  0.019040840253717 -0.049757955126745  0.003315672276934 -0.048439544916052  0.094357742781682  0.007725852797236 -0.042206115018339
-   10  ( 10)  0.030723138202058  0.012685537900520 -0.130253036286197  0.070878549267589 -0.073822499716479 -0.176856315004232 -0.024096584449109  0.033980770130198 -0.029602022179569
-   11  ( 11) -0.076338046412608 -0.058007647538535 -0.059625157558161 -0.072355446358478  0.100714683926583 -0.028164062896195 -0.037103331661254 -0.004159802100780 -0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007837140573608
-    1  (  1) -0.001271351061977
-    2  (  2)  0.056316152671545
-    3  (  3) -0.023558705106194
-    4  (  4) -0.071677402926291
-    5  (  5) -0.031036091810970
-    6  (  6)  0.060669139129724
-    7  (  7)  0.008329217020035
-    8  (  8)  0.058082899762783
-    9  (  9)  0.050026765138378
-   10  ( 10)  0.030419330923301
-   11  ( 11) -0.028289350786073
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.010782784489972  0.013050845930128  0.033023155215664 -0.015191714992095  0.005425132814901  0.026116394662957 -0.007256800612108  0.004570990183776  0.083505985646911
-    1  (  1) -0.004775248888120 -0.019609050610054  0.043741880650327 -0.000073954161324  0.027319440587928 -0.081090619324759 -0.046094626593374  0.004371816989341  0.079334747598806
-    2  (  2) -0.007829067250874 -0.005611745899100 -0.069924533643314  0.039501674728206  0.000927353784976 -0.005421401951033 -0.003817544999769  0.008629946885833  0.093259618314415
-    3  (  3)  0.018327078243591 -0.003795046417131  0.017900293895817 -0.029796535142542  0.026342994062962  0.087573876827112  0.029918989049988 -0.054199220040285 -0.044809777400716
-    4  (  4)  0.027183503470872  0.089536481638857  0.084857160463068 -0.036527297001861 -0.242538124561929 -0.016430382958973 -0.030531081573579  0.170538311757182  0.261658379411546
-    5  (  5) -0.020462782587523  0.074168804451800 -0.167834230231717  0.149604127852478 -0.243854217657690  0.044978789492557  0.032478673883371 -0.164731310430024  0.003040851330374
-    6  (  6) -0.075422914773902  0.018345498918631  0.109883881828728 -0.119442941495868  0.084779039670754 -0.177672686986939  0.254932779745392  0.179910297504286  0.058420300218360
-    7  (  7) -0.077293940205111 -0.171942167313393  0.155379720343131 -0.213627786676900  0.203405159942268 -0.435742440136601 -0.116233082588661  0.403785601702878  0.048376113482094
-    8  (  8) -0.113887453356696  0.134815689960008 -0.121289875435757 -0.381302435842573  0.140362613154441  0.094837304770689 -0.044125422076338 -0.354102164255088  0.021060221761777
-    9  (  9)  0.010381942177856 -0.091513821594073  0.090489398632436 -0.104640269057990  0.011526746486386 -0.174325672883320  0.095096801177535  0.162567420891194 -0.086584233440007
-   10  ( 10)  0.046140785323826 -0.004506559121454 -0.092261546126996  0.049590165687623  0.056546117609635  0.023211770714739  0.114566901687301 -0.007355072527000  0.045260763292278
-   11  ( 11)  0.210277389085871  0.043479475791959 -0.002620356919958 -0.027295607176521 -0.213582758279457 -0.049406759718245  0.038753842401848 -0.045549481042434  0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.000588783769111
-    1  (  1)  0.095074877441065
-    2  (  2) -0.094269658052775
-    3  (  3) -0.087042465113366
-    4  (  4)  0.229147969925312
-    5  (  5) -0.037090740492870
-    6  (  6)  0.008539965499391
-    7  (  7)  0.114631280540035
-    8  (  8) -0.035100938386537
-    9  (  9)  0.119410852550345
-   10  ( 10) -0.048938543804445
-   11  ( 11)  0.026842233365654
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000083177655875  0.020596022225207  0.023074380682109  0.123906982660277 -0.115856799969175 -0.077548996218664  0.033724258035794  0.015583195761424 -0.055304180213594
-    1  (  1) -0.020496643104719  0.000177442053919 -0.044849161409626 -0.200056054082230  0.192734988239744 -0.095810846356379  0.089592000858118  0.154865722471105 -0.062884487656521
-    2  (  2) -0.022893568520427  0.044914234916282 -0.000286887581780  0.110147204900385 -0.098101481651214  0.037544614577033 -0.063107876559817 -0.057867129267241  0.133662561842804
-    3  (  3) -0.123637708691857  0.200030347190693 -0.110276511900212 -0.000067254700333  0.150932238527093  0.295587503177329 -0.155559256339819 -0.250191288225748  0.068514494250419
-    4  (  4)  0.115217909263092 -0.191910599591419  0.098719023514077 -0.150564412486325 -0.000108066296459  0.207017027157466 -0.092817557275927 -0.119727699718554  0.027839136386995
-    5  (  5)  0.077201349586182  0.095637330323257 -0.037580888266386 -0.296037283435946 -0.206488013849544  0.000677656990837 -0.030142059938078 -0.107860538698997  0.317965442908009
-    6  (  6) -0.033520398034563 -0.089301712720516  0.063135446629119  0.155494983890111  0.093120397549751  0.029958661714230  0.000263665833745  0.031787895548351  0.052772032197117
-    7  (  7) -0.015173638148760 -0.154650785159269  0.057964322733043  0.249885773107303  0.119546085272213  0.107827018648257 -0.031752436246544  0.000037065640674  0.211400361545441
-    8  (  8)  0.055452136609395  0.063704146851438 -0.132109776961381 -0.067534716804367 -0.027512182553154 -0.319330567201196 -0.051501501228049 -0.211684727134552 -0.000062825592229
-    9  (  9)  0.059987775905021 -0.059013360455393 -0.001731139538261  0.025602282087959 -0.077406198911912  0.032289392048789 -0.044673931971007 -0.007013222782529  0.205272148471903
-   10  ( 10)  0.040816969333319 -0.029839999727295 -0.097606908985792  0.012730679444132  0.052120800982420  0.047092545087938 -0.097199457935824  0.008100744465293 -0.194519063749344
-   11  ( 11) -0.105565276750546  0.086850909183234  0.141349531156014  0.064538795649442  0.048769909889220 -0.098670307723293  0.132937762954191 -0.091749745952861 -0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.059727136016838 -0.040967341903913  0.106287777222309
-    1  (  1)  0.058687758282915  0.029394471353826 -0.086811620398375
-    2  (  2)  0.001293940264555  0.097641591345113 -0.142636172226853
-    3  (  3) -0.025821629306306 -0.013207208477272 -0.063793857996761
-    4  (  4)  0.076409112526474 -0.052575212530451 -0.047414860037356
-    5  (  5) -0.032527517350565 -0.045632421732577  0.095160623491729
-    6  (  6)  0.044231942651703  0.096152133696301 -0.132935625343693
-    7  (  7)  0.007372100254253 -0.008488811567739  0.092713079820202
-    8  (  8) -0.206938183650805  0.192802275414426  0.052611900153123
-    9  (  9)  0.000608554890156 -0.088592533061698  0.344380743508036
-   10  ( 10)  0.088950131298492  0.000863284429953  0.222751022723935
-   11  ( 11) -0.341005102874300 -0.224718204882492  0.000326394311109
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000338557997552 -0.011375035743392  0.029451193209236 -0.012043586883828 -0.021579660859347  0.039033326019946 -0.009990415550092  0.009478976983628 -0.045907412693585
-    1  (  1)  0.013672223167698 -0.000473657715584 -0.014851568055555  0.021895587564371 -0.022163590605075  0.051246172607775  0.019257625103746  0.003658602851281 -0.019552361048058
-    2  (  2) -0.032608942325713  0.014402827198054 -0.000746991250603 -0.029107751732300  0.054720608245644  0.057033646383303  0.001872360780591 -0.031698780852448  0.056602981887733
-    3  (  3)  0.014268935231542 -0.021459967996182  0.030313065636317 -0.000730068456009 -0.016766656065195 -0.058973632357354 -0.003002419788061  0.022431580465626 -0.134333948620083
-    4  (  4)  0.022372891038515  0.021355779916377 -0.052959509294565  0.015751198634933 -0.000391938857969 -0.016109226068828  0.004538544158672 -0.050308920012661  0.059340919102150
-    5  (  5) -0.040216234763810 -0.051875751817174 -0.055849318880052  0.058120412757832  0.016460961175898  0.000645475334216  0.019024299026328  0.068804307634402 -0.024311188622736
-    6  (  6)  0.009930727984206 -0.019074682595569 -0.002242770131548  0.003091320851947 -0.004596281406168 -0.019032186967740  0.000074596378968  0.032870219636189 -0.006741182978715
-    7  (  7) -0.009279418369258 -0.004264018479381  0.032087681361723 -0.022624894165436  0.049954824766487 -0.068907285150032 -0.032867640818893 -0.000029995356356 -0.011652937852273
-    8  (  8)  0.047260005865874  0.018493502167014 -0.056736132845076  0.135589678169431 -0.059916509278318  0.024164421049794  0.007333544303120  0.011763030881780 -0.000264400142459
-    9  (  9) -0.016875007958598  0.031435494057685 -0.089048257959160 -0.041017085631602  0.020420285065562  0.066513023484078  0.000739604154969 -0.091958006244489  0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.016438561460291
-    1  (  1) -0.031819705279686
-    2  (  2)  0.089217438029428
-    3  (  3)  0.040553914705774
-    4  (  4) -0.020554472275814
-    5  (  5) -0.066048736736302
-    6  (  6) -0.000688806170902
-    7  (  7)  0.091248940256931
-    8  (  8) -0.027663919394381
-    9  (  9) -0.000090314260367
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011888856297006 -0.017750932125153 -0.030381401096490  0.012819546160996 -0.007239420422718 -0.024248756043407  0.008035757610220 -0.005364063357974 -0.085646323747472
-    1  (  1)  0.005014728223890  0.026640078285976 -0.053625852742063 -0.001580773154934 -0.029513947501511  0.084681976949646  0.049070075720108 -0.003015931693788 -0.083533135335069
-    2  (  2)  0.005701802857788  0.001861436552455  0.077309348516175 -0.039227298256145 -0.002806617492516  0.004668173879327  0.004051055445085 -0.009725469213679 -0.098722432349714
-    3  (  3) -0.016358351457124 -0.001723600627698 -0.021225514928062  0.039815087581337 -0.022808569998795 -0.104140287911999 -0.033233738030323  0.056382556071864  0.046907957767316
-    4  (  4) -0.023138877563353 -0.095098707280146 -0.087666288227931  0.037561492255805  0.255193211004254  0.015544572331716  0.030557402755123 -0.180093964112144 -0.259856355700386
-    5  (  5)  0.024228572043234 -0.082834757201086  0.181139504221043 -0.153944959591839  0.252818375021614 -0.048862178579716 -0.036094966909273  0.170640955267472 -0.004551713568432
-    6  (  6)  0.085402345559358 -0.022737485412840 -0.117389155338347  0.122686430467103 -0.089994929534087  0.186662776489158 -0.276334552924253 -0.188945818003174 -0.062512631958960
-    7  (  7)  0.077377916753636  0.184413390881742 -0.161635032551528  0.217081818449181 -0.216158931990711  0.452250331823368  0.121365143499215 -0.427486936599919 -0.051141830029037
-    8  (  8)  0.109996402529651 -0.145159792225805  0.137471198251747  0.396423044911114 -0.145941263905056 -0.104134158957014  0.041227108112442  0.369426049626710 -0.017681253264412
-    9  (  9) -0.015271329763023  0.091667642816572 -0.093167229349338  0.105178289783052 -0.012072216330151  0.184888670947420 -0.104021366500691 -0.173041839821099  0.089774142402176
-   10  ( 10) -0.051871879465497  0.004911726396439  0.095027344602311 -0.050235453581707 -0.056755121586123 -0.023277306660177 -0.123771404812450  0.008953154661311 -0.042342746566353
-   11  ( 11) -0.213874614633354 -0.038620645156941  0.003918905035704  0.027644952213642  0.227437070959628  0.047768116418487 -0.043243210008693  0.046251908849224 -0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001231945309971
-    1  (  1) -0.099118498855930
-    2  (  2)  0.099462956417043
-    3  (  3)  0.089788110354890
-    4  (  4) -0.236379406660322
-    5  (  5)  0.043290372964682
-    6  (  6) -0.008471875583563
-    7  (  7) -0.118429426587662
-    8  (  8)  0.041151812398786
-    9  (  9) -0.121668252978460
-   10  ( 10)  0.047795297768532
-   11  ( 11) -0.026000603113831
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.092723408151075 -0.057215092134940 -0.054154926215137  0.012957083117559  0.028122190094715  0.031179347218855  0.013645641371598  0.009921258172339  0.037242536390232
-    1  (  1)  0.019990430092613 -0.002382806987559  0.016009786257367  0.011651136664597 -0.017212414198990 -0.024265249236370  0.152443472946687 -0.006755616148329  0.024207249541319
-    2  (  2)  0.009030755895234  0.085216520460363 -0.016500441499831 -0.009813164947617 -0.015713678712422  0.028373503652355 -0.075877310310795  0.039590492962937  0.081270933339189
-    3  (  3) -0.075043611755008 -0.103608833794547 -0.030676505925522 -0.013143510199953  0.006187488557257  0.045202449901574 -0.041605892889482 -0.001210820793539 -0.045033631139440
-    4  (  4) -0.122337112724117 -0.176460576265088 -0.085321001863374  0.041690733440160 -0.111448222796030  0.083092300673138 -0.094252463151414  0.071551603610925  0.059851091994803
-    5  (  5)  0.372712635775664  0.109553572239785  0.087636097688831  0.161393941368917 -0.091711881285738 -0.083559837956631  0.084048684818413 -0.114275654348762  0.004760374961166
-    6  (  6)  0.030431995544059 -0.095321795210779  0.159145740022025  0.376304340373359  0.189004479350399 -0.100683798175242 -0.128902751762968 -0.567857709085750 -0.002399331341204
-    7  (  7)  0.344039522571259  0.114279634125077  0.003626426979965 -0.177981236436906 -0.027932329764501 -0.026442462397652 -0.246808699479261  0.268819164710932 -0.106523620842343
-    8  (  8)  0.111643207885322  0.002836247769573 -0.018154026503924 -0.097243438328650  0.121498121615664  0.006682650130485  0.107315976978454 -0.036939727738377 -0.063237979028415
-    9  (  9) -0.063921675215150 -0.215994652248761 -0.065707412514049  0.003935136905129  0.142641982827575  0.026699050855783 -0.056962954862571 -0.164747861484427  0.081509018515780
-   10  ( 10)  0.058030998072116  0.060474289846612  0.205628226890442  0.038897333798042 -0.068097699807560 -0.116172285533776 -0.038858694654200 -0.255643829382515  0.001247633054968
-   11  ( 11)  0.085574013220044  0.030726962638802  0.008247473867838  0.106409310393215 -0.064469816287686 -0.072180462194277 -0.022620356444758 -0.070649638629627  0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015293746360799
-    1  (  1)  0.020176832366409
-    2  (  2)  0.007468634139779
-    3  (  3) -0.002013486296780
-    4  (  4)  0.055907379643807
-    5  (  5)  0.014548062338959
-    6  (  6)  0.210557719542813
-    7  (  7) -0.107773752705760
-    8  (  8) -0.004939471027833
-    9  (  9)  0.101796072438763
-   10  ( 10)  0.052197801100809
-   11  ( 11) -0.010791942309942
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000245185765728 -0.004422769142209 -0.195473142624697  0.067124189998810  0.027096370068160  0.099320185873800  0.032910569428743  0.079494520674282 -0.016762710819247
-    1  (  1)  0.004388313593185 -0.000165290846899  0.188129406432792 -0.063756474949075 -0.001128748240139 -0.126263116741295 -0.303817994309096  0.069854530583820  0.010310792522154
-    2  (  2)  0.194444327410373 -0.187906024270824  0.000538868177065 -0.115697813615881 -0.188025580722992 -0.063555095149569  0.109038200896130 -0.123360187528163  0.037347597176070
-    3  (  3) -0.066590814481336  0.063203632987523  0.115347217679990 -0.000002301796994  0.034584588669551  0.038983157581533  0.229948513873159 -0.131721887952800 -0.028384936970778
-    4  (  4) -0.026403437308072  0.000527986476725  0.186677671985474 -0.034818437947430 -0.000320297338463  0.037865478650564  0.201451121997014 -0.109301689008128 -0.005643097026329
-    5  (  5) -0.099409584232992  0.126346592032007  0.064419008019557 -0.039794220656347 -0.036855903902447 -0.000190318965932  0.088891480212760 -0.056789849447140  0.091073030281233
-    6  (  6) -0.033050985013878  0.303259624681304 -0.108281756633666 -0.230173439372417 -0.201331671706094 -0.089930560146314 -0.000311452672695 -0.221067383348441 -0.053494283573947
-    7  (  7) -0.079472710309908 -0.069297203366025  0.125033677339702  0.131451975782708  0.110125569334720  0.054839641157466  0.219945401741596 -0.001085047372961  0.089073871816377
-    8  (  8)  0.016952142014388 -0.010421932566239 -0.036927801153181  0.027792238689701  0.005351459000165 -0.090892785458666  0.052690955519676 -0.088985197141446 -0.000032698621213
-    9  (  9)  0.149061020700740 -0.058621114959186 -0.279965277538519 -0.021488283829580 -0.044200621925698 -0.026904718590704 -0.074208134755608 -0.037354078157659 -0.137372829291651
-   10  ( 10) -0.035190315077894  0.050814828300922  0.151303785089698 -0.062867991520111 -0.077053666036856 -0.075037906181509  0.133385625358484 -0.006791369727277 -0.121764957568739
-   11  ( 11)  0.016457666688676 -0.009560970830020 -0.030160709068648 -0.052615429880776 -0.007184814870880  0.147317585107930  0.048007656104932  0.024985856634055 -0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.149527127949477  0.035025203143730 -0.017236912650706
-    1  (  1)  0.058313378902528 -0.050420942142557  0.009474518218355
-    2  (  2)  0.278325755481738 -0.150562770304950  0.029989264213428
-    3  (  3)  0.020585218415975  0.063268588986747  0.052977667343551
-    4  (  4)  0.042114256624995  0.077316775027134  0.007960467665663
-    5  (  5)  0.031625284755674  0.074462306356205 -0.148447086799088
-    6  (  6)  0.074615124808937 -0.133170285550522 -0.049651682674137
-    7  (  7)  0.041592449377408  0.005910763914811 -0.024358506166719
-    8  (  8)  0.138294110971387  0.121744291260784  0.107918344276425
-    9  (  9) -0.001133592488713  0.474400799155993  0.192590673354496
-   10  ( 10) -0.472105353620486 -0.001334835966633 -0.192285927563244
-   11  ( 11) -0.191497735915320  0.194932828964948 -0.001344945845524
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000738836304181  0.037293198581408  0.029451404620807 -0.009378792471894  0.055701113540954 -0.035128933511984 -0.013954700067714 -0.072836702551235  0.051857122483535
-    1  (  1) -0.032660614374695  0.002015876922290  0.074058480716263 -0.021479421330690 -0.014966422603257 -0.166979967788261 -0.013073252080067 -0.022556560940623 -0.170972365950935
-    2  (  2) -0.029165553040464 -0.073308940131147  0.000753195727027 -0.033014777438001  0.000651481686764 -0.016615463822703 -0.030045410532860 -0.013342873064028 -0.078343409399381
-    3  (  3)  0.010384415064446  0.021326871974424  0.031305865808474  0.000583541727095 -0.005150844265660 -0.010972964083321 -0.024667426696971  0.003421011953857 -0.027197309287279
-    4  (  4) -0.055501401866642  0.014297660722118 -0.000710544848112  0.005493793084614 -0.000124683940717 -0.025126510553785 -0.000947638436962 -0.017069455654223  0.023650915169846
-    5  (  5)  0.033803616927021  0.164339399892725  0.017068168082329  0.010030727560507  0.025241735580020  0.000735433014139 -0.028603795353780  0.023029380344413  0.027599055296252
-    6  (  6)  0.013107540346806  0.012828435687407  0.030286401438565  0.024713021163335  0.001063605161759  0.029296491836886 -0.000025149030498 -0.111104514389532  0.102861376746943
-    7  (  7)  0.072733387901303  0.022465577956558  0.013436829086647 -0.003433808737295  0.017048766876852 -0.023125015384758  0.110934303358415  0.000037875914124  0.002935696551342
-    8  (  8) -0.053267672687232  0.170660201820078  0.076657788504288  0.028160893222526 -0.023606436991553 -0.027690933408034 -0.102626814241324 -0.002887530223588  0.000373637330912
-    9  (  9)  0.004804828900057  0.224333052817770  0.065186758028368  0.004091068046870  0.039040275694483 -0.042976408882840 -0.051197675519228 -0.024101682646066 -0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.005026329948406
-    1  (  1) -0.225373696682354
-    2  (  2) -0.064686362479745
-    3  (  3) -0.004567750792129
-    4  (  4) -0.038996417519414
-    5  (  5)  0.043485644851561
-    6  (  6)  0.051601626537389
-    7  (  7)  0.023715023759407
-    8  (  8)  0.001115391080639
-    9  (  9)  0.000048164004682
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.087860740756488  0.068261038905906  0.057593788019307 -0.011454237083441 -0.027305499289367 -0.032385982368371 -0.018173477269549 -0.009363386608796 -0.038732450559880
-    1  (  1) -0.013249632151170 -0.004184657414979 -0.019716507976896 -0.014744696478638  0.016703323694180  0.027386275287573 -0.163732376866413  0.007136524293248 -0.024482820661864
-    2  (  2) -0.007013218896085 -0.084657964294727  0.026004205374563  0.008076798202963  0.011641159214614 -0.031112856231507  0.081756432692912 -0.043486513055778 -0.085001128307205
-    3  (  3)  0.058477500387638  0.110048615847953  0.032104075685968  0.014807417786102 -0.004697674213231 -0.048123068402958  0.048143599431998  0.000645092439839  0.047260089330542
-    4  (  4)  0.110574498742467  0.188131348104213  0.086636459451987 -0.041361686502598  0.118556992954628 -0.089270642674348  0.104552978829704 -0.075153301656795 -0.057940099039356
-    5  (  5) -0.371487279658724 -0.115772941053656 -0.094845419594772 -0.167070991238391  0.094497706414686  0.087134798346335 -0.079465840043241  0.119932858558240 -0.004312964076576
-    6  (  6) -0.035255689937620  0.112028499449997 -0.168145842580037 -0.392683527257363 -0.194284650981365  0.110254467391126  0.135773335198962  0.599025983356266  0.001116295743642
-    7  (  7) -0.362602042970953 -0.115938705836042  0.002852393959785  0.186519834338995  0.026972926522319  0.023780474127448  0.271135694461778 -0.284033125501378  0.111247570725030
-    8  (  8) -0.111196944464455 -0.001239941376560  0.021205830532168  0.101329748088148 -0.128975240085324 -0.010144197632550 -0.108358474715393  0.037918096280026  0.066572090545295
-    9  (  9)  0.090967744709768  0.211201922436275  0.066377513424381 -0.007899083102241 -0.154707771160094 -0.037980948657754  0.073559352539101  0.172041273327275 -0.087426840520207
-   10  ( 10) -0.070112475488657 -0.079061926736069 -0.222919508358954 -0.040775801294398  0.061424635747658  0.113162621408555  0.037903862973014  0.270692474130444 -0.009570796789139
-   11  ( 11) -0.090924578792926 -0.040585886130445 -0.000311072794648 -0.117174234675791  0.063663959894116  0.077941781302743  0.027645133174923  0.073495241874676 -0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015882565008118
-    1  (  1) -0.020403231736073
-    2  (  2) -0.007241270504095
-    3  (  3)  0.003144444710549
-    4  (  4) -0.058793064689134
-    5  (  5) -0.012293150809123
-    6  (  6) -0.215177196230389
-    7  (  7)  0.113635102585609
-    8  (  8)  0.004824845555481
-    9  (  9) -0.113550918048735
-   10  ( 10) -0.063789409560574
-   11  ( 11)  0.007009974437012
-
 	Computing Mu_X-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        12.160379741462
-	   1        15.816174523843    5.168e-01
-	   2        18.062779512155    2.071e-01
-	   3        18.104564786524    2.511e-02
-	   4        18.116261991289    8.751e-03
-	   5        18.115485194621    2.112e-03
-	   6        18.115059982280    5.730e-04
-	   7        18.115134394893    1.705e-04
-	   8        18.115157029817    4.740e-05
-	   9        18.115144918624    1.473e-05
-	  10        18.115142408283    5.211e-06
-	  11        18.115143636266    1.931e-06
-	  12        18.115145112283    7.258e-07
-	  13        18.115145477182    2.142e-07
+	   0        12.160379612275
+	   1        15.816174341700    5.168e-01
+	   2        18.062779284335    2.071e-01
+	   3        18.104564557555    2.511e-02
+	   4        18.116261761865    8.751e-03
+	   5        18.115484965182    2.112e-03
+	   6        18.115059752859    5.730e-04
+	   7        18.115134165470    1.705e-04
+	   8        18.115156800393    4.740e-05
+	   9        18.115144689199    1.473e-05
+	  10        18.115142178859    5.211e-06
+	  11        18.115143406842    1.931e-06
+	  12        18.115144882859    7.258e-07
+	  13        18.115145247758    2.142e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 7.286e-08
 
 	Computing L_X-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.247381570398
-	   1         3.097286696418    2.898e-01
-	   2         3.812815684890    1.474e-01
-	   3         3.878389138947    3.548e-02
-	   4         3.885075613309    1.357e-02
-	   5         3.885547895791    6.311e-03
-	   6         3.886535950111    1.967e-03
-	   7         3.886738832588    6.592e-04
-	   8         3.886679713231    2.819e-04
-	   9         3.886672339402    1.105e-04
-	  10         3.886676080454    5.012e-05
-	  11         3.886677523890    1.563e-05
-	  12         3.886677551163    4.863e-06
-	  13         3.886676990819    1.570e-06
-	  14         3.886676826868    5.795e-07
-	  15         3.886676838546    2.540e-07
-	  16         3.886676917304    1.308e-07
+	   0         2.247381559583
+	   1         3.097286678889    2.898e-01
+	   2         3.812815657495    1.474e-01
+	   3         3.878389109615    3.548e-02
+	   4         3.885075583633    1.357e-02
+	   5         3.885547866024    6.311e-03
+	   6         3.886535920302    1.967e-03
+	   7         3.886738802769    6.592e-04
+	   8         3.886679683414    2.819e-04
+	   9         3.886672309586    1.105e-04
+	  10         3.886676050638    5.012e-05
+	  11         3.886677494073    1.563e-05
+	  12         3.886677521346    4.863e-06
+	  13         3.886676961002    1.570e-06
+	  14         3.886676797051    5.795e-07
+	  15         3.886676808729    2.540e-07
+	  16         3.886676887487    1.308e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 6.883e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.130822062475
-	   1        12.358074261722    3.642e-01
-	   2        13.442062697941    1.291e-01
-	   3        13.471739352430    1.980e-02
-	   4        13.480630220888    7.273e-03
-	   5        13.480482111186    1.462e-03
-	   6        13.480255761577    4.278e-04
-	   7        13.480295326973    1.238e-04
-	   8        13.480304392477    3.420e-05
-	   9        13.480298929543    1.069e-05
-	  10        13.480297559608    3.198e-06
-	  11        13.480298240037    7.251e-07
-	  12        13.480298711609    2.532e-07
+	   0        10.130821968318
+	   1        12.358074139910    3.642e-01
+	   2        13.442062557171    1.291e-01
+	   3        13.471739210883    1.980e-02
+	   4        13.480630079049    7.273e-03
+	   5        13.480481969339    1.462e-03
+	   6        13.480255619740    4.278e-04
+	   7        13.480295185134    1.238e-04
+	   8        13.480304250637    3.420e-05
+	   9        13.480298787704    1.069e-05
+	  10        13.480297417769    3.198e-06
+	  11        13.480298098199    7.251e-07
+	  12        13.480298569771    2.532e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 9.054e-08
 
 	Computing L_Y-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.495468881713
-	   1         8.714469933780    4.298e-01
-	   2        10.170173470139    1.995e-01
-	   3        10.331283511318    6.921e-02
-	   4        10.360950815162    2.497e-02
-	   5        10.363204453535    8.501e-03
-	   6        10.364371474881    2.215e-03
-	   7        10.364711826888    6.522e-04
-	   8        10.364648292493    2.423e-04
-	   9        10.364628223213    7.272e-05
-	  10        10.364631615168    3.241e-05
-	  11        10.364633942999    1.452e-05
-	  12        10.364636725945    5.118e-06
-	  13        10.364636745608    1.697e-06
-	  14        10.364636756352    7.200e-07
-	  15        10.364636915152    3.373e-07
-	  16        10.364637162966    1.655e-07
+	   0         6.495468855272
+	   1         8.714469893517    4.298e-01
+	   2        10.170173415291    1.995e-01
+	   3        10.331283452604    6.921e-02
+	   4        10.360950755185    2.497e-02
+	   5        10.363204393318    8.501e-03
+	   6        10.364371414609    2.215e-03
+	   7        10.364711766599    6.522e-04
+	   8        10.364648232207    2.423e-04
+	   9        10.364628162928    7.272e-05
+	  10        10.364631554883    3.241e-05
+	  11        10.364633882714    1.452e-05
+	  12        10.364636665660    5.118e-06
+	  13        10.364636685323    1.697e-06
+	  14        10.364636696067    7.200e-07
+	  15        10.364636854867    3.373e-07
+	  16        10.364637102681    1.655e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 7.578e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.375391025758
-	   1        13.056807714818    3.885e-01
-	   2        14.267494985739    1.302e-01
-	   3        14.292982280858    1.823e-02
-	   4        14.298034109371    5.608e-03
-	   5        14.297567113453    1.444e-03
-	   6        14.297518787356    3.537e-04
-	   7        14.297576376534    1.167e-04
-	   8        14.297573943020    4.005e-05
-	   9        14.297568725717    1.369e-05
-	  10        14.297568187114    4.565e-06
-	  11        14.297569333273    1.438e-06
-	  12        14.297569994269    3.760e-07
-	  13        14.297570136053    1.222e-07
+	   0        10.375390930433
+	   1        13.056807585749    3.885e-01
+	   2        14.267494835663    1.302e-01
+	   3        14.292982130148    1.823e-02
+	   4        14.298033958482    5.608e-03
+	   5        14.297566962565    1.444e-03
+	   6        14.297518636471    3.537e-04
+	   7        14.297576225647    1.167e-04
+	   8        14.297573792132    4.005e-05
+	   9        14.297568574830    1.369e-05
+	  10        14.297568036227    4.565e-06
+	  11        14.297569182386    1.438e-06
+	  12        14.297569843382    3.760e-07
+	  13        14.297569985166    1.222e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.855e-08
 
 	Computing L_Z-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.406503691255
-	   1         8.575077561846    4.321e-01
-	   2        10.070227409352    1.974e-01
-	   3        10.178849973996    4.501e-02
-	   4        10.189903730975    1.342e-02
-	   5        10.189264978603    6.893e-03
-	   6        10.190158032301    2.786e-03
-	   7        10.190619785921    9.701e-04
-	   8        10.190563386608    3.609e-04
-	   9        10.190560203221    1.081e-04
-	  10        10.190560065996    4.742e-05
-	  11        10.190566525109    2.069e-05
-	  12        10.190568754986    7.249e-06
-	  13        10.190568833026    2.676e-06
-	  14        10.190568924823    9.982e-07
-	  15        10.190569052782    3.921e-07
-	  16        10.190569155326    1.713e-07
+	   0         6.406503665499
+	   1         8.575077522609    4.321e-01
+	   2        10.070227354335    1.974e-01
+	   3        10.178849916572    4.501e-02
+	   4        10.189903673206    1.342e-02
+	   5        10.189264920800    6.893e-03
+	   6        10.190157974460    2.786e-03
+	   7        10.190619728058    9.701e-04
+	   8        10.190563328746    3.609e-04
+	   9        10.190560145360    1.081e-04
+	  10        10.190560008135    4.742e-05
+	  11        10.190566467248    2.069e-05
+	  12        10.190568697124    7.249e-06
+	  13        10.190568775164    2.676e-06
+	  14        10.190568866961    9.982e-07
+	  15        10.190568994920    3.921e-07
+	  16        10.190569097465    1.713e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 9.172e-08
 
 	Computing 1/2 <<Mu;L>>_(0.072) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008290776080582 -0.050801504097253  0.025635294562259 -0.003046442602711 -0.019839162173202 -0.042287718066775  0.002274291905087 -0.017250301075761 -0.063217582232324
-    1  (  1) -0.005656720485448  0.005906316890016 -0.013342327104385  0.062795095869537  0.034384806675368 -0.011824889654518 -0.010091423219065 -0.046942857543920 -0.048716688440686
-    2  (  2)  0.031253511604130  0.072637650556073 -0.014421891959526 -0.004213302445553  0.070727435854801 -0.065656867197555 -0.018370400388693 -0.002385908267158  0.006354255904041
-    3  (  3) -0.059832580241196 -0.053424480759820 -0.021451003825827 -0.018138018553495 -0.036100327164171  0.016134873511603  0.024740373136963  0.003793018506519 -0.167949395515151
-    4  (  4) -0.064204693944690 -0.131652862682136  0.117404639608972  0.157417127901485 -0.230036611567443  0.047515122725740  0.039984594404843  0.125482054176259 -0.256771627646738
-    5  (  5)  0.146085129938632  0.278398764610060 -0.159854012203638  0.282968510269086  0.101365891285813  0.356608825189021  0.125659431918166  0.044422988683829  0.166646852463301
-    6  (  6) -0.076564725597579  0.133650798922835 -0.020866614443156 -0.061441481951876  0.071232976830213 -0.204259413485531  0.443726141038863  0.031546384888620  0.054109942402284
-    7  (  7)  0.171392689665179  0.199512600411571 -0.417327799251045 -0.052763427688751  0.301472803852696  0.065491949787692 -0.090135905280205  0.243374803622146  0.087314234232365
-    8  (  8)  0.052750851527397  0.070024200557922 -0.379656051510646  0.506727880893360  0.456213741194719 -0.053888497905949  0.020349944072208  0.064388593842935 -0.270869373264179
-    9  (  9) -0.321512384290440  0.557302077819714  0.036935298894209  0.154840347992778  0.003043634782132  0.230873783877613  0.106477418838008  0.187200194326970 -0.093391131247138
-   10  ( 10) -0.965723013629727  0.203375174675727  0.231799200789465 -0.113515758170139  0.032657967963446 -0.147828874479423  0.019227710807050 -0.096617606939553  0.006766409668261
-   11  ( 11) -0.210596475192897  0.094976222444135 -0.072335244920971  0.290764752768263 -0.062314851229712  0.053607127427930  0.145285323049651  0.073900587412887 -0.326764941791807
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071285844130264
-    1  (  1)  0.010066343394199
-    2  (  2) -0.108617239028194
-    3  (  3) -0.063737900590760
-    4  (  4) -0.015793155353663
-    5  (  5)  0.238781543103224
-    6  (  6) -0.065357063243315
-    7  (  7)  0.120098496018758
-    8  (  8) -0.128051536292778
-    9  (  9)  0.179029916473930
-   10  ( 10) -0.084757737907666
-   11  ( 11)  0.159141561245499
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.230778688168130 -0.557039020018502  0.102231622004203 -0.365190061837505 -0.400431097899025 -0.011240783369823 -0.138486416116495  0.002452040812742 -0.004398637078623
-    1  (  1) -0.556776142920827 -2.040315056194718  0.915507378155102  1.014426942838368  0.734278848751725  0.048588577390964  0.281167270606351  0.301449170381432  0.094768863002394
-    2  (  2)  0.102191442528323  0.915686903851560  1.209547690777273 -0.958100119655737 -0.740471389480369 -0.004947182895568  0.495915674452131 -0.139783988312968  0.095073435804183
-    3  (  3) -0.364539165929170  1.014070571549057 -0.958316089423204 -0.283348551998825 -0.131889670325022 -1.271015261428147  0.039370973643206 -0.404136843612415 -0.596543898512850
-    4  (  4) -0.399870169082361  0.732987024839952 -0.742129335372324 -0.132056740778799  0.552809694709972  0.050609502973822 -0.485130318718432 -1.569135325660496 -0.955644372877197
-    5  (  5) -0.012067668711970  0.049395634351447 -0.004235997753528 -1.269867451709877  0.052501445594591  0.142961307435960 -0.243772741862524  0.815823088969846 -1.032660122676294
-    6  (  6) -0.138184751914924  0.281444487458849  0.496109632619357  0.039289252640444 -0.483545301414318 -0.244146373994899 -2.567548494258237  0.471042691193011  0.535768572608993
-    7  (  7)  0.002443724218529  0.302692867022601 -0.138498316501231 -0.403820450806263 -1.565811046199608  0.816611901103015  0.471628294535134 -1.688652935957108  0.671482803026688
-    8  (  8) -0.004344564384300  0.094578985136196  0.094798646138089 -0.597437555079113 -0.950266206536146 -1.030172101956222  0.534632090191761  0.669551052804072 -0.286047601971907
-    9  (  9)  0.321027459692546 -0.124494588251713 -0.355830352458176 -0.608802973418470 -0.402462352421951 -0.368076132570564 -1.240230517037675 -0.910561909620175  0.043652486559104
-   10  ( 10)  0.011815823949598 -0.051101513605038 -0.395397800969984  0.309598565761669  0.194737646185127  0.053604366895841 -0.879466474650196  0.757981021960396  0.138272602216670
-   11  ( 11)  0.159425836287601 -0.085783898744993 -0.370909602534729 -0.056636941516785 -0.307385996591224 -0.268976928323790 -0.442853482929670  0.013290639913097 -0.876205899626718
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.323082673575100  0.012827323300415  0.160383781034165
-    1  (  1) -0.126844464371028 -0.052604971080148 -0.086843133976977
-    2  (  2) -0.357788273401833 -0.396667921961515 -0.371902334820724
-    3  (  3) -0.612287607386654  0.306667669522199 -0.056656844524874
-    4  (  4) -0.405472668706639  0.195190062002348 -0.306615567899281
-    5  (  5) -0.367351821286147  0.055534904015428 -0.275720960811118
-    6  (  6) -1.243158670589035 -0.884111685009210 -0.446520521343404
-    7  (  7) -0.909610092856081  0.758960738026336  0.004121680213622
-    8  (  8)  0.044479614426162  0.142510706976164 -0.890141861038879
-    9  (  9)  0.430645603358394 -0.292573864178629 -0.177569371172063
-   10  ( 10) -0.297251468770778  0.639563517042984 -0.084252875076621
-   11  ( 11) -0.176313836183732 -0.086637188746477  1.226883274744448
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.555032728737771  0.712617672671401  0.419810286882489  0.050887754227596 -0.090842975445822 -0.470640518796941  0.705404320416024 -0.102097016449215  0.079849652538938
-    1  (  1)  0.712915390108471  0.338414908248977  0.746799463635505  0.289033465951793  0.281577689527702 -0.590080565321557 -1.163166129408219 -0.188838662213219  0.235465544716902
-    2  (  2)  0.420424419523684  0.746397208582966 -0.016153704953468 -0.358852287949201 -0.952285365412292  1.041198523267407 -0.387389024226280  0.231972398395418 -1.201681468114436
-    3  (  3)  0.052990374128029  0.287939592192507 -0.356997201476426 -0.860130940767887 -1.322600194001359 -0.190991097932252 -0.172427859143025  1.049268576710733  0.759838942947354
-    4  (  4) -0.091729674999201  0.281558404761801 -0.953826965790842 -1.321136801436185  1.452847715742109  0.019357804497789  0.219531843898996 -0.321163524474806  0.383368380154908
-    5  (  5) -0.468391179467906 -0.590920943851569  1.042843901419442 -0.190946364776948  0.019284064585406 -0.578157261908740  0.477982154885554  0.309192885886468  0.350343314103329
-    6  (  6)  0.705416628116867 -1.163498224121495 -0.385221267991331 -0.173426272959358  0.218834180811751  0.478203132617135 -2.784703127021582 -0.089827446409910  0.007438070857215
-    7  (  7) -0.100892718625019 -0.189193923309364  0.233172791358426  1.048794685120079 -0.321694154621351  0.309157324551256 -0.089653742381773 -3.228872513573496  0.508232911749822
-    8  (  8)  0.078189592702616  0.235740536359493 -1.205024775916881  0.762330717256039  0.383275686836382  0.348953623655193  0.008045450505770  0.508467502681986  0.472369144605263
-    9  (  9) -0.077760701800955  0.237396383481108 -0.096343734790574 -0.354923660187535 -0.984336588474142  1.335053740742370  0.269902452459777  0.319055275759352 -0.321749140962585
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.078162493766068
-    1  (  1)  0.238847682218727
-    2  (  2) -0.098903683747888
-    3  (  3) -0.354949509542455
-    4  (  4) -0.983822640646403
-    5  (  5)  1.333720211340158
-    6  (  6)  0.269441491786924
-    7  (  7)  0.318898660493929
-    8  (  8) -0.321196908799485
-    9  (  9) -0.198768714929451
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015331616498833 -0.019922018235360  0.024795453639952  0.001428994822442 -0.007662564632869 -0.030564864466354 -0.002998096035874 -0.014184257518557 -0.050369876521864
-    1  (  1)  0.002536892896206 -0.000724332833140 -0.010931820831771  0.061385329925525  0.034527384530112 -0.002930909394968 -0.006897041777642 -0.048924198461387 -0.045892788765523
-    2  (  2)  0.055930590988109  0.061668786229878 -0.009784880887058 -0.011292178101404  0.079575226023927 -0.052325708606337 -0.009086556132667 -0.001787844130138  0.008215255410943
-    3  (  3) -0.058532225277701 -0.048285500112225 -0.015912879350588  0.001479837376653 -0.030353501548890  0.023819914693463  0.021025260847826  0.014207102374829 -0.151577267379535
-    4  (  4) -0.056221687371934 -0.122358938171234  0.112292181821658  0.146881610350559 -0.213263741399596  0.056469707520368  0.037816511197979  0.118315319709634 -0.249164851234958
-    5  (  5)  0.125699079920792  0.245765102963436 -0.144688421941741  0.269480954167622  0.108175820650901  0.330495489462815  0.121717019021094  0.042981278927133  0.139107704893676
-    6  (  6) -0.090953864200081  0.138378038123711 -0.018999653387300 -0.059021477190613  0.070107383816014 -0.188422561576096  0.422479983427336  0.027031745312951  0.054392856003620
-    7  (  7)  0.157772366372595  0.187920697768143 -0.411777035755239 -0.046692805557951  0.283266431788380  0.074879967037488 -0.084103929184262  0.226658912465472  0.075512245279510
-    8  (  8)  0.054210291452992  0.062449071960101 -0.361963320103574  0.503001997291620  0.438083797101076 -0.063050427843078  0.017066076329137  0.069221757957400 -0.257467231990446
-    9  (  9) -0.273423536032774  0.529295983026682  0.033766766508851  0.151918529592259 -0.009418984940093  0.206571120107986  0.110624885223032  0.172829785443028 -0.101427788661059
-   10  ( 10) -0.861462052752320  0.172326691424178  0.212371997651326 -0.111218596621436  0.023269411258717 -0.143388725237391  0.039930804953421 -0.091843120858856  0.022422158283106
-   11  ( 11) -0.188670480611874  0.096820345118133 -0.066190773880029  0.287205832494666 -0.059420643781434  0.064429852032339  0.150091109571506  0.074231547885084 -0.343171650309577
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.057461514086606
-    1  (  1)  0.006963958755564
-    2  (  2) -0.098129328522494
-    3  (  3) -0.059012682268642
-    4  (  4) -0.004449861106028
-    5  (  5)  0.220945294639113
-    6  (  6) -0.063939488850868
-    7  (  7)  0.102360934503055
-    8  (  8) -0.118112557417407
-    9  (  9)  0.155151984964126
-   10  ( 10) -0.077691214009347
-   11  ( 11)  0.169304339523055
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007929033245727 -0.086776514026638 -0.041466992686244 -0.000624066975311 -0.013156595381987  0.043080477030762  0.042448060293463  0.012239880545527  0.029029915184304
-    1  (  1) -0.033878180177558  0.070173508648210  0.019230609095550 -0.003533880530575 -0.001550569267327 -0.001809299397526 -0.111518736659909 -0.001270571448457 -0.012934311690280
-    2  (  2)  0.053119512373320  0.091732793273830  0.021408607612661  0.032674571200622 -0.027446877387833  0.001428368203209  0.035760699595502 -0.016168017803360  0.076110316338229
-    3  (  3) -0.111768458659199  0.032123986864070  0.006283151908271 -0.033287020781358  0.043086093005307 -0.045344868585861  0.050504244775852 -0.018808552325982 -0.035145863401031
-    4  (  4) -0.008665305449844 -0.063452607411023 -0.029600165455924  0.047115677331559  0.019168666345381 -0.031501732622098  0.317766848542404 -0.025484653465158  0.136713668607013
-    5  (  5) -0.096942829349587  0.462416830630329  0.133842090994118  0.092985874350147 -0.099421870808029 -0.234587688959823 -0.217512036032000  0.115491679731730 -0.074046828271163
-    6  (  6)  0.147504151854231  0.176016277524490 -0.101374573515317 -0.288079277305196 -0.230919141922049  0.118478695990594  0.200039409574699  0.528080641738917 -0.150345125085143
-    7  (  7) -0.042669001755884  0.443406170499069  0.389143916519812  0.161315900065673 -0.044923622848274 -0.251217580401495  0.349139344106497 -0.313375744671926 -0.105308356658894
-    8  (  8) -0.090773283284028 -0.098945242676733  0.273219850231927 -0.153556988234685  0.012049248011756  0.153837601800696  0.096783765511278 -0.036655814574288 -0.158022323654812
-    9  (  9) -0.854099711852282 -0.117772176421944 -0.239016409160077 -0.177375733867881  0.100275769298913  0.252844583057920  0.226930144139075  0.153229528005110  0.127239027610851
-   10  ( 10)  0.395991653576375  0.538214267844356  0.096531314019954 -0.336382832184142  0.099895828912763  0.055956501178133 -0.146421756050995  0.134905206743007  0.024743642762261
-   11  ( 11)  0.048495982241480  0.204014858900645 -0.274325469868742  0.134595356909103  0.084519511625804 -0.191133538480751  0.069261639154394  0.103192119612584  0.176045180364651
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.028831087335228
-    1  (  1) -0.001371858337113
-    2  (  2)  0.086279641236700
-    3  (  3) -0.002619734805492
-    4  (  4) -0.021137684583830
-    5  (  5) -0.191430382947414
-    6  (  6) -0.264284919761669
-    7  (  7)  0.000269384690538
-    8  (  8)  0.116882729881709
-    9  (  9)  0.120074711434079
-   10  ( 10)  0.053632787996257
-   11  ( 11) -0.085463803953674
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.675541283858356 -0.292064021280293 -0.790025131233222  0.039304385342315 -0.142699371183327  0.268327500474091  0.055268589173706  0.193336176520280 -0.032498607183913
-    1  (  1) -0.292005367417511 -0.068094888399427 -0.091928539573230  0.129152126993159 -0.002672883933379  0.049262453691224  0.862140772831706 -0.434895002279636  0.030957963645570
-    2  (  2) -0.789447165009789 -0.092254483472880 -0.804853040833334  0.464036191543570  0.288328515691532 -0.782373392336952 -0.359658943728641 -0.388090328975242  0.068147997029207
-    3  (  3)  0.039444395620206  0.128939281409480  0.463903578747306 -0.241479807350799 -0.029257651091736  0.289330170364477 -0.078438871496667  0.246243716348015 -0.221624488999474
-    4  (  4) -0.142005033730652 -0.003441352982276  0.286700873937055 -0.029953661733414 -0.427750919311445 -0.225593242891832  0.001248695253401  0.308372097905189  0.608170303007273
-    5  (  5)  0.266046370608821  0.051710611539180 -0.778167579408912  0.290283723006215 -0.224453112864279 -0.369348441761130 -0.137527542499239  0.160088399589127  0.333141145250294
-    6  (  6)  0.055576665996038  0.861897091141550 -0.359382180614210 -0.079367338581182  0.001316960755447 -0.139592143084602 -0.236061692038733 -0.500995422630755 -0.152924823639678
-    7  (  7)  0.191190365321726 -0.433335934056497 -0.384226491533538  0.246895934047586  0.308256930114393  0.160145299200529 -0.499551364365546  0.169042466304747 -0.232433156817922
-    8  (  8) -0.032324733830521  0.030583581869279  0.067800595440523 -0.220839746025180  0.605132330733771  0.331428074510260 -0.152991449816876 -0.231671787208498 -0.624414674119492
-    9  (  9) -0.170133827289346  0.173802608390272  0.582650141434017 -0.560382911834174 -0.212565567455627  0.095754045184088 -0.282286783247438 -0.105642205052933 -0.000539730602912
-   10  ( 10)  0.052970874353821 -0.227531715435441 -0.648876828841383 -0.696767965643644 -0.268344000354012  0.568720278318329 -0.098598860256773  0.086269937526947 -0.081275470268861
-   11  ( 11)  0.025516552524119 -0.085059735579504 -0.121415959836865  0.018097922040376 -0.846374652520441 -0.307989344147049  0.044343294285023  0.231195949738532  0.168305572109582
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.171375974411067  0.055216931376792  0.025964207813788
-    1  (  1)  0.173220084938157 -0.230603891969826 -0.085840408679658
-    2  (  2)  0.586304150506699 -0.654210189691972 -0.122677885868631
-    3  (  3) -0.564217005061761 -0.698424845148049  0.018146779332832
-    4  (  4) -0.213592841407263 -0.268356081771837 -0.851093566817366
-    5  (  5)  0.095187708087751  0.569138844284334 -0.311815017332116
-    6  (  6) -0.283847446348569 -0.099361887898569  0.045327800607922
-    7  (  7) -0.106442929251796  0.084951820105520  0.232402123183799
-    8  (  8) -0.000679287280351 -0.083181582350312  0.174842773942352
-    9  (  9)  0.184137973286679  0.103441117955563 -0.011188766481418
-   10  ( 10)  0.107554052466808  0.106515041132340 -0.165743784884080
-   11  ( 11) -0.010550245981975 -0.165913802295303  0.859885805027657
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.229655435401251 -0.279601353643965 -0.085575827802352 -0.135048509105901 -0.463462610619003 -0.365248455770507 -0.039660777368333  0.191781963250870 -0.304572804139555
-    1  (  1) -0.279047925679444  0.077319987469585  0.204439247136492  0.070123615269243  0.055860395624731  0.138642318409271 -0.343207769076389 -0.182810883095464 -0.017999280994748
-    2  (  2) -0.085240959465133  0.204263364283089 -0.311156623733494  0.294688564065330  0.229669520218161 -0.281737981462645  0.137882893674030 -0.194668648298996  0.517507397185879
-    3  (  3) -0.137052652301458  0.068817803199155  0.294513347383327 -0.628744473812505  0.688526281107777  0.166771123104115  0.212803952843010 -0.269010206604892 -0.411620416751970
-    4  (  4) -0.461604619248266  0.055843287983042  0.230054478565236  0.688395074228786 -1.421511879446005  0.180495138052121 -0.177199847230662  0.268188410470329  0.119512289645345
-    5  (  5) -0.365099883123814  0.139122909294115 -0.282780063256330  0.166251175855828  0.181093271919847 -0.292775738602585 -0.240660983788926  0.305216197970317  0.235452232882587
-    6  (  6) -0.039141072198114 -0.342047900602042  0.138302509146164  0.211959339222516 -0.177087648441962 -0.240505624310098 -0.304304277829310 -0.910739369588832  0.202811323160239
-    7  (  7)  0.191443148224360 -0.183077517400336 -0.194209029769022 -0.269384260651775  0.268168725961981  0.305441092512858 -0.910852433205190  0.029633662055934 -0.204453968987965
-    8  (  8) -0.303246852232180 -0.018509744386768  0.519514080414653 -0.413340759430442  0.119384719254151  0.236362024043069  0.201991249845660 -0.204562219955504 -0.661555776893828
-    9  (  9) -0.300472910579648  0.170014354298783 -0.291259695102906  0.029160805834281  0.317264449488489 -0.326442124436524  0.007044557482429 -0.101763181058410  0.215338723709779
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301684802635884
-    1  (  1)  0.169719322346163
-    2  (  2) -0.289724655704096
-    3  (  3)  0.029002914588453
-    4  (  4)  0.316574855082561
-    5  (  5) -0.325796183326422
-    6  (  6)  0.007131791827115
-    7  (  7) -0.101918507704736
-    8  (  8)  0.215214193797303
-    9  (  9) -0.431317970778139
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009148490318064 -0.020309806158549 -0.015977532182931  0.004014783738387 -0.010489793112351  0.029667649783295  0.020232440585606  0.011223082041042  0.023312323786938
-    1  (  1) -0.044375857230131  0.052262766826166  0.015548487373741 -0.003662802577056 -0.002781875625079 -0.001383977859398 -0.098229640468489 -0.001043710758572 -0.010909270118946
-    2  (  2)  0.054181385020550  0.080128526478900  0.022828931876126  0.037487063410101 -0.042770056882922 -0.005218720540993  0.030479703829638 -0.014823518322437  0.065536667960166
-    3  (  3) -0.129996832535740  0.025539245172390 -0.001710767497197 -0.035208153932012  0.051497303033318 -0.033810939265315  0.041923713016432 -0.018028802137201 -0.031841589713416
-    4  (  4) -0.018797598258319 -0.055382521313148 -0.025678897036466  0.042677314096974  0.024119803445938 -0.028773903589126  0.288385579456642 -0.023957336001325  0.134022392012911
-    5  (  5) -0.085790126908808  0.402408359114006  0.110878458520312  0.084218998643581 -0.097302640260559 -0.211015098306590 -0.195826989075132  0.107508726926065 -0.059970385150068
-    6  (  6)  0.117117046001707  0.164907313314791 -0.092740522447941 -0.263892346037872 -0.208050086690414  0.121861415926763  0.180654068666643  0.487980567663863 -0.134813668081860
-    7  (  7) -0.052709991074355  0.381296251220592  0.349380237841959  0.145852911752160 -0.041346590279243 -0.220669429372274  0.328816279036270 -0.285726302429830 -0.093478286390337
-    8  (  8) -0.075491834851014 -0.090622807799606  0.261184981058617 -0.148637821570292  0.006281256453519  0.144842826611815  0.089811111402247 -0.036110485207390 -0.153520220179307
-    9  (  9) -0.696164148321021 -0.104910101886221 -0.203383144631185 -0.164870629493292  0.069977329160723  0.194202208543558  0.212076681930829  0.132693764051193  0.096725293429142
-   10  ( 10)  0.348175665954885  0.434442729860845  0.069207287013024 -0.311902381205193  0.086974667298470  0.051225223079379 -0.122216101880307  0.122874476488139  0.012079820457350
-   11  ( 11)  0.044712948857676  0.176004094735536 -0.255862724288287  0.126758826080010  0.078218473139894 -0.179984369340434  0.067110991111726  0.095360581673868  0.177561710091429
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.024402944617349
-    1  (  1) -0.001173348606223
-    2  (  2)  0.076484101898115
-    3  (  3)  0.001169431615315
-    4  (  4) -0.024935532887633
-    5  (  5) -0.174540155531575
-    6  (  6) -0.236517338782017
-    7  (  7)  0.008859575697215
-    8  (  8)  0.109927192293737
-    9  (  9)  0.089534068178409
-   10  ( 10)  0.043410237741554
-   11  ( 11) -0.093132968001143
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002170644752931 -0.022324956514099 -0.029394826211345  0.023309311068680 -0.000970852822634 -0.043511040680121  0.014013985960523  0.007860305508825 -0.031314125297178
-    1  (  1) -0.004975212184910 -0.009727238108985  0.081406434912428 -0.023252939392766  0.038928067463043 -0.010458408905981 -0.034913544836836  0.014265058471693  0.051735797486860
-    2  (  2)  0.017880176100707  0.015599348022774  0.096023531696764 -0.045237679689815 -0.002431886781376  0.077281603581543 -0.027482410098613 -0.002121837766367 -0.131596950090464
-    3  (  3) -0.033671282161329 -0.042247110815725  0.017614407066521  0.120482048147517 -0.071788669015437  0.100417130949899  0.026095439370731  0.024912292415628  0.128857994704884
-    4  (  4) -0.039094504869080  0.011586636873075 -0.201648756832533 -0.417167224027039  0.232183671922422 -0.365776066782585  0.000436512477144 -0.036487401941041 -0.092913589753420
-    5  (  5)  0.107020694538732  0.188165249192967  0.272788343236859 -0.444403017959699  0.118293552778212  0.528258782415562  0.125325642779073 -0.198753130098826  0.028672980278371
-    6  (  6)  0.121158671169740 -0.085565322151460  0.088586051783133  0.010298532059028 -0.107250216094850 -0.195698840050220  0.370534853760273  0.159194784952583 -0.016512860210084
-    7  (  7) -0.033804952616344 -0.168095045341921  0.398821112602689 -0.046726828449621 -0.030609711055064 -0.217531691733838 -0.115639511714214  0.399856930098400  0.150033235311716
-    8  (  8) -0.059559370905179  0.306305036465827 -0.595923646185890 -0.119277640805674 -0.722271918559490  0.001726267262613 -0.027179920353598 -0.211451038002310  0.148912062372910
-    9  (  9) -0.188866142842736  0.096789990486457  0.236442562527094  0.092757728041313  0.072651948101216 -0.016472461695526 -0.026914575117300  0.247244600184375  0.370870606832493
-   10  ( 10) -0.406957853798143  0.141958866881762 -0.085132936917023  0.102326296221874  0.017996095944708 -0.062553443565296 -0.105319900227601 -0.005069269037988  0.006423933602228
-   11  ( 11) -0.081915250147579  0.202583484157184 -0.282203343833431 -0.339304077428364  0.118298550150489 -0.126692826807318  0.005731143361727 -0.150166092159272 -0.134968415625333
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.038183979702674
-    1  (  1) -0.001758617329220
-    2  (  2) -0.002245458358924
-    3  (  3) -0.305015280585847
-    4  (  4) -0.011707659076193
-    5  (  5) -0.052479234679287
-    6  (  6)  0.143560462314116
-    7  (  7)  0.320971036748081
-    8  (  8)  0.148594551736844
-    9  (  9) -0.097500178466871
-   10  ( 10) -0.069870490871550
-   11  ( 11)  0.082515655756872
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.053221344681142 -0.117483147833985 -0.106139723247453 -0.495823955121092  0.391515874804455  0.212402958848530 -0.083769680573767 -0.039675371517883  0.058634274306531
-    1  (  1) -0.117410394687696 -0.001165915237512 -0.133100613626654 -0.630012634533085  0.317623482499555 -0.573984529169381  0.375575851008806  0.417091736224605 -0.210582306420709
-    2  (  2) -0.106116179316557 -0.133365754849436  0.099881677186242 -0.283389270168438  0.408842653260195  0.463415082290805 -0.094461635582511 -0.339728478273951 -0.187117729157411
-    3  (  3) -0.495487159854538 -0.630575218275538 -0.284210529100489 -0.394005207299682  0.243829412824131 -0.426368810438983  0.000017569224274 -0.316982847795332  1.182262387796268
-    4  (  4)  0.391977861689502  0.318458435778042  0.410524448216213  0.243871385545647 -0.262605821454379  0.313475558817429 -0.006238164976110  0.146232809940208 -0.404783357267945
-    5  (  5)  0.211677947989569 -0.572946112183618  0.465876094202739 -0.424891649228725  0.310576368667640  0.340119032966648 -0.103399884420596 -0.366027570904681  0.140243317389270
-    6  (  6) -0.083203642949521  0.374758513857944 -0.095474380553338 -0.000848431158077 -0.007011740191065 -0.103456952640946  0.035381526355376  0.100664517850410 -0.224617556800866
-    7  (  7) -0.039824177760467  0.417269525333673 -0.339848279473418 -0.316785009817077  0.144981956006953 -0.366591938133070  0.100487370214345  0.453363803566786 -0.284080848307595
-    8  (  8)  0.058454981179204 -0.209563433448112 -0.187086823104815  1.182437825563613 -0.401897920471953  0.141960153823608 -0.223791716105096 -0.283768269790238 -0.127258563076312
-    9  (  9)  0.176473367868989 -0.113695285962430 -0.191045562239273 -0.466077182834650  0.080353173846381 -0.392419296545826  0.139310719822578  0.097667658130615  0.260382741772322
-   10  ( 10)  0.087511748605763 -0.084525637542731 -0.451433812661641  0.087442027470754 -0.075301055147615  0.128254312442896  0.066832910809452  0.040269698765907  0.083963538620684
-   11  ( 11) -0.256000473516428  0.178934738319287  0.462669412659627  0.336070869572452 -0.226364820740552  0.220661186826050  0.015682276558009 -0.019696413835863 -0.320368477367524
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.177398660643495  0.088413661062507 -0.257047850800415
-    1  (  1) -0.114710761582569 -0.086001542477366  0.179468892454740
-    2  (  2) -0.191402905701337 -0.452554194931555  0.463985875678332
-    3  (  3) -0.467548510382317  0.086605995128391  0.336310348111395
-    4  (  4)  0.080907164839857 -0.077457000042675 -0.231693183962593
-    5  (  5) -0.391713702811823  0.124122145336547  0.233240659481206
-    6  (  6)  0.139727422139028  0.065972550943365  0.014736999139443
-    7  (  7)  0.097438431199858  0.039119593081805 -0.012607893852994
-    8  (  8)  0.258370481571402  0.084693167750785 -0.328679992068142
-    9  (  9) -0.027947875522173 -0.059452680730838  0.039102598209232
-   10  ( 10) -0.061112133253744 -0.042824028656813 -0.176907573001062
-   11  ( 11)  0.036269564126208 -0.174115037047438  0.046562990208638
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.221915567502623  0.240154969163816  0.089524025753548 -0.009891539023461 -0.105352264889997 -0.079728196437896 -0.186918344067447 -0.018609216798882 -0.150218987334760
-    1  (  1)  0.239595861160914  0.097635005536382 -0.020343203465831  0.252497393963625 -0.178770889626966  0.156659860903133  0.042031186852564 -0.226739274781765  0.050354579998016
-    2  (  2)  0.090047283413814 -0.021960432152020 -0.652704165096791 -0.484235858264924  0.265074532283746 -0.870240852693915  0.056963933090132  0.087593695232780 -0.397150344061483
-    3  (  3) -0.008304023565221  0.254514964099576 -0.488668744172267  0.243914942296862 -0.497430549408554 -0.651892044099941 -0.144949354151790  0.009197770416785  0.363155689203458
-    4  (  4) -0.105368055288416 -0.178968402377489  0.265813616023428 -0.498441236963999  0.117807978177016 -0.197938223960627  0.010977461550819  0.054866508200549 -0.633466747483980
-    5  (  5) -0.079092278611567  0.155211327907083 -0.870349858528248 -0.648891955877304 -0.198852995680930  0.056118287010249  0.077393750543525 -0.820063131904850 -0.522591293712200
-    6  (  6) -0.188319262904704  0.043235387216250  0.056704467242807 -0.145342612784415  0.011176054667898  0.077123788010048 -0.017043504447154 -0.229308594149143 -0.061253571825596
-    7  (  7) -0.017449220652026 -0.226052369590475  0.086398229140611  0.009988063298837  0.055257253277244 -0.820894010869112 -0.229107411788767  0.436891114659360  0.154693358924324
-    8  (  8) -0.147652836473568  0.050157233403955 -0.397985593672069  0.364902332737576 -0.632177325650741 -0.523669848989306 -0.060883358066048  0.155008994016302 -0.331322085722016
-    9  (  9) -0.012364053013731 -0.381902018882131  0.730234455154150  0.318717588976828  0.654372705810295  0.234910934996783  0.063436038641434  0.568676727219248  0.116095919775855
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010717409085818
-    1  (  1) -0.381606046587817
-    2  (  2)  0.729520232349256
-    3  (  3)  0.319801359646356
-    4  (  4)  0.655576694394483
-    5  (  5)  0.233766377042350
-    6  (  6)  0.063681628675817
-    7  (  7)  0.569047245691214
-    8  (  8)  0.115234955131862
-    9  (  9) -0.255200733989858
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006756611009239 -0.004812319108707 -0.015155246179453  0.018768861614548  0.003263846230316 -0.029956626691063  0.007768157616613  0.008654952545397 -0.024139771998296
-    1  (  1) -0.000276876655733 -0.007317152277636  0.067126401411285 -0.013873168496829  0.038395392580021 -0.004054864162186 -0.028032553908660  0.014238200673600  0.044802348000681
-    2  (  2)  0.034311733284435  0.014478380463186  0.079037871547464 -0.037480797351928  0.004455235189999  0.068266709703376 -0.020927095140560 -0.000590179941322 -0.116436689576599
-    3  (  3) -0.034781167081690 -0.039999835648210  0.017388947621558  0.117724049135840 -0.062309713575062  0.098214530429882  0.024529272430519  0.026637769905859  0.121592113448416
-    4  (  4) -0.036088452219928  0.018119725898309 -0.181397076074172 -0.381210957896193  0.211295234548894 -0.335046977567969 -0.001001209940803 -0.032788904430710 -0.087406508170972
-    5  (  5)  0.091932999121248  0.163472911292393  0.257039057929667 -0.406986018028708  0.108362880698111  0.483755223010107  0.114747171070721 -0.179816739697054  0.021814542430540
-    6  (  6)  0.102207313652244 -0.075273825473482  0.076700485775484  0.010389199522243 -0.095145363312679 -0.177269643268087  0.339312666537493  0.145893525857585 -0.013352577122472
-    7  (  7) -0.036776384387696 -0.162278963391709  0.362818814892890 -0.043460364327904 -0.026462409718549 -0.199351982461758 -0.104180059013018  0.364628559511404  0.137093791802520
-    8  (  8) -0.054133642075650  0.281937460317668 -0.549118750139198 -0.110766566728388 -0.665283649525633 -0.004014717984651 -0.026030812844979 -0.193249298632007  0.140185869779560
-    9  (  9) -0.149539825936769  0.083496187141563  0.222414359602469  0.086467924966290  0.058519767738283 -0.026610134648035 -0.023639345193443  0.224482305471681  0.335967535114734
-   10  ( 10) -0.342551768791105  0.115343806322270 -0.079695331214451  0.094078531732984  0.012984790263811 -0.052720281866277 -0.089289783188097 -0.003161584461577  0.011520822726607
-   11  ( 11) -0.067948144123858  0.170897803094304 -0.268478044795138 -0.331752793901224  0.110501398686606 -0.120431522039808  0.010421693063374 -0.142909196950524 -0.136584264097857
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.029945709624550
-    1  (  1) -0.003777838622564
-    2  (  2) -0.000494193391228
-    3  (  3) -0.283159255072162
-    4  (  4) -0.002056849846006
-    5  (  5) -0.055491249216550
-    6  (  6)  0.134241443599212
-    7  (  7)  0.294425347600366
-    8  (  8)  0.138732741810037
-    9  (  9) -0.100744739667680
-   10  ( 10) -0.062352827286650
-   11  ( 11)  0.087587602591740
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.057027762100789 -0.007489633887342  0.036964189813796 -0.021384352100284  0.004867815775604  0.032130235858782 -0.019486973797962 -0.000503926514732 -0.024868986663351
-    1  (  1)  0.007883399599923 -0.007529104506445 -0.013216566770749  0.001554286609489  0.002481002458300  0.003555137440754 -0.020216878378801  0.003435265519663  0.003420680709423
-    2  (  2)  0.005061763911744  0.024005030999464  0.016920245291348 -0.019760528227158 -0.007759414271484  0.029231812106945  0.009559298232843 -0.004745878981161 -0.053662769962019
-    3  (  3)  0.011903086348447 -0.106154395386531 -0.048846797682958  0.038122834717736 -0.042076447151745  0.017515736018254  0.021695004377211  0.017259669010754  0.058953679400153
-    4  (  4) -0.086846706941042  0.161257530089836  0.037361255861875 -0.089905419413410  0.174437646387183 -0.071028892880315 -0.038811212273731 -0.045200518155063 -0.066894551440516
-    5  (  5)  0.295118954821928  0.042171667688274  0.057142717280935 -0.095328920031059  0.118376834610768 -0.017202604507056 -0.038088685926927 -0.015413673756028 -0.019970185142534
-    6  (  6) -0.061695197805604 -0.041447416246154  0.107874329349021 -0.009310856499629 -0.028327062477196 -0.072556054900044  0.031173831746629  0.093673016450942  0.096470656575707
-    7  (  7)  0.040164356283535  0.019606328824315 -0.022514162311588  0.103095269177578 -0.105738125414362  0.000251323240260  0.190667102998226 -0.014251172141516  0.042544347999407
-    8  (  8) -0.209747539729284 -0.026225521984115 -0.065411218317390  0.108576414051802 -0.195951046046893  0.054935351774023 -0.181062671358124  0.048648601818055  0.037403343457353
-    9  (  9)  0.029537922421234 -0.045187174636289  0.013381512217286 -0.049426415359509  0.003411235911782 -0.045265306723710  0.096457278821335  0.006113492494935 -0.044165814974043
-   10  ( 10)  0.026870929841946  0.010513244846490 -0.122411818973730  0.066300236331789 -0.074150921852319 -0.175359501999903 -0.025219490294838  0.031299023505132 -0.032770162927265
-   11  ( 11) -0.076638806040972 -0.048660864910506 -0.054798136469999 -0.067410404189619  0.096042680906718 -0.030077767167195 -0.040609376761651 -0.003350033647470 -0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007613623485115
-    1  (  1) -0.001053219582711
-    2  (  2)  0.054751844139672
-    3  (  3) -0.021588797011546
-    4  (  4) -0.069416579868176
-    5  (  5) -0.031311068013170
-    6  (  6)  0.060683491342485
-    7  (  7)  0.004937786560826
-    8  (  8)  0.055843386605960
-    9  (  9)  0.053258374332423
-   10  ( 10)  0.029326398375861
-   11  ( 11) -0.027904630917537
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000025015734507  0.010198711087952  0.006474775958448  0.066946051563528 -0.066550206967977 -0.041188873125926  0.023552914991952  0.019202263160422 -0.006942946197737
-    1  (  1) -0.010140605887652 -0.000014394957877  0.022996796061328 -0.067092192493274  0.063685673857393  0.019093615376604 -0.005525180617760 -0.015031464830750  0.005320182556269
-    2  (  2) -0.006534739001904 -0.022969584694137  0.000183457658640 -0.211551326757209  0.218187807438925  0.104132114893528 -0.065436658246811 -0.042103919182146 -0.012243831904844
-    3  (  3) -0.066304931943444  0.066584833979085  0.210703888875489 -0.000394093515089 -0.011258600581601 -0.092530428436357 -0.131881992071255  0.026480578605083  0.063346368194022
-    4  (  4)  0.065779542430873 -0.062822415172501 -0.216601239538476  0.011617389043850  0.000720555249011  0.020159848057855  0.073942431465134  0.001119920964031  0.016120241216710
-    5  (  5)  0.040846799691504 -0.018979734118351 -0.103125251405654  0.092549855601907 -0.021623501291584 -0.000771447754999 -0.234552119202209 -0.000611164043666 -0.101606719343242
-    6  (  6) -0.023326218450828  0.005550385111505  0.065252405074981  0.131681855193961 -0.073575257938565  0.233645237851028  0.000193851682480 -0.255788429172446  0.079072823032341
-    7  (  7) -0.019055068515462  0.014786531642521  0.041539856986611 -0.026353850726780 -0.001700683540838  0.000445480591706  0.255766070671258  0.000118381893033 -0.151562772366571
-    8  (  8)  0.006620321009197 -0.005142966830662  0.011245852682541 -0.062510776113309 -0.015648596901915  0.102272652360209 -0.078381794853266  0.152302821501449 -0.000094469957927
-    9  (  9)  0.045347281960025 -0.040291069791943 -0.085226922335689 -0.018441757598111 -0.027467525239214 -0.004932928889320 -0.020868912898856  0.024483356625930  0.224180460199113
-   10  ( 10)  0.020374790573784 -0.028198954860440 -0.010392111666997 -0.120181326176130  0.060512260831236  0.109015894697222  0.047153104465120  0.043944046420833  0.103069326885495
-   11  ( 11) -0.049408052352300  0.045270280246414  0.110185553685008  0.041594160321979  0.088273360930753 -0.183934249639257  0.003285919080508 -0.178701510068243  0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.045673042542890 -0.020717466986083  0.050844518832522
-    1  (  1)  0.040043621408487  0.028287827625151 -0.045457031631407
-    2  (  2)  0.084888848710605  0.010052611398803 -0.109898373773783
-    3  (  3)  0.018088362425205  0.120534313520650 -0.041770057803413
-    4  (  4)  0.026789230886550 -0.060849702419905 -0.088673365261613
-    5  (  5)  0.008004711197727 -0.108432873838655  0.185071361149962
-    6  (  6)  0.020116775504235 -0.047889712574718 -0.001523439225442
-    7  (  7) -0.023964360822185 -0.043618854823263  0.177454217319223
-    8  (  8) -0.226734396044438 -0.102481459206944 -0.008115223439087
-    9  (  9)  0.000423083368406  0.309060226547434 -0.090400550219427
-   10  ( 10) -0.308249178857435  0.001017567434936  0.330623886780632
-   11  ( 11)  0.090136758927266 -0.334530610017321 -0.000453348817603
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000379496190680  0.036516557673727 -0.022488411844201 -0.041143099111719  0.015151024607555 -0.009820525598214 -0.001328546168408  0.002719718233480 -0.079787685858295
-    1  (  1) -0.035173743352485 -0.000509376348503  0.021748140811100  0.018984912310085  0.002571720003760 -0.101540537848848 -0.014107119535580 -0.020961802105584 -0.100916916558314
-    2  (  2)  0.024420430259890 -0.020833264343634  0.000589210441902  0.028690810435666 -0.025063562199365 -0.056845698692633 -0.019362765266970 -0.000534124800005 -0.061230653902760
-    3  (  3)  0.039980341452345 -0.019929624233720 -0.028127725164783 -0.000384377200086  0.012223469426354  0.007870420436516  0.021500821930750 -0.002985124038023  0.055850425927213
-    4  (  4) -0.015033200445576 -0.003096204403696  0.023799943458502 -0.011898049659739  0.000036971633887 -0.000277032322295 -0.021239662546675  0.005095064856192 -0.060237805990277
-    5  (  5)  0.010708008535887  0.101587409014600  0.056660431011914 -0.007350368054025 -0.000126941263904 -0.000065704202214  0.008506831299188 -0.011228150905342 -0.011964202302477
-    6  (  6)  0.000469087338482  0.014200163610075  0.019097267233085 -0.021632296910845  0.021392214011008 -0.008495741848254 -0.000109627873962  0.021812533614874  0.020464844726232
-    7  (  7) -0.002889338898616  0.020632474935553  0.000453752095144  0.002975803626006 -0.005037506724376  0.011335159213681 -0.021733393798695  0.000007087204356  0.019955598928897
-    8  (  8)  0.081293710509515  0.100918057466141  0.060971767857812 -0.055875536861090  0.060631757745431  0.011264467031019 -0.020209151997608 -0.020081495210629 -0.000340983773767
-    9  (  9) -0.080516503167305  0.106262951221757  0.031461397073353  0.007056184146683 -0.022432192781915 -0.017093833942137 -0.097099983466552  0.001349018368294 -0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.079753101670227
-    1  (  1) -0.106710217482987
-    2  (  2) -0.031619499292907
-    3  (  3) -0.007164069356259
-    4  (  4)  0.022223903647397
-    5  (  5)  0.017462464724719
-    6  (  6)  0.096957045420818
-    7  (  7) -0.001243112172754
-    8  (  8)  0.004611313750592
-    9  (  9)  0.000252169760563
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055343853322395  0.005338522209203 -0.036325792187091  0.020411379114398 -0.005004472559017 -0.030883540419705  0.019693764112942  0.000404480716013  0.025396203204216
-    1  (  1) -0.006570683600848  0.008768421568488  0.011573795638563 -0.000009175751903 -0.002770565739659 -0.004931208897901  0.022163570789429 -0.003290104656908 -0.003254936700297
-    2  (  2) -0.001674419203277 -0.021967102120902 -0.025831824909554  0.024758928994745  0.009340908203812 -0.034459015755376 -0.010228225914487  0.005919790861067  0.058115699230390
-    3  (  3) -0.007779977639509  0.106141218473434  0.050482163293278 -0.041812559908941  0.042606909564863 -0.016938249582167 -0.022723831963497 -0.018285942873731 -0.061788101761112
-    4  (  4)  0.087397972334062 -0.164590469335859 -0.035983465272717  0.095460926704216 -0.183399304764373  0.073380967092300  0.038295030471351  0.047026058194857  0.066959437295317
-    5  (  5) -0.293750190777910 -0.042648437038433 -0.056404874075468  0.100193237694056 -0.123782490033077  0.014652582564902  0.036251400704161  0.016769125982848  0.023410414575794
-    6  (  6)  0.063526410041118  0.042202406515953 -0.107158367449000  0.011222400592515  0.032805848689894  0.070775222023081 -0.034269417179590 -0.097599209765295 -0.095048599779477
-    7  (  7) -0.039213631545190 -0.016300797142278  0.022834925899151 -0.106699749704471  0.109813770660251  0.000567880224415 -0.192962587636570  0.013162275101134 -0.042958800457043
-    8  (  8)  0.207671023275567  0.021761663181296  0.066317329893717 -0.113575721461044  0.208505431005016 -0.053139089145086  0.182387663583988 -0.049317657695772 -0.039898751560786
-    9  (  9) -0.031717525025615  0.035452316963842 -0.019040840253717  0.049757955126745 -0.003315672276934  0.048439544916052 -0.094357742781682 -0.007725852797236  0.042206115018339
-   10  ( 10) -0.030723138202058 -0.012685537900520  0.130253036286197 -0.070878549267589  0.073822499716479  0.176856315004232  0.024096584449109 -0.033980770130198  0.029602022179569
-   11  ( 11)  0.076338046412608  0.058007647538535  0.059625157558161  0.072355446358478 -0.100714683926583  0.028164062896195  0.037103331661254  0.004159802100780  0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007837140573608
-    1  (  1)  0.001271351061977
-    2  (  2) -0.056316152671545
-    3  (  3)  0.023558705106194
-    4  (  4)  0.071677402926291
-    5  (  5)  0.031036091810970
-    6  (  6) -0.060669139129724
-    7  (  7) -0.008329217020035
-    8  (  8) -0.058082899762783
-    9  (  9) -0.050026765138378
-   10  ( 10) -0.030419330923301
-   11  ( 11)  0.028289350786073
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010782784489972 -0.013050845930128 -0.033023155215664  0.015191714992095 -0.005425132814901 -0.026116394662957  0.007256800612108 -0.004570990183776 -0.083505985646911
-    1  (  1)  0.004775248888120  0.019609050610054 -0.043741880650327  0.000073954161324 -0.027319440587928  0.081090619324759  0.046094626593374 -0.004371816989341 -0.079334747598806
-    2  (  2)  0.007829067250874  0.005611745899100  0.069924533643314 -0.039501674728206 -0.000927353784976  0.005421401951033  0.003817544999769 -0.008629946885833 -0.093259618314415
-    3  (  3) -0.018327078243591  0.003795046417131 -0.017900293895817  0.029796535142542 -0.026342994062962 -0.087573876827112 -0.029918989049988  0.054199220040285  0.044809777400716
-    4  (  4) -0.027183503470872 -0.089536481638857 -0.084857160463068  0.036527297001861  0.242538124561929  0.016430382958973  0.030531081573579 -0.170538311757182 -0.261658379411546
-    5  (  5)  0.020462782587523 -0.074168804451800  0.167834230231717 -0.149604127852478  0.243854217657690 -0.044978789492557 -0.032478673883371  0.164731310430024 -0.003040851330374
-    6  (  6)  0.075422914773902 -0.018345498918631 -0.109883881828728  0.119442941495868 -0.084779039670754  0.177672686986939 -0.254932779745392 -0.179910297504286 -0.058420300218360
-    7  (  7)  0.077293940205111  0.171942167313393 -0.155379720343131  0.213627786676900 -0.203405159942268  0.435742440136601  0.116233082588661 -0.403785601702878 -0.048376113482094
-    8  (  8)  0.113887453356696 -0.134815689960008  0.121289875435757  0.381302435842573 -0.140362613154441 -0.094837304770689  0.044125422076338  0.354102164255088 -0.021060221761777
-    9  (  9) -0.010381942177856  0.091513821594073 -0.090489398632436  0.104640269057990 -0.011526746486386  0.174325672883320 -0.095096801177535 -0.162567420891194  0.086584233440007
-   10  ( 10) -0.046140785323826  0.004506559121454  0.092261546126996 -0.049590165687623 -0.056546117609635 -0.023211770714739 -0.114566901687301  0.007355072527000 -0.045260763292278
-   11  ( 11) -0.210277389085871 -0.043479475791959  0.002620356919958  0.027295607176521  0.213582758279457  0.049406759718245 -0.038753842401848  0.045549481042434 -0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.000588783769111
-    1  (  1) -0.095074877441065
-    2  (  2)  0.094269658052775
-    3  (  3)  0.087042465113366
-    4  (  4) -0.229147969925312
-    5  (  5)  0.037090740492870
-    6  (  6) -0.008539965499391
-    7  (  7) -0.114631280540035
-    8  (  8)  0.035100938386537
-    9  (  9) -0.119410852550345
-   10  ( 10)  0.048938543804445
-   11  ( 11) -0.026842233365654
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000083177655875 -0.020596022225207 -0.023074380682109 -0.123906982660277  0.115856799969175  0.077548996218664 -0.033724258035794 -0.015583195761424  0.055304180213594
-    1  (  1)  0.020496643104719 -0.000177442053919  0.044849161409626  0.200056054082230 -0.192734988239744  0.095810846356379 -0.089592000858118 -0.154865722471105  0.062884487656521
-    2  (  2)  0.022893568520427 -0.044914234916282  0.000286887581780 -0.110147204900385  0.098101481651214 -0.037544614577033  0.063107876559817  0.057867129267241 -0.133662561842804
-    3  (  3)  0.123637708691857 -0.200030347190693  0.110276511900212  0.000067254700333 -0.150932238527093 -0.295587503177329  0.155559256339819  0.250191288225748 -0.068514494250419
-    4  (  4) -0.115217909263092  0.191910599591419 -0.098719023514077  0.150564412486325  0.000108066296459 -0.207017027157466  0.092817557275927  0.119727699718554 -0.027839136386995
-    5  (  5) -0.077201349586182 -0.095637330323257  0.037580888266386  0.296037283435946  0.206488013849544 -0.000677656990837  0.030142059938078  0.107860538698997 -0.317965442908009
-    6  (  6)  0.033520398034563  0.089301712720516 -0.063135446629119 -0.155494983890111 -0.093120397549751 -0.029958661714230 -0.000263665833745 -0.031787895548351 -0.052772032197117
-    7  (  7)  0.015173638148760  0.154650785159269 -0.057964322733043 -0.249885773107303 -0.119546085272213 -0.107827018648257  0.031752436246544 -0.000037065640674 -0.211400361545441
-    8  (  8) -0.055452136609395 -0.063704146851438  0.132109776961381  0.067534716804367  0.027512182553154  0.319330567201196  0.051501501228049  0.211684727134552  0.000062825592229
-    9  (  9) -0.059987775905021  0.059013360455393  0.001731139538261 -0.025602282087959  0.077406198911912 -0.032289392048789  0.044673931971007  0.007013222782529 -0.205272148471903
-   10  ( 10) -0.040816969333319  0.029839999727295  0.097606908985792 -0.012730679444132 -0.052120800982420 -0.047092545087938  0.097199457935824 -0.008100744465293  0.194519063749344
-   11  ( 11)  0.105565276750546 -0.086850909183234 -0.141349531156014 -0.064538795649442 -0.048769909889220  0.098670307723293 -0.132937762954191  0.091749745952861  0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.059727136016838  0.040967341903913 -0.106287777222309
-    1  (  1) -0.058687758282915 -0.029394471353826  0.086811620398375
-    2  (  2) -0.001293940264555 -0.097641591345113  0.142636172226853
-    3  (  3)  0.025821629306306  0.013207208477272  0.063793857996761
-    4  (  4) -0.076409112526474  0.052575212530451  0.047414860037356
-    5  (  5)  0.032527517350565  0.045632421732577 -0.095160623491729
-    6  (  6) -0.044231942651703 -0.096152133696301  0.132935625343693
-    7  (  7) -0.007372100254253  0.008488811567739 -0.092713079820202
-    8  (  8)  0.206938183650805 -0.192802275414426 -0.052611900153123
-    9  (  9) -0.000608554890156  0.088592533061698 -0.344380743508036
-   10  ( 10) -0.088950131298492 -0.000863284429953 -0.222751022723935
-   11  ( 11)  0.341005102874300  0.224718204882492 -0.000326394311109
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000338557997552  0.011375035743392 -0.029451193209236  0.012043586883828  0.021579660859347 -0.039033326019946  0.009990415550092 -0.009478976983628  0.045907412693585
-    1  (  1) -0.013672223167698  0.000473657715584  0.014851568055555 -0.021895587564371  0.022163590605075 -0.051246172607775 -0.019257625103746 -0.003658602851281  0.019552361048058
-    2  (  2)  0.032608942325713 -0.014402827198054  0.000746991250603  0.029107751732300 -0.054720608245644 -0.057033646383303 -0.001872360780591  0.031698780852448 -0.056602981887733
-    3  (  3) -0.014268935231542  0.021459967996182 -0.030313065636317  0.000730068456009  0.016766656065195  0.058973632357354  0.003002419788061 -0.022431580465626  0.134333948620083
-    4  (  4) -0.022372891038515 -0.021355779916377  0.052959509294565 -0.015751198634933  0.000391938857969  0.016109226068828 -0.004538544158672  0.050308920012661 -0.059340919102150
-    5  (  5)  0.040216234763810  0.051875751817174  0.055849318880052 -0.058120412757832 -0.016460961175898 -0.000645475334216 -0.019024299026328 -0.068804307634402  0.024311188622736
-    6  (  6) -0.009930727984206  0.019074682595569  0.002242770131548 -0.003091320851947  0.004596281406168  0.019032186967740 -0.000074596378968 -0.032870219636189  0.006741182978715
-    7  (  7)  0.009279418369258  0.004264018479381 -0.032087681361723  0.022624894165436 -0.049954824766487  0.068907285150032  0.032867640818893  0.000029995356356  0.011652937852273
-    8  (  8) -0.047260005865874 -0.018493502167014  0.056736132845076 -0.135589678169431  0.059916509278318 -0.024164421049794 -0.007333544303120 -0.011763030881780  0.000264400142459
-    9  (  9)  0.016875007958598 -0.031435494057685  0.089048257959160  0.041017085631602 -0.020420285065562 -0.066513023484078 -0.000739604154969  0.091958006244489 -0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.016438561460291
-    1  (  1)  0.031819705279686
-    2  (  2) -0.089217438029428
-    3  (  3) -0.040553914705774
-    4  (  4)  0.020554472275814
-    5  (  5)  0.066048736736302
-    6  (  6)  0.000688806170902
-    7  (  7) -0.091248940256931
-    8  (  8)  0.027663919394381
-    9  (  9)  0.000090314260367
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.011888856297006  0.017750932125153  0.030381401096490 -0.012819546160996  0.007239420422718  0.024248756043407 -0.008035757610220  0.005364063357974  0.085646323747472
-    1  (  1) -0.005014728223890 -0.026640078285976  0.053625852742063  0.001580773154934  0.029513947501511 -0.084681976949646 -0.049070075720108  0.003015931693788  0.083533135335069
-    2  (  2) -0.005701802857788 -0.001861436552455 -0.077309348516175  0.039227298256145  0.002806617492516 -0.004668173879327 -0.004051055445085  0.009725469213679  0.098722432349714
-    3  (  3)  0.016358351457124  0.001723600627698  0.021225514928062 -0.039815087581337  0.022808569998795  0.104140287911999  0.033233738030323 -0.056382556071864 -0.046907957767316
-    4  (  4)  0.023138877563353  0.095098707280146  0.087666288227931 -0.037561492255805 -0.255193211004254 -0.015544572331716 -0.030557402755123  0.180093964112144  0.259856355700386
-    5  (  5) -0.024228572043234  0.082834757201086 -0.181139504221043  0.153944959591839 -0.252818375021614  0.048862178579716  0.036094966909273 -0.170640955267472  0.004551713568432
-    6  (  6) -0.085402345559358  0.022737485412840  0.117389155338347 -0.122686430467103  0.089994929534087 -0.186662776489158  0.276334552924253  0.188945818003174  0.062512631958960
-    7  (  7) -0.077377916753636 -0.184413390881742  0.161635032551528 -0.217081818449181  0.216158931990711 -0.452250331823368 -0.121365143499215  0.427486936599919  0.051141830029037
-    8  (  8) -0.109996402529651  0.145159792225805 -0.137471198251747 -0.396423044911114  0.145941263905056  0.104134158957014 -0.041227108112442 -0.369426049626710  0.017681253264412
-    9  (  9)  0.015271329763023 -0.091667642816572  0.093167229349338 -0.105178289783052  0.012072216330151 -0.184888670947420  0.104021366500691  0.173041839821099 -0.089774142402176
-   10  ( 10)  0.051871879465497 -0.004911726396439 -0.095027344602311  0.050235453581707  0.056755121586123  0.023277306660177  0.123771404812450 -0.008953154661311  0.042342746566353
-   11  ( 11)  0.213874614633354  0.038620645156941 -0.003918905035704 -0.027644952213642 -0.227437070959628 -0.047768116418487  0.043243210008693 -0.046251908849224  0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001231945309971
-    1  (  1)  0.099118498855930
-    2  (  2) -0.099462956417043
-    3  (  3) -0.089788110354890
-    4  (  4)  0.236379406660322
-    5  (  5) -0.043290372964682
-    6  (  6)  0.008471875583563
-    7  (  7)  0.118429426587662
-    8  (  8) -0.041151812398786
-    9  (  9)  0.121668252978460
-   10  ( 10) -0.047795297768532
-   11  ( 11)  0.026000603113831
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.092723408151075  0.057215092134940  0.054154926215137 -0.012957083117559 -0.028122190094715 -0.031179347218855 -0.013645641371598 -0.009921258172339 -0.037242536390232
-    1  (  1) -0.019990430092613  0.002382806987559 -0.016009786257367 -0.011651136664597  0.017212414198990  0.024265249236370 -0.152443472946687  0.006755616148329 -0.024207249541319
-    2  (  2) -0.009030755895234 -0.085216520460363  0.016500441499831  0.009813164947617  0.015713678712422 -0.028373503652355  0.075877310310795 -0.039590492962937 -0.081270933339189
-    3  (  3)  0.075043611755008  0.103608833794547  0.030676505925522  0.013143510199953 -0.006187488557257 -0.045202449901574  0.041605892889482  0.001210820793539  0.045033631139440
-    4  (  4)  0.122337112724117  0.176460576265088  0.085321001863374 -0.041690733440160  0.111448222796030 -0.083092300673138  0.094252463151414 -0.071551603610925 -0.059851091994803
-    5  (  5) -0.372712635775664 -0.109553572239785 -0.087636097688831 -0.161393941368917  0.091711881285738  0.083559837956631 -0.084048684818413  0.114275654348762 -0.004760374961166
-    6  (  6) -0.030431995544059  0.095321795210779 -0.159145740022025 -0.376304340373359 -0.189004479350399  0.100683798175242  0.128902751762968  0.567857709085750  0.002399331341204
-    7  (  7) -0.344039522571259 -0.114279634125077 -0.003626426979965  0.177981236436906  0.027932329764501  0.026442462397652  0.246808699479261 -0.268819164710932  0.106523620842343
-    8  (  8) -0.111643207885322 -0.002836247769573  0.018154026503924  0.097243438328650 -0.121498121615664 -0.006682650130485 -0.107315976978454  0.036939727738377  0.063237979028415
-    9  (  9)  0.063921675215150  0.215994652248761  0.065707412514049 -0.003935136905129 -0.142641982827575 -0.026699050855783  0.056962954862571  0.164747861484427 -0.081509018515780
-   10  ( 10) -0.058030998072116 -0.060474289846612 -0.205628226890442 -0.038897333798042  0.068097699807560  0.116172285533776  0.038858694654200  0.255643829382515 -0.001247633054968
-   11  ( 11) -0.085574013220044 -0.030726962638802 -0.008247473867838 -0.106409310393215  0.064469816287686  0.072180462194277  0.022620356444758  0.070649638629627 -0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015293746360799
-    1  (  1) -0.020176832366409
-    2  (  2) -0.007468634139779
-    3  (  3)  0.002013486296780
-    4  (  4) -0.055907379643807
-    5  (  5) -0.014548062338959
-    6  (  6) -0.210557719542813
-    7  (  7)  0.107773752705760
-    8  (  8)  0.004939471027833
-    9  (  9) -0.101796072438763
-   10  ( 10) -0.052197801100809
-   11  ( 11)  0.010791942309942
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000245185765728  0.004422769142209  0.195473142624697 -0.067124189998810 -0.027096370068160 -0.099320185873800 -0.032910569428743 -0.079494520674282  0.016762710819247
-    1  (  1) -0.004388313593185  0.000165290846899 -0.188129406432792  0.063756474949075  0.001128748240139  0.126263116741295  0.303817994309096 -0.069854530583820 -0.010310792522154
-    2  (  2) -0.194444327410373  0.187906024270824 -0.000538868177065  0.115697813615881  0.188025580722992  0.063555095149569 -0.109038200896130  0.123360187528163 -0.037347597176070
-    3  (  3)  0.066590814481336 -0.063203632987523 -0.115347217679990  0.000002301796994 -0.034584588669551 -0.038983157581533 -0.229948513873159  0.131721887952800  0.028384936970778
-    4  (  4)  0.026403437308072 -0.000527986476725 -0.186677671985474  0.034818437947430  0.000320297338463 -0.037865478650564 -0.201451121997014  0.109301689008128  0.005643097026329
-    5  (  5)  0.099409584232992 -0.126346592032007 -0.064419008019557  0.039794220656347  0.036855903902447  0.000190318965932 -0.088891480212760  0.056789849447140 -0.091073030281233
-    6  (  6)  0.033050985013878 -0.303259624681304  0.108281756633666  0.230173439372417  0.201331671706094  0.089930560146314  0.000311452672695  0.221067383348441  0.053494283573947
-    7  (  7)  0.079472710309908  0.069297203366025 -0.125033677339702 -0.131451975782708 -0.110125569334720 -0.054839641157466 -0.219945401741596  0.001085047372961 -0.089073871816377
-    8  (  8) -0.016952142014388  0.010421932566239  0.036927801153181 -0.027792238689701 -0.005351459000165  0.090892785458666 -0.052690955519676  0.088985197141446  0.000032698621213
-    9  (  9) -0.149061020700740  0.058621114959186  0.279965277538519  0.021488283829580  0.044200621925698  0.026904718590704  0.074208134755608  0.037354078157659  0.137372829291651
-   10  ( 10)  0.035190315077894 -0.050814828300922 -0.151303785089698  0.062867991520111  0.077053666036856  0.075037906181509 -0.133385625358484  0.006791369727277  0.121764957568739
-   11  ( 11) -0.016457666688676  0.009560970830020  0.030160709068648  0.052615429880776  0.007184814870880 -0.147317585107930 -0.048007656104932 -0.024985856634055  0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.149527127949477 -0.035025203143730  0.017236912650706
-    1  (  1) -0.058313378902528  0.050420942142557 -0.009474518218355
-    2  (  2) -0.278325755481738  0.150562770304950 -0.029989264213428
-    3  (  3) -0.020585218415975 -0.063268588986747 -0.052977667343551
-    4  (  4) -0.042114256624995 -0.077316775027134 -0.007960467665663
-    5  (  5) -0.031625284755674 -0.074462306356205  0.148447086799088
-    6  (  6) -0.074615124808937  0.133170285550522  0.049651682674137
-    7  (  7) -0.041592449377408 -0.005910763914811  0.024358506166719
-    8  (  8) -0.138294110971387 -0.121744291260784 -0.107918344276425
-    9  (  9)  0.001133592488713 -0.474400799155993 -0.192590673354496
-   10  ( 10)  0.472105353620486  0.001334835966633  0.192285927563244
-   11  ( 11)  0.191497735915320 -0.194932828964948  0.001344945845524
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000738836304181 -0.037293198581408 -0.029451404620807  0.009378792471894 -0.055701113540954  0.035128933511984  0.013954700067714  0.072836702551235 -0.051857122483535
-    1  (  1)  0.032660614374695 -0.002015876922290 -0.074058480716263  0.021479421330690  0.014966422603257  0.166979967788261  0.013073252080067  0.022556560940623  0.170972365950935
-    2  (  2)  0.029165553040464  0.073308940131147 -0.000753195727027  0.033014777438001 -0.000651481686764  0.016615463822703  0.030045410532860  0.013342873064028  0.078343409399381
-    3  (  3) -0.010384415064446 -0.021326871974424 -0.031305865808474 -0.000583541727095  0.005150844265660  0.010972964083321  0.024667426696971 -0.003421011953857  0.027197309287279
-    4  (  4)  0.055501401866642 -0.014297660722118  0.000710544848112 -0.005493793084614  0.000124683940717  0.025126510553785  0.000947638436962  0.017069455654223 -0.023650915169846
-    5  (  5) -0.033803616927021 -0.164339399892725 -0.017068168082329 -0.010030727560507 -0.025241735580020 -0.000735433014139  0.028603795353780 -0.023029380344413 -0.027599055296252
-    6  (  6) -0.013107540346806 -0.012828435687407 -0.030286401438565 -0.024713021163335 -0.001063605161759 -0.029296491836886  0.000025149030498  0.111104514389532 -0.102861376746943
-    7  (  7) -0.072733387901303 -0.022465577956558 -0.013436829086647  0.003433808737295 -0.017048766876852  0.023125015384758 -0.110934303358415 -0.000037875914124 -0.002935696551342
-    8  (  8)  0.053267672687232 -0.170660201820078 -0.076657788504288 -0.028160893222526  0.023606436991553  0.027690933408034  0.102626814241324  0.002887530223588 -0.000373637330912
-    9  (  9) -0.004804828900057 -0.224333052817770 -0.065186758028368 -0.004091068046870 -0.039040275694483  0.042976408882840  0.051197675519228  0.024101682646066  0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.005026329948406
-    1  (  1)  0.225373696682354
-    2  (  2)  0.064686362479745
-    3  (  3)  0.004567750792129
-    4  (  4)  0.038996417519414
-    5  (  5) -0.043485644851561
-    6  (  6) -0.051601626537389
-    7  (  7) -0.023715023759407
-    8  (  8) -0.001115391080639
-    9  (  9) -0.000048164004682
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.087860740756488 -0.068261038905906 -0.057593788019307  0.011454237083441  0.027305499289367  0.032385982368371  0.018173477269549  0.009363386608796  0.038732450559880
-    1  (  1)  0.013249632151170  0.004184657414979  0.019716507976896  0.014744696478638 -0.016703323694180 -0.027386275287573  0.163732376866413 -0.007136524293248  0.024482820661864
-    2  (  2)  0.007013218896085  0.084657964294727 -0.026004205374563 -0.008076798202963 -0.011641159214614  0.031112856231507 -0.081756432692912  0.043486513055778  0.085001128307205
-    3  (  3) -0.058477500387638 -0.110048615847953 -0.032104075685968 -0.014807417786102  0.004697674213231  0.048123068402958 -0.048143599431998 -0.000645092439839 -0.047260089330542
-    4  (  4) -0.110574498742467 -0.188131348104213 -0.086636459451987  0.041361686502598 -0.118556992954628  0.089270642674348 -0.104552978829704  0.075153301656795  0.057940099039356
-    5  (  5)  0.371487279658724  0.115772941053656  0.094845419594772  0.167070991238391 -0.094497706414686 -0.087134798346335  0.079465840043241 -0.119932858558240  0.004312964076576
-    6  (  6)  0.035255689937620 -0.112028499449997  0.168145842580037  0.392683527257363  0.194284650981365 -0.110254467391126 -0.135773335198962 -0.599025983356266 -0.001116295743642
-    7  (  7)  0.362602042970953  0.115938705836042 -0.002852393959785 -0.186519834338995 -0.026972926522319 -0.023780474127448 -0.271135694461778  0.284033125501378 -0.111247570725030
-    8  (  8)  0.111196944464455  0.001239941376560 -0.021205830532168 -0.101329748088148  0.128975240085324  0.010144197632550  0.108358474715393 -0.037918096280026 -0.066572090545295
-    9  (  9) -0.090967744709768 -0.211201922436275 -0.066377513424381  0.007899083102241  0.154707771160094  0.037980948657754 -0.073559352539101 -0.172041273327275  0.087426840520207
-   10  ( 10)  0.070112475488657  0.079061926736069  0.222919508358954  0.040775801294398 -0.061424635747658 -0.113162621408555 -0.037903862973014 -0.270692474130444  0.009570796789139
-   11  ( 11)  0.090924578792926  0.040585886130445  0.000311072794648  0.117174234675791 -0.063663959894116 -0.077941781302743 -0.027645133174923 -0.073495241874676  0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015882565008118
-    1  (  1)  0.020403231736073
-    2  (  2)  0.007241270504095
-    3  (  3) -0.003144444710549
-    4  (  4)  0.058793064689134
-    5  (  5)  0.012293150809123
-    6  (  6)  0.215177196230389
-    7  (  7) -0.113635102585609
-    8  (  8) -0.004824845555481
-    9  (  9)  0.113550918048735
-   10  ( 10)  0.063789409560574
-   11  ( 11) -0.007009974437012
-
 	Computing Mu_X-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.846356606609
-	   1        18.555074266671    6.643e-01
-	   2        22.075193066305    2.999e-01
-	   3        22.166162582675    4.438e-02
-	   4        22.198725038235    1.790e-02
-	   5        22.196883805714    4.917e-03
-	   6        22.195656618255    1.496e-03
-	   7        22.195974558760    5.316e-04
-	   8        22.196061063112    1.890e-04
-	   9        22.195992155624    8.373e-05
-	  10        22.195966503337    4.271e-05
-	  11        22.195979843169    1.924e-05
-	  12        22.195997191192    5.833e-06
-	  13        22.196002010796    1.779e-06
-	  14        22.196003096576    6.978e-07
-	  15        22.196002913692    2.475e-07
+	   0        13.846356476046
+	   1        18.555074079128    6.643e-01
+	   2        22.075192821211    2.999e-01
+	   3        22.166162335795    4.438e-02
+	   4        22.198724790433    1.790e-02
+	   5        22.196883557838    4.917e-03
+	   6        22.195656370422    1.496e-03
+	   7        22.195974310923    5.316e-04
+	   8        22.196060815271    1.890e-04
+	   9        22.195991907784    8.373e-05
+	  10        22.195966255497    4.271e-05
+	  11        22.195979595329    1.924e-05
+	  12        22.195996943353    5.833e-06
+	  13        22.196001762957    1.779e-06
+	  14        22.196002848737    6.978e-07
+	  15        22.196002665853    2.475e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 9.655e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         1.993082407700
-	   1         2.661926789841    2.285e-01
-	   2         3.125160542473    1.040e-01
-	   3         3.153871273451    1.965e-02
-	   4         3.155350925518    5.736e-03
-	   5         3.155148466774    2.268e-03
-	   6         3.155339561298    5.752e-04
-	   7         3.155380391401    1.612e-04
-	   8         3.155370823029    5.839e-05
-	   9         3.155369244220    1.838e-05
-	  10         3.155369273694    7.314e-06
-	  11         3.155369577595    2.307e-06
-	  12         3.155369753410    5.947e-07
-	  13         3.155369780718    1.776e-07
+	   0         1.993082395865
+	   1         2.661926771206    2.285e-01
+	   2         3.125160515699    1.040e-01
+	   3         3.153871245653    1.965e-02
+	   4         3.155350897619    5.736e-03
+	   5         3.155148438865    2.268e-03
+	   6         3.155339533379    5.752e-04
+	   7         3.155380363480    1.612e-04
+	   8         3.155370795108    5.839e-05
+	   9         3.155369216299    1.838e-05
+	  10         3.155369245773    7.314e-06
+	  11         3.155369549674    2.307e-06
+	  12         3.155369725490    5.947e-07
+	  13         3.155369752798    1.776e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 6.239e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.491633833038
-	   1        14.325528173618    4.600e-01
-	   2        15.946338717172    1.816e-01
-	   3        16.002988012937    3.251e-02
-	   4        16.024404984176    1.379e-02
-	   5        16.024117426069    3.296e-03
-	   6        16.023484349499    1.102e-03
-	   7        16.023632588530    3.675e-04
-	   8        16.023661948343    1.113e-04
-	   9        16.023637390458    3.827e-05
-	  10        16.023630697228    1.296e-05
-	  11        16.023634244941    4.076e-06
-	  12        16.023637265724    1.779e-06
-	  13        16.023637797344    7.230e-07
-	  14        16.023637673535    3.149e-07
-	  15        16.023637527360    1.138e-07
+	   0        11.491633739892
+	   1        14.325528052049    4.600e-01
+	   2        15.946338573622    1.816e-01
+	   3        16.002987868273    3.251e-02
+	   4        16.024404838999    1.379e-02
+	   5        16.024117280864    3.296e-03
+	   6        16.023484204314    1.102e-03
+	   7        16.023632443344    3.675e-04
+	   8        16.023661803155    1.113e-04
+	   9        16.023637245271    3.827e-05
+	  10        16.023630552041    1.296e-05
+	  11        16.023634099754    4.076e-06
+	  12        16.023637120538    1.779e-06
+	  13        16.023637652157    7.230e-07
+	  14        16.023637528348    3.149e-07
+	  15        16.023637382173    1.138e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 4.989e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.791159923174
-	   1         7.553098419680    3.399e-01
-	   2         8.518194027602    1.388e-01
-	   3         8.582659260897    3.693e-02
-	   4         8.588885452756    1.031e-02
-	   5         8.588679902153    3.134e-03
-	   6         8.588873187545    7.089e-04
-	   7         8.588937195071    1.804e-04
-	   8         8.588925321614    6.111e-05
-	   9         8.588921396802    1.588e-05
-	  10         8.588921680481    5.619e-06
-	  11         8.588922181479    2.121e-06
-	  12         8.588922674015    6.416e-07
-	  13         8.588922766325    2.102e-07
+	   0         5.791159893401
+	   1         7.553098375112    3.399e-01
+	   2         8.518193969666    1.388e-01
+	   3         8.582659200806    3.693e-02
+	   4         8.588885392303    1.031e-02
+	   5         8.588679841673    3.134e-03
+	   6         8.588873127055    7.089e-04
+	   7         8.588937134577    1.804e-04
+	   8         8.588925261121    6.111e-05
+	   9         8.588921336309    1.588e-05
+	  10         8.588921619988    5.619e-06
+	  11         8.588922120986    2.121e-06
+	  12         8.588922613522    6.416e-07
+	  13         8.588922705833    2.102e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 8.234e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.676169332353
-	   1        15.057141797755    4.887e-01
-	   2        16.853596032682    1.830e-01
-	   3        16.904387581578    3.053e-02
-	   4        16.917668370366    1.106e-02
-	   5        16.916649326501    3.215e-03
-	   6        16.916537173305    9.443e-04
-	   7        16.916742088893    3.806e-04
-	   8        16.916723173325    1.557e-04
-	   9        16.916698709720    5.748e-05
-	  10        16.916695603839    2.165e-05
-	  11        16.916702600100    8.209e-06
-	  12        16.916706780794    2.319e-06
-	  13        16.916707584789    8.087e-07
-	  14        16.916707647601    3.498e-07
-	  15        16.916707556543    1.551e-07
+	   0        11.676169238139
+	   1        15.057141668530    4.887e-01
+	   2        16.853595878916    1.830e-01
+	   3        16.904387426930    3.053e-02
+	   4        16.917668215383    1.106e-02
+	   5        16.916649171503    3.215e-03
+	   6        16.916537018315    9.443e-04
+	   7        16.916741933899    3.806e-04
+	   8        16.916723018330    1.557e-04
+	   9        16.916698554726    5.748e-05
+	  10        16.916695448846    2.165e-05
+	  11        16.916702445106    8.209e-06
+	  12        16.916706625800    2.319e-06
+	  13        16.916707429795    8.087e-07
+	  14        16.916707492607    3.498e-07
+	  15        16.916707401549    1.551e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 7.316e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.697003192683
-	   1         7.412701290813    3.422e-01
-	   2         8.398847359038    1.398e-01
-	   3         8.449007540618    2.630e-02
-	   4         8.452331313248    6.136e-03
-	   5         8.451783250226    2.569e-03
-	   6         8.451917113488    8.394e-04
-	   7         8.452010648792    2.560e-04
-	   8         8.452001728013    8.428e-05
-	   9         8.452000464148    2.125e-05
-	  10         8.451999985355    7.738e-06
-	  11         8.452001063471    2.935e-06
-	  12         8.452001645265    8.138e-07
-	  13         8.452001808600    2.819e-07
+	   0         5.697003163738
+	   1         7.412701247520    3.422e-01
+	   2         8.398847301766    1.398e-01
+	   3         8.449007481902    2.630e-02
+	   4         8.452331254391    6.136e-03
+	   5         8.451783191373    2.569e-03
+	   6         8.451917054628    8.394e-04
+	   7         8.452010589926    2.560e-04
+	   8         8.452001669147    8.428e-05
+	   9         8.452000405283    2.125e-05
+	  10         8.451999926490    7.738e-06
+	  11         8.452001004606    2.935e-06
+	  12         8.452001586400    8.138e-07
+	  13         8.452001749735    2.819e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 9.980e-08
 
@@ -3056,2434 +862,274 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.098201230325156    -0.123180765782427    -0.033202860715367
-    1     -0.005923371969093     0.050810741827260    -0.134824731986808
-    2     -0.167593930540386     0.178586259084890    -0.134493401959856
+    0      0.098201230346589    -0.123180765268775    -0.033202860408374
+    1     -0.005923371966113     0.050810741960972    -0.134824732104664
+    2     -0.167593930849687     0.178586259349300    -0.134493401988512
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.072) =  -38.80517 deg/[dm (g/cm^3)]
-
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008290776080582 -0.050801504097253  0.025635294562259 -0.003046442602711 -0.019839162173202 -0.042287718066775  0.002274291905087 -0.017250301075761 -0.063217582232324
-    1  (  1) -0.005656720485448  0.005906316890016 -0.013342327104385  0.062795095869537  0.034384806675368 -0.011824889654518 -0.010091423219065 -0.046942857543920 -0.048716688440686
-    2  (  2)  0.031253511604130  0.072637650556073 -0.014421891959526 -0.004213302445553  0.070727435854801 -0.065656867197555 -0.018370400388693 -0.002385908267158  0.006354255904041
-    3  (  3) -0.059832580241196 -0.053424480759820 -0.021451003825827 -0.018138018553495 -0.036100327164171  0.016134873511603  0.024740373136963  0.003793018506519 -0.167949395515151
-    4  (  4) -0.064204693944690 -0.131652862682136  0.117404639608972  0.157417127901485 -0.230036611567443  0.047515122725740  0.039984594404843  0.125482054176259 -0.256771627646738
-    5  (  5)  0.146085129938632  0.278398764610060 -0.159854012203638  0.282968510269086  0.101365891285813  0.356608825189021  0.125659431918166  0.044422988683829  0.166646852463301
-    6  (  6) -0.076564725597579  0.133650798922835 -0.020866614443156 -0.061441481951876  0.071232976830213 -0.204259413485531  0.443726141038863  0.031546384888620  0.054109942402284
-    7  (  7)  0.171392689665179  0.199512600411571 -0.417327799251045 -0.052763427688751  0.301472803852696  0.065491949787692 -0.090135905280205  0.243374803622146  0.087314234232365
-    8  (  8)  0.052750851527397  0.070024200557922 -0.379656051510646  0.506727880893360  0.456213741194719 -0.053888497905949  0.020349944072208  0.064388593842935 -0.270869373264179
-    9  (  9) -0.321512384290440  0.557302077819714  0.036935298894209  0.154840347992778  0.003043634782132  0.230873783877613  0.106477418838008  0.187200194326970 -0.093391131247138
-   10  ( 10) -0.965723013629727  0.203375174675727  0.231799200789465 -0.113515758170139  0.032657967963446 -0.147828874479423  0.019227710807050 -0.096617606939553  0.006766409668261
-   11  ( 11) -0.210596475192897  0.094976222444135 -0.072335244920971  0.290764752768263 -0.062314851229712  0.053607127427930  0.145285323049651  0.073900587412887 -0.326764941791807
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071285844130264
-    1  (  1)  0.010066343394199
-    2  (  2) -0.108617239028194
-    3  (  3) -0.063737900590760
-    4  (  4) -0.015793155353663
-    5  (  5)  0.238781543103224
-    6  (  6) -0.065357063243315
-    7  (  7)  0.120098496018758
-    8  (  8) -0.128051536292778
-    9  (  9)  0.179029916473930
-   10  ( 10) -0.084757737907666
-   11  ( 11)  0.159141561245499
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.230778688168130 -0.557039020018502  0.102231622004203 -0.365190061837505 -0.400431097899025 -0.011240783369823 -0.138486416116495  0.002452040812742 -0.004398637078623
-    1  (  1) -0.556776142920827 -2.040315056194718  0.915507378155102  1.014426942838368  0.734278848751725  0.048588577390964  0.281167270606351  0.301449170381432  0.094768863002394
-    2  (  2)  0.102191442528323  0.915686903851560  1.209547690777273 -0.958100119655737 -0.740471389480369 -0.004947182895568  0.495915674452131 -0.139783988312968  0.095073435804183
-    3  (  3) -0.364539165929170  1.014070571549057 -0.958316089423204 -0.283348551998825 -0.131889670325022 -1.271015261428147  0.039370973643206 -0.404136843612415 -0.596543898512850
-    4  (  4) -0.399870169082361  0.732987024839952 -0.742129335372324 -0.132056740778799  0.552809694709972  0.050609502973822 -0.485130318718432 -1.569135325660496 -0.955644372877197
-    5  (  5) -0.012067668711970  0.049395634351447 -0.004235997753528 -1.269867451709877  0.052501445594591  0.142961307435960 -0.243772741862524  0.815823088969846 -1.032660122676294
-    6  (  6) -0.138184751914924  0.281444487458849  0.496109632619357  0.039289252640444 -0.483545301414318 -0.244146373994899 -2.567548494258237  0.471042691193011  0.535768572608993
-    7  (  7)  0.002443724218529  0.302692867022601 -0.138498316501231 -0.403820450806263 -1.565811046199608  0.816611901103015  0.471628294535134 -1.688652935957108  0.671482803026688
-    8  (  8) -0.004344564384300  0.094578985136196  0.094798646138089 -0.597437555079113 -0.950266206536146 -1.030172101956222  0.534632090191761  0.669551052804072 -0.286047601971907
-    9  (  9)  0.321027459692546 -0.124494588251713 -0.355830352458176 -0.608802973418470 -0.402462352421951 -0.368076132570564 -1.240230517037675 -0.910561909620175  0.043652486559104
-   10  ( 10)  0.011815823949598 -0.051101513605038 -0.395397800969984  0.309598565761669  0.194737646185127  0.053604366895841 -0.879466474650196  0.757981021960396  0.138272602216670
-   11  ( 11)  0.159425836287601 -0.085783898744993 -0.370909602534729 -0.056636941516785 -0.307385996591224 -0.268976928323790 -0.442853482929670  0.013290639913097 -0.876205899626718
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.323082673575100  0.012827323300415  0.160383781034165
-    1  (  1) -0.126844464371028 -0.052604971080148 -0.086843133976977
-    2  (  2) -0.357788273401833 -0.396667921961515 -0.371902334820724
-    3  (  3) -0.612287607386654  0.306667669522199 -0.056656844524874
-    4  (  4) -0.405472668706639  0.195190062002348 -0.306615567899281
-    5  (  5) -0.367351821286147  0.055534904015428 -0.275720960811118
-    6  (  6) -1.243158670589035 -0.884111685009210 -0.446520521343404
-    7  (  7) -0.909610092856081  0.758960738026336  0.004121680213622
-    8  (  8)  0.044479614426162  0.142510706976164 -0.890141861038879
-    9  (  9)  0.430645603358394 -0.292573864178629 -0.177569371172063
-   10  ( 10) -0.297251468770778  0.639563517042984 -0.084252875076621
-   11  ( 11) -0.176313836183732 -0.086637188746477  1.226883274744448
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.555032728737771  0.712617672671401  0.419810286882489  0.050887754227596 -0.090842975445822 -0.470640518796941  0.705404320416024 -0.102097016449215  0.079849652538938
-    1  (  1)  0.712915390108471  0.338414908248977  0.746799463635505  0.289033465951793  0.281577689527702 -0.590080565321557 -1.163166129408219 -0.188838662213219  0.235465544716902
-    2  (  2)  0.420424419523684  0.746397208582966 -0.016153704953468 -0.358852287949201 -0.952285365412292  1.041198523267407 -0.387389024226280  0.231972398395418 -1.201681468114436
-    3  (  3)  0.052990374128029  0.287939592192507 -0.356997201476426 -0.860130940767887 -1.322600194001359 -0.190991097932252 -0.172427859143025  1.049268576710733  0.759838942947354
-    4  (  4) -0.091729674999201  0.281558404761801 -0.953826965790842 -1.321136801436185  1.452847715742109  0.019357804497789  0.219531843898996 -0.321163524474806  0.383368380154908
-    5  (  5) -0.468391179467906 -0.590920943851569  1.042843901419442 -0.190946364776948  0.019284064585406 -0.578157261908740  0.477982154885554  0.309192885886468  0.350343314103329
-    6  (  6)  0.705416628116867 -1.163498224121495 -0.385221267991331 -0.173426272959358  0.218834180811751  0.478203132617135 -2.784703127021582 -0.089827446409910  0.007438070857215
-    7  (  7) -0.100892718625019 -0.189193923309364  0.233172791358426  1.048794685120079 -0.321694154621351  0.309157324551256 -0.089653742381773 -3.228872513573496  0.508232911749822
-    8  (  8)  0.078189592702616  0.235740536359493 -1.205024775916881  0.762330717256039  0.383275686836382  0.348953623655193  0.008045450505770  0.508467502681986  0.472369144605263
-    9  (  9) -0.077760701800955  0.237396383481108 -0.096343734790574 -0.354923660187535 -0.984336588474142  1.335053740742370  0.269902452459777  0.319055275759352 -0.321749140962585
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.078162493766068
-    1  (  1)  0.238847682218727
-    2  (  2) -0.098903683747888
-    3  (  3) -0.354949509542455
-    4  (  4) -0.983822640646403
-    5  (  5)  1.333720211340158
-    6  (  6)  0.269441491786924
-    7  (  7)  0.318898660493929
-    8  (  8) -0.321196908799485
-    9  (  9) -0.198768714929451
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015331616498833 -0.019922018235360  0.024795453639952  0.001428994822442 -0.007662564632869 -0.030564864466354 -0.002998096035874 -0.014184257518557 -0.050369876521864
-    1  (  1)  0.002536892896206 -0.000724332833140 -0.010931820831771  0.061385329925525  0.034527384530112 -0.002930909394968 -0.006897041777642 -0.048924198461387 -0.045892788765523
-    2  (  2)  0.055930590988109  0.061668786229878 -0.009784880887058 -0.011292178101404  0.079575226023927 -0.052325708606337 -0.009086556132667 -0.001787844130138  0.008215255410943
-    3  (  3) -0.058532225277701 -0.048285500112225 -0.015912879350588  0.001479837376653 -0.030353501548890  0.023819914693463  0.021025260847826  0.014207102374829 -0.151577267379535
-    4  (  4) -0.056221687371934 -0.122358938171234  0.112292181821658  0.146881610350559 -0.213263741399596  0.056469707520368  0.037816511197979  0.118315319709634 -0.249164851234958
-    5  (  5)  0.125699079920792  0.245765102963436 -0.144688421941741  0.269480954167622  0.108175820650901  0.330495489462815  0.121717019021094  0.042981278927133  0.139107704893676
-    6  (  6) -0.090953864200081  0.138378038123711 -0.018999653387300 -0.059021477190613  0.070107383816014 -0.188422561576096  0.422479983427336  0.027031745312951  0.054392856003620
-    7  (  7)  0.157772366372595  0.187920697768143 -0.411777035755239 -0.046692805557951  0.283266431788380  0.074879967037488 -0.084103929184262  0.226658912465472  0.075512245279510
-    8  (  8)  0.054210291452992  0.062449071960101 -0.361963320103574  0.503001997291620  0.438083797101076 -0.063050427843078  0.017066076329137  0.069221757957400 -0.257467231990446
-    9  (  9) -0.273423536032774  0.529295983026682  0.033766766508851  0.151918529592259 -0.009418984940093  0.206571120107986  0.110624885223032  0.172829785443028 -0.101427788661059
-   10  ( 10) -0.861462052752320  0.172326691424178  0.212371997651326 -0.111218596621436  0.023269411258717 -0.143388725237391  0.039930804953421 -0.091843120858856  0.022422158283106
-   11  ( 11) -0.188670480611874  0.096820345118133 -0.066190773880029  0.287205832494666 -0.059420643781434  0.064429852032339  0.150091109571506  0.074231547885084 -0.343171650309577
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.057461514086606
-    1  (  1)  0.006963958755564
-    2  (  2) -0.098129328522494
-    3  (  3) -0.059012682268642
-    4  (  4) -0.004449861106028
-    5  (  5)  0.220945294639113
-    6  (  6) -0.063939488850868
-    7  (  7)  0.102360934503055
-    8  (  8) -0.118112557417407
-    9  (  9)  0.155151984964126
-   10  ( 10) -0.077691214009347
-   11  ( 11)  0.169304339523055
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007929033245727 -0.086776514026638 -0.041466992686244 -0.000624066975311 -0.013156595381987  0.043080477030762  0.042448060293463  0.012239880545527  0.029029915184304
-    1  (  1) -0.033878180177558  0.070173508648210  0.019230609095550 -0.003533880530575 -0.001550569267327 -0.001809299397526 -0.111518736659909 -0.001270571448457 -0.012934311690280
-    2  (  2)  0.053119512373320  0.091732793273830  0.021408607612661  0.032674571200622 -0.027446877387833  0.001428368203209  0.035760699595502 -0.016168017803360  0.076110316338229
-    3  (  3) -0.111768458659199  0.032123986864070  0.006283151908271 -0.033287020781358  0.043086093005307 -0.045344868585861  0.050504244775852 -0.018808552325982 -0.035145863401031
-    4  (  4) -0.008665305449844 -0.063452607411023 -0.029600165455924  0.047115677331559  0.019168666345381 -0.031501732622098  0.317766848542404 -0.025484653465158  0.136713668607013
-    5  (  5) -0.096942829349587  0.462416830630329  0.133842090994118  0.092985874350147 -0.099421870808029 -0.234587688959823 -0.217512036032000  0.115491679731730 -0.074046828271163
-    6  (  6)  0.147504151854231  0.176016277524490 -0.101374573515317 -0.288079277305196 -0.230919141922049  0.118478695990594  0.200039409574699  0.528080641738917 -0.150345125085143
-    7  (  7) -0.042669001755884  0.443406170499069  0.389143916519812  0.161315900065673 -0.044923622848274 -0.251217580401495  0.349139344106497 -0.313375744671926 -0.105308356658894
-    8  (  8) -0.090773283284028 -0.098945242676733  0.273219850231927 -0.153556988234685  0.012049248011756  0.153837601800696  0.096783765511278 -0.036655814574288 -0.158022323654812
-    9  (  9) -0.854099711852282 -0.117772176421944 -0.239016409160077 -0.177375733867881  0.100275769298913  0.252844583057920  0.226930144139075  0.153229528005110  0.127239027610851
-   10  ( 10)  0.395991653576375  0.538214267844356  0.096531314019954 -0.336382832184142  0.099895828912763  0.055956501178133 -0.146421756050995  0.134905206743007  0.024743642762261
-   11  ( 11)  0.048495982241480  0.204014858900645 -0.274325469868742  0.134595356909103  0.084519511625804 -0.191133538480751  0.069261639154394  0.103192119612584  0.176045180364651
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.028831087335228
-    1  (  1) -0.001371858337113
-    2  (  2)  0.086279641236700
-    3  (  3) -0.002619734805492
-    4  (  4) -0.021137684583830
-    5  (  5) -0.191430382947414
-    6  (  6) -0.264284919761669
-    7  (  7)  0.000269384690538
-    8  (  8)  0.116882729881709
-    9  (  9)  0.120074711434079
-   10  ( 10)  0.053632787996257
-   11  ( 11) -0.085463803953674
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.675541283858356 -0.292064021280293 -0.790025131233222  0.039304385342315 -0.142699371183327  0.268327500474091  0.055268589173706  0.193336176520280 -0.032498607183913
-    1  (  1) -0.292005367417511 -0.068094888399427 -0.091928539573230  0.129152126993159 -0.002672883933379  0.049262453691224  0.862140772831706 -0.434895002279636  0.030957963645570
-    2  (  2) -0.789447165009789 -0.092254483472880 -0.804853040833334  0.464036191543570  0.288328515691532 -0.782373392336952 -0.359658943728641 -0.388090328975242  0.068147997029207
-    3  (  3)  0.039444395620206  0.128939281409480  0.463903578747306 -0.241479807350799 -0.029257651091736  0.289330170364477 -0.078438871496667  0.246243716348015 -0.221624488999474
-    4  (  4) -0.142005033730652 -0.003441352982276  0.286700873937055 -0.029953661733414 -0.427750919311445 -0.225593242891832  0.001248695253401  0.308372097905189  0.608170303007273
-    5  (  5)  0.266046370608821  0.051710611539180 -0.778167579408912  0.290283723006215 -0.224453112864279 -0.369348441761130 -0.137527542499239  0.160088399589127  0.333141145250294
-    6  (  6)  0.055576665996038  0.861897091141550 -0.359382180614210 -0.079367338581182  0.001316960755447 -0.139592143084602 -0.236061692038733 -0.500995422630755 -0.152924823639678
-    7  (  7)  0.191190365321726 -0.433335934056497 -0.384226491533538  0.246895934047586  0.308256930114393  0.160145299200529 -0.499551364365546  0.169042466304747 -0.232433156817922
-    8  (  8) -0.032324733830521  0.030583581869279  0.067800595440523 -0.220839746025180  0.605132330733771  0.331428074510260 -0.152991449816876 -0.231671787208498 -0.624414674119492
-    9  (  9) -0.170133827289346  0.173802608390272  0.582650141434017 -0.560382911834174 -0.212565567455627  0.095754045184088 -0.282286783247438 -0.105642205052933 -0.000539730602912
-   10  ( 10)  0.052970874353821 -0.227531715435441 -0.648876828841383 -0.696767965643644 -0.268344000354012  0.568720278318329 -0.098598860256773  0.086269937526947 -0.081275470268861
-   11  ( 11)  0.025516552524119 -0.085059735579504 -0.121415959836865  0.018097922040376 -0.846374652520441 -0.307989344147049  0.044343294285023  0.231195949738532  0.168305572109582
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.171375974411067  0.055216931376792  0.025964207813788
-    1  (  1)  0.173220084938157 -0.230603891969826 -0.085840408679658
-    2  (  2)  0.586304150506699 -0.654210189691972 -0.122677885868631
-    3  (  3) -0.564217005061761 -0.698424845148049  0.018146779332832
-    4  (  4) -0.213592841407263 -0.268356081771837 -0.851093566817366
-    5  (  5)  0.095187708087751  0.569138844284334 -0.311815017332116
-    6  (  6) -0.283847446348569 -0.099361887898569  0.045327800607922
-    7  (  7) -0.106442929251796  0.084951820105520  0.232402123183799
-    8  (  8) -0.000679287280351 -0.083181582350312  0.174842773942352
-    9  (  9)  0.184137973286679  0.103441117955563 -0.011188766481418
-   10  ( 10)  0.107554052466808  0.106515041132340 -0.165743784884080
-   11  ( 11) -0.010550245981975 -0.165913802295303  0.859885805027657
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.229655435401251 -0.279601353643965 -0.085575827802352 -0.135048509105901 -0.463462610619003 -0.365248455770507 -0.039660777368333  0.191781963250870 -0.304572804139555
-    1  (  1) -0.279047925679444  0.077319987469585  0.204439247136492  0.070123615269243  0.055860395624731  0.138642318409271 -0.343207769076389 -0.182810883095464 -0.017999280994748
-    2  (  2) -0.085240959465133  0.204263364283089 -0.311156623733494  0.294688564065330  0.229669520218161 -0.281737981462645  0.137882893674030 -0.194668648298996  0.517507397185879
-    3  (  3) -0.137052652301458  0.068817803199155  0.294513347383327 -0.628744473812505  0.688526281107777  0.166771123104115  0.212803952843010 -0.269010206604892 -0.411620416751970
-    4  (  4) -0.461604619248266  0.055843287983042  0.230054478565236  0.688395074228786 -1.421511879446005  0.180495138052121 -0.177199847230662  0.268188410470329  0.119512289645345
-    5  (  5) -0.365099883123814  0.139122909294115 -0.282780063256330  0.166251175855828  0.181093271919847 -0.292775738602585 -0.240660983788926  0.305216197970317  0.235452232882587
-    6  (  6) -0.039141072198114 -0.342047900602042  0.138302509146164  0.211959339222516 -0.177087648441962 -0.240505624310098 -0.304304277829310 -0.910739369588832  0.202811323160239
-    7  (  7)  0.191443148224360 -0.183077517400336 -0.194209029769022 -0.269384260651775  0.268168725961981  0.305441092512858 -0.910852433205190  0.029633662055934 -0.204453968987965
-    8  (  8) -0.303246852232180 -0.018509744386768  0.519514080414653 -0.413340759430442  0.119384719254151  0.236362024043069  0.201991249845660 -0.204562219955504 -0.661555776893828
-    9  (  9) -0.300472910579648  0.170014354298783 -0.291259695102906  0.029160805834281  0.317264449488489 -0.326442124436524  0.007044557482429 -0.101763181058410  0.215338723709779
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301684802635884
-    1  (  1)  0.169719322346163
-    2  (  2) -0.289724655704096
-    3  (  3)  0.029002914588453
-    4  (  4)  0.316574855082561
-    5  (  5) -0.325796183326422
-    6  (  6)  0.007131791827115
-    7  (  7) -0.101918507704736
-    8  (  8)  0.215214193797303
-    9  (  9) -0.431317970778139
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009148490318064 -0.020309806158549 -0.015977532182931  0.004014783738387 -0.010489793112351  0.029667649783295  0.020232440585606  0.011223082041042  0.023312323786938
-    1  (  1) -0.044375857230131  0.052262766826166  0.015548487373741 -0.003662802577056 -0.002781875625079 -0.001383977859398 -0.098229640468489 -0.001043710758572 -0.010909270118946
-    2  (  2)  0.054181385020550  0.080128526478900  0.022828931876126  0.037487063410101 -0.042770056882922 -0.005218720540993  0.030479703829638 -0.014823518322437  0.065536667960166
-    3  (  3) -0.129996832535740  0.025539245172390 -0.001710767497197 -0.035208153932012  0.051497303033318 -0.033810939265315  0.041923713016432 -0.018028802137201 -0.031841589713416
-    4  (  4) -0.018797598258319 -0.055382521313148 -0.025678897036466  0.042677314096974  0.024119803445938 -0.028773903589126  0.288385579456642 -0.023957336001325  0.134022392012911
-    5  (  5) -0.085790126908808  0.402408359114006  0.110878458520312  0.084218998643581 -0.097302640260559 -0.211015098306590 -0.195826989075132  0.107508726926065 -0.059970385150068
-    6  (  6)  0.117117046001707  0.164907313314791 -0.092740522447941 -0.263892346037872 -0.208050086690414  0.121861415926763  0.180654068666643  0.487980567663863 -0.134813668081860
-    7  (  7) -0.052709991074355  0.381296251220592  0.349380237841959  0.145852911752160 -0.041346590279243 -0.220669429372274  0.328816279036270 -0.285726302429830 -0.093478286390337
-    8  (  8) -0.075491834851014 -0.090622807799606  0.261184981058617 -0.148637821570292  0.006281256453519  0.144842826611815  0.089811111402247 -0.036110485207390 -0.153520220179307
-    9  (  9) -0.696164148321021 -0.104910101886221 -0.203383144631185 -0.164870629493292  0.069977329160723  0.194202208543558  0.212076681930829  0.132693764051193  0.096725293429142
-   10  ( 10)  0.348175665954885  0.434442729860845  0.069207287013024 -0.311902381205193  0.086974667298470  0.051225223079379 -0.122216101880307  0.122874476488139  0.012079820457350
-   11  ( 11)  0.044712948857676  0.176004094735536 -0.255862724288287  0.126758826080010  0.078218473139894 -0.179984369340434  0.067110991111726  0.095360581673868  0.177561710091429
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.024402944617349
-    1  (  1) -0.001173348606223
-    2  (  2)  0.076484101898115
-    3  (  3)  0.001169431615315
-    4  (  4) -0.024935532887633
-    5  (  5) -0.174540155531575
-    6  (  6) -0.236517338782017
-    7  (  7)  0.008859575697215
-    8  (  8)  0.109927192293737
-    9  (  9)  0.089534068178409
-   10  ( 10)  0.043410237741554
-   11  ( 11) -0.093132968001143
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002170644752931 -0.022324956514099 -0.029394826211345  0.023309311068680 -0.000970852822634 -0.043511040680121  0.014013985960523  0.007860305508825 -0.031314125297178
-    1  (  1) -0.004975212184910 -0.009727238108985  0.081406434912428 -0.023252939392766  0.038928067463043 -0.010458408905981 -0.034913544836836  0.014265058471693  0.051735797486860
-    2  (  2)  0.017880176100707  0.015599348022774  0.096023531696764 -0.045237679689815 -0.002431886781376  0.077281603581543 -0.027482410098613 -0.002121837766367 -0.131596950090464
-    3  (  3) -0.033671282161329 -0.042247110815725  0.017614407066521  0.120482048147517 -0.071788669015437  0.100417130949899  0.026095439370731  0.024912292415628  0.128857994704884
-    4  (  4) -0.039094504869080  0.011586636873075 -0.201648756832533 -0.417167224027039  0.232183671922422 -0.365776066782585  0.000436512477144 -0.036487401941041 -0.092913589753420
-    5  (  5)  0.107020694538732  0.188165249192967  0.272788343236859 -0.444403017959699  0.118293552778212  0.528258782415562  0.125325642779073 -0.198753130098826  0.028672980278371
-    6  (  6)  0.121158671169740 -0.085565322151460  0.088586051783133  0.010298532059028 -0.107250216094850 -0.195698840050220  0.370534853760273  0.159194784952583 -0.016512860210084
-    7  (  7) -0.033804952616344 -0.168095045341921  0.398821112602689 -0.046726828449621 -0.030609711055064 -0.217531691733838 -0.115639511714214  0.399856930098400  0.150033235311716
-    8  (  8) -0.059559370905179  0.306305036465827 -0.595923646185890 -0.119277640805674 -0.722271918559490  0.001726267262613 -0.027179920353598 -0.211451038002310  0.148912062372910
-    9  (  9) -0.188866142842736  0.096789990486457  0.236442562527094  0.092757728041313  0.072651948101216 -0.016472461695526 -0.026914575117300  0.247244600184375  0.370870606832493
-   10  ( 10) -0.406957853798143  0.141958866881762 -0.085132936917023  0.102326296221874  0.017996095944708 -0.062553443565296 -0.105319900227601 -0.005069269037988  0.006423933602228
-   11  ( 11) -0.081915250147579  0.202583484157184 -0.282203343833431 -0.339304077428364  0.118298550150489 -0.126692826807318  0.005731143361727 -0.150166092159272 -0.134968415625333
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.038183979702674
-    1  (  1) -0.001758617329220
-    2  (  2) -0.002245458358924
-    3  (  3) -0.305015280585847
-    4  (  4) -0.011707659076193
-    5  (  5) -0.052479234679287
-    6  (  6)  0.143560462314116
-    7  (  7)  0.320971036748081
-    8  (  8)  0.148594551736844
-    9  (  9) -0.097500178466871
-   10  ( 10) -0.069870490871550
-   11  ( 11)  0.082515655756872
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.053221344681142 -0.117483147833985 -0.106139723247453 -0.495823955121092  0.391515874804455  0.212402958848530 -0.083769680573767 -0.039675371517883  0.058634274306531
-    1  (  1) -0.117410394687696 -0.001165915237512 -0.133100613626654 -0.630012634533085  0.317623482499555 -0.573984529169381  0.375575851008806  0.417091736224605 -0.210582306420709
-    2  (  2) -0.106116179316557 -0.133365754849436  0.099881677186242 -0.283389270168438  0.408842653260195  0.463415082290805 -0.094461635582511 -0.339728478273951 -0.187117729157411
-    3  (  3) -0.495487159854538 -0.630575218275538 -0.284210529100489 -0.394005207299682  0.243829412824131 -0.426368810438983  0.000017569224274 -0.316982847795332  1.182262387796268
-    4  (  4)  0.391977861689502  0.318458435778042  0.410524448216213  0.243871385545647 -0.262605821454379  0.313475558817429 -0.006238164976110  0.146232809940208 -0.404783357267945
-    5  (  5)  0.211677947989569 -0.572946112183618  0.465876094202739 -0.424891649228725  0.310576368667640  0.340119032966648 -0.103399884420596 -0.366027570904681  0.140243317389270
-    6  (  6) -0.083203642949521  0.374758513857944 -0.095474380553338 -0.000848431158077 -0.007011740191065 -0.103456952640946  0.035381526355376  0.100664517850410 -0.224617556800866
-    7  (  7) -0.039824177760467  0.417269525333673 -0.339848279473418 -0.316785009817077  0.144981956006953 -0.366591938133070  0.100487370214345  0.453363803566786 -0.284080848307595
-    8  (  8)  0.058454981179204 -0.209563433448112 -0.187086823104815  1.182437825563613 -0.401897920471953  0.141960153823608 -0.223791716105096 -0.283768269790238 -0.127258563076312
-    9  (  9)  0.176473367868989 -0.113695285962430 -0.191045562239273 -0.466077182834650  0.080353173846381 -0.392419296545826  0.139310719822578  0.097667658130615  0.260382741772322
-   10  ( 10)  0.087511748605763 -0.084525637542731 -0.451433812661641  0.087442027470754 -0.075301055147615  0.128254312442896  0.066832910809452  0.040269698765907  0.083963538620684
-   11  ( 11) -0.256000473516428  0.178934738319287  0.462669412659627  0.336070869572452 -0.226364820740552  0.220661186826050  0.015682276558009 -0.019696413835863 -0.320368477367524
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.177398660643495  0.088413661062507 -0.257047850800415
-    1  (  1) -0.114710761582569 -0.086001542477366  0.179468892454740
-    2  (  2) -0.191402905701337 -0.452554194931555  0.463985875678332
-    3  (  3) -0.467548510382317  0.086605995128391  0.336310348111395
-    4  (  4)  0.080907164839857 -0.077457000042675 -0.231693183962593
-    5  (  5) -0.391713702811823  0.124122145336547  0.233240659481206
-    6  (  6)  0.139727422139028  0.065972550943365  0.014736999139443
-    7  (  7)  0.097438431199858  0.039119593081805 -0.012607893852994
-    8  (  8)  0.258370481571402  0.084693167750785 -0.328679992068142
-    9  (  9) -0.027947875522173 -0.059452680730838  0.039102598209232
-   10  ( 10) -0.061112133253744 -0.042824028656813 -0.176907573001062
-   11  ( 11)  0.036269564126208 -0.174115037047438  0.046562990208638
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.221915567502623  0.240154969163816  0.089524025753548 -0.009891539023461 -0.105352264889997 -0.079728196437896 -0.186918344067447 -0.018609216798882 -0.150218987334760
-    1  (  1)  0.239595861160914  0.097635005536382 -0.020343203465831  0.252497393963625 -0.178770889626966  0.156659860903133  0.042031186852564 -0.226739274781765  0.050354579998016
-    2  (  2)  0.090047283413814 -0.021960432152020 -0.652704165096791 -0.484235858264924  0.265074532283746 -0.870240852693915  0.056963933090132  0.087593695232780 -0.397150344061483
-    3  (  3) -0.008304023565221  0.254514964099576 -0.488668744172267  0.243914942296862 -0.497430549408554 -0.651892044099941 -0.144949354151790  0.009197770416785  0.363155689203458
-    4  (  4) -0.105368055288416 -0.178968402377489  0.265813616023428 -0.498441236963999  0.117807978177016 -0.197938223960627  0.010977461550819  0.054866508200549 -0.633466747483980
-    5  (  5) -0.079092278611567  0.155211327907083 -0.870349858528248 -0.648891955877304 -0.198852995680930  0.056118287010249  0.077393750543525 -0.820063131904850 -0.522591293712200
-    6  (  6) -0.188319262904704  0.043235387216250  0.056704467242807 -0.145342612784415  0.011176054667898  0.077123788010048 -0.017043504447154 -0.229308594149143 -0.061253571825596
-    7  (  7) -0.017449220652026 -0.226052369590475  0.086398229140611  0.009988063298837  0.055257253277244 -0.820894010869112 -0.229107411788767  0.436891114659360  0.154693358924324
-    8  (  8) -0.147652836473568  0.050157233403955 -0.397985593672069  0.364902332737576 -0.632177325650741 -0.523669848989306 -0.060883358066048  0.155008994016302 -0.331322085722016
-    9  (  9) -0.012364053013731 -0.381902018882131  0.730234455154150  0.318717588976828  0.654372705810295  0.234910934996783  0.063436038641434  0.568676727219248  0.116095919775855
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010717409085818
-    1  (  1) -0.381606046587817
-    2  (  2)  0.729520232349256
-    3  (  3)  0.319801359646356
-    4  (  4)  0.655576694394483
-    5  (  5)  0.233766377042350
-    6  (  6)  0.063681628675817
-    7  (  7)  0.569047245691214
-    8  (  8)  0.115234955131862
-    9  (  9) -0.255200733989858
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006756611009239 -0.004812319108707 -0.015155246179453  0.018768861614548  0.003263846230316 -0.029956626691063  0.007768157616613  0.008654952545397 -0.024139771998296
-    1  (  1) -0.000276876655733 -0.007317152277636  0.067126401411285 -0.013873168496829  0.038395392580021 -0.004054864162186 -0.028032553908660  0.014238200673600  0.044802348000681
-    2  (  2)  0.034311733284435  0.014478380463186  0.079037871547464 -0.037480797351928  0.004455235189999  0.068266709703376 -0.020927095140560 -0.000590179941322 -0.116436689576599
-    3  (  3) -0.034781167081690 -0.039999835648210  0.017388947621558  0.117724049135840 -0.062309713575062  0.098214530429882  0.024529272430519  0.026637769905859  0.121592113448416
-    4  (  4) -0.036088452219928  0.018119725898309 -0.181397076074172 -0.381210957896193  0.211295234548894 -0.335046977567969 -0.001001209940803 -0.032788904430710 -0.087406508170972
-    5  (  5)  0.091932999121248  0.163472911292393  0.257039057929667 -0.406986018028708  0.108362880698111  0.483755223010107  0.114747171070721 -0.179816739697054  0.021814542430540
-    6  (  6)  0.102207313652244 -0.075273825473482  0.076700485775484  0.010389199522243 -0.095145363312679 -0.177269643268087  0.339312666537493  0.145893525857585 -0.013352577122472
-    7  (  7) -0.036776384387696 -0.162278963391709  0.362818814892890 -0.043460364327904 -0.026462409718549 -0.199351982461758 -0.104180059013018  0.364628559511404  0.137093791802520
-    8  (  8) -0.054133642075650  0.281937460317668 -0.549118750139198 -0.110766566728388 -0.665283649525633 -0.004014717984651 -0.026030812844979 -0.193249298632007  0.140185869779560
-    9  (  9) -0.149539825936769  0.083496187141563  0.222414359602469  0.086467924966290  0.058519767738283 -0.026610134648035 -0.023639345193443  0.224482305471681  0.335967535114734
-   10  ( 10) -0.342551768791105  0.115343806322270 -0.079695331214451  0.094078531732984  0.012984790263811 -0.052720281866277 -0.089289783188097 -0.003161584461577  0.011520822726607
-   11  ( 11) -0.067948144123858  0.170897803094304 -0.268478044795138 -0.331752793901224  0.110501398686606 -0.120431522039808  0.010421693063374 -0.142909196950524 -0.136584264097857
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.029945709624550
-    1  (  1) -0.003777838622564
-    2  (  2) -0.000494193391228
-    3  (  3) -0.283159255072162
-    4  (  4) -0.002056849846006
-    5  (  5) -0.055491249216550
-    6  (  6)  0.134241443599212
-    7  (  7)  0.294425347600366
-    8  (  8)  0.138732741810037
-    9  (  9) -0.100744739667680
-   10  ( 10) -0.062352827286650
-   11  ( 11)  0.087587602591740
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057027762100789  0.007489633887342 -0.036964189813796  0.021384352100284 -0.004867815775604 -0.032130235858782  0.019486973797962  0.000503926514732  0.024868986663351
-    1  (  1) -0.007883399599923  0.007529104506445  0.013216566770749 -0.001554286609489 -0.002481002458300 -0.003555137440754  0.020216878378801 -0.003435265519663 -0.003420680709423
-    2  (  2) -0.005061763911744 -0.024005030999464 -0.016920245291348  0.019760528227158  0.007759414271484 -0.029231812106945 -0.009559298232843  0.004745878981161  0.053662769962019
-    3  (  3) -0.011903086348447  0.106154395386531  0.048846797682958 -0.038122834717736  0.042076447151745 -0.017515736018254 -0.021695004377211 -0.017259669010754 -0.058953679400153
-    4  (  4)  0.086846706941042 -0.161257530089836 -0.037361255861875  0.089905419413410 -0.174437646387183  0.071028892880315  0.038811212273731  0.045200518155063  0.066894551440516
-    5  (  5) -0.295118954821928 -0.042171667688274 -0.057142717280935  0.095328920031059 -0.118376834610768  0.017202604507056  0.038088685926927  0.015413673756028  0.019970185142534
-    6  (  6)  0.061695197805604  0.041447416246154 -0.107874329349021  0.009310856499629  0.028327062477196  0.072556054900044 -0.031173831746629 -0.093673016450942 -0.096470656575707
-    7  (  7) -0.040164356283535 -0.019606328824315  0.022514162311588 -0.103095269177578  0.105738125414362 -0.000251323240260 -0.190667102998226  0.014251172141516 -0.042544347999407
-    8  (  8)  0.209747539729284  0.026225521984115  0.065411218317390 -0.108576414051802  0.195951046046893 -0.054935351774023  0.181062671358124 -0.048648601818055 -0.037403343457353
-    9  (  9) -0.029537922421234  0.045187174636289 -0.013381512217286  0.049426415359509 -0.003411235911782  0.045265306723710 -0.096457278821335 -0.006113492494935  0.044165814974043
-   10  ( 10) -0.026870929841946 -0.010513244846490  0.122411818973730 -0.066300236331789  0.074150921852319  0.175359501999903  0.025219490294838 -0.031299023505132  0.032770162927265
-   11  ( 11)  0.076638806040972  0.048660864910506  0.054798136469999  0.067410404189619 -0.096042680906718  0.030077767167195  0.040609376761651  0.003350033647470  0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007613623485115
-    1  (  1)  0.001053219582711
-    2  (  2) -0.054751844139672
-    3  (  3)  0.021588797011546
-    4  (  4)  0.069416579868176
-    5  (  5)  0.031311068013170
-    6  (  6) -0.060683491342485
-    7  (  7) -0.004937786560826
-    8  (  8) -0.055843386605960
-    9  (  9) -0.053258374332423
-   10  ( 10) -0.029326398375861
-   11  ( 11)  0.027904630917537
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000025015734507 -0.010198711087952 -0.006474775958448 -0.066946051563528  0.066550206967977  0.041188873125926 -0.023552914991952 -0.019202263160422  0.006942946197737
-    1  (  1)  0.010140605887652  0.000014394957877 -0.022996796061328  0.067092192493274 -0.063685673857393 -0.019093615376604  0.005525180617760  0.015031464830750 -0.005320182556269
-    2  (  2)  0.006534739001904  0.022969584694137 -0.000183457658640  0.211551326757209 -0.218187807438925 -0.104132114893528  0.065436658246811  0.042103919182146  0.012243831904844
-    3  (  3)  0.066304931943444 -0.066584833979085 -0.210703888875489  0.000394093515089  0.011258600581601  0.092530428436357  0.131881992071255 -0.026480578605083 -0.063346368194022
-    4  (  4) -0.065779542430873  0.062822415172501  0.216601239538476 -0.011617389043850 -0.000720555249011 -0.020159848057855 -0.073942431465134 -0.001119920964031 -0.016120241216710
-    5  (  5) -0.040846799691504  0.018979734118351  0.103125251405654 -0.092549855601907  0.021623501291584  0.000771447754999  0.234552119202209  0.000611164043666  0.101606719343242
-    6  (  6)  0.023326218450828 -0.005550385111505 -0.065252405074981 -0.131681855193961  0.073575257938565 -0.233645237851028 -0.000193851682480  0.255788429172446 -0.079072823032341
-    7  (  7)  0.019055068515462 -0.014786531642521 -0.041539856986611  0.026353850726780  0.001700683540838 -0.000445480591706 -0.255766070671258 -0.000118381893033  0.151562772366571
-    8  (  8) -0.006620321009197  0.005142966830662 -0.011245852682541  0.062510776113309  0.015648596901915 -0.102272652360209  0.078381794853266 -0.152302821501449  0.000094469957927
-    9  (  9) -0.045347281960025  0.040291069791943  0.085226922335689  0.018441757598111  0.027467525239214  0.004932928889320  0.020868912898856 -0.024483356625930 -0.224180460199113
-   10  ( 10) -0.020374790573784  0.028198954860440  0.010392111666997  0.120181326176130 -0.060512260831236 -0.109015894697222 -0.047153104465120 -0.043944046420833 -0.103069326885495
-   11  ( 11)  0.049408052352300 -0.045270280246414 -0.110185553685008 -0.041594160321979 -0.088273360930753  0.183934249639257 -0.003285919080508  0.178701510068243 -0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.045673042542890  0.020717466986083 -0.050844518832522
-    1  (  1) -0.040043621408487 -0.028287827625151  0.045457031631407
-    2  (  2) -0.084888848710605 -0.010052611398803  0.109898373773783
-    3  (  3) -0.018088362425205 -0.120534313520650  0.041770057803413
-    4  (  4) -0.026789230886550  0.060849702419905  0.088673365261613
-    5  (  5) -0.008004711197727  0.108432873838655 -0.185071361149962
-    6  (  6) -0.020116775504235  0.047889712574718  0.001523439225442
-    7  (  7)  0.023964360822185  0.043618854823263 -0.177454217319223
-    8  (  8)  0.226734396044438  0.102481459206944  0.008115223439087
-    9  (  9) -0.000423083368406 -0.309060226547434  0.090400550219427
-   10  ( 10)  0.308249178857435 -0.001017567434936 -0.330623886780632
-   11  ( 11) -0.090136758927266  0.334530610017321  0.000453348817603
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000379496190680 -0.036516557673727  0.022488411844201  0.041143099111719 -0.015151024607555  0.009820525598214  0.001328546168408 -0.002719718233480  0.079787685858295
-    1  (  1)  0.035173743352485  0.000509376348503 -0.021748140811100 -0.018984912310085 -0.002571720003760  0.101540537848848  0.014107119535580  0.020961802105584  0.100916916558314
-    2  (  2) -0.024420430259890  0.020833264343634 -0.000589210441902 -0.028690810435666  0.025063562199365  0.056845698692633  0.019362765266970  0.000534124800005  0.061230653902760
-    3  (  3) -0.039980341452345  0.019929624233720  0.028127725164783  0.000384377200086 -0.012223469426354 -0.007870420436516 -0.021500821930750  0.002985124038023 -0.055850425927213
-    4  (  4)  0.015033200445576  0.003096204403696 -0.023799943458502  0.011898049659739 -0.000036971633887  0.000277032322295  0.021239662546675 -0.005095064856192  0.060237805990277
-    5  (  5) -0.010708008535887 -0.101587409014600 -0.056660431011914  0.007350368054025  0.000126941263904  0.000065704202214 -0.008506831299188  0.011228150905342  0.011964202302477
-    6  (  6) -0.000469087338482 -0.014200163610075 -0.019097267233085  0.021632296910845 -0.021392214011008  0.008495741848254  0.000109627873962 -0.021812533614874 -0.020464844726232
-    7  (  7)  0.002889338898616 -0.020632474935553 -0.000453752095144 -0.002975803626006  0.005037506724376 -0.011335159213681  0.021733393798695 -0.000007087204356 -0.019955598928897
-    8  (  8) -0.081293710509515 -0.100918057466141 -0.060971767857812  0.055875536861090 -0.060631757745431 -0.011264467031019  0.020209151997608  0.020081495210629  0.000340983773767
-    9  (  9)  0.080516503167305 -0.106262951221757 -0.031461397073353 -0.007056184146683  0.022432192781915  0.017093833942137  0.097099983466552 -0.001349018368294  0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.079753101670227
-    1  (  1)  0.106710217482987
-    2  (  2)  0.031619499292907
-    3  (  3)  0.007164069356259
-    4  (  4) -0.022223903647397
-    5  (  5) -0.017462464724719
-    6  (  6) -0.096957045420818
-    7  (  7)  0.001243112172754
-    8  (  8) -0.004611313750592
-    9  (  9) -0.000252169760563
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055343853322395 -0.005338522209203  0.036325792187091 -0.020411379114398  0.005004472559017  0.030883540419705 -0.019693764112942 -0.000404480716013 -0.025396203204216
-    1  (  1)  0.006570683600848 -0.008768421568488 -0.011573795638563  0.000009175751903  0.002770565739659  0.004931208897901 -0.022163570789429  0.003290104656908  0.003254936700297
-    2  (  2)  0.001674419203277  0.021967102120902  0.025831824909554 -0.024758928994745 -0.009340908203812  0.034459015755376  0.010228225914487 -0.005919790861067 -0.058115699230390
-    3  (  3)  0.007779977639509 -0.106141218473434 -0.050482163293278  0.041812559908941 -0.042606909564863  0.016938249582167  0.022723831963497  0.018285942873731  0.061788101761112
-    4  (  4) -0.087397972334062  0.164590469335859  0.035983465272717 -0.095460926704216  0.183399304764373 -0.073380967092300 -0.038295030471351 -0.047026058194857 -0.066959437295317
-    5  (  5)  0.293750190777910  0.042648437038433  0.056404874075468 -0.100193237694056  0.123782490033077 -0.014652582564902 -0.036251400704161 -0.016769125982848 -0.023410414575794
-    6  (  6) -0.063526410041118 -0.042202406515953  0.107158367449000 -0.011222400592515 -0.032805848689894 -0.070775222023081  0.034269417179590  0.097599209765295  0.095048599779477
-    7  (  7)  0.039213631545190  0.016300797142278 -0.022834925899151  0.106699749704471 -0.109813770660251 -0.000567880224415  0.192962587636570 -0.013162275101134  0.042958800457043
-    8  (  8) -0.207671023275567 -0.021761663181296 -0.066317329893717  0.113575721461044 -0.208505431005016  0.053139089145086 -0.182387663583988  0.049317657695772  0.039898751560786
-    9  (  9)  0.031717525025615 -0.035452316963842  0.019040840253717 -0.049757955126745  0.003315672276934 -0.048439544916052  0.094357742781682  0.007725852797236 -0.042206115018339
-   10  ( 10)  0.030723138202058  0.012685537900520 -0.130253036286197  0.070878549267589 -0.073822499716479 -0.176856315004232 -0.024096584449109  0.033980770130198 -0.029602022179569
-   11  ( 11) -0.076338046412608 -0.058007647538535 -0.059625157558161 -0.072355446358478  0.100714683926583 -0.028164062896195 -0.037103331661254 -0.004159802100780 -0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007837140573608
-    1  (  1) -0.001271351061977
-    2  (  2)  0.056316152671545
-    3  (  3) -0.023558705106194
-    4  (  4) -0.071677402926291
-    5  (  5) -0.031036091810970
-    6  (  6)  0.060669139129724
-    7  (  7)  0.008329217020035
-    8  (  8)  0.058082899762783
-    9  (  9)  0.050026765138378
-   10  ( 10)  0.030419330923301
-   11  ( 11) -0.028289350786073
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.010782784489972  0.013050845930128  0.033023155215664 -0.015191714992095  0.005425132814901  0.026116394662957 -0.007256800612108  0.004570990183776  0.083505985646911
-    1  (  1) -0.004775248888120 -0.019609050610054  0.043741880650327 -0.000073954161324  0.027319440587928 -0.081090619324759 -0.046094626593374  0.004371816989341  0.079334747598806
-    2  (  2) -0.007829067250874 -0.005611745899100 -0.069924533643314  0.039501674728206  0.000927353784976 -0.005421401951033 -0.003817544999769  0.008629946885833  0.093259618314415
-    3  (  3)  0.018327078243591 -0.003795046417131  0.017900293895817 -0.029796535142542  0.026342994062962  0.087573876827112  0.029918989049988 -0.054199220040285 -0.044809777400716
-    4  (  4)  0.027183503470872  0.089536481638857  0.084857160463068 -0.036527297001861 -0.242538124561929 -0.016430382958973 -0.030531081573579  0.170538311757182  0.261658379411546
-    5  (  5) -0.020462782587523  0.074168804451800 -0.167834230231717  0.149604127852478 -0.243854217657690  0.044978789492557  0.032478673883371 -0.164731310430024  0.003040851330374
-    6  (  6) -0.075422914773902  0.018345498918631  0.109883881828728 -0.119442941495868  0.084779039670754 -0.177672686986939  0.254932779745392  0.179910297504286  0.058420300218360
-    7  (  7) -0.077293940205111 -0.171942167313393  0.155379720343131 -0.213627786676900  0.203405159942268 -0.435742440136601 -0.116233082588661  0.403785601702878  0.048376113482094
-    8  (  8) -0.113887453356696  0.134815689960008 -0.121289875435757 -0.381302435842573  0.140362613154441  0.094837304770689 -0.044125422076338 -0.354102164255088  0.021060221761777
-    9  (  9)  0.010381942177856 -0.091513821594073  0.090489398632436 -0.104640269057990  0.011526746486386 -0.174325672883320  0.095096801177535  0.162567420891194 -0.086584233440007
-   10  ( 10)  0.046140785323826 -0.004506559121454 -0.092261546126996  0.049590165687623  0.056546117609635  0.023211770714739  0.114566901687301 -0.007355072527000  0.045260763292278
-   11  ( 11)  0.210277389085871  0.043479475791959 -0.002620356919958 -0.027295607176521 -0.213582758279457 -0.049406759718245  0.038753842401848 -0.045549481042434  0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.000588783769111
-    1  (  1)  0.095074877441065
-    2  (  2) -0.094269658052775
-    3  (  3) -0.087042465113366
-    4  (  4)  0.229147969925312
-    5  (  5) -0.037090740492870
-    6  (  6)  0.008539965499391
-    7  (  7)  0.114631280540035
-    8  (  8) -0.035100938386537
-    9  (  9)  0.119410852550345
-   10  ( 10) -0.048938543804445
-   11  ( 11)  0.026842233365654
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000083177655875  0.020596022225207  0.023074380682109  0.123906982660277 -0.115856799969175 -0.077548996218664  0.033724258035794  0.015583195761424 -0.055304180213594
-    1  (  1) -0.020496643104719  0.000177442053919 -0.044849161409626 -0.200056054082230  0.192734988239744 -0.095810846356379  0.089592000858118  0.154865722471105 -0.062884487656521
-    2  (  2) -0.022893568520427  0.044914234916282 -0.000286887581780  0.110147204900385 -0.098101481651214  0.037544614577033 -0.063107876559817 -0.057867129267241  0.133662561842804
-    3  (  3) -0.123637708691857  0.200030347190693 -0.110276511900212 -0.000067254700333  0.150932238527093  0.295587503177329 -0.155559256339819 -0.250191288225748  0.068514494250419
-    4  (  4)  0.115217909263092 -0.191910599591419  0.098719023514077 -0.150564412486325 -0.000108066296459  0.207017027157466 -0.092817557275927 -0.119727699718554  0.027839136386995
-    5  (  5)  0.077201349586182  0.095637330323257 -0.037580888266386 -0.296037283435946 -0.206488013849544  0.000677656990837 -0.030142059938078 -0.107860538698997  0.317965442908009
-    6  (  6) -0.033520398034563 -0.089301712720516  0.063135446629119  0.155494983890111  0.093120397549751  0.029958661714230  0.000263665833745  0.031787895548351  0.052772032197117
-    7  (  7) -0.015173638148760 -0.154650785159269  0.057964322733043  0.249885773107303  0.119546085272213  0.107827018648257 -0.031752436246544  0.000037065640674  0.211400361545441
-    8  (  8)  0.055452136609395  0.063704146851438 -0.132109776961381 -0.067534716804367 -0.027512182553154 -0.319330567201196 -0.051501501228049 -0.211684727134552 -0.000062825592229
-    9  (  9)  0.059987775905021 -0.059013360455393 -0.001731139538261  0.025602282087959 -0.077406198911912  0.032289392048789 -0.044673931971007 -0.007013222782529  0.205272148471903
-   10  ( 10)  0.040816969333319 -0.029839999727295 -0.097606908985792  0.012730679444132  0.052120800982420  0.047092545087938 -0.097199457935824  0.008100744465293 -0.194519063749344
-   11  ( 11) -0.105565276750546  0.086850909183234  0.141349531156014  0.064538795649442  0.048769909889220 -0.098670307723293  0.132937762954191 -0.091749745952861 -0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.059727136016838 -0.040967341903913  0.106287777222309
-    1  (  1)  0.058687758282915  0.029394471353826 -0.086811620398375
-    2  (  2)  0.001293940264555  0.097641591345113 -0.142636172226853
-    3  (  3) -0.025821629306306 -0.013207208477272 -0.063793857996761
-    4  (  4)  0.076409112526474 -0.052575212530451 -0.047414860037356
-    5  (  5) -0.032527517350565 -0.045632421732577  0.095160623491729
-    6  (  6)  0.044231942651703  0.096152133696301 -0.132935625343693
-    7  (  7)  0.007372100254253 -0.008488811567739  0.092713079820202
-    8  (  8) -0.206938183650805  0.192802275414426  0.052611900153123
-    9  (  9)  0.000608554890156 -0.088592533061698  0.344380743508036
-   10  ( 10)  0.088950131298492  0.000863284429953  0.222751022723935
-   11  ( 11) -0.341005102874300 -0.224718204882492  0.000326394311109
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000338557997552 -0.011375035743392  0.029451193209236 -0.012043586883828 -0.021579660859347  0.039033326019946 -0.009990415550092  0.009478976983628 -0.045907412693585
-    1  (  1)  0.013672223167698 -0.000473657715584 -0.014851568055555  0.021895587564371 -0.022163590605075  0.051246172607775  0.019257625103746  0.003658602851281 -0.019552361048058
-    2  (  2) -0.032608942325713  0.014402827198054 -0.000746991250603 -0.029107751732300  0.054720608245644  0.057033646383303  0.001872360780591 -0.031698780852448  0.056602981887733
-    3  (  3)  0.014268935231542 -0.021459967996182  0.030313065636317 -0.000730068456009 -0.016766656065195 -0.058973632357354 -0.003002419788061  0.022431580465626 -0.134333948620083
-    4  (  4)  0.022372891038515  0.021355779916377 -0.052959509294565  0.015751198634933 -0.000391938857969 -0.016109226068828  0.004538544158672 -0.050308920012661  0.059340919102150
-    5  (  5) -0.040216234763810 -0.051875751817174 -0.055849318880052  0.058120412757832  0.016460961175898  0.000645475334216  0.019024299026328  0.068804307634402 -0.024311188622736
-    6  (  6)  0.009930727984206 -0.019074682595569 -0.002242770131548  0.003091320851947 -0.004596281406168 -0.019032186967740  0.000074596378968  0.032870219636189 -0.006741182978715
-    7  (  7) -0.009279418369258 -0.004264018479381  0.032087681361723 -0.022624894165436  0.049954824766487 -0.068907285150032 -0.032867640818893 -0.000029995356356 -0.011652937852273
-    8  (  8)  0.047260005865874  0.018493502167014 -0.056736132845076  0.135589678169431 -0.059916509278318  0.024164421049794  0.007333544303120  0.011763030881780 -0.000264400142459
-    9  (  9) -0.016875007958598  0.031435494057685 -0.089048257959160 -0.041017085631602  0.020420285065562  0.066513023484078  0.000739604154969 -0.091958006244489  0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.016438561460291
-    1  (  1) -0.031819705279686
-    2  (  2)  0.089217438029428
-    3  (  3)  0.040553914705774
-    4  (  4) -0.020554472275814
-    5  (  5) -0.066048736736302
-    6  (  6) -0.000688806170902
-    7  (  7)  0.091248940256931
-    8  (  8) -0.027663919394381
-    9  (  9) -0.000090314260367
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011888856297006 -0.017750932125153 -0.030381401096490  0.012819546160996 -0.007239420422718 -0.024248756043407  0.008035757610220 -0.005364063357974 -0.085646323747472
-    1  (  1)  0.005014728223890  0.026640078285976 -0.053625852742063 -0.001580773154934 -0.029513947501511  0.084681976949646  0.049070075720108 -0.003015931693788 -0.083533135335069
-    2  (  2)  0.005701802857788  0.001861436552455  0.077309348516175 -0.039227298256145 -0.002806617492516  0.004668173879327  0.004051055445085 -0.009725469213679 -0.098722432349714
-    3  (  3) -0.016358351457124 -0.001723600627698 -0.021225514928062  0.039815087581337 -0.022808569998795 -0.104140287911999 -0.033233738030323  0.056382556071864  0.046907957767316
-    4  (  4) -0.023138877563353 -0.095098707280146 -0.087666288227931  0.037561492255805  0.255193211004254  0.015544572331716  0.030557402755123 -0.180093964112144 -0.259856355700386
-    5  (  5)  0.024228572043234 -0.082834757201086  0.181139504221043 -0.153944959591839  0.252818375021614 -0.048862178579716 -0.036094966909273  0.170640955267472 -0.004551713568432
-    6  (  6)  0.085402345559358 -0.022737485412840 -0.117389155338347  0.122686430467103 -0.089994929534087  0.186662776489158 -0.276334552924253 -0.188945818003174 -0.062512631958960
-    7  (  7)  0.077377916753636  0.184413390881742 -0.161635032551528  0.217081818449181 -0.216158931990711  0.452250331823368  0.121365143499215 -0.427486936599919 -0.051141830029037
-    8  (  8)  0.109996402529651 -0.145159792225805  0.137471198251747  0.396423044911114 -0.145941263905056 -0.104134158957014  0.041227108112442  0.369426049626710 -0.017681253264412
-    9  (  9) -0.015271329763023  0.091667642816572 -0.093167229349338  0.105178289783052 -0.012072216330151  0.184888670947420 -0.104021366500691 -0.173041839821099  0.089774142402176
-   10  ( 10) -0.051871879465497  0.004911726396439  0.095027344602311 -0.050235453581707 -0.056755121586123 -0.023277306660177 -0.123771404812450  0.008953154661311 -0.042342746566353
-   11  ( 11) -0.213874614633354 -0.038620645156941  0.003918905035704  0.027644952213642  0.227437070959628  0.047768116418487 -0.043243210008693  0.046251908849224 -0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001231945309971
-    1  (  1) -0.099118498855930
-    2  (  2)  0.099462956417043
-    3  (  3)  0.089788110354890
-    4  (  4) -0.236379406660322
-    5  (  5)  0.043290372964682
-    6  (  6) -0.008471875583563
-    7  (  7) -0.118429426587662
-    8  (  8)  0.041151812398786
-    9  (  9) -0.121668252978460
-   10  ( 10)  0.047795297768532
-   11  ( 11) -0.026000603113831
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.092723408151075 -0.057215092134940 -0.054154926215137  0.012957083117559  0.028122190094715  0.031179347218855  0.013645641371598  0.009921258172339  0.037242536390232
-    1  (  1)  0.019990430092613 -0.002382806987559  0.016009786257367  0.011651136664597 -0.017212414198990 -0.024265249236370  0.152443472946687 -0.006755616148329  0.024207249541319
-    2  (  2)  0.009030755895234  0.085216520460363 -0.016500441499831 -0.009813164947617 -0.015713678712422  0.028373503652355 -0.075877310310795  0.039590492962937  0.081270933339189
-    3  (  3) -0.075043611755008 -0.103608833794547 -0.030676505925522 -0.013143510199953  0.006187488557257  0.045202449901574 -0.041605892889482 -0.001210820793539 -0.045033631139440
-    4  (  4) -0.122337112724117 -0.176460576265088 -0.085321001863374  0.041690733440160 -0.111448222796030  0.083092300673138 -0.094252463151414  0.071551603610925  0.059851091994803
-    5  (  5)  0.372712635775664  0.109553572239785  0.087636097688831  0.161393941368917 -0.091711881285738 -0.083559837956631  0.084048684818413 -0.114275654348762  0.004760374961166
-    6  (  6)  0.030431995544059 -0.095321795210779  0.159145740022025  0.376304340373359  0.189004479350399 -0.100683798175242 -0.128902751762968 -0.567857709085750 -0.002399331341204
-    7  (  7)  0.344039522571259  0.114279634125077  0.003626426979965 -0.177981236436906 -0.027932329764501 -0.026442462397652 -0.246808699479261  0.268819164710932 -0.106523620842343
-    8  (  8)  0.111643207885322  0.002836247769573 -0.018154026503924 -0.097243438328650  0.121498121615664  0.006682650130485  0.107315976978454 -0.036939727738377 -0.063237979028415
-    9  (  9) -0.063921675215150 -0.215994652248761 -0.065707412514049  0.003935136905129  0.142641982827575  0.026699050855783 -0.056962954862571 -0.164747861484427  0.081509018515780
-   10  ( 10)  0.058030998072116  0.060474289846612  0.205628226890442  0.038897333798042 -0.068097699807560 -0.116172285533776 -0.038858694654200 -0.255643829382515  0.001247633054968
-   11  ( 11)  0.085574013220044  0.030726962638802  0.008247473867838  0.106409310393215 -0.064469816287686 -0.072180462194277 -0.022620356444758 -0.070649638629627  0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015293746360799
-    1  (  1)  0.020176832366409
-    2  (  2)  0.007468634139779
-    3  (  3) -0.002013486296780
-    4  (  4)  0.055907379643807
-    5  (  5)  0.014548062338959
-    6  (  6)  0.210557719542813
-    7  (  7) -0.107773752705760
-    8  (  8) -0.004939471027833
-    9  (  9)  0.101796072438763
-   10  ( 10)  0.052197801100809
-   11  ( 11) -0.010791942309942
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000245185765728 -0.004422769142209 -0.195473142624697  0.067124189998810  0.027096370068160  0.099320185873800  0.032910569428743  0.079494520674282 -0.016762710819247
-    1  (  1)  0.004388313593185 -0.000165290846899  0.188129406432792 -0.063756474949075 -0.001128748240139 -0.126263116741295 -0.303817994309096  0.069854530583820  0.010310792522154
-    2  (  2)  0.194444327410373 -0.187906024270824  0.000538868177065 -0.115697813615881 -0.188025580722992 -0.063555095149569  0.109038200896130 -0.123360187528163  0.037347597176070
-    3  (  3) -0.066590814481336  0.063203632987523  0.115347217679990 -0.000002301796994  0.034584588669551  0.038983157581533  0.229948513873159 -0.131721887952800 -0.028384936970778
-    4  (  4) -0.026403437308072  0.000527986476725  0.186677671985474 -0.034818437947430 -0.000320297338463  0.037865478650564  0.201451121997014 -0.109301689008128 -0.005643097026329
-    5  (  5) -0.099409584232992  0.126346592032007  0.064419008019557 -0.039794220656347 -0.036855903902447 -0.000190318965932  0.088891480212760 -0.056789849447140  0.091073030281233
-    6  (  6) -0.033050985013878  0.303259624681304 -0.108281756633666 -0.230173439372417 -0.201331671706094 -0.089930560146314 -0.000311452672695 -0.221067383348441 -0.053494283573947
-    7  (  7) -0.079472710309908 -0.069297203366025  0.125033677339702  0.131451975782708  0.110125569334720  0.054839641157466  0.219945401741596 -0.001085047372961  0.089073871816377
-    8  (  8)  0.016952142014388 -0.010421932566239 -0.036927801153181  0.027792238689701  0.005351459000165 -0.090892785458666  0.052690955519676 -0.088985197141446 -0.000032698621213
-    9  (  9)  0.149061020700740 -0.058621114959186 -0.279965277538519 -0.021488283829580 -0.044200621925698 -0.026904718590704 -0.074208134755608 -0.037354078157659 -0.137372829291651
-   10  ( 10) -0.035190315077894  0.050814828300922  0.151303785089698 -0.062867991520111 -0.077053666036856 -0.075037906181509  0.133385625358484 -0.006791369727277 -0.121764957568739
-   11  ( 11)  0.016457666688676 -0.009560970830020 -0.030160709068648 -0.052615429880776 -0.007184814870880  0.147317585107930  0.048007656104932  0.024985856634055 -0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.149527127949477  0.035025203143730 -0.017236912650706
-    1  (  1)  0.058313378902528 -0.050420942142557  0.009474518218355
-    2  (  2)  0.278325755481738 -0.150562770304950  0.029989264213428
-    3  (  3)  0.020585218415975  0.063268588986747  0.052977667343551
-    4  (  4)  0.042114256624995  0.077316775027134  0.007960467665663
-    5  (  5)  0.031625284755674  0.074462306356205 -0.148447086799088
-    6  (  6)  0.074615124808937 -0.133170285550522 -0.049651682674137
-    7  (  7)  0.041592449377408  0.005910763914811 -0.024358506166719
-    8  (  8)  0.138294110971387  0.121744291260784  0.107918344276425
-    9  (  9) -0.001133592488713  0.474400799155993  0.192590673354496
-   10  ( 10) -0.472105353620486 -0.001334835966633 -0.192285927563244
-   11  ( 11) -0.191497735915320  0.194932828964948 -0.001344945845524
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000738836304181  0.037293198581408  0.029451404620807 -0.009378792471894  0.055701113540954 -0.035128933511984 -0.013954700067714 -0.072836702551235  0.051857122483535
-    1  (  1) -0.032660614374695  0.002015876922290  0.074058480716263 -0.021479421330690 -0.014966422603257 -0.166979967788261 -0.013073252080067 -0.022556560940623 -0.170972365950935
-    2  (  2) -0.029165553040464 -0.073308940131147  0.000753195727027 -0.033014777438001  0.000651481686764 -0.016615463822703 -0.030045410532860 -0.013342873064028 -0.078343409399381
-    3  (  3)  0.010384415064446  0.021326871974424  0.031305865808474  0.000583541727095 -0.005150844265660 -0.010972964083321 -0.024667426696971  0.003421011953857 -0.027197309287279
-    4  (  4) -0.055501401866642  0.014297660722118 -0.000710544848112  0.005493793084614 -0.000124683940717 -0.025126510553785 -0.000947638436962 -0.017069455654223  0.023650915169846
-    5  (  5)  0.033803616927021  0.164339399892725  0.017068168082329  0.010030727560507  0.025241735580020  0.000735433014139 -0.028603795353780  0.023029380344413  0.027599055296252
-    6  (  6)  0.013107540346806  0.012828435687407  0.030286401438565  0.024713021163335  0.001063605161759  0.029296491836886 -0.000025149030498 -0.111104514389532  0.102861376746943
-    7  (  7)  0.072733387901303  0.022465577956558  0.013436829086647 -0.003433808737295  0.017048766876852 -0.023125015384758  0.110934303358415  0.000037875914124  0.002935696551342
-    8  (  8) -0.053267672687232  0.170660201820078  0.076657788504288  0.028160893222526 -0.023606436991553 -0.027690933408034 -0.102626814241324 -0.002887530223588  0.000373637330912
-    9  (  9)  0.004804828900057  0.224333052817770  0.065186758028368  0.004091068046870  0.039040275694483 -0.042976408882840 -0.051197675519228 -0.024101682646066 -0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.005026329948406
-    1  (  1) -0.225373696682354
-    2  (  2) -0.064686362479745
-    3  (  3) -0.004567750792129
-    4  (  4) -0.038996417519414
-    5  (  5)  0.043485644851561
-    6  (  6)  0.051601626537389
-    7  (  7)  0.023715023759407
-    8  (  8)  0.001115391080639
-    9  (  9)  0.000048164004682
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.087860740756488  0.068261038905906  0.057593788019307 -0.011454237083441 -0.027305499289367 -0.032385982368371 -0.018173477269549 -0.009363386608796 -0.038732450559880
-    1  (  1) -0.013249632151170 -0.004184657414979 -0.019716507976896 -0.014744696478638  0.016703323694180  0.027386275287573 -0.163732376866413  0.007136524293248 -0.024482820661864
-    2  (  2) -0.007013218896085 -0.084657964294727  0.026004205374563  0.008076798202963  0.011641159214614 -0.031112856231507  0.081756432692912 -0.043486513055778 -0.085001128307205
-    3  (  3)  0.058477500387638  0.110048615847953  0.032104075685968  0.014807417786102 -0.004697674213231 -0.048123068402958  0.048143599431998  0.000645092439839  0.047260089330542
-    4  (  4)  0.110574498742467  0.188131348104213  0.086636459451987 -0.041361686502598  0.118556992954628 -0.089270642674348  0.104552978829704 -0.075153301656795 -0.057940099039356
-    5  (  5) -0.371487279658724 -0.115772941053656 -0.094845419594772 -0.167070991238391  0.094497706414686  0.087134798346335 -0.079465840043241  0.119932858558240 -0.004312964076576
-    6  (  6) -0.035255689937620  0.112028499449997 -0.168145842580037 -0.392683527257363 -0.194284650981365  0.110254467391126  0.135773335198962  0.599025983356266  0.001116295743642
-    7  (  7) -0.362602042970953 -0.115938705836042  0.002852393959785  0.186519834338995  0.026972926522319  0.023780474127448  0.271135694461778 -0.284033125501378  0.111247570725030
-    8  (  8) -0.111196944464455 -0.001239941376560  0.021205830532168  0.101329748088148 -0.128975240085324 -0.010144197632550 -0.108358474715393  0.037918096280026  0.066572090545295
-    9  (  9)  0.090967744709768  0.211201922436275  0.066377513424381 -0.007899083102241 -0.154707771160094 -0.037980948657754  0.073559352539101  0.172041273327275 -0.087426840520207
-   10  ( 10) -0.070112475488657 -0.079061926736069 -0.222919508358954 -0.040775801294398  0.061424635747658  0.113162621408555  0.037903862973014  0.270692474130444 -0.009570796789139
-   11  ( 11) -0.090924578792926 -0.040585886130445 -0.000311072794648 -0.117174234675791  0.063663959894116  0.077941781302743  0.027645133174923  0.073495241874676 -0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015882565008118
-    1  (  1) -0.020403231736073
-    2  (  2) -0.007241270504095
-    3  (  3)  0.003144444710549
-    4  (  4) -0.058793064689134
-    5  (  5) -0.012293150809123
-    6  (  6) -0.215177196230389
-    7  (  7)  0.113635102585609
-    8  (  8)  0.004824845555481
-    9  (  9) -0.113550918048735
-   10  ( 10) -0.063789409560574
-   11  ( 11)  0.007009974437012
+	[alpha]_(0.072) =  -38.80516 deg/[dm (g/cm^3)]
 
 	Computing Mu_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.609438474538
-	   1        14.949778829192    4.728e-01
-	   2        16.871417912800    1.818e-01
-	   3        16.903632350164    2.076e-02
-	   4        16.911909723375    6.871e-03
-	   5        16.911348469601    1.590e-03
-	   6        16.911055110664    4.168e-04
-	   7        16.911101104419    1.181e-04
-	   8        16.911115584343    3.100e-05
-	   9        16.911108644993    8.873e-06
-	  10        16.911107420798    2.748e-06
-	  11        16.911108060559    8.445e-07
-	  12        16.911108716477    3.229e-07
-	  13        16.911108882845    1.006e-07
+	   0        11.609438346706
+	   1        14.949778650400    4.728e-01
+	   2        16.871417692589    1.818e-01
+	   3        16.903632128996    2.076e-02
+	   4        16.911909501859    6.871e-03
+	   5        16.911348248077    1.590e-03
+	   6        16.911054889154    4.168e-04
+	   7        16.911100882908    1.181e-04
+	   8        16.911115362831    3.100e-05
+	   9        16.911108423481    8.873e-06
+	  10        16.911107199286    2.748e-06
+	  11        16.911107839047    8.445e-07
+	  12        16.911108494964    3.229e-07
+	  13        16.911108661333    1.006e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 3.393e-08
 
 	Computing L_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.365981838078
-	   1         3.307945748661    3.211e-01
-	   2         4.174456209485    1.715e-01
-	   3         4.269850974405    4.658e-02
-	   4         4.282991556822    2.028e-02
-	   5         4.285355941743    1.031e-02
-	   6         4.287649413453    3.586e-03
-	   7         4.288126105952    1.317e-03
-	   8         4.287996753978    6.132e-04
-	   9         4.287984213469    2.655e-04
-	  10         4.288000306141    1.266e-04
-	  11         4.288002884836    3.944e-05
-	  12         4.288000978087    1.358e-05
-	  13         4.287998153041    4.621e-06
-	  14         4.287997246570    1.749e-06
-	  15         4.287997145458    7.724e-07
-	  16         4.287997375254    4.035e-07
-	  17         4.287997588021    2.315e-07
-	  18         4.287997696720    1.204e-07
+	   0         2.365981827940
+	   1         3.307945732087    3.211e-01
+	   2         4.174456182608    1.715e-01
+	   3         4.269850945043    4.658e-02
+	   4         4.282991526893    2.028e-02
+	   5         4.285355911607    1.031e-02
+	   6         4.287649383235    3.586e-03
+	   7         4.288126075711    1.317e-03
+	   8         4.287996723740    6.132e-04
+	   9         4.287984183232    2.655e-04
+	  10         4.288000275904    1.266e-04
+	  11         4.288002854598    3.944e-05
+	  12         4.288000947849    1.358e-05
+	  13         4.287998122803    4.621e-06
+	  14         4.287997216333    1.749e-06
+	  15         4.287997115220    7.724e-07
+	  16         4.287997345017    4.035e-07
+	  17         4.287997557783    2.315e-07
+	  18         4.287997666482    1.204e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.487e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.683420643863
-	   1        11.726517352238    3.351e-01
-	   2        12.667113826803    1.144e-01
-	   3        12.690850554821    1.675e-02
-	   4        12.697415629013    5.857e-03
-	   5        12.697300056585    1.117e-03
-	   6        12.697140731349    3.127e-04
-	   7        12.697166205779    8.608e-05
-	   8        12.697172250706    2.292e-05
-	   9        12.697169008955    6.916e-06
-	  10        12.697168220952    2.008e-06
-	  11        12.697168612405    4.233e-07
-	  12        12.697168870814    1.381e-07
+	   0         9.683420550099
+	   1        11.726517231508    3.351e-01
+	   2        12.667113688451    1.144e-01
+	   3        12.690850415800    1.675e-02
+	   4        12.697415489758    5.857e-03
+	   5        12.697299917326    1.117e-03
+	   6        12.697140592097    3.127e-04
+	   7        12.697166066526    8.608e-05
+	   8        12.697172111452    2.292e-05
+	   9        12.697168869702    6.916e-06
+	  10        12.697168081699    2.008e-06
+	  11        12.697168473152    4.233e-07
+	  12        12.697168731561    1.381e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 4.605e-08
 
 	Computing L_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.821298955897
-	   1         9.270412566803    4.757e-01
-	   2        11.011131444260    2.340e-01
-	   3        11.257035254842    9.221e-02
-	   4        11.319589156252    3.813e-02
-	   5        11.328095384208    1.392e-02
-	   6        11.331034422161    3.893e-03
-	   7        11.331839951353    1.222e-03
-	   8        11.331703066767    4.737e-04
-	   9        11.331658951021    1.553e-04
-	  10        11.331670754659    7.708e-05
-	  11        11.331674802802    3.674e-05
-	  12        11.331680584166    1.376e-05
-	  13        11.331679633207    4.703e-06
-	  14        11.331679408382    2.074e-06
-	  15        11.331679867305    9.994e-07
-	  16        11.331680729713    5.321e-07
-	  17        11.331681366724    2.712e-07
-	  18        11.331681575824    1.115e-07
+	   0         6.821298931527
+	   1         9.270412529668    4.757e-01
+	   2        11.011131392986    2.340e-01
+	   3        11.257035199032    9.221e-02
+	   4        11.319589098333    3.813e-02
+	   5        11.328095325705    1.392e-02
+	   6        11.331034363534    3.893e-03
+	   7        11.331839892689    1.222e-03
+	   8        11.331703008108    4.737e-04
+	   9        11.331658892364    1.553e-04
+	  10        11.331670696001    7.708e-05
+	  11        11.331674744144    3.674e-05
+	  12        11.331680525508    1.376e-05
+	  13        11.331679574549    4.703e-06
+	  14        11.331679349724    2.074e-06
+	  15        11.331679808647    9.994e-07
+	  16        11.331680671055    5.321e-07
+	  17        11.331681308066    2.712e-07
+	  18        11.331681517165    1.115e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 4.265e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.942856865762
-	   1        12.409442315798    3.578e-01
-	   2        13.462130383366    1.154e-01
-	   3        13.482241668256    1.530e-02
-	   4        13.485856949975    4.442e-03
-	   5        13.485508774227    1.101e-03
-	   6        13.485473659812    2.556e-04
-	   7        13.485511263548    7.911e-05
-	   8        13.485510160110    2.541e-05
-	   9        13.485507101909    8.446e-06
-	  10        13.485506815594    2.727e-06
-	  11        13.485507444103    8.066e-07
-	  12        13.485507798359    2.037e-07
+	   0         9.942856770729
+	   1        12.409442187907    3.578e-01
+	   2        13.462130235969    1.154e-01
+	   3        13.482241520314    1.530e-02
+	   4        13.485856801894    4.442e-03
+	   5        13.485508626148    1.101e-03
+	   6        13.485473511735    2.556e-04
+	   7        13.485511115470    7.911e-05
+	   8        13.485510012031    2.541e-05
+	   9        13.485506953831    8.446e-06
+	  10        13.485506667515    2.727e-06
+	  11        13.485507296024    8.066e-07
+	  12        13.485507650280    2.037e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 6.320e-08
 
 	Computing L_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.735910200359
-	   1         9.133135020546    4.778e-01
-	   2        10.927029646829    2.292e-01
-	   3        11.080909620080    5.746e-02
-	   4        11.099862939787    1.939e-02
-	   5        11.099968382686    1.096e-02
-	   6        11.102155976794    4.940e-03
-	   7        11.103195405059    1.851e-03
-	   8        11.103082922666    7.344e-04
-	   9        11.103082702435    2.438e-04
-	  10        11.103089096658    1.167e-04
-	  11        11.103104426387    5.351e-05
-	  12        11.103106729078    2.084e-05
-	  13        11.103104859860    7.992e-06
-	  14        11.103104626557    3.092e-06
-	  15        11.103104968971    1.266e-06
-	  16        11.103105331486    5.565e-07
-	  17        11.103105522147    3.115e-07
-	  18        11.103105571095    1.819e-07
+	   0         6.735910176610
+	   1         9.133134984299    4.778e-01
+	   2        10.927029594836    2.292e-01
+	   3        11.080909565214    5.746e-02
+	   4        11.099862884439    1.939e-02
+	   5        11.099968327253    1.096e-02
+	   6        11.102155921288    4.940e-03
+	   7        11.103195349510    1.851e-03
+	   8        11.103082867117    7.344e-04
+	   9        11.103082646886    2.438e-04
+	  10        11.103089041110    1.167e-04
+	  11        11.103104370838    5.351e-05
+	  12        11.103106673529    2.084e-05
+	  13        11.103104804310    7.992e-06
+	  14        11.103104571008    3.092e-06
+	  15        11.103104913421    1.266e-06
+	  16        11.103105275936    5.565e-07
+	  17        11.103105466598    3.115e-07
+	  18        11.103105515546    1.819e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 8.976e-08
 
 	Computing 1/2 <<Mu;L>>_(0.128) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008290776080582 -0.050801504097253  0.025635294562259 -0.003046442602711 -0.019839162173202 -0.042287718066775  0.002274291905087 -0.017250301075761 -0.063217582232324
-    1  (  1) -0.005656720485448  0.005906316890016 -0.013342327104385  0.062795095869537  0.034384806675368 -0.011824889654518 -0.010091423219065 -0.046942857543920 -0.048716688440686
-    2  (  2)  0.031253511604130  0.072637650556073 -0.014421891959526 -0.004213302445553  0.070727435854801 -0.065656867197555 -0.018370400388693 -0.002385908267158  0.006354255904041
-    3  (  3) -0.059832580241196 -0.053424480759820 -0.021451003825827 -0.018138018553495 -0.036100327164171  0.016134873511603  0.024740373136963  0.003793018506519 -0.167949395515151
-    4  (  4) -0.064204693944690 -0.131652862682136  0.117404639608972  0.157417127901485 -0.230036611567443  0.047515122725740  0.039984594404843  0.125482054176259 -0.256771627646738
-    5  (  5)  0.146085129938632  0.278398764610060 -0.159854012203638  0.282968510269086  0.101365891285813  0.356608825189021  0.125659431918166  0.044422988683829  0.166646852463301
-    6  (  6) -0.076564725597579  0.133650798922835 -0.020866614443156 -0.061441481951876  0.071232976830213 -0.204259413485531  0.443726141038863  0.031546384888620  0.054109942402284
-    7  (  7)  0.171392689665179  0.199512600411571 -0.417327799251045 -0.052763427688751  0.301472803852696  0.065491949787692 -0.090135905280205  0.243374803622146  0.087314234232365
-    8  (  8)  0.052750851527397  0.070024200557922 -0.379656051510646  0.506727880893360  0.456213741194719 -0.053888497905949  0.020349944072208  0.064388593842935 -0.270869373264179
-    9  (  9) -0.321512384290440  0.557302077819714  0.036935298894209  0.154840347992778  0.003043634782132  0.230873783877613  0.106477418838008  0.187200194326970 -0.093391131247138
-   10  ( 10) -0.965723013629727  0.203375174675727  0.231799200789465 -0.113515758170139  0.032657967963446 -0.147828874479423  0.019227710807050 -0.096617606939553  0.006766409668261
-   11  ( 11) -0.210596475192897  0.094976222444135 -0.072335244920971  0.290764752768263 -0.062314851229712  0.053607127427930  0.145285323049651  0.073900587412887 -0.326764941791807
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071285844130264
-    1  (  1)  0.010066343394199
-    2  (  2) -0.108617239028194
-    3  (  3) -0.063737900590760
-    4  (  4) -0.015793155353663
-    5  (  5)  0.238781543103224
-    6  (  6) -0.065357063243315
-    7  (  7)  0.120098496018758
-    8  (  8) -0.128051536292778
-    9  (  9)  0.179029916473930
-   10  ( 10) -0.084757737907666
-   11  ( 11)  0.159141561245499
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.230778688168130 -0.557039020018502  0.102231622004203 -0.365190061837505 -0.400431097899025 -0.011240783369823 -0.138486416116495  0.002452040812742 -0.004398637078623
-    1  (  1) -0.556776142920827 -2.040315056194718  0.915507378155102  1.014426942838368  0.734278848751725  0.048588577390964  0.281167270606351  0.301449170381432  0.094768863002394
-    2  (  2)  0.102191442528323  0.915686903851560  1.209547690777273 -0.958100119655737 -0.740471389480369 -0.004947182895568  0.495915674452131 -0.139783988312968  0.095073435804183
-    3  (  3) -0.364539165929170  1.014070571549057 -0.958316089423204 -0.283348551998825 -0.131889670325022 -1.271015261428147  0.039370973643206 -0.404136843612415 -0.596543898512850
-    4  (  4) -0.399870169082361  0.732987024839952 -0.742129335372324 -0.132056740778799  0.552809694709972  0.050609502973822 -0.485130318718432 -1.569135325660496 -0.955644372877197
-    5  (  5) -0.012067668711970  0.049395634351447 -0.004235997753528 -1.269867451709877  0.052501445594591  0.142961307435960 -0.243772741862524  0.815823088969846 -1.032660122676294
-    6  (  6) -0.138184751914924  0.281444487458849  0.496109632619357  0.039289252640444 -0.483545301414318 -0.244146373994899 -2.567548494258237  0.471042691193011  0.535768572608993
-    7  (  7)  0.002443724218529  0.302692867022601 -0.138498316501231 -0.403820450806263 -1.565811046199608  0.816611901103015  0.471628294535134 -1.688652935957108  0.671482803026688
-    8  (  8) -0.004344564384300  0.094578985136196  0.094798646138089 -0.597437555079113 -0.950266206536146 -1.030172101956222  0.534632090191761  0.669551052804072 -0.286047601971907
-    9  (  9)  0.321027459692546 -0.124494588251713 -0.355830352458176 -0.608802973418470 -0.402462352421951 -0.368076132570564 -1.240230517037675 -0.910561909620175  0.043652486559104
-   10  ( 10)  0.011815823949598 -0.051101513605038 -0.395397800969984  0.309598565761669  0.194737646185127  0.053604366895841 -0.879466474650196  0.757981021960396  0.138272602216670
-   11  ( 11)  0.159425836287601 -0.085783898744993 -0.370909602534729 -0.056636941516785 -0.307385996591224 -0.268976928323790 -0.442853482929670  0.013290639913097 -0.876205899626718
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.323082673575100  0.012827323300415  0.160383781034165
-    1  (  1) -0.126844464371028 -0.052604971080148 -0.086843133976977
-    2  (  2) -0.357788273401833 -0.396667921961515 -0.371902334820724
-    3  (  3) -0.612287607386654  0.306667669522199 -0.056656844524874
-    4  (  4) -0.405472668706639  0.195190062002348 -0.306615567899281
-    5  (  5) -0.367351821286147  0.055534904015428 -0.275720960811118
-    6  (  6) -1.243158670589035 -0.884111685009210 -0.446520521343404
-    7  (  7) -0.909610092856081  0.758960738026336  0.004121680213622
-    8  (  8)  0.044479614426162  0.142510706976164 -0.890141861038879
-    9  (  9)  0.430645603358394 -0.292573864178629 -0.177569371172063
-   10  ( 10) -0.297251468770778  0.639563517042984 -0.084252875076621
-   11  ( 11) -0.176313836183732 -0.086637188746477  1.226883274744448
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.555032728737771  0.712617672671401  0.419810286882489  0.050887754227596 -0.090842975445822 -0.470640518796941  0.705404320416024 -0.102097016449215  0.079849652538938
-    1  (  1)  0.712915390108471  0.338414908248977  0.746799463635505  0.289033465951793  0.281577689527702 -0.590080565321557 -1.163166129408219 -0.188838662213219  0.235465544716902
-    2  (  2)  0.420424419523684  0.746397208582966 -0.016153704953468 -0.358852287949201 -0.952285365412292  1.041198523267407 -0.387389024226280  0.231972398395418 -1.201681468114436
-    3  (  3)  0.052990374128029  0.287939592192507 -0.356997201476426 -0.860130940767887 -1.322600194001359 -0.190991097932252 -0.172427859143025  1.049268576710733  0.759838942947354
-    4  (  4) -0.091729674999201  0.281558404761801 -0.953826965790842 -1.321136801436185  1.452847715742109  0.019357804497789  0.219531843898996 -0.321163524474806  0.383368380154908
-    5  (  5) -0.468391179467906 -0.590920943851569  1.042843901419442 -0.190946364776948  0.019284064585406 -0.578157261908740  0.477982154885554  0.309192885886468  0.350343314103329
-    6  (  6)  0.705416628116867 -1.163498224121495 -0.385221267991331 -0.173426272959358  0.218834180811751  0.478203132617135 -2.784703127021582 -0.089827446409910  0.007438070857215
-    7  (  7) -0.100892718625019 -0.189193923309364  0.233172791358426  1.048794685120079 -0.321694154621351  0.309157324551256 -0.089653742381773 -3.228872513573496  0.508232911749822
-    8  (  8)  0.078189592702616  0.235740536359493 -1.205024775916881  0.762330717256039  0.383275686836382  0.348953623655193  0.008045450505770  0.508467502681986  0.472369144605263
-    9  (  9) -0.077760701800955  0.237396383481108 -0.096343734790574 -0.354923660187535 -0.984336588474142  1.335053740742370  0.269902452459777  0.319055275759352 -0.321749140962585
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.078162493766068
-    1  (  1)  0.238847682218727
-    2  (  2) -0.098903683747888
-    3  (  3) -0.354949509542455
-    4  (  4) -0.983822640646403
-    5  (  5)  1.333720211340158
-    6  (  6)  0.269441491786924
-    7  (  7)  0.318898660493929
-    8  (  8) -0.321196908799485
-    9  (  9) -0.198768714929451
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015331616498833 -0.019922018235360  0.024795453639952  0.001428994822442 -0.007662564632869 -0.030564864466354 -0.002998096035874 -0.014184257518557 -0.050369876521864
-    1  (  1)  0.002536892896206 -0.000724332833140 -0.010931820831771  0.061385329925525  0.034527384530112 -0.002930909394968 -0.006897041777642 -0.048924198461387 -0.045892788765523
-    2  (  2)  0.055930590988109  0.061668786229878 -0.009784880887058 -0.011292178101404  0.079575226023927 -0.052325708606337 -0.009086556132667 -0.001787844130138  0.008215255410943
-    3  (  3) -0.058532225277701 -0.048285500112225 -0.015912879350588  0.001479837376653 -0.030353501548890  0.023819914693463  0.021025260847826  0.014207102374829 -0.151577267379535
-    4  (  4) -0.056221687371934 -0.122358938171234  0.112292181821658  0.146881610350559 -0.213263741399596  0.056469707520368  0.037816511197979  0.118315319709634 -0.249164851234958
-    5  (  5)  0.125699079920792  0.245765102963436 -0.144688421941741  0.269480954167622  0.108175820650901  0.330495489462815  0.121717019021094  0.042981278927133  0.139107704893676
-    6  (  6) -0.090953864200081  0.138378038123711 -0.018999653387300 -0.059021477190613  0.070107383816014 -0.188422561576096  0.422479983427336  0.027031745312951  0.054392856003620
-    7  (  7)  0.157772366372595  0.187920697768143 -0.411777035755239 -0.046692805557951  0.283266431788380  0.074879967037488 -0.084103929184262  0.226658912465472  0.075512245279510
-    8  (  8)  0.054210291452992  0.062449071960101 -0.361963320103574  0.503001997291620  0.438083797101076 -0.063050427843078  0.017066076329137  0.069221757957400 -0.257467231990446
-    9  (  9) -0.273423536032774  0.529295983026682  0.033766766508851  0.151918529592259 -0.009418984940093  0.206571120107986  0.110624885223032  0.172829785443028 -0.101427788661059
-   10  ( 10) -0.861462052752320  0.172326691424178  0.212371997651326 -0.111218596621436  0.023269411258717 -0.143388725237391  0.039930804953421 -0.091843120858856  0.022422158283106
-   11  ( 11) -0.188670480611874  0.096820345118133 -0.066190773880029  0.287205832494666 -0.059420643781434  0.064429852032339  0.150091109571506  0.074231547885084 -0.343171650309577
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.057461514086606
-    1  (  1)  0.006963958755564
-    2  (  2) -0.098129328522494
-    3  (  3) -0.059012682268642
-    4  (  4) -0.004449861106028
-    5  (  5)  0.220945294639113
-    6  (  6) -0.063939488850868
-    7  (  7)  0.102360934503055
-    8  (  8) -0.118112557417407
-    9  (  9)  0.155151984964126
-   10  ( 10) -0.077691214009347
-   11  ( 11)  0.169304339523055
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007929033245727 -0.086776514026638 -0.041466992686244 -0.000624066975311 -0.013156595381987  0.043080477030762  0.042448060293463  0.012239880545527  0.029029915184304
-    1  (  1) -0.033878180177558  0.070173508648210  0.019230609095550 -0.003533880530575 -0.001550569267327 -0.001809299397526 -0.111518736659909 -0.001270571448457 -0.012934311690280
-    2  (  2)  0.053119512373320  0.091732793273830  0.021408607612661  0.032674571200622 -0.027446877387833  0.001428368203209  0.035760699595502 -0.016168017803360  0.076110316338229
-    3  (  3) -0.111768458659199  0.032123986864070  0.006283151908271 -0.033287020781358  0.043086093005307 -0.045344868585861  0.050504244775852 -0.018808552325982 -0.035145863401031
-    4  (  4) -0.008665305449844 -0.063452607411023 -0.029600165455924  0.047115677331559  0.019168666345381 -0.031501732622098  0.317766848542404 -0.025484653465158  0.136713668607013
-    5  (  5) -0.096942829349587  0.462416830630329  0.133842090994118  0.092985874350147 -0.099421870808029 -0.234587688959823 -0.217512036032000  0.115491679731730 -0.074046828271163
-    6  (  6)  0.147504151854231  0.176016277524490 -0.101374573515317 -0.288079277305196 -0.230919141922049  0.118478695990594  0.200039409574699  0.528080641738917 -0.150345125085143
-    7  (  7) -0.042669001755884  0.443406170499069  0.389143916519812  0.161315900065673 -0.044923622848274 -0.251217580401495  0.349139344106497 -0.313375744671926 -0.105308356658894
-    8  (  8) -0.090773283284028 -0.098945242676733  0.273219850231927 -0.153556988234685  0.012049248011756  0.153837601800696  0.096783765511278 -0.036655814574288 -0.158022323654812
-    9  (  9) -0.854099711852282 -0.117772176421944 -0.239016409160077 -0.177375733867881  0.100275769298913  0.252844583057920  0.226930144139075  0.153229528005110  0.127239027610851
-   10  ( 10)  0.395991653576375  0.538214267844356  0.096531314019954 -0.336382832184142  0.099895828912763  0.055956501178133 -0.146421756050995  0.134905206743007  0.024743642762261
-   11  ( 11)  0.048495982241480  0.204014858900645 -0.274325469868742  0.134595356909103  0.084519511625804 -0.191133538480751  0.069261639154394  0.103192119612584  0.176045180364651
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.028831087335228
-    1  (  1) -0.001371858337113
-    2  (  2)  0.086279641236700
-    3  (  3) -0.002619734805492
-    4  (  4) -0.021137684583830
-    5  (  5) -0.191430382947414
-    6  (  6) -0.264284919761669
-    7  (  7)  0.000269384690538
-    8  (  8)  0.116882729881709
-    9  (  9)  0.120074711434079
-   10  ( 10)  0.053632787996257
-   11  ( 11) -0.085463803953674
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.675541283858356 -0.292064021280293 -0.790025131233222  0.039304385342315 -0.142699371183327  0.268327500474091  0.055268589173706  0.193336176520280 -0.032498607183913
-    1  (  1) -0.292005367417511 -0.068094888399427 -0.091928539573230  0.129152126993159 -0.002672883933379  0.049262453691224  0.862140772831706 -0.434895002279636  0.030957963645570
-    2  (  2) -0.789447165009789 -0.092254483472880 -0.804853040833334  0.464036191543570  0.288328515691532 -0.782373392336952 -0.359658943728641 -0.388090328975242  0.068147997029207
-    3  (  3)  0.039444395620206  0.128939281409480  0.463903578747306 -0.241479807350799 -0.029257651091736  0.289330170364477 -0.078438871496667  0.246243716348015 -0.221624488999474
-    4  (  4) -0.142005033730652 -0.003441352982276  0.286700873937055 -0.029953661733414 -0.427750919311445 -0.225593242891832  0.001248695253401  0.308372097905189  0.608170303007273
-    5  (  5)  0.266046370608821  0.051710611539180 -0.778167579408912  0.290283723006215 -0.224453112864279 -0.369348441761130 -0.137527542499239  0.160088399589127  0.333141145250294
-    6  (  6)  0.055576665996038  0.861897091141550 -0.359382180614210 -0.079367338581182  0.001316960755447 -0.139592143084602 -0.236061692038733 -0.500995422630755 -0.152924823639678
-    7  (  7)  0.191190365321726 -0.433335934056497 -0.384226491533538  0.246895934047586  0.308256930114393  0.160145299200529 -0.499551364365546  0.169042466304747 -0.232433156817922
-    8  (  8) -0.032324733830521  0.030583581869279  0.067800595440523 -0.220839746025180  0.605132330733771  0.331428074510260 -0.152991449816876 -0.231671787208498 -0.624414674119492
-    9  (  9) -0.170133827289346  0.173802608390272  0.582650141434017 -0.560382911834174 -0.212565567455627  0.095754045184088 -0.282286783247438 -0.105642205052933 -0.000539730602912
-   10  ( 10)  0.052970874353821 -0.227531715435441 -0.648876828841383 -0.696767965643644 -0.268344000354012  0.568720278318329 -0.098598860256773  0.086269937526947 -0.081275470268861
-   11  ( 11)  0.025516552524119 -0.085059735579504 -0.121415959836865  0.018097922040376 -0.846374652520441 -0.307989344147049  0.044343294285023  0.231195949738532  0.168305572109582
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.171375974411067  0.055216931376792  0.025964207813788
-    1  (  1)  0.173220084938157 -0.230603891969826 -0.085840408679658
-    2  (  2)  0.586304150506699 -0.654210189691972 -0.122677885868631
-    3  (  3) -0.564217005061761 -0.698424845148049  0.018146779332832
-    4  (  4) -0.213592841407263 -0.268356081771837 -0.851093566817366
-    5  (  5)  0.095187708087751  0.569138844284334 -0.311815017332116
-    6  (  6) -0.283847446348569 -0.099361887898569  0.045327800607922
-    7  (  7) -0.106442929251796  0.084951820105520  0.232402123183799
-    8  (  8) -0.000679287280351 -0.083181582350312  0.174842773942352
-    9  (  9)  0.184137973286679  0.103441117955563 -0.011188766481418
-   10  ( 10)  0.107554052466808  0.106515041132340 -0.165743784884080
-   11  ( 11) -0.010550245981975 -0.165913802295303  0.859885805027657
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.229655435401251 -0.279601353643965 -0.085575827802352 -0.135048509105901 -0.463462610619003 -0.365248455770507 -0.039660777368333  0.191781963250870 -0.304572804139555
-    1  (  1) -0.279047925679444  0.077319987469585  0.204439247136492  0.070123615269243  0.055860395624731  0.138642318409271 -0.343207769076389 -0.182810883095464 -0.017999280994748
-    2  (  2) -0.085240959465133  0.204263364283089 -0.311156623733494  0.294688564065330  0.229669520218161 -0.281737981462645  0.137882893674030 -0.194668648298996  0.517507397185879
-    3  (  3) -0.137052652301458  0.068817803199155  0.294513347383327 -0.628744473812505  0.688526281107777  0.166771123104115  0.212803952843010 -0.269010206604892 -0.411620416751970
-    4  (  4) -0.461604619248266  0.055843287983042  0.230054478565236  0.688395074228786 -1.421511879446005  0.180495138052121 -0.177199847230662  0.268188410470329  0.119512289645345
-    5  (  5) -0.365099883123814  0.139122909294115 -0.282780063256330  0.166251175855828  0.181093271919847 -0.292775738602585 -0.240660983788926  0.305216197970317  0.235452232882587
-    6  (  6) -0.039141072198114 -0.342047900602042  0.138302509146164  0.211959339222516 -0.177087648441962 -0.240505624310098 -0.304304277829310 -0.910739369588832  0.202811323160239
-    7  (  7)  0.191443148224360 -0.183077517400336 -0.194209029769022 -0.269384260651775  0.268168725961981  0.305441092512858 -0.910852433205190  0.029633662055934 -0.204453968987965
-    8  (  8) -0.303246852232180 -0.018509744386768  0.519514080414653 -0.413340759430442  0.119384719254151  0.236362024043069  0.201991249845660 -0.204562219955504 -0.661555776893828
-    9  (  9) -0.300472910579648  0.170014354298783 -0.291259695102906  0.029160805834281  0.317264449488489 -0.326442124436524  0.007044557482429 -0.101763181058410  0.215338723709779
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301684802635884
-    1  (  1)  0.169719322346163
-    2  (  2) -0.289724655704096
-    3  (  3)  0.029002914588453
-    4  (  4)  0.316574855082561
-    5  (  5) -0.325796183326422
-    6  (  6)  0.007131791827115
-    7  (  7) -0.101918507704736
-    8  (  8)  0.215214193797303
-    9  (  9) -0.431317970778139
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009148490318064 -0.020309806158549 -0.015977532182931  0.004014783738387 -0.010489793112351  0.029667649783295  0.020232440585606  0.011223082041042  0.023312323786938
-    1  (  1) -0.044375857230131  0.052262766826166  0.015548487373741 -0.003662802577056 -0.002781875625079 -0.001383977859398 -0.098229640468489 -0.001043710758572 -0.010909270118946
-    2  (  2)  0.054181385020550  0.080128526478900  0.022828931876126  0.037487063410101 -0.042770056882922 -0.005218720540993  0.030479703829638 -0.014823518322437  0.065536667960166
-    3  (  3) -0.129996832535740  0.025539245172390 -0.001710767497197 -0.035208153932012  0.051497303033318 -0.033810939265315  0.041923713016432 -0.018028802137201 -0.031841589713416
-    4  (  4) -0.018797598258319 -0.055382521313148 -0.025678897036466  0.042677314096974  0.024119803445938 -0.028773903589126  0.288385579456642 -0.023957336001325  0.134022392012911
-    5  (  5) -0.085790126908808  0.402408359114006  0.110878458520312  0.084218998643581 -0.097302640260559 -0.211015098306590 -0.195826989075132  0.107508726926065 -0.059970385150068
-    6  (  6)  0.117117046001707  0.164907313314791 -0.092740522447941 -0.263892346037872 -0.208050086690414  0.121861415926763  0.180654068666643  0.487980567663863 -0.134813668081860
-    7  (  7) -0.052709991074355  0.381296251220592  0.349380237841959  0.145852911752160 -0.041346590279243 -0.220669429372274  0.328816279036270 -0.285726302429830 -0.093478286390337
-    8  (  8) -0.075491834851014 -0.090622807799606  0.261184981058617 -0.148637821570292  0.006281256453519  0.144842826611815  0.089811111402247 -0.036110485207390 -0.153520220179307
-    9  (  9) -0.696164148321021 -0.104910101886221 -0.203383144631185 -0.164870629493292  0.069977329160723  0.194202208543558  0.212076681930829  0.132693764051193  0.096725293429142
-   10  ( 10)  0.348175665954885  0.434442729860845  0.069207287013024 -0.311902381205193  0.086974667298470  0.051225223079379 -0.122216101880307  0.122874476488139  0.012079820457350
-   11  ( 11)  0.044712948857676  0.176004094735536 -0.255862724288287  0.126758826080010  0.078218473139894 -0.179984369340434  0.067110991111726  0.095360581673868  0.177561710091429
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.024402944617349
-    1  (  1) -0.001173348606223
-    2  (  2)  0.076484101898115
-    3  (  3)  0.001169431615315
-    4  (  4) -0.024935532887633
-    5  (  5) -0.174540155531575
-    6  (  6) -0.236517338782017
-    7  (  7)  0.008859575697215
-    8  (  8)  0.109927192293737
-    9  (  9)  0.089534068178409
-   10  ( 10)  0.043410237741554
-   11  ( 11) -0.093132968001143
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002170644752931 -0.022324956514099 -0.029394826211345  0.023309311068680 -0.000970852822634 -0.043511040680121  0.014013985960523  0.007860305508825 -0.031314125297178
-    1  (  1) -0.004975212184910 -0.009727238108985  0.081406434912428 -0.023252939392766  0.038928067463043 -0.010458408905981 -0.034913544836836  0.014265058471693  0.051735797486860
-    2  (  2)  0.017880176100707  0.015599348022774  0.096023531696764 -0.045237679689815 -0.002431886781376  0.077281603581543 -0.027482410098613 -0.002121837766367 -0.131596950090464
-    3  (  3) -0.033671282161329 -0.042247110815725  0.017614407066521  0.120482048147517 -0.071788669015437  0.100417130949899  0.026095439370731  0.024912292415628  0.128857994704884
-    4  (  4) -0.039094504869080  0.011586636873075 -0.201648756832533 -0.417167224027039  0.232183671922422 -0.365776066782585  0.000436512477144 -0.036487401941041 -0.092913589753420
-    5  (  5)  0.107020694538732  0.188165249192967  0.272788343236859 -0.444403017959699  0.118293552778212  0.528258782415562  0.125325642779073 -0.198753130098826  0.028672980278371
-    6  (  6)  0.121158671169740 -0.085565322151460  0.088586051783133  0.010298532059028 -0.107250216094850 -0.195698840050220  0.370534853760273  0.159194784952583 -0.016512860210084
-    7  (  7) -0.033804952616344 -0.168095045341921  0.398821112602689 -0.046726828449621 -0.030609711055064 -0.217531691733838 -0.115639511714214  0.399856930098400  0.150033235311716
-    8  (  8) -0.059559370905179  0.306305036465827 -0.595923646185890 -0.119277640805674 -0.722271918559490  0.001726267262613 -0.027179920353598 -0.211451038002310  0.148912062372910
-    9  (  9) -0.188866142842736  0.096789990486457  0.236442562527094  0.092757728041313  0.072651948101216 -0.016472461695526 -0.026914575117300  0.247244600184375  0.370870606832493
-   10  ( 10) -0.406957853798143  0.141958866881762 -0.085132936917023  0.102326296221874  0.017996095944708 -0.062553443565296 -0.105319900227601 -0.005069269037988  0.006423933602228
-   11  ( 11) -0.081915250147579  0.202583484157184 -0.282203343833431 -0.339304077428364  0.118298550150489 -0.126692826807318  0.005731143361727 -0.150166092159272 -0.134968415625333
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.038183979702674
-    1  (  1) -0.001758617329220
-    2  (  2) -0.002245458358924
-    3  (  3) -0.305015280585847
-    4  (  4) -0.011707659076193
-    5  (  5) -0.052479234679287
-    6  (  6)  0.143560462314116
-    7  (  7)  0.320971036748081
-    8  (  8)  0.148594551736844
-    9  (  9) -0.097500178466871
-   10  ( 10) -0.069870490871550
-   11  ( 11)  0.082515655756872
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.053221344681142 -0.117483147833985 -0.106139723247453 -0.495823955121092  0.391515874804455  0.212402958848530 -0.083769680573767 -0.039675371517883  0.058634274306531
-    1  (  1) -0.117410394687696 -0.001165915237512 -0.133100613626654 -0.630012634533085  0.317623482499555 -0.573984529169381  0.375575851008806  0.417091736224605 -0.210582306420709
-    2  (  2) -0.106116179316557 -0.133365754849436  0.099881677186242 -0.283389270168438  0.408842653260195  0.463415082290805 -0.094461635582511 -0.339728478273951 -0.187117729157411
-    3  (  3) -0.495487159854538 -0.630575218275538 -0.284210529100489 -0.394005207299682  0.243829412824131 -0.426368810438983  0.000017569224274 -0.316982847795332  1.182262387796268
-    4  (  4)  0.391977861689502  0.318458435778042  0.410524448216213  0.243871385545647 -0.262605821454379  0.313475558817429 -0.006238164976110  0.146232809940208 -0.404783357267945
-    5  (  5)  0.211677947989569 -0.572946112183618  0.465876094202739 -0.424891649228725  0.310576368667640  0.340119032966648 -0.103399884420596 -0.366027570904681  0.140243317389270
-    6  (  6) -0.083203642949521  0.374758513857944 -0.095474380553338 -0.000848431158077 -0.007011740191065 -0.103456952640946  0.035381526355376  0.100664517850410 -0.224617556800866
-    7  (  7) -0.039824177760467  0.417269525333673 -0.339848279473418 -0.316785009817077  0.144981956006953 -0.366591938133070  0.100487370214345  0.453363803566786 -0.284080848307595
-    8  (  8)  0.058454981179204 -0.209563433448112 -0.187086823104815  1.182437825563613 -0.401897920471953  0.141960153823608 -0.223791716105096 -0.283768269790238 -0.127258563076312
-    9  (  9)  0.176473367868989 -0.113695285962430 -0.191045562239273 -0.466077182834650  0.080353173846381 -0.392419296545826  0.139310719822578  0.097667658130615  0.260382741772322
-   10  ( 10)  0.087511748605763 -0.084525637542731 -0.451433812661641  0.087442027470754 -0.075301055147615  0.128254312442896  0.066832910809452  0.040269698765907  0.083963538620684
-   11  ( 11) -0.256000473516428  0.178934738319287  0.462669412659627  0.336070869572452 -0.226364820740552  0.220661186826050  0.015682276558009 -0.019696413835863 -0.320368477367524
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.177398660643495  0.088413661062507 -0.257047850800415
-    1  (  1) -0.114710761582569 -0.086001542477366  0.179468892454740
-    2  (  2) -0.191402905701337 -0.452554194931555  0.463985875678332
-    3  (  3) -0.467548510382317  0.086605995128391  0.336310348111395
-    4  (  4)  0.080907164839857 -0.077457000042675 -0.231693183962593
-    5  (  5) -0.391713702811823  0.124122145336547  0.233240659481206
-    6  (  6)  0.139727422139028  0.065972550943365  0.014736999139443
-    7  (  7)  0.097438431199858  0.039119593081805 -0.012607893852994
-    8  (  8)  0.258370481571402  0.084693167750785 -0.328679992068142
-    9  (  9) -0.027947875522173 -0.059452680730838  0.039102598209232
-   10  ( 10) -0.061112133253744 -0.042824028656813 -0.176907573001062
-   11  ( 11)  0.036269564126208 -0.174115037047438  0.046562990208638
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.221915567502623  0.240154969163816  0.089524025753548 -0.009891539023461 -0.105352264889997 -0.079728196437896 -0.186918344067447 -0.018609216798882 -0.150218987334760
-    1  (  1)  0.239595861160914  0.097635005536382 -0.020343203465831  0.252497393963625 -0.178770889626966  0.156659860903133  0.042031186852564 -0.226739274781765  0.050354579998016
-    2  (  2)  0.090047283413814 -0.021960432152020 -0.652704165096791 -0.484235858264924  0.265074532283746 -0.870240852693915  0.056963933090132  0.087593695232780 -0.397150344061483
-    3  (  3) -0.008304023565221  0.254514964099576 -0.488668744172267  0.243914942296862 -0.497430549408554 -0.651892044099941 -0.144949354151790  0.009197770416785  0.363155689203458
-    4  (  4) -0.105368055288416 -0.178968402377489  0.265813616023428 -0.498441236963999  0.117807978177016 -0.197938223960627  0.010977461550819  0.054866508200549 -0.633466747483980
-    5  (  5) -0.079092278611567  0.155211327907083 -0.870349858528248 -0.648891955877304 -0.198852995680930  0.056118287010249  0.077393750543525 -0.820063131904850 -0.522591293712200
-    6  (  6) -0.188319262904704  0.043235387216250  0.056704467242807 -0.145342612784415  0.011176054667898  0.077123788010048 -0.017043504447154 -0.229308594149143 -0.061253571825596
-    7  (  7) -0.017449220652026 -0.226052369590475  0.086398229140611  0.009988063298837  0.055257253277244 -0.820894010869112 -0.229107411788767  0.436891114659360  0.154693358924324
-    8  (  8) -0.147652836473568  0.050157233403955 -0.397985593672069  0.364902332737576 -0.632177325650741 -0.523669848989306 -0.060883358066048  0.155008994016302 -0.331322085722016
-    9  (  9) -0.012364053013731 -0.381902018882131  0.730234455154150  0.318717588976828  0.654372705810295  0.234910934996783  0.063436038641434  0.568676727219248  0.116095919775855
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010717409085818
-    1  (  1) -0.381606046587817
-    2  (  2)  0.729520232349256
-    3  (  3)  0.319801359646356
-    4  (  4)  0.655576694394483
-    5  (  5)  0.233766377042350
-    6  (  6)  0.063681628675817
-    7  (  7)  0.569047245691214
-    8  (  8)  0.115234955131862
-    9  (  9) -0.255200733989858
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006756611009239 -0.004812319108707 -0.015155246179453  0.018768861614548  0.003263846230316 -0.029956626691063  0.007768157616613  0.008654952545397 -0.024139771998296
-    1  (  1) -0.000276876655733 -0.007317152277636  0.067126401411285 -0.013873168496829  0.038395392580021 -0.004054864162186 -0.028032553908660  0.014238200673600  0.044802348000681
-    2  (  2)  0.034311733284435  0.014478380463186  0.079037871547464 -0.037480797351928  0.004455235189999  0.068266709703376 -0.020927095140560 -0.000590179941322 -0.116436689576599
-    3  (  3) -0.034781167081690 -0.039999835648210  0.017388947621558  0.117724049135840 -0.062309713575062  0.098214530429882  0.024529272430519  0.026637769905859  0.121592113448416
-    4  (  4) -0.036088452219928  0.018119725898309 -0.181397076074172 -0.381210957896193  0.211295234548894 -0.335046977567969 -0.001001209940803 -0.032788904430710 -0.087406508170972
-    5  (  5)  0.091932999121248  0.163472911292393  0.257039057929667 -0.406986018028708  0.108362880698111  0.483755223010107  0.114747171070721 -0.179816739697054  0.021814542430540
-    6  (  6)  0.102207313652244 -0.075273825473482  0.076700485775484  0.010389199522243 -0.095145363312679 -0.177269643268087  0.339312666537493  0.145893525857585 -0.013352577122472
-    7  (  7) -0.036776384387696 -0.162278963391709  0.362818814892890 -0.043460364327904 -0.026462409718549 -0.199351982461758 -0.104180059013018  0.364628559511404  0.137093791802520
-    8  (  8) -0.054133642075650  0.281937460317668 -0.549118750139198 -0.110766566728388 -0.665283649525633 -0.004014717984651 -0.026030812844979 -0.193249298632007  0.140185869779560
-    9  (  9) -0.149539825936769  0.083496187141563  0.222414359602469  0.086467924966290  0.058519767738283 -0.026610134648035 -0.023639345193443  0.224482305471681  0.335967535114734
-   10  ( 10) -0.342551768791105  0.115343806322270 -0.079695331214451  0.094078531732984  0.012984790263811 -0.052720281866277 -0.089289783188097 -0.003161584461577  0.011520822726607
-   11  ( 11) -0.067948144123858  0.170897803094304 -0.268478044795138 -0.331752793901224  0.110501398686606 -0.120431522039808  0.010421693063374 -0.142909196950524 -0.136584264097857
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.029945709624550
-    1  (  1) -0.003777838622564
-    2  (  2) -0.000494193391228
-    3  (  3) -0.283159255072162
-    4  (  4) -0.002056849846006
-    5  (  5) -0.055491249216550
-    6  (  6)  0.134241443599212
-    7  (  7)  0.294425347600366
-    8  (  8)  0.138732741810037
-    9  (  9) -0.100744739667680
-   10  ( 10) -0.062352827286650
-   11  ( 11)  0.087587602591740
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.057027762100789 -0.007489633887342  0.036964189813796 -0.021384352100284  0.004867815775604  0.032130235858782 -0.019486973797962 -0.000503926514732 -0.024868986663351
-    1  (  1)  0.007883399599923 -0.007529104506445 -0.013216566770749  0.001554286609489  0.002481002458300  0.003555137440754 -0.020216878378801  0.003435265519663  0.003420680709423
-    2  (  2)  0.005061763911744  0.024005030999464  0.016920245291348 -0.019760528227158 -0.007759414271484  0.029231812106945  0.009559298232843 -0.004745878981161 -0.053662769962019
-    3  (  3)  0.011903086348447 -0.106154395386531 -0.048846797682958  0.038122834717736 -0.042076447151745  0.017515736018254  0.021695004377211  0.017259669010754  0.058953679400153
-    4  (  4) -0.086846706941042  0.161257530089836  0.037361255861875 -0.089905419413410  0.174437646387183 -0.071028892880315 -0.038811212273731 -0.045200518155063 -0.066894551440516
-    5  (  5)  0.295118954821928  0.042171667688274  0.057142717280935 -0.095328920031059  0.118376834610768 -0.017202604507056 -0.038088685926927 -0.015413673756028 -0.019970185142534
-    6  (  6) -0.061695197805604 -0.041447416246154  0.107874329349021 -0.009310856499629 -0.028327062477196 -0.072556054900044  0.031173831746629  0.093673016450942  0.096470656575707
-    7  (  7)  0.040164356283535  0.019606328824315 -0.022514162311588  0.103095269177578 -0.105738125414362  0.000251323240260  0.190667102998226 -0.014251172141516  0.042544347999407
-    8  (  8) -0.209747539729284 -0.026225521984115 -0.065411218317390  0.108576414051802 -0.195951046046893  0.054935351774023 -0.181062671358124  0.048648601818055  0.037403343457353
-    9  (  9)  0.029537922421234 -0.045187174636289  0.013381512217286 -0.049426415359509  0.003411235911782 -0.045265306723710  0.096457278821335  0.006113492494935 -0.044165814974043
-   10  ( 10)  0.026870929841946  0.010513244846490 -0.122411818973730  0.066300236331789 -0.074150921852319 -0.175359501999903 -0.025219490294838  0.031299023505132 -0.032770162927265
-   11  ( 11) -0.076638806040972 -0.048660864910506 -0.054798136469999 -0.067410404189619  0.096042680906718 -0.030077767167195 -0.040609376761651 -0.003350033647470 -0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007613623485115
-    1  (  1) -0.001053219582711
-    2  (  2)  0.054751844139672
-    3  (  3) -0.021588797011546
-    4  (  4) -0.069416579868176
-    5  (  5) -0.031311068013170
-    6  (  6)  0.060683491342485
-    7  (  7)  0.004937786560826
-    8  (  8)  0.055843386605960
-    9  (  9)  0.053258374332423
-   10  ( 10)  0.029326398375861
-   11  ( 11) -0.027904630917537
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000025015734507  0.010198711087952  0.006474775958448  0.066946051563528 -0.066550206967977 -0.041188873125926  0.023552914991952  0.019202263160422 -0.006942946197737
-    1  (  1) -0.010140605887652 -0.000014394957877  0.022996796061328 -0.067092192493274  0.063685673857393  0.019093615376604 -0.005525180617760 -0.015031464830750  0.005320182556269
-    2  (  2) -0.006534739001904 -0.022969584694137  0.000183457658640 -0.211551326757209  0.218187807438925  0.104132114893528 -0.065436658246811 -0.042103919182146 -0.012243831904844
-    3  (  3) -0.066304931943444  0.066584833979085  0.210703888875489 -0.000394093515089 -0.011258600581601 -0.092530428436357 -0.131881992071255  0.026480578605083  0.063346368194022
-    4  (  4)  0.065779542430873 -0.062822415172501 -0.216601239538476  0.011617389043850  0.000720555249011  0.020159848057855  0.073942431465134  0.001119920964031  0.016120241216710
-    5  (  5)  0.040846799691504 -0.018979734118351 -0.103125251405654  0.092549855601907 -0.021623501291584 -0.000771447754999 -0.234552119202209 -0.000611164043666 -0.101606719343242
-    6  (  6) -0.023326218450828  0.005550385111505  0.065252405074981  0.131681855193961 -0.073575257938565  0.233645237851028  0.000193851682480 -0.255788429172446  0.079072823032341
-    7  (  7) -0.019055068515462  0.014786531642521  0.041539856986611 -0.026353850726780 -0.001700683540838  0.000445480591706  0.255766070671258  0.000118381893033 -0.151562772366571
-    8  (  8)  0.006620321009197 -0.005142966830662  0.011245852682541 -0.062510776113309 -0.015648596901915  0.102272652360209 -0.078381794853266  0.152302821501449 -0.000094469957927
-    9  (  9)  0.045347281960025 -0.040291069791943 -0.085226922335689 -0.018441757598111 -0.027467525239214 -0.004932928889320 -0.020868912898856  0.024483356625930  0.224180460199113
-   10  ( 10)  0.020374790573784 -0.028198954860440 -0.010392111666997 -0.120181326176130  0.060512260831236  0.109015894697222  0.047153104465120  0.043944046420833  0.103069326885495
-   11  ( 11) -0.049408052352300  0.045270280246414  0.110185553685008  0.041594160321979  0.088273360930753 -0.183934249639257  0.003285919080508 -0.178701510068243  0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.045673042542890 -0.020717466986083  0.050844518832522
-    1  (  1)  0.040043621408487  0.028287827625151 -0.045457031631407
-    2  (  2)  0.084888848710605  0.010052611398803 -0.109898373773783
-    3  (  3)  0.018088362425205  0.120534313520650 -0.041770057803413
-    4  (  4)  0.026789230886550 -0.060849702419905 -0.088673365261613
-    5  (  5)  0.008004711197727 -0.108432873838655  0.185071361149962
-    6  (  6)  0.020116775504235 -0.047889712574718 -0.001523439225442
-    7  (  7) -0.023964360822185 -0.043618854823263  0.177454217319223
-    8  (  8) -0.226734396044438 -0.102481459206944 -0.008115223439087
-    9  (  9)  0.000423083368406  0.309060226547434 -0.090400550219427
-   10  ( 10) -0.308249178857435  0.001017567434936  0.330623886780632
-   11  ( 11)  0.090136758927266 -0.334530610017321 -0.000453348817603
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000379496190680  0.036516557673727 -0.022488411844201 -0.041143099111719  0.015151024607555 -0.009820525598214 -0.001328546168408  0.002719718233480 -0.079787685858295
-    1  (  1) -0.035173743352485 -0.000509376348503  0.021748140811100  0.018984912310085  0.002571720003760 -0.101540537848848 -0.014107119535580 -0.020961802105584 -0.100916916558314
-    2  (  2)  0.024420430259890 -0.020833264343634  0.000589210441902  0.028690810435666 -0.025063562199365 -0.056845698692633 -0.019362765266970 -0.000534124800005 -0.061230653902760
-    3  (  3)  0.039980341452345 -0.019929624233720 -0.028127725164783 -0.000384377200086  0.012223469426354  0.007870420436516  0.021500821930750 -0.002985124038023  0.055850425927213
-    4  (  4) -0.015033200445576 -0.003096204403696  0.023799943458502 -0.011898049659739  0.000036971633887 -0.000277032322295 -0.021239662546675  0.005095064856192 -0.060237805990277
-    5  (  5)  0.010708008535887  0.101587409014600  0.056660431011914 -0.007350368054025 -0.000126941263904 -0.000065704202214  0.008506831299188 -0.011228150905342 -0.011964202302477
-    6  (  6)  0.000469087338482  0.014200163610075  0.019097267233085 -0.021632296910845  0.021392214011008 -0.008495741848254 -0.000109627873962  0.021812533614874  0.020464844726232
-    7  (  7) -0.002889338898616  0.020632474935553  0.000453752095144  0.002975803626006 -0.005037506724376  0.011335159213681 -0.021733393798695  0.000007087204356  0.019955598928897
-    8  (  8)  0.081293710509515  0.100918057466141  0.060971767857812 -0.055875536861090  0.060631757745431  0.011264467031019 -0.020209151997608 -0.020081495210629 -0.000340983773767
-    9  (  9) -0.080516503167305  0.106262951221757  0.031461397073353  0.007056184146683 -0.022432192781915 -0.017093833942137 -0.097099983466552  0.001349018368294 -0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.079753101670227
-    1  (  1) -0.106710217482987
-    2  (  2) -0.031619499292907
-    3  (  3) -0.007164069356259
-    4  (  4)  0.022223903647397
-    5  (  5)  0.017462464724719
-    6  (  6)  0.096957045420818
-    7  (  7) -0.001243112172754
-    8  (  8)  0.004611313750592
-    9  (  9)  0.000252169760563
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055343853322395  0.005338522209203 -0.036325792187091  0.020411379114398 -0.005004472559017 -0.030883540419705  0.019693764112942  0.000404480716013  0.025396203204216
-    1  (  1) -0.006570683600848  0.008768421568488  0.011573795638563 -0.000009175751903 -0.002770565739659 -0.004931208897901  0.022163570789429 -0.003290104656908 -0.003254936700297
-    2  (  2) -0.001674419203277 -0.021967102120902 -0.025831824909554  0.024758928994745  0.009340908203812 -0.034459015755376 -0.010228225914487  0.005919790861067  0.058115699230390
-    3  (  3) -0.007779977639509  0.106141218473434  0.050482163293278 -0.041812559908941  0.042606909564863 -0.016938249582167 -0.022723831963497 -0.018285942873731 -0.061788101761112
-    4  (  4)  0.087397972334062 -0.164590469335859 -0.035983465272717  0.095460926704216 -0.183399304764373  0.073380967092300  0.038295030471351  0.047026058194857  0.066959437295317
-    5  (  5) -0.293750190777910 -0.042648437038433 -0.056404874075468  0.100193237694056 -0.123782490033077  0.014652582564902  0.036251400704161  0.016769125982848  0.023410414575794
-    6  (  6)  0.063526410041118  0.042202406515953 -0.107158367449000  0.011222400592515  0.032805848689894  0.070775222023081 -0.034269417179590 -0.097599209765295 -0.095048599779477
-    7  (  7) -0.039213631545190 -0.016300797142278  0.022834925899151 -0.106699749704471  0.109813770660251  0.000567880224415 -0.192962587636570  0.013162275101134 -0.042958800457043
-    8  (  8)  0.207671023275567  0.021761663181296  0.066317329893717 -0.113575721461044  0.208505431005016 -0.053139089145086  0.182387663583988 -0.049317657695772 -0.039898751560786
-    9  (  9) -0.031717525025615  0.035452316963842 -0.019040840253717  0.049757955126745 -0.003315672276934  0.048439544916052 -0.094357742781682 -0.007725852797236  0.042206115018339
-   10  ( 10) -0.030723138202058 -0.012685537900520  0.130253036286197 -0.070878549267589  0.073822499716479  0.176856315004232  0.024096584449109 -0.033980770130198  0.029602022179569
-   11  ( 11)  0.076338046412608  0.058007647538535  0.059625157558161  0.072355446358478 -0.100714683926583  0.028164062896195  0.037103331661254  0.004159802100780  0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007837140573608
-    1  (  1)  0.001271351061977
-    2  (  2) -0.056316152671545
-    3  (  3)  0.023558705106194
-    4  (  4)  0.071677402926291
-    5  (  5)  0.031036091810970
-    6  (  6) -0.060669139129724
-    7  (  7) -0.008329217020035
-    8  (  8) -0.058082899762783
-    9  (  9) -0.050026765138378
-   10  ( 10) -0.030419330923301
-   11  ( 11)  0.028289350786073
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010782784489972 -0.013050845930128 -0.033023155215664  0.015191714992095 -0.005425132814901 -0.026116394662957  0.007256800612108 -0.004570990183776 -0.083505985646911
-    1  (  1)  0.004775248888120  0.019609050610054 -0.043741880650327  0.000073954161324 -0.027319440587928  0.081090619324759  0.046094626593374 -0.004371816989341 -0.079334747598806
-    2  (  2)  0.007829067250874  0.005611745899100  0.069924533643314 -0.039501674728206 -0.000927353784976  0.005421401951033  0.003817544999769 -0.008629946885833 -0.093259618314415
-    3  (  3) -0.018327078243591  0.003795046417131 -0.017900293895817  0.029796535142542 -0.026342994062962 -0.087573876827112 -0.029918989049988  0.054199220040285  0.044809777400716
-    4  (  4) -0.027183503470872 -0.089536481638857 -0.084857160463068  0.036527297001861  0.242538124561929  0.016430382958973  0.030531081573579 -0.170538311757182 -0.261658379411546
-    5  (  5)  0.020462782587523 -0.074168804451800  0.167834230231717 -0.149604127852478  0.243854217657690 -0.044978789492557 -0.032478673883371  0.164731310430024 -0.003040851330374
-    6  (  6)  0.075422914773902 -0.018345498918631 -0.109883881828728  0.119442941495868 -0.084779039670754  0.177672686986939 -0.254932779745392 -0.179910297504286 -0.058420300218360
-    7  (  7)  0.077293940205111  0.171942167313393 -0.155379720343131  0.213627786676900 -0.203405159942268  0.435742440136601  0.116233082588661 -0.403785601702878 -0.048376113482094
-    8  (  8)  0.113887453356696 -0.134815689960008  0.121289875435757  0.381302435842573 -0.140362613154441 -0.094837304770689  0.044125422076338  0.354102164255088 -0.021060221761777
-    9  (  9) -0.010381942177856  0.091513821594073 -0.090489398632436  0.104640269057990 -0.011526746486386  0.174325672883320 -0.095096801177535 -0.162567420891194  0.086584233440007
-   10  ( 10) -0.046140785323826  0.004506559121454  0.092261546126996 -0.049590165687623 -0.056546117609635 -0.023211770714739 -0.114566901687301  0.007355072527000 -0.045260763292278
-   11  ( 11) -0.210277389085871 -0.043479475791959  0.002620356919958  0.027295607176521  0.213582758279457  0.049406759718245 -0.038753842401848  0.045549481042434 -0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.000588783769111
-    1  (  1) -0.095074877441065
-    2  (  2)  0.094269658052775
-    3  (  3)  0.087042465113366
-    4  (  4) -0.229147969925312
-    5  (  5)  0.037090740492870
-    6  (  6) -0.008539965499391
-    7  (  7) -0.114631280540035
-    8  (  8)  0.035100938386537
-    9  (  9) -0.119410852550345
-   10  ( 10)  0.048938543804445
-   11  ( 11) -0.026842233365654
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000083177655875 -0.020596022225207 -0.023074380682109 -0.123906982660277  0.115856799969175  0.077548996218664 -0.033724258035794 -0.015583195761424  0.055304180213594
-    1  (  1)  0.020496643104719 -0.000177442053919  0.044849161409626  0.200056054082230 -0.192734988239744  0.095810846356379 -0.089592000858118 -0.154865722471105  0.062884487656521
-    2  (  2)  0.022893568520427 -0.044914234916282  0.000286887581780 -0.110147204900385  0.098101481651214 -0.037544614577033  0.063107876559817  0.057867129267241 -0.133662561842804
-    3  (  3)  0.123637708691857 -0.200030347190693  0.110276511900212  0.000067254700333 -0.150932238527093 -0.295587503177329  0.155559256339819  0.250191288225748 -0.068514494250419
-    4  (  4) -0.115217909263092  0.191910599591419 -0.098719023514077  0.150564412486325  0.000108066296459 -0.207017027157466  0.092817557275927  0.119727699718554 -0.027839136386995
-    5  (  5) -0.077201349586182 -0.095637330323257  0.037580888266386  0.296037283435946  0.206488013849544 -0.000677656990837  0.030142059938078  0.107860538698997 -0.317965442908009
-    6  (  6)  0.033520398034563  0.089301712720516 -0.063135446629119 -0.155494983890111 -0.093120397549751 -0.029958661714230 -0.000263665833745 -0.031787895548351 -0.052772032197117
-    7  (  7)  0.015173638148760  0.154650785159269 -0.057964322733043 -0.249885773107303 -0.119546085272213 -0.107827018648257  0.031752436246544 -0.000037065640674 -0.211400361545441
-    8  (  8) -0.055452136609395 -0.063704146851438  0.132109776961381  0.067534716804367  0.027512182553154  0.319330567201196  0.051501501228049  0.211684727134552  0.000062825592229
-    9  (  9) -0.059987775905021  0.059013360455393  0.001731139538261 -0.025602282087959  0.077406198911912 -0.032289392048789  0.044673931971007  0.007013222782529 -0.205272148471903
-   10  ( 10) -0.040816969333319  0.029839999727295  0.097606908985792 -0.012730679444132 -0.052120800982420 -0.047092545087938  0.097199457935824 -0.008100744465293  0.194519063749344
-   11  ( 11)  0.105565276750546 -0.086850909183234 -0.141349531156014 -0.064538795649442 -0.048769909889220  0.098670307723293 -0.132937762954191  0.091749745952861  0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.059727136016838  0.040967341903913 -0.106287777222309
-    1  (  1) -0.058687758282915 -0.029394471353826  0.086811620398375
-    2  (  2) -0.001293940264555 -0.097641591345113  0.142636172226853
-    3  (  3)  0.025821629306306  0.013207208477272  0.063793857996761
-    4  (  4) -0.076409112526474  0.052575212530451  0.047414860037356
-    5  (  5)  0.032527517350565  0.045632421732577 -0.095160623491729
-    6  (  6) -0.044231942651703 -0.096152133696301  0.132935625343693
-    7  (  7) -0.007372100254253  0.008488811567739 -0.092713079820202
-    8  (  8)  0.206938183650805 -0.192802275414426 -0.052611900153123
-    9  (  9) -0.000608554890156  0.088592533061698 -0.344380743508036
-   10  ( 10) -0.088950131298492 -0.000863284429953 -0.222751022723935
-   11  ( 11)  0.341005102874300  0.224718204882492 -0.000326394311109
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000338557997552  0.011375035743392 -0.029451193209236  0.012043586883828  0.021579660859347 -0.039033326019946  0.009990415550092 -0.009478976983628  0.045907412693585
-    1  (  1) -0.013672223167698  0.000473657715584  0.014851568055555 -0.021895587564371  0.022163590605075 -0.051246172607775 -0.019257625103746 -0.003658602851281  0.019552361048058
-    2  (  2)  0.032608942325713 -0.014402827198054  0.000746991250603  0.029107751732300 -0.054720608245644 -0.057033646383303 -0.001872360780591  0.031698780852448 -0.056602981887733
-    3  (  3) -0.014268935231542  0.021459967996182 -0.030313065636317  0.000730068456009  0.016766656065195  0.058973632357354  0.003002419788061 -0.022431580465626  0.134333948620083
-    4  (  4) -0.022372891038515 -0.021355779916377  0.052959509294565 -0.015751198634933  0.000391938857969  0.016109226068828 -0.004538544158672  0.050308920012661 -0.059340919102150
-    5  (  5)  0.040216234763810  0.051875751817174  0.055849318880052 -0.058120412757832 -0.016460961175898 -0.000645475334216 -0.019024299026328 -0.068804307634402  0.024311188622736
-    6  (  6) -0.009930727984206  0.019074682595569  0.002242770131548 -0.003091320851947  0.004596281406168  0.019032186967740 -0.000074596378968 -0.032870219636189  0.006741182978715
-    7  (  7)  0.009279418369258  0.004264018479381 -0.032087681361723  0.022624894165436 -0.049954824766487  0.068907285150032  0.032867640818893  0.000029995356356  0.011652937852273
-    8  (  8) -0.047260005865874 -0.018493502167014  0.056736132845076 -0.135589678169431  0.059916509278318 -0.024164421049794 -0.007333544303120 -0.011763030881780  0.000264400142459
-    9  (  9)  0.016875007958598 -0.031435494057685  0.089048257959160  0.041017085631602 -0.020420285065562 -0.066513023484078 -0.000739604154969  0.091958006244489 -0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.016438561460291
-    1  (  1)  0.031819705279686
-    2  (  2) -0.089217438029428
-    3  (  3) -0.040553914705774
-    4  (  4)  0.020554472275814
-    5  (  5)  0.066048736736302
-    6  (  6)  0.000688806170902
-    7  (  7) -0.091248940256931
-    8  (  8)  0.027663919394381
-    9  (  9)  0.000090314260367
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.011888856297006  0.017750932125153  0.030381401096490 -0.012819546160996  0.007239420422718  0.024248756043407 -0.008035757610220  0.005364063357974  0.085646323747472
-    1  (  1) -0.005014728223890 -0.026640078285976  0.053625852742063  0.001580773154934  0.029513947501511 -0.084681976949646 -0.049070075720108  0.003015931693788  0.083533135335069
-    2  (  2) -0.005701802857788 -0.001861436552455 -0.077309348516175  0.039227298256145  0.002806617492516 -0.004668173879327 -0.004051055445085  0.009725469213679  0.098722432349714
-    3  (  3)  0.016358351457124  0.001723600627698  0.021225514928062 -0.039815087581337  0.022808569998795  0.104140287911999  0.033233738030323 -0.056382556071864 -0.046907957767316
-    4  (  4)  0.023138877563353  0.095098707280146  0.087666288227931 -0.037561492255805 -0.255193211004254 -0.015544572331716 -0.030557402755123  0.180093964112144  0.259856355700386
-    5  (  5) -0.024228572043234  0.082834757201086 -0.181139504221043  0.153944959591839 -0.252818375021614  0.048862178579716  0.036094966909273 -0.170640955267472  0.004551713568432
-    6  (  6) -0.085402345559358  0.022737485412840  0.117389155338347 -0.122686430467103  0.089994929534087 -0.186662776489158  0.276334552924253  0.188945818003174  0.062512631958960
-    7  (  7) -0.077377916753636 -0.184413390881742  0.161635032551528 -0.217081818449181  0.216158931990711 -0.452250331823368 -0.121365143499215  0.427486936599919  0.051141830029037
-    8  (  8) -0.109996402529651  0.145159792225805 -0.137471198251747 -0.396423044911114  0.145941263905056  0.104134158957014 -0.041227108112442 -0.369426049626710  0.017681253264412
-    9  (  9)  0.015271329763023 -0.091667642816572  0.093167229349338 -0.105178289783052  0.012072216330151 -0.184888670947420  0.104021366500691  0.173041839821099 -0.089774142402176
-   10  ( 10)  0.051871879465497 -0.004911726396439 -0.095027344602311  0.050235453581707  0.056755121586123  0.023277306660177  0.123771404812450 -0.008953154661311  0.042342746566353
-   11  ( 11)  0.213874614633354  0.038620645156941 -0.003918905035704 -0.027644952213642 -0.227437070959628 -0.047768116418487  0.043243210008693 -0.046251908849224  0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001231945309971
-    1  (  1)  0.099118498855930
-    2  (  2) -0.099462956417043
-    3  (  3) -0.089788110354890
-    4  (  4)  0.236379406660322
-    5  (  5) -0.043290372964682
-    6  (  6)  0.008471875583563
-    7  (  7)  0.118429426587662
-    8  (  8) -0.041151812398786
-    9  (  9)  0.121668252978460
-   10  ( 10) -0.047795297768532
-   11  ( 11)  0.026000603113831
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.092723408151075  0.057215092134940  0.054154926215137 -0.012957083117559 -0.028122190094715 -0.031179347218855 -0.013645641371598 -0.009921258172339 -0.037242536390232
-    1  (  1) -0.019990430092613  0.002382806987559 -0.016009786257367 -0.011651136664597  0.017212414198990  0.024265249236370 -0.152443472946687  0.006755616148329 -0.024207249541319
-    2  (  2) -0.009030755895234 -0.085216520460363  0.016500441499831  0.009813164947617  0.015713678712422 -0.028373503652355  0.075877310310795 -0.039590492962937 -0.081270933339189
-    3  (  3)  0.075043611755008  0.103608833794547  0.030676505925522  0.013143510199953 -0.006187488557257 -0.045202449901574  0.041605892889482  0.001210820793539  0.045033631139440
-    4  (  4)  0.122337112724117  0.176460576265088  0.085321001863374 -0.041690733440160  0.111448222796030 -0.083092300673138  0.094252463151414 -0.071551603610925 -0.059851091994803
-    5  (  5) -0.372712635775664 -0.109553572239785 -0.087636097688831 -0.161393941368917  0.091711881285738  0.083559837956631 -0.084048684818413  0.114275654348762 -0.004760374961166
-    6  (  6) -0.030431995544059  0.095321795210779 -0.159145740022025 -0.376304340373359 -0.189004479350399  0.100683798175242  0.128902751762968  0.567857709085750  0.002399331341204
-    7  (  7) -0.344039522571259 -0.114279634125077 -0.003626426979965  0.177981236436906  0.027932329764501  0.026442462397652  0.246808699479261 -0.268819164710932  0.106523620842343
-    8  (  8) -0.111643207885322 -0.002836247769573  0.018154026503924  0.097243438328650 -0.121498121615664 -0.006682650130485 -0.107315976978454  0.036939727738377  0.063237979028415
-    9  (  9)  0.063921675215150  0.215994652248761  0.065707412514049 -0.003935136905129 -0.142641982827575 -0.026699050855783  0.056962954862571  0.164747861484427 -0.081509018515780
-   10  ( 10) -0.058030998072116 -0.060474289846612 -0.205628226890442 -0.038897333798042  0.068097699807560  0.116172285533776  0.038858694654200  0.255643829382515 -0.001247633054968
-   11  ( 11) -0.085574013220044 -0.030726962638802 -0.008247473867838 -0.106409310393215  0.064469816287686  0.072180462194277  0.022620356444758  0.070649638629627 -0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015293746360799
-    1  (  1) -0.020176832366409
-    2  (  2) -0.007468634139779
-    3  (  3)  0.002013486296780
-    4  (  4) -0.055907379643807
-    5  (  5) -0.014548062338959
-    6  (  6) -0.210557719542813
-    7  (  7)  0.107773752705760
-    8  (  8)  0.004939471027833
-    9  (  9) -0.101796072438763
-   10  ( 10) -0.052197801100809
-   11  ( 11)  0.010791942309942
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000245185765728  0.004422769142209  0.195473142624697 -0.067124189998810 -0.027096370068160 -0.099320185873800 -0.032910569428743 -0.079494520674282  0.016762710819247
-    1  (  1) -0.004388313593185  0.000165290846899 -0.188129406432792  0.063756474949075  0.001128748240139  0.126263116741295  0.303817994309096 -0.069854530583820 -0.010310792522154
-    2  (  2) -0.194444327410373  0.187906024270824 -0.000538868177065  0.115697813615881  0.188025580722992  0.063555095149569 -0.109038200896130  0.123360187528163 -0.037347597176070
-    3  (  3)  0.066590814481336 -0.063203632987523 -0.115347217679990  0.000002301796994 -0.034584588669551 -0.038983157581533 -0.229948513873159  0.131721887952800  0.028384936970778
-    4  (  4)  0.026403437308072 -0.000527986476725 -0.186677671985474  0.034818437947430  0.000320297338463 -0.037865478650564 -0.201451121997014  0.109301689008128  0.005643097026329
-    5  (  5)  0.099409584232992 -0.126346592032007 -0.064419008019557  0.039794220656347  0.036855903902447  0.000190318965932 -0.088891480212760  0.056789849447140 -0.091073030281233
-    6  (  6)  0.033050985013878 -0.303259624681304  0.108281756633666  0.230173439372417  0.201331671706094  0.089930560146314  0.000311452672695  0.221067383348441  0.053494283573947
-    7  (  7)  0.079472710309908  0.069297203366025 -0.125033677339702 -0.131451975782708 -0.110125569334720 -0.054839641157466 -0.219945401741596  0.001085047372961 -0.089073871816377
-    8  (  8) -0.016952142014388  0.010421932566239  0.036927801153181 -0.027792238689701 -0.005351459000165  0.090892785458666 -0.052690955519676  0.088985197141446  0.000032698621213
-    9  (  9) -0.149061020700740  0.058621114959186  0.279965277538519  0.021488283829580  0.044200621925698  0.026904718590704  0.074208134755608  0.037354078157659  0.137372829291651
-   10  ( 10)  0.035190315077894 -0.050814828300922 -0.151303785089698  0.062867991520111  0.077053666036856  0.075037906181509 -0.133385625358484  0.006791369727277  0.121764957568739
-   11  ( 11) -0.016457666688676  0.009560970830020  0.030160709068648  0.052615429880776  0.007184814870880 -0.147317585107930 -0.048007656104932 -0.024985856634055  0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.149527127949477 -0.035025203143730  0.017236912650706
-    1  (  1) -0.058313378902528  0.050420942142557 -0.009474518218355
-    2  (  2) -0.278325755481738  0.150562770304950 -0.029989264213428
-    3  (  3) -0.020585218415975 -0.063268588986747 -0.052977667343551
-    4  (  4) -0.042114256624995 -0.077316775027134 -0.007960467665663
-    5  (  5) -0.031625284755674 -0.074462306356205  0.148447086799088
-    6  (  6) -0.074615124808937  0.133170285550522  0.049651682674137
-    7  (  7) -0.041592449377408 -0.005910763914811  0.024358506166719
-    8  (  8) -0.138294110971387 -0.121744291260784 -0.107918344276425
-    9  (  9)  0.001133592488713 -0.474400799155993 -0.192590673354496
-   10  ( 10)  0.472105353620486  0.001334835966633  0.192285927563244
-   11  ( 11)  0.191497735915320 -0.194932828964948  0.001344945845524
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000738836304181 -0.037293198581408 -0.029451404620807  0.009378792471894 -0.055701113540954  0.035128933511984  0.013954700067714  0.072836702551235 -0.051857122483535
-    1  (  1)  0.032660614374695 -0.002015876922290 -0.074058480716263  0.021479421330690  0.014966422603257  0.166979967788261  0.013073252080067  0.022556560940623  0.170972365950935
-    2  (  2)  0.029165553040464  0.073308940131147 -0.000753195727027  0.033014777438001 -0.000651481686764  0.016615463822703  0.030045410532860  0.013342873064028  0.078343409399381
-    3  (  3) -0.010384415064446 -0.021326871974424 -0.031305865808474 -0.000583541727095  0.005150844265660  0.010972964083321  0.024667426696971 -0.003421011953857  0.027197309287279
-    4  (  4)  0.055501401866642 -0.014297660722118  0.000710544848112 -0.005493793084614  0.000124683940717  0.025126510553785  0.000947638436962  0.017069455654223 -0.023650915169846
-    5  (  5) -0.033803616927021 -0.164339399892725 -0.017068168082329 -0.010030727560507 -0.025241735580020 -0.000735433014139  0.028603795353780 -0.023029380344413 -0.027599055296252
-    6  (  6) -0.013107540346806 -0.012828435687407 -0.030286401438565 -0.024713021163335 -0.001063605161759 -0.029296491836886  0.000025149030498  0.111104514389532 -0.102861376746943
-    7  (  7) -0.072733387901303 -0.022465577956558 -0.013436829086647  0.003433808737295 -0.017048766876852  0.023125015384758 -0.110934303358415 -0.000037875914124 -0.002935696551342
-    8  (  8)  0.053267672687232 -0.170660201820078 -0.076657788504288 -0.028160893222526  0.023606436991553  0.027690933408034  0.102626814241324  0.002887530223588 -0.000373637330912
-    9  (  9) -0.004804828900057 -0.224333052817770 -0.065186758028368 -0.004091068046870 -0.039040275694483  0.042976408882840  0.051197675519228  0.024101682646066  0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.005026329948406
-    1  (  1)  0.225373696682354
-    2  (  2)  0.064686362479745
-    3  (  3)  0.004567750792129
-    4  (  4)  0.038996417519414
-    5  (  5) -0.043485644851561
-    6  (  6) -0.051601626537389
-    7  (  7) -0.023715023759407
-    8  (  8) -0.001115391080639
-    9  (  9) -0.000048164004682
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.087860740756488 -0.068261038905906 -0.057593788019307  0.011454237083441  0.027305499289367  0.032385982368371  0.018173477269549  0.009363386608796  0.038732450559880
-    1  (  1)  0.013249632151170  0.004184657414979  0.019716507976896  0.014744696478638 -0.016703323694180 -0.027386275287573  0.163732376866413 -0.007136524293248  0.024482820661864
-    2  (  2)  0.007013218896085  0.084657964294727 -0.026004205374563 -0.008076798202963 -0.011641159214614  0.031112856231507 -0.081756432692912  0.043486513055778  0.085001128307205
-    3  (  3) -0.058477500387638 -0.110048615847953 -0.032104075685968 -0.014807417786102  0.004697674213231  0.048123068402958 -0.048143599431998 -0.000645092439839 -0.047260089330542
-    4  (  4) -0.110574498742467 -0.188131348104213 -0.086636459451987  0.041361686502598 -0.118556992954628  0.089270642674348 -0.104552978829704  0.075153301656795  0.057940099039356
-    5  (  5)  0.371487279658724  0.115772941053656  0.094845419594772  0.167070991238391 -0.094497706414686 -0.087134798346335  0.079465840043241 -0.119932858558240  0.004312964076576
-    6  (  6)  0.035255689937620 -0.112028499449997  0.168145842580037  0.392683527257363  0.194284650981365 -0.110254467391126 -0.135773335198962 -0.599025983356266 -0.001116295743642
-    7  (  7)  0.362602042970953  0.115938705836042 -0.002852393959785 -0.186519834338995 -0.026972926522319 -0.023780474127448 -0.271135694461778  0.284033125501378 -0.111247570725030
-    8  (  8)  0.111196944464455  0.001239941376560 -0.021205830532168 -0.101329748088148  0.128975240085324  0.010144197632550  0.108358474715393 -0.037918096280026 -0.066572090545295
-    9  (  9) -0.090967744709768 -0.211201922436275 -0.066377513424381  0.007899083102241  0.154707771160094  0.037980948657754 -0.073559352539101 -0.172041273327275  0.087426840520207
-   10  ( 10)  0.070112475488657  0.079061926736069  0.222919508358954  0.040775801294398 -0.061424635747658 -0.113162621408555 -0.037903862973014 -0.270692474130444  0.009570796789139
-   11  ( 11)  0.090924578792926  0.040585886130445  0.000311072794648  0.117174234675791 -0.063663959894116 -0.077941781302743 -0.027645133174923 -0.073495241874676  0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015882565008118
-    1  (  1)  0.020403231736073
-    2  (  2)  0.007241270504095
-    3  (  3) -0.003144444710549
-    4  (  4)  0.058793064689134
-    5  (  5)  0.012293150809123
-    6  (  6)  0.215177196230389
-    7  (  7) -0.113635102585609
-    8  (  8) -0.004824845555481
-    9  (  9)  0.113550918048735
-   10  ( 10)  0.063789409560574
-   11  ( 11) -0.007009974437012
-
 	Computing Mu_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        14.646057913664
-	   1        19.900740748221    7.415e-01
-	   2        24.202679156489    3.530e-01
-	   3        24.333910708305    5.786e-02
-	   4        24.386483066105    2.489e-02
-	   5        24.384011165183    7.288e-03
-	   6        24.382065088424    2.366e-03
-	   7        24.382700715455    9.330e-04
-	   8        24.382865717115    3.872e-04
-	   9        24.382703786034    2.028e-04
-	  10        24.382629501640    1.136e-04
-	  11        24.382672663324    5.108e-05
-	  12        24.382725217329    1.491e-05
-	  13        24.382740206450    4.837e-06
-	  14        24.382743815154    2.005e-06
-	  15        24.382743156157    7.537e-07
-	  16        24.382742798204    3.075e-07
-	  17        24.382742886125    1.381e-07
+	   0        14.646057783933
+	   1        19.900740560938    7.415e-01
+	   2        24.202678907650    3.530e-01
+	   3        24.333910457480    5.786e-02
+	   4        24.386482814098    2.489e-02
+	   5        24.384010913035    7.288e-03
+	   6        24.382064836339    2.366e-03
+	   7        24.382700463367    9.330e-04
+	   8        24.382865465020    3.872e-04
+	   9        24.382703533938    2.028e-04
+	  10        24.382629249546    1.136e-04
+	  11        24.382672411233    5.108e-05
+	  12        24.382724965238    1.491e-05
+	  13        24.382739954358    4.837e-06
+	  14        24.382743563062    2.005e-06
+	  15        24.382742904064    7.537e-07
+	  16        24.382742546112    3.075e-07
+	  17        24.382742634033    1.381e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 6.116e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         1.908748848060
-	   1         2.522419107674    2.099e-01
-	   2         2.920051794462    9.194e-02
-	   3         2.941681476796    1.609e-02
-	   4         2.942548695016    4.298e-03
-	   5         2.942363089528    1.619e-03
-	   6         2.942476596522    3.856e-04
-	   7         2.942501377803    1.022e-04
-	   8         2.942496335975    3.516e-05
-	   9         2.942495426078    1.030e-05
-	  10         2.942495389151    3.887e-06
-	  11         2.942495558250    1.223e-06
-	  12         2.942495669318    2.989e-07
+	   0         1.908748836016
+	   1         2.522419088932    2.099e-01
+	   2         2.920051768265    9.194e-02
+	   3         2.941681449791    1.609e-02
+	   4         2.942548667946    4.298e-03
+	   5         2.942363062455    1.619e-03
+	   6         2.942476569443    3.856e-04
+	   7         2.942501350723    1.022e-04
+	   8         2.942496308895    3.516e-05
+	   9         2.942495398998    1.030e-05
+	  10         2.942495362070    3.887e-06
+	  11         2.942495531169    1.223e-06
+	  12         2.942495642238    2.989e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 8.750e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        12.132525424194
-	   1        15.276412075449    5.092e-01
-	   2        17.210437160386    2.109e-01
-	   3        17.286411907319    4.091e-02
-	   4        17.318464424712    1.854e-02
-	   5        17.318141518833    4.833e-03
-	   6        17.317143734080    1.713e-03
-	   7        17.317421323740    6.058e-04
-	   8        17.317472143230    1.907e-04
-	   9        17.317424416210    6.910e-05
-	  10        17.317410508800    2.580e-05
-	  11        17.317418268887    9.916e-06
-	  12        17.317425792174    4.665e-06
-	  13        17.317426840328    1.897e-06
-	  14        17.317426337304    8.194e-07
-	  15        17.317425894162    3.197e-07
-	  16        17.317425811495    1.607e-07
+	   0        12.132525332684
+	   1        15.276411955967    5.092e-01
+	   2        17.210437018418    2.109e-01
+	   3        17.286411764119    4.091e-02
+	   4        17.318464280897    1.854e-02
+	   5        17.318141374969    4.833e-03
+	   6        17.317143590244    1.713e-03
+	   7        17.317421179904    6.058e-04
+	   8        17.317471999391    1.907e-04
+	   9        17.317424272372    6.910e-05
+	  10        17.317410364963    2.580e-05
+	  11        17.317418125049    9.916e-06
+	  12        17.317425648337    4.665e-06
+	  13        17.317426696491    1.897e-06
+	  14        17.317426193466    8.194e-07
+	  15        17.317425750325    3.197e-07
+	  16        17.317425667657    1.607e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 8.766e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.555861136875
-	   1         7.177212316115    3.126e-01
-	   2         8.011578153227    1.222e-01
-	   3         8.058975386592    2.985e-02
-	   4         8.062684542750    7.695e-03
-	   5         8.062432115876    2.264e-03
-	   6         8.062541186112    4.903e-04
-	   7         8.062578910302    1.186e-04
-	   8         8.062572201748    3.889e-05
-	   9         8.062569913381    9.756e-06
-	  10         8.062570044441    3.221e-06
-	  11         8.062570332289    1.140e-06
-	  12         8.062570599451    3.217e-07
-	  13         8.062570659305    1.046e-07
+	   0         5.555861106333
+	   1         7.177212270797    3.126e-01
+	   2         8.011578095349    1.222e-01
+	   3         8.058975327010    2.985e-02
+	   4         8.062684482936    7.695e-03
+	   5         8.062432056051    2.264e-03
+	   6         8.062541126281    4.903e-04
+	   7         8.062578850469    1.186e-04
+	   8         8.062572141915    3.889e-05
+	   9         8.062569853548    9.756e-06
+	  10         8.062569984608    3.221e-06
+	  11         8.062570272456    1.140e-06
+	  12         8.062570539618    3.217e-07
+	  13         8.062570599473    1.046e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 3.987e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        12.281082759100
-	   1        16.014852206849    5.396e-01
-	   2        18.149152044303    2.121e-01
-	   3        18.218730734708    3.868e-02
-	   4        18.239340149111    1.507e-02
-	   5        18.237988197076    4.658e-03
-	   6        18.237840034963    1.504e-03
-	   7        18.238212549558    6.648e-04
-	   8        18.238168578145    2.924e-04
-	   9        18.238119678376    1.131e-04
-	  10        18.238112985217    4.594e-05
-	  11        18.238129525742    1.886e-05
-	  12        18.238139425675    5.440e-06
-	  13        18.238141128719    1.853e-06
-	  14        18.238141186246    7.411e-07
-	  15        18.238140962304    2.771e-07
-	  16        18.238140974172    1.229e-07
+	   0        12.281082666430
+	   1        16.014852079418    5.396e-01
+	   2        18.149151891564    2.121e-01
+	   3        18.218730581041    3.868e-02
+	   4        18.239339995036    1.507e-02
+	   5        18.237988042967    4.658e-03
+	   6        18.237839880868    1.504e-03
+	   7        18.238212395457    6.648e-04
+	   8        18.238168424043    2.924e-04
+	   9        18.238119524276    1.131e-04
+	  10        18.238112831118    4.594e-05
+	  11        18.238129371642    1.886e-05
+	  12        18.238139271574    5.440e-06
+	  13        18.238140974619    1.853e-06
+	  14        18.238141032145    7.411e-07
+	  15        18.238140808204    2.771e-07
+	  16        18.238140820071    1.229e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 6.493e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.460761061417
-	   1         7.037583289127    3.147e-01
-	   2         7.888897856946    1.236e-01
-	   3         7.927306342634    2.188e-02
-	   4         7.929487644358    4.727e-03
-	   5         7.929054857895    1.852e-03
-	   6         7.929123937184    5.650e-04
-	   7         7.929179781307    1.652e-04
-	   8         7.929175406835    5.229e-05
-	   9         7.929174612924    1.264e-05
-	  10         7.929174328030    4.348e-06
-	  11         7.929174923165    1.561e-06
-	  12         7.929175254900    3.990e-07
-	  13         7.929175355364    1.342e-07
+	   0         5.460761031750
+	   1         7.037583245153    3.147e-01
+	   2         7.888897799925    1.236e-01
+	   3         7.927306284430    2.188e-02
+	   4         7.929487586053    4.727e-03
+	   5         7.929054799598    1.852e-03
+	   6         7.929123878882    5.650e-04
+	   7         7.929179723002    1.652e-04
+	   8         7.929175348530    5.229e-05
+	   9         7.929174554619    1.264e-05
+	  10         7.929174269725    4.348e-06
+	  11         7.929174864860    1.561e-06
+	  12         7.929175196595    3.990e-07
+	  13         7.929175297059    1.342e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 4.665e-08
 
@@ -5496,12 +1142,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.180382563837796    -0.231277803091418    -0.067393277098506
-    1     -0.011460339714520     0.093901050002511    -0.240574201477729
-    2     -0.302759284932568     0.322187346703909    -0.246887973979225
+    0      0.180382563931021    -0.231277802328226    -0.067393276664584
+    1     -0.011460339705175     0.093901050342524    -0.240574201690021
+    2     -0.302759285560127     0.322187347251801    -0.246887974136866
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) = -130.56373 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -130.56371 deg/[dm (g/cm^3)]
 
    ------------------------------------------
        CCSD Length-Gauge Optical Rotation
@@ -5509,17 +1155,10 @@ Total time:
        Omega           alpha
     E_h      nm   deg/[dm (g/cm^3)]
    -----   ------ ------------------
-   0.072   633.00       -38.80517
-   0.128   355.00      -130.56373
+   0.072   633.00       -38.80516
+   0.128   355.00      -130.56371
 
-*** tstop() called on psinet at Mon May 15 15:34:41 2017
-Module time:
-	user time   =       3.00 seconds =       0.05 minutes
-	system time =       2.50 seconds =       0.04 minutes
-	total time  =          6 seconds =       0.10 minutes
-Total time:
-	user time   =       4.11 seconds =       0.07 minutes
-	system time =       2.91 seconds =       0.05 minutes
-	total time  =          7 seconds =       0.12 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
+    Psi4 wall time for execution: 0:00:15.00
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc31/output.ref
+++ b/tests/cc31/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:24PM
 
-    Process ID:  12734
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65694
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -51,28 +64,26 @@ set {
   basis STO-3G
 }
 
-property('ccsd',properties=['rotation'])
+properties('ccsd',properties=['rotation'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:34 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:09 2022
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-3  entry C          line    60 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 4    entry O          line    80 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 5-10 entry H          line    18 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1-3  entry C          line    61 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 4    entry O          line    81 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 5-10 entry H          line    19 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -86,22 +97,22 @@ property('ccsd',properties=['rotation'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.210991841737     0.047663662717     0.483960886619    12.000000000000
-           C         -0.960965312103     0.688519555303    -0.115848688934    12.000000000000
-           C          1.558206749694     0.047460114159    -0.180267436891    12.000000000000
-           O         -0.815251456906    -0.734986972268    -0.138532905591    15.994914619560
-           H          0.223550547304    -0.045637654519     1.567373484970     1.007825032070
-           H         -1.759483315918     1.063259112311     0.516330435381     1.007825032070
-           H         -0.862256972568     1.177986074652    -1.079897880020     1.007825032070
-           H          2.088617117792    -0.883541600456     0.026321487274     1.007825032070
-           H          2.169362364888     0.872235726981     0.192209317060     1.007825032070
-           H          1.455347299576     0.149768052462    -1.260354487995     1.007825032070
+         C            0.210991841728     0.047663662711     0.483960886619    12.000000000000
+         C           -0.960965312112     0.688519555297    -0.115848688934    12.000000000000
+         C            1.558206749685     0.047460114153    -0.180267436891    12.000000000000
+         O           -0.815251456915    -0.734986972274    -0.138532905591    15.994914619570
+         H            0.223550547295    -0.045637654525     1.567373484970     1.007825032230
+         H           -1.759483315927     1.063259112305     0.516330435381     1.007825032230
+         H           -0.862256972577     1.177986074646    -1.079897880020     1.007825032230
+         H            2.088617117783    -0.883541600462     0.026321487274     1.007825032230
+         H            2.169362364879     0.872235726975     0.192209317060     1.007825032230
+         H            1.455347299567     0.149768052456    -1.260354487995     1.007825032230
 
   Running in c1 symmetry.
 
   Rotational constants: A =      0.60799  B =      0.22239  C =      0.19815 [cm^-1]
-  Rotational constants: A =  18226.99774  B =   6666.95622  C =   5940.33276 [MHz]
-  Nuclear repulsion =  124.788534121263865
+  Rotational constants: A =  18226.99788  B =   6666.95627  C =   5940.33280 [MHz]
+  Nuclear repulsion =  124.788534611761449
 
   Charge       = 0
   Multiplicity = 1
@@ -118,27 +129,17 @@ property('ccsd',properties=['rotation'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 18
-    Number of basis function: 26
+    Number of basis functions: 26
     Number of Cartesian functions: 26
     Spherical Harmonics?: true
     Max angular momentum: 1
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         26      26       0       0       0       0
-   -------------------------------------------------------
-    Total      26      26      16      16      16       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -157,45 +158,59 @@ property('ccsd',properties=['rotation'])
   Using 123552 doubles for integral storage.
   We computed 14355 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.0902507179E-01.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.0902506889E-01.
+  Reciprocal condition number of the overlap matrix is 8.4122044079E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         26      26 
+   -------------------------
+    Total      26      26
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -189.14691005126650   -1.89147e+02   1.09501e-01 
-   @RHF iter   1:  -189.43036886409882   -2.83459e-01   1.10564e-02 
-   @RHF iter   2:  -189.50510750165620   -7.47386e-02   3.37004e-03 DIIS
-   @RHF iter   3:  -189.51246555575443   -7.35805e-03   1.05795e-03 DIIS
-   @RHF iter   4:  -189.51330985896300   -8.44303e-04   2.79860e-04 DIIS
-   @RHF iter   5:  -189.51340579507908   -9.59361e-05   9.48346e-05 DIIS
-   @RHF iter   6:  -189.51341658460973   -1.07895e-05   2.52558e-05 DIIS
-   @RHF iter   7:  -189.51341720881524   -6.24206e-07   5.08705e-06 DIIS
-   @RHF iter   8:  -189.51341723639678   -2.75815e-08   1.05884e-06 DIIS
-   @RHF iter   9:  -189.51341723745801   -1.06124e-09   3.08858e-07 DIIS
-   @RHF iter  10:  -189.51341723757079   -1.12777e-10   8.22657e-08 DIIS
-   @RHF iter  11:  -189.51341723757943   -8.64020e-12   1.90570e-08 DIIS
-   @RHF iter  12:  -189.51341723757997   -5.40012e-13   3.37648e-09 DIIS
-   @RHF iter  13:  -189.51341723757986    1.13687e-13   6.27883e-10 DIIS
-   @RHF iter  14:  -189.51341723758011   -2.55795e-13   1.53694e-10 DIIS
-   @RHF iter  15:  -189.51341723757997    1.42109e-13   4.68260e-11 DIIS
+   @RHF iter SAD:  -186.43072166022969   -1.86431e+02   0.00000e+00 
+   @RHF iter   1:  -189.43266126778431   -3.00194e+00   1.28222e-02 DIIS/ADIIS
+   @RHF iter   2:  -189.50256237003049   -6.99011e-02   5.10734e-03 DIIS/ADIIS
+   @RHF iter   3:  -189.51308752257810   -1.05252e-02   6.61403e-04 DIIS/ADIIS
+   @RHF iter   4:  -189.51341362083576   -3.26098e-04   6.54297e-05 DIIS
+   @RHF iter   5:  -189.51341710353671   -3.48270e-06   1.19638e-05 DIIS
+   @RHF iter   6:  -189.51341723375197   -1.30215e-07   1.91468e-06 DIIS
+   @RHF iter   7:  -189.51341723649421   -2.74224e-09   7.28366e-07 DIIS
+   @RHF iter   8:  -189.51341723702996   -5.35749e-10   2.37098e-07 DIIS
+   @RHF iter   9:  -189.51341723710055   -7.05995e-11   4.41139e-08 DIIS
+   @RHF iter  10:  -189.51341723710277   -2.21689e-12   7.00241e-09 DIIS
+   @RHF iter  11:  -189.51341723710271    5.68434e-14   1.79171e-09 DIIS
+   @RHF iter  12:  -189.51341723710263    8.52651e-14   4.46110e-10 DIIS
+   @RHF iter  13:  -189.51341723710271   -8.52651e-14   1.14588e-10 DIIS
+   @RHF iter  14:  -189.51341723710269    2.84217e-14   1.75058e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -217,49 +232,44 @@ property('ccsd',properties=['rotation'])
               A 
     DOCC [    16 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -189.51341723757997
+  @RHF Final Energy:  -189.51341723710269
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =            124.7885341212638650
-    One-Electron Energy =                -505.7302694793730211
-    Two-Electron Energy =                 191.4283181205291839
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -189.5134172375799722
+    Nuclear Repulsion Energy =            124.7885346117614489
+    One-Electron Energy =                -505.7302704013783909
+    Two-Electron Energy =                 191.4283185525142414
+    Total Energy =                       -189.5134172371026864
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     3.1039      Y:     2.1846      Z:    -0.0363
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:    -2.8119      Y:    -1.6853      Z:     0.1750
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.2920      Y:     0.4993      Z:     0.1387     Total:     0.5948
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.7422      Y:     1.2690      Z:     0.3525     Total:     1.5118
 
 
-*** tstop() called on psinet at Mon May 15 15:34:34 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:11 2022
 Module time:
-	user time   =       0.64 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.64 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -273,19 +283,19 @@ Total time:
       Number of basis functions:        26
 
       Number of irreps:                  1
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  26 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 61560 non-zero two-electron integrals.
+      Computed 60685 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:35 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:11 2022
 
 
 	Wfn Parameters:
@@ -307,7 +317,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -343,7 +353,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -209.07983613514418
+	Frozen core energy     =   -209.07983635006988
 
 	Size of irrep 0 of <ab|cd> integrals:      0.010 (MW) /      0.080 (MB)
 	Total:                                     0.010 (MW) /      0.080 (MB)
@@ -354,34 +364,30 @@ Total time:
 	Size of irrep 0 of tijab amplitudes:       0.014 (MW) /      0.115 (MB)
 	Total:                                     0.014 (MW) /      0.115 (MB)
 
-	Nuclear Rep. energy          =    124.78853412126387
-	SCF energy                   =   -189.51341723757997
-	One-electron energy          =   -194.60728307298822
-	Two-electron energy          =     89.38516784928819
-	Reference energy             =   -189.51341723758034
+	Nuclear Rep. energy          =    124.78853461176145
+	SCF energy                   =   -189.51341723710269
+	One-electron energy          =   -194.60728356878721
+	Two-electron energy          =     89.38516806999309
+	Reference energy             =   -189.51341723710254
 
-*** tstop() called on psinet at Mon May 15 15:34:35 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:11 2022
 Module time:
 	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.79 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:35 2017
-
+	user time   =       1.52 seconds =       0.03 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =  124.788534121263865
-    SCF energy          (wfn)     = -189.513417237579972
-    Reference energy    (file100) = -189.513417237580342
+    Nuclear Rep. energy (wfn)     =  124.788534611761449
+    SCF energy          (wfn)     = -189.513417237102686
+    Reference energy    (file100) = -189.513417237102544
 
     Input parameters:
     -----------------
@@ -409,81 +415,69 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.1984983537949022
+MP2 correlation energy -0.1984983521050313
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.198498353794902    0.000e+00    0.000000    0.000000    0.000000    0.124632
-     1        -0.237008933272351    7.197e-02    0.005013    0.019208    0.019208    0.149707
-     2        -0.254270371793138    2.556e-02    0.005982    0.022682    0.022682    0.163374
-     3        -0.255782956694382    5.592e-03    0.006458    0.025003    0.025003    0.165523
-     4        -0.256080298178184    1.875e-03    0.006481    0.025202    0.025202    0.166491
-     5        -0.256086467634576    4.302e-04    0.006487    0.025253    0.025253    0.166665
-     6        -0.256081473680009    9.732e-05    0.006489    0.025260    0.025260    0.166678
-     7        -0.256081021850376    2.919e-05    0.006488    0.025256    0.025256    0.166681
-     8        -0.256081381420835    1.108e-05    0.006488    0.025254    0.025254    0.166682
-     9        -0.256081421006700    3.133e-06    0.006488    0.025253    0.025253    0.166681
-    10        -0.256081359603313    1.163e-06    0.006488    0.025253    0.025253    0.166681
-    11        -0.256081358475880    4.447e-07    0.006488    0.025253    0.025253    0.166681
-    12        -0.256081369429196    1.783e-07    0.006488    0.025253    0.025253    0.166681
-    13        -0.256081379627737    5.451e-08    0.006488    0.025253    0.025253    0.166681
-    14        -0.256081381334090    1.813e-08    0.006488    0.025253    0.025253    0.166681
-    15        -0.256081380880501    6.961e-09    0.006488    0.025253    0.025253    0.166681
+     0        -0.198498352105031    0.000e+00    0.000000    0.000000    0.000000    0.124632
+     1        -0.237008931308751    7.197e-02    0.005013    0.019208    0.019208    0.149707
+     2        -0.254270369637538    2.556e-02    0.005982    0.022682    0.022682    0.163374
+     3        -0.255782954497087    5.592e-03    0.006458    0.025003    0.025003    0.165523
+     4        -0.256080295969144    1.875e-03    0.006481    0.025202    0.025202    0.166491
+     5        -0.256086465424992    4.302e-04    0.006487    0.025253    0.025253    0.166665
+     6        -0.256081471470671    9.732e-05    0.006489    0.025260    0.025260    0.166678
+     7        -0.256081019641028    2.919e-05    0.006488    0.025256    0.025256    0.166681
+     8        -0.256081379211469    1.108e-05    0.006488    0.025254    0.025254    0.166682
+     9        -0.256081418797327    3.133e-06    0.006488    0.025253    0.025253    0.166681
+    10        -0.256081357393936    1.163e-06    0.006488    0.025253    0.025253    0.166681
+    11        -0.256081356266501    4.447e-07    0.006488    0.025253    0.025253    0.166681
+    12        -0.256081367219822    1.783e-07    0.006488    0.025253    0.025253    0.166681
+    13        -0.256081377418367    5.451e-08    0.006488    0.025253    0.025253    0.166681
+    14        -0.256081379124717    1.813e-08    0.006488    0.025253    0.025253    0.166681
+    15        -0.256081378671129    6.961e-09    0.006488    0.025253    0.025253    0.166681
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-             11   2         0.0172860478
+             11   2         0.0172860477
              11   3        -0.0101252597
-              9   0         0.0093896207
-             11   5         0.0079607188
-             11   1        -0.0067478297
-              2   1         0.0067121219
-              4   2        -0.0059054293
-             10   1        -0.0053242037
-             10   2        -0.0053113232
-              4   1         0.0046921707
+              9   0         0.0093896208
+             11   5         0.0079607182
+             11   1        -0.0067478301
+              2   1         0.0067121218
+              4   2        -0.0059054292
+             10   1        -0.0053242035
+             10   2        -0.0053113229
+              4   1         0.0046921708
 
     Largest TIjAb Amplitudes:
-     10  10   0   0        -0.0729527920
-      9   9   0   0        -0.0599470174
-      6   6   6   6        -0.0458883504
-      9  10   0   1         0.0399836404
-     10   9   1   0         0.0399836404
-     10  10   1   1        -0.0353807714
-      9  10   1   0         0.0308742315
-     10   9   0   1         0.0308742315
-      8   8   2   2        -0.0255613060
-      9   9   1   1        -0.0225414535
+     10  10   0   0        -0.0729527916
+      9   9   0   0        -0.0599470167
+      6   6   6   6        -0.0458883494
+      9  10   0   1         0.0399836398
+     10   9   1   0         0.0399836398
+     10  10   1   1        -0.0353807705
+      9  10   1   0         0.0308742310
+     10   9   0   1         0.0308742310
+      8   8   2   2        -0.0255613056
+      9   9   1   1        -0.0225414532
 
-    SCF energy       (wfn)                    = -189.513417237579972
-    Reference energy (file100)                = -189.513417237580342
+    SCF energy       (wfn)                    = -189.513417237102686
+    Reference energy (file100)                = -189.513417237102544
 
-    Opposite-spin MP2 correlation energy      =   -0.172369086868551
-    Same-spin MP2 correlation energy          =   -0.026129266926351
-    MP2 correlation energy                    =   -0.198498353794902
-      * MP2 total energy                      = -189.711915591375231
+    Opposite-spin MP2 correlation energy      =   -0.172369085425351
+    Same-spin MP2 correlation energy          =   -0.026129266679681
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.198498352105031
+      * MP2 total energy                      = -189.711915589207564
 
-    Opposite-spin CCSD correlation energy     =   -0.233276064934856
-    Same-spin CCSD correlation energy         =   -0.022805315945625
-    CCSD correlation energy                   =   -0.256081380880501
-      * CCSD total energy                     = -189.769498618460830
-
-
-*** tstop() called on psinet at Mon May 15 15:34:35 2017
-Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.02 seconds =       0.02 minutes
-	system time =       0.41 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:35 2017
+    Opposite-spin CCSD correlation energy     =   -0.233276062832105
+    Same-spin CCSD correlation energy         =   -0.022805315839024
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.256081378671129
+      * CCSD total energy                     = -189.769498615773671
 
 
 			**************************
@@ -493,31 +487,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:36 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.04 seconds =       0.02 minutes
-	system time =       0.44 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:36 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =  124.788534121263865
+	Nuclear Rep. energy (wfn)     =  124.788534611761449
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -189.513417237579972
-	Reference energy    (CC_INFO) = -189.513417237580342
-	CCSD energy         (CC_INFO) =   -0.256081380880501
-	Total CCSD energy   (CC_INFO) = -189.769498618460830
+	SCF energy          (wfn)     = -189.513417237102686
+	Reference energy    (CC_INFO) = -189.513417237102544
+	CCSD energy         (CC_INFO) =   -0.256081378671129
+	Total CCSD energy   (CC_INFO) = -189.769498615773671
 
 	Input parameters:
 	-----------------
@@ -530,7 +510,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -543,61 +523,47 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.256237915146067    0.000e+00
-	   1        -0.252169339226238    1.810e-02
-	   2        -0.250666632448738    3.407e-03
-	   3        -0.250393618703240    1.323e-03
-	   4        -0.250341130499737    4.043e-04
-	   5        -0.250345489448306    1.111e-04
-	   6        -0.250347132052883    2.991e-05
-	   7        -0.250347367903609    8.505e-06
-	   8        -0.250347455571628    3.205e-06
-	   9        -0.250347484175278    1.342e-06
-	  10        -0.250347488134282    5.615e-07
-	  11        -0.250347483074131    2.263e-07
-	  12        -0.250347479746485    7.512e-08
+	   0        -0.256237912933552    0.000e+00
+	   1        -0.252169337111640    1.810e-02
+	   2        -0.250666630366034    3.407e-03
+	   3        -0.250393616625877    1.323e-03
+	   4        -0.250341128423953    4.043e-04
+	   5        -0.250345487372515    1.111e-04
+	   6        -0.250347129977033    2.991e-05
+	   7        -0.250347365827743    8.505e-06
+	   8        -0.250347453495757    3.205e-06
+	   9        -0.250347482099403    1.342e-06
+	  10        -0.250347486058407    5.615e-07
+	  11        -0.250347480998257    2.263e-07
+	  12        -0.250347477670610    7.512e-08
 
 	Largest LIA Amplitudes:
-	         11   2         0.0118111422
+	         11   2         0.0118111420
 	         11   3        -0.0069061034
-	         11   5         0.0053763874
-	          2   1         0.0052385543
-	         11   1        -0.0038870567
-	          0   1        -0.0037819862
-	          9   0         0.0036545358
-	          1   1         0.0034939138
+	         11   5         0.0053763870
+	          2   1         0.0052385542
+	         11   1        -0.0038870571
+	          0   1        -0.0037819861
+	          9   0         0.0036545359
+	          1   1         0.0034939137
 	          4   2        -0.0032795874
-	         11   4        -0.0027053346
+	         11   4        -0.0027053355
 
 	Largest LIjAb Amplitudes:
-	 10  10   0   0        -0.0698116835
-	  9   9   0   0        -0.0569655616
-	  6   6   6   6        -0.0455822736
-	  9  10   0   1         0.0384444666
-	 10   9   1   0         0.0384444666
-	 10  10   1   1        -0.0342780652
-	  9  10   1   0         0.0298886045
-	 10   9   0   1         0.0298886045
-	  8   8   2   2        -0.0251518867
-	  9   9   1   1        -0.0223865008
+	 10  10   0   0        -0.0698116831
+	  9   9   0   0        -0.0569655610
+	  6   6   6   6        -0.0455822726
+	  9  10   0   1         0.0384444660
+	 10   9   1   0         0.0384444660
+	 10  10   1   1        -0.0342780644
+	  9  10   1   0         0.0298886040
+	 10   9   0   1         0.0298886040
+	  8   8   2   2        -0.0251518864
+	  9   9   1   1        -0.0223865005
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.86083040552
-
-*** tstop() called on psinet at Mon May 15 15:34:36 2017
-Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.12 seconds =       0.02 minutes
-	system time =       0.49 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:36 2017
-
+	Overlap <L|e^T> =        0.86083040761
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -631,1210 +597,130 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016434384667148  0.059537003054536 -0.018382703913455 -0.001901473074516  0.028510164358282  0.077646279855039  0.000356251398219  0.021408373218989  0.091393977088558
-    1  (  1) -0.005835140019102 -0.006847303402179  0.005801307077118 -0.092503110731406 -0.040640220398500 -0.004476772769023  0.006707493956919  0.025598358653730  0.054742040386929
-    2  (  2) -0.032576552661469 -0.022759352669700  0.015700451044420  0.017659613283536 -0.033691301649134  0.071320914458495  0.010810523808367 -0.000599142203483  0.006831611161324
-    3  (  3)  0.028439441517722  0.025978253338493  0.005227408482745  0.004129515933235  0.042131401342259  0.005061996623806 -0.014819468597155 -0.029813444208053  0.124931870713391
-    4  (  4)  0.026711661740657  0.065952388204908 -0.070397760617197 -0.113357837258571  0.162062952662508 -0.007050708037022 -0.019958512448364 -0.113599468912823  0.186779858191589
-    5  (  5) -0.054225682429018 -0.150592673565962  0.090221508528394 -0.165469278587529 -0.105075744052049 -0.235926758500148 -0.076402735009682 -0.065221510888654 -0.109078486285223
-    6  (  6)  0.036820767703606 -0.045049000362756  0.022079029118092  0.038075092578984 -0.045448669142688  0.103567825475646 -0.243196158948954 -0.024866082639399 -0.028667254743547
-    7  (  7) -0.064079984215095 -0.104489316033204  0.208936934850580  0.011404897999585 -0.191297065299167 -0.062928087633658  0.036625785426208 -0.182329767369539 -0.046827781359629
-    8  (  8) -0.029820488646987 -0.037609170202879  0.184366833470305 -0.250608304245861 -0.266157936861978 -0.003343240964033 -0.026232571891440 -0.068560106516425  0.143703222469330
-    9  (  9)  0.097477133499219 -0.253919330671861 -0.022474002349921 -0.091068839306237 -0.030773177890121 -0.124639301979492 -0.057377848460010 -0.129428480584789  0.052503813838482
-   10  ( 10)  0.308102321981415 -0.100099264744172 -0.103502297395079  0.030595871425367  0.027930037535271  0.082924987589621 -0.003621479559882  0.051467583495009  0.001729710593298
-   11  ( 11)  0.065171614185219 -0.083076013227694  0.007781121482082 -0.129638416743258  0.025583078029705 -0.021102804445382 -0.038969277950233 -0.054649593445510  0.156415144250598
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.100574711969240
-    1  (  1) -0.017311198418314
-    2  (  2)  0.099207008690223
-    3  (  3)  0.049312818935542
-    4  (  4)  0.020969683268895
-    5  (  5) -0.168478941844432
-    6  (  6)  0.036633223806040
-    7  (  7) -0.083149987934917
-    8  (  8)  0.054463823630147
-    9  (  9) -0.105100295511211
-   10  ( 10)  0.049112459843749
-   11  ( 11) -0.074285789462190
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000150860459877  0.171933918231252 -0.041419056803072  0.170616058570147  0.200856757156520 -0.002034169374196  0.083717100185599  0.000516882277833 -0.000760835570240
-    1  (  1) -0.171458970665860  0.000052671693709 -0.080477211012241 -0.158047078345989 -0.171611945068556 -0.020781553144960 -0.081182987020708 -0.096111050666912 -0.028348265964974
-    2  (  2)  0.041612402589055  0.080354514984744 -0.000394264947173  0.065176020012681  0.096961733142428  0.000557038525025 -0.109435480142694  0.034287451388532 -0.031868099666052
-    3  (  3) -0.170115569606579  0.158386367352469 -0.064620104688982  0.000274195329164  0.003073114771818  0.155980931184969 -0.002438060010510  0.075892612616599  0.118957615446809
-    4  (  4) -0.200436196772240  0.171813138083843 -0.096620398683267 -0.002372485388961  0.000742978447135 -0.018013393904637  0.033369149651403  0.120720251055992  0.104550918281167
-    5  (  5)  0.002211117433298  0.019930957908302 -0.000666901496264 -0.157204484557621  0.015901976339486 -0.000217821561163  0.009428657942981 -0.039993958187839  0.071492158249729
-    6  (  6) -0.083537896232863  0.081216293971867  0.109652154032100  0.002769108821106 -0.033489275419838 -0.010079357840938 -0.000064832704676 -0.012979883425805 -0.022286123614410
-    7  (  7) -0.000446183372454  0.095595436198971 -0.034260265949943 -0.076357839284767 -0.123056525926531  0.039576937592408  0.012836423633655  0.000276922615353 -0.011862614885765
-    8  (  8)  0.000763780194579  0.028492759060566  0.031582546116686 -0.118324194064185 -0.106500675879643 -0.072862382850876  0.022267846900148  0.011936132807121 -0.000309785123822
-    9  (  9)  0.200009372729413 -0.049971216489633 -0.123430272682259 -0.142933103185242 -0.066275175614906 -0.011400665529444 -0.086697488232449 -0.026102313931474  0.001060546754189
-   10  ( 10)  0.021852700751396 -0.017163247777288 -0.127823592278093  0.091613120127056  0.051604501451930  0.012175072674142 -0.083661634147568  0.068820029767420  0.010286004757943
-   11  ( 11)  0.114973761942494 -0.044704429189879 -0.150112248621738 -0.031470261050302 -0.054465549098901 -0.018492073632933 -0.052809037569742  0.018588462631583 -0.062465552340744
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.199650432776970 -0.021769646283719 -0.115014099877643
-    1  (  1)  0.048847979709979  0.016224624083658  0.045739997653995
-    2  (  2)  0.121535202952087  0.127110081169448  0.150689800369572
-    3  (  3)  0.141534079657396 -0.092900464386430  0.030906929300398
-    4  (  4)  0.064777188331671 -0.052294246689992  0.052576843649814
-    5  (  5)  0.012798646161060 -0.011617495484096  0.021426191620278
-    6  (  6)  0.085439453581865  0.082177824690696  0.054044239620785
-    7  (  7)  0.026881359606727 -0.069312090513404 -0.013578395284128
-    8  (  8) -0.000980665289481 -0.011875108407812  0.069843147407046
-    9  (  9)  0.001396130223525  0.045043795365458  0.018886220574768
-   10  ( 10) -0.041412670665906  0.001872911812120 -0.033067578033610
-   11  ( 11) -0.016567946659153  0.031899396551867  0.001929777984873
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001411268359160 -0.010548061189878 -0.012234985630211  0.023975313562280 -0.023062230820039  0.045437732948681 -0.106872881296076  0.025944637778051 -0.029363485311898
-    1  (  1)  0.014640801150040 -0.001773735046594 -0.029549963184092  0.020758435544442  0.007635590000279  0.056071060358736  0.088482364466965  0.027605241546487 -0.020492843216977
-    2  (  2)  0.013184523566191  0.031261847780049 -0.000489474253254  0.031775189074985  0.038538471296270 -0.038607714449183  0.007921641905981 -0.014600160708699  0.097026534080847
-    3  (  3) -0.023325695791557 -0.021331801923242 -0.030636705569878 -0.000479373870642  0.011687430157835 -0.060845116281804  0.009020253210307  0.020543788213974 -0.119533313623190
-    4  (  4)  0.023654300689698 -0.009020483406481 -0.038301937767707 -0.011962372815437 -0.000301509800453  0.037261192743398  0.029045239001199  0.041781275442091 -0.051627710213779
-    5  (  5) -0.044386181810683 -0.057414182896665  0.038267122468401  0.061256729128929 -0.037800933596037 -0.000260698778894 -0.001511863535883  0.016380337639677 -0.072487672330699
-    6  (  6)  0.106206323004553 -0.087758718377781 -0.007560784408469 -0.009263545408533 -0.028871039692754  0.002023613184462 -0.000132116955283 -0.000735561511998 -0.010945124965688
-    7  (  7) -0.025425283561814 -0.027796807869910  0.014997640380461 -0.020644254386635 -0.041827532757913 -0.016146444702388  0.000831333123472  0.000058581308311 -0.017035220679833
-    8  (  8)  0.029580773528628  0.019460244903885 -0.099428018149333  0.121448802541844  0.052251959451872  0.071719334941988  0.011527870420583  0.017438360216925 -0.000376592607811
-    9  (  9) -0.011323796835811  0.022846032797884 -0.003463845070647  0.010590766229841 -0.093908204414477  0.097279630619014  0.016132246312287  0.052832474295790 -0.033804637999018
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.012386803276718
-    1  (  1) -0.025331755243544
-    2  (  2)  0.004701299813181
-    3  (  3) -0.011259859427831
-    4  (  4)  0.092847122914529
-    5  (  5) -0.097092353171668
-    6  (  6) -0.015797039269438
-    7  (  7) -0.052823551833136
-    8  (  8)  0.033708639353932
-    9  (  9) -0.000241834945391
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019875399821365 -0.067213072995023  0.012299941717659  0.003468875187880 -0.030128328426274 -0.082822743936825  0.001897897698354 -0.021797662835713 -0.095153762344945
-    1  (  1)  0.006451292960481  0.005754162581844 -0.002884034500734  0.094974935426192  0.041098451485401  0.000058064511604 -0.008894806239621 -0.025485003895974 -0.057087471632476
-    2  (  2)  0.026223355242450  0.024273603088334 -0.016292189081393 -0.015844039410231  0.030633853079712 -0.077008417539564 -0.014788316606733  0.000243822647885 -0.007976439135467
-    3  (  3) -0.025334252850709 -0.027648721071750 -0.005856451162092 -0.011279594978250 -0.045220581787047 -0.007788112252830  0.015791844926599  0.026413664639332 -0.132992803966333
-    4  (  4) -0.028858615977169 -0.070880006979721  0.078385497137577  0.115909817357349 -0.170672806468397  0.002802625270051  0.018507237940661  0.116641608428124 -0.183930260352482
-    5  (  5)  0.062029310382341  0.165059238935656 -0.096438123628463  0.170982438012572  0.101168051978722  0.247462788062147  0.078143137508448  0.065503368874352  0.123407161852621
-    6  (  6) -0.029868108814055  0.043826434723281 -0.020536879880122 -0.040118359069746  0.047262891605686 -0.111204577364818  0.250427612151989  0.027185217329734  0.027972758218343
-    7  (  7)  0.071045843569722  0.110497052752988 -0.212396167514294 -0.014472401617176  0.201746291025428  0.058726820006450 -0.038658609736798  0.191686821472890  0.051568740310987
-    8  (  8)  0.030231001314245  0.039607181613347 -0.190237369746058  0.251586833919896  0.277372132160808  0.008690855780340  0.027285881313233  0.066231456708385 -0.148705440863578
-    9  (  9) -0.119406447574908  0.267992491845044  0.024723477609567  0.092623842023547  0.035484932702787  0.135905292178670  0.058976108500788  0.137156317198896 -0.050622979340015
-   10  ( 10) -0.354731988399122  0.114731465978240  0.113605854938311 -0.033621899430544 -0.024886546894064 -0.086388159191061 -0.001760250802633 -0.054814426010942 -0.004266849862045
-   11  ( 11) -0.074987139083159  0.087839869817099 -0.017174937068014  0.139817452729011 -0.030459814346611  0.019645857821193  0.042455388198899  0.058190403006369 -0.165317136166192
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.104159520209993
-    1  (  1)  0.017365114579609
-    2  (  2) -0.105508249406411
-    3  (  3) -0.051333283782025
-    4  (  4) -0.026824469147080
-    5  (  5)  0.172355785037806
-    6  (  6) -0.037231897229526
-    7  (  7)  0.092488656033236
-    8  (  8) -0.060576527966250
-    9  (  9)  0.114591221791530
-   10  ( 10) -0.052791324163552
-   11  ( 11)  0.078009502545252
-
 	Computing P_X-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.065196902456
-	   1         5.289235072058    3.016e-01
-	   2         6.035782688042    1.206e-01
-	   3         6.050755009231    1.524e-02
-	   4         6.054490318375    5.848e-03
-	   5         6.054302383239    1.785e-03
-	   6         6.054175236492    5.901e-04
-	   7         6.054227707026    2.244e-04
-	   8         6.054244376198    7.798e-05
-	   9         6.054237418499    2.687e-05
-	  10         6.054236507599    8.863e-06
-	  11         6.054238050562    2.815e-06
-	  12         6.054239388557    9.367e-07
-	  13         6.054239796463    3.564e-07
-	  14         6.054239879064    1.637e-07
+	   0         4.065196923463
+	   1         5.289235095470    3.016e-01
+	   2         6.035782708779    1.206e-01
+	   3         6.050755029744    1.524e-02
+	   4         6.054490338796    5.848e-03
+	   5         6.054302403649    1.785e-03
+	   6         6.054175256904    5.901e-04
+	   7         6.054227727436    2.244e-04
+	   8         6.054244396607    7.798e-05
+	   9         6.054237438909    2.687e-05
+	  10         6.054236528009    8.863e-06
+	  11         6.054238070972    2.815e-06
+	  12         6.054239408967    9.367e-07
+	  13         6.054239816873    3.564e-07
+	  14         6.054239899474    1.637e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 6.710e-08
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057027762100789  0.007489633887342 -0.036964189813796  0.021384352100284 -0.004867815775604 -0.032130235858782  0.019486973797962  0.000503926514732  0.024868986663351
-    1  (  1) -0.007883399599923  0.007529104506445  0.013216566770749 -0.001554286609489 -0.002481002458300 -0.003555137440754  0.020216878378801 -0.003435265519663 -0.003420680709423
-    2  (  2) -0.005061763911744 -0.024005030999464 -0.016920245291348  0.019760528227158  0.007759414271484 -0.029231812106945 -0.009559298232843  0.004745878981161  0.053662769962019
-    3  (  3) -0.011903086348447  0.106154395386531  0.048846797682958 -0.038122834717736  0.042076447151745 -0.017515736018254 -0.021695004377211 -0.017259669010754 -0.058953679400153
-    4  (  4)  0.086846706941042 -0.161257530089836 -0.037361255861875  0.089905419413410 -0.174437646387183  0.071028892880315  0.038811212273731  0.045200518155063  0.066894551440516
-    5  (  5) -0.295118954821928 -0.042171667688274 -0.057142717280935  0.095328920031059 -0.118376834610768  0.017202604507056  0.038088685926927  0.015413673756028  0.019970185142534
-    6  (  6)  0.061695197805604  0.041447416246154 -0.107874329349021  0.009310856499629  0.028327062477196  0.072556054900044 -0.031173831746629 -0.093673016450942 -0.096470656575707
-    7  (  7) -0.040164356283535 -0.019606328824315  0.022514162311588 -0.103095269177578  0.105738125414362 -0.000251323240260 -0.190667102998226  0.014251172141516 -0.042544347999407
-    8  (  8)  0.209747539729284  0.026225521984115  0.065411218317390 -0.108576414051802  0.195951046046893 -0.054935351774023  0.181062671358124 -0.048648601818055 -0.037403343457353
-    9  (  9) -0.029537922421234  0.045187174636289 -0.013381512217286  0.049426415359509 -0.003411235911782  0.045265306723710 -0.096457278821335 -0.006113492494935  0.044165814974043
-   10  ( 10) -0.026870929841946 -0.010513244846490  0.122411818973730 -0.066300236331789  0.074150921852319  0.175359501999903  0.025219490294838 -0.031299023505132  0.032770162927265
-   11  ( 11)  0.076638806040972  0.048660864910506  0.054798136469999  0.067410404189619 -0.096042680906718  0.030077767167195  0.040609376761651  0.003350033647470  0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007613623485115
-    1  (  1)  0.001053219582711
-    2  (  2) -0.054751844139672
-    3  (  3)  0.021588797011546
-    4  (  4)  0.069416579868176
-    5  (  5)  0.031311068013170
-    6  (  6) -0.060683491342485
-    7  (  7) -0.004937786560826
-    8  (  8) -0.055843386605960
-    9  (  9) -0.053258374332423
-   10  ( 10) -0.029326398375861
-   11  ( 11)  0.027904630917537
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000025015734507 -0.010198711087952 -0.006474775958448 -0.066946051563528  0.066550206967977  0.041188873125926 -0.023552914991952 -0.019202263160422  0.006942946197737
-    1  (  1)  0.010140605887652  0.000014394957877 -0.022996796061328  0.067092192493274 -0.063685673857393 -0.019093615376604  0.005525180617760  0.015031464830750 -0.005320182556269
-    2  (  2)  0.006534739001904  0.022969584694137 -0.000183457658640  0.211551326757209 -0.218187807438925 -0.104132114893528  0.065436658246811  0.042103919182146  0.012243831904844
-    3  (  3)  0.066304931943444 -0.066584833979085 -0.210703888875489  0.000394093515089  0.011258600581601  0.092530428436357  0.131881992071255 -0.026480578605083 -0.063346368194022
-    4  (  4) -0.065779542430873  0.062822415172501  0.216601239538476 -0.011617389043850 -0.000720555249011 -0.020159848057855 -0.073942431465134 -0.001119920964031 -0.016120241216710
-    5  (  5) -0.040846799691504  0.018979734118351  0.103125251405654 -0.092549855601907  0.021623501291584  0.000771447754999  0.234552119202209  0.000611164043666  0.101606719343242
-    6  (  6)  0.023326218450828 -0.005550385111505 -0.065252405074981 -0.131681855193961  0.073575257938565 -0.233645237851028 -0.000193851682480  0.255788429172446 -0.079072823032341
-    7  (  7)  0.019055068515462 -0.014786531642521 -0.041539856986611  0.026353850726780  0.001700683540838 -0.000445480591706 -0.255766070671258 -0.000118381893033  0.151562772366571
-    8  (  8) -0.006620321009197  0.005142966830662 -0.011245852682541  0.062510776113309  0.015648596901915 -0.102272652360209  0.078381794853266 -0.152302821501449  0.000094469957927
-    9  (  9) -0.045347281960025  0.040291069791943  0.085226922335689  0.018441757598111  0.027467525239214  0.004932928889320  0.020868912898856 -0.024483356625930 -0.224180460199113
-   10  ( 10) -0.020374790573784  0.028198954860440  0.010392111666997  0.120181326176130 -0.060512260831236 -0.109015894697222 -0.047153104465120 -0.043944046420833 -0.103069326885495
-   11  ( 11)  0.049408052352300 -0.045270280246414 -0.110185553685008 -0.041594160321979 -0.088273360930753  0.183934249639257 -0.003285919080508  0.178701510068243 -0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.045673042542890  0.020717466986083 -0.050844518832522
-    1  (  1) -0.040043621408487 -0.028287827625151  0.045457031631407
-    2  (  2) -0.084888848710605 -0.010052611398803  0.109898373773783
-    3  (  3) -0.018088362425205 -0.120534313520650  0.041770057803413
-    4  (  4) -0.026789230886550  0.060849702419905  0.088673365261613
-    5  (  5) -0.008004711197727  0.108432873838655 -0.185071361149961
-    6  (  6) -0.020116775504235  0.047889712574718  0.001523439225442
-    7  (  7)  0.023964360822185  0.043618854823263 -0.177454217319223
-    8  (  8)  0.226734396044438  0.102481459206944  0.008115223439087
-    9  (  9) -0.000423083368406 -0.309060226547434  0.090400550219427
-   10  ( 10)  0.308249178857435 -0.001017567434936 -0.330623886780632
-   11  ( 11) -0.090136758927266  0.334530610017321  0.000453348817603
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000379496190680 -0.036516557673727  0.022488411844201  0.041143099111719 -0.015151024607555  0.009820525598214  0.001328546168408 -0.002719718233480  0.079787685858295
-    1  (  1)  0.035173743352485  0.000509376348503 -0.021748140811100 -0.018984912310085 -0.002571720003760  0.101540537848848  0.014107119535580  0.020961802105584  0.100916916558314
-    2  (  2) -0.024420430259890  0.020833264343634 -0.000589210441902 -0.028690810435666  0.025063562199365  0.056845698692633  0.019362765266970  0.000534124800005  0.061230653902760
-    3  (  3) -0.039980341452345  0.019929624233720  0.028127725164783  0.000384377200086 -0.012223469426354 -0.007870420436516 -0.021500821930750  0.002985124038023 -0.055850425927213
-    4  (  4)  0.015033200445576  0.003096204403696 -0.023799943458502  0.011898049659739 -0.000036971633887  0.000277032322295  0.021239662546675 -0.005095064856192  0.060237805990277
-    5  (  5) -0.010708008535887 -0.101587409014600 -0.056660431011914  0.007350368054025  0.000126941263904  0.000065704202214 -0.008506831299188  0.011228150905342  0.011964202302477
-    6  (  6) -0.000469087338482 -0.014200163610075 -0.019097267233085  0.021632296910845 -0.021392214011008  0.008495741848254  0.000109627873962 -0.021812533614874 -0.020464844726232
-    7  (  7)  0.002889338898616 -0.020632474935553 -0.000453752095144 -0.002975803626006  0.005037506724376 -0.011335159213681  0.021733393798695 -0.000007087204356 -0.019955598928897
-    8  (  8) -0.081293710509515 -0.100918057466141 -0.060971767857812  0.055875536861090 -0.060631757745431 -0.011264467031019  0.020209151997608  0.020081495210629  0.000340983773767
-    9  (  9)  0.080516503167305 -0.106262951221757 -0.031461397073353 -0.007056184146683  0.022432192781915  0.017093833942137  0.097099983466552 -0.001349018368294  0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.079753101670227
-    1  (  1)  0.106710217482987
-    2  (  2)  0.031619499292907
-    3  (  3)  0.007164069356259
-    4  (  4) -0.022223903647397
-    5  (  5) -0.017462464724719
-    6  (  6) -0.096957045420818
-    7  (  7)  0.001243112172754
-    8  (  8) -0.004611313750592
-    9  (  9) -0.000252169760563
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055343853322395 -0.005338522209203  0.036325792187091 -0.020411379114398  0.005004472559017  0.030883540419705 -0.019693764112942 -0.000404480716013 -0.025396203204216
-    1  (  1)  0.006570683600848 -0.008768421568488 -0.011573795638563  0.000009175751903  0.002770565739659  0.004931208897901 -0.022163570789429  0.003290104656908  0.003254936700297
-    2  (  2)  0.001674419203277  0.021967102120902  0.025831824909554 -0.024758928994745 -0.009340908203812  0.034459015755376  0.010228225914487 -0.005919790861067 -0.058115699230390
-    3  (  3)  0.007779977639509 -0.106141218473434 -0.050482163293278  0.041812559908941 -0.042606909564863  0.016938249582167  0.022723831963497  0.018285942873731  0.061788101761112
-    4  (  4) -0.087397972334062  0.164590469335859  0.035983465272717 -0.095460926704216  0.183399304764373 -0.073380967092300 -0.038295030471351 -0.047026058194857 -0.066959437295317
-    5  (  5)  0.293750190777910  0.042648437038433  0.056404874075468 -0.100193237694056  0.123782490033077 -0.014652582564902 -0.036251400704161 -0.016769125982848 -0.023410414575794
-    6  (  6) -0.063526410041118 -0.042202406515953  0.107158367449000 -0.011222400592515 -0.032805848689894 -0.070775222023081  0.034269417179590  0.097599209765295  0.095048599779477
-    7  (  7)  0.039213631545190  0.016300797142278 -0.022834925899151  0.106699749704471 -0.109813770660251 -0.000567880224415  0.192962587636570 -0.013162275101134  0.042958800457043
-    8  (  8) -0.207671023275567 -0.021761663181296 -0.066317329893717  0.113575721461044 -0.208505431005016  0.053139089145086 -0.182387663583988  0.049317657695772  0.039898751560786
-    9  (  9)  0.031717525025615 -0.035452316963842  0.019040840253717 -0.049757955126745  0.003315672276934 -0.048439544916052  0.094357742781682  0.007725852797236 -0.042206115018339
-   10  ( 10)  0.030723138202058  0.012685537900520 -0.130253036286197  0.070878549267589 -0.073822499716479 -0.176856315004232 -0.024096584449109  0.033980770130198 -0.029602022179569
-   11  ( 11) -0.076338046412608 -0.058007647538535 -0.059625157558161 -0.072355446358478  0.100714683926583 -0.028164062896195 -0.037103331661254 -0.004159802100780 -0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007837140573608
-    1  (  1) -0.001271351061977
-    2  (  2)  0.056316152671545
-    3  (  3) -0.023558705106194
-    4  (  4) -0.071677402926291
-    5  (  5) -0.031036091810970
-    6  (  6)  0.060669139129724
-    7  (  7)  0.008329217020035
-    8  (  8)  0.058082899762783
-    9  (  9)  0.050026765138378
-   10  ( 10)  0.030419330923301
-   11  ( 11) -0.028289350786073
 
 	Computing L_X-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.112468381390
-	   1         2.863557091342    2.563e-01
-	   2         3.434225465682    1.230e-01
-	   3         3.476720359624    2.598e-02
-	   4         3.479765870196    8.602e-03
-	   5         3.479646260863    3.657e-03
-	   6         3.480051736431    1.018e-03
-	   7         3.480136198350    3.096e-04
-	   8         3.480113267789    1.209e-04
-	   9         3.480109916269    4.219e-05
-	  10         3.480110476167    1.795e-05
-	  11         3.480111136196    5.637e-06
-	  12         3.480111401888    1.579e-06
-	  13         3.480111366362    4.869e-07
-	  14         3.480111364699    1.754e-07
+	   0         2.112468369961
+	   1         2.863557073074    2.563e-01
+	   2         3.434225438375    1.230e-01
+	   3         3.476720330915    2.598e-02
+	   4         3.479765841302    8.602e-03
+	   5         3.479646231938    3.657e-03
+	   6         3.480051707487    1.018e-03
+	   7         3.480136169401    3.096e-04
+	   8         3.480113238841    1.209e-04
+	   9         3.480109887322    4.219e-05
+	  10         3.480110447220    1.795e-05
+	  11         3.480111107249    5.637e-06
+	  12         3.480111372941    1.579e-06
+	  13         3.480111337414    4.869e-07
+	  14         3.480111335752    1.754e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 7.534e-08
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.013905849892992  0.105574256292555  0.058365326510732  0.011150777040830  0.004301162141041 -0.055780562682692 -0.053115864387752 -0.011951099406770 -0.044340643594202
-    1  (  1)  0.013705956820555 -0.025309547841960 -0.001538984041734 -0.001849504741603  0.005133976748632 -0.012878903904056  0.096751125536924 -0.003812996689903  0.009632709529968
-    2  (  2) -0.020569845493093 -0.032320703460180 -0.011944643866745 -0.047792544188734  0.032679729361416 -0.019407207672949 -0.038230397931919  0.003676283556944 -0.058784384336985
-    3  (  3)  0.071874917867093 -0.002631775952960  0.003539152259809  0.028170151218425 -0.033082337295689  0.021301963625855 -0.050188554745657  0.011804977856767  0.016979295260921
-    4  (  4)  0.014914728990396  0.041337858840349  0.031774187859112 -0.031846901880618 -0.020737884741536  0.009318588686327 -0.180587918491444  0.014608314108616 -0.091927794627027
-    5  (  5)  0.043163603381900 -0.253570894625469 -0.078110646309368 -0.060207643631253  0.083755719198877  0.160896258343551  0.127680183234514 -0.074831092977117  0.060961655981049
-    6  (  6) -0.044917686060828 -0.074437543040067  0.066817478801761  0.141365137531753  0.114156889702257 -0.038201515939482 -0.107320317731531 -0.348968351908512  0.116558406175751
-    7  (  7)  0.034184804469893 -0.226667134284391 -0.206947793731390 -0.080987919933847  0.050884738274657  0.136027438420489 -0.157869432700479  0.195670168357032  0.055408723502488
-    8  (  8)  0.031166515249721  0.045258191750987 -0.124213591624855  0.070497635611886 -0.013839913877531 -0.080645709057116 -0.048975111106761  0.013846985677438  0.081456527024621
-    9  (  9)  0.260272045600859  0.057970015239195  0.114635559073584  0.083827066916392 -0.094102194410800 -0.136997319599706 -0.136846202555835 -0.093755934766235 -0.066197390562813
-   10  ( 10) -0.128170228467008 -0.270987976538407 -0.063355286850330  0.080149940628318 -0.057123968341669 -0.051813056590924  0.080732658365778 -0.110930691434851 -0.002284134974517
-   11  ( 11) -0.014638573493894 -0.093181336572008  0.090893348615143 -0.060951699754620 -0.036152243930201  0.068685591001865 -0.022141424075597 -0.054226980293487 -0.076820031900454
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045178917656151
-    1  (  1)  0.000506654263468
-    2  (  2) -0.062622183647669
-    3  (  3) -0.006475863513060
-    4  (  4)  0.009581278166545
-    5  (  5)  0.123788681467482
-    6  (  6)  0.140490962930464
-    7  (  7)  0.012343887711756
-    8  (  8) -0.065924555702067
-    9  (  9) -0.071777365622544
-   10  ( 10) -0.030198414714018
-   11  ( 11)  0.038206097812612
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000441373721971  0.087271451504254  0.308356080671030 -0.018077607068688  0.073688004857476 -0.153028983755896 -0.021375900910730 -0.125940926422186  0.021636449149896
-    1  (  1) -0.086671311731224 -0.000204963757277  0.004083848977647 -0.019054726614325  0.000357076891570 -0.008883507874300 -0.245817294107565  0.139613669494547 -0.011872389377551
-    2  (  2) -0.307138366785038 -0.004537268804354 -0.000000947821260 -0.032420162338715 -0.044765722657128  0.148620348284250  0.082511203687099  0.091836400843881 -0.021157739960336
-    3  (  3)  0.018180307170497  0.018806737266631  0.032304346608179 -0.000164575589082  0.000048486967076 -0.033944617253518  0.017906518922370 -0.039367589983503  0.041014607610233
-    4  (  4) -0.073708499176395 -0.000188579066207  0.045384824461272  0.000051244255112 -0.000118131709454  0.009319825672971  0.005919844337701 -0.028188407915503 -0.062383088971619
-    5  (  5)  0.153503404134916  0.008021529263725 -0.150851560923171  0.033683034219721 -0.010920406889103  0.000843675018215 -0.002305152210287 -0.006419896281910 -0.018802686354169
-    6  (  6)  0.021663782224978  0.245568524819791 -0.082607420634013 -0.017861578854728 -0.005717491537118  0.001465956881798  0.000164104368228  0.019402844307281  0.008582138264613
-    7  (  7)  0.126272473343725 -0.140132379196136 -0.093779865985419  0.039016174646910  0.027756266123623  0.008788078328085 -0.019927753575961  0.000986178708271  0.006276129856304
-    8  (  8) -0.021659942465065  0.012093240675092  0.021224721403549 -0.041292366946203  0.063444639030514  0.018952234899780 -0.008805846385022 -0.006555018834286  0.000619883795504
-    9  (  9) -0.110032896200750  0.071298113833135  0.163479589536219 -0.111444129990912 -0.024671365993001 -0.003210445766199 -0.009378587102769 -0.014713425509001  0.000839110373856
-   10  ( 10)  0.069217830582824 -0.088543829220743 -0.203682134643279 -0.186485128327869 -0.053425964853416  0.063005981229243 -0.018184933705949  0.000540007105749 -0.005219687452082
-   11  ( 11)  0.023959189620953 -0.030895371890558 -0.044769544498433 -0.009068900298863 -0.130492147876274 -0.035762663243292 -0.002770335503139  0.023536235288276  0.010103727285469
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.109799080219678 -0.069203346900770 -0.023919903278421
-    1  (  1) -0.071129060568146  0.087605257548157  0.030425173883571
-    2  (  2) -0.162026048331677  0.201435103487415  0.044723919546572
-    3  (  3)  0.110972252607892  0.185860701404063  0.009243336757067
-    4  (  4)  0.024458462243726  0.052145051182170  0.130041721565426
-    5  (  5)  0.002181441725954 -0.060001657923379  0.037138509415485
-    6  (  6)  0.007938597292020  0.017379429117453  0.002521412739913
-    7  (  7)  0.012919580840703  0.002428706377795 -0.023595862068092
-    8  (  8) -0.000273485582407  0.005817339116375 -0.014280567707235
-    9  (  9)  0.003328589668182 -0.017803512680764 -0.001063197928266
-   10  ( 10)  0.016699725327030  0.001798758796680 -0.002170763958318
-   11  ( 11)  0.001212933542278  0.001783778903851  0.003563107345321
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002010159634630  0.000220404084817  0.003192882122880 -0.011052627613533  0.003562668031365 -0.009837814318177  0.002544312104621 -0.035965473851195  0.038472004952375
-    1  (  1) -0.001452297302852 -0.003072719747229  0.008838287240450  0.026771929595669 -0.046483406284037 -0.009889595128182  0.035422086740367  0.011912247720366 -0.000936796016060
-    2  (  2) -0.004597077371462 -0.009797303502342 -0.002356759440367  0.013160928599717 -0.036596664601802  0.014914711645441 -0.014591721304407  0.007418668493650 -0.037805835513950
-    3  (  3)  0.010591350137419 -0.026807560073439 -0.010708663838159 -0.000566073142147 -0.006877298509595  0.015806087254090  0.036616622156539  0.004527327935437  0.052470069694755
-    4  (  4) -0.002197180048840  0.045360469690206  0.037290055709025  0.006377690547549 -0.000197738244084 -0.043135976717434  0.013927669894978 -0.013270906950991 -0.034225968512880
-    5  (  5)  0.012223872820757  0.012276608732166 -0.015974082159209 -0.014788689444500  0.043434889585929 -0.001241108463199  0.022259649308453  0.002776600972090 -0.020757469065177
-    6  (  6) -0.002236227833952 -0.033698361699947  0.015413577603851 -0.037176700349159 -0.013637799368342 -0.022481473057898 -0.000196461263851 -0.066878572107562  0.012948719456691
-    7  (  7)  0.036159618368672 -0.011023728969868 -0.006496546324176 -0.004756159901056  0.013088014945893 -0.003050957277162  0.066534588876792 -0.000038997802685  0.018679498186635
-    8  (  8) -0.037272822971437  0.001025968499180  0.039463494780131 -0.053213044947716  0.033933492458794  0.020627554065949 -0.012927451364571 -0.019084958215300 -0.000379158267741
-    9  (  9) -0.044713556544603  0.031925295057843 -0.027454374007067 -0.016949911467799  0.043552787687819 -0.029362229767510  0.013081869754981 -0.017575107888422  0.005208148088787
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.046477985245624
-    1  (  1) -0.031367776651430
-    2  (  2)  0.027386023407765
-    3  (  3)  0.017151073595537
-    4  (  4) -0.043659143705007
-    5  (  5)  0.028276225310864
-    6  (  6) -0.013015371352964
-    7  (  7)  0.017243006711225
-    8  (  8) -0.005600961681940
-    9  (  9) -0.000315129095420
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016735058692801 -0.127427648471711 -0.067812616467594 -0.013558783551809 -0.005269296599083  0.059347294870606  0.061177076545679  0.011973162399102  0.046187859594365
-    1  (  1) -0.006127975507731  0.027720789931143  0.002131386760238  0.002129686454541 -0.005489719844856  0.015177604183485 -0.105071662567975  0.004089530302215 -0.010958371300164
-    2  (  2)  0.014625553671885  0.033500045224482  0.010197102842648  0.049282810089046 -0.029146517326401  0.023890316169967  0.041396999030433 -0.003031629472559  0.064649337167924
-    3  (  3) -0.059287322502299  0.004510597912865 -0.001550787253983 -0.026031838087948  0.030781241595677 -0.028268360125230  0.056263472143293 -0.012481413064923 -0.018331852915645
-    4  (  4) -0.010310728455768 -0.048004310504315 -0.024726014802135  0.029487545392420  0.016798380655264 -0.006146311288820  0.193469287289224 -0.016404156709459  0.090545229018770
-    5  (  5) -0.048438874849073  0.279911055793901  0.091858080305683  0.061529389949110 -0.086013764646970 -0.169909289190226 -0.137573811978801  0.079110070379465 -0.068315894389439
-    6  (  6)  0.059086874754328  0.080452543242778 -0.072102486682582 -0.152740972704247 -0.124804294386305  0.037562128266895  0.116816705616042  0.371092921921504 -0.124060147180532
-    7  (  7) -0.029687956296635  0.256142179942571  0.224177989138016  0.089126356257227 -0.052538373002914 -0.151219359570602  0.169667778296547 -0.210592113990055 -0.060100313305223
-    8  (  8) -0.037809640230564 -0.049847669441603  0.131510551596478 -0.073995987264147  0.016613192275803  0.085953668087854  0.052289681067999 -0.014235003810069 -0.085573468377869
-    9  (  9) -0.334054043680738 -0.062946651230341 -0.131443841559570 -0.090838578825240  0.107669515927940  0.163692131260888  0.145222895910058  0.104796708213769  0.078942908507754
-   10  ( 10)  0.149544392295761  0.318224503990855  0.078211068857457 -0.094418507207579  0.062827781432203  0.056112671791795 -0.092070650285035  0.118729407251681  0.005066399630771
-   11  ( 11)  0.017252785597153  0.111183203080125 -0.114995811791783  0.075235812067226  0.042976611330520 -0.083335038142330  0.026013221761888  0.060774659749613  0.084239808865889
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.046526303364398
-    1  (  1) -0.000196633156806
-    2  (  2)  0.068136524138653
-    3  (  3)  0.003983938855648
-    4  (  4) -0.006861374242241
-    5  (  5) -0.130771416331255
-    6  (  6) -0.153069412317755
-    7  (  7) -0.016354872554726
-    8  (  8)  0.070442312778792
-    9  (  9)  0.084886961073099
-   10  ( 10)  0.034495414084981
-   11  ( 11) -0.039745136609744
 
 	Computing P_Y-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.194101001919
-	   1         5.093904241769    2.384e-01
-	   2         5.535854205176    8.562e-02
-	   3         5.551769071716    1.677e-02
-	   4         5.556456100351    7.078e-03
-	   5         5.556365099148    1.594e-03
-	   6         5.556271139920    4.947e-04
-	   7         5.556296665886    1.516e-04
-	   8         5.556302069326    4.256e-05
-	   9         5.556299917465    1.442e-05
-	  10         5.556299275643    4.822e-06
-	  11         5.556300131438    1.329e-06
-	  12         5.556300649875    4.815e-07
-	  13         5.556300742167    1.694e-07
+	   0         4.194101019820
+	   1         5.093904261066    2.384e-01
+	   2         5.535854222875    8.562e-02
+	   3         5.551769089192    1.677e-02
+	   4         5.556456117717    7.078e-03
+	   5         5.556365116511    1.594e-03
+	   6         5.556271157286    4.947e-04
+	   7         5.556296683251    1.516e-04
+	   8         5.556302086691    4.256e-05
+	   9         5.556299934829    1.442e-05
+	  10         5.556299293008    4.822e-06
+	  11         5.556300148802    1.329e-06
+	  12         5.556300667239    4.815e-07
+	  13         5.556300759532    1.694e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 7.132e-08
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.010782784489972  0.013050845930128  0.033023155215664 -0.015191714992095  0.005425132814901  0.026116394662957 -0.007256800612108  0.004570990183776  0.083505985646911
-    1  (  1) -0.004775248888120 -0.019609050610054  0.043741880650327 -0.000073954161324  0.027319440587928 -0.081090619324759 -0.046094626593374  0.004371816989341  0.079334747598806
-    2  (  2) -0.007829067250874 -0.005611745899100 -0.069924533643314  0.039501674728206  0.000927353784976 -0.005421401951033 -0.003817544999769  0.008629946885833  0.093259618314415
-    3  (  3)  0.018327078243591 -0.003795046417131  0.017900293895817 -0.029796535142542  0.026342994062962  0.087573876827112  0.029918989049988 -0.054199220040285 -0.044809777400716
-    4  (  4)  0.027183503470872  0.089536481638857  0.084857160463068 -0.036527297001861 -0.242538124561929 -0.016430382958973 -0.030531081573579  0.170538311757182  0.261658379411546
-    5  (  5) -0.020462782587523  0.074168804451800 -0.167834230231717  0.149604127852478 -0.243854217657690  0.044978789492557  0.032478673883371 -0.164731310430024  0.003040851330374
-    6  (  6) -0.075422914773902  0.018345498918631  0.109883881828728 -0.119442941495868  0.084779039670754 -0.177672686986939  0.254932779745392  0.179910297504286  0.058420300218360
-    7  (  7) -0.077293940205111 -0.171942167313393  0.155379720343131 -0.213627786676900  0.203405159942268 -0.435742440136601 -0.116233082588661  0.403785601702878  0.048376113482094
-    8  (  8) -0.113887453356696  0.134815689960008 -0.121289875435757 -0.381302435842573  0.140362613154441  0.094837304770689 -0.044125422076338 -0.354102164255088  0.021060221761777
-    9  (  9)  0.010381942177856 -0.091513821594073  0.090489398632436 -0.104640269057990  0.011526746486386 -0.174325672883320  0.095096801177535  0.162567420891194 -0.086584233440007
-   10  ( 10)  0.046140785323826 -0.004506559121454 -0.092261546126996  0.049590165687623  0.056546117609635  0.023211770714739  0.114566901687301 -0.007355072527000  0.045260763292278
-   11  ( 11)  0.210277389085871  0.043479475791959 -0.002620356919958 -0.027295607176521 -0.213582758279457 -0.049406759718245  0.038753842401848 -0.045549481042434  0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.000588783769111
-    1  (  1)  0.095074877441065
-    2  (  2) -0.094269658052775
-    3  (  3) -0.087042465113366
-    4  (  4)  0.229147969925312
-    5  (  5) -0.037090740492870
-    6  (  6)  0.008539965499391
-    7  (  7)  0.114631280540035
-    8  (  8) -0.035100938386537
-    9  (  9)  0.119410852550345
-   10  ( 10) -0.048938543804445
-   11  ( 11)  0.026842233365654
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000083177655875  0.020596022225207  0.023074380682109  0.123906982660277 -0.115856799969175 -0.077548996218664  0.033724258035794  0.015583195761424 -0.055304180213594
-    1  (  1) -0.020496643104719  0.000177442053919 -0.044849161409626 -0.200056054082230  0.192734988239744 -0.095810846356379  0.089592000858118  0.154865722471105 -0.062884487656521
-    2  (  2) -0.022893568520427  0.044914234916282 -0.000286887581780  0.110147204900385 -0.098101481651214  0.037544614577033 -0.063107876559817 -0.057867129267241  0.133662561842804
-    3  (  3) -0.123637708691857  0.200030347190693 -0.110276511900212 -0.000067254700333  0.150932238527093  0.295587503177329 -0.155559256339819 -0.250191288225748  0.068514494250419
-    4  (  4)  0.115217909263092 -0.191910599591419  0.098719023514077 -0.150564412486325 -0.000108066296459  0.207017027157466 -0.092817557275927 -0.119727699718554  0.027839136386995
-    5  (  5)  0.077201349586182  0.095637330323257 -0.037580888266386 -0.296037283435946 -0.206488013849544  0.000677656990837 -0.030142059938078 -0.107860538698997  0.317965442908009
-    6  (  6) -0.033520398034563 -0.089301712720516  0.063135446629119  0.155494983890111  0.093120397549751  0.029958661714230  0.000263665833745  0.031787895548351  0.052772032197117
-    7  (  7) -0.015173638148760 -0.154650785159269  0.057964322733043  0.249885773107303  0.119546085272213  0.107827018648257 -0.031752436246544  0.000037065640674  0.211400361545441
-    8  (  8)  0.055452136609395  0.063704146851438 -0.132109776961381 -0.067534716804367 -0.027512182553154 -0.319330567201196 -0.051501501228049 -0.211684727134552 -0.000062825592229
-    9  (  9)  0.059987775905021 -0.059013360455393 -0.001731139538261  0.025602282087959 -0.077406198911912  0.032289392048789 -0.044673931971007 -0.007013222782529  0.205272148471903
-   10  ( 10)  0.040816969333319 -0.029839999727295 -0.097606908985792  0.012730679444132  0.052120800982420  0.047092545087938 -0.097199457935824  0.008100744465293 -0.194519063749344
-   11  ( 11) -0.105565276750546  0.086850909183234  0.141349531156014  0.064538795649442  0.048769909889220 -0.098670307723293  0.132937762954191 -0.091749745952861 -0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.059727136016838 -0.040967341903913  0.106287777222309
-    1  (  1)  0.058687758282915  0.029394471353826 -0.086811620398375
-    2  (  2)  0.001293940264555  0.097641591345113 -0.142636172226853
-    3  (  3) -0.025821629306306 -0.013207208477272 -0.063793857996761
-    4  (  4)  0.076409112526474 -0.052575212530451 -0.047414860037356
-    5  (  5) -0.032527517350565 -0.045632421732577  0.095160623491729
-    6  (  6)  0.044231942651703  0.096152133696301 -0.132935625343693
-    7  (  7)  0.007372100254253 -0.008488811567739  0.092713079820202
-    8  (  8) -0.206938183650805  0.192802275414426  0.052611900153123
-    9  (  9)  0.000608554890156 -0.088592533061698  0.344380743508036
-   10  ( 10)  0.088950131298492  0.000863284429953  0.222751022723935
-   11  ( 11) -0.341005102874300 -0.224718204882492  0.000326394311109
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000338557997552 -0.011375035743392  0.029451193209236 -0.012043586883828 -0.021579660859347  0.039033326019946 -0.009990415550092  0.009478976983628 -0.045907412693585
-    1  (  1)  0.013672223167698 -0.000473657715584 -0.014851568055555  0.021895587564371 -0.022163590605075  0.051246172607775  0.019257625103746  0.003658602851281 -0.019552361048058
-    2  (  2) -0.032608942325713  0.014402827198054 -0.000746991250603 -0.029107751732300  0.054720608245644  0.057033646383303  0.001872360780591 -0.031698780852448  0.056602981887733
-    3  (  3)  0.014268935231542 -0.021459967996182  0.030313065636317 -0.000730068456009 -0.016766656065195 -0.058973632357354 -0.003002419788061  0.022431580465626 -0.134333948620083
-    4  (  4)  0.022372891038515  0.021355779916377 -0.052959509294565  0.015751198634933 -0.000391938857969 -0.016109226068828  0.004538544158672 -0.050308920012661  0.059340919102150
-    5  (  5) -0.040216234763810 -0.051875751817174 -0.055849318880052  0.058120412757832  0.016460961175898  0.000645475334216  0.019024299026328  0.068804307634402 -0.024311188622736
-    6  (  6)  0.009930727984206 -0.019074682595569 -0.002242770131548  0.003091320851947 -0.004596281406168 -0.019032186967740  0.000074596378968  0.032870219636189 -0.006741182978715
-    7  (  7) -0.009279418369258 -0.004264018479381  0.032087681361723 -0.022624894165436  0.049954824766487 -0.068907285150032 -0.032867640818893 -0.000029995356356 -0.011652937852273
-    8  (  8)  0.047260005865874  0.018493502167014 -0.056736132845076  0.135589678169431 -0.059916509278318  0.024164421049794  0.007333544303120  0.011763030881780 -0.000264400142459
-    9  (  9) -0.016875007958598  0.031435494057685 -0.089048257959160 -0.041017085631602  0.020420285065562  0.066513023484078  0.000739604154969 -0.091958006244489  0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.016438561460291
-    1  (  1) -0.031819705279686
-    2  (  2)  0.089217438029428
-    3  (  3)  0.040553914705774
-    4  (  4) -0.020554472275814
-    5  (  5) -0.066048736736302
-    6  (  6) -0.000688806170902
-    7  (  7)  0.091248940256931
-    8  (  8) -0.027663919394381
-    9  (  9) -0.000090314260367
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011888856297006 -0.017750932125153 -0.030381401096490  0.012819546160996 -0.007239420422718 -0.024248756043407  0.008035757610220 -0.005364063357974 -0.085646323747472
-    1  (  1)  0.005014728223890  0.026640078285976 -0.053625852742063 -0.001580773154934 -0.029513947501511  0.084681976949646  0.049070075720108 -0.003015931693788 -0.083533135335069
-    2  (  2)  0.005701802857788  0.001861436552455  0.077309348516175 -0.039227298256145 -0.002806617492516  0.004668173879327  0.004051055445085 -0.009725469213679 -0.098722432349714
-    3  (  3) -0.016358351457124 -0.001723600627698 -0.021225514928062  0.039815087581337 -0.022808569998795 -0.104140287911999 -0.033233738030323  0.056382556071864  0.046907957767316
-    4  (  4) -0.023138877563353 -0.095098707280146 -0.087666288227931  0.037561492255805  0.255193211004254  0.015544572331716  0.030557402755123 -0.180093964112144 -0.259856355700386
-    5  (  5)  0.024228572043234 -0.082834757201086  0.181139504221043 -0.153944959591839  0.252818375021614 -0.048862178579716 -0.036094966909273  0.170640955267472 -0.004551713568432
-    6  (  6)  0.085402345559358 -0.022737485412840 -0.117389155338347  0.122686430467103 -0.089994929534087  0.186662776489157 -0.276334552924253 -0.188945818003174 -0.062512631958960
-    7  (  7)  0.077377916753636  0.184413390881742 -0.161635032551528  0.217081818449181 -0.216158931990711  0.452250331823368  0.121365143499215 -0.427486936599919 -0.051141830029037
-    8  (  8)  0.109996402529651 -0.145159792225805  0.137471198251747  0.396423044911114 -0.145941263905056 -0.104134158957014  0.041227108112442  0.369426049626710 -0.017681253264412
-    9  (  9) -0.015271329763023  0.091667642816572 -0.093167229349338  0.105178289783052 -0.012072216330151  0.184888670947420 -0.104021366500691 -0.173041839821099  0.089774142402176
-   10  ( 10) -0.051871879465497  0.004911726396439  0.095027344602311 -0.050235453581707 -0.056755121586123 -0.023277306660177 -0.123771404812450  0.008953154661311 -0.042342746566353
-   11  ( 11) -0.213874614633354 -0.038620645156941  0.003918905035704  0.027644952213642  0.227437070959628  0.047768116418487 -0.043243210008693  0.046251908849224 -0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001231945309971
-    1  (  1) -0.099118498855930
-    2  (  2)  0.099462956417043
-    3  (  3)  0.089788110354890
-    4  (  4) -0.236379406660322
-    5  (  5)  0.043290372964682
-    6  (  6) -0.008471875583563
-    7  (  7) -0.118429426587662
-    8  (  8)  0.041151812398786
-    9  (  9) -0.121668252978460
-   10  ( 10)  0.047795297768532
-   11  ( 11) -0.026000603113831
 
 	Computing L_Y-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.122782461967
-	   1         8.093115650754    3.807e-01
-	   2         9.269394011294    1.652e-01
-	   3         9.368649580441    4.972e-02
-	   4         9.381570450616    1.559e-02
-	   5         9.381785504671    4.977e-03
-	   6         9.382226037003    1.201e-03
-	   7         9.382363520298    3.277e-04
-	   8         9.382337267320    1.160e-04
-	   9         9.382328862306    3.202e-05
-	  10         9.382329743631    1.260e-05
-	  11         9.382330807389    5.186e-06
-	  12         9.382331943950    1.700e-06
-	  13         9.382332079788    5.581e-07
-	  14         9.382332117019    2.269e-07
-	  15         9.382332167469    1.016e-07
+	   0         6.122782433570
+	   1         8.093115607813    3.807e-01
+	   2         9.269393954129    1.652e-01
+	   3         9.368649520361    4.972e-02
+	   4         9.381570389873    1.559e-02
+	   5         9.381785443847    4.977e-03
+	   6         9.382225976157    1.201e-03
+	   7         9.382363459445    3.277e-04
+	   8         9.382337206468    1.160e-04
+	   9         9.382328801454    3.202e-05
+	  10         9.382329682780    1.260e-05
+	  11         9.382330746537    5.186e-06
+	  12         9.382331883098    1.700e-06
+	  13         9.382332018936    5.581e-07
+	  14         9.382332056167    2.269e-07
+	  15         9.382332106617    1.016e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 4.469e-08
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007512480776319  0.036140698221162  0.006614016091629 -0.006989344711517  0.012538055579667  0.047719007710800 -0.011438854389831  0.001348837643708  0.043912417866150
-    1  (  1)  0.000217941106815  0.023674382271911 -0.074458985850499  0.018669991150763 -0.024216220760344  0.026693268127322  0.030529166464713 -0.009220514907509 -0.051390413902716
-    2  (  2) -0.018657169402382 -0.000504863635670 -0.063891633981927  0.031237660505947  0.009378378679164 -0.057274634026543  0.010216661924779  0.007277876487311  0.107239917659553
-    3  (  3)  0.016066164003828  0.014293064557711 -0.024640166827267 -0.100199283130149  0.053038409095112 -0.079899101326132 -0.014809180078406 -0.008036171971183 -0.093693488350467
-    4  (  4)  0.014907654111593 -0.000249634614143  0.129575540220445  0.265751473143634 -0.141781144259113  0.223368583932083 -0.004368931811378  0.027043226757367  0.062609693461921
-    5  (  5) -0.041914834745247 -0.097616041138947 -0.135770321463814  0.246024098805421 -0.106912109293501 -0.321253251117319 -0.068788844583990  0.142290197287628 -0.046076100892295
-    6  (  6) -0.039123394394723  0.039408255038257 -0.037211012657418 -0.010312056024403  0.060353960942951  0.114209155992994 -0.186728746530896 -0.112616911396924  0.025666796391066
-    7  (  7)  0.018468061945917  0.067823974613178 -0.190104823535190  0.003755811520253  0.014064572484241  0.109658452638694  0.056630665145805 -0.263520506917883 -0.064583476374394
-    8  (  8)  0.033210755622659 -0.136136968498900  0.263316618160002  0.077412830589797  0.422459728217546  0.053553377730948  0.034175715906935  0.165897217652793 -0.074779388344555
-    9  (  9)  0.055036749751630 -0.056894038751104 -0.107311287797063 -0.058290191137784 -0.056944188937166 -0.005725850016316  0.009926099968286 -0.140696143209114 -0.190545524907610
-   10  ( 10)  0.130997705273781 -0.090153965609249  0.007790248268810 -0.054524064976066  0.013947321007330  0.034280119179197  0.056585811356156 -0.002663395414836  0.003086708496419
-   11  ( 11)  0.024354529821742 -0.002391484587850  0.132211150437169  0.155582434877820 -0.034543780627935  0.051588565499349 -0.027770703760258  0.083659992199369  0.057647900826746
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.055482114656335
-    1  (  1) -0.000101235030463
-    2  (  2)  0.010234508711291
-    3  (  3)  0.213846558445248
-    4  (  4)  0.006630092722992
-    5  (  5)  0.012814259546957
-    6  (  6) -0.078975443650986
-    7  (  7) -0.184930804112230
-    8  (  8) -0.058689588477811
-    9  (  9)  0.044249382467578
-   10  ( 10)  0.036865706935893
-   11  ( 11) -0.030515341975517
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000120442405581  0.037525975792407  0.039028837738652  0.219221358143393 -0.183820180818448 -0.112972286408530  0.047240063409728  0.020414149561154 -0.034238085799271
-    1  (  1) -0.037241793728452 -0.000047287882243  0.009729516430168  0.094202030077235 -0.063477866953276  0.160286164587806 -0.109752667557022 -0.131207263236284  0.068887611832074
-    2  (  2) -0.038783295216622 -0.009745201912242 -0.000258217562465  0.013038009614076 -0.045399222161827 -0.081371094984120  0.019570499748086  0.076966277295000  0.058756671783764
-    3  (  3) -0.218771475127948 -0.094047631347429 -0.012728901107962  0.000222898647350 -0.006965466758731  0.051483080000543  0.001032959857400  0.046617530443310 -0.239873280201692
-    4  (  4)  0.183500005674293  0.063741918250972  0.045633149570229  0.007771962048066 -0.000752652425378  0.016686259902744 -0.006062931975271  0.002941130184259  0.039794941498885
-    5  (  5)  0.112922744463035 -0.160447948543053  0.080839610143832 -0.052938181517924 -0.014759035093032  0.001963138533058  0.004122965199026  0.030082971847399 -0.018688716203396
-    6  (  6) -0.047223957422349  0.110045906731433 -0.018982606895220 -0.000425116658999  0.006190502350060 -0.005177802298965  0.000459941844479 -0.006641133881612  0.015637294529107
-    7  (  7) -0.020258099631627  0.130980408805956 -0.076838250722457 -0.047153827019528 -0.001697177794538 -0.030097214957006  0.006397035656861 -0.000314330689973  0.000958762971255
-    8  (  8)  0.034242059158271 -0.069241386609174 -0.058253268615506  0.239551778865238 -0.041466100486767  0.019183970473991 -0.016012586324303 -0.000462521772429 -0.000639781016008
-    9  (  9)  0.110158178577256 -0.043113630563978 -0.067267974845207 -0.106313996022487  0.002243251219660 -0.021517985932208  0.002884772712544  0.010112074041123  0.004700729741936
-   10  ( 10)  0.070149397127063 -0.040299222838292 -0.154071817441956  0.030869069243567 -0.038016470293222  0.011150694193011  0.007490401305220  0.020531677805594 -0.003859946060401
-   11  ( 11) -0.176636225337744  0.095095393142691  0.195177688825668  0.108802410559496 -0.020149361123103 -0.001298105635127  0.020927308070429 -0.032058427881699 -0.018315736142454
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.110002482243441 -0.070133081529118  0.176505754583752
-    1  (  1)  0.042468765075500  0.040212942886088 -0.096465231599211
-    2  (  2)  0.066618057955858  0.153916879455284 -0.197045228959983
-    3  (  3)  0.105738247971788 -0.031572929220209 -0.109334469149534
-    4  (  4) -0.002665514835355  0.037310624735359  0.021518865524247
-    5  (  5)  0.022104060533187 -0.008811719711463 -0.005069793238862
-    6  (  6) -0.004143184140488 -0.008777342033569 -0.020657864679248
-    7  (  7) -0.010048741121033 -0.019686189563806  0.029679561142739
-    8  (  8) -0.004305480816755  0.003474531743331  0.021387666942059
-    9  (  9)  0.000592809919997  0.021935245808500 -0.003238719819323
-   10  ( 10) -0.019997593459389  0.000606363597873  0.056392578735375
-   11  ( 11)  0.002880485106043 -0.055206554617854  0.001235092281117
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000888157000468  0.002604640035267  0.004433898987700  0.017327910307372 -0.010855912598213  0.001781915278721  0.008615460934422  0.004078735474285  0.032557314773045
-    1  (  1) -0.000573161245420 -0.000624628285884  0.035628999167227 -0.001815728764627  0.008946874115813  0.029170863803310 -0.000115513436505  0.008856710566910  0.004031507153659
-    2  (  2) -0.003701039844373 -0.036575536539622 -0.001091193696307 -0.032172216141300  0.001275865950015  0.022397487526299  0.009622303363090  0.007231877711175  0.019725778025116
-    3  (  3) -0.016821693036289  0.002844602963518  0.032977853684673  0.000161455575952 -0.028542188119355  0.026304537820681 -0.001013466229083 -0.013057607695183 -0.044876693583426
-    4  (  4)  0.011431384588178 -0.009478622864698 -0.000774534739031  0.028965078860221  0.000058413694986  0.014596515715548  0.009143536386555  0.018007246969037  0.087822521777407
-    5  (  5) -0.001221856014832 -0.030845996389588 -0.023077706374501 -0.025758114847142 -0.014593714027409 -0.000250583717006  0.003873642475734 -0.026298757281796  0.079590541434343
-    6  (  6) -0.009743031224748  0.000827857567403 -0.008744416704428  0.000735028308095 -0.009056595663713 -0.003266063160321 -0.000168072469286 -0.014668639254903  0.020470938456272
-    7  (  7) -0.003647754834421 -0.008460886211306 -0.007264440669328  0.013024018123218 -0.017787838957003  0.026317221009114  0.014749296379031 -0.000019923943455 -0.029438703128615
-    8  (  8) -0.031026550181144 -0.004477343275687 -0.020769831071035  0.045275173918403 -0.088633054403976 -0.080566188830968 -0.020052483095054  0.029483325674276  0.000128037153401
-    9  (  9)  0.012269663364479 -0.042319244263402  0.071429692849981  0.076602220709806  0.093629733790147  0.065554975939979  0.020165870906458  0.076547332424074  0.015636093570251
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.012474935539863
-    1  (  1)  0.041072842913216
-    2  (  2) -0.070651080248399
-    3  (  3) -0.076892460848025
-    4  (  4) -0.093624677134694
-    5  (  5) -0.065506732660539
-    6  (  6) -0.019889038609582
-    7  (  7) -0.076305954221087
-    8  (  8) -0.015612091565202
-    9  (  9) -0.000252880154158
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.009427979504735 -0.045069494658558 -0.001947285705090  0.002710338034860 -0.015522926834851 -0.047663635028120  0.012944383860693 -0.002408628963511 -0.046667839995062
-    1  (  1) -0.000029889909955 -0.026801338329852  0.080490862472698 -0.019668739880126  0.025396971257700 -0.032890092829257 -0.033906444326876  0.009364690845122  0.055325390015170
-    2  (  2)  0.013223768231853  0.001284266713521  0.066553348308937 -0.032573816116206 -0.011585258035685  0.060717975924391 -0.011936168857210 -0.007853073890483 -0.116794956739995
-    3  (  3) -0.012900769345878 -0.013623437855550  0.022570570921494  0.105173709434029 -0.056797034187850  0.081144841159178  0.016572432074935  0.007712189870591  0.096484218880683
-    4  (  4) -0.015650650711432 -0.003889202049455 -0.137621535484575 -0.283731289627315  0.151612143157194 -0.236884111934266  0.005136759708167 -0.028125482384447 -0.063101070821467
-    5  (  5)  0.049233650528213  0.108628515589384  0.145433760308553 -0.264881634113210  0.112823478790252  0.343941453835902  0.074580579832084 -0.152217918461378  0.050073263216128
-    6  (  6)  0.047771378538329 -0.043773249125745  0.042587468032780  0.011128298856248 -0.066617092775075 -0.124136463076967  0.204572752605319  0.119847093573235 -0.027500955272741
-    7  (  7) -0.017888279952241 -0.071752886460858  0.208298887916757 -0.005542743128559 -0.016702047381836 -0.119479054133457 -0.062994319192022  0.283598496506144  0.069642269402630
-    8  (  8) -0.037568403528376  0.148073898852809 -0.285205978681411 -0.081955004515730 -0.456336274750824 -0.051315761340278 -0.035910751818194 -0.176384561285241  0.080264248689634
-    9  (  9) -0.073735844540901  0.063193611128899  0.114658323070558  0.062815237579419  0.064185887519018  0.009313244304943 -0.011480973281939  0.153753080425913  0.207572044587912
-   10  ( 10) -0.162215796938684  0.102608816758085 -0.007760654943323  0.059426107703524 -0.013639971522339 -0.037904077339461 -0.064744743002174  0.002349088500079 -0.003377674546375
-   11  ( 11) -0.030714567047902  0.017149469368505 -0.148281723814033 -0.168021936553750  0.043219337814574 -0.059348822268391  0.027602295508655 -0.090506279699096 -0.064287335914591
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.058979846663424
-    1  (  1)  0.000234151433416
-    2  (  2) -0.011430006640806
-    3  (  3) -0.225608458896205
-    4  (  4) -0.014102875489979
-    5  (  5) -0.012200282245874
-    6  (  6)  0.083455375182168
-    7  (  7)  0.198201250764442
-    8  (  8)  0.062481817545980
-    9  (  9) -0.043390015833605
-   10  ( 10) -0.040973644943399
-   11  ( 11)  0.034098640710675
 
 	Computing P_Z-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.537114759666
-	   1         5.752302579375    2.689e-01
-	   2         6.311451165735    9.070e-02
-	   3         6.323320519177    1.430e-02
-	   4         6.325811100877    5.643e-03
-	   5         6.325656808145    2.057e-03
-	   6         6.325697836204    5.466e-04
-	   7         6.325746159938    1.655e-04
-	   8         6.325744099017    5.208e-05
-	   9         6.325741556317    1.619e-05
-	  10         6.325741067378    5.425e-06
-	  11         6.325741898268    1.845e-06
-	  12         6.325742420425    5.898e-07
-	  13         6.325742549696    2.459e-07
-	  14         6.325742553157    1.075e-07
+	   0         4.537114775105
+	   1         5.752302595452    2.689e-01
+	   2         6.311451179593    9.070e-02
+	   3         6.323320532821    1.430e-02
+	   4         6.325811114439    5.643e-03
+	   5         6.325656821699    2.057e-03
+	   6         6.325697849755    5.466e-04
+	   7         6.325746173487    1.655e-04
+	   8         6.325744112566    5.208e-05
+	   9         6.325741569866    1.619e-05
+	  10         6.325741080927    5.425e-06
+	  11         6.325741911817    1.845e-06
+	  12         6.325742433974    5.898e-07
+	  13         6.325742563245    2.459e-07
+	  14         6.325742566706    1.075e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 4.411e-08
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.092723408151075 -0.057215092134940 -0.054154926215137  0.012957083117559  0.028122190094715  0.031179347218855  0.013645641371598  0.009921258172339  0.037242536390232
-    1  (  1)  0.019990430092613 -0.002382806987559  0.016009786257367  0.011651136664597 -0.017212414198990 -0.024265249236370  0.152443472946687 -0.006755616148329  0.024207249541319
-    2  (  2)  0.009030755895234  0.085216520460363 -0.016500441499831 -0.009813164947617 -0.015713678712422  0.028373503652355 -0.075877310310795  0.039590492962937  0.081270933339189
-    3  (  3) -0.075043611755008 -0.103608833794547 -0.030676505925522 -0.013143510199953  0.006187488557257  0.045202449901574 -0.041605892889482 -0.001210820793539 -0.045033631139440
-    4  (  4) -0.122337112724117 -0.176460576265088 -0.085321001863374  0.041690733440160 -0.111448222796030  0.083092300673138 -0.094252463151414  0.071551603610925  0.059851091994803
-    5  (  5)  0.372712635775664  0.109553572239785  0.087636097688831  0.161393941368917 -0.091711881285738 -0.083559837956631  0.084048684818413 -0.114275654348762  0.004760374961166
-    6  (  6)  0.030431995544059 -0.095321795210779  0.159145740022025  0.376304340373359  0.189004479350399 -0.100683798175242 -0.128902751762968 -0.567857709085750 -0.002399331341204
-    7  (  7)  0.344039522571259  0.114279634125077  0.003626426979965 -0.177981236436906 -0.027932329764501 -0.026442462397652 -0.246808699479261  0.268819164710932 -0.106523620842343
-    8  (  8)  0.111643207885322  0.002836247769573 -0.018154026503924 -0.097243438328650  0.121498121615664  0.006682650130485  0.107315976978454 -0.036939727738377 -0.063237979028415
-    9  (  9) -0.063921675215150 -0.215994652248761 -0.065707412514049  0.003935136905129  0.142641982827575  0.026699050855783 -0.056962954862571 -0.164747861484427  0.081509018515780
-   10  ( 10)  0.058030998072116  0.060474289846612  0.205628226890442  0.038897333798042 -0.068097699807560 -0.116172285533776 -0.038858694654200 -0.255643829382515  0.001247633054968
-   11  ( 11)  0.085574013220044  0.030726962638802  0.008247473867838  0.106409310393215 -0.064469816287686 -0.072180462194277 -0.022620356444758 -0.070649638629627  0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015293746360799
-    1  (  1)  0.020176832366409
-    2  (  2)  0.007468634139779
-    3  (  3) -0.002013486296780
-    4  (  4)  0.055907379643807
-    5  (  5)  0.014548062338959
-    6  (  6)  0.210557719542813
-    7  (  7) -0.107773752705760
-    8  (  8) -0.004939471027833
-    9  (  9)  0.101796072438763
-   10  ( 10)  0.052197801100809
-   11  ( 11) -0.010791942309942
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000245185765728 -0.004422769142209 -0.195473142624697  0.067124189998810  0.027096370068160  0.099320185873800  0.032910569428743  0.079494520674282 -0.016762710819247
-    1  (  1)  0.004388313593185 -0.000165290846899  0.188129406432792 -0.063756474949075 -0.001128748240139 -0.126263116741295 -0.303817994309096  0.069854530583820  0.010310792522154
-    2  (  2)  0.194444327410373 -0.187906024270824  0.000538868177065 -0.115697813615881 -0.188025580722992 -0.063555095149569  0.109038200896130 -0.123360187528163  0.037347597176070
-    3  (  3) -0.066590814481336  0.063203632987523  0.115347217679990 -0.000002301796994  0.034584588669551  0.038983157581533  0.229948513873159 -0.131721887952800 -0.028384936970778
-    4  (  4) -0.026403437308072  0.000527986476725  0.186677671985474 -0.034818437947430 -0.000320297338463  0.037865478650564  0.201451121997014 -0.109301689008128 -0.005643097026329
-    5  (  5) -0.099409584232992  0.126346592032007  0.064419008019557 -0.039794220656347 -0.036855903902447 -0.000190318965932  0.088891480212760 -0.056789849447140  0.091073030281233
-    6  (  6) -0.033050985013878  0.303259624681304 -0.108281756633666 -0.230173439372417 -0.201331671706094 -0.089930560146314 -0.000311452672695 -0.221067383348441 -0.053494283573947
-    7  (  7) -0.079472710309908 -0.069297203366025  0.125033677339702  0.131451975782708  0.110125569334720  0.054839641157466  0.219945401741596 -0.001085047372961  0.089073871816377
-    8  (  8)  0.016952142014388 -0.010421932566239 -0.036927801153181  0.027792238689701  0.005351459000165 -0.090892785458666  0.052690955519676 -0.088985197141446 -0.000032698621213
-    9  (  9)  0.149061020700740 -0.058621114959186 -0.279965277538519 -0.021488283829580 -0.044200621925698 -0.026904718590704 -0.074208134755608 -0.037354078157659 -0.137372829291651
-   10  ( 10) -0.035190315077894  0.050814828300922  0.151303785089698 -0.062867991520111 -0.077053666036856 -0.075037906181509  0.133385625358484 -0.006791369727277 -0.121764957568739
-   11  ( 11)  0.016457666688676 -0.009560970830020 -0.030160709068648 -0.052615429880776 -0.007184814870880  0.147317585107930  0.048007656104932  0.024985856634055 -0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.149527127949477  0.035025203143730 -0.017236912650706
-    1  (  1)  0.058313378902528 -0.050420942142557  0.009474518218355
-    2  (  2)  0.278325755481738 -0.150562770304950  0.029989264213428
-    3  (  3)  0.020585218415975  0.063268588986747  0.052977667343551
-    4  (  4)  0.042114256624995  0.077316775027134  0.007960467665663
-    5  (  5)  0.031625284755674  0.074462306356205 -0.148447086799088
-    6  (  6)  0.074615124808937 -0.133170285550522 -0.049651682674137
-    7  (  7)  0.041592449377408  0.005910763914811 -0.024358506166719
-    8  (  8)  0.138294110971387  0.121744291260784  0.107918344276425
-    9  (  9) -0.001133592488713  0.474400799155993  0.192590673354496
-   10  ( 10) -0.472105353620486 -0.001334835966633 -0.192285927563244
-   11  ( 11) -0.191497735915320  0.194932828964948 -0.001344945845524
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000738836304181  0.037293198581408  0.029451404620807 -0.009378792471894  0.055701113540954 -0.035128933511984 -0.013954700067714 -0.072836702551235  0.051857122483535
-    1  (  1) -0.032660614374695  0.002015876922290  0.074058480716263 -0.021479421330690 -0.014966422603257 -0.166979967788261 -0.013073252080067 -0.022556560940623 -0.170972365950935
-    2  (  2) -0.029165553040464 -0.073308940131147  0.000753195727027 -0.033014777438001  0.000651481686764 -0.016615463822703 -0.030045410532860 -0.013342873064028 -0.078343409399381
-    3  (  3)  0.010384415064446  0.021326871974424  0.031305865808474  0.000583541727095 -0.005150844265660 -0.010972964083321 -0.024667426696971  0.003421011953857 -0.027197309287279
-    4  (  4) -0.055501401866642  0.014297660722118 -0.000710544848112  0.005493793084614 -0.000124683940717 -0.025126510553785 -0.000947638436962 -0.017069455654223  0.023650915169846
-    5  (  5)  0.033803616927021  0.164339399892725  0.017068168082329  0.010030727560507  0.025241735580020  0.000735433014139 -0.028603795353780  0.023029380344413  0.027599055296252
-    6  (  6)  0.013107540346806  0.012828435687407  0.030286401438565  0.024713021163335  0.001063605161759  0.029296491836886 -0.000025149030498 -0.111104514389532  0.102861376746943
-    7  (  7)  0.072733387901303  0.022465577956558  0.013436829086647 -0.003433808737295  0.017048766876852 -0.023125015384758  0.110934303358415  0.000037875914124  0.002935696551342
-    8  (  8) -0.053267672687232  0.170660201820078  0.076657788504288  0.028160893222526 -0.023606436991553 -0.027690933408034 -0.102626814241324 -0.002887530223588  0.000373637330912
-    9  (  9)  0.004804828900057  0.224333052817770  0.065186758028368  0.004091068046870  0.039040275694483 -0.042976408882840 -0.051197675519228 -0.024101682646066 -0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.005026329948406
-    1  (  1) -0.225373696682354
-    2  (  2) -0.064686362479745
-    3  (  3) -0.004567750792129
-    4  (  4) -0.038996417519414
-    5  (  5)  0.043485644851561
-    6  (  6)  0.051601626537389
-    7  (  7)  0.023715023759407
-    8  (  8)  0.001115391080639
-    9  (  9)  0.000048164004682
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.087860740756488  0.068261038905906  0.057593788019307 -0.011454237083441 -0.027305499289367 -0.032385982368371 -0.018173477269549 -0.009363386608796 -0.038732450559880
-    1  (  1) -0.013249632151170 -0.004184657414979 -0.019716507976896 -0.014744696478638  0.016703323694180  0.027386275287573 -0.163732376866413  0.007136524293248 -0.024482820661864
-    2  (  2) -0.007013218896085 -0.084657964294727  0.026004205374563  0.008076798202963  0.011641159214614 -0.031112856231507  0.081756432692912 -0.043486513055778 -0.085001128307205
-    3  (  3)  0.058477500387638  0.110048615847953  0.032104075685968  0.014807417786102 -0.004697674213231 -0.048123068402958  0.048143599431998  0.000645092439839  0.047260089330542
-    4  (  4)  0.110574498742467  0.188131348104213  0.086636459451987 -0.041361686502598  0.118556992954628 -0.089270642674348  0.104552978829704 -0.075153301656795 -0.057940099039356
-    5  (  5) -0.371487279658724 -0.115772941053656 -0.094845419594772 -0.167070991238391  0.094497706414686  0.087134798346335 -0.079465840043241  0.119932858558240 -0.004312964076576
-    6  (  6) -0.035255689937620  0.112028499449997 -0.168145842580037 -0.392683527257363 -0.194284650981365  0.110254467391126  0.135773335198962  0.599025983356266  0.001116295743642
-    7  (  7) -0.362602042970953 -0.115938705836042  0.002852393959785  0.186519834338995  0.026972926522319  0.023780474127448  0.271135694461778 -0.284033125501378  0.111247570725030
-    8  (  8) -0.111196944464455 -0.001239941376560  0.021205830532168  0.101329748088148 -0.128975240085324 -0.010144197632550 -0.108358474715393  0.037918096280026  0.066572090545295
-    9  (  9)  0.090967744709768  0.211201922436275  0.066377513424381 -0.007899083102241 -0.154707771160094 -0.037980948657754  0.073559352539101  0.172041273327275 -0.087426840520207
-   10  ( 10) -0.070112475488657 -0.079061926736069 -0.222919508358954 -0.040775801294398  0.061424635747658  0.113162621408555  0.037903862973014  0.270692474130444 -0.009570796789139
-   11  ( 11) -0.090924578792926 -0.040585886130445 -0.000311072794648 -0.117174234675791  0.063663959894116  0.077941781302743  0.027645133174923  0.073495241874676 -0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015882565008118
-    1  (  1) -0.020403231736073
-    2  (  2) -0.007241270504095
-    3  (  3)  0.003144444710549
-    4  (  4) -0.058793064689134
-    5  (  5) -0.012293150809123
-    6  (  6) -0.215177196230389
-    7  (  7)  0.113635102585609
-    8  (  8)  0.004824845555481
-    9  (  9) -0.113550918048735
-   10  ( 10) -0.063789409560574
-   11  ( 11)  0.007009974437012
 
 	Computing L_Z-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.030631738493
-	   1         7.952575742179    3.830e-01
-	   2         9.157176971869    1.651e-01
-	   3         9.229644597230    3.394e-02
-	   4         9.235546366775    8.861e-03
-	   5         9.234853235497    4.081e-03
-	   6         9.235181683380    1.471e-03
-	   7         9.235376895868    4.763e-04
-	   8         9.235354587267    1.658e-04
-	   9         9.235352362508    4.491e-05
-	  10         9.235351578201    1.782e-05
-	  11         9.235354067435    7.263e-06
-	  12         9.235355263431    2.254e-06
-	  13         9.235355526310    8.056e-07
-	  14         9.235355612529    2.914e-07
-	  15         9.235355653344    1.088e-07
+	   0         6.030631710855
+	   1         7.952575700404    3.830e-01
+	   2         9.157176915030    1.651e-01
+	   3         9.229644538521    3.394e-02
+	   4         9.235546307846    8.861e-03
+	   5         9.234853176563    4.081e-03
+	   6         9.235181624429    1.471e-03
+	   7         9.235376836907    4.763e-04
+	   8         9.235354528307    1.658e-04
+	   9         9.235352303548    4.491e-05
+	  10         9.235351519241    1.782e-05
+	  11         9.235354008475    7.263e-06
+	  12         9.235355204471    2.254e-06
+	  13         9.235355467350    8.056e-07
+	  14         9.235355553569    2.914e-07
+	  15         9.235355594384    1.088e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 4.530e-08
 
@@ -1847,3627 +733,387 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.605289638824142     0.048740746315961     0.271073735050428
-    1     -0.001536207352879     0.196630797562022    -1.341882102683265
-    2     -1.398139516533775     1.430868104057238    -0.796817192386296
-
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008290776080582 -0.050801504097253  0.025635294562259 -0.003046442602711 -0.019839162173202 -0.042287718066775  0.002274291905087 -0.017250301075761 -0.063217582232324
-    1  (  1) -0.005656720485448  0.005906316890016 -0.013342327104385  0.062795095869537  0.034384806675368 -0.011824889654518 -0.010091423219065 -0.046942857543920 -0.048716688440686
-    2  (  2)  0.031253511604130  0.072637650556073 -0.014421891959526 -0.004213302445553  0.070727435854801 -0.065656867197555 -0.018370400388693 -0.002385908267158  0.006354255904041
-    3  (  3) -0.059832580241196 -0.053424480759820 -0.021451003825827 -0.018138018553495 -0.036100327164171  0.016134873511603  0.024740373136963  0.003793018506519 -0.167949395515151
-    4  (  4) -0.064204693944690 -0.131652862682136  0.117404639608972  0.157417127901485 -0.230036611567443  0.047515122725740  0.039984594404843  0.125482054176259 -0.256771627646738
-    5  (  5)  0.146085129938632  0.278398764610060 -0.159854012203638  0.282968510269086  0.101365891285813  0.356608825189021  0.125659431918166  0.044422988683829  0.166646852463301
-    6  (  6) -0.076564725597579  0.133650798922835 -0.020866614443156 -0.061441481951876  0.071232976830213 -0.204259413485531  0.443726141038863  0.031546384888620  0.054109942402284
-    7  (  7)  0.171392689665179  0.199512600411571 -0.417327799251045 -0.052763427688751  0.301472803852696  0.065491949787692 -0.090135905280205  0.243374803622146  0.087314234232365
-    8  (  8)  0.052750851527397  0.070024200557922 -0.379656051510646  0.506727880893360  0.456213741194719 -0.053888497905949  0.020349944072208  0.064388593842935 -0.270869373264179
-    9  (  9) -0.321512384290440  0.557302077819714  0.036935298894209  0.154840347992778  0.003043634782132  0.230873783877613  0.106477418838008  0.187200194326970 -0.093391131247138
-   10  ( 10) -0.965723013629727  0.203375174675727  0.231799200789465 -0.113515758170139  0.032657967963446 -0.147828874479423  0.019227710807050 -0.096617606939553  0.006766409668261
-   11  ( 11) -0.210596475192897  0.094976222444135 -0.072335244920971  0.290764752768263 -0.062314851229712  0.053607127427930  0.145285323049651  0.073900587412887 -0.326764941791807
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071285844130264
-    1  (  1)  0.010066343394199
-    2  (  2) -0.108617239028194
-    3  (  3) -0.063737900590760
-    4  (  4) -0.015793155353663
-    5  (  5)  0.238781543103224
-    6  (  6) -0.065357063243315
-    7  (  7)  0.120098496018758
-    8  (  8) -0.128051536292778
-    9  (  9)  0.179029916473930
-   10  ( 10) -0.084757737907666
-   11  ( 11)  0.159141561245499
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.230778688168130 -0.557039020018502  0.102231622004203 -0.365190061837505 -0.400431097899025 -0.011240783369823 -0.138486416116495  0.002452040812742 -0.004398637078623
-    1  (  1) -0.556776142920827 -2.040315056194718  0.915507378155102  1.014426942838368  0.734278848751725  0.048588577390964  0.281167270606351  0.301449170381432  0.094768863002394
-    2  (  2)  0.102191442528323  0.915686903851560  1.209547690777273 -0.958100119655737 -0.740471389480369 -0.004947182895568  0.495915674452131 -0.139783988312968  0.095073435804183
-    3  (  3) -0.364539165929170  1.014070571549057 -0.958316089423204 -0.283348551998825 -0.131889670325022 -1.271015261428147  0.039370973643206 -0.404136843612415 -0.596543898512850
-    4  (  4) -0.399870169082361  0.732987024839952 -0.742129335372324 -0.132056740778799  0.552809694709972  0.050609502973822 -0.485130318718432 -1.569135325660496 -0.955644372877197
-    5  (  5) -0.012067668711970  0.049395634351447 -0.004235997753528 -1.269867451709877  0.052501445594591  0.142961307435960 -0.243772741862524  0.815823088969846 -1.032660122676294
-    6  (  6) -0.138184751914924  0.281444487458849  0.496109632619357  0.039289252640444 -0.483545301414318 -0.244146373994899 -2.567548494258237  0.471042691193011  0.535768572608993
-    7  (  7)  0.002443724218529  0.302692867022601 -0.138498316501231 -0.403820450806263 -1.565811046199608  0.816611901103015  0.471628294535134 -1.688652935957108  0.671482803026688
-    8  (  8) -0.004344564384300  0.094578985136196  0.094798646138089 -0.597437555079113 -0.950266206536146 -1.030172101956222  0.534632090191761  0.669551052804072 -0.286047601971907
-    9  (  9)  0.321027459692546 -0.124494588251713 -0.355830352458176 -0.608802973418470 -0.402462352421951 -0.368076132570564 -1.240230517037675 -0.910561909620175  0.043652486559104
-   10  ( 10)  0.011815823949598 -0.051101513605038 -0.395397800969984  0.309598565761669  0.194737646185127  0.053604366895841 -0.879466474650196  0.757981021960396  0.138272602216670
-   11  ( 11)  0.159425836287601 -0.085783898744993 -0.370909602534729 -0.056636941516785 -0.307385996591224 -0.268976928323790 -0.442853482929670  0.013290639913097 -0.876205899626718
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.323082673575100  0.012827323300415  0.160383781034165
-    1  (  1) -0.126844464371028 -0.052604971080148 -0.086843133976977
-    2  (  2) -0.357788273401833 -0.396667921961515 -0.371902334820724
-    3  (  3) -0.612287607386654  0.306667669522199 -0.056656844524874
-    4  (  4) -0.405472668706639  0.195190062002348 -0.306615567899281
-    5  (  5) -0.367351821286147  0.055534904015428 -0.275720960811118
-    6  (  6) -1.243158670589035 -0.884111685009210 -0.446520521343404
-    7  (  7) -0.909610092856081  0.758960738026336  0.004121680213622
-    8  (  8)  0.044479614426162  0.142510706976164 -0.890141861038879
-    9  (  9)  0.430645603358394 -0.292573864178629 -0.177569371172063
-   10  ( 10) -0.297251468770778  0.639563517042984 -0.084252875076621
-   11  ( 11) -0.176313836183732 -0.086637188746477  1.226883274744448
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.555032728737771  0.712617672671401  0.419810286882489  0.050887754227596 -0.090842975445822 -0.470640518796941  0.705404320416024 -0.102097016449215  0.079849652538938
-    1  (  1)  0.712915390108471  0.338414908248977  0.746799463635505  0.289033465951793  0.281577689527702 -0.590080565321557 -1.163166129408219 -0.188838662213219  0.235465544716902
-    2  (  2)  0.420424419523684  0.746397208582966 -0.016153704953468 -0.358852287949201 -0.952285365412292  1.041198523267407 -0.387389024226280  0.231972398395418 -1.201681468114436
-    3  (  3)  0.052990374128029  0.287939592192507 -0.356997201476426 -0.860130940767887 -1.322600194001359 -0.190991097932252 -0.172427859143025  1.049268576710733  0.759838942947354
-    4  (  4) -0.091729674999201  0.281558404761801 -0.953826965790842 -1.321136801436185  1.452847715742109  0.019357804497789  0.219531843898996 -0.321163524474806  0.383368380154908
-    5  (  5) -0.468391179467906 -0.590920943851569  1.042843901419442 -0.190946364776948  0.019284064585406 -0.578157261908740  0.477982154885554  0.309192885886468  0.350343314103329
-    6  (  6)  0.705416628116867 -1.163498224121495 -0.385221267991331 -0.173426272959358  0.218834180811751  0.478203132617135 -2.784703127021582 -0.089827446409910  0.007438070857215
-    7  (  7) -0.100892718625019 -0.189193923309364  0.233172791358426  1.048794685120079 -0.321694154621351  0.309157324551256 -0.089653742381773 -3.228872513573496  0.508232911749822
-    8  (  8)  0.078189592702616  0.235740536359493 -1.205024775916881  0.762330717256039  0.383275686836382  0.348953623655193  0.008045450505770  0.508467502681986  0.472369144605263
-    9  (  9) -0.077760701800955  0.237396383481108 -0.096343734790574 -0.354923660187535 -0.984336588474142  1.335053740742370  0.269902452459777  0.319055275759352 -0.321749140962585
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.078162493766068
-    1  (  1)  0.238847682218727
-    2  (  2) -0.098903683747888
-    3  (  3) -0.354949509542455
-    4  (  4) -0.983822640646403
-    5  (  5)  1.333720211340158
-    6  (  6)  0.269441491786924
-    7  (  7)  0.318898660493929
-    8  (  8) -0.321196908799485
-    9  (  9) -0.198768714929451
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015331616498833 -0.019922018235360  0.024795453639952  0.001428994822442 -0.007662564632869 -0.030564864466354 -0.002998096035874 -0.014184257518557 -0.050369876521864
-    1  (  1)  0.002536892896206 -0.000724332833140 -0.010931820831771  0.061385329925525  0.034527384530112 -0.002930909394968 -0.006897041777642 -0.048924198461387 -0.045892788765523
-    2  (  2)  0.055930590988109  0.061668786229878 -0.009784880887058 -0.011292178101404  0.079575226023927 -0.052325708606337 -0.009086556132667 -0.001787844130138  0.008215255410943
-    3  (  3) -0.058532225277701 -0.048285500112225 -0.015912879350588  0.001479837376653 -0.030353501548890  0.023819914693464  0.021025260847826  0.014207102374829 -0.151577267379535
-    4  (  4) -0.056221687371934 -0.122358938171234  0.112292181821658  0.146881610350559 -0.213263741399596  0.056469707520368  0.037816511197979  0.118315319709634 -0.249164851234958
-    5  (  5)  0.125699079920792  0.245765102963436 -0.144688421941741  0.269480954167622  0.108175820650901  0.330495489462815  0.121717019021094  0.042981278927133  0.139107704893676
-    6  (  6) -0.090953864200081  0.138378038123711 -0.018999653387300 -0.059021477190613  0.070107383816014 -0.188422561576096  0.422479983427336  0.027031745312951  0.054392856003620
-    7  (  7)  0.157772366372595  0.187920697768143 -0.411777035755239 -0.046692805557951  0.283266431788380  0.074879967037488 -0.084103929184262  0.226658912465472  0.075512245279510
-    8  (  8)  0.054210291452992  0.062449071960101 -0.361963320103574  0.503001997291620  0.438083797101076 -0.063050427843078  0.017066076329137  0.069221757957400 -0.257467231990446
-    9  (  9) -0.273423536032774  0.529295983026682  0.033766766508851  0.151918529592259 -0.009418984940093  0.206571120107986  0.110624885223032  0.172829785443028 -0.101427788661059
-   10  ( 10) -0.861462052752320  0.172326691424178  0.212371997651326 -0.111218596621436  0.023269411258717 -0.143388725237391  0.039930804953421 -0.091843120858856  0.022422158283106
-   11  ( 11) -0.188670480611874  0.096820345118133 -0.066190773880029  0.287205832494666 -0.059420643781434  0.064429852032339  0.150091109571506  0.074231547885084 -0.343171650309577
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.057461514086606
-    1  (  1)  0.006963958755564
-    2  (  2) -0.098129328522494
-    3  (  3) -0.059012682268642
-    4  (  4) -0.004449861106028
-    5  (  5)  0.220945294639113
-    6  (  6) -0.063939488850868
-    7  (  7)  0.102360934503055
-    8  (  8) -0.118112557417407
-    9  (  9)  0.155151984964126
-   10  ( 10) -0.077691214009347
-   11  ( 11)  0.169304339523055
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007929033245727 -0.086776514026638 -0.041466992686244 -0.000624066975311 -0.013156595381987  0.043080477030762  0.042448060293463  0.012239880545527  0.029029915184304
-    1  (  1) -0.033878180177558  0.070173508648210  0.019230609095550 -0.003533880530575 -0.001550569267327 -0.001809299397526 -0.111518736659909 -0.001270571448457 -0.012934311690280
-    2  (  2)  0.053119512373320  0.091732793273830  0.021408607612661  0.032674571200622 -0.027446877387833  0.001428368203209  0.035760699595502 -0.016168017803360  0.076110316338229
-    3  (  3) -0.111768458659199  0.032123986864070  0.006283151908271 -0.033287020781358  0.043086093005307 -0.045344868585861  0.050504244775852 -0.018808552325982 -0.035145863401031
-    4  (  4) -0.008665305449844 -0.063452607411023 -0.029600165455924  0.047115677331559  0.019168666345381 -0.031501732622098  0.317766848542404 -0.025484653465158  0.136713668607013
-    5  (  5) -0.096942829349587  0.462416830630329  0.133842090994118  0.092985874350147 -0.099421870808029 -0.234587688959823 -0.217512036032000  0.115491679731730 -0.074046828271163
-    6  (  6)  0.147504151854231  0.176016277524490 -0.101374573515317 -0.288079277305196 -0.230919141922049  0.118478695990594  0.200039409574699  0.528080641738917 -0.150345125085143
-    7  (  7) -0.042669001755884  0.443406170499069  0.389143916519812  0.161315900065673 -0.044923622848274 -0.251217580401495  0.349139344106497 -0.313375744671926 -0.105308356658894
-    8  (  8) -0.090773283284028 -0.098945242676733  0.273219850231927 -0.153556988234685  0.012049248011756  0.153837601800696  0.096783765511278 -0.036655814574288 -0.158022323654812
-    9  (  9) -0.854099711852282 -0.117772176421944 -0.239016409160077 -0.177375733867881  0.100275769298913  0.252844583057920  0.226930144139075  0.153229528005110  0.127239027610851
-   10  ( 10)  0.395991653576375  0.538214267844356  0.096531314019954 -0.336382832184142  0.099895828912763  0.055956501178133 -0.146421756050995  0.134905206743007  0.024743642762261
-   11  ( 11)  0.048495982241480  0.204014858900645 -0.274325469868742  0.134595356909103  0.084519511625804 -0.191133538480751  0.069261639154394  0.103192119612584  0.176045180364651
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.028831087335228
-    1  (  1) -0.001371858337113
-    2  (  2)  0.086279641236700
-    3  (  3) -0.002619734805492
-    4  (  4) -0.021137684583830
-    5  (  5) -0.191430382947414
-    6  (  6) -0.264284919761669
-    7  (  7)  0.000269384690538
-    8  (  8)  0.116882729881709
-    9  (  9)  0.120074711434079
-   10  ( 10)  0.053632787996257
-   11  ( 11) -0.085463803953674
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.675541283858356 -0.292064021280293 -0.790025131233222  0.039304385342315 -0.142699371183327  0.268327500474091  0.055268589173706  0.193336176520280 -0.032498607183913
-    1  (  1) -0.292005367417511 -0.068094888399427 -0.091928539573230  0.129152126993159 -0.002672883933379  0.049262453691224  0.862140772831706 -0.434895002279636  0.030957963645570
-    2  (  2) -0.789447165009789 -0.092254483472880 -0.804853040833334  0.464036191543570  0.288328515691532 -0.782373392336952 -0.359658943728641 -0.388090328975242  0.068147997029207
-    3  (  3)  0.039444395620206  0.128939281409480  0.463903578747306 -0.241479807350799 -0.029257651091736  0.289330170364477 -0.078438871496667  0.246243716348015 -0.221624488999474
-    4  (  4) -0.142005033730652 -0.003441352982276  0.286700873937055 -0.029953661733414 -0.427750919311445 -0.225593242891832  0.001248695253401  0.308372097905189  0.608170303007273
-    5  (  5)  0.266046370608821  0.051710611539180 -0.778167579408912  0.290283723006215 -0.224453112864279 -0.369348441761130 -0.137527542499239  0.160088399589127  0.333141145250294
-    6  (  6)  0.055576665996038  0.861897091141550 -0.359382180614210 -0.079367338581182  0.001316960755447 -0.139592143084602 -0.236061692038733 -0.500995422630755 -0.152924823639678
-    7  (  7)  0.191190365321726 -0.433335934056497 -0.384226491533538  0.246895934047586  0.308256930114393  0.160145299200529 -0.499551364365546  0.169042466304747 -0.232433156817922
-    8  (  8) -0.032324733830521  0.030583581869279  0.067800595440523 -0.220839746025180  0.605132330733771  0.331428074510260 -0.152991449816876 -0.231671787208498 -0.624414674119492
-    9  (  9) -0.170133827289346  0.173802608390272  0.582650141434017 -0.560382911834174 -0.212565567455627  0.095754045184088 -0.282286783247438 -0.105642205052933 -0.000539730602912
-   10  ( 10)  0.052970874353821 -0.227531715435441 -0.648876828841383 -0.696767965643644 -0.268344000354012  0.568720278318329 -0.098598860256773  0.086269937526947 -0.081275470268861
-   11  ( 11)  0.025516552524119 -0.085059735579504 -0.121415959836865  0.018097922040376 -0.846374652520441 -0.307989344147049  0.044343294285023  0.231195949738532  0.168305572109582
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.171375974411067  0.055216931376792  0.025964207813788
-    1  (  1)  0.173220084938157 -0.230603891969826 -0.085840408679658
-    2  (  2)  0.586304150506699 -0.654210189691972 -0.122677885868631
-    3  (  3) -0.564217005061761 -0.698424845148049  0.018146779332832
-    4  (  4) -0.213592841407263 -0.268356081771837 -0.851093566817366
-    5  (  5)  0.095187708087751  0.569138844284334 -0.311815017332116
-    6  (  6) -0.283847446348569 -0.099361887898569  0.045327800607922
-    7  (  7) -0.106442929251796  0.084951820105521  0.232402123183799
-    8  (  8) -0.000679287280351 -0.083181582350312  0.174842773942352
-    9  (  9)  0.184137973286679  0.103441117955563 -0.011188766481418
-   10  ( 10)  0.107554052466808  0.106515041132340 -0.165743784884080
-   11  ( 11) -0.010550245981975 -0.165913802295303  0.859885805027657
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.229655435401251 -0.279601353643965 -0.085575827802352 -0.135048509105901 -0.463462610619003 -0.365248455770507 -0.039660777368333  0.191781963250870 -0.304572804139555
-    1  (  1) -0.279047925679444  0.077319987469585  0.204439247136492  0.070123615269243  0.055860395624731  0.138642318409271 -0.343207769076389 -0.182810883095464 -0.017999280994748
-    2  (  2) -0.085240959465133  0.204263364283089 -0.311156623733494  0.294688564065330  0.229669520218161 -0.281737981462645  0.137882893674030 -0.194668648298996  0.517507397185879
-    3  (  3) -0.137052652301458  0.068817803199155  0.294513347383327 -0.628744473812505  0.688526281107777  0.166771123104115  0.212803952843010 -0.269010206604892 -0.411620416751970
-    4  (  4) -0.461604619248266  0.055843287983042  0.230054478565236  0.688395074228786 -1.421511879446005  0.180495138052121 -0.177199847230662  0.268188410470329  0.119512289645345
-    5  (  5) -0.365099883123814  0.139122909294115 -0.282780063256330  0.166251175855828  0.181093271919847 -0.292775738602585 -0.240660983788926  0.305216197970317  0.235452232882587
-    6  (  6) -0.039141072198114 -0.342047900602042  0.138302509146164  0.211959339222516 -0.177087648441962 -0.240505624310098 -0.304304277829310 -0.910739369588832  0.202811323160239
-    7  (  7)  0.191443148224360 -0.183077517400336 -0.194209029769022 -0.269384260651775  0.268168725961981  0.305441092512858 -0.910852433205190  0.029633662055934 -0.204453968987965
-    8  (  8) -0.303246852232180 -0.018509744386768  0.519514080414653 -0.413340759430442  0.119384719254151  0.236362024043069  0.201991249845660 -0.204562219955504 -0.661555776893828
-    9  (  9) -0.300472910579648  0.170014354298783 -0.291259695102906  0.029160805834281  0.317264449488489 -0.326442124436524  0.007044557482429 -0.101763181058410  0.215338723709779
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301684802635884
-    1  (  1)  0.169719322346163
-    2  (  2) -0.289724655704096
-    3  (  3)  0.029002914588453
-    4  (  4)  0.316574855082561
-    5  (  5) -0.325796183326422
-    6  (  6)  0.007131791827115
-    7  (  7) -0.101918507704736
-    8  (  8)  0.215214193797303
-    9  (  9) -0.431317970778139
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009148490318064 -0.020309806158549 -0.015977532182931  0.004014783738387 -0.010489793112351  0.029667649783295  0.020232440585606  0.011223082041042  0.023312323786938
-    1  (  1) -0.044375857230131  0.052262766826166  0.015548487373741 -0.003662802577056 -0.002781875625079 -0.001383977859398 -0.098229640468489 -0.001043710758572 -0.010909270118946
-    2  (  2)  0.054181385020550  0.080128526478900  0.022828931876126  0.037487063410101 -0.042770056882922 -0.005218720540993  0.030479703829638 -0.014823518322437  0.065536667960166
-    3  (  3) -0.129996832535740  0.025539245172390 -0.001710767497197 -0.035208153932012  0.051497303033318 -0.033810939265315  0.041923713016432 -0.018028802137201 -0.031841589713416
-    4  (  4) -0.018797598258319 -0.055382521313148 -0.025678897036466  0.042677314096974  0.024119803445938 -0.028773903589126  0.288385579456642 -0.023957336001325  0.134022392012911
-    5  (  5) -0.085790126908808  0.402408359114006  0.110878458520312  0.084218998643581 -0.097302640260559 -0.211015098306590 -0.195826989075132  0.107508726926065 -0.059970385150068
-    6  (  6)  0.117117046001707  0.164907313314791 -0.092740522447941 -0.263892346037872 -0.208050086690414  0.121861415926763  0.180654068666643  0.487980567663863 -0.134813668081860
-    7  (  7) -0.052709991074355  0.381296251220592  0.349380237841959  0.145852911752160 -0.041346590279243 -0.220669429372274  0.328816279036270 -0.285726302429830 -0.093478286390337
-    8  (  8) -0.075491834851014 -0.090622807799606  0.261184981058617 -0.148637821570292  0.006281256453519  0.144842826611815  0.089811111402247 -0.036110485207390 -0.153520220179307
-    9  (  9) -0.696164148321021 -0.104910101886221 -0.203383144631185 -0.164870629493292  0.069977329160723  0.194202208543558  0.212076681930829  0.132693764051193  0.096725293429142
-   10  ( 10)  0.348175665954885  0.434442729860845  0.069207287013024 -0.311902381205193  0.086974667298470  0.051225223079379 -0.122216101880307  0.122874476488139  0.012079820457350
-   11  ( 11)  0.044712948857676  0.176004094735536 -0.255862724288287  0.126758826080010  0.078218473139894 -0.179984369340434  0.067110991111726  0.095360581673868  0.177561710091429
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.024402944617349
-    1  (  1) -0.001173348606223
-    2  (  2)  0.076484101898115
-    3  (  3)  0.001169431615315
-    4  (  4) -0.024935532887633
-    5  (  5) -0.174540155531575
-    6  (  6) -0.236517338782017
-    7  (  7)  0.008859575697215
-    8  (  8)  0.109927192293737
-    9  (  9)  0.089534068178409
-   10  ( 10)  0.043410237741554
-   11  ( 11) -0.093132968001143
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002170644752931 -0.022324956514099 -0.029394826211345  0.023309311068680 -0.000970852822634 -0.043511040680121  0.014013985960523  0.007860305508825 -0.031314125297178
-    1  (  1) -0.004975212184910 -0.009727238108985  0.081406434912428 -0.023252939392766  0.038928067463043 -0.010458408905981 -0.034913544836836  0.014265058471693  0.051735797486860
-    2  (  2)  0.017880176100707  0.015599348022774  0.096023531696764 -0.045237679689815 -0.002431886781376  0.077281603581543 -0.027482410098613 -0.002121837766367 -0.131596950090464
-    3  (  3) -0.033671282161329 -0.042247110815725  0.017614407066521  0.120482048147517 -0.071788669015437  0.100417130949899  0.026095439370731  0.024912292415628  0.128857994704884
-    4  (  4) -0.039094504869080  0.011586636873075 -0.201648756832533 -0.417167224027039  0.232183671922422 -0.365776066782585  0.000436512477144 -0.036487401941041 -0.092913589753420
-    5  (  5)  0.107020694538732  0.188165249192967  0.272788343236859 -0.444403017959699  0.118293552778212  0.528258782415562  0.125325642779073 -0.198753130098826  0.028672980278371
-    6  (  6)  0.121158671169740 -0.085565322151460  0.088586051783133  0.010298532059028 -0.107250216094850 -0.195698840050220  0.370534853760273  0.159194784952583 -0.016512860210084
-    7  (  7) -0.033804952616344 -0.168095045341921  0.398821112602689 -0.046726828449621 -0.030609711055064 -0.217531691733838 -0.115639511714214  0.399856930098400  0.150033235311716
-    8  (  8) -0.059559370905179  0.306305036465827 -0.595923646185890 -0.119277640805674 -0.722271918559490  0.001726267262613 -0.027179920353598 -0.211451038002310  0.148912062372910
-    9  (  9) -0.188866142842736  0.096789990486457  0.236442562527094  0.092757728041313  0.072651948101216 -0.016472461695526 -0.026914575117300  0.247244600184375  0.370870606832493
-   10  ( 10) -0.406957853798143  0.141958866881762 -0.085132936917023  0.102326296221874  0.017996095944708 -0.062553443565296 -0.105319900227601 -0.005069269037988  0.006423933602228
-   11  ( 11) -0.081915250147579  0.202583484157184 -0.282203343833431 -0.339304077428364  0.118298550150489 -0.126692826807318  0.005731143361727 -0.150166092159272 -0.134968415625333
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.038183979702674
-    1  (  1) -0.001758617329220
-    2  (  2) -0.002245458358924
-    3  (  3) -0.305015280585847
-    4  (  4) -0.011707659076193
-    5  (  5) -0.052479234679287
-    6  (  6)  0.143560462314116
-    7  (  7)  0.320971036748081
-    8  (  8)  0.148594551736844
-    9  (  9) -0.097500178466871
-   10  ( 10) -0.069870490871550
-   11  ( 11)  0.082515655756872
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.053221344681142 -0.117483147833985 -0.106139723247453 -0.495823955121092  0.391515874804455  0.212402958848530 -0.083769680573767 -0.039675371517883  0.058634274306531
-    1  (  1) -0.117410394687696 -0.001165915237512 -0.133100613626654 -0.630012634533085  0.317623482499555 -0.573984529169381  0.375575851008806  0.417091736224605 -0.210582306420709
-    2  (  2) -0.106116179316557 -0.133365754849436  0.099881677186242 -0.283389270168438  0.408842653260195  0.463415082290805 -0.094461635582511 -0.339728478273951 -0.187117729157411
-    3  (  3) -0.495487159854538 -0.630575218275538 -0.284210529100489 -0.394005207299682  0.243829412824131 -0.426368810438983  0.000017569224274 -0.316982847795332  1.182262387796268
-    4  (  4)  0.391977861689502  0.318458435778042  0.410524448216213  0.243871385545647 -0.262605821454379  0.313475558817429 -0.006238164976110  0.146232809940208 -0.404783357267945
-    5  (  5)  0.211677947989569 -0.572946112183618  0.465876094202739 -0.424891649228725  0.310576368667640  0.340119032966648 -0.103399884420596 -0.366027570904681  0.140243317389270
-    6  (  6) -0.083203642949521  0.374758513857944 -0.095474380553338 -0.000848431158077 -0.007011740191065 -0.103456952640946  0.035381526355376  0.100664517850410 -0.224617556800866
-    7  (  7) -0.039824177760467  0.417269525333673 -0.339848279473418 -0.316785009817077  0.144981956006953 -0.366591938133070  0.100487370214345  0.453363803566786 -0.284080848307595
-    8  (  8)  0.058454981179204 -0.209563433448112 -0.187086823104815  1.182437825563613 -0.401897920471953  0.141960153823608 -0.223791716105096 -0.283768269790238 -0.127258563076312
-    9  (  9)  0.176473367868989 -0.113695285962430 -0.191045562239273 -0.466077182834650  0.080353173846381 -0.392419296545826  0.139310719822578  0.097667658130615  0.260382741772322
-   10  ( 10)  0.087511748605763 -0.084525637542731 -0.451433812661641  0.087442027470754 -0.075301055147615  0.128254312442896  0.066832910809452  0.040269698765907  0.083963538620684
-   11  ( 11) -0.256000473516428  0.178934738319287  0.462669412659627  0.336070869572452 -0.226364820740552  0.220661186826050  0.015682276558009 -0.019696413835863 -0.320368477367524
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.177398660643495  0.088413661062507 -0.257047850800415
-    1  (  1) -0.114710761582569 -0.086001542477366  0.179468892454740
-    2  (  2) -0.191402905701337 -0.452554194931555  0.463985875678332
-    3  (  3) -0.467548510382317  0.086605995128391  0.336310348111395
-    4  (  4)  0.080907164839857 -0.077457000042675 -0.231693183962593
-    5  (  5) -0.391713702811823  0.124122145336547  0.233240659481206
-    6  (  6)  0.139727422139028  0.065972550943365  0.014736999139443
-    7  (  7)  0.097438431199858  0.039119593081805 -0.012607893852994
-    8  (  8)  0.258370481571402  0.084693167750785 -0.328679992068142
-    9  (  9) -0.027947875522173 -0.059452680730838  0.039102598209232
-   10  ( 10) -0.061112133253744 -0.042824028656813 -0.176907573001062
-   11  ( 11)  0.036269564126208 -0.174115037047438  0.046562990208638
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.221915567502623  0.240154969163816  0.089524025753548 -0.009891539023461 -0.105352264889997 -0.079728196437896 -0.186918344067447 -0.018609216798882 -0.150218987334760
-    1  (  1)  0.239595861160914  0.097635005536382 -0.020343203465831  0.252497393963625 -0.178770889626966  0.156659860903133  0.042031186852564 -0.226739274781765  0.050354579998016
-    2  (  2)  0.090047283413814 -0.021960432152020 -0.652704165096791 -0.484235858264924  0.265074532283746 -0.870240852693915  0.056963933090132  0.087593695232780 -0.397150344061483
-    3  (  3) -0.008304023565221  0.254514964099576 -0.488668744172267  0.243914942296862 -0.497430549408554 -0.651892044099941 -0.144949354151790  0.009197770416785  0.363155689203458
-    4  (  4) -0.105368055288416 -0.178968402377489  0.265813616023428 -0.498441236963999  0.117807978177016 -0.197938223960627  0.010977461550819  0.054866508200549 -0.633466747483980
-    5  (  5) -0.079092278611567  0.155211327907083 -0.870349858528248 -0.648891955877304 -0.198852995680930  0.056118287010249  0.077393750543525 -0.820063131904850 -0.522591293712200
-    6  (  6) -0.188319262904704  0.043235387216250  0.056704467242807 -0.145342612784415  0.011176054667898  0.077123788010048 -0.017043504447154 -0.229308594149143 -0.061253571825596
-    7  (  7) -0.017449220652026 -0.226052369590475  0.086398229140611  0.009988063298837  0.055257253277244 -0.820894010869112 -0.229107411788767  0.436891114659360  0.154693358924324
-    8  (  8) -0.147652836473568  0.050157233403955 -0.397985593672069  0.364902332737576 -0.632177325650741 -0.523669848989306 -0.060883358066048  0.155008994016302 -0.331322085722016
-    9  (  9) -0.012364053013731 -0.381902018882131  0.730234455154150  0.318717588976828  0.654372705810295  0.234910934996783  0.063436038641434  0.568676727219248  0.116095919775855
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010717409085818
-    1  (  1) -0.381606046587817
-    2  (  2)  0.729520232349256
-    3  (  3)  0.319801359646356
-    4  (  4)  0.655576694394483
-    5  (  5)  0.233766377042350
-    6  (  6)  0.063681628675817
-    7  (  7)  0.569047245691214
-    8  (  8)  0.115234955131862
-    9  (  9) -0.255200733989858
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006756611009239 -0.004812319108707 -0.015155246179453  0.018768861614548  0.003263846230316 -0.029956626691063  0.007768157616613  0.008654952545397 -0.024139771998296
-    1  (  1) -0.000276876655733 -0.007317152277636  0.067126401411285 -0.013873168496829  0.038395392580021 -0.004054864162186 -0.028032553908660  0.014238200673600  0.044802348000681
-    2  (  2)  0.034311733284435  0.014478380463186  0.079037871547464 -0.037480797351928  0.004455235189999  0.068266709703376 -0.020927095140560 -0.000590179941322 -0.116436689576599
-    3  (  3) -0.034781167081690 -0.039999835648210  0.017388947621558  0.117724049135840 -0.062309713575062  0.098214530429882  0.024529272430519  0.026637769905859  0.121592113448416
-    4  (  4) -0.036088452219928  0.018119725898309 -0.181397076074172 -0.381210957896193  0.211295234548894 -0.335046977567969 -0.001001209940803 -0.032788904430710 -0.087406508170972
-    5  (  5)  0.091932999121248  0.163472911292393  0.257039057929667 -0.406986018028708  0.108362880698111  0.483755223010107  0.114747171070721 -0.179816739697054  0.021814542430540
-    6  (  6)  0.102207313652244 -0.075273825473482  0.076700485775484  0.010389199522243 -0.095145363312679 -0.177269643268087  0.339312666537493  0.145893525857585 -0.013352577122472
-    7  (  7) -0.036776384387696 -0.162278963391709  0.362818814892890 -0.043460364327904 -0.026462409718549 -0.199351982461758 -0.104180059013018  0.364628559511404  0.137093791802520
-    8  (  8) -0.054133642075650  0.281937460317668 -0.549118750139198 -0.110766566728388 -0.665283649525633 -0.004014717984651 -0.026030812844979 -0.193249298632007  0.140185869779560
-    9  (  9) -0.149539825936769  0.083496187141563  0.222414359602469  0.086467924966290  0.058519767738283 -0.026610134648035 -0.023639345193443  0.224482305471681  0.335967535114734
-   10  ( 10) -0.342551768791105  0.115343806322270 -0.079695331214451  0.094078531732984  0.012984790263811 -0.052720281866277 -0.089289783188097 -0.003161584461577  0.011520822726607
-   11  ( 11) -0.067948144123858  0.170897803094304 -0.268478044795138 -0.331752793901224  0.110501398686606 -0.120431522039808  0.010421693063374 -0.142909196950524 -0.136584264097857
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.029945709624550
-    1  (  1) -0.003777838622564
-    2  (  2) -0.000494193391228
-    3  (  3) -0.283159255072162
-    4  (  4) -0.002056849846006
-    5  (  5) -0.055491249216550
-    6  (  6)  0.134241443599212
-    7  (  7)  0.294425347600366
-    8  (  8)  0.138732741810037
-    9  (  9) -0.100744739667681
-   10  ( 10) -0.062352827286650
-   11  ( 11)  0.087587602591740
-
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016434384667148  0.059537003054536 -0.018382703913455 -0.001901473074516  0.028510164358282  0.077646279855039  0.000356251398219  0.021408373218989  0.091393977088558
-    1  (  1) -0.005835140019102 -0.006847303402179  0.005801307077118 -0.092503110731406 -0.040640220398500 -0.004476772769023  0.006707493956919  0.025598358653730  0.054742040386929
-    2  (  2) -0.032576552661469 -0.022759352669700  0.015700451044420  0.017659613283536 -0.033691301649134  0.071320914458495  0.010810523808367 -0.000599142203483  0.006831611161324
-    3  (  3)  0.028439441517722  0.025978253338493  0.005227408482745  0.004129515933235  0.042131401342259  0.005061996623806 -0.014819468597155 -0.029813444208053  0.124931870713391
-    4  (  4)  0.026711661740657  0.065952388204908 -0.070397760617197 -0.113357837258571  0.162062952662508 -0.007050708037022 -0.019958512448364 -0.113599468912823  0.186779858191589
-    5  (  5) -0.054225682429018 -0.150592673565962  0.090221508528394 -0.165469278587529 -0.105075744052049 -0.235926758500148 -0.076402735009682 -0.065221510888654 -0.109078486285223
-    6  (  6)  0.036820767703606 -0.045049000362756  0.022079029118092  0.038075092578984 -0.045448669142688  0.103567825475646 -0.243196158948954 -0.024866082639399 -0.028667254743547
-    7  (  7) -0.064079984215095 -0.104489316033204  0.208936934850580  0.011404897999585 -0.191297065299167 -0.062928087633658  0.036625785426208 -0.182329767369539 -0.046827781359629
-    8  (  8) -0.029820488646987 -0.037609170202879  0.184366833470305 -0.250608304245861 -0.266157936861978 -0.003343240964033 -0.026232571891440 -0.068560106516425  0.143703222469330
-    9  (  9)  0.097477133499219 -0.253919330671861 -0.022474002349921 -0.091068839306237 -0.030773177890121 -0.124639301979492 -0.057377848460010 -0.129428480584789  0.052503813838482
-   10  ( 10)  0.308102321981415 -0.100099264744172 -0.103502297395079  0.030595871425367  0.027930037535271  0.082924987589621 -0.003621479559882  0.051467583495009  0.001729710593298
-   11  ( 11)  0.065171614185219 -0.083076013227694  0.007781121482082 -0.129638416743258  0.025583078029705 -0.021102804445382 -0.038969277950233 -0.054649593445510  0.156415144250598
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.100574711969240
-    1  (  1) -0.017311198418314
-    2  (  2)  0.099207008690223
-    3  (  3)  0.049312818935542
-    4  (  4)  0.020969683268895
-    5  (  5) -0.168478941844432
-    6  (  6)  0.036633223806040
-    7  (  7) -0.083149987934917
-    8  (  8)  0.054463823630147
-    9  (  9) -0.105100295511211
-   10  ( 10)  0.049112459843749
-   11  ( 11) -0.074285789462190
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000150860459877  0.171933918231252 -0.041419056803072  0.170616058570147  0.200856757156520 -0.002034169374196  0.083717100185599  0.000516882277833 -0.000760835570240
-    1  (  1) -0.171458970665860  0.000052671693709 -0.080477211012241 -0.158047078345989 -0.171611945068556 -0.020781553144960 -0.081182987020708 -0.096111050666912 -0.028348265964974
-    2  (  2)  0.041612402589055  0.080354514984744 -0.000394264947173  0.065176020012681  0.096961733142428  0.000557038525025 -0.109435480142694  0.034287451388532 -0.031868099666052
-    3  (  3) -0.170115569606579  0.158386367352469 -0.064620104688982  0.000274195329164  0.003073114771818  0.155980931184969 -0.002438060010510  0.075892612616599  0.118957615446809
-    4  (  4) -0.200436196772240  0.171813138083843 -0.096620398683267 -0.002372485388961  0.000742978447135 -0.018013393904637  0.033369149651403  0.120720251055992  0.104550918281167
-    5  (  5)  0.002211117433298  0.019930957908302 -0.000666901496264 -0.157204484557621  0.015901976339486 -0.000217821561163  0.009428657942981 -0.039993958187839  0.071492158249729
-    6  (  6) -0.083537896232863  0.081216293971867  0.109652154032100  0.002769108821106 -0.033489275419838 -0.010079357840938 -0.000064832704676 -0.012979883425805 -0.022286123614410
-    7  (  7) -0.000446183372454  0.095595436198971 -0.034260265949943 -0.076357839284767 -0.123056525926531  0.039576937592408  0.012836423633655  0.000276922615353 -0.011862614885765
-    8  (  8)  0.000763780194579  0.028492759060566  0.031582546116686 -0.118324194064185 -0.106500675879643 -0.072862382850876  0.022267846900148  0.011936132807121 -0.000309785123822
-    9  (  9)  0.200009372729413 -0.049971216489633 -0.123430272682259 -0.142933103185242 -0.066275175614906 -0.011400665529444 -0.086697488232449 -0.026102313931474  0.001060546754189
-   10  ( 10)  0.021852700751396 -0.017163247777288 -0.127823592278093  0.091613120127056  0.051604501451930  0.012175072674142 -0.083661634147568  0.068820029767420  0.010286004757943
-   11  ( 11)  0.114973761942494 -0.044704429189879 -0.150112248621738 -0.031470261050302 -0.054465549098901 -0.018492073632933 -0.052809037569742  0.018588462631583 -0.062465552340744
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.199650432776970 -0.021769646283719 -0.115014099877643
-    1  (  1)  0.048847979709979  0.016224624083658  0.045739997653995
-    2  (  2)  0.121535202952087  0.127110081169448  0.150689800369572
-    3  (  3)  0.141534079657396 -0.092900464386430  0.030906929300398
-    4  (  4)  0.064777188331671 -0.052294246689992  0.052576843649814
-    5  (  5)  0.012798646161060 -0.011617495484096  0.021426191620278
-    6  (  6)  0.085439453581865  0.082177824690696  0.054044239620785
-    7  (  7)  0.026881359606727 -0.069312090513404 -0.013578395284128
-    8  (  8) -0.000980665289481 -0.011875108407812  0.069843147407046
-    9  (  9)  0.001396130223525  0.045043795365458  0.018886220574768
-   10  ( 10) -0.041412670665906  0.001872911812120 -0.033067578033610
-   11  ( 11) -0.016567946659153  0.031899396551867  0.001929777984873
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001411268359160 -0.010548061189878 -0.012234985630211  0.023975313562280 -0.023062230820039  0.045437732948681 -0.106872881296076  0.025944637778051 -0.029363485311898
-    1  (  1)  0.014640801150040 -0.001773735046594 -0.029549963184092  0.020758435544442  0.007635590000279  0.056071060358736  0.088482364466965  0.027605241546487 -0.020492843216977
-    2  (  2)  0.013184523566191  0.031261847780049 -0.000489474253254  0.031775189074985  0.038538471296270 -0.038607714449183  0.007921641905981 -0.014600160708699  0.097026534080847
-    3  (  3) -0.023325695791557 -0.021331801923242 -0.030636705569878 -0.000479373870642  0.011687430157835 -0.060845116281804  0.009020253210307  0.020543788213974 -0.119533313623190
-    4  (  4)  0.023654300689698 -0.009020483406481 -0.038301937767707 -0.011962372815437 -0.000301509800453  0.037261192743398  0.029045239001199  0.041781275442091 -0.051627710213779
-    5  (  5) -0.044386181810683 -0.057414182896665  0.038267122468401  0.061256729128929 -0.037800933596037 -0.000260698778894 -0.001511863535883  0.016380337639677 -0.072487672330699
-    6  (  6)  0.106206323004553 -0.087758718377781 -0.007560784408469 -0.009263545408533 -0.028871039692754  0.002023613184462 -0.000132116955283 -0.000735561511998 -0.010945124965688
-    7  (  7) -0.025425283561814 -0.027796807869910  0.014997640380461 -0.020644254386635 -0.041827532757913 -0.016146444702388  0.000831333123472  0.000058581308311 -0.017035220679833
-    8  (  8)  0.029580773528628  0.019460244903885 -0.099428018149333  0.121448802541844  0.052251959451872  0.071719334941988  0.011527870420583  0.017438360216925 -0.000376592607811
-    9  (  9) -0.011323796835811  0.022846032797884 -0.003463845070647  0.010590766229841 -0.093908204414477  0.097279630619014  0.016132246312287  0.052832474295790 -0.033804637999018
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.012386803276718
-    1  (  1) -0.025331755243544
-    2  (  2)  0.004701299813181
-    3  (  3) -0.011259859427831
-    4  (  4)  0.092847122914529
-    5  (  5) -0.097092353171668
-    6  (  6) -0.015797039269438
-    7  (  7) -0.052823551833136
-    8  (  8)  0.033708639353932
-    9  (  9) -0.000241834945391
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019875399821365 -0.067213072995023  0.012299941717659  0.003468875187880 -0.030128328426274 -0.082822743936825  0.001897897698354 -0.021797662835713 -0.095153762344945
-    1  (  1)  0.006451292960481  0.005754162581844 -0.002884034500734  0.094974935426192  0.041098451485401  0.000058064511604 -0.008894806239621 -0.025485003895974 -0.057087471632476
-    2  (  2)  0.026223355242450  0.024273603088334 -0.016292189081393 -0.015844039410231  0.030633853079712 -0.077008417539564 -0.014788316606733  0.000243822647885 -0.007976439135467
-    3  (  3) -0.025334252850709 -0.027648721071750 -0.005856451162092 -0.011279594978250 -0.045220581787047 -0.007788112252830  0.015791844926599  0.026413664639332 -0.132992803966333
-    4  (  4) -0.028858615977169 -0.070880006979721  0.078385497137577  0.115909817357349 -0.170672806468397  0.002802625270051  0.018507237940661  0.116641608428124 -0.183930260352482
-    5  (  5)  0.062029310382341  0.165059238935656 -0.096438123628463  0.170982438012572  0.101168051978722  0.247462788062147  0.078143137508448  0.065503368874352  0.123407161852621
-    6  (  6) -0.029868108814055  0.043826434723281 -0.020536879880122 -0.040118359069746  0.047262891605686 -0.111204577364818  0.250427612151989  0.027185217329734  0.027972758218343
-    7  (  7)  0.071045843569722  0.110497052752988 -0.212396167514294 -0.014472401617176  0.201746291025428  0.058726820006450 -0.038658609736798  0.191686821472890  0.051568740310987
-    8  (  8)  0.030231001314245  0.039607181613347 -0.190237369746058  0.251586833919896  0.277372132160808  0.008690855780340  0.027285881313233  0.066231456708385 -0.148705440863578
-    9  (  9) -0.119406447574908  0.267992491845044  0.024723477609567  0.092623842023547  0.035484932702787  0.135905292178670  0.058976108500788  0.137156317198896 -0.050622979340015
-   10  ( 10) -0.354731988399122  0.114731465978240  0.113605854938311 -0.033621899430544 -0.024886546894064 -0.086388159191061 -0.001760250802633 -0.054814426010942 -0.004266849862045
-   11  ( 11) -0.074987139083159  0.087839869817099 -0.017174937068014  0.139817452729011 -0.030459814346611  0.019645857821193  0.042455388198899  0.058190403006369 -0.165317136166192
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.104159520209993
-    1  (  1)  0.017365114579609
-    2  (  2) -0.105508249406411
-    3  (  3) -0.051333283782025
-    4  (  4) -0.026824469147080
-    5  (  5)  0.172355785037806
-    6  (  6) -0.037231897229526
-    7  (  7)  0.092488656033236
-    8  (  8) -0.060576527966250
-    9  (  9)  0.114591221791530
-   10  ( 10) -0.052791324163552
-   11  ( 11)  0.078009502545252
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.013905849892992  0.105574256292555  0.058365326510732  0.011150777040830  0.004301162141041 -0.055780562682692 -0.053115864387752 -0.011951099406770 -0.044340643594202
-    1  (  1)  0.013705956820555 -0.025309547841960 -0.001538984041734 -0.001849504741603  0.005133976748632 -0.012878903904056  0.096751125536924 -0.003812996689903  0.009632709529968
-    2  (  2) -0.020569845493093 -0.032320703460180 -0.011944643866745 -0.047792544188734  0.032679729361416 -0.019407207672949 -0.038230397931919  0.003676283556944 -0.058784384336985
-    3  (  3)  0.071874917867093 -0.002631775952960  0.003539152259809  0.028170151218425 -0.033082337295689  0.021301963625855 -0.050188554745657  0.011804977856767  0.016979295260921
-    4  (  4)  0.014914728990396  0.041337858840349  0.031774187859112 -0.031846901880618 -0.020737884741536  0.009318588686327 -0.180587918491444  0.014608314108616 -0.091927794627027
-    5  (  5)  0.043163603381900 -0.253570894625469 -0.078110646309368 -0.060207643631253  0.083755719198877  0.160896258343551  0.127680183234514 -0.074831092977117  0.060961655981049
-    6  (  6) -0.044917686060828 -0.074437543040067  0.066817478801761  0.141365137531753  0.114156889702257 -0.038201515939482 -0.107320317731531 -0.348968351908512  0.116558406175751
-    7  (  7)  0.034184804469893 -0.226667134284391 -0.206947793731390 -0.080987919933847  0.050884738274657  0.136027438420489 -0.157869432700479  0.195670168357032  0.055408723502488
-    8  (  8)  0.031166515249721  0.045258191750987 -0.124213591624855  0.070497635611886 -0.013839913877531 -0.080645709057116 -0.048975111106761  0.013846985677438  0.081456527024621
-    9  (  9)  0.260272045600859  0.057970015239195  0.114635559073584  0.083827066916392 -0.094102194410800 -0.136997319599706 -0.136846202555835 -0.093755934766235 -0.066197390562813
-   10  ( 10) -0.128170228467008 -0.270987976538407 -0.063355286850330  0.080149940628318 -0.057123968341669 -0.051813056590924  0.080732658365778 -0.110930691434851 -0.002284134974517
-   11  ( 11) -0.014638573493894 -0.093181336572008  0.090893348615143 -0.060951699754620 -0.036152243930201  0.068685591001865 -0.022141424075597 -0.054226980293487 -0.076820031900454
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045178917656151
-    1  (  1)  0.000506654263468
-    2  (  2) -0.062622183647669
-    3  (  3) -0.006475863513060
-    4  (  4)  0.009581278166545
-    5  (  5)  0.123788681467482
-    6  (  6)  0.140490962930464
-    7  (  7)  0.012343887711756
-    8  (  8) -0.065924555702067
-    9  (  9) -0.071777365622544
-   10  ( 10) -0.030198414714018
-   11  ( 11)  0.038206097812612
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000441373721971  0.087271451504254  0.308356080671030 -0.018077607068688  0.073688004857476 -0.153028983755896 -0.021375900910730 -0.125940926422186  0.021636449149896
-    1  (  1) -0.086671311731224 -0.000204963757277  0.004083848977647 -0.019054726614325  0.000357076891570 -0.008883507874300 -0.245817294107565  0.139613669494547 -0.011872389377551
-    2  (  2) -0.307138366785038 -0.004537268804354 -0.000000947821260 -0.032420162338715 -0.044765722657128  0.148620348284250  0.082511203687099  0.091836400843881 -0.021157739960336
-    3  (  3)  0.018180307170497  0.018806737266631  0.032304346608179 -0.000164575589082  0.000048486967076 -0.033944617253518  0.017906518922370 -0.039367589983503  0.041014607610233
-    4  (  4) -0.073708499176395 -0.000188579066207  0.045384824461272  0.000051244255112 -0.000118131709454  0.009319825672971  0.005919844337701 -0.028188407915503 -0.062383088971619
-    5  (  5)  0.153503404134916  0.008021529263725 -0.150851560923171  0.033683034219721 -0.010920406889103  0.000843675018215 -0.002305152210287 -0.006419896281910 -0.018802686354169
-    6  (  6)  0.021663782224978  0.245568524819791 -0.082607420634013 -0.017861578854728 -0.005717491537118  0.001465956881798  0.000164104368228  0.019402844307281  0.008582138264613
-    7  (  7)  0.126272473343725 -0.140132379196136 -0.093779865985419  0.039016174646910  0.027756266123623  0.008788078328085 -0.019927753575961  0.000986178708271  0.006276129856304
-    8  (  8) -0.021659942465065  0.012093240675092  0.021224721403549 -0.041292366946203  0.063444639030514  0.018952234899780 -0.008805846385022 -0.006555018834286  0.000619883795504
-    9  (  9) -0.110032896200750  0.071298113833135  0.163479589536219 -0.111444129990912 -0.024671365993001 -0.003210445766199 -0.009378587102769 -0.014713425509001  0.000839110373856
-   10  ( 10)  0.069217830582824 -0.088543829220743 -0.203682134643279 -0.186485128327869 -0.053425964853416  0.063005981229243 -0.018184933705949  0.000540007105749 -0.005219687452082
-   11  ( 11)  0.023959189620953 -0.030895371890558 -0.044769544498433 -0.009068900298863 -0.130492147876274 -0.035762663243292 -0.002770335503139  0.023536235288276  0.010103727285469
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.109799080219678 -0.069203346900770 -0.023919903278421
-    1  (  1) -0.071129060568146  0.087605257548157  0.030425173883571
-    2  (  2) -0.162026048331677  0.201435103487415  0.044723919546572
-    3  (  3)  0.110972252607892  0.185860701404063  0.009243336757067
-    4  (  4)  0.024458462243726  0.052145051182170  0.130041721565426
-    5  (  5)  0.002181441725954 -0.060001657923379  0.037138509415485
-    6  (  6)  0.007938597292020  0.017379429117453  0.002521412739913
-    7  (  7)  0.012919580840703  0.002428706377795 -0.023595862068092
-    8  (  8) -0.000273485582407  0.005817339116375 -0.014280567707235
-    9  (  9)  0.003328589668182 -0.017803512680764 -0.001063197928266
-   10  ( 10)  0.016699725327030  0.001798758796680 -0.002170763958318
-   11  ( 11)  0.001212933542278  0.001783778903851  0.003563107345321
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002010159634630  0.000220404084817  0.003192882122880 -0.011052627613533  0.003562668031365 -0.009837814318177  0.002544312104621 -0.035965473851195  0.038472004952375
-    1  (  1) -0.001452297302852 -0.003072719747229  0.008838287240450  0.026771929595669 -0.046483406284037 -0.009889595128182  0.035422086740367  0.011912247720366 -0.000936796016060
-    2  (  2) -0.004597077371462 -0.009797303502342 -0.002356759440367  0.013160928599717 -0.036596664601802  0.014914711645441 -0.014591721304407  0.007418668493650 -0.037805835513950
-    3  (  3)  0.010591350137419 -0.026807560073439 -0.010708663838159 -0.000566073142147 -0.006877298509595  0.015806087254090  0.036616622156539  0.004527327935437  0.052470069694755
-    4  (  4) -0.002197180048840  0.045360469690206  0.037290055709025  0.006377690547549 -0.000197738244084 -0.043135976717434  0.013927669894978 -0.013270906950991 -0.034225968512880
-    5  (  5)  0.012223872820757  0.012276608732166 -0.015974082159209 -0.014788689444500  0.043434889585929 -0.001241108463199  0.022259649308453  0.002776600972090 -0.020757469065177
-    6  (  6) -0.002236227833952 -0.033698361699947  0.015413577603851 -0.037176700349159 -0.013637799368342 -0.022481473057898 -0.000196461263851 -0.066878572107562  0.012948719456691
-    7  (  7)  0.036159618368672 -0.011023728969868 -0.006496546324176 -0.004756159901056  0.013088014945893 -0.003050957277162  0.066534588876792 -0.000038997802685  0.018679498186635
-    8  (  8) -0.037272822971437  0.001025968499180  0.039463494780131 -0.053213044947716  0.033933492458794  0.020627554065949 -0.012927451364571 -0.019084958215300 -0.000379158267741
-    9  (  9) -0.044713556544603  0.031925295057843 -0.027454374007067 -0.016949911467799  0.043552787687819 -0.029362229767510  0.013081869754981 -0.017575107888422  0.005208148088787
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.046477985245624
-    1  (  1) -0.031367776651430
-    2  (  2)  0.027386023407765
-    3  (  3)  0.017151073595537
-    4  (  4) -0.043659143705007
-    5  (  5)  0.028276225310864
-    6  (  6) -0.013015371352964
-    7  (  7)  0.017243006711225
-    8  (  8) -0.005600961681940
-    9  (  9) -0.000315129095420
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016735058692801 -0.127427648471711 -0.067812616467594 -0.013558783551809 -0.005269296599083  0.059347294870606  0.061177076545679  0.011973162399102  0.046187859594365
-    1  (  1) -0.006127975507731  0.027720789931143  0.002131386760238  0.002129686454541 -0.005489719844856  0.015177604183485 -0.105071662567975  0.004089530302215 -0.010958371300164
-    2  (  2)  0.014625553671885  0.033500045224482  0.010197102842648  0.049282810089046 -0.029146517326401  0.023890316169967  0.041396999030433 -0.003031629472559  0.064649337167924
-    3  (  3) -0.059287322502299  0.004510597912865 -0.001550787253983 -0.026031838087948  0.030781241595677 -0.028268360125230  0.056263472143293 -0.012481413064923 -0.018331852915645
-    4  (  4) -0.010310728455768 -0.048004310504315 -0.024726014802135  0.029487545392420  0.016798380655264 -0.006146311288820  0.193469287289224 -0.016404156709459  0.090545229018770
-    5  (  5) -0.048438874849073  0.279911055793901  0.091858080305683  0.061529389949110 -0.086013764646970 -0.169909289190226 -0.137573811978801  0.079110070379465 -0.068315894389439
-    6  (  6)  0.059086874754328  0.080452543242778 -0.072102486682582 -0.152740972704247 -0.124804294386305  0.037562128266895  0.116816705616042  0.371092921921504 -0.124060147180532
-    7  (  7) -0.029687956296635  0.256142179942571  0.224177989138016  0.089126356257227 -0.052538373002914 -0.151219359570602  0.169667778296547 -0.210592113990055 -0.060100313305223
-    8  (  8) -0.037809640230564 -0.049847669441603  0.131510551596478 -0.073995987264147  0.016613192275803  0.085953668087854  0.052289681067999 -0.014235003810069 -0.085573468377869
-    9  (  9) -0.334054043680738 -0.062946651230341 -0.131443841559570 -0.090838578825240  0.107669515927940  0.163692131260888  0.145222895910058  0.104796708213769  0.078942908507754
-   10  ( 10)  0.149544392295761  0.318224503990855  0.078211068857457 -0.094418507207579  0.062827781432203  0.056112671791795 -0.092070650285035  0.118729407251681  0.005066399630771
-   11  ( 11)  0.017252785597153  0.111183203080125 -0.114995811791783  0.075235812067226  0.042976611330520 -0.083335038142330  0.026013221761888  0.060774659749613  0.084239808865889
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.046526303364398
-    1  (  1) -0.000196633156806
-    2  (  2)  0.068136524138653
-    3  (  3)  0.003983938855648
-    4  (  4) -0.006861374242241
-    5  (  5) -0.130771416331255
-    6  (  6) -0.153069412317755
-    7  (  7) -0.016354872554726
-    8  (  8)  0.070442312778792
-    9  (  9)  0.084886961073099
-   10  ( 10)  0.034495414084981
-   11  ( 11) -0.039745136609744
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007512480776319  0.036140698221162  0.006614016091629 -0.006989344711517  0.012538055579667  0.047719007710800 -0.011438854389831  0.001348837643708  0.043912417866150
-    1  (  1)  0.000217941106815  0.023674382271911 -0.074458985850499  0.018669991150763 -0.024216220760344  0.026693268127322  0.030529166464713 -0.009220514907509 -0.051390413902716
-    2  (  2) -0.018657169402382 -0.000504863635670 -0.063891633981927  0.031237660505947  0.009378378679164 -0.057274634026543  0.010216661924779  0.007277876487311  0.107239917659553
-    3  (  3)  0.016066164003828  0.014293064557711 -0.024640166827267 -0.100199283130149  0.053038409095112 -0.079899101326132 -0.014809180078406 -0.008036171971183 -0.093693488350467
-    4  (  4)  0.014907654111593 -0.000249634614143  0.129575540220445  0.265751473143634 -0.141781144259113  0.223368583932083 -0.004368931811378  0.027043226757367  0.062609693461921
-    5  (  5) -0.041914834745247 -0.097616041138947 -0.135770321463814  0.246024098805421 -0.106912109293501 -0.321253251117319 -0.068788844583990  0.142290197287628 -0.046076100892295
-    6  (  6) -0.039123394394723  0.039408255038257 -0.037211012657418 -0.010312056024403  0.060353960942951  0.114209155992994 -0.186728746530896 -0.112616911396924  0.025666796391066
-    7  (  7)  0.018468061945917  0.067823974613178 -0.190104823535190  0.003755811520253  0.014064572484241  0.109658452638694  0.056630665145805 -0.263520506917883 -0.064583476374394
-    8  (  8)  0.033210755622659 -0.136136968498900  0.263316618160002  0.077412830589797  0.422459728217546  0.053553377730948  0.034175715906935  0.165897217652793 -0.074779388344555
-    9  (  9)  0.055036749751630 -0.056894038751104 -0.107311287797063 -0.058290191137784 -0.056944188937166 -0.005725850016316  0.009926099968286 -0.140696143209114 -0.190545524907610
-   10  ( 10)  0.130997705273781 -0.090153965609249  0.007790248268810 -0.054524064976066  0.013947321007330  0.034280119179197  0.056585811356156 -0.002663395414836  0.003086708496419
-   11  ( 11)  0.024354529821742 -0.002391484587850  0.132211150437169  0.155582434877820 -0.034543780627935  0.051588565499349 -0.027770703760258  0.083659992199369  0.057647900826746
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.055482114656335
-    1  (  1) -0.000101235030463
-    2  (  2)  0.010234508711291
-    3  (  3)  0.213846558445248
-    4  (  4)  0.006630092722992
-    5  (  5)  0.012814259546957
-    6  (  6) -0.078975443650986
-    7  (  7) -0.184930804112230
-    8  (  8) -0.058689588477811
-    9  (  9)  0.044249382467578
-   10  ( 10)  0.036865706935893
-   11  ( 11) -0.030515341975517
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000120442405581  0.037525975792407  0.039028837738652  0.219221358143393 -0.183820180818448 -0.112972286408530  0.047240063409728  0.020414149561154 -0.034238085799271
-    1  (  1) -0.037241793728452 -0.000047287882243  0.009729516430168  0.094202030077235 -0.063477866953276  0.160286164587806 -0.109752667557022 -0.131207263236284  0.068887611832074
-    2  (  2) -0.038783295216622 -0.009745201912242 -0.000258217562465  0.013038009614076 -0.045399222161827 -0.081371094984120  0.019570499748086  0.076966277295000  0.058756671783764
-    3  (  3) -0.218771475127948 -0.094047631347429 -0.012728901107962  0.000222898647350 -0.006965466758731  0.051483080000543  0.001032959857400  0.046617530443310 -0.239873280201692
-    4  (  4)  0.183500005674293  0.063741918250972  0.045633149570229  0.007771962048066 -0.000752652425378  0.016686259902744 -0.006062931975271  0.002941130184259  0.039794941498885
-    5  (  5)  0.112922744463035 -0.160447948543053  0.080839610143832 -0.052938181517924 -0.014759035093032  0.001963138533058  0.004122965199026  0.030082971847399 -0.018688716203396
-    6  (  6) -0.047223957422349  0.110045906731433 -0.018982606895220 -0.000425116658999  0.006190502350060 -0.005177802298965  0.000459941844479 -0.006641133881612  0.015637294529107
-    7  (  7) -0.020258099631627  0.130980408805956 -0.076838250722457 -0.047153827019528 -0.001697177794538 -0.030097214957006  0.006397035656861 -0.000314330689973  0.000958762971255
-    8  (  8)  0.034242059158271 -0.069241386609174 -0.058253268615506  0.239551778865238 -0.041466100486767  0.019183970473991 -0.016012586324303 -0.000462521772429 -0.000639781016008
-    9  (  9)  0.110158178577256 -0.043113630563978 -0.067267974845207 -0.106313996022487  0.002243251219660 -0.021517985932208  0.002884772712544  0.010112074041123  0.004700729741936
-   10  ( 10)  0.070149397127063 -0.040299222838292 -0.154071817441956  0.030869069243567 -0.038016470293222  0.011150694193011  0.007490401305220  0.020531677805594 -0.003859946060401
-   11  ( 11) -0.176636225337744  0.095095393142691  0.195177688825668  0.108802410559496 -0.020149361123103 -0.001298105635127  0.020927308070429 -0.032058427881699 -0.018315736142454
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.110002482243441 -0.070133081529118  0.176505754583752
-    1  (  1)  0.042468765075500  0.040212942886088 -0.096465231599211
-    2  (  2)  0.066618057955858  0.153916879455284 -0.197045228959983
-    3  (  3)  0.105738247971788 -0.031572929220209 -0.109334469149534
-    4  (  4) -0.002665514835355  0.037310624735359  0.021518865524247
-    5  (  5)  0.022104060533187 -0.008811719711463 -0.005069793238862
-    6  (  6) -0.004143184140488 -0.008777342033569 -0.020657864679248
-    7  (  7) -0.010048741121033 -0.019686189563806  0.029679561142739
-    8  (  8) -0.004305480816755  0.003474531743331  0.021387666942059
-    9  (  9)  0.000592809919997  0.021935245808500 -0.003238719819323
-   10  ( 10) -0.019997593459389  0.000606363597873  0.056392578735375
-   11  ( 11)  0.002880485106043 -0.055206554617854  0.001235092281117
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000888157000468  0.002604640035267  0.004433898987700  0.017327910307372 -0.010855912598213  0.001781915278721  0.008615460934422  0.004078735474285  0.032557314773045
-    1  (  1) -0.000573161245420 -0.000624628285884  0.035628999167227 -0.001815728764627  0.008946874115813  0.029170863803310 -0.000115513436505  0.008856710566910  0.004031507153659
-    2  (  2) -0.003701039844373 -0.036575536539622 -0.001091193696307 -0.032172216141300  0.001275865950015  0.022397487526299  0.009622303363090  0.007231877711175  0.019725778025116
-    3  (  3) -0.016821693036289  0.002844602963518  0.032977853684673  0.000161455575952 -0.028542188119355  0.026304537820681 -0.001013466229083 -0.013057607695183 -0.044876693583426
-    4  (  4)  0.011431384588178 -0.009478622864698 -0.000774534739031  0.028965078860221  0.000058413694986  0.014596515715548  0.009143536386555  0.018007246969037  0.087822521777407
-    5  (  5) -0.001221856014832 -0.030845996389588 -0.023077706374501 -0.025758114847142 -0.014593714027409 -0.000250583717006  0.003873642475734 -0.026298757281796  0.079590541434343
-    6  (  6) -0.009743031224748  0.000827857567403 -0.008744416704428  0.000735028308095 -0.009056595663713 -0.003266063160321 -0.000168072469286 -0.014668639254903  0.020470938456272
-    7  (  7) -0.003647754834421 -0.008460886211306 -0.007264440669328  0.013024018123218 -0.017787838957003  0.026317221009114  0.014749296379031 -0.000019923943455 -0.029438703128615
-    8  (  8) -0.031026550181144 -0.004477343275687 -0.020769831071035  0.045275173918403 -0.088633054403976 -0.080566188830968 -0.020052483095054  0.029483325674276  0.000128037153401
-    9  (  9)  0.012269663364479 -0.042319244263402  0.071429692849981  0.076602220709806  0.093629733790147  0.065554975939979  0.020165870906458  0.076547332424074  0.015636093570251
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.012474935539863
-    1  (  1)  0.041072842913216
-    2  (  2) -0.070651080248399
-    3  (  3) -0.076892460848025
-    4  (  4) -0.093624677134694
-    5  (  5) -0.065506732660539
-    6  (  6) -0.019889038609582
-    7  (  7) -0.076305954221087
-    8  (  8) -0.015612091565202
-    9  (  9) -0.000252880154158
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.009427979504735 -0.045069494658558 -0.001947285705090  0.002710338034860 -0.015522926834851 -0.047663635028120  0.012944383860693 -0.002408628963511 -0.046667839995062
-    1  (  1) -0.000029889909955 -0.026801338329852  0.080490862472698 -0.019668739880126  0.025396971257700 -0.032890092829257 -0.033906444326876  0.009364690845122  0.055325390015170
-    2  (  2)  0.013223768231853  0.001284266713521  0.066553348308937 -0.032573816116206 -0.011585258035685  0.060717975924391 -0.011936168857210 -0.007853073890483 -0.116794956739995
-    3  (  3) -0.012900769345878 -0.013623437855550  0.022570570921494  0.105173709434029 -0.056797034187850  0.081144841159178  0.016572432074935  0.007712189870591  0.096484218880683
-    4  (  4) -0.015650650711432 -0.003889202049455 -0.137621535484575 -0.283731289627315  0.151612143157194 -0.236884111934266  0.005136759708167 -0.028125482384447 -0.063101070821467
-    5  (  5)  0.049233650528213  0.108628515589384  0.145433760308553 -0.264881634113210  0.112823478790252  0.343941453835902  0.074580579832084 -0.152217918461378  0.050073263216128
-    6  (  6)  0.047771378538329 -0.043773249125745  0.042587468032780  0.011128298856248 -0.066617092775075 -0.124136463076967  0.204572752605319  0.119847093573235 -0.027500955272741
-    7  (  7) -0.017888279952241 -0.071752886460858  0.208298887916757 -0.005542743128559 -0.016702047381836 -0.119479054133457 -0.062994319192022  0.283598496506144  0.069642269402630
-    8  (  8) -0.037568403528376  0.148073898852809 -0.285205978681411 -0.081955004515730 -0.456336274750824 -0.051315761340278 -0.035910751818194 -0.176384561285241  0.080264248689634
-    9  (  9) -0.073735844540901  0.063193611128899  0.114658323070558  0.062815237579419  0.064185887519018  0.009313244304943 -0.011480973281939  0.153753080425913  0.207572044587912
-   10  ( 10) -0.162215796938684  0.102608816758085 -0.007760654943323  0.059426107703524 -0.013639971522339 -0.037904077339461 -0.064744743002174  0.002349088500079 -0.003377674546375
-   11  ( 11) -0.030714567047902  0.017149469368505 -0.148281723814033 -0.168021936553750  0.043219337814574 -0.059348822268391  0.027602295508655 -0.090506279699096 -0.064287335914591
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.058979846663424
-    1  (  1)  0.000234151433416
-    2  (  2) -0.011430006640806
-    3  (  3) -0.225608458896205
-    4  (  4) -0.014102875489979
-    5  (  5) -0.012200282245874
-    6  (  6)  0.083455375182168
-    7  (  7)  0.198201250764442
-    8  (  8)  0.062481817545980
-    9  (  9) -0.043390015833605
-   10  ( 10) -0.040973644943399
-   11  ( 11)  0.034098640710675
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057027762100789  0.007489633887342 -0.036964189813796  0.021384352100284 -0.004867815775604 -0.032130235858782  0.019486973797962  0.000503926514732  0.024868986663351
-    1  (  1) -0.007883399599923  0.007529104506445  0.013216566770749 -0.001554286609489 -0.002481002458300 -0.003555137440754  0.020216878378801 -0.003435265519663 -0.003420680709423
-    2  (  2) -0.005061763911744 -0.024005030999464 -0.016920245291348  0.019760528227158  0.007759414271484 -0.029231812106945 -0.009559298232843  0.004745878981161  0.053662769962019
-    3  (  3) -0.011903086348447  0.106154395386531  0.048846797682958 -0.038122834717736  0.042076447151745 -0.017515736018254 -0.021695004377211 -0.017259669010754 -0.058953679400153
-    4  (  4)  0.086846706941042 -0.161257530089836 -0.037361255861875  0.089905419413410 -0.174437646387183  0.071028892880315  0.038811212273731  0.045200518155063  0.066894551440516
-    5  (  5) -0.295118954821928 -0.042171667688274 -0.057142717280935  0.095328920031059 -0.118376834610768  0.017202604507056  0.038088685926927  0.015413673756028  0.019970185142534
-    6  (  6)  0.061695197805604  0.041447416246154 -0.107874329349021  0.009310856499629  0.028327062477196  0.072556054900044 -0.031173831746629 -0.093673016450942 -0.096470656575707
-    7  (  7) -0.040164356283535 -0.019606328824315  0.022514162311588 -0.103095269177578  0.105738125414362 -0.000251323240260 -0.190667102998226  0.014251172141516 -0.042544347999407
-    8  (  8)  0.209747539729284  0.026225521984115  0.065411218317390 -0.108576414051802  0.195951046046893 -0.054935351774023  0.181062671358124 -0.048648601818055 -0.037403343457353
-    9  (  9) -0.029537922421234  0.045187174636289 -0.013381512217286  0.049426415359509 -0.003411235911782  0.045265306723710 -0.096457278821335 -0.006113492494935  0.044165814974043
-   10  ( 10) -0.026870929841946 -0.010513244846490  0.122411818973730 -0.066300236331789  0.074150921852319  0.175359501999903  0.025219490294838 -0.031299023505132  0.032770162927265
-   11  ( 11)  0.076638806040972  0.048660864910506  0.054798136469999  0.067410404189619 -0.096042680906718  0.030077767167195  0.040609376761651  0.003350033647470  0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007613623485115
-    1  (  1)  0.001053219582711
-    2  (  2) -0.054751844139672
-    3  (  3)  0.021588797011546
-    4  (  4)  0.069416579868176
-    5  (  5)  0.031311068013170
-    6  (  6) -0.060683491342485
-    7  (  7) -0.004937786560826
-    8  (  8) -0.055843386605960
-    9  (  9) -0.053258374332423
-   10  ( 10) -0.029326398375861
-   11  ( 11)  0.027904630917537
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000025015734507 -0.010198711087952 -0.006474775958448 -0.066946051563528  0.066550206967977  0.041188873125926 -0.023552914991952 -0.019202263160422  0.006942946197737
-    1  (  1)  0.010140605887652  0.000014394957877 -0.022996796061328  0.067092192493274 -0.063685673857393 -0.019093615376604  0.005525180617760  0.015031464830750 -0.005320182556269
-    2  (  2)  0.006534739001904  0.022969584694137 -0.000183457658640  0.211551326757209 -0.218187807438925 -0.104132114893528  0.065436658246811  0.042103919182146  0.012243831904844
-    3  (  3)  0.066304931943444 -0.066584833979085 -0.210703888875489  0.000394093515089  0.011258600581601  0.092530428436357  0.131881992071255 -0.026480578605083 -0.063346368194022
-    4  (  4) -0.065779542430873  0.062822415172501  0.216601239538476 -0.011617389043850 -0.000720555249011 -0.020159848057855 -0.073942431465134 -0.001119920964031 -0.016120241216710
-    5  (  5) -0.040846799691504  0.018979734118351  0.103125251405654 -0.092549855601907  0.021623501291584  0.000771447754999  0.234552119202209  0.000611164043666  0.101606719343242
-    6  (  6)  0.023326218450828 -0.005550385111505 -0.065252405074981 -0.131681855193961  0.073575257938565 -0.233645237851028 -0.000193851682480  0.255788429172446 -0.079072823032341
-    7  (  7)  0.019055068515462 -0.014786531642521 -0.041539856986611  0.026353850726780  0.001700683540838 -0.000445480591706 -0.255766070671258 -0.000118381893033  0.151562772366571
-    8  (  8) -0.006620321009197  0.005142966830662 -0.011245852682541  0.062510776113309  0.015648596901915 -0.102272652360209  0.078381794853266 -0.152302821501449  0.000094469957927
-    9  (  9) -0.045347281960025  0.040291069791943  0.085226922335689  0.018441757598111  0.027467525239214  0.004932928889320  0.020868912898856 -0.024483356625930 -0.224180460199113
-   10  ( 10) -0.020374790573784  0.028198954860440  0.010392111666997  0.120181326176130 -0.060512260831236 -0.109015894697222 -0.047153104465120 -0.043944046420833 -0.103069326885495
-   11  ( 11)  0.049408052352300 -0.045270280246414 -0.110185553685008 -0.041594160321979 -0.088273360930753  0.183934249639257 -0.003285919080508  0.178701510068243 -0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.045673042542890  0.020717466986083 -0.050844518832522
-    1  (  1) -0.040043621408487 -0.028287827625151  0.045457031631407
-    2  (  2) -0.084888848710605 -0.010052611398803  0.109898373773783
-    3  (  3) -0.018088362425205 -0.120534313520650  0.041770057803413
-    4  (  4) -0.026789230886550  0.060849702419905  0.088673365261613
-    5  (  5) -0.008004711197727  0.108432873838655 -0.185071361149961
-    6  (  6) -0.020116775504235  0.047889712574718  0.001523439225442
-    7  (  7)  0.023964360822185  0.043618854823263 -0.177454217319223
-    8  (  8)  0.226734396044438  0.102481459206944  0.008115223439087
-    9  (  9) -0.000423083368406 -0.309060226547434  0.090400550219427
-   10  ( 10)  0.308249178857435 -0.001017567434936 -0.330623886780632
-   11  ( 11) -0.090136758927266  0.334530610017321  0.000453348817603
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000379496190680 -0.036516557673727  0.022488411844201  0.041143099111719 -0.015151024607555  0.009820525598214  0.001328546168408 -0.002719718233480  0.079787685858295
-    1  (  1)  0.035173743352485  0.000509376348503 -0.021748140811100 -0.018984912310085 -0.002571720003760  0.101540537848848  0.014107119535580  0.020961802105584  0.100916916558314
-    2  (  2) -0.024420430259890  0.020833264343634 -0.000589210441902 -0.028690810435666  0.025063562199365  0.056845698692633  0.019362765266970  0.000534124800005  0.061230653902760
-    3  (  3) -0.039980341452345  0.019929624233720  0.028127725164783  0.000384377200086 -0.012223469426354 -0.007870420436516 -0.021500821930750  0.002985124038023 -0.055850425927213
-    4  (  4)  0.015033200445576  0.003096204403696 -0.023799943458502  0.011898049659739 -0.000036971633887  0.000277032322295  0.021239662546675 -0.005095064856192  0.060237805990277
-    5  (  5) -0.010708008535887 -0.101587409014600 -0.056660431011914  0.007350368054025  0.000126941263904  0.000065704202214 -0.008506831299188  0.011228150905342  0.011964202302477
-    6  (  6) -0.000469087338482 -0.014200163610075 -0.019097267233085  0.021632296910845 -0.021392214011008  0.008495741848254  0.000109627873962 -0.021812533614874 -0.020464844726232
-    7  (  7)  0.002889338898616 -0.020632474935553 -0.000453752095144 -0.002975803626006  0.005037506724376 -0.011335159213681  0.021733393798695 -0.000007087204356 -0.019955598928897
-    8  (  8) -0.081293710509515 -0.100918057466141 -0.060971767857812  0.055875536861090 -0.060631757745431 -0.011264467031019  0.020209151997608  0.020081495210629  0.000340983773767
-    9  (  9)  0.080516503167305 -0.106262951221757 -0.031461397073353 -0.007056184146683  0.022432192781915  0.017093833942137  0.097099983466552 -0.001349018368294  0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.079753101670227
-    1  (  1)  0.106710217482987
-    2  (  2)  0.031619499292907
-    3  (  3)  0.007164069356259
-    4  (  4) -0.022223903647397
-    5  (  5) -0.017462464724719
-    6  (  6) -0.096957045420818
-    7  (  7)  0.001243112172754
-    8  (  8) -0.004611313750592
-    9  (  9) -0.000252169760563
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055343853322395 -0.005338522209203  0.036325792187091 -0.020411379114398  0.005004472559017  0.030883540419705 -0.019693764112942 -0.000404480716013 -0.025396203204216
-    1  (  1)  0.006570683600848 -0.008768421568488 -0.011573795638563  0.000009175751903  0.002770565739659  0.004931208897901 -0.022163570789429  0.003290104656908  0.003254936700297
-    2  (  2)  0.001674419203277  0.021967102120902  0.025831824909554 -0.024758928994745 -0.009340908203812  0.034459015755376  0.010228225914487 -0.005919790861067 -0.058115699230390
-    3  (  3)  0.007779977639509 -0.106141218473434 -0.050482163293278  0.041812559908941 -0.042606909564863  0.016938249582167  0.022723831963497  0.018285942873731  0.061788101761112
-    4  (  4) -0.087397972334062  0.164590469335859  0.035983465272717 -0.095460926704216  0.183399304764373 -0.073380967092300 -0.038295030471351 -0.047026058194857 -0.066959437295317
-    5  (  5)  0.293750190777910  0.042648437038433  0.056404874075468 -0.100193237694056  0.123782490033077 -0.014652582564902 -0.036251400704161 -0.016769125982848 -0.023410414575794
-    6  (  6) -0.063526410041118 -0.042202406515953  0.107158367449000 -0.011222400592515 -0.032805848689894 -0.070775222023081  0.034269417179590  0.097599209765295  0.095048599779477
-    7  (  7)  0.039213631545190  0.016300797142278 -0.022834925899151  0.106699749704471 -0.109813770660251 -0.000567880224415  0.192962587636570 -0.013162275101134  0.042958800457043
-    8  (  8) -0.207671023275567 -0.021761663181296 -0.066317329893717  0.113575721461044 -0.208505431005016  0.053139089145086 -0.182387663583988  0.049317657695772  0.039898751560786
-    9  (  9)  0.031717525025615 -0.035452316963842  0.019040840253717 -0.049757955126745  0.003315672276934 -0.048439544916052  0.094357742781682  0.007725852797236 -0.042206115018339
-   10  ( 10)  0.030723138202058  0.012685537900520 -0.130253036286197  0.070878549267589 -0.073822499716479 -0.176856315004232 -0.024096584449109  0.033980770130198 -0.029602022179569
-   11  ( 11) -0.076338046412608 -0.058007647538535 -0.059625157558161 -0.072355446358478  0.100714683926583 -0.028164062896195 -0.037103331661254 -0.004159802100780 -0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007837140573608
-    1  (  1) -0.001271351061977
-    2  (  2)  0.056316152671545
-    3  (  3) -0.023558705106194
-    4  (  4) -0.071677402926291
-    5  (  5) -0.031036091810970
-    6  (  6)  0.060669139129724
-    7  (  7)  0.008329217020035
-    8  (  8)  0.058082899762783
-    9  (  9)  0.050026765138378
-   10  ( 10)  0.030419330923301
-   11  ( 11) -0.028289350786073
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.010782784489972  0.013050845930128  0.033023155215664 -0.015191714992095  0.005425132814901  0.026116394662957 -0.007256800612108  0.004570990183776  0.083505985646911
-    1  (  1) -0.004775248888120 -0.019609050610054  0.043741880650327 -0.000073954161324  0.027319440587928 -0.081090619324759 -0.046094626593374  0.004371816989341  0.079334747598806
-    2  (  2) -0.007829067250874 -0.005611745899100 -0.069924533643314  0.039501674728206  0.000927353784976 -0.005421401951033 -0.003817544999769  0.008629946885833  0.093259618314415
-    3  (  3)  0.018327078243591 -0.003795046417131  0.017900293895817 -0.029796535142542  0.026342994062962  0.087573876827112  0.029918989049988 -0.054199220040285 -0.044809777400716
-    4  (  4)  0.027183503470872  0.089536481638857  0.084857160463068 -0.036527297001861 -0.242538124561929 -0.016430382958973 -0.030531081573579  0.170538311757182  0.261658379411546
-    5  (  5) -0.020462782587523  0.074168804451800 -0.167834230231717  0.149604127852478 -0.243854217657690  0.044978789492557  0.032478673883371 -0.164731310430024  0.003040851330374
-    6  (  6) -0.075422914773902  0.018345498918631  0.109883881828728 -0.119442941495868  0.084779039670754 -0.177672686986939  0.254932779745392  0.179910297504286  0.058420300218360
-    7  (  7) -0.077293940205111 -0.171942167313393  0.155379720343131 -0.213627786676900  0.203405159942268 -0.435742440136601 -0.116233082588661  0.403785601702878  0.048376113482094
-    8  (  8) -0.113887453356696  0.134815689960008 -0.121289875435757 -0.381302435842573  0.140362613154441  0.094837304770689 -0.044125422076338 -0.354102164255088  0.021060221761777
-    9  (  9)  0.010381942177856 -0.091513821594073  0.090489398632436 -0.104640269057990  0.011526746486386 -0.174325672883320  0.095096801177535  0.162567420891194 -0.086584233440007
-   10  ( 10)  0.046140785323826 -0.004506559121454 -0.092261546126996  0.049590165687623  0.056546117609635  0.023211770714739  0.114566901687301 -0.007355072527000  0.045260763292278
-   11  ( 11)  0.210277389085871  0.043479475791959 -0.002620356919958 -0.027295607176521 -0.213582758279457 -0.049406759718245  0.038753842401848 -0.045549481042434  0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.000588783769111
-    1  (  1)  0.095074877441065
-    2  (  2) -0.094269658052775
-    3  (  3) -0.087042465113366
-    4  (  4)  0.229147969925312
-    5  (  5) -0.037090740492870
-    6  (  6)  0.008539965499391
-    7  (  7)  0.114631280540035
-    8  (  8) -0.035100938386537
-    9  (  9)  0.119410852550345
-   10  ( 10) -0.048938543804445
-   11  ( 11)  0.026842233365654
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000083177655875  0.020596022225207  0.023074380682109  0.123906982660277 -0.115856799969175 -0.077548996218664  0.033724258035794  0.015583195761424 -0.055304180213594
-    1  (  1) -0.020496643104719  0.000177442053919 -0.044849161409626 -0.200056054082230  0.192734988239744 -0.095810846356379  0.089592000858118  0.154865722471105 -0.062884487656521
-    2  (  2) -0.022893568520427  0.044914234916282 -0.000286887581780  0.110147204900385 -0.098101481651214  0.037544614577033 -0.063107876559817 -0.057867129267241  0.133662561842804
-    3  (  3) -0.123637708691857  0.200030347190693 -0.110276511900212 -0.000067254700333  0.150932238527093  0.295587503177329 -0.155559256339819 -0.250191288225748  0.068514494250419
-    4  (  4)  0.115217909263092 -0.191910599591419  0.098719023514077 -0.150564412486325 -0.000108066296459  0.207017027157466 -0.092817557275927 -0.119727699718554  0.027839136386995
-    5  (  5)  0.077201349586182  0.095637330323257 -0.037580888266386 -0.296037283435946 -0.206488013849544  0.000677656990837 -0.030142059938078 -0.107860538698997  0.317965442908009
-    6  (  6) -0.033520398034563 -0.089301712720516  0.063135446629119  0.155494983890111  0.093120397549751  0.029958661714230  0.000263665833745  0.031787895548351  0.052772032197117
-    7  (  7) -0.015173638148760 -0.154650785159269  0.057964322733043  0.249885773107303  0.119546085272213  0.107827018648257 -0.031752436246544  0.000037065640674  0.211400361545441
-    8  (  8)  0.055452136609395  0.063704146851438 -0.132109776961381 -0.067534716804367 -0.027512182553154 -0.319330567201196 -0.051501501228049 -0.211684727134552 -0.000062825592229
-    9  (  9)  0.059987775905021 -0.059013360455393 -0.001731139538261  0.025602282087959 -0.077406198911912  0.032289392048789 -0.044673931971007 -0.007013222782529  0.205272148471903
-   10  ( 10)  0.040816969333319 -0.029839999727295 -0.097606908985792  0.012730679444132  0.052120800982420  0.047092545087938 -0.097199457935824  0.008100744465293 -0.194519063749344
-   11  ( 11) -0.105565276750546  0.086850909183234  0.141349531156014  0.064538795649442  0.048769909889220 -0.098670307723293  0.132937762954191 -0.091749745952861 -0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.059727136016838 -0.040967341903913  0.106287777222309
-    1  (  1)  0.058687758282915  0.029394471353826 -0.086811620398375
-    2  (  2)  0.001293940264555  0.097641591345113 -0.142636172226853
-    3  (  3) -0.025821629306306 -0.013207208477272 -0.063793857996761
-    4  (  4)  0.076409112526474 -0.052575212530451 -0.047414860037356
-    5  (  5) -0.032527517350565 -0.045632421732577  0.095160623491729
-    6  (  6)  0.044231942651703  0.096152133696301 -0.132935625343693
-    7  (  7)  0.007372100254253 -0.008488811567739  0.092713079820202
-    8  (  8) -0.206938183650805  0.192802275414426  0.052611900153123
-    9  (  9)  0.000608554890156 -0.088592533061698  0.344380743508036
-   10  ( 10)  0.088950131298492  0.000863284429953  0.222751022723935
-   11  ( 11) -0.341005102874300 -0.224718204882492  0.000326394311109
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000338557997552 -0.011375035743392  0.029451193209236 -0.012043586883828 -0.021579660859347  0.039033326019946 -0.009990415550092  0.009478976983628 -0.045907412693585
-    1  (  1)  0.013672223167698 -0.000473657715584 -0.014851568055555  0.021895587564371 -0.022163590605075  0.051246172607775  0.019257625103746  0.003658602851281 -0.019552361048058
-    2  (  2) -0.032608942325713  0.014402827198054 -0.000746991250603 -0.029107751732300  0.054720608245644  0.057033646383303  0.001872360780591 -0.031698780852448  0.056602981887733
-    3  (  3)  0.014268935231542 -0.021459967996182  0.030313065636317 -0.000730068456009 -0.016766656065195 -0.058973632357354 -0.003002419788061  0.022431580465626 -0.134333948620083
-    4  (  4)  0.022372891038515  0.021355779916377 -0.052959509294565  0.015751198634933 -0.000391938857969 -0.016109226068828  0.004538544158672 -0.050308920012661  0.059340919102150
-    5  (  5) -0.040216234763810 -0.051875751817174 -0.055849318880052  0.058120412757832  0.016460961175898  0.000645475334216  0.019024299026328  0.068804307634402 -0.024311188622736
-    6  (  6)  0.009930727984206 -0.019074682595569 -0.002242770131548  0.003091320851947 -0.004596281406168 -0.019032186967740  0.000074596378968  0.032870219636189 -0.006741182978715
-    7  (  7) -0.009279418369258 -0.004264018479381  0.032087681361723 -0.022624894165436  0.049954824766487 -0.068907285150032 -0.032867640818893 -0.000029995356356 -0.011652937852273
-    8  (  8)  0.047260005865874  0.018493502167014 -0.056736132845076  0.135589678169431 -0.059916509278318  0.024164421049794  0.007333544303120  0.011763030881780 -0.000264400142459
-    9  (  9) -0.016875007958598  0.031435494057685 -0.089048257959160 -0.041017085631602  0.020420285065562  0.066513023484078  0.000739604154969 -0.091958006244489  0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.016438561460291
-    1  (  1) -0.031819705279686
-    2  (  2)  0.089217438029428
-    3  (  3)  0.040553914705774
-    4  (  4) -0.020554472275814
-    5  (  5) -0.066048736736302
-    6  (  6) -0.000688806170902
-    7  (  7)  0.091248940256931
-    8  (  8) -0.027663919394381
-    9  (  9) -0.000090314260367
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011888856297006 -0.017750932125153 -0.030381401096490  0.012819546160996 -0.007239420422718 -0.024248756043407  0.008035757610220 -0.005364063357974 -0.085646323747472
-    1  (  1)  0.005014728223890  0.026640078285976 -0.053625852742063 -0.001580773154934 -0.029513947501511  0.084681976949646  0.049070075720108 -0.003015931693788 -0.083533135335069
-    2  (  2)  0.005701802857788  0.001861436552455  0.077309348516175 -0.039227298256145 -0.002806617492516  0.004668173879327  0.004051055445085 -0.009725469213679 -0.098722432349714
-    3  (  3) -0.016358351457124 -0.001723600627698 -0.021225514928062  0.039815087581337 -0.022808569998795 -0.104140287911999 -0.033233738030323  0.056382556071864  0.046907957767316
-    4  (  4) -0.023138877563353 -0.095098707280146 -0.087666288227931  0.037561492255805  0.255193211004254  0.015544572331716  0.030557402755123 -0.180093964112144 -0.259856355700386
-    5  (  5)  0.024228572043234 -0.082834757201086  0.181139504221043 -0.153944959591839  0.252818375021614 -0.048862178579716 -0.036094966909273  0.170640955267472 -0.004551713568432
-    6  (  6)  0.085402345559358 -0.022737485412840 -0.117389155338347  0.122686430467103 -0.089994929534087  0.186662776489157 -0.276334552924253 -0.188945818003174 -0.062512631958960
-    7  (  7)  0.077377916753636  0.184413390881742 -0.161635032551528  0.217081818449181 -0.216158931990711  0.452250331823368  0.121365143499215 -0.427486936599919 -0.051141830029037
-    8  (  8)  0.109996402529651 -0.145159792225805  0.137471198251747  0.396423044911114 -0.145941263905056 -0.104134158957014  0.041227108112442  0.369426049626710 -0.017681253264412
-    9  (  9) -0.015271329763023  0.091667642816572 -0.093167229349338  0.105178289783052 -0.012072216330151  0.184888670947420 -0.104021366500691 -0.173041839821099  0.089774142402176
-   10  ( 10) -0.051871879465497  0.004911726396439  0.095027344602311 -0.050235453581707 -0.056755121586123 -0.023277306660177 -0.123771404812450  0.008953154661311 -0.042342746566353
-   11  ( 11) -0.213874614633354 -0.038620645156941  0.003918905035704  0.027644952213642  0.227437070959628  0.047768116418487 -0.043243210008693  0.046251908849224 -0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001231945309971
-    1  (  1) -0.099118498855930
-    2  (  2)  0.099462956417043
-    3  (  3)  0.089788110354890
-    4  (  4) -0.236379406660322
-    5  (  5)  0.043290372964682
-    6  (  6) -0.008471875583563
-    7  (  7) -0.118429426587662
-    8  (  8)  0.041151812398786
-    9  (  9) -0.121668252978460
-   10  ( 10)  0.047795297768532
-   11  ( 11) -0.026000603113831
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.092723408151075 -0.057215092134940 -0.054154926215137  0.012957083117559  0.028122190094715  0.031179347218855  0.013645641371598  0.009921258172339  0.037242536390232
-    1  (  1)  0.019990430092613 -0.002382806987559  0.016009786257367  0.011651136664597 -0.017212414198990 -0.024265249236370  0.152443472946687 -0.006755616148329  0.024207249541319
-    2  (  2)  0.009030755895234  0.085216520460363 -0.016500441499831 -0.009813164947617 -0.015713678712422  0.028373503652355 -0.075877310310795  0.039590492962937  0.081270933339189
-    3  (  3) -0.075043611755008 -0.103608833794547 -0.030676505925522 -0.013143510199953  0.006187488557257  0.045202449901574 -0.041605892889482 -0.001210820793539 -0.045033631139440
-    4  (  4) -0.122337112724117 -0.176460576265088 -0.085321001863374  0.041690733440160 -0.111448222796030  0.083092300673138 -0.094252463151414  0.071551603610925  0.059851091994803
-    5  (  5)  0.372712635775664  0.109553572239785  0.087636097688831  0.161393941368917 -0.091711881285738 -0.083559837956631  0.084048684818413 -0.114275654348762  0.004760374961166
-    6  (  6)  0.030431995544059 -0.095321795210779  0.159145740022025  0.376304340373359  0.189004479350399 -0.100683798175242 -0.128902751762968 -0.567857709085750 -0.002399331341204
-    7  (  7)  0.344039522571259  0.114279634125077  0.003626426979965 -0.177981236436906 -0.027932329764501 -0.026442462397652 -0.246808699479261  0.268819164710932 -0.106523620842343
-    8  (  8)  0.111643207885322  0.002836247769573 -0.018154026503924 -0.097243438328650  0.121498121615664  0.006682650130485  0.107315976978454 -0.036939727738377 -0.063237979028415
-    9  (  9) -0.063921675215150 -0.215994652248761 -0.065707412514049  0.003935136905129  0.142641982827575  0.026699050855783 -0.056962954862571 -0.164747861484427  0.081509018515780
-   10  ( 10)  0.058030998072116  0.060474289846612  0.205628226890442  0.038897333798042 -0.068097699807560 -0.116172285533776 -0.038858694654200 -0.255643829382515  0.001247633054968
-   11  ( 11)  0.085574013220044  0.030726962638802  0.008247473867838  0.106409310393215 -0.064469816287686 -0.072180462194277 -0.022620356444758 -0.070649638629627  0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015293746360799
-    1  (  1)  0.020176832366409
-    2  (  2)  0.007468634139779
-    3  (  3) -0.002013486296780
-    4  (  4)  0.055907379643807
-    5  (  5)  0.014548062338959
-    6  (  6)  0.210557719542813
-    7  (  7) -0.107773752705760
-    8  (  8) -0.004939471027833
-    9  (  9)  0.101796072438763
-   10  ( 10)  0.052197801100809
-   11  ( 11) -0.010791942309942
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000245185765728 -0.004422769142209 -0.195473142624697  0.067124189998810  0.027096370068160  0.099320185873800  0.032910569428743  0.079494520674282 -0.016762710819247
-    1  (  1)  0.004388313593185 -0.000165290846899  0.188129406432792 -0.063756474949075 -0.001128748240139 -0.126263116741295 -0.303817994309096  0.069854530583820  0.010310792522154
-    2  (  2)  0.194444327410373 -0.187906024270824  0.000538868177065 -0.115697813615881 -0.188025580722992 -0.063555095149569  0.109038200896130 -0.123360187528163  0.037347597176070
-    3  (  3) -0.066590814481336  0.063203632987523  0.115347217679990 -0.000002301796994  0.034584588669551  0.038983157581533  0.229948513873159 -0.131721887952800 -0.028384936970778
-    4  (  4) -0.026403437308072  0.000527986476725  0.186677671985474 -0.034818437947430 -0.000320297338463  0.037865478650564  0.201451121997014 -0.109301689008128 -0.005643097026329
-    5  (  5) -0.099409584232992  0.126346592032007  0.064419008019557 -0.039794220656347 -0.036855903902447 -0.000190318965932  0.088891480212760 -0.056789849447140  0.091073030281233
-    6  (  6) -0.033050985013878  0.303259624681304 -0.108281756633666 -0.230173439372417 -0.201331671706094 -0.089930560146314 -0.000311452672695 -0.221067383348441 -0.053494283573947
-    7  (  7) -0.079472710309908 -0.069297203366025  0.125033677339702  0.131451975782708  0.110125569334720  0.054839641157466  0.219945401741596 -0.001085047372961  0.089073871816377
-    8  (  8)  0.016952142014388 -0.010421932566239 -0.036927801153181  0.027792238689701  0.005351459000165 -0.090892785458666  0.052690955519676 -0.088985197141446 -0.000032698621213
-    9  (  9)  0.149061020700740 -0.058621114959186 -0.279965277538519 -0.021488283829580 -0.044200621925698 -0.026904718590704 -0.074208134755608 -0.037354078157659 -0.137372829291651
-   10  ( 10) -0.035190315077894  0.050814828300922  0.151303785089698 -0.062867991520111 -0.077053666036856 -0.075037906181509  0.133385625358484 -0.006791369727277 -0.121764957568739
-   11  ( 11)  0.016457666688676 -0.009560970830020 -0.030160709068648 -0.052615429880776 -0.007184814870880  0.147317585107930  0.048007656104932  0.024985856634055 -0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.149527127949477  0.035025203143730 -0.017236912650706
-    1  (  1)  0.058313378902528 -0.050420942142557  0.009474518218355
-    2  (  2)  0.278325755481738 -0.150562770304950  0.029989264213428
-    3  (  3)  0.020585218415975  0.063268588986747  0.052977667343551
-    4  (  4)  0.042114256624995  0.077316775027134  0.007960467665663
-    5  (  5)  0.031625284755674  0.074462306356205 -0.148447086799088
-    6  (  6)  0.074615124808937 -0.133170285550522 -0.049651682674137
-    7  (  7)  0.041592449377408  0.005910763914811 -0.024358506166719
-    8  (  8)  0.138294110971387  0.121744291260784  0.107918344276425
-    9  (  9) -0.001133592488713  0.474400799155993  0.192590673354496
-   10  ( 10) -0.472105353620486 -0.001334835966633 -0.192285927563244
-   11  ( 11) -0.191497735915320  0.194932828964948 -0.001344945845524
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000738836304181  0.037293198581408  0.029451404620807 -0.009378792471894  0.055701113540954 -0.035128933511984 -0.013954700067714 -0.072836702551235  0.051857122483535
-    1  (  1) -0.032660614374695  0.002015876922290  0.074058480716263 -0.021479421330690 -0.014966422603257 -0.166979967788261 -0.013073252080067 -0.022556560940623 -0.170972365950935
-    2  (  2) -0.029165553040464 -0.073308940131147  0.000753195727027 -0.033014777438001  0.000651481686764 -0.016615463822703 -0.030045410532860 -0.013342873064028 -0.078343409399381
-    3  (  3)  0.010384415064446  0.021326871974424  0.031305865808474  0.000583541727095 -0.005150844265660 -0.010972964083321 -0.024667426696971  0.003421011953857 -0.027197309287279
-    4  (  4) -0.055501401866642  0.014297660722118 -0.000710544848112  0.005493793084614 -0.000124683940717 -0.025126510553785 -0.000947638436962 -0.017069455654223  0.023650915169846
-    5  (  5)  0.033803616927021  0.164339399892725  0.017068168082329  0.010030727560507  0.025241735580020  0.000735433014139 -0.028603795353780  0.023029380344413  0.027599055296252
-    6  (  6)  0.013107540346806  0.012828435687407  0.030286401438565  0.024713021163335  0.001063605161759  0.029296491836886 -0.000025149030498 -0.111104514389532  0.102861376746943
-    7  (  7)  0.072733387901303  0.022465577956558  0.013436829086647 -0.003433808737295  0.017048766876852 -0.023125015384758  0.110934303358415  0.000037875914124  0.002935696551342
-    8  (  8) -0.053267672687232  0.170660201820078  0.076657788504288  0.028160893222526 -0.023606436991553 -0.027690933408034 -0.102626814241324 -0.002887530223588  0.000373637330912
-    9  (  9)  0.004804828900057  0.224333052817770  0.065186758028368  0.004091068046870  0.039040275694483 -0.042976408882840 -0.051197675519228 -0.024101682646066 -0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.005026329948406
-    1  (  1) -0.225373696682354
-    2  (  2) -0.064686362479745
-    3  (  3) -0.004567750792129
-    4  (  4) -0.038996417519414
-    5  (  5)  0.043485644851561
-    6  (  6)  0.051601626537389
-    7  (  7)  0.023715023759407
-    8  (  8)  0.001115391080639
-    9  (  9)  0.000048164004682
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.087860740756488  0.068261038905906  0.057593788019307 -0.011454237083441 -0.027305499289367 -0.032385982368371 -0.018173477269549 -0.009363386608796 -0.038732450559880
-    1  (  1) -0.013249632151170 -0.004184657414979 -0.019716507976896 -0.014744696478638  0.016703323694180  0.027386275287573 -0.163732376866413  0.007136524293248 -0.024482820661864
-    2  (  2) -0.007013218896085 -0.084657964294727  0.026004205374563  0.008076798202963  0.011641159214614 -0.031112856231507  0.081756432692912 -0.043486513055778 -0.085001128307205
-    3  (  3)  0.058477500387638  0.110048615847953  0.032104075685968  0.014807417786102 -0.004697674213231 -0.048123068402958  0.048143599431998  0.000645092439839  0.047260089330542
-    4  (  4)  0.110574498742467  0.188131348104213  0.086636459451987 -0.041361686502598  0.118556992954628 -0.089270642674348  0.104552978829704 -0.075153301656795 -0.057940099039356
-    5  (  5) -0.371487279658724 -0.115772941053656 -0.094845419594772 -0.167070991238391  0.094497706414686  0.087134798346335 -0.079465840043241  0.119932858558240 -0.004312964076576
-    6  (  6) -0.035255689937620  0.112028499449997 -0.168145842580037 -0.392683527257363 -0.194284650981365  0.110254467391126  0.135773335198962  0.599025983356266  0.001116295743642
-    7  (  7) -0.362602042970953 -0.115938705836042  0.002852393959785  0.186519834338995  0.026972926522319  0.023780474127448  0.271135694461778 -0.284033125501378  0.111247570725030
-    8  (  8) -0.111196944464455 -0.001239941376560  0.021205830532168  0.101329748088148 -0.128975240085324 -0.010144197632550 -0.108358474715393  0.037918096280026  0.066572090545295
-    9  (  9)  0.090967744709768  0.211201922436275  0.066377513424381 -0.007899083102241 -0.154707771160094 -0.037980948657754  0.073559352539101  0.172041273327275 -0.087426840520207
-   10  ( 10) -0.070112475488657 -0.079061926736069 -0.222919508358954 -0.040775801294398  0.061424635747658  0.113162621408555  0.037903862973014  0.270692474130444 -0.009570796789139
-   11  ( 11) -0.090924578792926 -0.040585886130445 -0.000311072794648 -0.117174234675791  0.063663959894116  0.077941781302743  0.027645133174923  0.073495241874676 -0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015882565008118
-    1  (  1) -0.020403231736073
-    2  (  2) -0.007241270504095
-    3  (  3)  0.003144444710549
-    4  (  4) -0.058793064689134
-    5  (  5) -0.012293150809123
-    6  (  6) -0.215177196230389
-    7  (  7)  0.113635102585609
-    8  (  8)  0.004824845555481
-    9  (  9) -0.113550918048735
-   10  ( 10) -0.063789409560574
-   11  ( 11)  0.007009974437012
+    0      0.605289638418384     0.048740741628601     0.271073733548877
+    1     -0.001536208130150     0.196630796843716    -1.341882095959049
+    2     -1.398139512807611     1.430868100910363    -0.796817191295826
 
 	Computing Mu_X-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        12.160379741462
-	   1        15.816174523843    5.168e-01
-	   2        18.062779512155    2.071e-01
-	   3        18.104564786524    2.511e-02
-	   4        18.116261991289    8.751e-03
-	   5        18.115485194621    2.112e-03
-	   6        18.115059982280    5.730e-04
-	   7        18.115134394893    1.705e-04
-	   8        18.115157029817    4.740e-05
-	   9        18.115144918624    1.473e-05
-	  10        18.115142408283    5.211e-06
-	  11        18.115143636266    1.931e-06
-	  12        18.115145112283    7.258e-07
-	  13        18.115145477182    2.142e-07
+	   0        12.160379612275
+	   1        15.816174341700    5.168e-01
+	   2        18.062779284335    2.071e-01
+	   3        18.104564557555    2.511e-02
+	   4        18.116261761865    8.751e-03
+	   5        18.115484965182    2.112e-03
+	   6        18.115059752859    5.730e-04
+	   7        18.115134165470    1.705e-04
+	   8        18.115156800393    4.740e-05
+	   9        18.115144689199    1.473e-05
+	  10        18.115142178859    5.211e-06
+	  11        18.115143406842    1.931e-06
+	  12        18.115144882859    7.258e-07
+	  13        18.115145247758    2.142e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 7.286e-08
 
 	Computing P_X-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.833344976436
-	   1         4.923299529264    2.688e-01
-	   2         5.532896219889    1.017e-01
-	   3         5.543641394212    1.185e-02
-	   4         5.546007361241    4.217e-03
-	   5         5.545880134344    1.190e-03
-	   6         5.545801456097    3.680e-04
-	   7         5.545827088806    1.294e-04
-	   8         5.545835350169    4.155e-05
-	   9         5.545832112072    1.361e-05
-	  10         5.545831758797    4.253e-06
-	  11         5.545832434032    1.232e-06
-	  12         5.545832972783    3.909e-07
-	  13         5.545833130413    1.357e-07
+	   0         3.833344994430
+	   1         4.923299548355    2.688e-01
+	   2         5.532896235832    1.017e-01
+	   3         5.543641409962    1.185e-02
+	   4         5.546007376923    4.217e-03
+	   5         5.545880150020    1.190e-03
+	   6         5.545801471775    3.680e-04
+	   7         5.545827104483    1.294e-04
+	   8         5.545835365846    4.155e-05
+	   9         5.545832127748    1.361e-05
+	  10         5.545831774473    4.253e-06
+	  11         5.545832449708    1.232e-06
+	  12         5.545832988459    3.909e-07
+	  13         5.545833146090    1.357e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 5.666e-08
 
 	Computing L_X-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.247381570398
-	   1         3.097286696418    2.898e-01
-	   2         3.812815684890    1.474e-01
-	   3         3.878389138947    3.548e-02
-	   4         3.885075613309    1.357e-02
-	   5         3.885547895791    6.311e-03
-	   6         3.886535950111    1.967e-03
-	   7         3.886738832588    6.592e-04
-	   8         3.886679713231    2.819e-04
-	   9         3.886672339402    1.105e-04
-	  10         3.886676080454    5.012e-05
-	  11         3.886677523890    1.563e-05
-	  12         3.886677551163    4.863e-06
-	  13         3.886676990819    1.570e-06
-	  14         3.886676826868    5.795e-07
-	  15         3.886676838546    2.540e-07
-	  16         3.886676917304    1.308e-07
+	   0         2.247381559583
+	   1         3.097286678889    2.898e-01
+	   2         3.812815657495    1.474e-01
+	   3         3.878389109615    3.548e-02
+	   4         3.885075583633    1.357e-02
+	   5         3.885547866024    6.311e-03
+	   6         3.886535920302    1.967e-03
+	   7         3.886738802769    6.592e-04
+	   8         3.886679683414    2.819e-04
+	   9         3.886672309586    1.105e-04
+	  10         3.886676050638    5.012e-05
+	  11         3.886677494073    1.563e-05
+	  12         3.886677521346    4.863e-06
+	  13         3.886676961002    1.570e-06
+	  14         3.886676797051    5.795e-07
+	  15         3.886676808729    2.540e-07
+	  16         3.886676887487    1.308e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 6.883e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.130822062475
-	   1        12.358074261722    3.642e-01
-	   2        13.442062697941    1.291e-01
-	   3        13.471739352430    1.980e-02
-	   4        13.480630220888    7.273e-03
-	   5        13.480482111186    1.462e-03
-	   6        13.480255761577    4.278e-04
-	   7        13.480295326973    1.238e-04
-	   8        13.480304392477    3.420e-05
-	   9        13.480298929543    1.069e-05
-	  10        13.480297559608    3.198e-06
-	  11        13.480298240037    7.251e-07
-	  12        13.480298711609    2.532e-07
+	   0        10.130821968318
+	   1        12.358074139910    3.642e-01
+	   2        13.442062557171    1.291e-01
+	   3        13.471739210883    1.980e-02
+	   4        13.480630079049    7.273e-03
+	   5        13.480481969339    1.462e-03
+	   6        13.480255619740    4.278e-04
+	   7        13.480295185134    1.238e-04
+	   8        13.480304250637    3.420e-05
+	   9        13.480298787704    1.069e-05
+	  10        13.480297417769    3.198e-06
+	  11        13.480298098199    7.251e-07
+	  12        13.480298569771    2.532e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 9.054e-08
 
 	Computing P_Y-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.954725115289
-	   1         4.757625754893    2.134e-01
-	   2         5.123619537234    7.283e-02
-	   3         5.135430985714    1.331e-02
-	   4         5.138438532066    5.250e-03
-	   5         5.138361498125    1.093e-03
-	   6         5.138299341700    3.234e-04
-	   7         5.138312401037    9.451e-05
-	   8         5.138315363376    2.538e-05
-	   9         5.138314233200    8.153e-06
-	  10         5.138313960854    2.552e-06
-	  11         5.138314370912    6.083e-07
-	  12         5.138314593662    1.910e-07
+	   0         3.954725130222
+	   1         4.757625770266    2.134e-01
+	   2         5.123619550676    7.283e-02
+	   3         5.135430998956    1.331e-02
+	   4         5.138438545227    5.250e-03
+	   5         5.138361511284    1.093e-03
+	   6         5.138299354861    3.234e-04
+	   7         5.138312414197    9.451e-05
+	   8         5.138315376537    2.538e-05
+	   9         5.138314246361    8.153e-06
+	  10         5.138313974014    2.552e-06
+	  11         5.138314384073    6.083e-07
+	  12         5.138314606822    1.910e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 5.762e-08
 
 	Computing L_Y-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.495468881713
-	   1         8.714469933780    4.298e-01
-	   2        10.170173470139    1.995e-01
-	   3        10.331283511318    6.921e-02
-	   4        10.360950815162    2.497e-02
-	   5        10.363204453535    8.501e-03
-	   6        10.364371474881    2.215e-03
-	   7        10.364711826888    6.522e-04
-	   8        10.364648292493    2.423e-04
-	   9        10.364628223213    7.272e-05
-	  10        10.364631615168    3.241e-05
-	  11        10.364633942999    1.452e-05
-	  12        10.364636725945    5.118e-06
-	  13        10.364636745608    1.697e-06
-	  14        10.364636756352    7.200e-07
-	  15        10.364636915152    3.373e-07
-	  16        10.364637162966    1.655e-07
+	   0         6.495468855272
+	   1         8.714469893517    4.298e-01
+	   2        10.170173415291    1.995e-01
+	   3        10.331283452604    6.921e-02
+	   4        10.360950755185    2.497e-02
+	   5        10.363204393318    8.501e-03
+	   6        10.364371414609    2.215e-03
+	   7        10.364711766599    6.522e-04
+	   8        10.364648232207    2.423e-04
+	   9        10.364628162928    7.272e-05
+	  10        10.364631554883    3.241e-05
+	  11        10.364633882714    1.452e-05
+	  12        10.364636665660    5.118e-06
+	  13        10.364636685323    1.697e-06
+	  14        10.364636696067    7.200e-07
+	  15        10.364636854867    3.373e-07
+	  16        10.364637102681    1.655e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 7.578e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.375391025758
-	   1        13.056807714818    3.885e-01
-	   2        14.267494985739    1.302e-01
-	   3        14.292982280858    1.823e-02
-	   4        14.298034109371    5.608e-03
-	   5        14.297567113453    1.444e-03
-	   6        14.297518787356    3.537e-04
-	   7        14.297576376534    1.167e-04
-	   8        14.297573943020    4.005e-05
-	   9        14.297568725717    1.369e-05
-	  10        14.297568187114    4.565e-06
-	  11        14.297569333273    1.438e-06
-	  12        14.297569994269    3.760e-07
-	  13        14.297570136053    1.222e-07
+	   0        10.375390930433
+	   1        13.056807585749    3.885e-01
+	   2        14.267494835663    1.302e-01
+	   3        14.292982130148    1.823e-02
+	   4        14.298033958482    5.608e-03
+	   5        14.297566962565    1.444e-03
+	   6        14.297518636471    3.537e-04
+	   7        14.297576225647    1.167e-04
+	   8        14.297573792132    4.005e-05
+	   9        14.297568574830    1.369e-05
+	  10        14.297568036227    4.565e-06
+	  11        14.297569182386    1.438e-06
+	  12        14.297569843382    3.760e-07
+	  13        14.297569985166    1.222e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.855e-08
 
 	Computing P_Z-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.292134036476
-	   1         5.380878105036    2.411e-01
-	   2         5.845351000584    7.719e-02
-	   3         5.853989779193    1.115e-02
-	   4         5.855496158324    4.005e-03
-	   5         5.855362511562    1.360e-03
-	   6         5.855378974132    3.374e-04
-	   7         5.855404179390    9.539e-05
-	   8         5.855403261369    2.772e-05
-	   9         5.855401974781    8.316e-06
-	  10         5.855401761087    2.657e-06
-	  11         5.855402129375    8.202e-07
-	  12         5.855402348400    2.315e-07
+	   0         4.292134049027
+	   1         5.380878117118    2.411e-01
+	   2         5.845351010108    7.719e-02
+	   3         5.853989788538    1.115e-02
+	   4         5.855496167615    4.005e-03
+	   5         5.855362520850    1.360e-03
+	   6         5.855378983419    3.374e-04
+	   7         5.855404188676    9.539e-05
+	   8         5.855403270655    2.772e-05
+	   9         5.855401984067    8.316e-06
+	  10         5.855401770373    2.657e-06
+	  11         5.855402138661    8.202e-07
+	  12         5.855402357686    2.315e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 8.666e-08
 
 	Computing L_Z-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.406503691255
-	   1         8.575077561846    4.321e-01
-	   2        10.070227409352    1.974e-01
-	   3        10.178849973996    4.501e-02
-	   4        10.189903730975    1.342e-02
-	   5        10.189264978603    6.893e-03
-	   6        10.190158032301    2.786e-03
-	   7        10.190619785921    9.701e-04
-	   8        10.190563386608    3.609e-04
-	   9        10.190560203221    1.081e-04
-	  10        10.190560065996    4.742e-05
-	  11        10.190566525109    2.069e-05
-	  12        10.190568754986    7.249e-06
-	  13        10.190568833026    2.676e-06
-	  14        10.190568924823    9.982e-07
-	  15        10.190569052782    3.921e-07
-	  16        10.190569155326    1.713e-07
+	   0         6.406503665499
+	   1         8.575077522609    4.321e-01
+	   2        10.070227354335    1.974e-01
+	   3        10.178849916572    4.501e-02
+	   4        10.189903673206    1.342e-02
+	   5        10.189264920800    6.893e-03
+	   6        10.190157974460    2.786e-03
+	   7        10.190619728058    9.701e-04
+	   8        10.190563328746    3.609e-04
+	   9        10.190560145360    1.081e-04
+	  10        10.190560008135    4.742e-05
+	  11        10.190566467248    2.069e-05
+	  12        10.190568697124    7.249e-06
+	  13        10.190568775164    2.676e-06
+	  14        10.190568866961    9.982e-07
+	  15        10.190568994920    3.921e-07
+	  16        10.190569097465    1.713e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 9.172e-08
 
 	Computing 1/2 <<Mu;L>>_(0.072) tensor.
 	Computing 1/2 <<P;L>>_(0.072) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008290776080582 -0.050801504097253  0.025635294562259 -0.003046442602711 -0.019839162173202 -0.042287718066775  0.002274291905087 -0.017250301075761 -0.063217582232324
-    1  (  1) -0.005656720485448  0.005906316890016 -0.013342327104385  0.062795095869537  0.034384806675368 -0.011824889654518 -0.010091423219065 -0.046942857543920 -0.048716688440686
-    2  (  2)  0.031253511604130  0.072637650556073 -0.014421891959526 -0.004213302445553  0.070727435854801 -0.065656867197555 -0.018370400388693 -0.002385908267158  0.006354255904041
-    3  (  3) -0.059832580241196 -0.053424480759820 -0.021451003825827 -0.018138018553495 -0.036100327164171  0.016134873511603  0.024740373136963  0.003793018506519 -0.167949395515151
-    4  (  4) -0.064204693944690 -0.131652862682136  0.117404639608972  0.157417127901485 -0.230036611567443  0.047515122725740  0.039984594404843  0.125482054176259 -0.256771627646738
-    5  (  5)  0.146085129938632  0.278398764610060 -0.159854012203638  0.282968510269086  0.101365891285813  0.356608825189021  0.125659431918166  0.044422988683829  0.166646852463301
-    6  (  6) -0.076564725597579  0.133650798922835 -0.020866614443156 -0.061441481951876  0.071232976830213 -0.204259413485531  0.443726141038863  0.031546384888620  0.054109942402284
-    7  (  7)  0.171392689665179  0.199512600411571 -0.417327799251045 -0.052763427688751  0.301472803852696  0.065491949787692 -0.090135905280205  0.243374803622146  0.087314234232365
-    8  (  8)  0.052750851527397  0.070024200557922 -0.379656051510646  0.506727880893360  0.456213741194719 -0.053888497905949  0.020349944072208  0.064388593842935 -0.270869373264179
-    9  (  9) -0.321512384290440  0.557302077819714  0.036935298894209  0.154840347992778  0.003043634782132  0.230873783877613  0.106477418838008  0.187200194326970 -0.093391131247138
-   10  ( 10) -0.965723013629727  0.203375174675727  0.231799200789465 -0.113515758170139  0.032657967963446 -0.147828874479423  0.019227710807050 -0.096617606939553  0.006766409668261
-   11  ( 11) -0.210596475192897  0.094976222444135 -0.072335244920971  0.290764752768263 -0.062314851229712  0.053607127427930  0.145285323049651  0.073900587412887 -0.326764941791807
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071285844130264
-    1  (  1)  0.010066343394199
-    2  (  2) -0.108617239028194
-    3  (  3) -0.063737900590760
-    4  (  4) -0.015793155353663
-    5  (  5)  0.238781543103224
-    6  (  6) -0.065357063243315
-    7  (  7)  0.120098496018758
-    8  (  8) -0.128051536292778
-    9  (  9)  0.179029916473930
-   10  ( 10) -0.084757737907666
-   11  ( 11)  0.159141561245499
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.230778688168130 -0.557039020018502  0.102231622004203 -0.365190061837505 -0.400431097899025 -0.011240783369823 -0.138486416116495  0.002452040812742 -0.004398637078623
-    1  (  1) -0.556776142920827 -2.040315056194718  0.915507378155102  1.014426942838368  0.734278848751725  0.048588577390964  0.281167270606351  0.301449170381432  0.094768863002394
-    2  (  2)  0.102191442528323  0.915686903851560  1.209547690777273 -0.958100119655737 -0.740471389480369 -0.004947182895568  0.495915674452131 -0.139783988312968  0.095073435804183
-    3  (  3) -0.364539165929170  1.014070571549057 -0.958316089423204 -0.283348551998825 -0.131889670325022 -1.271015261428147  0.039370973643206 -0.404136843612415 -0.596543898512850
-    4  (  4) -0.399870169082361  0.732987024839952 -0.742129335372324 -0.132056740778799  0.552809694709972  0.050609502973822 -0.485130318718432 -1.569135325660496 -0.955644372877197
-    5  (  5) -0.012067668711970  0.049395634351447 -0.004235997753528 -1.269867451709877  0.052501445594591  0.142961307435960 -0.243772741862524  0.815823088969846 -1.032660122676294
-    6  (  6) -0.138184751914924  0.281444487458849  0.496109632619357  0.039289252640444 -0.483545301414318 -0.244146373994899 -2.567548494258237  0.471042691193011  0.535768572608993
-    7  (  7)  0.002443724218529  0.302692867022601 -0.138498316501231 -0.403820450806263 -1.565811046199608  0.816611901103015  0.471628294535134 -1.688652935957108  0.671482803026688
-    8  (  8) -0.004344564384300  0.094578985136196  0.094798646138089 -0.597437555079113 -0.950266206536146 -1.030172101956222  0.534632090191761  0.669551052804072 -0.286047601971907
-    9  (  9)  0.321027459692546 -0.124494588251713 -0.355830352458176 -0.608802973418470 -0.402462352421951 -0.368076132570564 -1.240230517037675 -0.910561909620175  0.043652486559104
-   10  ( 10)  0.011815823949598 -0.051101513605038 -0.395397800969984  0.309598565761669  0.194737646185127  0.053604366895841 -0.879466474650196  0.757981021960396  0.138272602216670
-   11  ( 11)  0.159425836287601 -0.085783898744993 -0.370909602534729 -0.056636941516785 -0.307385996591224 -0.268976928323790 -0.442853482929670  0.013290639913097 -0.876205899626718
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.323082673575100  0.012827323300415  0.160383781034165
-    1  (  1) -0.126844464371028 -0.052604971080148 -0.086843133976977
-    2  (  2) -0.357788273401833 -0.396667921961515 -0.371902334820724
-    3  (  3) -0.612287607386654  0.306667669522199 -0.056656844524874
-    4  (  4) -0.405472668706639  0.195190062002348 -0.306615567899281
-    5  (  5) -0.367351821286147  0.055534904015428 -0.275720960811118
-    6  (  6) -1.243158670589035 -0.884111685009210 -0.446520521343404
-    7  (  7) -0.909610092856081  0.758960738026336  0.004121680213622
-    8  (  8)  0.044479614426162  0.142510706976164 -0.890141861038879
-    9  (  9)  0.430645603358394 -0.292573864178629 -0.177569371172063
-   10  ( 10) -0.297251468770778  0.639563517042984 -0.084252875076621
-   11  ( 11) -0.176313836183732 -0.086637188746477  1.226883274744448
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.555032728737771  0.712617672671401  0.419810286882489  0.050887754227596 -0.090842975445822 -0.470640518796941  0.705404320416024 -0.102097016449215  0.079849652538938
-    1  (  1)  0.712915390108471  0.338414908248977  0.746799463635505  0.289033465951793  0.281577689527702 -0.590080565321557 -1.163166129408219 -0.188838662213219  0.235465544716902
-    2  (  2)  0.420424419523684  0.746397208582966 -0.016153704953468 -0.358852287949201 -0.952285365412292  1.041198523267407 -0.387389024226280  0.231972398395418 -1.201681468114436
-    3  (  3)  0.052990374128029  0.287939592192507 -0.356997201476426 -0.860130940767887 -1.322600194001359 -0.190991097932252 -0.172427859143025  1.049268576710733  0.759838942947354
-    4  (  4) -0.091729674999201  0.281558404761801 -0.953826965790842 -1.321136801436185  1.452847715742109  0.019357804497789  0.219531843898996 -0.321163524474806  0.383368380154908
-    5  (  5) -0.468391179467906 -0.590920943851569  1.042843901419442 -0.190946364776948  0.019284064585406 -0.578157261908740  0.477982154885554  0.309192885886468  0.350343314103329
-    6  (  6)  0.705416628116867 -1.163498224121495 -0.385221267991331 -0.173426272959358  0.218834180811751  0.478203132617135 -2.784703127021582 -0.089827446409910  0.007438070857215
-    7  (  7) -0.100892718625019 -0.189193923309364  0.233172791358426  1.048794685120079 -0.321694154621351  0.309157324551256 -0.089653742381773 -3.228872513573496  0.508232911749822
-    8  (  8)  0.078189592702616  0.235740536359493 -1.205024775916881  0.762330717256039  0.383275686836382  0.348953623655193  0.008045450505770  0.508467502681986  0.472369144605263
-    9  (  9) -0.077760701800955  0.237396383481108 -0.096343734790574 -0.354923660187535 -0.984336588474142  1.335053740742370  0.269902452459777  0.319055275759352 -0.321749140962585
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.078162493766068
-    1  (  1)  0.238847682218727
-    2  (  2) -0.098903683747888
-    3  (  3) -0.354949509542455
-    4  (  4) -0.983822640646403
-    5  (  5)  1.333720211340158
-    6  (  6)  0.269441491786924
-    7  (  7)  0.318898660493929
-    8  (  8) -0.321196908799485
-    9  (  9) -0.198768714929451
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015331616498833 -0.019922018235360  0.024795453639952  0.001428994822442 -0.007662564632869 -0.030564864466354 -0.002998096035874 -0.014184257518557 -0.050369876521864
-    1  (  1)  0.002536892896206 -0.000724332833140 -0.010931820831771  0.061385329925525  0.034527384530112 -0.002930909394968 -0.006897041777642 -0.048924198461387 -0.045892788765523
-    2  (  2)  0.055930590988109  0.061668786229878 -0.009784880887058 -0.011292178101404  0.079575226023927 -0.052325708606337 -0.009086556132667 -0.001787844130138  0.008215255410943
-    3  (  3) -0.058532225277701 -0.048285500112225 -0.015912879350588  0.001479837376653 -0.030353501548890  0.023819914693464  0.021025260847826  0.014207102374829 -0.151577267379535
-    4  (  4) -0.056221687371934 -0.122358938171234  0.112292181821658  0.146881610350559 -0.213263741399596  0.056469707520368  0.037816511197979  0.118315319709634 -0.249164851234958
-    5  (  5)  0.125699079920792  0.245765102963436 -0.144688421941741  0.269480954167622  0.108175820650901  0.330495489462815  0.121717019021094  0.042981278927133  0.139107704893676
-    6  (  6) -0.090953864200081  0.138378038123711 -0.018999653387300 -0.059021477190613  0.070107383816014 -0.188422561576096  0.422479983427336  0.027031745312951  0.054392856003620
-    7  (  7)  0.157772366372595  0.187920697768143 -0.411777035755239 -0.046692805557951  0.283266431788380  0.074879967037488 -0.084103929184262  0.226658912465472  0.075512245279510
-    8  (  8)  0.054210291452992  0.062449071960101 -0.361963320103574  0.503001997291620  0.438083797101076 -0.063050427843078  0.017066076329137  0.069221757957400 -0.257467231990446
-    9  (  9) -0.273423536032774  0.529295983026682  0.033766766508851  0.151918529592259 -0.009418984940093  0.206571120107986  0.110624885223032  0.172829785443028 -0.101427788661059
-   10  ( 10) -0.861462052752320  0.172326691424178  0.212371997651326 -0.111218596621436  0.023269411258717 -0.143388725237391  0.039930804953421 -0.091843120858856  0.022422158283106
-   11  ( 11) -0.188670480611874  0.096820345118133 -0.066190773880029  0.287205832494666 -0.059420643781434  0.064429852032339  0.150091109571506  0.074231547885084 -0.343171650309577
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.057461514086606
-    1  (  1)  0.006963958755564
-    2  (  2) -0.098129328522494
-    3  (  3) -0.059012682268642
-    4  (  4) -0.004449861106028
-    5  (  5)  0.220945294639113
-    6  (  6) -0.063939488850868
-    7  (  7)  0.102360934503055
-    8  (  8) -0.118112557417407
-    9  (  9)  0.155151984964126
-   10  ( 10) -0.077691214009347
-   11  ( 11)  0.169304339523055
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007929033245727 -0.086776514026638 -0.041466992686244 -0.000624066975311 -0.013156595381987  0.043080477030762  0.042448060293463  0.012239880545527  0.029029915184304
-    1  (  1) -0.033878180177558  0.070173508648210  0.019230609095550 -0.003533880530575 -0.001550569267327 -0.001809299397526 -0.111518736659909 -0.001270571448457 -0.012934311690280
-    2  (  2)  0.053119512373320  0.091732793273830  0.021408607612661  0.032674571200622 -0.027446877387833  0.001428368203209  0.035760699595502 -0.016168017803360  0.076110316338229
-    3  (  3) -0.111768458659199  0.032123986864070  0.006283151908271 -0.033287020781358  0.043086093005307 -0.045344868585861  0.050504244775852 -0.018808552325982 -0.035145863401031
-    4  (  4) -0.008665305449844 -0.063452607411023 -0.029600165455924  0.047115677331559  0.019168666345381 -0.031501732622098  0.317766848542404 -0.025484653465158  0.136713668607013
-    5  (  5) -0.096942829349587  0.462416830630329  0.133842090994118  0.092985874350147 -0.099421870808029 -0.234587688959823 -0.217512036032000  0.115491679731730 -0.074046828271163
-    6  (  6)  0.147504151854231  0.176016277524490 -0.101374573515317 -0.288079277305196 -0.230919141922049  0.118478695990594  0.200039409574699  0.528080641738917 -0.150345125085143
-    7  (  7) -0.042669001755884  0.443406170499069  0.389143916519812  0.161315900065673 -0.044923622848274 -0.251217580401495  0.349139344106497 -0.313375744671926 -0.105308356658894
-    8  (  8) -0.090773283284028 -0.098945242676733  0.273219850231927 -0.153556988234685  0.012049248011756  0.153837601800696  0.096783765511278 -0.036655814574288 -0.158022323654812
-    9  (  9) -0.854099711852282 -0.117772176421944 -0.239016409160077 -0.177375733867881  0.100275769298913  0.252844583057920  0.226930144139075  0.153229528005110  0.127239027610851
-   10  ( 10)  0.395991653576375  0.538214267844356  0.096531314019954 -0.336382832184142  0.099895828912763  0.055956501178133 -0.146421756050995  0.134905206743007  0.024743642762261
-   11  ( 11)  0.048495982241480  0.204014858900645 -0.274325469868742  0.134595356909103  0.084519511625804 -0.191133538480751  0.069261639154394  0.103192119612584  0.176045180364651
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.028831087335228
-    1  (  1) -0.001371858337113
-    2  (  2)  0.086279641236700
-    3  (  3) -0.002619734805492
-    4  (  4) -0.021137684583830
-    5  (  5) -0.191430382947414
-    6  (  6) -0.264284919761669
-    7  (  7)  0.000269384690538
-    8  (  8)  0.116882729881709
-    9  (  9)  0.120074711434079
-   10  ( 10)  0.053632787996257
-   11  ( 11) -0.085463803953674
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.675541283858356 -0.292064021280293 -0.790025131233222  0.039304385342315 -0.142699371183327  0.268327500474091  0.055268589173706  0.193336176520280 -0.032498607183913
-    1  (  1) -0.292005367417511 -0.068094888399427 -0.091928539573230  0.129152126993159 -0.002672883933379  0.049262453691224  0.862140772831706 -0.434895002279636  0.030957963645570
-    2  (  2) -0.789447165009789 -0.092254483472880 -0.804853040833334  0.464036191543570  0.288328515691532 -0.782373392336952 -0.359658943728641 -0.388090328975242  0.068147997029207
-    3  (  3)  0.039444395620206  0.128939281409480  0.463903578747306 -0.241479807350799 -0.029257651091736  0.289330170364477 -0.078438871496667  0.246243716348015 -0.221624488999474
-    4  (  4) -0.142005033730652 -0.003441352982276  0.286700873937055 -0.029953661733414 -0.427750919311445 -0.225593242891832  0.001248695253401  0.308372097905189  0.608170303007273
-    5  (  5)  0.266046370608821  0.051710611539180 -0.778167579408912  0.290283723006215 -0.224453112864279 -0.369348441761130 -0.137527542499239  0.160088399589127  0.333141145250294
-    6  (  6)  0.055576665996038  0.861897091141550 -0.359382180614210 -0.079367338581182  0.001316960755447 -0.139592143084602 -0.236061692038733 -0.500995422630755 -0.152924823639678
-    7  (  7)  0.191190365321726 -0.433335934056497 -0.384226491533538  0.246895934047586  0.308256930114393  0.160145299200529 -0.499551364365546  0.169042466304747 -0.232433156817922
-    8  (  8) -0.032324733830521  0.030583581869279  0.067800595440523 -0.220839746025180  0.605132330733771  0.331428074510260 -0.152991449816876 -0.231671787208498 -0.624414674119492
-    9  (  9) -0.170133827289346  0.173802608390272  0.582650141434017 -0.560382911834174 -0.212565567455627  0.095754045184088 -0.282286783247438 -0.105642205052933 -0.000539730602912
-   10  ( 10)  0.052970874353821 -0.227531715435441 -0.648876828841383 -0.696767965643644 -0.268344000354012  0.568720278318329 -0.098598860256773  0.086269937526947 -0.081275470268861
-   11  ( 11)  0.025516552524119 -0.085059735579504 -0.121415959836865  0.018097922040376 -0.846374652520441 -0.307989344147049  0.044343294285023  0.231195949738532  0.168305572109582
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.171375974411067  0.055216931376792  0.025964207813788
-    1  (  1)  0.173220084938157 -0.230603891969826 -0.085840408679658
-    2  (  2)  0.586304150506699 -0.654210189691972 -0.122677885868631
-    3  (  3) -0.564217005061761 -0.698424845148049  0.018146779332832
-    4  (  4) -0.213592841407263 -0.268356081771837 -0.851093566817366
-    5  (  5)  0.095187708087751  0.569138844284334 -0.311815017332116
-    6  (  6) -0.283847446348569 -0.099361887898569  0.045327800607922
-    7  (  7) -0.106442929251796  0.084951820105521  0.232402123183799
-    8  (  8) -0.000679287280351 -0.083181582350312  0.174842773942352
-    9  (  9)  0.184137973286679  0.103441117955563 -0.011188766481418
-   10  ( 10)  0.107554052466808  0.106515041132340 -0.165743784884080
-   11  ( 11) -0.010550245981975 -0.165913802295303  0.859885805027657
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.229655435401251 -0.279601353643965 -0.085575827802352 -0.135048509105901 -0.463462610619003 -0.365248455770507 -0.039660777368333  0.191781963250870 -0.304572804139555
-    1  (  1) -0.279047925679444  0.077319987469585  0.204439247136492  0.070123615269243  0.055860395624731  0.138642318409271 -0.343207769076389 -0.182810883095464 -0.017999280994748
-    2  (  2) -0.085240959465133  0.204263364283089 -0.311156623733494  0.294688564065330  0.229669520218161 -0.281737981462645  0.137882893674030 -0.194668648298996  0.517507397185879
-    3  (  3) -0.137052652301458  0.068817803199155  0.294513347383327 -0.628744473812505  0.688526281107777  0.166771123104115  0.212803952843010 -0.269010206604892 -0.411620416751970
-    4  (  4) -0.461604619248266  0.055843287983042  0.230054478565236  0.688395074228786 -1.421511879446005  0.180495138052121 -0.177199847230662  0.268188410470329  0.119512289645345
-    5  (  5) -0.365099883123814  0.139122909294115 -0.282780063256330  0.166251175855828  0.181093271919847 -0.292775738602585 -0.240660983788926  0.305216197970317  0.235452232882587
-    6  (  6) -0.039141072198114 -0.342047900602042  0.138302509146164  0.211959339222516 -0.177087648441962 -0.240505624310098 -0.304304277829310 -0.910739369588832  0.202811323160239
-    7  (  7)  0.191443148224360 -0.183077517400336 -0.194209029769022 -0.269384260651775  0.268168725961981  0.305441092512858 -0.910852433205190  0.029633662055934 -0.204453968987965
-    8  (  8) -0.303246852232180 -0.018509744386768  0.519514080414653 -0.413340759430442  0.119384719254151  0.236362024043069  0.201991249845660 -0.204562219955504 -0.661555776893828
-    9  (  9) -0.300472910579648  0.170014354298783 -0.291259695102906  0.029160805834281  0.317264449488489 -0.326442124436524  0.007044557482429 -0.101763181058410  0.215338723709779
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301684802635884
-    1  (  1)  0.169719322346163
-    2  (  2) -0.289724655704096
-    3  (  3)  0.029002914588453
-    4  (  4)  0.316574855082561
-    5  (  5) -0.325796183326422
-    6  (  6)  0.007131791827115
-    7  (  7) -0.101918507704736
-    8  (  8)  0.215214193797303
-    9  (  9) -0.431317970778139
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009148490318064 -0.020309806158549 -0.015977532182931  0.004014783738387 -0.010489793112351  0.029667649783295  0.020232440585606  0.011223082041042  0.023312323786938
-    1  (  1) -0.044375857230131  0.052262766826166  0.015548487373741 -0.003662802577056 -0.002781875625079 -0.001383977859398 -0.098229640468489 -0.001043710758572 -0.010909270118946
-    2  (  2)  0.054181385020550  0.080128526478900  0.022828931876126  0.037487063410101 -0.042770056882922 -0.005218720540993  0.030479703829638 -0.014823518322437  0.065536667960166
-    3  (  3) -0.129996832535740  0.025539245172390 -0.001710767497197 -0.035208153932012  0.051497303033318 -0.033810939265315  0.041923713016432 -0.018028802137201 -0.031841589713416
-    4  (  4) -0.018797598258319 -0.055382521313148 -0.025678897036466  0.042677314096974  0.024119803445938 -0.028773903589126  0.288385579456642 -0.023957336001325  0.134022392012911
-    5  (  5) -0.085790126908808  0.402408359114006  0.110878458520312  0.084218998643581 -0.097302640260559 -0.211015098306590 -0.195826989075132  0.107508726926065 -0.059970385150068
-    6  (  6)  0.117117046001707  0.164907313314791 -0.092740522447941 -0.263892346037872 -0.208050086690414  0.121861415926763  0.180654068666643  0.487980567663863 -0.134813668081860
-    7  (  7) -0.052709991074355  0.381296251220592  0.349380237841959  0.145852911752160 -0.041346590279243 -0.220669429372274  0.328816279036270 -0.285726302429830 -0.093478286390337
-    8  (  8) -0.075491834851014 -0.090622807799606  0.261184981058617 -0.148637821570292  0.006281256453519  0.144842826611815  0.089811111402247 -0.036110485207390 -0.153520220179307
-    9  (  9) -0.696164148321021 -0.104910101886221 -0.203383144631185 -0.164870629493292  0.069977329160723  0.194202208543558  0.212076681930829  0.132693764051193  0.096725293429142
-   10  ( 10)  0.348175665954885  0.434442729860845  0.069207287013024 -0.311902381205193  0.086974667298470  0.051225223079379 -0.122216101880307  0.122874476488139  0.012079820457350
-   11  ( 11)  0.044712948857676  0.176004094735536 -0.255862724288287  0.126758826080010  0.078218473139894 -0.179984369340434  0.067110991111726  0.095360581673868  0.177561710091429
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.024402944617349
-    1  (  1) -0.001173348606223
-    2  (  2)  0.076484101898115
-    3  (  3)  0.001169431615315
-    4  (  4) -0.024935532887633
-    5  (  5) -0.174540155531575
-    6  (  6) -0.236517338782017
-    7  (  7)  0.008859575697215
-    8  (  8)  0.109927192293737
-    9  (  9)  0.089534068178409
-   10  ( 10)  0.043410237741554
-   11  ( 11) -0.093132968001143
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002170644752931 -0.022324956514099 -0.029394826211345  0.023309311068680 -0.000970852822634 -0.043511040680121  0.014013985960523  0.007860305508825 -0.031314125297178
-    1  (  1) -0.004975212184910 -0.009727238108985  0.081406434912428 -0.023252939392766  0.038928067463043 -0.010458408905981 -0.034913544836836  0.014265058471693  0.051735797486860
-    2  (  2)  0.017880176100707  0.015599348022774  0.096023531696764 -0.045237679689815 -0.002431886781376  0.077281603581543 -0.027482410098613 -0.002121837766367 -0.131596950090464
-    3  (  3) -0.033671282161329 -0.042247110815725  0.017614407066521  0.120482048147517 -0.071788669015437  0.100417130949899  0.026095439370731  0.024912292415628  0.128857994704884
-    4  (  4) -0.039094504869080  0.011586636873075 -0.201648756832533 -0.417167224027039  0.232183671922422 -0.365776066782585  0.000436512477144 -0.036487401941041 -0.092913589753420
-    5  (  5)  0.107020694538732  0.188165249192967  0.272788343236859 -0.444403017959699  0.118293552778212  0.528258782415562  0.125325642779073 -0.198753130098826  0.028672980278371
-    6  (  6)  0.121158671169740 -0.085565322151460  0.088586051783133  0.010298532059028 -0.107250216094850 -0.195698840050220  0.370534853760273  0.159194784952583 -0.016512860210084
-    7  (  7) -0.033804952616344 -0.168095045341921  0.398821112602689 -0.046726828449621 -0.030609711055064 -0.217531691733838 -0.115639511714214  0.399856930098400  0.150033235311716
-    8  (  8) -0.059559370905179  0.306305036465827 -0.595923646185890 -0.119277640805674 -0.722271918559490  0.001726267262613 -0.027179920353598 -0.211451038002310  0.148912062372910
-    9  (  9) -0.188866142842736  0.096789990486457  0.236442562527094  0.092757728041313  0.072651948101216 -0.016472461695526 -0.026914575117300  0.247244600184375  0.370870606832493
-   10  ( 10) -0.406957853798143  0.141958866881762 -0.085132936917023  0.102326296221874  0.017996095944708 -0.062553443565296 -0.105319900227601 -0.005069269037988  0.006423933602228
-   11  ( 11) -0.081915250147579  0.202583484157184 -0.282203343833431 -0.339304077428364  0.118298550150489 -0.126692826807318  0.005731143361727 -0.150166092159272 -0.134968415625333
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.038183979702674
-    1  (  1) -0.001758617329220
-    2  (  2) -0.002245458358924
-    3  (  3) -0.305015280585847
-    4  (  4) -0.011707659076193
-    5  (  5) -0.052479234679287
-    6  (  6)  0.143560462314116
-    7  (  7)  0.320971036748081
-    8  (  8)  0.148594551736844
-    9  (  9) -0.097500178466871
-   10  ( 10) -0.069870490871550
-   11  ( 11)  0.082515655756872
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.053221344681142 -0.117483147833985 -0.106139723247453 -0.495823955121092  0.391515874804455  0.212402958848530 -0.083769680573767 -0.039675371517883  0.058634274306531
-    1  (  1) -0.117410394687696 -0.001165915237512 -0.133100613626654 -0.630012634533085  0.317623482499555 -0.573984529169381  0.375575851008806  0.417091736224605 -0.210582306420709
-    2  (  2) -0.106116179316557 -0.133365754849436  0.099881677186242 -0.283389270168438  0.408842653260195  0.463415082290805 -0.094461635582511 -0.339728478273951 -0.187117729157411
-    3  (  3) -0.495487159854538 -0.630575218275538 -0.284210529100489 -0.394005207299682  0.243829412824131 -0.426368810438983  0.000017569224274 -0.316982847795332  1.182262387796268
-    4  (  4)  0.391977861689502  0.318458435778042  0.410524448216213  0.243871385545647 -0.262605821454379  0.313475558817429 -0.006238164976110  0.146232809940208 -0.404783357267945
-    5  (  5)  0.211677947989569 -0.572946112183618  0.465876094202739 -0.424891649228725  0.310576368667640  0.340119032966648 -0.103399884420596 -0.366027570904681  0.140243317389270
-    6  (  6) -0.083203642949521  0.374758513857944 -0.095474380553338 -0.000848431158077 -0.007011740191065 -0.103456952640946  0.035381526355376  0.100664517850410 -0.224617556800866
-    7  (  7) -0.039824177760467  0.417269525333673 -0.339848279473418 -0.316785009817077  0.144981956006953 -0.366591938133070  0.100487370214345  0.453363803566786 -0.284080848307595
-    8  (  8)  0.058454981179204 -0.209563433448112 -0.187086823104815  1.182437825563613 -0.401897920471953  0.141960153823608 -0.223791716105096 -0.283768269790238 -0.127258563076312
-    9  (  9)  0.176473367868989 -0.113695285962430 -0.191045562239273 -0.466077182834650  0.080353173846381 -0.392419296545826  0.139310719822578  0.097667658130615  0.260382741772322
-   10  ( 10)  0.087511748605763 -0.084525637542731 -0.451433812661641  0.087442027470754 -0.075301055147615  0.128254312442896  0.066832910809452  0.040269698765907  0.083963538620684
-   11  ( 11) -0.256000473516428  0.178934738319287  0.462669412659627  0.336070869572452 -0.226364820740552  0.220661186826050  0.015682276558009 -0.019696413835863 -0.320368477367524
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.177398660643495  0.088413661062507 -0.257047850800415
-    1  (  1) -0.114710761582569 -0.086001542477366  0.179468892454740
-    2  (  2) -0.191402905701337 -0.452554194931555  0.463985875678332
-    3  (  3) -0.467548510382317  0.086605995128391  0.336310348111395
-    4  (  4)  0.080907164839857 -0.077457000042675 -0.231693183962593
-    5  (  5) -0.391713702811823  0.124122145336547  0.233240659481206
-    6  (  6)  0.139727422139028  0.065972550943365  0.014736999139443
-    7  (  7)  0.097438431199858  0.039119593081805 -0.012607893852994
-    8  (  8)  0.258370481571402  0.084693167750785 -0.328679992068142
-    9  (  9) -0.027947875522173 -0.059452680730838  0.039102598209232
-   10  ( 10) -0.061112133253744 -0.042824028656813 -0.176907573001062
-   11  ( 11)  0.036269564126208 -0.174115037047438  0.046562990208638
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.221915567502623  0.240154969163816  0.089524025753548 -0.009891539023461 -0.105352264889997 -0.079728196437896 -0.186918344067447 -0.018609216798882 -0.150218987334760
-    1  (  1)  0.239595861160914  0.097635005536382 -0.020343203465831  0.252497393963625 -0.178770889626966  0.156659860903133  0.042031186852564 -0.226739274781765  0.050354579998016
-    2  (  2)  0.090047283413814 -0.021960432152020 -0.652704165096791 -0.484235858264924  0.265074532283746 -0.870240852693915  0.056963933090132  0.087593695232780 -0.397150344061483
-    3  (  3) -0.008304023565221  0.254514964099576 -0.488668744172267  0.243914942296862 -0.497430549408554 -0.651892044099941 -0.144949354151790  0.009197770416785  0.363155689203458
-    4  (  4) -0.105368055288416 -0.178968402377489  0.265813616023428 -0.498441236963999  0.117807978177016 -0.197938223960627  0.010977461550819  0.054866508200549 -0.633466747483980
-    5  (  5) -0.079092278611567  0.155211327907083 -0.870349858528248 -0.648891955877304 -0.198852995680930  0.056118287010249  0.077393750543525 -0.820063131904850 -0.522591293712200
-    6  (  6) -0.188319262904704  0.043235387216250  0.056704467242807 -0.145342612784415  0.011176054667898  0.077123788010048 -0.017043504447154 -0.229308594149143 -0.061253571825596
-    7  (  7) -0.017449220652026 -0.226052369590475  0.086398229140611  0.009988063298837  0.055257253277244 -0.820894010869112 -0.229107411788767  0.436891114659360  0.154693358924324
-    8  (  8) -0.147652836473568  0.050157233403955 -0.397985593672069  0.364902332737576 -0.632177325650741 -0.523669848989306 -0.060883358066048  0.155008994016302 -0.331322085722016
-    9  (  9) -0.012364053013731 -0.381902018882131  0.730234455154150  0.318717588976828  0.654372705810295  0.234910934996783  0.063436038641434  0.568676727219248  0.116095919775855
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010717409085818
-    1  (  1) -0.381606046587817
-    2  (  2)  0.729520232349256
-    3  (  3)  0.319801359646356
-    4  (  4)  0.655576694394483
-    5  (  5)  0.233766377042350
-    6  (  6)  0.063681628675817
-    7  (  7)  0.569047245691214
-    8  (  8)  0.115234955131862
-    9  (  9) -0.255200733989858
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006756611009239 -0.004812319108707 -0.015155246179453  0.018768861614548  0.003263846230316 -0.029956626691063  0.007768157616613  0.008654952545397 -0.024139771998296
-    1  (  1) -0.000276876655733 -0.007317152277636  0.067126401411285 -0.013873168496829  0.038395392580021 -0.004054864162186 -0.028032553908660  0.014238200673600  0.044802348000681
-    2  (  2)  0.034311733284435  0.014478380463186  0.079037871547464 -0.037480797351928  0.004455235189999  0.068266709703376 -0.020927095140560 -0.000590179941322 -0.116436689576599
-    3  (  3) -0.034781167081690 -0.039999835648210  0.017388947621558  0.117724049135840 -0.062309713575062  0.098214530429882  0.024529272430519  0.026637769905859  0.121592113448416
-    4  (  4) -0.036088452219928  0.018119725898309 -0.181397076074172 -0.381210957896193  0.211295234548894 -0.335046977567969 -0.001001209940803 -0.032788904430710 -0.087406508170972
-    5  (  5)  0.091932999121248  0.163472911292393  0.257039057929667 -0.406986018028708  0.108362880698111  0.483755223010107  0.114747171070721 -0.179816739697054  0.021814542430540
-    6  (  6)  0.102207313652244 -0.075273825473482  0.076700485775484  0.010389199522243 -0.095145363312679 -0.177269643268087  0.339312666537493  0.145893525857585 -0.013352577122472
-    7  (  7) -0.036776384387696 -0.162278963391709  0.362818814892890 -0.043460364327904 -0.026462409718549 -0.199351982461758 -0.104180059013018  0.364628559511404  0.137093791802520
-    8  (  8) -0.054133642075650  0.281937460317668 -0.549118750139198 -0.110766566728388 -0.665283649525633 -0.004014717984651 -0.026030812844979 -0.193249298632007  0.140185869779560
-    9  (  9) -0.149539825936769  0.083496187141563  0.222414359602469  0.086467924966290  0.058519767738283 -0.026610134648035 -0.023639345193443  0.224482305471681  0.335967535114734
-   10  ( 10) -0.342551768791105  0.115343806322270 -0.079695331214451  0.094078531732984  0.012984790263811 -0.052720281866277 -0.089289783188097 -0.003161584461577  0.011520822726607
-   11  ( 11) -0.067948144123858  0.170897803094304 -0.268478044795138 -0.331752793901224  0.110501398686606 -0.120431522039808  0.010421693063374 -0.142909196950524 -0.136584264097857
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.029945709624550
-    1  (  1) -0.003777838622564
-    2  (  2) -0.000494193391228
-    3  (  3) -0.283159255072162
-    4  (  4) -0.002056849846006
-    5  (  5) -0.055491249216550
-    6  (  6)  0.134241443599212
-    7  (  7)  0.294425347600366
-    8  (  8)  0.138732741810037
-    9  (  9) -0.100744739667681
-   10  ( 10) -0.062352827286650
-   11  ( 11)  0.087587602591740
-
-	DPD File2: P*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.016434384667148 -0.059537003054536  0.018382703913455  0.001901473074516 -0.028510164358282 -0.077646279855039 -0.000356251398219 -0.021408373218989 -0.091393977088558
-    1  (  1)  0.005835140019102  0.006847303402179 -0.005801307077118  0.092503110731406  0.040640220398500  0.004476772769023 -0.006707493956919 -0.025598358653730 -0.054742040386929
-    2  (  2)  0.032576552661469  0.022759352669700 -0.015700451044420 -0.017659613283536  0.033691301649134 -0.071320914458495 -0.010810523808367  0.000599142203483 -0.006831611161324
-    3  (  3) -0.028439441517722 -0.025978253338493 -0.005227408482745 -0.004129515933235 -0.042131401342259 -0.005061996623806  0.014819468597155  0.029813444208053 -0.124931870713391
-    4  (  4) -0.026711661740657 -0.065952388204908  0.070397760617197  0.113357837258571 -0.162062952662508  0.007050708037022  0.019958512448364  0.113599468912823 -0.186779858191589
-    5  (  5)  0.054225682429018  0.150592673565962 -0.090221508528394  0.165469278587529  0.105075744052049  0.235926758500148  0.076402735009682  0.065221510888654  0.109078486285223
-    6  (  6) -0.036820767703606  0.045049000362756 -0.022079029118092 -0.038075092578984  0.045448669142688 -0.103567825475646  0.243196158948954  0.024866082639399  0.028667254743547
-    7  (  7)  0.064079984215095  0.104489316033204 -0.208936934850580 -0.011404897999585  0.191297065299167  0.062928087633658 -0.036625785426208  0.182329767369539  0.046827781359629
-    8  (  8)  0.029820488646987  0.037609170202879 -0.184366833470305  0.250608304245861  0.266157936861978  0.003343240964033  0.026232571891440  0.068560106516425 -0.143703222469330
-    9  (  9) -0.097477133499219  0.253919330671861  0.022474002349921  0.091068839306237  0.030773177890121  0.124639301979492  0.057377848460010  0.129428480584789 -0.052503813838482
-   10  ( 10) -0.308102321981415  0.100099264744172  0.103502297395079 -0.030595871425367 -0.027930037535271 -0.082924987589621  0.003621479559882 -0.051467583495009 -0.001729710593298
-   11  ( 11) -0.065171614185219  0.083076013227694 -0.007781121482082  0.129638416743258 -0.025583078029705  0.021102804445382  0.038969277950233  0.054649593445510 -0.156415144250598
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.100574711969240
-    1  (  1)  0.017311198418314
-    2  (  2) -0.099207008690223
-    3  (  3) -0.049312818935542
-    4  (  4) -0.020969683268895
-    5  (  5)  0.168478941844432
-    6  (  6) -0.036633223806040
-    7  (  7)  0.083149987934917
-    8  (  8) -0.054463823630147
-    9  (  9)  0.105100295511211
-   10  ( 10) -0.049112459843749
-   11  ( 11)  0.074285789462190
-
-	DPD File2: P*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000150860459877 -0.171933918231252  0.041419056803072 -0.170616058570147 -0.200856757156520  0.002034169374196 -0.083717100185599 -0.000516882277833  0.000760835570240
-    1  (  1)  0.171458970665860 -0.000052671693709  0.080477211012241  0.158047078345989  0.171611945068556  0.020781553144960  0.081182987020708  0.096111050666912  0.028348265964974
-    2  (  2) -0.041612402589055 -0.080354514984744  0.000394264947173 -0.065176020012681 -0.096961733142428 -0.000557038525025  0.109435480142694 -0.034287451388532  0.031868099666052
-    3  (  3)  0.170115569606579 -0.158386367352469  0.064620104688982 -0.000274195329164 -0.003073114771818 -0.155980931184969  0.002438060010510 -0.075892612616599 -0.118957615446809
-    4  (  4)  0.200436196772240 -0.171813138083843  0.096620398683267  0.002372485388961 -0.000742978447135  0.018013393904637 -0.033369149651403 -0.120720251055992 -0.104550918281167
-    5  (  5) -0.002211117433298 -0.019930957908302  0.000666901496264  0.157204484557621 -0.015901976339486  0.000217821561163 -0.009428657942981  0.039993958187839 -0.071492158249729
-    6  (  6)  0.083537896232863 -0.081216293971867 -0.109652154032100 -0.002769108821106  0.033489275419838  0.010079357840938  0.000064832704676  0.012979883425805  0.022286123614410
-    7  (  7)  0.000446183372454 -0.095595436198971  0.034260265949943  0.076357839284767  0.123056525926531 -0.039576937592408 -0.012836423633655 -0.000276922615353  0.011862614885765
-    8  (  8) -0.000763780194579 -0.028492759060566 -0.031582546116686  0.118324194064185  0.106500675879643  0.072862382850876 -0.022267846900148 -0.011936132807121  0.000309785123822
-    9  (  9) -0.200009372729413  0.049971216489633  0.123430272682259  0.142933103185242  0.066275175614906  0.011400665529444  0.086697488232449  0.026102313931474 -0.001060546754189
-   10  ( 10) -0.021852700751396  0.017163247777288  0.127823592278093 -0.091613120127056 -0.051604501451930 -0.012175072674142  0.083661634147568 -0.068820029767420 -0.010286004757943
-   11  ( 11) -0.114973761942494  0.044704429189879  0.150112248621738  0.031470261050302  0.054465549098901  0.018492073632933  0.052809037569742 -0.018588462631583  0.062465552340744
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.199650432776970  0.021769646283719  0.115014099877643
-    1  (  1) -0.048847979709979 -0.016224624083658 -0.045739997653995
-    2  (  2) -0.121535202952087 -0.127110081169448 -0.150689800369572
-    3  (  3) -0.141534079657396  0.092900464386430 -0.030906929300398
-    4  (  4) -0.064777188331671  0.052294246689992 -0.052576843649814
-    5  (  5) -0.012798646161060  0.011617495484096 -0.021426191620278
-    6  (  6) -0.085439453581865 -0.082177824690696 -0.054044239620785
-    7  (  7) -0.026881359606727  0.069312090513404  0.013578395284128
-    8  (  8)  0.000980665289481  0.011875108407812 -0.069843147407046
-    9  (  9) -0.001396130223525 -0.045043795365458 -0.018886220574768
-   10  ( 10)  0.041412670665906 -0.001872911812120  0.033067578033610
-   11  ( 11)  0.016567946659153 -0.031899396551867 -0.001929777984873
-
-	DPD File2: P*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.001411268359160  0.010548061189878  0.012234985630211 -0.023975313562280  0.023062230820039 -0.045437732948681  0.106872881296076 -0.025944637778051  0.029363485311898
-    1  (  1) -0.014640801150040  0.001773735046594  0.029549963184092 -0.020758435544442 -0.007635590000279 -0.056071060358736 -0.088482364466965 -0.027605241546487  0.020492843216977
-    2  (  2) -0.013184523566191 -0.031261847780049  0.000489474253254 -0.031775189074985 -0.038538471296270  0.038607714449183 -0.007921641905981  0.014600160708699 -0.097026534080847
-    3  (  3)  0.023325695791557  0.021331801923242  0.030636705569878  0.000479373870642 -0.011687430157835  0.060845116281804 -0.009020253210307 -0.020543788213974  0.119533313623190
-    4  (  4) -0.023654300689698  0.009020483406481  0.038301937767707  0.011962372815437  0.000301509800453 -0.037261192743398 -0.029045239001199 -0.041781275442091  0.051627710213779
-    5  (  5)  0.044386181810683  0.057414182896665 -0.038267122468401 -0.061256729128929  0.037800933596037  0.000260698778894  0.001511863535883 -0.016380337639677  0.072487672330699
-    6  (  6) -0.106206323004553  0.087758718377781  0.007560784408469  0.009263545408533  0.028871039692754 -0.002023613184462  0.000132116955283  0.000735561511998  0.010945124965688
-    7  (  7)  0.025425283561814  0.027796807869910 -0.014997640380461  0.020644254386635  0.041827532757913  0.016146444702388 -0.000831333123472 -0.000058581308311  0.017035220679833
-    8  (  8) -0.029580773528628 -0.019460244903885  0.099428018149333 -0.121448802541844 -0.052251959451872 -0.071719334941988 -0.011527870420583 -0.017438360216925  0.000376592607811
-    9  (  9)  0.011323796835811 -0.022846032797884  0.003463845070647 -0.010590766229841  0.093908204414477 -0.097279630619014 -0.016132246312287 -0.052832474295790  0.033804637999018
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.012386803276718
-    1  (  1)  0.025331755243544
-    2  (  2) -0.004701299813181
-    3  (  3)  0.011259859427831
-    4  (  4) -0.092847122914529
-    5  (  5)  0.097092353171668
-    6  (  6)  0.015797039269438
-    7  (  7)  0.052823551833136
-    8  (  8) -0.033708639353932
-    9  (  9)  0.000241834945391
-
-	DPD File2: P*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019875399821365  0.067213072995023 -0.012299941717659 -0.003468875187880  0.030128328426274  0.082822743936825 -0.001897897698354  0.021797662835713  0.095153762344945
-    1  (  1) -0.006451292960481 -0.005754162581844  0.002884034500734 -0.094974935426192 -0.041098451485401 -0.000058064511604  0.008894806239621  0.025485003895974  0.057087471632476
-    2  (  2) -0.026223355242450 -0.024273603088334  0.016292189081393  0.015844039410231 -0.030633853079712  0.077008417539564  0.014788316606733 -0.000243822647885  0.007976439135467
-    3  (  3)  0.025334252850709  0.027648721071750  0.005856451162092  0.011279594978250  0.045220581787047  0.007788112252830 -0.015791844926599 -0.026413664639332  0.132992803966333
-    4  (  4)  0.028858615977169  0.070880006979721 -0.078385497137577 -0.115909817357349  0.170672806468397 -0.002802625270051 -0.018507237940661 -0.116641608428124  0.183930260352482
-    5  (  5) -0.062029310382341 -0.165059238935656  0.096438123628463 -0.170982438012572 -0.101168051978722 -0.247462788062147 -0.078143137508448 -0.065503368874352 -0.123407161852621
-    6  (  6)  0.029868108814055 -0.043826434723281  0.020536879880122  0.040118359069746 -0.047262891605686  0.111204577364818 -0.250427612151989 -0.027185217329734 -0.027972758218343
-    7  (  7) -0.071045843569722 -0.110497052752988  0.212396167514294  0.014472401617176 -0.201746291025428 -0.058726820006450  0.038658609736798 -0.191686821472890 -0.051568740310987
-    8  (  8) -0.030231001314245 -0.039607181613347  0.190237369746058 -0.251586833919896 -0.277372132160808 -0.008690855780340 -0.027285881313233 -0.066231456708385  0.148705440863578
-    9  (  9)  0.119406447574908 -0.267992491845044 -0.024723477609567 -0.092623842023547 -0.035484932702787 -0.135905292178670 -0.058976108500788 -0.137156317198896  0.050622979340015
-   10  ( 10)  0.354731988399122 -0.114731465978240 -0.113605854938311  0.033621899430544  0.024886546894064  0.086388159191061  0.001760250802633  0.054814426010942  0.004266849862045
-   11  ( 11)  0.074987139083159 -0.087839869817099  0.017174937068014 -0.139817452729011  0.030459814346611 -0.019645857821193 -0.042455388198899 -0.058190403006369  0.165317136166192
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.104159520209993
-    1  (  1) -0.017365114579609
-    2  (  2)  0.105508249406411
-    3  (  3)  0.051333283782025
-    4  (  4)  0.026824469147080
-    5  (  5) -0.172355785037806
-    6  (  6)  0.037231897229526
-    7  (  7) -0.092488656033236
-    8  (  8)  0.060576527966250
-    9  (  9) -0.114591221791530
-   10  ( 10)  0.052791324163552
-   11  ( 11) -0.078009502545252
-
-	DPD File2: P*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.013905849892992 -0.105574256292555 -0.058365326510732 -0.011150777040830 -0.004301162141041  0.055780562682692  0.053115864387752  0.011951099406770  0.044340643594202
-    1  (  1) -0.013705956820555  0.025309547841960  0.001538984041734  0.001849504741603 -0.005133976748632  0.012878903904056 -0.096751125536924  0.003812996689903 -0.009632709529968
-    2  (  2)  0.020569845493093  0.032320703460180  0.011944643866745  0.047792544188734 -0.032679729361416  0.019407207672949  0.038230397931919 -0.003676283556944  0.058784384336985
-    3  (  3) -0.071874917867093  0.002631775952960 -0.003539152259809 -0.028170151218425  0.033082337295689 -0.021301963625855  0.050188554745657 -0.011804977856767 -0.016979295260921
-    4  (  4) -0.014914728990396 -0.041337858840349 -0.031774187859112  0.031846901880618  0.020737884741536 -0.009318588686327  0.180587918491444 -0.014608314108616  0.091927794627027
-    5  (  5) -0.043163603381900  0.253570894625469  0.078110646309368  0.060207643631253 -0.083755719198877 -0.160896258343551 -0.127680183234514  0.074831092977117 -0.060961655981049
-    6  (  6)  0.044917686060828  0.074437543040067 -0.066817478801761 -0.141365137531753 -0.114156889702257  0.038201515939482  0.107320317731531  0.348968351908512 -0.116558406175751
-    7  (  7) -0.034184804469893  0.226667134284391  0.206947793731390  0.080987919933847 -0.050884738274657 -0.136027438420489  0.157869432700479 -0.195670168357032 -0.055408723502488
-    8  (  8) -0.031166515249721 -0.045258191750987  0.124213591624855 -0.070497635611886  0.013839913877531  0.080645709057116  0.048975111106761 -0.013846985677438 -0.081456527024621
-    9  (  9) -0.260272045600859 -0.057970015239195 -0.114635559073584 -0.083827066916392  0.094102194410800  0.136997319599706  0.136846202555835  0.093755934766235  0.066197390562813
-   10  ( 10)  0.128170228467008  0.270987976538407  0.063355286850330 -0.080149940628318  0.057123968341669  0.051813056590924 -0.080732658365778  0.110930691434851  0.002284134974517
-   11  ( 11)  0.014638573493894  0.093181336572008 -0.090893348615143  0.060951699754620  0.036152243930201 -0.068685591001865  0.022141424075597  0.054226980293487  0.076820031900454
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.045178917656151
-    1  (  1) -0.000506654263468
-    2  (  2)  0.062622183647669
-    3  (  3)  0.006475863513060
-    4  (  4) -0.009581278166545
-    5  (  5) -0.123788681467482
-    6  (  6) -0.140490962930464
-    7  (  7) -0.012343887711756
-    8  (  8)  0.065924555702067
-    9  (  9)  0.071777365622544
-   10  ( 10)  0.030198414714018
-   11  ( 11) -0.038206097812612
-
-	DPD File2: P*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000441373721971 -0.087271451504254 -0.308356080671030  0.018077607068688 -0.073688004857476  0.153028983755896  0.021375900910730  0.125940926422186 -0.021636449149896
-    1  (  1)  0.086671311731224  0.000204963757277 -0.004083848977647  0.019054726614325 -0.000357076891570  0.008883507874300  0.245817294107565 -0.139613669494547  0.011872389377551
-    2  (  2)  0.307138366785038  0.004537268804354  0.000000947821260  0.032420162338715  0.044765722657128 -0.148620348284250 -0.082511203687099 -0.091836400843881  0.021157739960336
-    3  (  3) -0.018180307170497 -0.018806737266631 -0.032304346608179  0.000164575589082 -0.000048486967076  0.033944617253518 -0.017906518922370  0.039367589983503 -0.041014607610233
-    4  (  4)  0.073708499176395  0.000188579066207 -0.045384824461272 -0.000051244255112  0.000118131709454 -0.009319825672971 -0.005919844337701  0.028188407915503  0.062383088971619
-    5  (  5) -0.153503404134916 -0.008021529263725  0.150851560923171 -0.033683034219721  0.010920406889103 -0.000843675018215  0.002305152210287  0.006419896281910  0.018802686354169
-    6  (  6) -0.021663782224978 -0.245568524819791  0.082607420634013  0.017861578854728  0.005717491537118 -0.001465956881798 -0.000164104368228 -0.019402844307281 -0.008582138264613
-    7  (  7) -0.126272473343725  0.140132379196136  0.093779865985419 -0.039016174646910 -0.027756266123623 -0.008788078328085  0.019927753575961 -0.000986178708271 -0.006276129856304
-    8  (  8)  0.021659942465065 -0.012093240675092 -0.021224721403549  0.041292366946203 -0.063444639030514 -0.018952234899780  0.008805846385022  0.006555018834286 -0.000619883795504
-    9  (  9)  0.110032896200750 -0.071298113833135 -0.163479589536219  0.111444129990912  0.024671365993001  0.003210445766199  0.009378587102769  0.014713425509001 -0.000839110373856
-   10  ( 10) -0.069217830582824  0.088543829220743  0.203682134643279  0.186485128327869  0.053425964853416 -0.063005981229243  0.018184933705949 -0.000540007105749  0.005219687452082
-   11  ( 11) -0.023959189620953  0.030895371890558  0.044769544498433  0.009068900298863  0.130492147876274  0.035762663243292  0.002770335503139 -0.023536235288276 -0.010103727285469
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.109799080219678  0.069203346900770  0.023919903278421
-    1  (  1)  0.071129060568146 -0.087605257548157 -0.030425173883571
-    2  (  2)  0.162026048331677 -0.201435103487415 -0.044723919546572
-    3  (  3) -0.110972252607892 -0.185860701404063 -0.009243336757067
-    4  (  4) -0.024458462243726 -0.052145051182170 -0.130041721565426
-    5  (  5) -0.002181441725954  0.060001657923379 -0.037138509415485
-    6  (  6) -0.007938597292020 -0.017379429117453 -0.002521412739913
-    7  (  7) -0.012919580840703 -0.002428706377795  0.023595862068092
-    8  (  8)  0.000273485582407 -0.005817339116375  0.014280567707235
-    9  (  9) -0.003328589668182  0.017803512680764  0.001063197928266
-   10  ( 10) -0.016699725327030 -0.001798758796680  0.002170763958318
-   11  ( 11) -0.001212933542278 -0.001783778903851 -0.003563107345321
-
-	DPD File2: P*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.002010159634630 -0.000220404084817 -0.003192882122880  0.011052627613533 -0.003562668031365  0.009837814318177 -0.002544312104621  0.035965473851195 -0.038472004952375
-    1  (  1)  0.001452297302852  0.003072719747229 -0.008838287240450 -0.026771929595669  0.046483406284037  0.009889595128182 -0.035422086740367 -0.011912247720366  0.000936796016060
-    2  (  2)  0.004597077371462  0.009797303502342  0.002356759440367 -0.013160928599717  0.036596664601802 -0.014914711645441  0.014591721304407 -0.007418668493650  0.037805835513950
-    3  (  3) -0.010591350137419  0.026807560073439  0.010708663838159  0.000566073142147  0.006877298509595 -0.015806087254090 -0.036616622156539 -0.004527327935437 -0.052470069694755
-    4  (  4)  0.002197180048840 -0.045360469690206 -0.037290055709025 -0.006377690547549  0.000197738244084  0.043135976717434 -0.013927669894978  0.013270906950991  0.034225968512880
-    5  (  5) -0.012223872820757 -0.012276608732166  0.015974082159209  0.014788689444500 -0.043434889585929  0.001241108463199 -0.022259649308453 -0.002776600972090  0.020757469065177
-    6  (  6)  0.002236227833952  0.033698361699947 -0.015413577603851  0.037176700349159  0.013637799368342  0.022481473057898  0.000196461263851  0.066878572107562 -0.012948719456691
-    7  (  7) -0.036159618368672  0.011023728969868  0.006496546324176  0.004756159901056 -0.013088014945893  0.003050957277162 -0.066534588876792  0.000038997802685 -0.018679498186635
-    8  (  8)  0.037272822971437 -0.001025968499180 -0.039463494780131  0.053213044947716 -0.033933492458794 -0.020627554065949  0.012927451364571  0.019084958215300  0.000379158267741
-    9  (  9)  0.044713556544603 -0.031925295057843  0.027454374007067  0.016949911467799 -0.043552787687819  0.029362229767510 -0.013081869754981  0.017575107888422 -0.005208148088787
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.046477985245624
-    1  (  1)  0.031367776651430
-    2  (  2) -0.027386023407765
-    3  (  3) -0.017151073595537
-    4  (  4)  0.043659143705007
-    5  (  5) -0.028276225310864
-    6  (  6)  0.013015371352964
-    7  (  7) -0.017243006711225
-    8  (  8)  0.005600961681940
-    9  (  9)  0.000315129095420
-
-	DPD File2: P*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.016735058692801  0.127427648471711  0.067812616467594  0.013558783551809  0.005269296599083 -0.059347294870606 -0.061177076545679 -0.011973162399102 -0.046187859594365
-    1  (  1)  0.006127975507731 -0.027720789931143 -0.002131386760238 -0.002129686454541  0.005489719844856 -0.015177604183485  0.105071662567975 -0.004089530302215  0.010958371300164
-    2  (  2) -0.014625553671885 -0.033500045224482 -0.010197102842648 -0.049282810089046  0.029146517326401 -0.023890316169967 -0.041396999030433  0.003031629472559 -0.064649337167924
-    3  (  3)  0.059287322502299 -0.004510597912865  0.001550787253983  0.026031838087948 -0.030781241595677  0.028268360125230 -0.056263472143293  0.012481413064923  0.018331852915645
-    4  (  4)  0.010310728455768  0.048004310504315  0.024726014802135 -0.029487545392420 -0.016798380655264  0.006146311288820 -0.193469287289224  0.016404156709459 -0.090545229018770
-    5  (  5)  0.048438874849073 -0.279911055793901 -0.091858080305683 -0.061529389949110  0.086013764646970  0.169909289190226  0.137573811978801 -0.079110070379465  0.068315894389439
-    6  (  6) -0.059086874754328 -0.080452543242778  0.072102486682582  0.152740972704247  0.124804294386305 -0.037562128266895 -0.116816705616042 -0.371092921921504  0.124060147180532
-    7  (  7)  0.029687956296635 -0.256142179942571 -0.224177989138016 -0.089126356257227  0.052538373002914  0.151219359570602 -0.169667778296547  0.210592113990055  0.060100313305223
-    8  (  8)  0.037809640230564  0.049847669441603 -0.131510551596478  0.073995987264147 -0.016613192275803 -0.085953668087854 -0.052289681067999  0.014235003810069  0.085573468377869
-    9  (  9)  0.334054043680738  0.062946651230341  0.131443841559570  0.090838578825240 -0.107669515927940 -0.163692131260888 -0.145222895910058 -0.104796708213769 -0.078942908507754
-   10  ( 10) -0.149544392295761 -0.318224503990855 -0.078211068857457  0.094418507207579 -0.062827781432203 -0.056112671791795  0.092070650285035 -0.118729407251681 -0.005066399630771
-   11  ( 11) -0.017252785597153 -0.111183203080125  0.114995811791783 -0.075235812067226 -0.042976611330520  0.083335038142330 -0.026013221761888 -0.060774659749613 -0.084239808865889
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.046526303364398
-    1  (  1)  0.000196633156806
-    2  (  2) -0.068136524138653
-    3  (  3) -0.003983938855648
-    4  (  4)  0.006861374242241
-    5  (  5)  0.130771416331255
-    6  (  6)  0.153069412317755
-    7  (  7)  0.016354872554726
-    8  (  8) -0.070442312778792
-    9  (  9) -0.084886961073099
-   10  ( 10) -0.034495414084981
-   11  ( 11)  0.039745136609744
-
-	DPD File2: P*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.007512480776319 -0.036140698221162 -0.006614016091629  0.006989344711517 -0.012538055579667 -0.047719007710800  0.011438854389831 -0.001348837643708 -0.043912417866150
-    1  (  1) -0.000217941106815 -0.023674382271911  0.074458985850499 -0.018669991150763  0.024216220760344 -0.026693268127322 -0.030529166464713  0.009220514907509  0.051390413902716
-    2  (  2)  0.018657169402382  0.000504863635670  0.063891633981927 -0.031237660505947 -0.009378378679164  0.057274634026543 -0.010216661924779 -0.007277876487311 -0.107239917659553
-    3  (  3) -0.016066164003828 -0.014293064557711  0.024640166827267  0.100199283130149 -0.053038409095112  0.079899101326132  0.014809180078406  0.008036171971183  0.093693488350467
-    4  (  4) -0.014907654111593  0.000249634614143 -0.129575540220445 -0.265751473143634  0.141781144259113 -0.223368583932083  0.004368931811378 -0.027043226757367 -0.062609693461921
-    5  (  5)  0.041914834745247  0.097616041138947  0.135770321463814 -0.246024098805421  0.106912109293501  0.321253251117319  0.068788844583990 -0.142290197287628  0.046076100892295
-    6  (  6)  0.039123394394723 -0.039408255038257  0.037211012657418  0.010312056024403 -0.060353960942951 -0.114209155992994  0.186728746530896  0.112616911396924 -0.025666796391066
-    7  (  7) -0.018468061945917 -0.067823974613178  0.190104823535190 -0.003755811520253 -0.014064572484241 -0.109658452638694 -0.056630665145805  0.263520506917883  0.064583476374394
-    8  (  8) -0.033210755622659  0.136136968498900 -0.263316618160002 -0.077412830589797 -0.422459728217546 -0.053553377730948 -0.034175715906935 -0.165897217652793  0.074779388344555
-    9  (  9) -0.055036749751630  0.056894038751104  0.107311287797063  0.058290191137784  0.056944188937166  0.005725850016316 -0.009926099968286  0.140696143209114  0.190545524907610
-   10  ( 10) -0.130997705273781  0.090153965609249 -0.007790248268810  0.054524064976066 -0.013947321007330 -0.034280119179197 -0.056585811356156  0.002663395414836 -0.003086708496419
-   11  ( 11) -0.024354529821742  0.002391484587850 -0.132211150437169 -0.155582434877820  0.034543780627935 -0.051588565499349  0.027770703760258 -0.083659992199369 -0.057647900826746
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.055482114656335
-    1  (  1)  0.000101235030463
-    2  (  2) -0.010234508711291
-    3  (  3) -0.213846558445248
-    4  (  4) -0.006630092722992
-    5  (  5) -0.012814259546957
-    6  (  6)  0.078975443650986
-    7  (  7)  0.184930804112230
-    8  (  8)  0.058689588477811
-    9  (  9) -0.044249382467578
-   10  ( 10) -0.036865706935893
-   11  ( 11)  0.030515341975517
-
-	DPD File2: P*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000120442405581 -0.037525975792407 -0.039028837738652 -0.219221358143393  0.183820180818448  0.112972286408530 -0.047240063409728 -0.020414149561154  0.034238085799271
-    1  (  1)  0.037241793728452  0.000047287882243 -0.009729516430168 -0.094202030077235  0.063477866953276 -0.160286164587806  0.109752667557022  0.131207263236284 -0.068887611832074
-    2  (  2)  0.038783295216622  0.009745201912242  0.000258217562465 -0.013038009614076  0.045399222161827  0.081371094984120 -0.019570499748086 -0.076966277295000 -0.058756671783764
-    3  (  3)  0.218771475127948  0.094047631347429  0.012728901107962 -0.000222898647350  0.006965466758731 -0.051483080000543 -0.001032959857400 -0.046617530443310  0.239873280201692
-    4  (  4) -0.183500005674293 -0.063741918250972 -0.045633149570229 -0.007771962048066  0.000752652425378 -0.016686259902744  0.006062931975271 -0.002941130184259 -0.039794941498885
-    5  (  5) -0.112922744463035  0.160447948543053 -0.080839610143832  0.052938181517924  0.014759035093032 -0.001963138533058 -0.004122965199026 -0.030082971847399  0.018688716203396
-    6  (  6)  0.047223957422349 -0.110045906731433  0.018982606895220  0.000425116658999 -0.006190502350060  0.005177802298965 -0.000459941844479  0.006641133881612 -0.015637294529107
-    7  (  7)  0.020258099631627 -0.130980408805956  0.076838250722457  0.047153827019528  0.001697177794538  0.030097214957006 -0.006397035656861  0.000314330689973 -0.000958762971255
-    8  (  8) -0.034242059158271  0.069241386609174  0.058253268615506 -0.239551778865238  0.041466100486767 -0.019183970473991  0.016012586324303  0.000462521772429  0.000639781016008
-    9  (  9) -0.110158178577256  0.043113630563978  0.067267974845207  0.106313996022487 -0.002243251219660  0.021517985932208 -0.002884772712544 -0.010112074041123 -0.004700729741936
-   10  ( 10) -0.070149397127063  0.040299222838292  0.154071817441956 -0.030869069243567  0.038016470293222 -0.011150694193011 -0.007490401305220 -0.020531677805594  0.003859946060401
-   11  ( 11)  0.176636225337744 -0.095095393142691 -0.195177688825668 -0.108802410559496  0.020149361123103  0.001298105635127 -0.020927308070429  0.032058427881699  0.018315736142454
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.110002482243441  0.070133081529118 -0.176505754583752
-    1  (  1) -0.042468765075500 -0.040212942886088  0.096465231599211
-    2  (  2) -0.066618057955858 -0.153916879455284  0.197045228959983
-    3  (  3) -0.105738247971788  0.031572929220209  0.109334469149534
-    4  (  4)  0.002665514835355 -0.037310624735359 -0.021518865524247
-    5  (  5) -0.022104060533187  0.008811719711463  0.005069793238862
-    6  (  6)  0.004143184140488  0.008777342033569  0.020657864679248
-    7  (  7)  0.010048741121033  0.019686189563806 -0.029679561142739
-    8  (  8)  0.004305480816755 -0.003474531743331 -0.021387666942059
-    9  (  9) -0.000592809919997 -0.021935245808500  0.003238719819323
-   10  ( 10)  0.019997593459389 -0.000606363597873 -0.056392578735375
-   11  ( 11) -0.002880485106043  0.055206554617854 -0.001235092281117
-
-	DPD File2: P*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000888157000468 -0.002604640035267 -0.004433898987700 -0.017327910307372  0.010855912598213 -0.001781915278721 -0.008615460934422 -0.004078735474285 -0.032557314773045
-    1  (  1)  0.000573161245420  0.000624628285884 -0.035628999167227  0.001815728764627 -0.008946874115813 -0.029170863803310  0.000115513436505 -0.008856710566910 -0.004031507153659
-    2  (  2)  0.003701039844373  0.036575536539622  0.001091193696307  0.032172216141300 -0.001275865950015 -0.022397487526299 -0.009622303363090 -0.007231877711175 -0.019725778025116
-    3  (  3)  0.016821693036289 -0.002844602963518 -0.032977853684673 -0.000161455575952  0.028542188119355 -0.026304537820681  0.001013466229083  0.013057607695183  0.044876693583426
-    4  (  4) -0.011431384588178  0.009478622864698  0.000774534739031 -0.028965078860221 -0.000058413694986 -0.014596515715548 -0.009143536386555 -0.018007246969037 -0.087822521777407
-    5  (  5)  0.001221856014832  0.030845996389588  0.023077706374501  0.025758114847142  0.014593714027409  0.000250583717006 -0.003873642475734  0.026298757281796 -0.079590541434343
-    6  (  6)  0.009743031224748 -0.000827857567403  0.008744416704428 -0.000735028308095  0.009056595663713  0.003266063160321  0.000168072469286  0.014668639254903 -0.020470938456272
-    7  (  7)  0.003647754834421  0.008460886211306  0.007264440669328 -0.013024018123218  0.017787838957003 -0.026317221009114 -0.014749296379031  0.000019923943455  0.029438703128615
-    8  (  8)  0.031026550181144  0.004477343275687  0.020769831071035 -0.045275173918403  0.088633054403976  0.080566188830968  0.020052483095054 -0.029483325674276 -0.000128037153401
-    9  (  9) -0.012269663364479  0.042319244263402 -0.071429692849981 -0.076602220709806 -0.093629733790147 -0.065554975939979 -0.020165870906458 -0.076547332424074 -0.015636093570251
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.012474935539863
-    1  (  1) -0.041072842913216
-    2  (  2)  0.070651080248399
-    3  (  3)  0.076892460848025
-    4  (  4)  0.093624677134694
-    5  (  5)  0.065506732660539
-    6  (  6)  0.019889038609582
-    7  (  7)  0.076305954221087
-    8  (  8)  0.015612091565202
-    9  (  9)  0.000252880154158
-
-	DPD File2: P*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009427979504735  0.045069494658558  0.001947285705090 -0.002710338034860  0.015522926834851  0.047663635028120 -0.012944383860693  0.002408628963511  0.046667839995062
-    1  (  1)  0.000029889909955  0.026801338329852 -0.080490862472698  0.019668739880126 -0.025396971257700  0.032890092829257  0.033906444326876 -0.009364690845122 -0.055325390015170
-    2  (  2) -0.013223768231853 -0.001284266713521 -0.066553348308937  0.032573816116206  0.011585258035685 -0.060717975924391  0.011936168857210  0.007853073890483  0.116794956739995
-    3  (  3)  0.012900769345878  0.013623437855550 -0.022570570921494 -0.105173709434029  0.056797034187850 -0.081144841159178 -0.016572432074935 -0.007712189870591 -0.096484218880683
-    4  (  4)  0.015650650711432  0.003889202049455  0.137621535484575  0.283731289627315 -0.151612143157194  0.236884111934266 -0.005136759708167  0.028125482384447  0.063101070821467
-    5  (  5) -0.049233650528213 -0.108628515589384 -0.145433760308553  0.264881634113210 -0.112823478790252 -0.343941453835902 -0.074580579832084  0.152217918461378 -0.050073263216128
-    6  (  6) -0.047771378538329  0.043773249125745 -0.042587468032780 -0.011128298856248  0.066617092775075  0.124136463076967 -0.204572752605319 -0.119847093573235  0.027500955272741
-    7  (  7)  0.017888279952241  0.071752886460858 -0.208298887916757  0.005542743128559  0.016702047381836  0.119479054133457  0.062994319192022 -0.283598496506144 -0.069642269402630
-    8  (  8)  0.037568403528376 -0.148073898852809  0.285205978681411  0.081955004515730  0.456336274750824  0.051315761340278  0.035910751818194  0.176384561285241 -0.080264248689634
-    9  (  9)  0.073735844540901 -0.063193611128899 -0.114658323070558 -0.062815237579419 -0.064185887519018 -0.009313244304943  0.011480973281939 -0.153753080425913 -0.207572044587912
-   10  ( 10)  0.162215796938684 -0.102608816758085  0.007760654943323 -0.059426107703524  0.013639971522339  0.037904077339461  0.064744743002174 -0.002349088500079  0.003377674546375
-   11  ( 11)  0.030714567047902 -0.017149469368505  0.148281723814033  0.168021936553750 -0.043219337814574  0.059348822268391 -0.027602295508655  0.090506279699096  0.064287335914591
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.058979846663424
-    1  (  1) -0.000234151433416
-    2  (  2)  0.011430006640806
-    3  (  3)  0.225608458896205
-    4  (  4)  0.014102875489979
-    5  (  5)  0.012200282245874
-    6  (  6) -0.083455375182168
-    7  (  7) -0.198201250764442
-    8  (  8) -0.062481817545980
-    9  (  9)  0.043390015833605
-   10  ( 10)  0.040973644943399
-   11  ( 11) -0.034098640710675
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.057027762100789 -0.007489633887342  0.036964189813796 -0.021384352100284  0.004867815775604  0.032130235858782 -0.019486973797962 -0.000503926514732 -0.024868986663351
-    1  (  1)  0.007883399599923 -0.007529104506445 -0.013216566770749  0.001554286609489  0.002481002458300  0.003555137440754 -0.020216878378801  0.003435265519663  0.003420680709423
-    2  (  2)  0.005061763911744  0.024005030999464  0.016920245291348 -0.019760528227158 -0.007759414271484  0.029231812106945  0.009559298232843 -0.004745878981161 -0.053662769962019
-    3  (  3)  0.011903086348447 -0.106154395386531 -0.048846797682958  0.038122834717736 -0.042076447151745  0.017515736018254  0.021695004377211  0.017259669010754  0.058953679400153
-    4  (  4) -0.086846706941042  0.161257530089836  0.037361255861875 -0.089905419413410  0.174437646387183 -0.071028892880315 -0.038811212273731 -0.045200518155063 -0.066894551440516
-    5  (  5)  0.295118954821928  0.042171667688274  0.057142717280935 -0.095328920031059  0.118376834610768 -0.017202604507056 -0.038088685926927 -0.015413673756028 -0.019970185142534
-    6  (  6) -0.061695197805604 -0.041447416246154  0.107874329349021 -0.009310856499629 -0.028327062477196 -0.072556054900044  0.031173831746629  0.093673016450942  0.096470656575707
-    7  (  7)  0.040164356283535  0.019606328824315 -0.022514162311588  0.103095269177578 -0.105738125414362  0.000251323240260  0.190667102998226 -0.014251172141516  0.042544347999407
-    8  (  8) -0.209747539729284 -0.026225521984115 -0.065411218317390  0.108576414051802 -0.195951046046893  0.054935351774023 -0.181062671358124  0.048648601818055  0.037403343457353
-    9  (  9)  0.029537922421234 -0.045187174636289  0.013381512217286 -0.049426415359509  0.003411235911782 -0.045265306723710  0.096457278821335  0.006113492494935 -0.044165814974043
-   10  ( 10)  0.026870929841946  0.010513244846490 -0.122411818973730  0.066300236331789 -0.074150921852319 -0.175359501999903 -0.025219490294838  0.031299023505132 -0.032770162927265
-   11  ( 11) -0.076638806040972 -0.048660864910506 -0.054798136469999 -0.067410404189619  0.096042680906718 -0.030077767167195 -0.040609376761651 -0.003350033647470 -0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007613623485115
-    1  (  1) -0.001053219582711
-    2  (  2)  0.054751844139672
-    3  (  3) -0.021588797011546
-    4  (  4) -0.069416579868176
-    5  (  5) -0.031311068013170
-    6  (  6)  0.060683491342485
-    7  (  7)  0.004937786560826
-    8  (  8)  0.055843386605960
-    9  (  9)  0.053258374332423
-   10  ( 10)  0.029326398375861
-   11  ( 11) -0.027904630917537
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000025015734507  0.010198711087952  0.006474775958448  0.066946051563528 -0.066550206967977 -0.041188873125926  0.023552914991952  0.019202263160422 -0.006942946197737
-    1  (  1) -0.010140605887652 -0.000014394957877  0.022996796061328 -0.067092192493274  0.063685673857393  0.019093615376604 -0.005525180617760 -0.015031464830750  0.005320182556269
-    2  (  2) -0.006534739001904 -0.022969584694137  0.000183457658640 -0.211551326757209  0.218187807438925  0.104132114893528 -0.065436658246811 -0.042103919182146 -0.012243831904844
-    3  (  3) -0.066304931943444  0.066584833979085  0.210703888875489 -0.000394093515089 -0.011258600581601 -0.092530428436357 -0.131881992071255  0.026480578605083  0.063346368194022
-    4  (  4)  0.065779542430873 -0.062822415172501 -0.216601239538476  0.011617389043850  0.000720555249011  0.020159848057855  0.073942431465134  0.001119920964031  0.016120241216710
-    5  (  5)  0.040846799691504 -0.018979734118351 -0.103125251405654  0.092549855601907 -0.021623501291584 -0.000771447754999 -0.234552119202209 -0.000611164043666 -0.101606719343242
-    6  (  6) -0.023326218450828  0.005550385111505  0.065252405074981  0.131681855193961 -0.073575257938565  0.233645237851028  0.000193851682480 -0.255788429172446  0.079072823032341
-    7  (  7) -0.019055068515462  0.014786531642521  0.041539856986611 -0.026353850726780 -0.001700683540838  0.000445480591706  0.255766070671258  0.000118381893033 -0.151562772366571
-    8  (  8)  0.006620321009197 -0.005142966830662  0.011245852682541 -0.062510776113309 -0.015648596901915  0.102272652360209 -0.078381794853266  0.152302821501449 -0.000094469957927
-    9  (  9)  0.045347281960025 -0.040291069791943 -0.085226922335689 -0.018441757598111 -0.027467525239214 -0.004932928889320 -0.020868912898856  0.024483356625930  0.224180460199113
-   10  ( 10)  0.020374790573784 -0.028198954860440 -0.010392111666997 -0.120181326176130  0.060512260831236  0.109015894697222  0.047153104465120  0.043944046420833  0.103069326885495
-   11  ( 11) -0.049408052352300  0.045270280246414  0.110185553685008  0.041594160321979  0.088273360930753 -0.183934249639257  0.003285919080508 -0.178701510068243  0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.045673042542890 -0.020717466986083  0.050844518832522
-    1  (  1)  0.040043621408487  0.028287827625151 -0.045457031631407
-    2  (  2)  0.084888848710605  0.010052611398803 -0.109898373773783
-    3  (  3)  0.018088362425205  0.120534313520650 -0.041770057803413
-    4  (  4)  0.026789230886550 -0.060849702419905 -0.088673365261613
-    5  (  5)  0.008004711197727 -0.108432873838655  0.185071361149961
-    6  (  6)  0.020116775504235 -0.047889712574718 -0.001523439225442
-    7  (  7) -0.023964360822185 -0.043618854823263  0.177454217319223
-    8  (  8) -0.226734396044438 -0.102481459206944 -0.008115223439087
-    9  (  9)  0.000423083368406  0.309060226547434 -0.090400550219427
-   10  ( 10) -0.308249178857435  0.001017567434936  0.330623886780632
-   11  ( 11)  0.090136758927266 -0.334530610017321 -0.000453348817603
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000379496190680  0.036516557673727 -0.022488411844201 -0.041143099111719  0.015151024607555 -0.009820525598214 -0.001328546168408  0.002719718233480 -0.079787685858295
-    1  (  1) -0.035173743352485 -0.000509376348503  0.021748140811100  0.018984912310085  0.002571720003760 -0.101540537848848 -0.014107119535580 -0.020961802105584 -0.100916916558314
-    2  (  2)  0.024420430259890 -0.020833264343634  0.000589210441902  0.028690810435666 -0.025063562199365 -0.056845698692633 -0.019362765266970 -0.000534124800005 -0.061230653902760
-    3  (  3)  0.039980341452345 -0.019929624233720 -0.028127725164783 -0.000384377200086  0.012223469426354  0.007870420436516  0.021500821930750 -0.002985124038023  0.055850425927213
-    4  (  4) -0.015033200445576 -0.003096204403696  0.023799943458502 -0.011898049659739  0.000036971633887 -0.000277032322295 -0.021239662546675  0.005095064856192 -0.060237805990277
-    5  (  5)  0.010708008535887  0.101587409014600  0.056660431011914 -0.007350368054025 -0.000126941263904 -0.000065704202214  0.008506831299188 -0.011228150905342 -0.011964202302477
-    6  (  6)  0.000469087338482  0.014200163610075  0.019097267233085 -0.021632296910845  0.021392214011008 -0.008495741848254 -0.000109627873962  0.021812533614874  0.020464844726232
-    7  (  7) -0.002889338898616  0.020632474935553  0.000453752095144  0.002975803626006 -0.005037506724376  0.011335159213681 -0.021733393798695  0.000007087204356  0.019955598928897
-    8  (  8)  0.081293710509515  0.100918057466141  0.060971767857812 -0.055875536861090  0.060631757745431  0.011264467031019 -0.020209151997608 -0.020081495210629 -0.000340983773767
-    9  (  9) -0.080516503167305  0.106262951221757  0.031461397073353  0.007056184146683 -0.022432192781915 -0.017093833942137 -0.097099983466552  0.001349018368294 -0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.079753101670227
-    1  (  1) -0.106710217482987
-    2  (  2) -0.031619499292907
-    3  (  3) -0.007164069356259
-    4  (  4)  0.022223903647397
-    5  (  5)  0.017462464724719
-    6  (  6)  0.096957045420818
-    7  (  7) -0.001243112172754
-    8  (  8)  0.004611313750592
-    9  (  9)  0.000252169760563
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055343853322395  0.005338522209203 -0.036325792187091  0.020411379114398 -0.005004472559017 -0.030883540419705  0.019693764112942  0.000404480716013  0.025396203204216
-    1  (  1) -0.006570683600848  0.008768421568488  0.011573795638563 -0.000009175751903 -0.002770565739659 -0.004931208897901  0.022163570789429 -0.003290104656908 -0.003254936700297
-    2  (  2) -0.001674419203277 -0.021967102120902 -0.025831824909554  0.024758928994745  0.009340908203812 -0.034459015755376 -0.010228225914487  0.005919790861067  0.058115699230390
-    3  (  3) -0.007779977639509  0.106141218473434  0.050482163293278 -0.041812559908941  0.042606909564863 -0.016938249582167 -0.022723831963497 -0.018285942873731 -0.061788101761112
-    4  (  4)  0.087397972334062 -0.164590469335859 -0.035983465272717  0.095460926704216 -0.183399304764373  0.073380967092300  0.038295030471351  0.047026058194857  0.066959437295317
-    5  (  5) -0.293750190777910 -0.042648437038433 -0.056404874075468  0.100193237694056 -0.123782490033077  0.014652582564902  0.036251400704161  0.016769125982848  0.023410414575794
-    6  (  6)  0.063526410041118  0.042202406515953 -0.107158367449000  0.011222400592515  0.032805848689894  0.070775222023081 -0.034269417179590 -0.097599209765295 -0.095048599779477
-    7  (  7) -0.039213631545190 -0.016300797142278  0.022834925899151 -0.106699749704471  0.109813770660251  0.000567880224415 -0.192962587636570  0.013162275101134 -0.042958800457043
-    8  (  8)  0.207671023275567  0.021761663181296  0.066317329893717 -0.113575721461044  0.208505431005016 -0.053139089145086  0.182387663583988 -0.049317657695772 -0.039898751560786
-    9  (  9) -0.031717525025615  0.035452316963842 -0.019040840253717  0.049757955126745 -0.003315672276934  0.048439544916052 -0.094357742781682 -0.007725852797236  0.042206115018339
-   10  ( 10) -0.030723138202058 -0.012685537900520  0.130253036286197 -0.070878549267589  0.073822499716479  0.176856315004232  0.024096584449109 -0.033980770130198  0.029602022179569
-   11  ( 11)  0.076338046412608  0.058007647538535  0.059625157558161  0.072355446358478 -0.100714683926583  0.028164062896195  0.037103331661254  0.004159802100780  0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007837140573608
-    1  (  1)  0.001271351061977
-    2  (  2) -0.056316152671545
-    3  (  3)  0.023558705106194
-    4  (  4)  0.071677402926291
-    5  (  5)  0.031036091810970
-    6  (  6) -0.060669139129724
-    7  (  7) -0.008329217020035
-    8  (  8) -0.058082899762783
-    9  (  9) -0.050026765138378
-   10  ( 10) -0.030419330923301
-   11  ( 11)  0.028289350786073
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010782784489972 -0.013050845930128 -0.033023155215664  0.015191714992095 -0.005425132814901 -0.026116394662957  0.007256800612108 -0.004570990183776 -0.083505985646911
-    1  (  1)  0.004775248888120  0.019609050610054 -0.043741880650327  0.000073954161324 -0.027319440587928  0.081090619324759  0.046094626593374 -0.004371816989341 -0.079334747598806
-    2  (  2)  0.007829067250874  0.005611745899100  0.069924533643314 -0.039501674728206 -0.000927353784976  0.005421401951033  0.003817544999769 -0.008629946885833 -0.093259618314415
-    3  (  3) -0.018327078243591  0.003795046417131 -0.017900293895817  0.029796535142542 -0.026342994062962 -0.087573876827112 -0.029918989049988  0.054199220040285  0.044809777400716
-    4  (  4) -0.027183503470872 -0.089536481638857 -0.084857160463068  0.036527297001861  0.242538124561929  0.016430382958973  0.030531081573579 -0.170538311757182 -0.261658379411546
-    5  (  5)  0.020462782587523 -0.074168804451800  0.167834230231717 -0.149604127852478  0.243854217657690 -0.044978789492557 -0.032478673883371  0.164731310430024 -0.003040851330374
-    6  (  6)  0.075422914773902 -0.018345498918631 -0.109883881828728  0.119442941495868 -0.084779039670754  0.177672686986939 -0.254932779745392 -0.179910297504286 -0.058420300218360
-    7  (  7)  0.077293940205111  0.171942167313393 -0.155379720343131  0.213627786676900 -0.203405159942268  0.435742440136601  0.116233082588661 -0.403785601702878 -0.048376113482094
-    8  (  8)  0.113887453356696 -0.134815689960008  0.121289875435757  0.381302435842573 -0.140362613154441 -0.094837304770689  0.044125422076338  0.354102164255088 -0.021060221761777
-    9  (  9) -0.010381942177856  0.091513821594073 -0.090489398632436  0.104640269057990 -0.011526746486386  0.174325672883320 -0.095096801177535 -0.162567420891194  0.086584233440007
-   10  ( 10) -0.046140785323826  0.004506559121454  0.092261546126996 -0.049590165687623 -0.056546117609635 -0.023211770714739 -0.114566901687301  0.007355072527000 -0.045260763292278
-   11  ( 11) -0.210277389085871 -0.043479475791959  0.002620356919958  0.027295607176521  0.213582758279457  0.049406759718245 -0.038753842401848  0.045549481042434 -0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.000588783769111
-    1  (  1) -0.095074877441065
-    2  (  2)  0.094269658052775
-    3  (  3)  0.087042465113366
-    4  (  4) -0.229147969925312
-    5  (  5)  0.037090740492870
-    6  (  6) -0.008539965499391
-    7  (  7) -0.114631280540035
-    8  (  8)  0.035100938386537
-    9  (  9) -0.119410852550345
-   10  ( 10)  0.048938543804445
-   11  ( 11) -0.026842233365654
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000083177655875 -0.020596022225207 -0.023074380682109 -0.123906982660277  0.115856799969175  0.077548996218664 -0.033724258035794 -0.015583195761424  0.055304180213594
-    1  (  1)  0.020496643104719 -0.000177442053919  0.044849161409626  0.200056054082230 -0.192734988239744  0.095810846356379 -0.089592000858118 -0.154865722471105  0.062884487656521
-    2  (  2)  0.022893568520427 -0.044914234916282  0.000286887581780 -0.110147204900385  0.098101481651214 -0.037544614577033  0.063107876559817  0.057867129267241 -0.133662561842804
-    3  (  3)  0.123637708691857 -0.200030347190693  0.110276511900212  0.000067254700333 -0.150932238527093 -0.295587503177329  0.155559256339819  0.250191288225748 -0.068514494250419
-    4  (  4) -0.115217909263092  0.191910599591419 -0.098719023514077  0.150564412486325  0.000108066296459 -0.207017027157466  0.092817557275927  0.119727699718554 -0.027839136386995
-    5  (  5) -0.077201349586182 -0.095637330323257  0.037580888266386  0.296037283435946  0.206488013849544 -0.000677656990837  0.030142059938078  0.107860538698997 -0.317965442908009
-    6  (  6)  0.033520398034563  0.089301712720516 -0.063135446629119 -0.155494983890111 -0.093120397549751 -0.029958661714230 -0.000263665833745 -0.031787895548351 -0.052772032197117
-    7  (  7)  0.015173638148760  0.154650785159269 -0.057964322733043 -0.249885773107303 -0.119546085272213 -0.107827018648257  0.031752436246544 -0.000037065640674 -0.211400361545441
-    8  (  8) -0.055452136609395 -0.063704146851438  0.132109776961381  0.067534716804367  0.027512182553154  0.319330567201196  0.051501501228049  0.211684727134552  0.000062825592229
-    9  (  9) -0.059987775905021  0.059013360455393  0.001731139538261 -0.025602282087959  0.077406198911912 -0.032289392048789  0.044673931971007  0.007013222782529 -0.205272148471903
-   10  ( 10) -0.040816969333319  0.029839999727295  0.097606908985792 -0.012730679444132 -0.052120800982420 -0.047092545087938  0.097199457935824 -0.008100744465293  0.194519063749344
-   11  ( 11)  0.105565276750546 -0.086850909183234 -0.141349531156014 -0.064538795649442 -0.048769909889220  0.098670307723293 -0.132937762954191  0.091749745952861  0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.059727136016838  0.040967341903913 -0.106287777222309
-    1  (  1) -0.058687758282915 -0.029394471353826  0.086811620398375
-    2  (  2) -0.001293940264555 -0.097641591345113  0.142636172226853
-    3  (  3)  0.025821629306306  0.013207208477272  0.063793857996761
-    4  (  4) -0.076409112526474  0.052575212530451  0.047414860037356
-    5  (  5)  0.032527517350565  0.045632421732577 -0.095160623491729
-    6  (  6) -0.044231942651703 -0.096152133696301  0.132935625343693
-    7  (  7) -0.007372100254253  0.008488811567739 -0.092713079820202
-    8  (  8)  0.206938183650805 -0.192802275414426 -0.052611900153123
-    9  (  9) -0.000608554890156  0.088592533061698 -0.344380743508036
-   10  ( 10) -0.088950131298492 -0.000863284429953 -0.222751022723935
-   11  ( 11)  0.341005102874300  0.224718204882492 -0.000326394311109
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000338557997552  0.011375035743392 -0.029451193209236  0.012043586883828  0.021579660859347 -0.039033326019946  0.009990415550092 -0.009478976983628  0.045907412693585
-    1  (  1) -0.013672223167698  0.000473657715584  0.014851568055555 -0.021895587564371  0.022163590605075 -0.051246172607775 -0.019257625103746 -0.003658602851281  0.019552361048058
-    2  (  2)  0.032608942325713 -0.014402827198054  0.000746991250603  0.029107751732300 -0.054720608245644 -0.057033646383303 -0.001872360780591  0.031698780852448 -0.056602981887733
-    3  (  3) -0.014268935231542  0.021459967996182 -0.030313065636317  0.000730068456009  0.016766656065195  0.058973632357354  0.003002419788061 -0.022431580465626  0.134333948620083
-    4  (  4) -0.022372891038515 -0.021355779916377  0.052959509294565 -0.015751198634933  0.000391938857969  0.016109226068828 -0.004538544158672  0.050308920012661 -0.059340919102150
-    5  (  5)  0.040216234763810  0.051875751817174  0.055849318880052 -0.058120412757832 -0.016460961175898 -0.000645475334216 -0.019024299026328 -0.068804307634402  0.024311188622736
-    6  (  6) -0.009930727984206  0.019074682595569  0.002242770131548 -0.003091320851947  0.004596281406168  0.019032186967740 -0.000074596378968 -0.032870219636189  0.006741182978715
-    7  (  7)  0.009279418369258  0.004264018479381 -0.032087681361723  0.022624894165436 -0.049954824766487  0.068907285150032  0.032867640818893  0.000029995356356  0.011652937852273
-    8  (  8) -0.047260005865874 -0.018493502167014  0.056736132845076 -0.135589678169431  0.059916509278318 -0.024164421049794 -0.007333544303120 -0.011763030881780  0.000264400142459
-    9  (  9)  0.016875007958598 -0.031435494057685  0.089048257959160  0.041017085631602 -0.020420285065562 -0.066513023484078 -0.000739604154969  0.091958006244489 -0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.016438561460291
-    1  (  1)  0.031819705279686
-    2  (  2) -0.089217438029428
-    3  (  3) -0.040553914705774
-    4  (  4)  0.020554472275814
-    5  (  5)  0.066048736736302
-    6  (  6)  0.000688806170902
-    7  (  7) -0.091248940256931
-    8  (  8)  0.027663919394381
-    9  (  9)  0.000090314260367
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.011888856297006  0.017750932125153  0.030381401096490 -0.012819546160996  0.007239420422718  0.024248756043407 -0.008035757610220  0.005364063357974  0.085646323747472
-    1  (  1) -0.005014728223890 -0.026640078285976  0.053625852742063  0.001580773154934  0.029513947501511 -0.084681976949646 -0.049070075720108  0.003015931693788  0.083533135335069
-    2  (  2) -0.005701802857788 -0.001861436552455 -0.077309348516175  0.039227298256145  0.002806617492516 -0.004668173879327 -0.004051055445085  0.009725469213679  0.098722432349714
-    3  (  3)  0.016358351457124  0.001723600627698  0.021225514928062 -0.039815087581337  0.022808569998795  0.104140287911999  0.033233738030323 -0.056382556071864 -0.046907957767316
-    4  (  4)  0.023138877563353  0.095098707280146  0.087666288227931 -0.037561492255805 -0.255193211004254 -0.015544572331716 -0.030557402755123  0.180093964112144  0.259856355700386
-    5  (  5) -0.024228572043234  0.082834757201086 -0.181139504221043  0.153944959591839 -0.252818375021614  0.048862178579716  0.036094966909273 -0.170640955267472  0.004551713568432
-    6  (  6) -0.085402345559358  0.022737485412840  0.117389155338347 -0.122686430467103  0.089994929534087 -0.186662776489157  0.276334552924253  0.188945818003174  0.062512631958960
-    7  (  7) -0.077377916753636 -0.184413390881742  0.161635032551528 -0.217081818449181  0.216158931990711 -0.452250331823368 -0.121365143499215  0.427486936599919  0.051141830029037
-    8  (  8) -0.109996402529651  0.145159792225805 -0.137471198251747 -0.396423044911114  0.145941263905056  0.104134158957014 -0.041227108112442 -0.369426049626710  0.017681253264412
-    9  (  9)  0.015271329763023 -0.091667642816572  0.093167229349338 -0.105178289783052  0.012072216330151 -0.184888670947420  0.104021366500691  0.173041839821099 -0.089774142402176
-   10  ( 10)  0.051871879465497 -0.004911726396439 -0.095027344602311  0.050235453581707  0.056755121586123  0.023277306660177  0.123771404812450 -0.008953154661311  0.042342746566353
-   11  ( 11)  0.213874614633354  0.038620645156941 -0.003918905035704 -0.027644952213642 -0.227437070959628 -0.047768116418487  0.043243210008693 -0.046251908849224  0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001231945309971
-    1  (  1)  0.099118498855930
-    2  (  2) -0.099462956417043
-    3  (  3) -0.089788110354890
-    4  (  4)  0.236379406660322
-    5  (  5) -0.043290372964682
-    6  (  6)  0.008471875583563
-    7  (  7)  0.118429426587662
-    8  (  8) -0.041151812398786
-    9  (  9)  0.121668252978460
-   10  ( 10) -0.047795297768532
-   11  ( 11)  0.026000603113831
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.092723408151075  0.057215092134940  0.054154926215137 -0.012957083117559 -0.028122190094715 -0.031179347218855 -0.013645641371598 -0.009921258172339 -0.037242536390232
-    1  (  1) -0.019990430092613  0.002382806987559 -0.016009786257367 -0.011651136664597  0.017212414198990  0.024265249236370 -0.152443472946687  0.006755616148329 -0.024207249541319
-    2  (  2) -0.009030755895234 -0.085216520460363  0.016500441499831  0.009813164947617  0.015713678712422 -0.028373503652355  0.075877310310795 -0.039590492962937 -0.081270933339189
-    3  (  3)  0.075043611755008  0.103608833794547  0.030676505925522  0.013143510199953 -0.006187488557257 -0.045202449901574  0.041605892889482  0.001210820793539  0.045033631139440
-    4  (  4)  0.122337112724117  0.176460576265088  0.085321001863374 -0.041690733440160  0.111448222796030 -0.083092300673138  0.094252463151414 -0.071551603610925 -0.059851091994803
-    5  (  5) -0.372712635775664 -0.109553572239785 -0.087636097688831 -0.161393941368917  0.091711881285738  0.083559837956631 -0.084048684818413  0.114275654348762 -0.004760374961166
-    6  (  6) -0.030431995544059  0.095321795210779 -0.159145740022025 -0.376304340373359 -0.189004479350399  0.100683798175242  0.128902751762968  0.567857709085750  0.002399331341204
-    7  (  7) -0.344039522571259 -0.114279634125077 -0.003626426979965  0.177981236436906  0.027932329764501  0.026442462397652  0.246808699479261 -0.268819164710932  0.106523620842343
-    8  (  8) -0.111643207885322 -0.002836247769573  0.018154026503924  0.097243438328650 -0.121498121615664 -0.006682650130485 -0.107315976978454  0.036939727738377  0.063237979028415
-    9  (  9)  0.063921675215150  0.215994652248761  0.065707412514049 -0.003935136905129 -0.142641982827575 -0.026699050855783  0.056962954862571  0.164747861484427 -0.081509018515780
-   10  ( 10) -0.058030998072116 -0.060474289846612 -0.205628226890442 -0.038897333798042  0.068097699807560  0.116172285533776  0.038858694654200  0.255643829382515 -0.001247633054968
-   11  ( 11) -0.085574013220044 -0.030726962638802 -0.008247473867838 -0.106409310393215  0.064469816287686  0.072180462194277  0.022620356444758  0.070649638629627 -0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015293746360799
-    1  (  1) -0.020176832366409
-    2  (  2) -0.007468634139779
-    3  (  3)  0.002013486296780
-    4  (  4) -0.055907379643807
-    5  (  5) -0.014548062338959
-    6  (  6) -0.210557719542813
-    7  (  7)  0.107773752705760
-    8  (  8)  0.004939471027833
-    9  (  9) -0.101796072438763
-   10  ( 10) -0.052197801100809
-   11  ( 11)  0.010791942309942
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000245185765728  0.004422769142209  0.195473142624697 -0.067124189998810 -0.027096370068160 -0.099320185873800 -0.032910569428743 -0.079494520674282  0.016762710819247
-    1  (  1) -0.004388313593185  0.000165290846899 -0.188129406432792  0.063756474949075  0.001128748240139  0.126263116741295  0.303817994309096 -0.069854530583820 -0.010310792522154
-    2  (  2) -0.194444327410373  0.187906024270824 -0.000538868177065  0.115697813615881  0.188025580722992  0.063555095149569 -0.109038200896130  0.123360187528163 -0.037347597176070
-    3  (  3)  0.066590814481336 -0.063203632987523 -0.115347217679990  0.000002301796994 -0.034584588669551 -0.038983157581533 -0.229948513873159  0.131721887952800  0.028384936970778
-    4  (  4)  0.026403437308072 -0.000527986476725 -0.186677671985474  0.034818437947430  0.000320297338463 -0.037865478650564 -0.201451121997014  0.109301689008128  0.005643097026329
-    5  (  5)  0.099409584232992 -0.126346592032007 -0.064419008019557  0.039794220656347  0.036855903902447  0.000190318965932 -0.088891480212760  0.056789849447140 -0.091073030281233
-    6  (  6)  0.033050985013878 -0.303259624681304  0.108281756633666  0.230173439372417  0.201331671706094  0.089930560146314  0.000311452672695  0.221067383348441  0.053494283573947
-    7  (  7)  0.079472710309908  0.069297203366025 -0.125033677339702 -0.131451975782708 -0.110125569334720 -0.054839641157466 -0.219945401741596  0.001085047372961 -0.089073871816377
-    8  (  8) -0.016952142014388  0.010421932566239  0.036927801153181 -0.027792238689701 -0.005351459000165  0.090892785458666 -0.052690955519676  0.088985197141446  0.000032698621213
-    9  (  9) -0.149061020700740  0.058621114959186  0.279965277538519  0.021488283829580  0.044200621925698  0.026904718590704  0.074208134755608  0.037354078157659  0.137372829291651
-   10  ( 10)  0.035190315077894 -0.050814828300922 -0.151303785089698  0.062867991520111  0.077053666036856  0.075037906181509 -0.133385625358484  0.006791369727277  0.121764957568739
-   11  ( 11) -0.016457666688676  0.009560970830020  0.030160709068648  0.052615429880776  0.007184814870880 -0.147317585107930 -0.048007656104932 -0.024985856634055  0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.149527127949477 -0.035025203143730  0.017236912650706
-    1  (  1) -0.058313378902528  0.050420942142557 -0.009474518218355
-    2  (  2) -0.278325755481738  0.150562770304950 -0.029989264213428
-    3  (  3) -0.020585218415975 -0.063268588986747 -0.052977667343551
-    4  (  4) -0.042114256624995 -0.077316775027134 -0.007960467665663
-    5  (  5) -0.031625284755674 -0.074462306356205  0.148447086799088
-    6  (  6) -0.074615124808937  0.133170285550522  0.049651682674137
-    7  (  7) -0.041592449377408 -0.005910763914811  0.024358506166719
-    8  (  8) -0.138294110971387 -0.121744291260784 -0.107918344276425
-    9  (  9)  0.001133592488713 -0.474400799155993 -0.192590673354496
-   10  ( 10)  0.472105353620486  0.001334835966633  0.192285927563244
-   11  ( 11)  0.191497735915320 -0.194932828964948  0.001344945845524
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000738836304181 -0.037293198581408 -0.029451404620807  0.009378792471894 -0.055701113540954  0.035128933511984  0.013954700067714  0.072836702551235 -0.051857122483535
-    1  (  1)  0.032660614374695 -0.002015876922290 -0.074058480716263  0.021479421330690  0.014966422603257  0.166979967788261  0.013073252080067  0.022556560940623  0.170972365950935
-    2  (  2)  0.029165553040464  0.073308940131147 -0.000753195727027  0.033014777438001 -0.000651481686764  0.016615463822703  0.030045410532860  0.013342873064028  0.078343409399381
-    3  (  3) -0.010384415064446 -0.021326871974424 -0.031305865808474 -0.000583541727095  0.005150844265660  0.010972964083321  0.024667426696971 -0.003421011953857  0.027197309287279
-    4  (  4)  0.055501401866642 -0.014297660722118  0.000710544848112 -0.005493793084614  0.000124683940717  0.025126510553785  0.000947638436962  0.017069455654223 -0.023650915169846
-    5  (  5) -0.033803616927021 -0.164339399892725 -0.017068168082329 -0.010030727560507 -0.025241735580020 -0.000735433014139  0.028603795353780 -0.023029380344413 -0.027599055296252
-    6  (  6) -0.013107540346806 -0.012828435687407 -0.030286401438565 -0.024713021163335 -0.001063605161759 -0.029296491836886  0.000025149030498  0.111104514389532 -0.102861376746943
-    7  (  7) -0.072733387901303 -0.022465577956558 -0.013436829086647  0.003433808737295 -0.017048766876852  0.023125015384758 -0.110934303358415 -0.000037875914124 -0.002935696551342
-    8  (  8)  0.053267672687232 -0.170660201820078 -0.076657788504288 -0.028160893222526  0.023606436991553  0.027690933408034  0.102626814241324  0.002887530223588 -0.000373637330912
-    9  (  9) -0.004804828900057 -0.224333052817770 -0.065186758028368 -0.004091068046870 -0.039040275694483  0.042976408882840  0.051197675519228  0.024101682646066  0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.005026329948406
-    1  (  1)  0.225373696682354
-    2  (  2)  0.064686362479745
-    3  (  3)  0.004567750792129
-    4  (  4)  0.038996417519414
-    5  (  5) -0.043485644851561
-    6  (  6) -0.051601626537389
-    7  (  7) -0.023715023759407
-    8  (  8) -0.001115391080639
-    9  (  9) -0.000048164004682
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.087860740756488 -0.068261038905906 -0.057593788019307  0.011454237083441  0.027305499289367  0.032385982368371  0.018173477269549  0.009363386608796  0.038732450559880
-    1  (  1)  0.013249632151170  0.004184657414979  0.019716507976896  0.014744696478638 -0.016703323694180 -0.027386275287573  0.163732376866413 -0.007136524293248  0.024482820661864
-    2  (  2)  0.007013218896085  0.084657964294727 -0.026004205374563 -0.008076798202963 -0.011641159214614  0.031112856231507 -0.081756432692912  0.043486513055778  0.085001128307205
-    3  (  3) -0.058477500387638 -0.110048615847953 -0.032104075685968 -0.014807417786102  0.004697674213231  0.048123068402958 -0.048143599431998 -0.000645092439839 -0.047260089330542
-    4  (  4) -0.110574498742467 -0.188131348104213 -0.086636459451987  0.041361686502598 -0.118556992954628  0.089270642674348 -0.104552978829704  0.075153301656795  0.057940099039356
-    5  (  5)  0.371487279658724  0.115772941053656  0.094845419594772  0.167070991238391 -0.094497706414686 -0.087134798346335  0.079465840043241 -0.119932858558240  0.004312964076576
-    6  (  6)  0.035255689937620 -0.112028499449997  0.168145842580037  0.392683527257363  0.194284650981365 -0.110254467391126 -0.135773335198962 -0.599025983356266 -0.001116295743642
-    7  (  7)  0.362602042970953  0.115938705836042 -0.002852393959785 -0.186519834338995 -0.026972926522319 -0.023780474127448 -0.271135694461778  0.284033125501378 -0.111247570725030
-    8  (  8)  0.111196944464455  0.001239941376560 -0.021205830532168 -0.101329748088148  0.128975240085324  0.010144197632550  0.108358474715393 -0.037918096280026 -0.066572090545295
-    9  (  9) -0.090967744709768 -0.211201922436275 -0.066377513424381  0.007899083102241  0.154707771160094  0.037980948657754 -0.073559352539101 -0.172041273327275  0.087426840520207
-   10  ( 10)  0.070112475488657  0.079061926736069  0.222919508358954  0.040775801294398 -0.061424635747658 -0.113162621408555 -0.037903862973014 -0.270692474130444  0.009570796789139
-   11  ( 11)  0.090924578792926  0.040585886130445  0.000311072794648  0.117174234675791 -0.063663959894116 -0.077941781302743 -0.027645133174923 -0.073495241874676  0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015882565008118
-    1  (  1)  0.020403231736073
-    2  (  2)  0.007241270504095
-    3  (  3) -0.003144444710549
-    4  (  4)  0.058793064689134
-    5  (  5)  0.012293150809123
-    6  (  6)  0.215177196230389
-    7  (  7) -0.113635102585609
-    8  (  8) -0.004824845555481
-    9  (  9)  0.113550918048735
-   10  ( 10)  0.063789409560574
-   11  ( 11) -0.007009974437012
-
 	Computing Mu_X-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.846356606609
-	   1        18.555074266671    6.643e-01
-	   2        22.075193066305    2.999e-01
-	   3        22.166162582675    4.438e-02
-	   4        22.198725038235    1.790e-02
-	   5        22.196883805714    4.917e-03
-	   6        22.195656618255    1.496e-03
-	   7        22.195974558760    5.316e-04
-	   8        22.196061063112    1.890e-04
-	   9        22.195992155624    8.373e-05
-	  10        22.195966503337    4.271e-05
-	  11        22.195979843169    1.924e-05
-	  12        22.195997191192    5.833e-06
-	  13        22.196002010796    1.779e-06
-	  14        22.196003096576    6.978e-07
-	  15        22.196002913692    2.475e-07
+	   0        13.846356476046
+	   1        18.555074079128    6.643e-01
+	   2        22.075192821211    2.999e-01
+	   3        22.166162335795    4.438e-02
+	   4        22.198724790433    1.790e-02
+	   5        22.196883557838    4.917e-03
+	   6        22.195656370422    1.496e-03
+	   7        22.195974310923    5.316e-04
+	   8        22.196060815271    1.890e-04
+	   9        22.195991907784    8.373e-05
+	  10        22.195966255497    4.271e-05
+	  11        22.195979595329    1.924e-05
+	  12        22.195996943353    5.833e-06
+	  13        22.196001762957    1.779e-06
+	  14        22.196002848737    6.978e-07
+	  15        22.196002665853    2.475e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 9.655e-08
 
 	Computing P*_X-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.327923016308
-	   1         5.713365186365    3.414e-01
-	   2         6.643711732224    1.449e-01
-	   3         6.665433458137    2.025e-02
-	   4         6.671659819928    8.438e-03
-	   5         6.671393446175    2.810e-03
-	   6         6.671182917163    1.003e-03
-	   7         6.671299575317    4.184e-04
-	   8         6.671336401077    1.589e-04
-	   9         6.671320127264    5.791e-05
-	  10         6.671317562841    2.040e-05
-	  11         6.671321498177    7.103e-06
-	  12         6.671325190181    2.442e-06
-	  13         6.671326361431    1.009e-06
-	  14         6.671326629087    5.171e-07
-	  15         6.671326471682    2.427e-07
+	   0         4.327923041014
+	   1         5.713365215315    3.414e-01
+	   2         6.643711759595    1.449e-01
+	   3         6.665433485270    2.025e-02
+	   4         6.671659846941    8.438e-03
+	   5         6.671393473165    2.810e-03
+	   6         6.671182944156    1.003e-03
+	   7         6.671299602307    4.184e-04
+	   8         6.671336428065    1.589e-04
+	   9         6.671320154253    5.791e-05
+	  10         6.671317589830    2.040e-05
+	  11         6.671321525166    7.103e-06
+	  12         6.671325217169    2.442e-06
+	  13         6.671326388419    1.009e-06
+	  14         6.671326656075    5.171e-07
+	  15         6.671326498670    2.427e-07
 	-----------------------------------------
 	Converged P*_X-Perturbed Wfn to 9.772e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         1.993082407700
-	   1         2.661926789841    2.285e-01
-	   2         3.125160542473    1.040e-01
-	   3         3.153871273451    1.965e-02
-	   4         3.155350925518    5.736e-03
-	   5         3.155148466774    2.268e-03
-	   6         3.155339561298    5.752e-04
-	   7         3.155380391401    1.612e-04
-	   8         3.155370823029    5.839e-05
-	   9         3.155369244220    1.838e-05
-	  10         3.155369273694    7.314e-06
-	  11         3.155369577595    2.307e-06
-	  12         3.155369753410    5.947e-07
-	  13         3.155369780718    1.776e-07
+	   0         1.993082395865
+	   1         2.661926771206    2.285e-01
+	   2         3.125160515699    1.040e-01
+	   3         3.153871245653    1.965e-02
+	   4         3.155350897619    5.736e-03
+	   5         3.155148438865    2.268e-03
+	   6         3.155339533379    5.752e-04
+	   7         3.155380363480    1.612e-04
+	   8         3.155370795108    5.839e-05
+	   9         3.155369216299    1.838e-05
+	  10         3.155369245773    7.314e-06
+	  11         3.155369549674    2.307e-06
+	  12         3.155369725490    5.947e-07
+	  13         3.155369752798    1.776e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 6.239e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.491633833038
-	   1        14.325528173618    4.600e-01
-	   2        15.946338717172    1.816e-01
-	   3        16.002988012937    3.251e-02
-	   4        16.024404984176    1.379e-02
-	   5        16.024117426069    3.296e-03
-	   6        16.023484349499    1.102e-03
-	   7        16.023632588530    3.675e-04
-	   8        16.023661948343    1.113e-04
-	   9        16.023637390458    3.827e-05
-	  10        16.023630697228    1.296e-05
-	  11        16.023634244941    4.076e-06
-	  12        16.023637265724    1.779e-06
-	  13        16.023637797344    7.230e-07
-	  14        16.023637673535    3.149e-07
-	  15        16.023637527360    1.138e-07
+	   0        11.491633739892
+	   1        14.325528052049    4.600e-01
+	   2        15.946338573622    1.816e-01
+	   3        16.002987868273    3.251e-02
+	   4        16.024404838999    1.379e-02
+	   5        16.024117280864    3.296e-03
+	   6        16.023484204314    1.102e-03
+	   7        16.023632443344    3.675e-04
+	   8        16.023661803155    1.113e-04
+	   9        16.023637245271    3.827e-05
+	  10        16.023630552041    1.296e-05
+	  11        16.023634099754    4.076e-06
+	  12        16.023637120538    1.779e-06
+	  13        16.023637652157    7.230e-07
+	  14        16.023637528348    3.149e-07
+	  15        16.023637382173    1.138e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 4.989e-08
 
 	Computing P*_Y-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.465101702802
-	   1         5.481013283242    2.683e-01
-	   2         6.022384251042    1.018e-01
-	   3         6.044373507273    2.162e-02
-	   4         6.051975102917    9.828e-03
-	   5         6.051893076576    2.418e-03
-	   6         6.051749347191    7.923e-04
-	   7         6.051802663966    2.565e-04
-	   8         6.051813326810    7.611e-05
-	   9         6.051809008846    2.779e-05
-	  10         6.051807362043    1.037e-05
-	  11         6.051809350276    3.580e-06
-	  12         6.051810784159    1.499e-06
-	  13         6.051810986024    5.687e-07
-	  14         6.051810928376    2.417e-07
+	   0         4.465101724362
+	   1         5.481013307540    2.683e-01
+	   2         6.022384274428    1.018e-01
+	   3         6.044373530426    2.162e-02
+	   4         6.051975125927    9.828e-03
+	   5         6.051893099578    2.418e-03
+	   6         6.051749370196    7.923e-04
+	   7         6.051802686969    2.565e-04
+	   8         6.051813349812    7.611e-05
+	   9         6.051809031848    2.779e-05
+	  10         6.051807385046    1.037e-05
+	  11         6.051809373278    3.580e-06
+	  12         6.051810807161    1.499e-06
+	  13         6.051811009027    5.687e-07
+	  14         6.051810951378    2.417e-07
 	-----------------------------------------
 	Converged P*_Y-Perturbed Wfn to 9.222e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.791159923174
-	   1         7.553098419680    3.399e-01
-	   2         8.518194027602    1.388e-01
-	   3         8.582659260897    3.693e-02
-	   4         8.588885452756    1.031e-02
-	   5         8.588679902153    3.134e-03
-	   6         8.588873187545    7.089e-04
-	   7         8.588937195071    1.804e-04
-	   8         8.588925321614    6.111e-05
-	   9         8.588921396802    1.588e-05
-	  10         8.588921680481    5.619e-06
-	  11         8.588922181479    2.121e-06
-	  12         8.588922674015    6.416e-07
-	  13         8.588922766325    2.102e-07
+	   0         5.791159893401
+	   1         7.553098375112    3.399e-01
+	   2         8.518193969666    1.388e-01
+	   3         8.582659200806    3.693e-02
+	   4         8.588885392303    1.031e-02
+	   5         8.588679841673    3.134e-03
+	   6         8.588873127055    7.089e-04
+	   7         8.588937134577    1.804e-04
+	   8         8.588925261121    6.111e-05
+	   9         8.588921336309    1.588e-05
+	  10         8.588921619988    5.619e-06
+	  11         8.588922120986    2.121e-06
+	  12         8.588922613522    6.416e-07
+	  13         8.588922705833    2.102e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 8.234e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.676169332353
-	   1        15.057141797755    4.887e-01
-	   2        16.853596032682    1.830e-01
-	   3        16.904387581578    3.053e-02
-	   4        16.917668370366    1.106e-02
-	   5        16.916649326501    3.215e-03
-	   6        16.916537173305    9.443e-04
-	   7        16.916742088893    3.806e-04
-	   8        16.916723173325    1.557e-04
-	   9        16.916698709720    5.748e-05
-	  10        16.916695603839    2.165e-05
-	  11        16.916702600100    8.209e-06
-	  12        16.916706780794    2.319e-06
-	  13        16.916707584789    8.087e-07
-	  14        16.916707647601    3.498e-07
-	  15        16.916707556543    1.551e-07
+	   0        11.676169238139
+	   1        15.057141668530    4.887e-01
+	   2        16.853595878916    1.830e-01
+	   3        16.904387426930    3.053e-02
+	   4        16.917668215383    1.106e-02
+	   5        16.916649171503    3.215e-03
+	   6        16.916537018315    9.443e-04
+	   7        16.916741933899    3.806e-04
+	   8        16.916723018330    1.557e-04
+	   9        16.916698554726    5.748e-05
+	  10        16.916695448846    2.165e-05
+	  11        16.916702445106    8.209e-06
+	  12        16.916706625800    2.319e-06
+	  13        16.916707429795    8.087e-07
+	  14        16.916707492607    3.498e-07
+	  15        16.916707401549    1.551e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 7.316e-08
 
 	Computing P*_Z-Perturbed Wave Function (0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.812280792682
-	   1         6.177741862182    3.020e-01
-	   2         6.860063377623    1.078e-01
-	   3         6.876869787395    1.884e-02
-	   4         6.881199611094    8.236e-03
-	   5         6.881093580057    3.258e-03
-	   6         6.881202452910    9.461e-04
-	   7         6.881304282791    3.114e-04
-	   8         6.881299555440    1.066e-04
-	   9         6.881294212917    3.436e-05
-	  10         6.881293017762    1.228e-05
-	  11         6.881295095195    4.751e-06
-	  12         6.881296496867    1.787e-06
-	  13         6.881296808492    8.340e-07
-	  14         6.881296766604    3.909e-07
-	  15         6.881296676773    1.706e-07
+	   0         4.812280811654
+	   1         6.177741883343    3.020e-01
+	   2         6.860063397291    1.078e-01
+	   3         6.876869806816    1.884e-02
+	   4         6.881199630391    8.236e-03
+	   5         6.881093599330    3.258e-03
+	   6         6.881202472177    9.461e-04
+	   7         6.881304302054    3.114e-04
+	   8         6.881299574703    1.066e-04
+	   9         6.881294232180    3.436e-05
+	  10         6.881293037025    1.228e-05
+	  11         6.881295114459    4.751e-06
+	  12         6.881296516130    1.787e-06
+	  13         6.881296827755    8.340e-07
+	  14         6.881296785868    3.909e-07
+	  15         6.881296696036    1.706e-07
 	-----------------------------------------
 	Converged P*_Z-Perturbed Wfn to 6.633e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.072 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.697003192683
-	   1         7.412701290813    3.422e-01
-	   2         8.398847359038    1.398e-01
-	   3         8.449007540618    2.630e-02
-	   4         8.452331313248    6.136e-03
-	   5         8.451783250226    2.569e-03
-	   6         8.451917113488    8.394e-04
-	   7         8.452010648792    2.560e-04
-	   8         8.452001728013    8.428e-05
-	   9         8.452000464148    2.125e-05
-	  10         8.451999985355    7.738e-06
-	  11         8.452001063471    2.935e-06
-	  12         8.452001645265    8.138e-07
-	  13         8.452001808600    2.819e-07
+	   0         5.697003163738
+	   1         7.412701247520    3.422e-01
+	   2         8.398847301766    1.398e-01
+	   3         8.449007481902    2.630e-02
+	   4         8.452331254391    6.136e-03
+	   5         8.451783191373    2.569e-03
+	   6         8.451917054628    8.394e-04
+	   7         8.452010589926    2.560e-04
+	   8         8.452001669147    8.428e-05
+	   9         8.452000405283    2.125e-05
+	  10         8.451999926490    7.738e-06
+	  11         8.452001004606    2.935e-06
+	  12         8.452001586400    8.138e-07
+	  13         8.452001749735    2.819e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 9.980e-08
 
@@ -5482,12 +1128,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.098201230325156    -0.123180765782427    -0.033202860715366
-    1     -0.005923371969093     0.050810741827260    -0.134824731986808
-    2     -0.167593930540385     0.178586259084890    -0.134493401959856
+    0      0.098201230346589    -0.123180765268775    -0.033202860408374
+    1     -0.005923371966113     0.050810741960972    -0.134824732104664
+    2     -0.167593930849687     0.178586259349300    -0.134493401988512
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.072) =  -38.80517 deg/[dm (g/cm^3)]
+	[alpha]_(0.072) =  -38.80516 deg/[dm (g/cm^3)]
 
          CCSD Optical Rotation Tensor (Velocity Gauge):
   -------------------------------------------------------------------------
@@ -5496,12 +1142,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.611826438443296     0.042104359157571     0.269204670538483
-    1     -0.001881373397426     0.199307810330118    -1.347788244432381
-    2     -1.408413499700999     1.440039975849318    -0.805016828624069
+    0      0.611826438096407     0.042104354406333     0.269204668983955
+    1     -0.001881374198962     0.199307809647682    -1.347788237786693
+    2     -1.408413496046982     1.440039972795155    -0.805016827624939
 
    Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.072) = -227.15489 deg/[dm (g/cm^3)]
+	[alpha]_(0.072) = -227.15486 deg/[dm (g/cm^3)]
 
         CCSD Optical Rotation Tensor (Modified Velocity Gauge):
   -------------------------------------------------------------------------
@@ -5510,9 +1156,9 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.006536799619153    -0.006636387158390    -0.001869064511944
-    1     -0.000345166044547     0.002677012768096    -0.005906141749116
-    2     -0.010273983167223     0.009171871792079    -0.008199636237773
+    0      0.006536799678023    -0.006636387222268    -0.001869064564922
+    1     -0.000345166068812     0.002677012803965    -0.005906141827644
+    2     -0.010273983239371     0.009171871884792    -0.008199636329113
 
    Specific rotation using modified velocity-gauge Rosenfeld tensor.
 	[alpha]_(0.072) =  -37.65886 deg/[dm (g/cm^3)]
@@ -5520,3636 +1166,396 @@ Total time:
    Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.
      Delta_x =  -1.53   Delta_y =   0.59   Delta_z =  -3.27
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008290776080582 -0.050801504097253  0.025635294562259 -0.003046442602711 -0.019839162173202 -0.042287718066775  0.002274291905087 -0.017250301075761 -0.063217582232324
-    1  (  1) -0.005656720485448  0.005906316890016 -0.013342327104385  0.062795095869537  0.034384806675368 -0.011824889654518 -0.010091423219065 -0.046942857543920 -0.048716688440686
-    2  (  2)  0.031253511604130  0.072637650556073 -0.014421891959526 -0.004213302445553  0.070727435854801 -0.065656867197555 -0.018370400388693 -0.002385908267158  0.006354255904041
-    3  (  3) -0.059832580241196 -0.053424480759820 -0.021451003825827 -0.018138018553495 -0.036100327164171  0.016134873511603  0.024740373136963  0.003793018506519 -0.167949395515151
-    4  (  4) -0.064204693944690 -0.131652862682136  0.117404639608972  0.157417127901485 -0.230036611567443  0.047515122725740  0.039984594404843  0.125482054176259 -0.256771627646738
-    5  (  5)  0.146085129938632  0.278398764610060 -0.159854012203638  0.282968510269086  0.101365891285813  0.356608825189021  0.125659431918166  0.044422988683829  0.166646852463301
-    6  (  6) -0.076564725597579  0.133650798922835 -0.020866614443156 -0.061441481951876  0.071232976830213 -0.204259413485531  0.443726141038863  0.031546384888620  0.054109942402284
-    7  (  7)  0.171392689665179  0.199512600411571 -0.417327799251045 -0.052763427688751  0.301472803852696  0.065491949787692 -0.090135905280205  0.243374803622146  0.087314234232365
-    8  (  8)  0.052750851527397  0.070024200557922 -0.379656051510646  0.506727880893360  0.456213741194719 -0.053888497905949  0.020349944072208  0.064388593842935 -0.270869373264179
-    9  (  9) -0.321512384290440  0.557302077819714  0.036935298894209  0.154840347992778  0.003043634782132  0.230873783877613  0.106477418838008  0.187200194326970 -0.093391131247138
-   10  ( 10) -0.965723013629727  0.203375174675727  0.231799200789465 -0.113515758170139  0.032657967963446 -0.147828874479423  0.019227710807050 -0.096617606939553  0.006766409668261
-   11  ( 11) -0.210596475192897  0.094976222444135 -0.072335244920971  0.290764752768263 -0.062314851229712  0.053607127427930  0.145285323049651  0.073900587412887 -0.326764941791807
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071285844130264
-    1  (  1)  0.010066343394199
-    2  (  2) -0.108617239028194
-    3  (  3) -0.063737900590760
-    4  (  4) -0.015793155353663
-    5  (  5)  0.238781543103224
-    6  (  6) -0.065357063243315
-    7  (  7)  0.120098496018758
-    8  (  8) -0.128051536292778
-    9  (  9)  0.179029916473930
-   10  ( 10) -0.084757737907666
-   11  ( 11)  0.159141561245499
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.230778688168130 -0.557039020018502  0.102231622004203 -0.365190061837505 -0.400431097899025 -0.011240783369823 -0.138486416116495  0.002452040812742 -0.004398637078623
-    1  (  1) -0.556776142920827 -2.040315056194718  0.915507378155102  1.014426942838368  0.734278848751725  0.048588577390964  0.281167270606351  0.301449170381432  0.094768863002394
-    2  (  2)  0.102191442528323  0.915686903851560  1.209547690777273 -0.958100119655737 -0.740471389480369 -0.004947182895568  0.495915674452131 -0.139783988312968  0.095073435804183
-    3  (  3) -0.364539165929170  1.014070571549057 -0.958316089423204 -0.283348551998825 -0.131889670325022 -1.271015261428147  0.039370973643206 -0.404136843612415 -0.596543898512850
-    4  (  4) -0.399870169082361  0.732987024839952 -0.742129335372324 -0.132056740778799  0.552809694709972  0.050609502973822 -0.485130318718432 -1.569135325660496 -0.955644372877197
-    5  (  5) -0.012067668711970  0.049395634351447 -0.004235997753528 -1.269867451709877  0.052501445594591  0.142961307435960 -0.243772741862524  0.815823088969846 -1.032660122676294
-    6  (  6) -0.138184751914924  0.281444487458849  0.496109632619357  0.039289252640444 -0.483545301414318 -0.244146373994899 -2.567548494258237  0.471042691193011  0.535768572608993
-    7  (  7)  0.002443724218529  0.302692867022601 -0.138498316501231 -0.403820450806263 -1.565811046199608  0.816611901103015  0.471628294535134 -1.688652935957108  0.671482803026688
-    8  (  8) -0.004344564384300  0.094578985136196  0.094798646138089 -0.597437555079113 -0.950266206536146 -1.030172101956222  0.534632090191761  0.669551052804072 -0.286047601971907
-    9  (  9)  0.321027459692546 -0.124494588251713 -0.355830352458176 -0.608802973418470 -0.402462352421951 -0.368076132570564 -1.240230517037675 -0.910561909620175  0.043652486559104
-   10  ( 10)  0.011815823949598 -0.051101513605038 -0.395397800969984  0.309598565761669  0.194737646185127  0.053604366895841 -0.879466474650196  0.757981021960396  0.138272602216670
-   11  ( 11)  0.159425836287601 -0.085783898744993 -0.370909602534729 -0.056636941516785 -0.307385996591224 -0.268976928323790 -0.442853482929670  0.013290639913097 -0.876205899626718
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.323082673575100  0.012827323300415  0.160383781034165
-    1  (  1) -0.126844464371028 -0.052604971080148 -0.086843133976977
-    2  (  2) -0.357788273401833 -0.396667921961515 -0.371902334820724
-    3  (  3) -0.612287607386654  0.306667669522199 -0.056656844524874
-    4  (  4) -0.405472668706639  0.195190062002348 -0.306615567899281
-    5  (  5) -0.367351821286147  0.055534904015428 -0.275720960811118
-    6  (  6) -1.243158670589035 -0.884111685009210 -0.446520521343404
-    7  (  7) -0.909610092856081  0.758960738026336  0.004121680213622
-    8  (  8)  0.044479614426162  0.142510706976164 -0.890141861038879
-    9  (  9)  0.430645603358394 -0.292573864178629 -0.177569371172063
-   10  ( 10) -0.297251468770778  0.639563517042984 -0.084252875076621
-   11  ( 11) -0.176313836183732 -0.086637188746477  1.226883274744448
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.555032728737771  0.712617672671401  0.419810286882489  0.050887754227596 -0.090842975445822 -0.470640518796941  0.705404320416024 -0.102097016449215  0.079849652538938
-    1  (  1)  0.712915390108471  0.338414908248977  0.746799463635505  0.289033465951793  0.281577689527702 -0.590080565321557 -1.163166129408219 -0.188838662213219  0.235465544716902
-    2  (  2)  0.420424419523684  0.746397208582966 -0.016153704953468 -0.358852287949201 -0.952285365412292  1.041198523267407 -0.387389024226280  0.231972398395418 -1.201681468114436
-    3  (  3)  0.052990374128029  0.287939592192507 -0.356997201476426 -0.860130940767887 -1.322600194001359 -0.190991097932252 -0.172427859143025  1.049268576710733  0.759838942947354
-    4  (  4) -0.091729674999201  0.281558404761801 -0.953826965790842 -1.321136801436185  1.452847715742109  0.019357804497789  0.219531843898996 -0.321163524474806  0.383368380154908
-    5  (  5) -0.468391179467906 -0.590920943851569  1.042843901419442 -0.190946364776948  0.019284064585406 -0.578157261908740  0.477982154885554  0.309192885886468  0.350343314103329
-    6  (  6)  0.705416628116867 -1.163498224121495 -0.385221267991331 -0.173426272959358  0.218834180811751  0.478203132617135 -2.784703127021582 -0.089827446409910  0.007438070857215
-    7  (  7) -0.100892718625019 -0.189193923309364  0.233172791358426  1.048794685120079 -0.321694154621351  0.309157324551256 -0.089653742381773 -3.228872513573496  0.508232911749822
-    8  (  8)  0.078189592702616  0.235740536359493 -1.205024775916881  0.762330717256039  0.383275686836382  0.348953623655193  0.008045450505770  0.508467502681986  0.472369144605263
-    9  (  9) -0.077760701800955  0.237396383481108 -0.096343734790574 -0.354923660187535 -0.984336588474142  1.335053740742370  0.269902452459777  0.319055275759352 -0.321749140962585
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.078162493766068
-    1  (  1)  0.238847682218727
-    2  (  2) -0.098903683747888
-    3  (  3) -0.354949509542455
-    4  (  4) -0.983822640646403
-    5  (  5)  1.333720211340158
-    6  (  6)  0.269441491786924
-    7  (  7)  0.318898660493929
-    8  (  8) -0.321196908799485
-    9  (  9) -0.198768714929451
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015331616498833 -0.019922018235360  0.024795453639952  0.001428994822442 -0.007662564632869 -0.030564864466354 -0.002998096035874 -0.014184257518557 -0.050369876521864
-    1  (  1)  0.002536892896206 -0.000724332833140 -0.010931820831771  0.061385329925525  0.034527384530112 -0.002930909394968 -0.006897041777642 -0.048924198461387 -0.045892788765523
-    2  (  2)  0.055930590988109  0.061668786229878 -0.009784880887058 -0.011292178101404  0.079575226023927 -0.052325708606337 -0.009086556132667 -0.001787844130138  0.008215255410943
-    3  (  3) -0.058532225277701 -0.048285500112225 -0.015912879350588  0.001479837376653 -0.030353501548890  0.023819914693464  0.021025260847826  0.014207102374829 -0.151577267379535
-    4  (  4) -0.056221687371934 -0.122358938171234  0.112292181821658  0.146881610350559 -0.213263741399596  0.056469707520368  0.037816511197979  0.118315319709634 -0.249164851234958
-    5  (  5)  0.125699079920792  0.245765102963436 -0.144688421941741  0.269480954167622  0.108175820650901  0.330495489462815  0.121717019021094  0.042981278927133  0.139107704893676
-    6  (  6) -0.090953864200081  0.138378038123711 -0.018999653387300 -0.059021477190613  0.070107383816014 -0.188422561576096  0.422479983427336  0.027031745312951  0.054392856003620
-    7  (  7)  0.157772366372595  0.187920697768143 -0.411777035755239 -0.046692805557951  0.283266431788380  0.074879967037488 -0.084103929184262  0.226658912465472  0.075512245279510
-    8  (  8)  0.054210291452992  0.062449071960101 -0.361963320103574  0.503001997291620  0.438083797101076 -0.063050427843078  0.017066076329137  0.069221757957400 -0.257467231990446
-    9  (  9) -0.273423536032774  0.529295983026682  0.033766766508851  0.151918529592259 -0.009418984940093  0.206571120107986  0.110624885223032  0.172829785443028 -0.101427788661059
-   10  ( 10) -0.861462052752320  0.172326691424178  0.212371997651326 -0.111218596621436  0.023269411258717 -0.143388725237391  0.039930804953421 -0.091843120858856  0.022422158283106
-   11  ( 11) -0.188670480611874  0.096820345118133 -0.066190773880029  0.287205832494666 -0.059420643781434  0.064429852032339  0.150091109571506  0.074231547885084 -0.343171650309577
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.057461514086606
-    1  (  1)  0.006963958755564
-    2  (  2) -0.098129328522494
-    3  (  3) -0.059012682268642
-    4  (  4) -0.004449861106028
-    5  (  5)  0.220945294639113
-    6  (  6) -0.063939488850868
-    7  (  7)  0.102360934503055
-    8  (  8) -0.118112557417407
-    9  (  9)  0.155151984964126
-   10  ( 10) -0.077691214009347
-   11  ( 11)  0.169304339523055
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007929033245727 -0.086776514026638 -0.041466992686244 -0.000624066975311 -0.013156595381987  0.043080477030762  0.042448060293463  0.012239880545527  0.029029915184304
-    1  (  1) -0.033878180177558  0.070173508648210  0.019230609095550 -0.003533880530575 -0.001550569267327 -0.001809299397526 -0.111518736659909 -0.001270571448457 -0.012934311690280
-    2  (  2)  0.053119512373320  0.091732793273830  0.021408607612661  0.032674571200622 -0.027446877387833  0.001428368203209  0.035760699595502 -0.016168017803360  0.076110316338229
-    3  (  3) -0.111768458659199  0.032123986864070  0.006283151908271 -0.033287020781358  0.043086093005307 -0.045344868585861  0.050504244775852 -0.018808552325982 -0.035145863401031
-    4  (  4) -0.008665305449844 -0.063452607411023 -0.029600165455924  0.047115677331559  0.019168666345381 -0.031501732622098  0.317766848542404 -0.025484653465158  0.136713668607013
-    5  (  5) -0.096942829349587  0.462416830630329  0.133842090994118  0.092985874350147 -0.099421870808029 -0.234587688959823 -0.217512036032000  0.115491679731730 -0.074046828271163
-    6  (  6)  0.147504151854231  0.176016277524490 -0.101374573515317 -0.288079277305196 -0.230919141922049  0.118478695990594  0.200039409574699  0.528080641738917 -0.150345125085143
-    7  (  7) -0.042669001755884  0.443406170499069  0.389143916519812  0.161315900065673 -0.044923622848274 -0.251217580401495  0.349139344106497 -0.313375744671926 -0.105308356658894
-    8  (  8) -0.090773283284028 -0.098945242676733  0.273219850231927 -0.153556988234685  0.012049248011756  0.153837601800696  0.096783765511278 -0.036655814574288 -0.158022323654812
-    9  (  9) -0.854099711852282 -0.117772176421944 -0.239016409160077 -0.177375733867881  0.100275769298913  0.252844583057920  0.226930144139075  0.153229528005110  0.127239027610851
-   10  ( 10)  0.395991653576375  0.538214267844356  0.096531314019954 -0.336382832184142  0.099895828912763  0.055956501178133 -0.146421756050995  0.134905206743007  0.024743642762261
-   11  ( 11)  0.048495982241480  0.204014858900645 -0.274325469868742  0.134595356909103  0.084519511625804 -0.191133538480751  0.069261639154394  0.103192119612584  0.176045180364651
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.028831087335228
-    1  (  1) -0.001371858337113
-    2  (  2)  0.086279641236700
-    3  (  3) -0.002619734805492
-    4  (  4) -0.021137684583830
-    5  (  5) -0.191430382947414
-    6  (  6) -0.264284919761669
-    7  (  7)  0.000269384690538
-    8  (  8)  0.116882729881709
-    9  (  9)  0.120074711434079
-   10  ( 10)  0.053632787996257
-   11  ( 11) -0.085463803953674
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.675541283858356 -0.292064021280293 -0.790025131233222  0.039304385342315 -0.142699371183327  0.268327500474091  0.055268589173706  0.193336176520280 -0.032498607183913
-    1  (  1) -0.292005367417511 -0.068094888399427 -0.091928539573230  0.129152126993159 -0.002672883933379  0.049262453691224  0.862140772831706 -0.434895002279636  0.030957963645570
-    2  (  2) -0.789447165009789 -0.092254483472880 -0.804853040833334  0.464036191543570  0.288328515691532 -0.782373392336952 -0.359658943728641 -0.388090328975242  0.068147997029207
-    3  (  3)  0.039444395620206  0.128939281409480  0.463903578747306 -0.241479807350799 -0.029257651091736  0.289330170364477 -0.078438871496667  0.246243716348015 -0.221624488999474
-    4  (  4) -0.142005033730652 -0.003441352982276  0.286700873937055 -0.029953661733414 -0.427750919311445 -0.225593242891832  0.001248695253401  0.308372097905189  0.608170303007273
-    5  (  5)  0.266046370608821  0.051710611539180 -0.778167579408912  0.290283723006215 -0.224453112864279 -0.369348441761130 -0.137527542499239  0.160088399589127  0.333141145250294
-    6  (  6)  0.055576665996038  0.861897091141550 -0.359382180614210 -0.079367338581182  0.001316960755447 -0.139592143084602 -0.236061692038733 -0.500995422630755 -0.152924823639678
-    7  (  7)  0.191190365321726 -0.433335934056497 -0.384226491533538  0.246895934047586  0.308256930114393  0.160145299200529 -0.499551364365546  0.169042466304747 -0.232433156817922
-    8  (  8) -0.032324733830521  0.030583581869279  0.067800595440523 -0.220839746025180  0.605132330733771  0.331428074510260 -0.152991449816876 -0.231671787208498 -0.624414674119492
-    9  (  9) -0.170133827289346  0.173802608390272  0.582650141434017 -0.560382911834174 -0.212565567455627  0.095754045184088 -0.282286783247438 -0.105642205052933 -0.000539730602912
-   10  ( 10)  0.052970874353821 -0.227531715435441 -0.648876828841383 -0.696767965643644 -0.268344000354012  0.568720278318329 -0.098598860256773  0.086269937526947 -0.081275470268861
-   11  ( 11)  0.025516552524119 -0.085059735579504 -0.121415959836865  0.018097922040376 -0.846374652520441 -0.307989344147049  0.044343294285023  0.231195949738532  0.168305572109582
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.171375974411067  0.055216931376792  0.025964207813788
-    1  (  1)  0.173220084938157 -0.230603891969826 -0.085840408679658
-    2  (  2)  0.586304150506699 -0.654210189691972 -0.122677885868631
-    3  (  3) -0.564217005061761 -0.698424845148049  0.018146779332832
-    4  (  4) -0.213592841407263 -0.268356081771837 -0.851093566817366
-    5  (  5)  0.095187708087751  0.569138844284334 -0.311815017332116
-    6  (  6) -0.283847446348569 -0.099361887898569  0.045327800607922
-    7  (  7) -0.106442929251796  0.084951820105521  0.232402123183799
-    8  (  8) -0.000679287280351 -0.083181582350312  0.174842773942352
-    9  (  9)  0.184137973286679  0.103441117955563 -0.011188766481418
-   10  ( 10)  0.107554052466808  0.106515041132340 -0.165743784884080
-   11  ( 11) -0.010550245981975 -0.165913802295303  0.859885805027657
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.229655435401251 -0.279601353643965 -0.085575827802352 -0.135048509105901 -0.463462610619003 -0.365248455770507 -0.039660777368333  0.191781963250870 -0.304572804139555
-    1  (  1) -0.279047925679444  0.077319987469585  0.204439247136492  0.070123615269243  0.055860395624731  0.138642318409271 -0.343207769076389 -0.182810883095464 -0.017999280994748
-    2  (  2) -0.085240959465133  0.204263364283089 -0.311156623733494  0.294688564065330  0.229669520218161 -0.281737981462645  0.137882893674030 -0.194668648298996  0.517507397185879
-    3  (  3) -0.137052652301458  0.068817803199155  0.294513347383327 -0.628744473812505  0.688526281107777  0.166771123104115  0.212803952843010 -0.269010206604892 -0.411620416751970
-    4  (  4) -0.461604619248266  0.055843287983042  0.230054478565236  0.688395074228786 -1.421511879446005  0.180495138052121 -0.177199847230662  0.268188410470329  0.119512289645345
-    5  (  5) -0.365099883123814  0.139122909294115 -0.282780063256330  0.166251175855828  0.181093271919847 -0.292775738602585 -0.240660983788926  0.305216197970317  0.235452232882587
-    6  (  6) -0.039141072198114 -0.342047900602042  0.138302509146164  0.211959339222516 -0.177087648441962 -0.240505624310098 -0.304304277829310 -0.910739369588832  0.202811323160239
-    7  (  7)  0.191443148224360 -0.183077517400336 -0.194209029769022 -0.269384260651775  0.268168725961981  0.305441092512858 -0.910852433205190  0.029633662055934 -0.204453968987965
-    8  (  8) -0.303246852232180 -0.018509744386768  0.519514080414653 -0.413340759430442  0.119384719254151  0.236362024043069  0.201991249845660 -0.204562219955504 -0.661555776893828
-    9  (  9) -0.300472910579648  0.170014354298783 -0.291259695102906  0.029160805834281  0.317264449488489 -0.326442124436524  0.007044557482429 -0.101763181058410  0.215338723709779
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301684802635884
-    1  (  1)  0.169719322346163
-    2  (  2) -0.289724655704096
-    3  (  3)  0.029002914588453
-    4  (  4)  0.316574855082561
-    5  (  5) -0.325796183326422
-    6  (  6)  0.007131791827115
-    7  (  7) -0.101918507704736
-    8  (  8)  0.215214193797303
-    9  (  9) -0.431317970778139
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009148490318064 -0.020309806158549 -0.015977532182931  0.004014783738387 -0.010489793112351  0.029667649783295  0.020232440585606  0.011223082041042  0.023312323786938
-    1  (  1) -0.044375857230131  0.052262766826166  0.015548487373741 -0.003662802577056 -0.002781875625079 -0.001383977859398 -0.098229640468489 -0.001043710758572 -0.010909270118946
-    2  (  2)  0.054181385020550  0.080128526478900  0.022828931876126  0.037487063410101 -0.042770056882922 -0.005218720540993  0.030479703829638 -0.014823518322437  0.065536667960166
-    3  (  3) -0.129996832535740  0.025539245172390 -0.001710767497197 -0.035208153932012  0.051497303033318 -0.033810939265315  0.041923713016432 -0.018028802137201 -0.031841589713416
-    4  (  4) -0.018797598258319 -0.055382521313148 -0.025678897036466  0.042677314096974  0.024119803445938 -0.028773903589126  0.288385579456642 -0.023957336001325  0.134022392012911
-    5  (  5) -0.085790126908808  0.402408359114006  0.110878458520312  0.084218998643581 -0.097302640260559 -0.211015098306590 -0.195826989075132  0.107508726926065 -0.059970385150068
-    6  (  6)  0.117117046001707  0.164907313314791 -0.092740522447941 -0.263892346037872 -0.208050086690414  0.121861415926763  0.180654068666643  0.487980567663863 -0.134813668081860
-    7  (  7) -0.052709991074355  0.381296251220592  0.349380237841959  0.145852911752160 -0.041346590279243 -0.220669429372274  0.328816279036270 -0.285726302429830 -0.093478286390337
-    8  (  8) -0.075491834851014 -0.090622807799606  0.261184981058617 -0.148637821570292  0.006281256453519  0.144842826611815  0.089811111402247 -0.036110485207390 -0.153520220179307
-    9  (  9) -0.696164148321021 -0.104910101886221 -0.203383144631185 -0.164870629493292  0.069977329160723  0.194202208543558  0.212076681930829  0.132693764051193  0.096725293429142
-   10  ( 10)  0.348175665954885  0.434442729860845  0.069207287013024 -0.311902381205193  0.086974667298470  0.051225223079379 -0.122216101880307  0.122874476488139  0.012079820457350
-   11  ( 11)  0.044712948857676  0.176004094735536 -0.255862724288287  0.126758826080010  0.078218473139894 -0.179984369340434  0.067110991111726  0.095360581673868  0.177561710091429
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.024402944617349
-    1  (  1) -0.001173348606223
-    2  (  2)  0.076484101898115
-    3  (  3)  0.001169431615315
-    4  (  4) -0.024935532887633
-    5  (  5) -0.174540155531575
-    6  (  6) -0.236517338782017
-    7  (  7)  0.008859575697215
-    8  (  8)  0.109927192293737
-    9  (  9)  0.089534068178409
-   10  ( 10)  0.043410237741554
-   11  ( 11) -0.093132968001143
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002170644752931 -0.022324956514099 -0.029394826211345  0.023309311068680 -0.000970852822634 -0.043511040680121  0.014013985960523  0.007860305508825 -0.031314125297178
-    1  (  1) -0.004975212184910 -0.009727238108985  0.081406434912428 -0.023252939392766  0.038928067463043 -0.010458408905981 -0.034913544836836  0.014265058471693  0.051735797486860
-    2  (  2)  0.017880176100707  0.015599348022774  0.096023531696764 -0.045237679689815 -0.002431886781376  0.077281603581543 -0.027482410098613 -0.002121837766367 -0.131596950090464
-    3  (  3) -0.033671282161329 -0.042247110815725  0.017614407066521  0.120482048147517 -0.071788669015437  0.100417130949899  0.026095439370731  0.024912292415628  0.128857994704884
-    4  (  4) -0.039094504869080  0.011586636873075 -0.201648756832533 -0.417167224027039  0.232183671922422 -0.365776066782585  0.000436512477144 -0.036487401941041 -0.092913589753420
-    5  (  5)  0.107020694538732  0.188165249192967  0.272788343236859 -0.444403017959699  0.118293552778212  0.528258782415562  0.125325642779073 -0.198753130098826  0.028672980278371
-    6  (  6)  0.121158671169740 -0.085565322151460  0.088586051783133  0.010298532059028 -0.107250216094850 -0.195698840050220  0.370534853760273  0.159194784952583 -0.016512860210084
-    7  (  7) -0.033804952616344 -0.168095045341921  0.398821112602689 -0.046726828449621 -0.030609711055064 -0.217531691733838 -0.115639511714214  0.399856930098400  0.150033235311716
-    8  (  8) -0.059559370905179  0.306305036465827 -0.595923646185890 -0.119277640805674 -0.722271918559490  0.001726267262613 -0.027179920353598 -0.211451038002310  0.148912062372910
-    9  (  9) -0.188866142842736  0.096789990486457  0.236442562527094  0.092757728041313  0.072651948101216 -0.016472461695526 -0.026914575117300  0.247244600184375  0.370870606832493
-   10  ( 10) -0.406957853798143  0.141958866881762 -0.085132936917023  0.102326296221874  0.017996095944708 -0.062553443565296 -0.105319900227601 -0.005069269037988  0.006423933602228
-   11  ( 11) -0.081915250147579  0.202583484157184 -0.282203343833431 -0.339304077428364  0.118298550150489 -0.126692826807318  0.005731143361727 -0.150166092159272 -0.134968415625333
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.038183979702674
-    1  (  1) -0.001758617329220
-    2  (  2) -0.002245458358924
-    3  (  3) -0.305015280585847
-    4  (  4) -0.011707659076193
-    5  (  5) -0.052479234679287
-    6  (  6)  0.143560462314116
-    7  (  7)  0.320971036748081
-    8  (  8)  0.148594551736844
-    9  (  9) -0.097500178466871
-   10  ( 10) -0.069870490871550
-   11  ( 11)  0.082515655756872
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.053221344681142 -0.117483147833985 -0.106139723247453 -0.495823955121092  0.391515874804455  0.212402958848530 -0.083769680573767 -0.039675371517883  0.058634274306531
-    1  (  1) -0.117410394687696 -0.001165915237512 -0.133100613626654 -0.630012634533085  0.317623482499555 -0.573984529169381  0.375575851008806  0.417091736224605 -0.210582306420709
-    2  (  2) -0.106116179316557 -0.133365754849436  0.099881677186242 -0.283389270168438  0.408842653260195  0.463415082290805 -0.094461635582511 -0.339728478273951 -0.187117729157411
-    3  (  3) -0.495487159854538 -0.630575218275538 -0.284210529100489 -0.394005207299682  0.243829412824131 -0.426368810438983  0.000017569224274 -0.316982847795332  1.182262387796268
-    4  (  4)  0.391977861689502  0.318458435778042  0.410524448216213  0.243871385545647 -0.262605821454379  0.313475558817429 -0.006238164976110  0.146232809940208 -0.404783357267945
-    5  (  5)  0.211677947989569 -0.572946112183618  0.465876094202739 -0.424891649228725  0.310576368667640  0.340119032966648 -0.103399884420596 -0.366027570904681  0.140243317389270
-    6  (  6) -0.083203642949521  0.374758513857944 -0.095474380553338 -0.000848431158077 -0.007011740191065 -0.103456952640946  0.035381526355376  0.100664517850410 -0.224617556800866
-    7  (  7) -0.039824177760467  0.417269525333673 -0.339848279473418 -0.316785009817077  0.144981956006953 -0.366591938133070  0.100487370214345  0.453363803566786 -0.284080848307595
-    8  (  8)  0.058454981179204 -0.209563433448112 -0.187086823104815  1.182437825563613 -0.401897920471953  0.141960153823608 -0.223791716105096 -0.283768269790238 -0.127258563076312
-    9  (  9)  0.176473367868989 -0.113695285962430 -0.191045562239273 -0.466077182834650  0.080353173846381 -0.392419296545826  0.139310719822578  0.097667658130615  0.260382741772322
-   10  ( 10)  0.087511748605763 -0.084525637542731 -0.451433812661641  0.087442027470754 -0.075301055147615  0.128254312442896  0.066832910809452  0.040269698765907  0.083963538620684
-   11  ( 11) -0.256000473516428  0.178934738319287  0.462669412659627  0.336070869572452 -0.226364820740552  0.220661186826050  0.015682276558009 -0.019696413835863 -0.320368477367524
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.177398660643495  0.088413661062507 -0.257047850800415
-    1  (  1) -0.114710761582569 -0.086001542477366  0.179468892454740
-    2  (  2) -0.191402905701337 -0.452554194931555  0.463985875678332
-    3  (  3) -0.467548510382317  0.086605995128391  0.336310348111395
-    4  (  4)  0.080907164839857 -0.077457000042675 -0.231693183962593
-    5  (  5) -0.391713702811823  0.124122145336547  0.233240659481206
-    6  (  6)  0.139727422139028  0.065972550943365  0.014736999139443
-    7  (  7)  0.097438431199858  0.039119593081805 -0.012607893852994
-    8  (  8)  0.258370481571402  0.084693167750785 -0.328679992068142
-    9  (  9) -0.027947875522173 -0.059452680730838  0.039102598209232
-   10  ( 10) -0.061112133253744 -0.042824028656813 -0.176907573001062
-   11  ( 11)  0.036269564126208 -0.174115037047438  0.046562990208638
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.221915567502623  0.240154969163816  0.089524025753548 -0.009891539023461 -0.105352264889997 -0.079728196437896 -0.186918344067447 -0.018609216798882 -0.150218987334760
-    1  (  1)  0.239595861160914  0.097635005536382 -0.020343203465831  0.252497393963625 -0.178770889626966  0.156659860903133  0.042031186852564 -0.226739274781765  0.050354579998016
-    2  (  2)  0.090047283413814 -0.021960432152020 -0.652704165096791 -0.484235858264924  0.265074532283746 -0.870240852693915  0.056963933090132  0.087593695232780 -0.397150344061483
-    3  (  3) -0.008304023565221  0.254514964099576 -0.488668744172267  0.243914942296862 -0.497430549408554 -0.651892044099941 -0.144949354151790  0.009197770416785  0.363155689203458
-    4  (  4) -0.105368055288416 -0.178968402377489  0.265813616023428 -0.498441236963999  0.117807978177016 -0.197938223960627  0.010977461550819  0.054866508200549 -0.633466747483980
-    5  (  5) -0.079092278611567  0.155211327907083 -0.870349858528248 -0.648891955877304 -0.198852995680930  0.056118287010249  0.077393750543525 -0.820063131904850 -0.522591293712200
-    6  (  6) -0.188319262904704  0.043235387216250  0.056704467242807 -0.145342612784415  0.011176054667898  0.077123788010048 -0.017043504447154 -0.229308594149143 -0.061253571825596
-    7  (  7) -0.017449220652026 -0.226052369590475  0.086398229140611  0.009988063298837  0.055257253277244 -0.820894010869112 -0.229107411788767  0.436891114659360  0.154693358924324
-    8  (  8) -0.147652836473568  0.050157233403955 -0.397985593672069  0.364902332737576 -0.632177325650741 -0.523669848989306 -0.060883358066048  0.155008994016302 -0.331322085722016
-    9  (  9) -0.012364053013731 -0.381902018882131  0.730234455154150  0.318717588976828  0.654372705810295  0.234910934996783  0.063436038641434  0.568676727219248  0.116095919775855
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010717409085818
-    1  (  1) -0.381606046587817
-    2  (  2)  0.729520232349256
-    3  (  3)  0.319801359646356
-    4  (  4)  0.655576694394483
-    5  (  5)  0.233766377042350
-    6  (  6)  0.063681628675817
-    7  (  7)  0.569047245691214
-    8  (  8)  0.115234955131862
-    9  (  9) -0.255200733989858
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006756611009239 -0.004812319108707 -0.015155246179453  0.018768861614548  0.003263846230316 -0.029956626691063  0.007768157616613  0.008654952545397 -0.024139771998296
-    1  (  1) -0.000276876655733 -0.007317152277636  0.067126401411285 -0.013873168496829  0.038395392580021 -0.004054864162186 -0.028032553908660  0.014238200673600  0.044802348000681
-    2  (  2)  0.034311733284435  0.014478380463186  0.079037871547464 -0.037480797351928  0.004455235189999  0.068266709703376 -0.020927095140560 -0.000590179941322 -0.116436689576599
-    3  (  3) -0.034781167081690 -0.039999835648210  0.017388947621558  0.117724049135840 -0.062309713575062  0.098214530429882  0.024529272430519  0.026637769905859  0.121592113448416
-    4  (  4) -0.036088452219928  0.018119725898309 -0.181397076074172 -0.381210957896193  0.211295234548894 -0.335046977567969 -0.001001209940803 -0.032788904430710 -0.087406508170972
-    5  (  5)  0.091932999121248  0.163472911292393  0.257039057929667 -0.406986018028708  0.108362880698111  0.483755223010107  0.114747171070721 -0.179816739697054  0.021814542430540
-    6  (  6)  0.102207313652244 -0.075273825473482  0.076700485775484  0.010389199522243 -0.095145363312679 -0.177269643268087  0.339312666537493  0.145893525857585 -0.013352577122472
-    7  (  7) -0.036776384387696 -0.162278963391709  0.362818814892890 -0.043460364327904 -0.026462409718549 -0.199351982461758 -0.104180059013018  0.364628559511404  0.137093791802520
-    8  (  8) -0.054133642075650  0.281937460317668 -0.549118750139198 -0.110766566728388 -0.665283649525633 -0.004014717984651 -0.026030812844979 -0.193249298632007  0.140185869779560
-    9  (  9) -0.149539825936769  0.083496187141563  0.222414359602469  0.086467924966290  0.058519767738283 -0.026610134648035 -0.023639345193443  0.224482305471681  0.335967535114734
-   10  ( 10) -0.342551768791105  0.115343806322270 -0.079695331214451  0.094078531732984  0.012984790263811 -0.052720281866277 -0.089289783188097 -0.003161584461577  0.011520822726607
-   11  ( 11) -0.067948144123858  0.170897803094304 -0.268478044795138 -0.331752793901224  0.110501398686606 -0.120431522039808  0.010421693063374 -0.142909196950524 -0.136584264097857
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.029945709624550
-    1  (  1) -0.003777838622564
-    2  (  2) -0.000494193391228
-    3  (  3) -0.283159255072162
-    4  (  4) -0.002056849846006
-    5  (  5) -0.055491249216550
-    6  (  6)  0.134241443599212
-    7  (  7)  0.294425347600366
-    8  (  8)  0.138732741810037
-    9  (  9) -0.100744739667681
-   10  ( 10) -0.062352827286650
-   11  ( 11)  0.087587602591740
-
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016434384667148  0.059537003054536 -0.018382703913455 -0.001901473074516  0.028510164358282  0.077646279855039  0.000356251398219  0.021408373218989  0.091393977088558
-    1  (  1) -0.005835140019102 -0.006847303402179  0.005801307077118 -0.092503110731406 -0.040640220398500 -0.004476772769023  0.006707493956919  0.025598358653730  0.054742040386929
-    2  (  2) -0.032576552661469 -0.022759352669700  0.015700451044420  0.017659613283536 -0.033691301649134  0.071320914458495  0.010810523808367 -0.000599142203483  0.006831611161324
-    3  (  3)  0.028439441517722  0.025978253338493  0.005227408482745  0.004129515933235  0.042131401342259  0.005061996623806 -0.014819468597155 -0.029813444208053  0.124931870713391
-    4  (  4)  0.026711661740657  0.065952388204908 -0.070397760617197 -0.113357837258571  0.162062952662508 -0.007050708037022 -0.019958512448364 -0.113599468912823  0.186779858191589
-    5  (  5) -0.054225682429018 -0.150592673565962  0.090221508528394 -0.165469278587529 -0.105075744052049 -0.235926758500148 -0.076402735009682 -0.065221510888654 -0.109078486285223
-    6  (  6)  0.036820767703606 -0.045049000362756  0.022079029118092  0.038075092578984 -0.045448669142688  0.103567825475646 -0.243196158948954 -0.024866082639399 -0.028667254743547
-    7  (  7) -0.064079984215095 -0.104489316033204  0.208936934850580  0.011404897999585 -0.191297065299167 -0.062928087633658  0.036625785426208 -0.182329767369539 -0.046827781359629
-    8  (  8) -0.029820488646987 -0.037609170202879  0.184366833470305 -0.250608304245861 -0.266157936861978 -0.003343240964033 -0.026232571891440 -0.068560106516425  0.143703222469330
-    9  (  9)  0.097477133499219 -0.253919330671861 -0.022474002349921 -0.091068839306237 -0.030773177890121 -0.124639301979492 -0.057377848460010 -0.129428480584789  0.052503813838482
-   10  ( 10)  0.308102321981415 -0.100099264744172 -0.103502297395079  0.030595871425367  0.027930037535271  0.082924987589621 -0.003621479559882  0.051467583495009  0.001729710593298
-   11  ( 11)  0.065171614185219 -0.083076013227694  0.007781121482082 -0.129638416743258  0.025583078029705 -0.021102804445382 -0.038969277950233 -0.054649593445510  0.156415144250598
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.100574711969240
-    1  (  1) -0.017311198418314
-    2  (  2)  0.099207008690223
-    3  (  3)  0.049312818935542
-    4  (  4)  0.020969683268895
-    5  (  5) -0.168478941844432
-    6  (  6)  0.036633223806040
-    7  (  7) -0.083149987934917
-    8  (  8)  0.054463823630147
-    9  (  9) -0.105100295511211
-   10  ( 10)  0.049112459843749
-   11  ( 11) -0.074285789462190
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000150860459877  0.171933918231252 -0.041419056803072  0.170616058570147  0.200856757156520 -0.002034169374196  0.083717100185599  0.000516882277833 -0.000760835570240
-    1  (  1) -0.171458970665860  0.000052671693709 -0.080477211012241 -0.158047078345989 -0.171611945068556 -0.020781553144960 -0.081182987020708 -0.096111050666912 -0.028348265964974
-    2  (  2)  0.041612402589055  0.080354514984744 -0.000394264947173  0.065176020012681  0.096961733142428  0.000557038525025 -0.109435480142694  0.034287451388532 -0.031868099666052
-    3  (  3) -0.170115569606579  0.158386367352469 -0.064620104688982  0.000274195329164  0.003073114771818  0.155980931184969 -0.002438060010510  0.075892612616599  0.118957615446809
-    4  (  4) -0.200436196772240  0.171813138083843 -0.096620398683267 -0.002372485388961  0.000742978447135 -0.018013393904637  0.033369149651403  0.120720251055992  0.104550918281167
-    5  (  5)  0.002211117433298  0.019930957908302 -0.000666901496264 -0.157204484557621  0.015901976339486 -0.000217821561163  0.009428657942981 -0.039993958187839  0.071492158249729
-    6  (  6) -0.083537896232863  0.081216293971867  0.109652154032100  0.002769108821106 -0.033489275419838 -0.010079357840938 -0.000064832704676 -0.012979883425805 -0.022286123614410
-    7  (  7) -0.000446183372454  0.095595436198971 -0.034260265949943 -0.076357839284767 -0.123056525926531  0.039576937592408  0.012836423633655  0.000276922615353 -0.011862614885765
-    8  (  8)  0.000763780194579  0.028492759060566  0.031582546116686 -0.118324194064185 -0.106500675879643 -0.072862382850876  0.022267846900148  0.011936132807121 -0.000309785123822
-    9  (  9)  0.200009372729413 -0.049971216489633 -0.123430272682259 -0.142933103185242 -0.066275175614906 -0.011400665529444 -0.086697488232449 -0.026102313931474  0.001060546754189
-   10  ( 10)  0.021852700751396 -0.017163247777288 -0.127823592278093  0.091613120127056  0.051604501451930  0.012175072674142 -0.083661634147568  0.068820029767420  0.010286004757943
-   11  ( 11)  0.114973761942494 -0.044704429189879 -0.150112248621738 -0.031470261050302 -0.054465549098901 -0.018492073632933 -0.052809037569742  0.018588462631583 -0.062465552340744
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.199650432776970 -0.021769646283719 -0.115014099877643
-    1  (  1)  0.048847979709979  0.016224624083658  0.045739997653995
-    2  (  2)  0.121535202952087  0.127110081169448  0.150689800369572
-    3  (  3)  0.141534079657396 -0.092900464386430  0.030906929300398
-    4  (  4)  0.064777188331671 -0.052294246689992  0.052576843649814
-    5  (  5)  0.012798646161060 -0.011617495484096  0.021426191620278
-    6  (  6)  0.085439453581865  0.082177824690696  0.054044239620785
-    7  (  7)  0.026881359606727 -0.069312090513404 -0.013578395284128
-    8  (  8) -0.000980665289481 -0.011875108407812  0.069843147407046
-    9  (  9)  0.001396130223525  0.045043795365458  0.018886220574768
-   10  ( 10) -0.041412670665906  0.001872911812120 -0.033067578033610
-   11  ( 11) -0.016567946659153  0.031899396551867  0.001929777984873
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001411268359160 -0.010548061189878 -0.012234985630211  0.023975313562280 -0.023062230820039  0.045437732948681 -0.106872881296076  0.025944637778051 -0.029363485311898
-    1  (  1)  0.014640801150040 -0.001773735046594 -0.029549963184092  0.020758435544442  0.007635590000279  0.056071060358736  0.088482364466965  0.027605241546487 -0.020492843216977
-    2  (  2)  0.013184523566191  0.031261847780049 -0.000489474253254  0.031775189074985  0.038538471296270 -0.038607714449183  0.007921641905981 -0.014600160708699  0.097026534080847
-    3  (  3) -0.023325695791557 -0.021331801923242 -0.030636705569878 -0.000479373870642  0.011687430157835 -0.060845116281804  0.009020253210307  0.020543788213974 -0.119533313623190
-    4  (  4)  0.023654300689698 -0.009020483406481 -0.038301937767707 -0.011962372815437 -0.000301509800453  0.037261192743398  0.029045239001199  0.041781275442091 -0.051627710213779
-    5  (  5) -0.044386181810683 -0.057414182896665  0.038267122468401  0.061256729128929 -0.037800933596037 -0.000260698778894 -0.001511863535883  0.016380337639677 -0.072487672330699
-    6  (  6)  0.106206323004553 -0.087758718377781 -0.007560784408469 -0.009263545408533 -0.028871039692754  0.002023613184462 -0.000132116955283 -0.000735561511998 -0.010945124965688
-    7  (  7) -0.025425283561814 -0.027796807869910  0.014997640380461 -0.020644254386635 -0.041827532757913 -0.016146444702388  0.000831333123472  0.000058581308311 -0.017035220679833
-    8  (  8)  0.029580773528628  0.019460244903885 -0.099428018149333  0.121448802541844  0.052251959451872  0.071719334941988  0.011527870420583  0.017438360216925 -0.000376592607811
-    9  (  9) -0.011323796835811  0.022846032797884 -0.003463845070647  0.010590766229841 -0.093908204414477  0.097279630619014  0.016132246312287  0.052832474295790 -0.033804637999018
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.012386803276718
-    1  (  1) -0.025331755243544
-    2  (  2)  0.004701299813181
-    3  (  3) -0.011259859427831
-    4  (  4)  0.092847122914529
-    5  (  5) -0.097092353171668
-    6  (  6) -0.015797039269438
-    7  (  7) -0.052823551833136
-    8  (  8)  0.033708639353932
-    9  (  9) -0.000241834945391
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019875399821365 -0.067213072995023  0.012299941717659  0.003468875187880 -0.030128328426274 -0.082822743936825  0.001897897698354 -0.021797662835713 -0.095153762344945
-    1  (  1)  0.006451292960481  0.005754162581844 -0.002884034500734  0.094974935426192  0.041098451485401  0.000058064511604 -0.008894806239621 -0.025485003895974 -0.057087471632476
-    2  (  2)  0.026223355242450  0.024273603088334 -0.016292189081393 -0.015844039410231  0.030633853079712 -0.077008417539564 -0.014788316606733  0.000243822647885 -0.007976439135467
-    3  (  3) -0.025334252850709 -0.027648721071750 -0.005856451162092 -0.011279594978250 -0.045220581787047 -0.007788112252830  0.015791844926599  0.026413664639332 -0.132992803966333
-    4  (  4) -0.028858615977169 -0.070880006979721  0.078385497137577  0.115909817357349 -0.170672806468397  0.002802625270051  0.018507237940661  0.116641608428124 -0.183930260352482
-    5  (  5)  0.062029310382341  0.165059238935656 -0.096438123628463  0.170982438012572  0.101168051978722  0.247462788062147  0.078143137508448  0.065503368874352  0.123407161852621
-    6  (  6) -0.029868108814055  0.043826434723281 -0.020536879880122 -0.040118359069746  0.047262891605686 -0.111204577364818  0.250427612151989  0.027185217329734  0.027972758218343
-    7  (  7)  0.071045843569722  0.110497052752988 -0.212396167514294 -0.014472401617176  0.201746291025428  0.058726820006450 -0.038658609736798  0.191686821472890  0.051568740310987
-    8  (  8)  0.030231001314245  0.039607181613347 -0.190237369746058  0.251586833919896  0.277372132160808  0.008690855780340  0.027285881313233  0.066231456708385 -0.148705440863578
-    9  (  9) -0.119406447574908  0.267992491845044  0.024723477609567  0.092623842023547  0.035484932702787  0.135905292178670  0.058976108500788  0.137156317198896 -0.050622979340015
-   10  ( 10) -0.354731988399122  0.114731465978240  0.113605854938311 -0.033621899430544 -0.024886546894064 -0.086388159191061 -0.001760250802633 -0.054814426010942 -0.004266849862045
-   11  ( 11) -0.074987139083159  0.087839869817099 -0.017174937068014  0.139817452729011 -0.030459814346611  0.019645857821193  0.042455388198899  0.058190403006369 -0.165317136166192
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.104159520209993
-    1  (  1)  0.017365114579609
-    2  (  2) -0.105508249406411
-    3  (  3) -0.051333283782025
-    4  (  4) -0.026824469147080
-    5  (  5)  0.172355785037806
-    6  (  6) -0.037231897229526
-    7  (  7)  0.092488656033236
-    8  (  8) -0.060576527966250
-    9  (  9)  0.114591221791530
-   10  ( 10) -0.052791324163552
-   11  ( 11)  0.078009502545252
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.013905849892992  0.105574256292555  0.058365326510732  0.011150777040830  0.004301162141041 -0.055780562682692 -0.053115864387752 -0.011951099406770 -0.044340643594202
-    1  (  1)  0.013705956820555 -0.025309547841960 -0.001538984041734 -0.001849504741603  0.005133976748632 -0.012878903904056  0.096751125536924 -0.003812996689903  0.009632709529968
-    2  (  2) -0.020569845493093 -0.032320703460180 -0.011944643866745 -0.047792544188734  0.032679729361416 -0.019407207672949 -0.038230397931919  0.003676283556944 -0.058784384336985
-    3  (  3)  0.071874917867093 -0.002631775952960  0.003539152259809  0.028170151218425 -0.033082337295689  0.021301963625855 -0.050188554745657  0.011804977856767  0.016979295260921
-    4  (  4)  0.014914728990396  0.041337858840349  0.031774187859112 -0.031846901880618 -0.020737884741536  0.009318588686327 -0.180587918491444  0.014608314108616 -0.091927794627027
-    5  (  5)  0.043163603381900 -0.253570894625469 -0.078110646309368 -0.060207643631253  0.083755719198877  0.160896258343551  0.127680183234514 -0.074831092977117  0.060961655981049
-    6  (  6) -0.044917686060828 -0.074437543040067  0.066817478801761  0.141365137531753  0.114156889702257 -0.038201515939482 -0.107320317731531 -0.348968351908512  0.116558406175751
-    7  (  7)  0.034184804469893 -0.226667134284391 -0.206947793731390 -0.080987919933847  0.050884738274657  0.136027438420489 -0.157869432700479  0.195670168357032  0.055408723502488
-    8  (  8)  0.031166515249721  0.045258191750987 -0.124213591624855  0.070497635611886 -0.013839913877531 -0.080645709057116 -0.048975111106761  0.013846985677438  0.081456527024621
-    9  (  9)  0.260272045600859  0.057970015239195  0.114635559073584  0.083827066916392 -0.094102194410800 -0.136997319599706 -0.136846202555835 -0.093755934766235 -0.066197390562813
-   10  ( 10) -0.128170228467008 -0.270987976538407 -0.063355286850330  0.080149940628318 -0.057123968341669 -0.051813056590924  0.080732658365778 -0.110930691434851 -0.002284134974517
-   11  ( 11) -0.014638573493894 -0.093181336572008  0.090893348615143 -0.060951699754620 -0.036152243930201  0.068685591001865 -0.022141424075597 -0.054226980293487 -0.076820031900454
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045178917656151
-    1  (  1)  0.000506654263468
-    2  (  2) -0.062622183647669
-    3  (  3) -0.006475863513060
-    4  (  4)  0.009581278166545
-    5  (  5)  0.123788681467482
-    6  (  6)  0.140490962930464
-    7  (  7)  0.012343887711756
-    8  (  8) -0.065924555702067
-    9  (  9) -0.071777365622544
-   10  ( 10) -0.030198414714018
-   11  ( 11)  0.038206097812612
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000441373721971  0.087271451504254  0.308356080671030 -0.018077607068688  0.073688004857476 -0.153028983755896 -0.021375900910730 -0.125940926422186  0.021636449149896
-    1  (  1) -0.086671311731224 -0.000204963757277  0.004083848977647 -0.019054726614325  0.000357076891570 -0.008883507874300 -0.245817294107565  0.139613669494547 -0.011872389377551
-    2  (  2) -0.307138366785038 -0.004537268804354 -0.000000947821260 -0.032420162338715 -0.044765722657128  0.148620348284250  0.082511203687099  0.091836400843881 -0.021157739960336
-    3  (  3)  0.018180307170497  0.018806737266631  0.032304346608179 -0.000164575589082  0.000048486967076 -0.033944617253518  0.017906518922370 -0.039367589983503  0.041014607610233
-    4  (  4) -0.073708499176395 -0.000188579066207  0.045384824461272  0.000051244255112 -0.000118131709454  0.009319825672971  0.005919844337701 -0.028188407915503 -0.062383088971619
-    5  (  5)  0.153503404134916  0.008021529263725 -0.150851560923171  0.033683034219721 -0.010920406889103  0.000843675018215 -0.002305152210287 -0.006419896281910 -0.018802686354169
-    6  (  6)  0.021663782224978  0.245568524819791 -0.082607420634013 -0.017861578854728 -0.005717491537118  0.001465956881798  0.000164104368228  0.019402844307281  0.008582138264613
-    7  (  7)  0.126272473343725 -0.140132379196136 -0.093779865985419  0.039016174646910  0.027756266123623  0.008788078328085 -0.019927753575961  0.000986178708271  0.006276129856304
-    8  (  8) -0.021659942465065  0.012093240675092  0.021224721403549 -0.041292366946203  0.063444639030514  0.018952234899780 -0.008805846385022 -0.006555018834286  0.000619883795504
-    9  (  9) -0.110032896200750  0.071298113833135  0.163479589536219 -0.111444129990912 -0.024671365993001 -0.003210445766199 -0.009378587102769 -0.014713425509001  0.000839110373856
-   10  ( 10)  0.069217830582824 -0.088543829220743 -0.203682134643279 -0.186485128327869 -0.053425964853416  0.063005981229243 -0.018184933705949  0.000540007105749 -0.005219687452082
-   11  ( 11)  0.023959189620953 -0.030895371890558 -0.044769544498433 -0.009068900298863 -0.130492147876274 -0.035762663243292 -0.002770335503139  0.023536235288276  0.010103727285469
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.109799080219678 -0.069203346900770 -0.023919903278421
-    1  (  1) -0.071129060568146  0.087605257548157  0.030425173883571
-    2  (  2) -0.162026048331677  0.201435103487415  0.044723919546572
-    3  (  3)  0.110972252607892  0.185860701404063  0.009243336757067
-    4  (  4)  0.024458462243726  0.052145051182170  0.130041721565426
-    5  (  5)  0.002181441725954 -0.060001657923379  0.037138509415485
-    6  (  6)  0.007938597292020  0.017379429117453  0.002521412739913
-    7  (  7)  0.012919580840703  0.002428706377795 -0.023595862068092
-    8  (  8) -0.000273485582407  0.005817339116375 -0.014280567707235
-    9  (  9)  0.003328589668182 -0.017803512680764 -0.001063197928266
-   10  ( 10)  0.016699725327030  0.001798758796680 -0.002170763958318
-   11  ( 11)  0.001212933542278  0.001783778903851  0.003563107345321
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002010159634630  0.000220404084817  0.003192882122880 -0.011052627613533  0.003562668031365 -0.009837814318177  0.002544312104621 -0.035965473851195  0.038472004952375
-    1  (  1) -0.001452297302852 -0.003072719747229  0.008838287240450  0.026771929595669 -0.046483406284037 -0.009889595128182  0.035422086740367  0.011912247720366 -0.000936796016060
-    2  (  2) -0.004597077371462 -0.009797303502342 -0.002356759440367  0.013160928599717 -0.036596664601802  0.014914711645441 -0.014591721304407  0.007418668493650 -0.037805835513950
-    3  (  3)  0.010591350137419 -0.026807560073439 -0.010708663838159 -0.000566073142147 -0.006877298509595  0.015806087254090  0.036616622156539  0.004527327935437  0.052470069694755
-    4  (  4) -0.002197180048840  0.045360469690206  0.037290055709025  0.006377690547549 -0.000197738244084 -0.043135976717434  0.013927669894978 -0.013270906950991 -0.034225968512880
-    5  (  5)  0.012223872820757  0.012276608732166 -0.015974082159209 -0.014788689444500  0.043434889585929 -0.001241108463199  0.022259649308453  0.002776600972090 -0.020757469065177
-    6  (  6) -0.002236227833952 -0.033698361699947  0.015413577603851 -0.037176700349159 -0.013637799368342 -0.022481473057898 -0.000196461263851 -0.066878572107562  0.012948719456691
-    7  (  7)  0.036159618368672 -0.011023728969868 -0.006496546324176 -0.004756159901056  0.013088014945893 -0.003050957277162  0.066534588876792 -0.000038997802685  0.018679498186635
-    8  (  8) -0.037272822971437  0.001025968499180  0.039463494780131 -0.053213044947716  0.033933492458794  0.020627554065949 -0.012927451364571 -0.019084958215300 -0.000379158267741
-    9  (  9) -0.044713556544603  0.031925295057843 -0.027454374007067 -0.016949911467799  0.043552787687819 -0.029362229767510  0.013081869754981 -0.017575107888422  0.005208148088787
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.046477985245624
-    1  (  1) -0.031367776651430
-    2  (  2)  0.027386023407765
-    3  (  3)  0.017151073595537
-    4  (  4) -0.043659143705007
-    5  (  5)  0.028276225310864
-    6  (  6) -0.013015371352964
-    7  (  7)  0.017243006711225
-    8  (  8) -0.005600961681940
-    9  (  9) -0.000315129095420
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016735058692801 -0.127427648471711 -0.067812616467594 -0.013558783551809 -0.005269296599083  0.059347294870606  0.061177076545679  0.011973162399102  0.046187859594365
-    1  (  1) -0.006127975507731  0.027720789931143  0.002131386760238  0.002129686454541 -0.005489719844856  0.015177604183485 -0.105071662567975  0.004089530302215 -0.010958371300164
-    2  (  2)  0.014625553671885  0.033500045224482  0.010197102842648  0.049282810089046 -0.029146517326401  0.023890316169967  0.041396999030433 -0.003031629472559  0.064649337167924
-    3  (  3) -0.059287322502299  0.004510597912865 -0.001550787253983 -0.026031838087948  0.030781241595677 -0.028268360125230  0.056263472143293 -0.012481413064923 -0.018331852915645
-    4  (  4) -0.010310728455768 -0.048004310504315 -0.024726014802135  0.029487545392420  0.016798380655264 -0.006146311288820  0.193469287289224 -0.016404156709459  0.090545229018770
-    5  (  5) -0.048438874849073  0.279911055793901  0.091858080305683  0.061529389949110 -0.086013764646970 -0.169909289190226 -0.137573811978801  0.079110070379465 -0.068315894389439
-    6  (  6)  0.059086874754328  0.080452543242778 -0.072102486682582 -0.152740972704247 -0.124804294386305  0.037562128266895  0.116816705616042  0.371092921921504 -0.124060147180532
-    7  (  7) -0.029687956296635  0.256142179942571  0.224177989138016  0.089126356257227 -0.052538373002914 -0.151219359570602  0.169667778296547 -0.210592113990055 -0.060100313305223
-    8  (  8) -0.037809640230564 -0.049847669441603  0.131510551596478 -0.073995987264147  0.016613192275803  0.085953668087854  0.052289681067999 -0.014235003810069 -0.085573468377869
-    9  (  9) -0.334054043680738 -0.062946651230341 -0.131443841559570 -0.090838578825240  0.107669515927940  0.163692131260888  0.145222895910058  0.104796708213769  0.078942908507754
-   10  ( 10)  0.149544392295761  0.318224503990855  0.078211068857457 -0.094418507207579  0.062827781432203  0.056112671791795 -0.092070650285035  0.118729407251681  0.005066399630771
-   11  ( 11)  0.017252785597153  0.111183203080125 -0.114995811791783  0.075235812067226  0.042976611330520 -0.083335038142330  0.026013221761888  0.060774659749613  0.084239808865889
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.046526303364398
-    1  (  1) -0.000196633156806
-    2  (  2)  0.068136524138653
-    3  (  3)  0.003983938855648
-    4  (  4) -0.006861374242241
-    5  (  5) -0.130771416331255
-    6  (  6) -0.153069412317755
-    7  (  7) -0.016354872554726
-    8  (  8)  0.070442312778792
-    9  (  9)  0.084886961073099
-   10  ( 10)  0.034495414084981
-   11  ( 11) -0.039745136609744
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007512480776319  0.036140698221162  0.006614016091629 -0.006989344711517  0.012538055579667  0.047719007710800 -0.011438854389831  0.001348837643708  0.043912417866150
-    1  (  1)  0.000217941106815  0.023674382271911 -0.074458985850499  0.018669991150763 -0.024216220760344  0.026693268127322  0.030529166464713 -0.009220514907509 -0.051390413902716
-    2  (  2) -0.018657169402382 -0.000504863635670 -0.063891633981927  0.031237660505947  0.009378378679164 -0.057274634026543  0.010216661924779  0.007277876487311  0.107239917659553
-    3  (  3)  0.016066164003828  0.014293064557711 -0.024640166827267 -0.100199283130149  0.053038409095112 -0.079899101326132 -0.014809180078406 -0.008036171971183 -0.093693488350467
-    4  (  4)  0.014907654111593 -0.000249634614143  0.129575540220445  0.265751473143634 -0.141781144259113  0.223368583932083 -0.004368931811378  0.027043226757367  0.062609693461921
-    5  (  5) -0.041914834745247 -0.097616041138947 -0.135770321463814  0.246024098805421 -0.106912109293501 -0.321253251117319 -0.068788844583990  0.142290197287628 -0.046076100892295
-    6  (  6) -0.039123394394723  0.039408255038257 -0.037211012657418 -0.010312056024403  0.060353960942951  0.114209155992994 -0.186728746530896 -0.112616911396924  0.025666796391066
-    7  (  7)  0.018468061945917  0.067823974613178 -0.190104823535190  0.003755811520253  0.014064572484241  0.109658452638694  0.056630665145805 -0.263520506917883 -0.064583476374394
-    8  (  8)  0.033210755622659 -0.136136968498900  0.263316618160002  0.077412830589797  0.422459728217546  0.053553377730948  0.034175715906935  0.165897217652793 -0.074779388344555
-    9  (  9)  0.055036749751630 -0.056894038751104 -0.107311287797063 -0.058290191137784 -0.056944188937166 -0.005725850016316  0.009926099968286 -0.140696143209114 -0.190545524907610
-   10  ( 10)  0.130997705273781 -0.090153965609249  0.007790248268810 -0.054524064976066  0.013947321007330  0.034280119179197  0.056585811356156 -0.002663395414836  0.003086708496419
-   11  ( 11)  0.024354529821742 -0.002391484587850  0.132211150437169  0.155582434877820 -0.034543780627935  0.051588565499349 -0.027770703760258  0.083659992199369  0.057647900826746
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.055482114656335
-    1  (  1) -0.000101235030463
-    2  (  2)  0.010234508711291
-    3  (  3)  0.213846558445248
-    4  (  4)  0.006630092722992
-    5  (  5)  0.012814259546957
-    6  (  6) -0.078975443650986
-    7  (  7) -0.184930804112230
-    8  (  8) -0.058689588477811
-    9  (  9)  0.044249382467578
-   10  ( 10)  0.036865706935893
-   11  ( 11) -0.030515341975517
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000120442405581  0.037525975792407  0.039028837738652  0.219221358143393 -0.183820180818448 -0.112972286408530  0.047240063409728  0.020414149561154 -0.034238085799271
-    1  (  1) -0.037241793728452 -0.000047287882243  0.009729516430168  0.094202030077235 -0.063477866953276  0.160286164587806 -0.109752667557022 -0.131207263236284  0.068887611832074
-    2  (  2) -0.038783295216622 -0.009745201912242 -0.000258217562465  0.013038009614076 -0.045399222161827 -0.081371094984120  0.019570499748086  0.076966277295000  0.058756671783764
-    3  (  3) -0.218771475127948 -0.094047631347429 -0.012728901107962  0.000222898647350 -0.006965466758731  0.051483080000543  0.001032959857400  0.046617530443310 -0.239873280201692
-    4  (  4)  0.183500005674293  0.063741918250972  0.045633149570229  0.007771962048066 -0.000752652425378  0.016686259902744 -0.006062931975271  0.002941130184259  0.039794941498885
-    5  (  5)  0.112922744463035 -0.160447948543053  0.080839610143832 -0.052938181517924 -0.014759035093032  0.001963138533058  0.004122965199026  0.030082971847399 -0.018688716203396
-    6  (  6) -0.047223957422349  0.110045906731433 -0.018982606895220 -0.000425116658999  0.006190502350060 -0.005177802298965  0.000459941844479 -0.006641133881612  0.015637294529107
-    7  (  7) -0.020258099631627  0.130980408805956 -0.076838250722457 -0.047153827019528 -0.001697177794538 -0.030097214957006  0.006397035656861 -0.000314330689973  0.000958762971255
-    8  (  8)  0.034242059158271 -0.069241386609174 -0.058253268615506  0.239551778865238 -0.041466100486767  0.019183970473991 -0.016012586324303 -0.000462521772429 -0.000639781016008
-    9  (  9)  0.110158178577256 -0.043113630563978 -0.067267974845207 -0.106313996022487  0.002243251219660 -0.021517985932208  0.002884772712544  0.010112074041123  0.004700729741936
-   10  ( 10)  0.070149397127063 -0.040299222838292 -0.154071817441956  0.030869069243567 -0.038016470293222  0.011150694193011  0.007490401305220  0.020531677805594 -0.003859946060401
-   11  ( 11) -0.176636225337744  0.095095393142691  0.195177688825668  0.108802410559496 -0.020149361123103 -0.001298105635127  0.020927308070429 -0.032058427881699 -0.018315736142454
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.110002482243441 -0.070133081529118  0.176505754583752
-    1  (  1)  0.042468765075500  0.040212942886088 -0.096465231599211
-    2  (  2)  0.066618057955858  0.153916879455284 -0.197045228959983
-    3  (  3)  0.105738247971788 -0.031572929220209 -0.109334469149534
-    4  (  4) -0.002665514835355  0.037310624735359  0.021518865524247
-    5  (  5)  0.022104060533187 -0.008811719711463 -0.005069793238862
-    6  (  6) -0.004143184140488 -0.008777342033569 -0.020657864679248
-    7  (  7) -0.010048741121033 -0.019686189563806  0.029679561142739
-    8  (  8) -0.004305480816755  0.003474531743331  0.021387666942059
-    9  (  9)  0.000592809919997  0.021935245808500 -0.003238719819323
-   10  ( 10) -0.019997593459389  0.000606363597873  0.056392578735375
-   11  ( 11)  0.002880485106043 -0.055206554617854  0.001235092281117
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000888157000468  0.002604640035267  0.004433898987700  0.017327910307372 -0.010855912598213  0.001781915278721  0.008615460934422  0.004078735474285  0.032557314773045
-    1  (  1) -0.000573161245420 -0.000624628285884  0.035628999167227 -0.001815728764627  0.008946874115813  0.029170863803310 -0.000115513436505  0.008856710566910  0.004031507153659
-    2  (  2) -0.003701039844373 -0.036575536539622 -0.001091193696307 -0.032172216141300  0.001275865950015  0.022397487526299  0.009622303363090  0.007231877711175  0.019725778025116
-    3  (  3) -0.016821693036289  0.002844602963518  0.032977853684673  0.000161455575952 -0.028542188119355  0.026304537820681 -0.001013466229083 -0.013057607695183 -0.044876693583426
-    4  (  4)  0.011431384588178 -0.009478622864698 -0.000774534739031  0.028965078860221  0.000058413694986  0.014596515715548  0.009143536386555  0.018007246969037  0.087822521777407
-    5  (  5) -0.001221856014832 -0.030845996389588 -0.023077706374501 -0.025758114847142 -0.014593714027409 -0.000250583717006  0.003873642475734 -0.026298757281796  0.079590541434343
-    6  (  6) -0.009743031224748  0.000827857567403 -0.008744416704428  0.000735028308095 -0.009056595663713 -0.003266063160321 -0.000168072469286 -0.014668639254903  0.020470938456272
-    7  (  7) -0.003647754834421 -0.008460886211306 -0.007264440669328  0.013024018123218 -0.017787838957003  0.026317221009114  0.014749296379031 -0.000019923943455 -0.029438703128615
-    8  (  8) -0.031026550181144 -0.004477343275687 -0.020769831071035  0.045275173918403 -0.088633054403976 -0.080566188830968 -0.020052483095054  0.029483325674276  0.000128037153401
-    9  (  9)  0.012269663364479 -0.042319244263402  0.071429692849981  0.076602220709806  0.093629733790147  0.065554975939979  0.020165870906458  0.076547332424074  0.015636093570251
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.012474935539863
-    1  (  1)  0.041072842913216
-    2  (  2) -0.070651080248399
-    3  (  3) -0.076892460848025
-    4  (  4) -0.093624677134694
-    5  (  5) -0.065506732660539
-    6  (  6) -0.019889038609582
-    7  (  7) -0.076305954221087
-    8  (  8) -0.015612091565202
-    9  (  9) -0.000252880154158
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.009427979504735 -0.045069494658558 -0.001947285705090  0.002710338034860 -0.015522926834851 -0.047663635028120  0.012944383860693 -0.002408628963511 -0.046667839995062
-    1  (  1) -0.000029889909955 -0.026801338329852  0.080490862472698 -0.019668739880126  0.025396971257700 -0.032890092829257 -0.033906444326876  0.009364690845122  0.055325390015170
-    2  (  2)  0.013223768231853  0.001284266713521  0.066553348308937 -0.032573816116206 -0.011585258035685  0.060717975924391 -0.011936168857210 -0.007853073890483 -0.116794956739995
-    3  (  3) -0.012900769345878 -0.013623437855550  0.022570570921494  0.105173709434029 -0.056797034187850  0.081144841159178  0.016572432074935  0.007712189870591  0.096484218880683
-    4  (  4) -0.015650650711432 -0.003889202049455 -0.137621535484575 -0.283731289627315  0.151612143157194 -0.236884111934266  0.005136759708167 -0.028125482384447 -0.063101070821467
-    5  (  5)  0.049233650528213  0.108628515589384  0.145433760308553 -0.264881634113210  0.112823478790252  0.343941453835902  0.074580579832084 -0.152217918461378  0.050073263216128
-    6  (  6)  0.047771378538329 -0.043773249125745  0.042587468032780  0.011128298856248 -0.066617092775075 -0.124136463076967  0.204572752605319  0.119847093573235 -0.027500955272741
-    7  (  7) -0.017888279952241 -0.071752886460858  0.208298887916757 -0.005542743128559 -0.016702047381836 -0.119479054133457 -0.062994319192022  0.283598496506144  0.069642269402630
-    8  (  8) -0.037568403528376  0.148073898852809 -0.285205978681411 -0.081955004515730 -0.456336274750824 -0.051315761340278 -0.035910751818194 -0.176384561285241  0.080264248689634
-    9  (  9) -0.073735844540901  0.063193611128899  0.114658323070558  0.062815237579419  0.064185887519018  0.009313244304943 -0.011480973281939  0.153753080425913  0.207572044587912
-   10  ( 10) -0.162215796938684  0.102608816758085 -0.007760654943323  0.059426107703524 -0.013639971522339 -0.037904077339461 -0.064744743002174  0.002349088500079 -0.003377674546375
-   11  ( 11) -0.030714567047902  0.017149469368505 -0.148281723814033 -0.168021936553750  0.043219337814574 -0.059348822268391  0.027602295508655 -0.090506279699096 -0.064287335914591
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.058979846663424
-    1  (  1)  0.000234151433416
-    2  (  2) -0.011430006640806
-    3  (  3) -0.225608458896205
-    4  (  4) -0.014102875489979
-    5  (  5) -0.012200282245874
-    6  (  6)  0.083455375182168
-    7  (  7)  0.198201250764442
-    8  (  8)  0.062481817545980
-    9  (  9) -0.043390015833605
-   10  ( 10) -0.040973644943399
-   11  ( 11)  0.034098640710675
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057027762100789  0.007489633887342 -0.036964189813796  0.021384352100284 -0.004867815775604 -0.032130235858782  0.019486973797962  0.000503926514732  0.024868986663351
-    1  (  1) -0.007883399599923  0.007529104506445  0.013216566770749 -0.001554286609489 -0.002481002458300 -0.003555137440754  0.020216878378801 -0.003435265519663 -0.003420680709423
-    2  (  2) -0.005061763911744 -0.024005030999464 -0.016920245291348  0.019760528227158  0.007759414271484 -0.029231812106945 -0.009559298232843  0.004745878981161  0.053662769962019
-    3  (  3) -0.011903086348447  0.106154395386531  0.048846797682958 -0.038122834717736  0.042076447151745 -0.017515736018254 -0.021695004377211 -0.017259669010754 -0.058953679400153
-    4  (  4)  0.086846706941042 -0.161257530089836 -0.037361255861875  0.089905419413410 -0.174437646387183  0.071028892880315  0.038811212273731  0.045200518155063  0.066894551440516
-    5  (  5) -0.295118954821928 -0.042171667688274 -0.057142717280935  0.095328920031059 -0.118376834610768  0.017202604507056  0.038088685926927  0.015413673756028  0.019970185142534
-    6  (  6)  0.061695197805604  0.041447416246154 -0.107874329349021  0.009310856499629  0.028327062477196  0.072556054900044 -0.031173831746629 -0.093673016450942 -0.096470656575707
-    7  (  7) -0.040164356283535 -0.019606328824315  0.022514162311588 -0.103095269177578  0.105738125414362 -0.000251323240260 -0.190667102998226  0.014251172141516 -0.042544347999407
-    8  (  8)  0.209747539729284  0.026225521984115  0.065411218317390 -0.108576414051802  0.195951046046893 -0.054935351774023  0.181062671358124 -0.048648601818055 -0.037403343457353
-    9  (  9) -0.029537922421234  0.045187174636289 -0.013381512217286  0.049426415359509 -0.003411235911782  0.045265306723710 -0.096457278821335 -0.006113492494935  0.044165814974043
-   10  ( 10) -0.026870929841946 -0.010513244846490  0.122411818973730 -0.066300236331789  0.074150921852319  0.175359501999903  0.025219490294838 -0.031299023505132  0.032770162927265
-   11  ( 11)  0.076638806040972  0.048660864910506  0.054798136469999  0.067410404189619 -0.096042680906718  0.030077767167195  0.040609376761651  0.003350033647470  0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007613623485115
-    1  (  1)  0.001053219582711
-    2  (  2) -0.054751844139672
-    3  (  3)  0.021588797011546
-    4  (  4)  0.069416579868176
-    5  (  5)  0.031311068013170
-    6  (  6) -0.060683491342485
-    7  (  7) -0.004937786560826
-    8  (  8) -0.055843386605960
-    9  (  9) -0.053258374332423
-   10  ( 10) -0.029326398375861
-   11  ( 11)  0.027904630917537
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000025015734507 -0.010198711087952 -0.006474775958448 -0.066946051563528  0.066550206967977  0.041188873125926 -0.023552914991952 -0.019202263160422  0.006942946197737
-    1  (  1)  0.010140605887652  0.000014394957877 -0.022996796061328  0.067092192493274 -0.063685673857393 -0.019093615376604  0.005525180617760  0.015031464830750 -0.005320182556269
-    2  (  2)  0.006534739001904  0.022969584694137 -0.000183457658640  0.211551326757209 -0.218187807438925 -0.104132114893528  0.065436658246811  0.042103919182146  0.012243831904844
-    3  (  3)  0.066304931943444 -0.066584833979085 -0.210703888875489  0.000394093515089  0.011258600581601  0.092530428436357  0.131881992071255 -0.026480578605083 -0.063346368194022
-    4  (  4) -0.065779542430873  0.062822415172501  0.216601239538476 -0.011617389043850 -0.000720555249011 -0.020159848057855 -0.073942431465134 -0.001119920964031 -0.016120241216710
-    5  (  5) -0.040846799691504  0.018979734118351  0.103125251405654 -0.092549855601907  0.021623501291584  0.000771447754999  0.234552119202209  0.000611164043666  0.101606719343242
-    6  (  6)  0.023326218450828 -0.005550385111505 -0.065252405074981 -0.131681855193961  0.073575257938565 -0.233645237851028 -0.000193851682480  0.255788429172446 -0.079072823032341
-    7  (  7)  0.019055068515462 -0.014786531642521 -0.041539856986611  0.026353850726780  0.001700683540838 -0.000445480591706 -0.255766070671258 -0.000118381893033  0.151562772366571
-    8  (  8) -0.006620321009197  0.005142966830662 -0.011245852682541  0.062510776113309  0.015648596901915 -0.102272652360209  0.078381794853266 -0.152302821501449  0.000094469957927
-    9  (  9) -0.045347281960025  0.040291069791943  0.085226922335689  0.018441757598111  0.027467525239214  0.004932928889320  0.020868912898856 -0.024483356625930 -0.224180460199113
-   10  ( 10) -0.020374790573784  0.028198954860440  0.010392111666997  0.120181326176130 -0.060512260831236 -0.109015894697222 -0.047153104465120 -0.043944046420833 -0.103069326885495
-   11  ( 11)  0.049408052352300 -0.045270280246414 -0.110185553685008 -0.041594160321979 -0.088273360930753  0.183934249639257 -0.003285919080508  0.178701510068243 -0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.045673042542890  0.020717466986083 -0.050844518832522
-    1  (  1) -0.040043621408487 -0.028287827625151  0.045457031631407
-    2  (  2) -0.084888848710605 -0.010052611398803  0.109898373773783
-    3  (  3) -0.018088362425205 -0.120534313520650  0.041770057803413
-    4  (  4) -0.026789230886550  0.060849702419905  0.088673365261613
-    5  (  5) -0.008004711197727  0.108432873838655 -0.185071361149961
-    6  (  6) -0.020116775504235  0.047889712574718  0.001523439225442
-    7  (  7)  0.023964360822185  0.043618854823263 -0.177454217319223
-    8  (  8)  0.226734396044438  0.102481459206944  0.008115223439087
-    9  (  9) -0.000423083368406 -0.309060226547434  0.090400550219427
-   10  ( 10)  0.308249178857435 -0.001017567434936 -0.330623886780632
-   11  ( 11) -0.090136758927266  0.334530610017321  0.000453348817603
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000379496190680 -0.036516557673727  0.022488411844201  0.041143099111719 -0.015151024607555  0.009820525598214  0.001328546168408 -0.002719718233480  0.079787685858295
-    1  (  1)  0.035173743352485  0.000509376348503 -0.021748140811100 -0.018984912310085 -0.002571720003760  0.101540537848848  0.014107119535580  0.020961802105584  0.100916916558314
-    2  (  2) -0.024420430259890  0.020833264343634 -0.000589210441902 -0.028690810435666  0.025063562199365  0.056845698692633  0.019362765266970  0.000534124800005  0.061230653902760
-    3  (  3) -0.039980341452345  0.019929624233720  0.028127725164783  0.000384377200086 -0.012223469426354 -0.007870420436516 -0.021500821930750  0.002985124038023 -0.055850425927213
-    4  (  4)  0.015033200445576  0.003096204403696 -0.023799943458502  0.011898049659739 -0.000036971633887  0.000277032322295  0.021239662546675 -0.005095064856192  0.060237805990277
-    5  (  5) -0.010708008535887 -0.101587409014600 -0.056660431011914  0.007350368054025  0.000126941263904  0.000065704202214 -0.008506831299188  0.011228150905342  0.011964202302477
-    6  (  6) -0.000469087338482 -0.014200163610075 -0.019097267233085  0.021632296910845 -0.021392214011008  0.008495741848254  0.000109627873962 -0.021812533614874 -0.020464844726232
-    7  (  7)  0.002889338898616 -0.020632474935553 -0.000453752095144 -0.002975803626006  0.005037506724376 -0.011335159213681  0.021733393798695 -0.000007087204356 -0.019955598928897
-    8  (  8) -0.081293710509515 -0.100918057466141 -0.060971767857812  0.055875536861090 -0.060631757745431 -0.011264467031019  0.020209151997608  0.020081495210629  0.000340983773767
-    9  (  9)  0.080516503167305 -0.106262951221757 -0.031461397073353 -0.007056184146683  0.022432192781915  0.017093833942137  0.097099983466552 -0.001349018368294  0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.079753101670227
-    1  (  1)  0.106710217482987
-    2  (  2)  0.031619499292907
-    3  (  3)  0.007164069356259
-    4  (  4) -0.022223903647397
-    5  (  5) -0.017462464724719
-    6  (  6) -0.096957045420818
-    7  (  7)  0.001243112172754
-    8  (  8) -0.004611313750592
-    9  (  9) -0.000252169760563
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055343853322395 -0.005338522209203  0.036325792187091 -0.020411379114398  0.005004472559017  0.030883540419705 -0.019693764112942 -0.000404480716013 -0.025396203204216
-    1  (  1)  0.006570683600848 -0.008768421568488 -0.011573795638563  0.000009175751903  0.002770565739659  0.004931208897901 -0.022163570789429  0.003290104656908  0.003254936700297
-    2  (  2)  0.001674419203277  0.021967102120902  0.025831824909554 -0.024758928994745 -0.009340908203812  0.034459015755376  0.010228225914487 -0.005919790861067 -0.058115699230390
-    3  (  3)  0.007779977639509 -0.106141218473434 -0.050482163293278  0.041812559908941 -0.042606909564863  0.016938249582167  0.022723831963497  0.018285942873731  0.061788101761112
-    4  (  4) -0.087397972334062  0.164590469335859  0.035983465272717 -0.095460926704216  0.183399304764373 -0.073380967092300 -0.038295030471351 -0.047026058194857 -0.066959437295317
-    5  (  5)  0.293750190777910  0.042648437038433  0.056404874075468 -0.100193237694056  0.123782490033077 -0.014652582564902 -0.036251400704161 -0.016769125982848 -0.023410414575794
-    6  (  6) -0.063526410041118 -0.042202406515953  0.107158367449000 -0.011222400592515 -0.032805848689894 -0.070775222023081  0.034269417179590  0.097599209765295  0.095048599779477
-    7  (  7)  0.039213631545190  0.016300797142278 -0.022834925899151  0.106699749704471 -0.109813770660251 -0.000567880224415  0.192962587636570 -0.013162275101134  0.042958800457043
-    8  (  8) -0.207671023275567 -0.021761663181296 -0.066317329893717  0.113575721461044 -0.208505431005016  0.053139089145086 -0.182387663583988  0.049317657695772  0.039898751560786
-    9  (  9)  0.031717525025615 -0.035452316963842  0.019040840253717 -0.049757955126745  0.003315672276934 -0.048439544916052  0.094357742781682  0.007725852797236 -0.042206115018339
-   10  ( 10)  0.030723138202058  0.012685537900520 -0.130253036286197  0.070878549267589 -0.073822499716479 -0.176856315004232 -0.024096584449109  0.033980770130198 -0.029602022179569
-   11  ( 11) -0.076338046412608 -0.058007647538535 -0.059625157558161 -0.072355446358478  0.100714683926583 -0.028164062896195 -0.037103331661254 -0.004159802100780 -0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007837140573608
-    1  (  1) -0.001271351061977
-    2  (  2)  0.056316152671545
-    3  (  3) -0.023558705106194
-    4  (  4) -0.071677402926291
-    5  (  5) -0.031036091810970
-    6  (  6)  0.060669139129724
-    7  (  7)  0.008329217020035
-    8  (  8)  0.058082899762783
-    9  (  9)  0.050026765138378
-   10  ( 10)  0.030419330923301
-   11  ( 11) -0.028289350786073
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.010782784489972  0.013050845930128  0.033023155215664 -0.015191714992095  0.005425132814901  0.026116394662957 -0.007256800612108  0.004570990183776  0.083505985646911
-    1  (  1) -0.004775248888120 -0.019609050610054  0.043741880650327 -0.000073954161324  0.027319440587928 -0.081090619324759 -0.046094626593374  0.004371816989341  0.079334747598806
-    2  (  2) -0.007829067250874 -0.005611745899100 -0.069924533643314  0.039501674728206  0.000927353784976 -0.005421401951033 -0.003817544999769  0.008629946885833  0.093259618314415
-    3  (  3)  0.018327078243591 -0.003795046417131  0.017900293895817 -0.029796535142542  0.026342994062962  0.087573876827112  0.029918989049988 -0.054199220040285 -0.044809777400716
-    4  (  4)  0.027183503470872  0.089536481638857  0.084857160463068 -0.036527297001861 -0.242538124561929 -0.016430382958973 -0.030531081573579  0.170538311757182  0.261658379411546
-    5  (  5) -0.020462782587523  0.074168804451800 -0.167834230231717  0.149604127852478 -0.243854217657690  0.044978789492557  0.032478673883371 -0.164731310430024  0.003040851330374
-    6  (  6) -0.075422914773902  0.018345498918631  0.109883881828728 -0.119442941495868  0.084779039670754 -0.177672686986939  0.254932779745392  0.179910297504286  0.058420300218360
-    7  (  7) -0.077293940205111 -0.171942167313393  0.155379720343131 -0.213627786676900  0.203405159942268 -0.435742440136601 -0.116233082588661  0.403785601702878  0.048376113482094
-    8  (  8) -0.113887453356696  0.134815689960008 -0.121289875435757 -0.381302435842573  0.140362613154441  0.094837304770689 -0.044125422076338 -0.354102164255088  0.021060221761777
-    9  (  9)  0.010381942177856 -0.091513821594073  0.090489398632436 -0.104640269057990  0.011526746486386 -0.174325672883320  0.095096801177535  0.162567420891194 -0.086584233440007
-   10  ( 10)  0.046140785323826 -0.004506559121454 -0.092261546126996  0.049590165687623  0.056546117609635  0.023211770714739  0.114566901687301 -0.007355072527000  0.045260763292278
-   11  ( 11)  0.210277389085871  0.043479475791959 -0.002620356919958 -0.027295607176521 -0.213582758279457 -0.049406759718245  0.038753842401848 -0.045549481042434  0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.000588783769111
-    1  (  1)  0.095074877441065
-    2  (  2) -0.094269658052775
-    3  (  3) -0.087042465113366
-    4  (  4)  0.229147969925312
-    5  (  5) -0.037090740492870
-    6  (  6)  0.008539965499391
-    7  (  7)  0.114631280540035
-    8  (  8) -0.035100938386537
-    9  (  9)  0.119410852550345
-   10  ( 10) -0.048938543804445
-   11  ( 11)  0.026842233365654
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000083177655875  0.020596022225207  0.023074380682109  0.123906982660277 -0.115856799969175 -0.077548996218664  0.033724258035794  0.015583195761424 -0.055304180213594
-    1  (  1) -0.020496643104719  0.000177442053919 -0.044849161409626 -0.200056054082230  0.192734988239744 -0.095810846356379  0.089592000858118  0.154865722471105 -0.062884487656521
-    2  (  2) -0.022893568520427  0.044914234916282 -0.000286887581780  0.110147204900385 -0.098101481651214  0.037544614577033 -0.063107876559817 -0.057867129267241  0.133662561842804
-    3  (  3) -0.123637708691857  0.200030347190693 -0.110276511900212 -0.000067254700333  0.150932238527093  0.295587503177329 -0.155559256339819 -0.250191288225748  0.068514494250419
-    4  (  4)  0.115217909263092 -0.191910599591419  0.098719023514077 -0.150564412486325 -0.000108066296459  0.207017027157466 -0.092817557275927 -0.119727699718554  0.027839136386995
-    5  (  5)  0.077201349586182  0.095637330323257 -0.037580888266386 -0.296037283435946 -0.206488013849544  0.000677656990837 -0.030142059938078 -0.107860538698997  0.317965442908009
-    6  (  6) -0.033520398034563 -0.089301712720516  0.063135446629119  0.155494983890111  0.093120397549751  0.029958661714230  0.000263665833745  0.031787895548351  0.052772032197117
-    7  (  7) -0.015173638148760 -0.154650785159269  0.057964322733043  0.249885773107303  0.119546085272213  0.107827018648257 -0.031752436246544  0.000037065640674  0.211400361545441
-    8  (  8)  0.055452136609395  0.063704146851438 -0.132109776961381 -0.067534716804367 -0.027512182553154 -0.319330567201196 -0.051501501228049 -0.211684727134552 -0.000062825592229
-    9  (  9)  0.059987775905021 -0.059013360455393 -0.001731139538261  0.025602282087959 -0.077406198911912  0.032289392048789 -0.044673931971007 -0.007013222782529  0.205272148471903
-   10  ( 10)  0.040816969333319 -0.029839999727295 -0.097606908985792  0.012730679444132  0.052120800982420  0.047092545087938 -0.097199457935824  0.008100744465293 -0.194519063749344
-   11  ( 11) -0.105565276750546  0.086850909183234  0.141349531156014  0.064538795649442  0.048769909889220 -0.098670307723293  0.132937762954191 -0.091749745952861 -0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.059727136016838 -0.040967341903913  0.106287777222309
-    1  (  1)  0.058687758282915  0.029394471353826 -0.086811620398375
-    2  (  2)  0.001293940264555  0.097641591345113 -0.142636172226853
-    3  (  3) -0.025821629306306 -0.013207208477272 -0.063793857996761
-    4  (  4)  0.076409112526474 -0.052575212530451 -0.047414860037356
-    5  (  5) -0.032527517350565 -0.045632421732577  0.095160623491729
-    6  (  6)  0.044231942651703  0.096152133696301 -0.132935625343693
-    7  (  7)  0.007372100254253 -0.008488811567739  0.092713079820202
-    8  (  8) -0.206938183650805  0.192802275414426  0.052611900153123
-    9  (  9)  0.000608554890156 -0.088592533061698  0.344380743508036
-   10  ( 10)  0.088950131298492  0.000863284429953  0.222751022723935
-   11  ( 11) -0.341005102874300 -0.224718204882492  0.000326394311109
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000338557997552 -0.011375035743392  0.029451193209236 -0.012043586883828 -0.021579660859347  0.039033326019946 -0.009990415550092  0.009478976983628 -0.045907412693585
-    1  (  1)  0.013672223167698 -0.000473657715584 -0.014851568055555  0.021895587564371 -0.022163590605075  0.051246172607775  0.019257625103746  0.003658602851281 -0.019552361048058
-    2  (  2) -0.032608942325713  0.014402827198054 -0.000746991250603 -0.029107751732300  0.054720608245644  0.057033646383303  0.001872360780591 -0.031698780852448  0.056602981887733
-    3  (  3)  0.014268935231542 -0.021459967996182  0.030313065636317 -0.000730068456009 -0.016766656065195 -0.058973632357354 -0.003002419788061  0.022431580465626 -0.134333948620083
-    4  (  4)  0.022372891038515  0.021355779916377 -0.052959509294565  0.015751198634933 -0.000391938857969 -0.016109226068828  0.004538544158672 -0.050308920012661  0.059340919102150
-    5  (  5) -0.040216234763810 -0.051875751817174 -0.055849318880052  0.058120412757832  0.016460961175898  0.000645475334216  0.019024299026328  0.068804307634402 -0.024311188622736
-    6  (  6)  0.009930727984206 -0.019074682595569 -0.002242770131548  0.003091320851947 -0.004596281406168 -0.019032186967740  0.000074596378968  0.032870219636189 -0.006741182978715
-    7  (  7) -0.009279418369258 -0.004264018479381  0.032087681361723 -0.022624894165436  0.049954824766487 -0.068907285150032 -0.032867640818893 -0.000029995356356 -0.011652937852273
-    8  (  8)  0.047260005865874  0.018493502167014 -0.056736132845076  0.135589678169431 -0.059916509278318  0.024164421049794  0.007333544303120  0.011763030881780 -0.000264400142459
-    9  (  9) -0.016875007958598  0.031435494057685 -0.089048257959160 -0.041017085631602  0.020420285065562  0.066513023484078  0.000739604154969 -0.091958006244489  0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.016438561460291
-    1  (  1) -0.031819705279686
-    2  (  2)  0.089217438029428
-    3  (  3)  0.040553914705774
-    4  (  4) -0.020554472275814
-    5  (  5) -0.066048736736302
-    6  (  6) -0.000688806170902
-    7  (  7)  0.091248940256931
-    8  (  8) -0.027663919394381
-    9  (  9) -0.000090314260367
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011888856297006 -0.017750932125153 -0.030381401096490  0.012819546160996 -0.007239420422718 -0.024248756043407  0.008035757610220 -0.005364063357974 -0.085646323747472
-    1  (  1)  0.005014728223890  0.026640078285976 -0.053625852742063 -0.001580773154934 -0.029513947501511  0.084681976949646  0.049070075720108 -0.003015931693788 -0.083533135335069
-    2  (  2)  0.005701802857788  0.001861436552455  0.077309348516175 -0.039227298256145 -0.002806617492516  0.004668173879327  0.004051055445085 -0.009725469213679 -0.098722432349714
-    3  (  3) -0.016358351457124 -0.001723600627698 -0.021225514928062  0.039815087581337 -0.022808569998795 -0.104140287911999 -0.033233738030323  0.056382556071864  0.046907957767316
-    4  (  4) -0.023138877563353 -0.095098707280146 -0.087666288227931  0.037561492255805  0.255193211004254  0.015544572331716  0.030557402755123 -0.180093964112144 -0.259856355700386
-    5  (  5)  0.024228572043234 -0.082834757201086  0.181139504221043 -0.153944959591839  0.252818375021614 -0.048862178579716 -0.036094966909273  0.170640955267472 -0.004551713568432
-    6  (  6)  0.085402345559358 -0.022737485412840 -0.117389155338347  0.122686430467103 -0.089994929534087  0.186662776489157 -0.276334552924253 -0.188945818003174 -0.062512631958960
-    7  (  7)  0.077377916753636  0.184413390881742 -0.161635032551528  0.217081818449181 -0.216158931990711  0.452250331823368  0.121365143499215 -0.427486936599919 -0.051141830029037
-    8  (  8)  0.109996402529651 -0.145159792225805  0.137471198251747  0.396423044911114 -0.145941263905056 -0.104134158957014  0.041227108112442  0.369426049626710 -0.017681253264412
-    9  (  9) -0.015271329763023  0.091667642816572 -0.093167229349338  0.105178289783052 -0.012072216330151  0.184888670947420 -0.104021366500691 -0.173041839821099  0.089774142402176
-   10  ( 10) -0.051871879465497  0.004911726396439  0.095027344602311 -0.050235453581707 -0.056755121586123 -0.023277306660177 -0.123771404812450  0.008953154661311 -0.042342746566353
-   11  ( 11) -0.213874614633354 -0.038620645156941  0.003918905035704  0.027644952213642  0.227437070959628  0.047768116418487 -0.043243210008693  0.046251908849224 -0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001231945309971
-    1  (  1) -0.099118498855930
-    2  (  2)  0.099462956417043
-    3  (  3)  0.089788110354890
-    4  (  4) -0.236379406660322
-    5  (  5)  0.043290372964682
-    6  (  6) -0.008471875583563
-    7  (  7) -0.118429426587662
-    8  (  8)  0.041151812398786
-    9  (  9) -0.121668252978460
-   10  ( 10)  0.047795297768532
-   11  ( 11) -0.026000603113831
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.092723408151075 -0.057215092134940 -0.054154926215137  0.012957083117559  0.028122190094715  0.031179347218855  0.013645641371598  0.009921258172339  0.037242536390232
-    1  (  1)  0.019990430092613 -0.002382806987559  0.016009786257367  0.011651136664597 -0.017212414198990 -0.024265249236370  0.152443472946687 -0.006755616148329  0.024207249541319
-    2  (  2)  0.009030755895234  0.085216520460363 -0.016500441499831 -0.009813164947617 -0.015713678712422  0.028373503652355 -0.075877310310795  0.039590492962937  0.081270933339189
-    3  (  3) -0.075043611755008 -0.103608833794547 -0.030676505925522 -0.013143510199953  0.006187488557257  0.045202449901574 -0.041605892889482 -0.001210820793539 -0.045033631139440
-    4  (  4) -0.122337112724117 -0.176460576265088 -0.085321001863374  0.041690733440160 -0.111448222796030  0.083092300673138 -0.094252463151414  0.071551603610925  0.059851091994803
-    5  (  5)  0.372712635775664  0.109553572239785  0.087636097688831  0.161393941368917 -0.091711881285738 -0.083559837956631  0.084048684818413 -0.114275654348762  0.004760374961166
-    6  (  6)  0.030431995544059 -0.095321795210779  0.159145740022025  0.376304340373359  0.189004479350399 -0.100683798175242 -0.128902751762968 -0.567857709085750 -0.002399331341204
-    7  (  7)  0.344039522571259  0.114279634125077  0.003626426979965 -0.177981236436906 -0.027932329764501 -0.026442462397652 -0.246808699479261  0.268819164710932 -0.106523620842343
-    8  (  8)  0.111643207885322  0.002836247769573 -0.018154026503924 -0.097243438328650  0.121498121615664  0.006682650130485  0.107315976978454 -0.036939727738377 -0.063237979028415
-    9  (  9) -0.063921675215150 -0.215994652248761 -0.065707412514049  0.003935136905129  0.142641982827575  0.026699050855783 -0.056962954862571 -0.164747861484427  0.081509018515780
-   10  ( 10)  0.058030998072116  0.060474289846612  0.205628226890442  0.038897333798042 -0.068097699807560 -0.116172285533776 -0.038858694654200 -0.255643829382515  0.001247633054968
-   11  ( 11)  0.085574013220044  0.030726962638802  0.008247473867838  0.106409310393215 -0.064469816287686 -0.072180462194277 -0.022620356444758 -0.070649638629627  0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015293746360799
-    1  (  1)  0.020176832366409
-    2  (  2)  0.007468634139779
-    3  (  3) -0.002013486296780
-    4  (  4)  0.055907379643807
-    5  (  5)  0.014548062338959
-    6  (  6)  0.210557719542813
-    7  (  7) -0.107773752705760
-    8  (  8) -0.004939471027833
-    9  (  9)  0.101796072438763
-   10  ( 10)  0.052197801100809
-   11  ( 11) -0.010791942309942
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000245185765728 -0.004422769142209 -0.195473142624697  0.067124189998810  0.027096370068160  0.099320185873800  0.032910569428743  0.079494520674282 -0.016762710819247
-    1  (  1)  0.004388313593185 -0.000165290846899  0.188129406432792 -0.063756474949075 -0.001128748240139 -0.126263116741295 -0.303817994309096  0.069854530583820  0.010310792522154
-    2  (  2)  0.194444327410373 -0.187906024270824  0.000538868177065 -0.115697813615881 -0.188025580722992 -0.063555095149569  0.109038200896130 -0.123360187528163  0.037347597176070
-    3  (  3) -0.066590814481336  0.063203632987523  0.115347217679990 -0.000002301796994  0.034584588669551  0.038983157581533  0.229948513873159 -0.131721887952800 -0.028384936970778
-    4  (  4) -0.026403437308072  0.000527986476725  0.186677671985474 -0.034818437947430 -0.000320297338463  0.037865478650564  0.201451121997014 -0.109301689008128 -0.005643097026329
-    5  (  5) -0.099409584232992  0.126346592032007  0.064419008019557 -0.039794220656347 -0.036855903902447 -0.000190318965932  0.088891480212760 -0.056789849447140  0.091073030281233
-    6  (  6) -0.033050985013878  0.303259624681304 -0.108281756633666 -0.230173439372417 -0.201331671706094 -0.089930560146314 -0.000311452672695 -0.221067383348441 -0.053494283573947
-    7  (  7) -0.079472710309908 -0.069297203366025  0.125033677339702  0.131451975782708  0.110125569334720  0.054839641157466  0.219945401741596 -0.001085047372961  0.089073871816377
-    8  (  8)  0.016952142014388 -0.010421932566239 -0.036927801153181  0.027792238689701  0.005351459000165 -0.090892785458666  0.052690955519676 -0.088985197141446 -0.000032698621213
-    9  (  9)  0.149061020700740 -0.058621114959186 -0.279965277538519 -0.021488283829580 -0.044200621925698 -0.026904718590704 -0.074208134755608 -0.037354078157659 -0.137372829291651
-   10  ( 10) -0.035190315077894  0.050814828300922  0.151303785089698 -0.062867991520111 -0.077053666036856 -0.075037906181509  0.133385625358484 -0.006791369727277 -0.121764957568739
-   11  ( 11)  0.016457666688676 -0.009560970830020 -0.030160709068648 -0.052615429880776 -0.007184814870880  0.147317585107930  0.048007656104932  0.024985856634055 -0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.149527127949477  0.035025203143730 -0.017236912650706
-    1  (  1)  0.058313378902528 -0.050420942142557  0.009474518218355
-    2  (  2)  0.278325755481738 -0.150562770304950  0.029989264213428
-    3  (  3)  0.020585218415975  0.063268588986747  0.052977667343551
-    4  (  4)  0.042114256624995  0.077316775027134  0.007960467665663
-    5  (  5)  0.031625284755674  0.074462306356205 -0.148447086799088
-    6  (  6)  0.074615124808937 -0.133170285550522 -0.049651682674137
-    7  (  7)  0.041592449377408  0.005910763914811 -0.024358506166719
-    8  (  8)  0.138294110971387  0.121744291260784  0.107918344276425
-    9  (  9) -0.001133592488713  0.474400799155993  0.192590673354496
-   10  ( 10) -0.472105353620486 -0.001334835966633 -0.192285927563244
-   11  ( 11) -0.191497735915320  0.194932828964948 -0.001344945845524
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000738836304181  0.037293198581408  0.029451404620807 -0.009378792471894  0.055701113540954 -0.035128933511984 -0.013954700067714 -0.072836702551235  0.051857122483535
-    1  (  1) -0.032660614374695  0.002015876922290  0.074058480716263 -0.021479421330690 -0.014966422603257 -0.166979967788261 -0.013073252080067 -0.022556560940623 -0.170972365950935
-    2  (  2) -0.029165553040464 -0.073308940131147  0.000753195727027 -0.033014777438001  0.000651481686764 -0.016615463822703 -0.030045410532860 -0.013342873064028 -0.078343409399381
-    3  (  3)  0.010384415064446  0.021326871974424  0.031305865808474  0.000583541727095 -0.005150844265660 -0.010972964083321 -0.024667426696971  0.003421011953857 -0.027197309287279
-    4  (  4) -0.055501401866642  0.014297660722118 -0.000710544848112  0.005493793084614 -0.000124683940717 -0.025126510553785 -0.000947638436962 -0.017069455654223  0.023650915169846
-    5  (  5)  0.033803616927021  0.164339399892725  0.017068168082329  0.010030727560507  0.025241735580020  0.000735433014139 -0.028603795353780  0.023029380344413  0.027599055296252
-    6  (  6)  0.013107540346806  0.012828435687407  0.030286401438565  0.024713021163335  0.001063605161759  0.029296491836886 -0.000025149030498 -0.111104514389532  0.102861376746943
-    7  (  7)  0.072733387901303  0.022465577956558  0.013436829086647 -0.003433808737295  0.017048766876852 -0.023125015384758  0.110934303358415  0.000037875914124  0.002935696551342
-    8  (  8) -0.053267672687232  0.170660201820078  0.076657788504288  0.028160893222526 -0.023606436991553 -0.027690933408034 -0.102626814241324 -0.002887530223588  0.000373637330912
-    9  (  9)  0.004804828900057  0.224333052817770  0.065186758028368  0.004091068046870  0.039040275694483 -0.042976408882840 -0.051197675519228 -0.024101682646066 -0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.005026329948406
-    1  (  1) -0.225373696682354
-    2  (  2) -0.064686362479745
-    3  (  3) -0.004567750792129
-    4  (  4) -0.038996417519414
-    5  (  5)  0.043485644851561
-    6  (  6)  0.051601626537389
-    7  (  7)  0.023715023759407
-    8  (  8)  0.001115391080639
-    9  (  9)  0.000048164004682
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.087860740756488  0.068261038905906  0.057593788019307 -0.011454237083441 -0.027305499289367 -0.032385982368371 -0.018173477269549 -0.009363386608796 -0.038732450559880
-    1  (  1) -0.013249632151170 -0.004184657414979 -0.019716507976896 -0.014744696478638  0.016703323694180  0.027386275287573 -0.163732376866413  0.007136524293248 -0.024482820661864
-    2  (  2) -0.007013218896085 -0.084657964294727  0.026004205374563  0.008076798202963  0.011641159214614 -0.031112856231507  0.081756432692912 -0.043486513055778 -0.085001128307205
-    3  (  3)  0.058477500387638  0.110048615847953  0.032104075685968  0.014807417786102 -0.004697674213231 -0.048123068402958  0.048143599431998  0.000645092439839  0.047260089330542
-    4  (  4)  0.110574498742467  0.188131348104213  0.086636459451987 -0.041361686502598  0.118556992954628 -0.089270642674348  0.104552978829704 -0.075153301656795 -0.057940099039356
-    5  (  5) -0.371487279658724 -0.115772941053656 -0.094845419594772 -0.167070991238391  0.094497706414686  0.087134798346335 -0.079465840043241  0.119932858558240 -0.004312964076576
-    6  (  6) -0.035255689937620  0.112028499449997 -0.168145842580037 -0.392683527257363 -0.194284650981365  0.110254467391126  0.135773335198962  0.599025983356266  0.001116295743642
-    7  (  7) -0.362602042970953 -0.115938705836042  0.002852393959785  0.186519834338995  0.026972926522319  0.023780474127448  0.271135694461778 -0.284033125501378  0.111247570725030
-    8  (  8) -0.111196944464455 -0.001239941376560  0.021205830532168  0.101329748088148 -0.128975240085324 -0.010144197632550 -0.108358474715393  0.037918096280026  0.066572090545295
-    9  (  9)  0.090967744709768  0.211201922436275  0.066377513424381 -0.007899083102241 -0.154707771160094 -0.037980948657754  0.073559352539101  0.172041273327275 -0.087426840520207
-   10  ( 10) -0.070112475488657 -0.079061926736069 -0.222919508358954 -0.040775801294398  0.061424635747658  0.113162621408555  0.037903862973014  0.270692474130444 -0.009570796789139
-   11  ( 11) -0.090924578792926 -0.040585886130445 -0.000311072794648 -0.117174234675791  0.063663959894116  0.077941781302743  0.027645133174923  0.073495241874676 -0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015882565008118
-    1  (  1) -0.020403231736073
-    2  (  2) -0.007241270504095
-    3  (  3)  0.003144444710549
-    4  (  4) -0.058793064689134
-    5  (  5) -0.012293150809123
-    6  (  6) -0.215177196230389
-    7  (  7)  0.113635102585609
-    8  (  8)  0.004824845555481
-    9  (  9) -0.113550918048735
-   10  ( 10) -0.063789409560574
-   11  ( 11)  0.007009974437012
-
 	Computing Mu_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.609438474538
-	   1        14.949778829192    4.728e-01
-	   2        16.871417912800    1.818e-01
-	   3        16.903632350164    2.076e-02
-	   4        16.911909723375    6.871e-03
-	   5        16.911348469601    1.590e-03
-	   6        16.911055110664    4.168e-04
-	   7        16.911101104419    1.181e-04
-	   8        16.911115584343    3.100e-05
-	   9        16.911108644993    8.873e-06
-	  10        16.911107420798    2.748e-06
-	  11        16.911108060559    8.445e-07
-	  12        16.911108716477    3.229e-07
-	  13        16.911108882845    1.006e-07
+	   0        11.609438346706
+	   1        14.949778650400    4.728e-01
+	   2        16.871417692589    1.818e-01
+	   3        16.903632128996    2.076e-02
+	   4        16.911909501859    6.871e-03
+	   5        16.911348248077    1.590e-03
+	   6        16.911054889154    4.168e-04
+	   7        16.911100882908    1.181e-04
+	   8        16.911115362831    3.100e-05
+	   9        16.911108423481    8.873e-06
+	  10        16.911107199286    2.748e-06
+	  11        16.911107839047    8.445e-07
+	  12        16.911108494964    3.229e-07
+	  13        16.911108661333    1.006e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 3.393e-08
 
 	Computing P_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.669889514401
-	   1         4.669995496378    2.468e-01
-	   2         5.195541442266    8.967e-02
-	   3         5.204011537077    9.904e-03
-	   4         5.205714084386    3.340e-03
-	   5         5.205620046987    8.910e-04
-	   6         5.205564850636    2.628e-04
-	   7         5.205580150515    8.756e-05
-	   8         5.205585161935    2.659e-05
-	   9         5.205583294336    8.385e-06
-	  10         5.205583119547    2.525e-06
-	  11         5.205583494841    6.832e-07
-	  12         5.205583775549    2.087e-07
+	   0         3.669889530411
+	   1         4.669995512726    2.468e-01
+	   2         5.195541455333    8.967e-02
+	   3         5.204011549976    9.904e-03
+	   4         5.205714097232    3.340e-03
+	   5         5.205620059830    8.910e-04
+	   6         5.205564863480    2.628e-04
+	   7         5.205580163358    8.756e-05
+	   8         5.205585174778    2.659e-05
+	   9         5.205583307179    8.385e-06
+	  10         5.205583132390    2.525e-06
+	  11         5.205583507684    6.832e-07
+	  12         5.205583788392    2.087e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 6.771e-08
 
 	Computing L_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.365981838078
-	   1         3.307945748661    3.211e-01
-	   2         4.174456209485    1.715e-01
-	   3         4.269850974405    4.658e-02
-	   4         4.282991556822    2.028e-02
-	   5         4.285355941743    1.031e-02
-	   6         4.287649413453    3.586e-03
-	   7         4.288126105952    1.317e-03
-	   8         4.287996753978    6.132e-04
-	   9         4.287984213469    2.655e-04
-	  10         4.288000306141    1.266e-04
-	  11         4.288002884836    3.944e-05
-	  12         4.288000978087    1.358e-05
-	  13         4.287998153041    4.621e-06
-	  14         4.287997246570    1.749e-06
-	  15         4.287997145458    7.724e-07
-	  16         4.287997375254    4.035e-07
-	  17         4.287997588021    2.315e-07
-	  18         4.287997696720    1.204e-07
+	   0         2.365981827940
+	   1         3.307945732087    3.211e-01
+	   2         4.174456182608    1.715e-01
+	   3         4.269850945043    4.658e-02
+	   4         4.282991526893    2.028e-02
+	   5         4.285355911607    1.031e-02
+	   6         4.287649383235    3.586e-03
+	   7         4.288126075711    1.317e-03
+	   8         4.287996723740    6.132e-04
+	   9         4.287984183232    2.655e-04
+	  10         4.288000275904    1.266e-04
+	  11         4.288002854598    3.944e-05
+	  12         4.288000947849    1.358e-05
+	  13         4.287998122803    4.621e-06
+	  14         4.287997216333    1.749e-06
+	  15         4.287997115220    7.724e-07
+	  16         4.287997345017    4.035e-07
+	  17         4.287997557783    2.315e-07
+	  18         4.287997666482    1.204e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.487e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.683420643863
-	   1        11.726517352238    3.351e-01
-	   2        12.667113826803    1.144e-01
-	   3        12.690850554821    1.675e-02
-	   4        12.697415629013    5.857e-03
-	   5        12.697300056585    1.117e-03
-	   6        12.697140731349    3.127e-04
-	   7        12.697166205779    8.608e-05
-	   8        12.697172250706    2.292e-05
-	   9        12.697169008955    6.916e-06
-	  10        12.697168220952    2.008e-06
-	  11        12.697168612405    4.233e-07
-	  12        12.697168870814    1.381e-07
+	   0         9.683420550099
+	   1        11.726517231508    3.351e-01
+	   2        12.667113688451    1.144e-01
+	   3        12.690850415800    1.675e-02
+	   4        12.697415489758    5.857e-03
+	   5        12.697299917326    1.117e-03
+	   6        12.697140592097    3.127e-04
+	   7        12.697166066526    8.608e-05
+	   8        12.697172111452    2.292e-05
+	   9        12.697168869702    6.916e-06
+	  10        12.697168081699    2.008e-06
+	  11        12.697168473152    4.233e-07
+	  12        12.697168731561    1.381e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 4.605e-08
 
 	Computing P_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.785864094774
-	   1         4.523604579875    1.966e-01
-	   2         4.842103592969    6.462e-02
-	   3         4.851592494384    1.125e-02
-	   4         4.853764685821    4.225e-03
-	   5         4.853700603667    8.327e-04
-	   6         4.853654990869    2.379e-04
-	   7         4.853662994813    6.720e-05
-	   8         4.853664924550    1.751e-05
-	   9         4.853664221815    5.431e-06
-	  10         4.853664079190    1.640e-06
-	  11         4.853664322766    3.652e-07
-	  12         4.853664448190    1.064e-07
+	   0         3.785864107761
+	   1         4.523604592746    1.966e-01
+	   2         4.842103603794    6.462e-02
+	   3         4.851592505030    1.125e-02
+	   4         4.853764696402    4.225e-03
+	   5         4.853700614248    8.327e-04
+	   6         4.853655001452    2.379e-04
+	   7         4.853663005395    6.720e-05
+	   8         4.853664935132    1.751e-05
+	   9         4.853664232397    5.431e-06
+	  10         4.853664089772    1.640e-06
+	  11         4.853664333348    3.652e-07
+	  12         4.853664458772    1.064e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 2.881e-08
 
 	Computing L_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.821298955897
-	   1         9.270412566803    4.757e-01
-	   2        11.011131444260    2.340e-01
-	   3        11.257035254842    9.221e-02
-	   4        11.319589156252    3.813e-02
-	   5        11.328095384208    1.392e-02
-	   6        11.331034422161    3.893e-03
-	   7        11.331839951353    1.222e-03
-	   8        11.331703066767    4.737e-04
-	   9        11.331658951021    1.553e-04
-	  10        11.331670754659    7.708e-05
-	  11        11.331674802802    3.674e-05
-	  12        11.331680584166    1.376e-05
-	  13        11.331679633207    4.703e-06
-	  14        11.331679408382    2.074e-06
-	  15        11.331679867305    9.994e-07
-	  16        11.331680729713    5.321e-07
-	  17        11.331681366724    2.712e-07
-	  18        11.331681575824    1.115e-07
+	   0         6.821298931527
+	   1         9.270412529668    4.757e-01
+	   2        11.011131392986    2.340e-01
+	   3        11.257035199032    9.221e-02
+	   4        11.319589098333    3.813e-02
+	   5        11.328095325705    1.392e-02
+	   6        11.331034363534    3.893e-03
+	   7        11.331839892689    1.222e-03
+	   8        11.331703008108    4.737e-04
+	   9        11.331658892364    1.553e-04
+	  10        11.331670696001    7.708e-05
+	  11        11.331674744144    3.674e-05
+	  12        11.331680525508    1.376e-05
+	  13        11.331679574549    4.703e-06
+	  14        11.331679349724    2.074e-06
+	  15        11.331679808647    9.994e-07
+	  16        11.331680671055    5.321e-07
+	  17        11.331681308066    2.712e-07
+	  18        11.331681517165    1.115e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 4.265e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.942856865762
-	   1        12.409442315798    3.578e-01
-	   2        13.462130383366    1.154e-01
-	   3        13.482241668256    1.530e-02
-	   4        13.485856949975    4.442e-03
-	   5        13.485508774227    1.101e-03
-	   6        13.485473659812    2.556e-04
-	   7        13.485511263548    7.911e-05
-	   8        13.485510160110    2.541e-05
-	   9        13.485507101909    8.446e-06
-	  10        13.485506815594    2.727e-06
-	  11        13.485507444103    8.066e-07
-	  12        13.485507798359    2.037e-07
+	   0         9.942856770729
+	   1        12.409442187907    3.578e-01
+	   2        13.462130235969    1.154e-01
+	   3        13.482241520314    1.530e-02
+	   4        13.485856801894    4.442e-03
+	   5        13.485508626148    1.101e-03
+	   6        13.485473511735    2.556e-04
+	   7        13.485511115470    7.911e-05
+	   8        13.485510012031    2.541e-05
+	   9        13.485506953831    8.446e-06
+	  10        13.485506667515    2.727e-06
+	  11        13.485507296024    8.066e-07
+	  12        13.485507650280    2.037e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 6.320e-08
 
 	Computing P_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.118239707855
-	   1         5.121420775478    2.224e-01
-	   2         5.526427145845    6.849e-02
-	   3         5.533281078484    9.319e-03
-	   4         5.534326312945    3.126e-03
-	   5         5.534216636006    1.010e-03
-	   6         5.534224802651    2.397e-04
-	   7         5.534240706419    6.477e-05
-	   8         5.534240212323    1.776e-05
-	   9         5.534239428828    5.177e-06
-	  10         5.534239313475    1.602e-06
-	  11         5.534239519529    4.650e-07
-	  12         5.534239637519    1.219e-07
+	   0         4.118239718502
+	   1         5.121420785015    2.224e-01
+	   2         5.526427152718    6.849e-02
+	   3         5.533281085203    9.319e-03
+	   4         5.534326319625    3.126e-03
+	   5         5.534216642684    1.010e-03
+	   6         5.534224809329    2.397e-04
+	   7         5.534240713096    6.477e-05
+	   8         5.534240219000    1.776e-05
+	   9         5.534239435505    5.177e-06
+	  10         5.534239320152    1.602e-06
+	  11         5.534239526206    4.650e-07
+	  12         5.534239644196    1.219e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 4.220e-08
 
 	Computing L_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.735910200359
-	   1         9.133135020546    4.778e-01
-	   2        10.927029646829    2.292e-01
-	   3        11.080909620080    5.746e-02
-	   4        11.099862939787    1.939e-02
-	   5        11.099968382686    1.096e-02
-	   6        11.102155976794    4.940e-03
-	   7        11.103195405059    1.851e-03
-	   8        11.103082922666    7.344e-04
-	   9        11.103082702435    2.438e-04
-	  10        11.103089096658    1.167e-04
-	  11        11.103104426387    5.351e-05
-	  12        11.103106729078    2.084e-05
-	  13        11.103104859860    7.992e-06
-	  14        11.103104626557    3.092e-06
-	  15        11.103104968971    1.266e-06
-	  16        11.103105331486    5.565e-07
-	  17        11.103105522147    3.115e-07
-	  18        11.103105571095    1.819e-07
+	   0         6.735910176610
+	   1         9.133134984299    4.778e-01
+	   2        10.927029594836    2.292e-01
+	   3        11.080909565214    5.746e-02
+	   4        11.099862884439    1.939e-02
+	   5        11.099968327253    1.096e-02
+	   6        11.102155921288    4.940e-03
+	   7        11.103195349510    1.851e-03
+	   8        11.103082867117    7.344e-04
+	   9        11.103082646886    2.438e-04
+	  10        11.103089041110    1.167e-04
+	  11        11.103104370838    5.351e-05
+	  12        11.103106673529    2.084e-05
+	  13        11.103104804310    7.992e-06
+	  14        11.103104571008    3.092e-06
+	  15        11.103104913421    1.266e-06
+	  16        11.103105275936    5.565e-07
+	  17        11.103105466598    3.115e-07
+	  18        11.103105515546    1.819e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 8.976e-08
 
 	Computing 1/2 <<Mu;L>>_(0.128) tensor.
 	Computing 1/2 <<P;L>>_(0.128) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008290776080582 -0.050801504097253  0.025635294562259 -0.003046442602711 -0.019839162173202 -0.042287718066775  0.002274291905087 -0.017250301075761 -0.063217582232324
-    1  (  1) -0.005656720485448  0.005906316890016 -0.013342327104385  0.062795095869537  0.034384806675368 -0.011824889654518 -0.010091423219065 -0.046942857543920 -0.048716688440686
-    2  (  2)  0.031253511604130  0.072637650556073 -0.014421891959526 -0.004213302445553  0.070727435854801 -0.065656867197555 -0.018370400388693 -0.002385908267158  0.006354255904041
-    3  (  3) -0.059832580241196 -0.053424480759820 -0.021451003825827 -0.018138018553495 -0.036100327164171  0.016134873511603  0.024740373136963  0.003793018506519 -0.167949395515151
-    4  (  4) -0.064204693944690 -0.131652862682136  0.117404639608972  0.157417127901485 -0.230036611567443  0.047515122725740  0.039984594404843  0.125482054176259 -0.256771627646738
-    5  (  5)  0.146085129938632  0.278398764610060 -0.159854012203638  0.282968510269086  0.101365891285813  0.356608825189021  0.125659431918166  0.044422988683829  0.166646852463301
-    6  (  6) -0.076564725597579  0.133650798922835 -0.020866614443156 -0.061441481951876  0.071232976830213 -0.204259413485531  0.443726141038863  0.031546384888620  0.054109942402284
-    7  (  7)  0.171392689665179  0.199512600411571 -0.417327799251045 -0.052763427688751  0.301472803852696  0.065491949787692 -0.090135905280205  0.243374803622146  0.087314234232365
-    8  (  8)  0.052750851527397  0.070024200557922 -0.379656051510646  0.506727880893360  0.456213741194719 -0.053888497905949  0.020349944072208  0.064388593842935 -0.270869373264179
-    9  (  9) -0.321512384290440  0.557302077819714  0.036935298894209  0.154840347992778  0.003043634782132  0.230873783877613  0.106477418838008  0.187200194326970 -0.093391131247138
-   10  ( 10) -0.965723013629727  0.203375174675727  0.231799200789465 -0.113515758170139  0.032657967963446 -0.147828874479423  0.019227710807050 -0.096617606939553  0.006766409668261
-   11  ( 11) -0.210596475192897  0.094976222444135 -0.072335244920971  0.290764752768263 -0.062314851229712  0.053607127427930  0.145285323049651  0.073900587412887 -0.326764941791807
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071285844130264
-    1  (  1)  0.010066343394199
-    2  (  2) -0.108617239028194
-    3  (  3) -0.063737900590760
-    4  (  4) -0.015793155353663
-    5  (  5)  0.238781543103224
-    6  (  6) -0.065357063243315
-    7  (  7)  0.120098496018758
-    8  (  8) -0.128051536292778
-    9  (  9)  0.179029916473930
-   10  ( 10) -0.084757737907666
-   11  ( 11)  0.159141561245499
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.230778688168130 -0.557039020018502  0.102231622004203 -0.365190061837505 -0.400431097899025 -0.011240783369823 -0.138486416116495  0.002452040812742 -0.004398637078623
-    1  (  1) -0.556776142920827 -2.040315056194718  0.915507378155102  1.014426942838368  0.734278848751725  0.048588577390964  0.281167270606351  0.301449170381432  0.094768863002394
-    2  (  2)  0.102191442528323  0.915686903851560  1.209547690777273 -0.958100119655737 -0.740471389480369 -0.004947182895568  0.495915674452131 -0.139783988312968  0.095073435804183
-    3  (  3) -0.364539165929170  1.014070571549057 -0.958316089423204 -0.283348551998825 -0.131889670325022 -1.271015261428147  0.039370973643206 -0.404136843612415 -0.596543898512850
-    4  (  4) -0.399870169082361  0.732987024839952 -0.742129335372324 -0.132056740778799  0.552809694709972  0.050609502973822 -0.485130318718432 -1.569135325660496 -0.955644372877197
-    5  (  5) -0.012067668711970  0.049395634351447 -0.004235997753528 -1.269867451709877  0.052501445594591  0.142961307435960 -0.243772741862524  0.815823088969846 -1.032660122676294
-    6  (  6) -0.138184751914924  0.281444487458849  0.496109632619357  0.039289252640444 -0.483545301414318 -0.244146373994899 -2.567548494258237  0.471042691193011  0.535768572608993
-    7  (  7)  0.002443724218529  0.302692867022601 -0.138498316501231 -0.403820450806263 -1.565811046199608  0.816611901103015  0.471628294535134 -1.688652935957108  0.671482803026688
-    8  (  8) -0.004344564384300  0.094578985136196  0.094798646138089 -0.597437555079113 -0.950266206536146 -1.030172101956222  0.534632090191761  0.669551052804072 -0.286047601971907
-    9  (  9)  0.321027459692546 -0.124494588251713 -0.355830352458176 -0.608802973418470 -0.402462352421951 -0.368076132570564 -1.240230517037675 -0.910561909620175  0.043652486559104
-   10  ( 10)  0.011815823949598 -0.051101513605038 -0.395397800969984  0.309598565761669  0.194737646185127  0.053604366895841 -0.879466474650196  0.757981021960396  0.138272602216670
-   11  ( 11)  0.159425836287601 -0.085783898744993 -0.370909602534729 -0.056636941516785 -0.307385996591224 -0.268976928323790 -0.442853482929670  0.013290639913097 -0.876205899626718
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.323082673575100  0.012827323300415  0.160383781034165
-    1  (  1) -0.126844464371028 -0.052604971080148 -0.086843133976977
-    2  (  2) -0.357788273401833 -0.396667921961515 -0.371902334820724
-    3  (  3) -0.612287607386654  0.306667669522199 -0.056656844524874
-    4  (  4) -0.405472668706639  0.195190062002348 -0.306615567899281
-    5  (  5) -0.367351821286147  0.055534904015428 -0.275720960811118
-    6  (  6) -1.243158670589035 -0.884111685009210 -0.446520521343404
-    7  (  7) -0.909610092856081  0.758960738026336  0.004121680213622
-    8  (  8)  0.044479614426162  0.142510706976164 -0.890141861038879
-    9  (  9)  0.430645603358394 -0.292573864178629 -0.177569371172063
-   10  ( 10) -0.297251468770778  0.639563517042984 -0.084252875076621
-   11  ( 11) -0.176313836183732 -0.086637188746477  1.226883274744448
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.555032728737771  0.712617672671401  0.419810286882489  0.050887754227596 -0.090842975445822 -0.470640518796941  0.705404320416024 -0.102097016449215  0.079849652538938
-    1  (  1)  0.712915390108471  0.338414908248977  0.746799463635505  0.289033465951793  0.281577689527702 -0.590080565321557 -1.163166129408219 -0.188838662213219  0.235465544716902
-    2  (  2)  0.420424419523684  0.746397208582966 -0.016153704953468 -0.358852287949201 -0.952285365412292  1.041198523267407 -0.387389024226280  0.231972398395418 -1.201681468114436
-    3  (  3)  0.052990374128029  0.287939592192507 -0.356997201476426 -0.860130940767887 -1.322600194001359 -0.190991097932252 -0.172427859143025  1.049268576710733  0.759838942947354
-    4  (  4) -0.091729674999201  0.281558404761801 -0.953826965790842 -1.321136801436185  1.452847715742109  0.019357804497789  0.219531843898996 -0.321163524474806  0.383368380154908
-    5  (  5) -0.468391179467906 -0.590920943851569  1.042843901419442 -0.190946364776948  0.019284064585406 -0.578157261908740  0.477982154885554  0.309192885886468  0.350343314103329
-    6  (  6)  0.705416628116867 -1.163498224121495 -0.385221267991331 -0.173426272959358  0.218834180811751  0.478203132617135 -2.784703127021582 -0.089827446409910  0.007438070857215
-    7  (  7) -0.100892718625019 -0.189193923309364  0.233172791358426  1.048794685120079 -0.321694154621351  0.309157324551256 -0.089653742381773 -3.228872513573496  0.508232911749822
-    8  (  8)  0.078189592702616  0.235740536359493 -1.205024775916881  0.762330717256039  0.383275686836382  0.348953623655193  0.008045450505770  0.508467502681986  0.472369144605263
-    9  (  9) -0.077760701800955  0.237396383481108 -0.096343734790574 -0.354923660187535 -0.984336588474142  1.335053740742370  0.269902452459777  0.319055275759352 -0.321749140962585
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.078162493766068
-    1  (  1)  0.238847682218727
-    2  (  2) -0.098903683747888
-    3  (  3) -0.354949509542455
-    4  (  4) -0.983822640646403
-    5  (  5)  1.333720211340158
-    6  (  6)  0.269441491786924
-    7  (  7)  0.318898660493929
-    8  (  8) -0.321196908799485
-    9  (  9) -0.198768714929451
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015331616498833 -0.019922018235360  0.024795453639952  0.001428994822442 -0.007662564632869 -0.030564864466354 -0.002998096035874 -0.014184257518557 -0.050369876521864
-    1  (  1)  0.002536892896206 -0.000724332833140 -0.010931820831771  0.061385329925525  0.034527384530112 -0.002930909394968 -0.006897041777642 -0.048924198461387 -0.045892788765523
-    2  (  2)  0.055930590988109  0.061668786229878 -0.009784880887058 -0.011292178101404  0.079575226023927 -0.052325708606337 -0.009086556132667 -0.001787844130138  0.008215255410943
-    3  (  3) -0.058532225277701 -0.048285500112225 -0.015912879350588  0.001479837376653 -0.030353501548890  0.023819914693464  0.021025260847826  0.014207102374829 -0.151577267379535
-    4  (  4) -0.056221687371934 -0.122358938171234  0.112292181821658  0.146881610350559 -0.213263741399596  0.056469707520368  0.037816511197979  0.118315319709634 -0.249164851234958
-    5  (  5)  0.125699079920792  0.245765102963436 -0.144688421941741  0.269480954167622  0.108175820650901  0.330495489462815  0.121717019021094  0.042981278927133  0.139107704893676
-    6  (  6) -0.090953864200081  0.138378038123711 -0.018999653387300 -0.059021477190613  0.070107383816014 -0.188422561576096  0.422479983427336  0.027031745312951  0.054392856003620
-    7  (  7)  0.157772366372595  0.187920697768143 -0.411777035755239 -0.046692805557951  0.283266431788380  0.074879967037488 -0.084103929184262  0.226658912465472  0.075512245279510
-    8  (  8)  0.054210291452992  0.062449071960101 -0.361963320103574  0.503001997291620  0.438083797101076 -0.063050427843078  0.017066076329137  0.069221757957400 -0.257467231990446
-    9  (  9) -0.273423536032774  0.529295983026682  0.033766766508851  0.151918529592259 -0.009418984940093  0.206571120107986  0.110624885223032  0.172829785443028 -0.101427788661059
-   10  ( 10) -0.861462052752320  0.172326691424178  0.212371997651326 -0.111218596621436  0.023269411258717 -0.143388725237391  0.039930804953421 -0.091843120858856  0.022422158283106
-   11  ( 11) -0.188670480611874  0.096820345118133 -0.066190773880029  0.287205832494666 -0.059420643781434  0.064429852032339  0.150091109571506  0.074231547885084 -0.343171650309577
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.057461514086606
-    1  (  1)  0.006963958755564
-    2  (  2) -0.098129328522494
-    3  (  3) -0.059012682268642
-    4  (  4) -0.004449861106028
-    5  (  5)  0.220945294639113
-    6  (  6) -0.063939488850868
-    7  (  7)  0.102360934503055
-    8  (  8) -0.118112557417407
-    9  (  9)  0.155151984964126
-   10  ( 10) -0.077691214009347
-   11  ( 11)  0.169304339523055
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007929033245727 -0.086776514026638 -0.041466992686244 -0.000624066975311 -0.013156595381987  0.043080477030762  0.042448060293463  0.012239880545527  0.029029915184304
-    1  (  1) -0.033878180177558  0.070173508648210  0.019230609095550 -0.003533880530575 -0.001550569267327 -0.001809299397526 -0.111518736659909 -0.001270571448457 -0.012934311690280
-    2  (  2)  0.053119512373320  0.091732793273830  0.021408607612661  0.032674571200622 -0.027446877387833  0.001428368203209  0.035760699595502 -0.016168017803360  0.076110316338229
-    3  (  3) -0.111768458659199  0.032123986864070  0.006283151908271 -0.033287020781358  0.043086093005307 -0.045344868585861  0.050504244775852 -0.018808552325982 -0.035145863401031
-    4  (  4) -0.008665305449844 -0.063452607411023 -0.029600165455924  0.047115677331559  0.019168666345381 -0.031501732622098  0.317766848542404 -0.025484653465158  0.136713668607013
-    5  (  5) -0.096942829349587  0.462416830630329  0.133842090994118  0.092985874350147 -0.099421870808029 -0.234587688959823 -0.217512036032000  0.115491679731730 -0.074046828271163
-    6  (  6)  0.147504151854231  0.176016277524490 -0.101374573515317 -0.288079277305196 -0.230919141922049  0.118478695990594  0.200039409574699  0.528080641738917 -0.150345125085143
-    7  (  7) -0.042669001755884  0.443406170499069  0.389143916519812  0.161315900065673 -0.044923622848274 -0.251217580401495  0.349139344106497 -0.313375744671926 -0.105308356658894
-    8  (  8) -0.090773283284028 -0.098945242676733  0.273219850231927 -0.153556988234685  0.012049248011756  0.153837601800696  0.096783765511278 -0.036655814574288 -0.158022323654812
-    9  (  9) -0.854099711852282 -0.117772176421944 -0.239016409160077 -0.177375733867881  0.100275769298913  0.252844583057920  0.226930144139075  0.153229528005110  0.127239027610851
-   10  ( 10)  0.395991653576375  0.538214267844356  0.096531314019954 -0.336382832184142  0.099895828912763  0.055956501178133 -0.146421756050995  0.134905206743007  0.024743642762261
-   11  ( 11)  0.048495982241480  0.204014858900645 -0.274325469868742  0.134595356909103  0.084519511625804 -0.191133538480751  0.069261639154394  0.103192119612584  0.176045180364651
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.028831087335228
-    1  (  1) -0.001371858337113
-    2  (  2)  0.086279641236700
-    3  (  3) -0.002619734805492
-    4  (  4) -0.021137684583830
-    5  (  5) -0.191430382947414
-    6  (  6) -0.264284919761669
-    7  (  7)  0.000269384690538
-    8  (  8)  0.116882729881709
-    9  (  9)  0.120074711434079
-   10  ( 10)  0.053632787996257
-   11  ( 11) -0.085463803953674
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.675541283858356 -0.292064021280293 -0.790025131233222  0.039304385342315 -0.142699371183327  0.268327500474091  0.055268589173706  0.193336176520280 -0.032498607183913
-    1  (  1) -0.292005367417511 -0.068094888399427 -0.091928539573230  0.129152126993159 -0.002672883933379  0.049262453691224  0.862140772831706 -0.434895002279636  0.030957963645570
-    2  (  2) -0.789447165009789 -0.092254483472880 -0.804853040833334  0.464036191543570  0.288328515691532 -0.782373392336952 -0.359658943728641 -0.388090328975242  0.068147997029207
-    3  (  3)  0.039444395620206  0.128939281409480  0.463903578747306 -0.241479807350799 -0.029257651091736  0.289330170364477 -0.078438871496667  0.246243716348015 -0.221624488999474
-    4  (  4) -0.142005033730652 -0.003441352982276  0.286700873937055 -0.029953661733414 -0.427750919311445 -0.225593242891832  0.001248695253401  0.308372097905189  0.608170303007273
-    5  (  5)  0.266046370608821  0.051710611539180 -0.778167579408912  0.290283723006215 -0.224453112864279 -0.369348441761130 -0.137527542499239  0.160088399589127  0.333141145250294
-    6  (  6)  0.055576665996038  0.861897091141550 -0.359382180614210 -0.079367338581182  0.001316960755447 -0.139592143084602 -0.236061692038733 -0.500995422630755 -0.152924823639678
-    7  (  7)  0.191190365321726 -0.433335934056497 -0.384226491533538  0.246895934047586  0.308256930114393  0.160145299200529 -0.499551364365546  0.169042466304747 -0.232433156817922
-    8  (  8) -0.032324733830521  0.030583581869279  0.067800595440523 -0.220839746025180  0.605132330733771  0.331428074510260 -0.152991449816876 -0.231671787208498 -0.624414674119492
-    9  (  9) -0.170133827289346  0.173802608390272  0.582650141434017 -0.560382911834174 -0.212565567455627  0.095754045184088 -0.282286783247438 -0.105642205052933 -0.000539730602912
-   10  ( 10)  0.052970874353821 -0.227531715435441 -0.648876828841383 -0.696767965643644 -0.268344000354012  0.568720278318329 -0.098598860256773  0.086269937526947 -0.081275470268861
-   11  ( 11)  0.025516552524119 -0.085059735579504 -0.121415959836865  0.018097922040376 -0.846374652520441 -0.307989344147049  0.044343294285023  0.231195949738532  0.168305572109582
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.171375974411067  0.055216931376792  0.025964207813788
-    1  (  1)  0.173220084938157 -0.230603891969826 -0.085840408679658
-    2  (  2)  0.586304150506699 -0.654210189691972 -0.122677885868631
-    3  (  3) -0.564217005061761 -0.698424845148049  0.018146779332832
-    4  (  4) -0.213592841407263 -0.268356081771837 -0.851093566817366
-    5  (  5)  0.095187708087751  0.569138844284334 -0.311815017332116
-    6  (  6) -0.283847446348569 -0.099361887898569  0.045327800607922
-    7  (  7) -0.106442929251796  0.084951820105521  0.232402123183799
-    8  (  8) -0.000679287280351 -0.083181582350312  0.174842773942352
-    9  (  9)  0.184137973286679  0.103441117955563 -0.011188766481418
-   10  ( 10)  0.107554052466808  0.106515041132340 -0.165743784884080
-   11  ( 11) -0.010550245981975 -0.165913802295303  0.859885805027657
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.229655435401251 -0.279601353643965 -0.085575827802352 -0.135048509105901 -0.463462610619003 -0.365248455770507 -0.039660777368333  0.191781963250870 -0.304572804139555
-    1  (  1) -0.279047925679444  0.077319987469585  0.204439247136492  0.070123615269243  0.055860395624731  0.138642318409271 -0.343207769076389 -0.182810883095464 -0.017999280994748
-    2  (  2) -0.085240959465133  0.204263364283089 -0.311156623733494  0.294688564065330  0.229669520218161 -0.281737981462645  0.137882893674030 -0.194668648298996  0.517507397185879
-    3  (  3) -0.137052652301458  0.068817803199155  0.294513347383327 -0.628744473812505  0.688526281107777  0.166771123104115  0.212803952843010 -0.269010206604892 -0.411620416751970
-    4  (  4) -0.461604619248266  0.055843287983042  0.230054478565236  0.688395074228786 -1.421511879446005  0.180495138052121 -0.177199847230662  0.268188410470329  0.119512289645345
-    5  (  5) -0.365099883123814  0.139122909294115 -0.282780063256330  0.166251175855828  0.181093271919847 -0.292775738602585 -0.240660983788926  0.305216197970317  0.235452232882587
-    6  (  6) -0.039141072198114 -0.342047900602042  0.138302509146164  0.211959339222516 -0.177087648441962 -0.240505624310098 -0.304304277829310 -0.910739369588832  0.202811323160239
-    7  (  7)  0.191443148224360 -0.183077517400336 -0.194209029769022 -0.269384260651775  0.268168725961981  0.305441092512858 -0.910852433205190  0.029633662055934 -0.204453968987965
-    8  (  8) -0.303246852232180 -0.018509744386768  0.519514080414653 -0.413340759430442  0.119384719254151  0.236362024043069  0.201991249845660 -0.204562219955504 -0.661555776893828
-    9  (  9) -0.300472910579648  0.170014354298783 -0.291259695102906  0.029160805834281  0.317264449488489 -0.326442124436524  0.007044557482429 -0.101763181058410  0.215338723709779
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301684802635884
-    1  (  1)  0.169719322346163
-    2  (  2) -0.289724655704096
-    3  (  3)  0.029002914588453
-    4  (  4)  0.316574855082561
-    5  (  5) -0.325796183326422
-    6  (  6)  0.007131791827115
-    7  (  7) -0.101918507704736
-    8  (  8)  0.215214193797303
-    9  (  9) -0.431317970778139
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009148490318064 -0.020309806158549 -0.015977532182931  0.004014783738387 -0.010489793112351  0.029667649783295  0.020232440585606  0.011223082041042  0.023312323786938
-    1  (  1) -0.044375857230131  0.052262766826166  0.015548487373741 -0.003662802577056 -0.002781875625079 -0.001383977859398 -0.098229640468489 -0.001043710758572 -0.010909270118946
-    2  (  2)  0.054181385020550  0.080128526478900  0.022828931876126  0.037487063410101 -0.042770056882922 -0.005218720540993  0.030479703829638 -0.014823518322437  0.065536667960166
-    3  (  3) -0.129996832535740  0.025539245172390 -0.001710767497197 -0.035208153932012  0.051497303033318 -0.033810939265315  0.041923713016432 -0.018028802137201 -0.031841589713416
-    4  (  4) -0.018797598258319 -0.055382521313148 -0.025678897036466  0.042677314096974  0.024119803445938 -0.028773903589126  0.288385579456642 -0.023957336001325  0.134022392012911
-    5  (  5) -0.085790126908808  0.402408359114006  0.110878458520312  0.084218998643581 -0.097302640260559 -0.211015098306590 -0.195826989075132  0.107508726926065 -0.059970385150068
-    6  (  6)  0.117117046001707  0.164907313314791 -0.092740522447941 -0.263892346037872 -0.208050086690414  0.121861415926763  0.180654068666643  0.487980567663863 -0.134813668081860
-    7  (  7) -0.052709991074355  0.381296251220592  0.349380237841959  0.145852911752160 -0.041346590279243 -0.220669429372274  0.328816279036270 -0.285726302429830 -0.093478286390337
-    8  (  8) -0.075491834851014 -0.090622807799606  0.261184981058617 -0.148637821570292  0.006281256453519  0.144842826611815  0.089811111402247 -0.036110485207390 -0.153520220179307
-    9  (  9) -0.696164148321021 -0.104910101886221 -0.203383144631185 -0.164870629493292  0.069977329160723  0.194202208543558  0.212076681930829  0.132693764051193  0.096725293429142
-   10  ( 10)  0.348175665954885  0.434442729860845  0.069207287013024 -0.311902381205193  0.086974667298470  0.051225223079379 -0.122216101880307  0.122874476488139  0.012079820457350
-   11  ( 11)  0.044712948857676  0.176004094735536 -0.255862724288287  0.126758826080010  0.078218473139894 -0.179984369340434  0.067110991111726  0.095360581673868  0.177561710091429
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.024402944617349
-    1  (  1) -0.001173348606223
-    2  (  2)  0.076484101898115
-    3  (  3)  0.001169431615315
-    4  (  4) -0.024935532887633
-    5  (  5) -0.174540155531575
-    6  (  6) -0.236517338782017
-    7  (  7)  0.008859575697215
-    8  (  8)  0.109927192293737
-    9  (  9)  0.089534068178409
-   10  ( 10)  0.043410237741554
-   11  ( 11) -0.093132968001143
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002170644752931 -0.022324956514099 -0.029394826211345  0.023309311068680 -0.000970852822634 -0.043511040680121  0.014013985960523  0.007860305508825 -0.031314125297178
-    1  (  1) -0.004975212184910 -0.009727238108985  0.081406434912428 -0.023252939392766  0.038928067463043 -0.010458408905981 -0.034913544836836  0.014265058471693  0.051735797486860
-    2  (  2)  0.017880176100707  0.015599348022774  0.096023531696764 -0.045237679689815 -0.002431886781376  0.077281603581543 -0.027482410098613 -0.002121837766367 -0.131596950090464
-    3  (  3) -0.033671282161329 -0.042247110815725  0.017614407066521  0.120482048147517 -0.071788669015437  0.100417130949899  0.026095439370731  0.024912292415628  0.128857994704884
-    4  (  4) -0.039094504869080  0.011586636873075 -0.201648756832533 -0.417167224027039  0.232183671922422 -0.365776066782585  0.000436512477144 -0.036487401941041 -0.092913589753420
-    5  (  5)  0.107020694538732  0.188165249192967  0.272788343236859 -0.444403017959699  0.118293552778212  0.528258782415562  0.125325642779073 -0.198753130098826  0.028672980278371
-    6  (  6)  0.121158671169740 -0.085565322151460  0.088586051783133  0.010298532059028 -0.107250216094850 -0.195698840050220  0.370534853760273  0.159194784952583 -0.016512860210084
-    7  (  7) -0.033804952616344 -0.168095045341921  0.398821112602689 -0.046726828449621 -0.030609711055064 -0.217531691733838 -0.115639511714214  0.399856930098400  0.150033235311716
-    8  (  8) -0.059559370905179  0.306305036465827 -0.595923646185890 -0.119277640805674 -0.722271918559490  0.001726267262613 -0.027179920353598 -0.211451038002310  0.148912062372910
-    9  (  9) -0.188866142842736  0.096789990486457  0.236442562527094  0.092757728041313  0.072651948101216 -0.016472461695526 -0.026914575117300  0.247244600184375  0.370870606832493
-   10  ( 10) -0.406957853798143  0.141958866881762 -0.085132936917023  0.102326296221874  0.017996095944708 -0.062553443565296 -0.105319900227601 -0.005069269037988  0.006423933602228
-   11  ( 11) -0.081915250147579  0.202583484157184 -0.282203343833431 -0.339304077428364  0.118298550150489 -0.126692826807318  0.005731143361727 -0.150166092159272 -0.134968415625333
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.038183979702674
-    1  (  1) -0.001758617329220
-    2  (  2) -0.002245458358924
-    3  (  3) -0.305015280585847
-    4  (  4) -0.011707659076193
-    5  (  5) -0.052479234679287
-    6  (  6)  0.143560462314116
-    7  (  7)  0.320971036748081
-    8  (  8)  0.148594551736844
-    9  (  9) -0.097500178466871
-   10  ( 10) -0.069870490871550
-   11  ( 11)  0.082515655756872
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.053221344681142 -0.117483147833985 -0.106139723247453 -0.495823955121092  0.391515874804455  0.212402958848530 -0.083769680573767 -0.039675371517883  0.058634274306531
-    1  (  1) -0.117410394687696 -0.001165915237512 -0.133100613626654 -0.630012634533085  0.317623482499555 -0.573984529169381  0.375575851008806  0.417091736224605 -0.210582306420709
-    2  (  2) -0.106116179316557 -0.133365754849436  0.099881677186242 -0.283389270168438  0.408842653260195  0.463415082290805 -0.094461635582511 -0.339728478273951 -0.187117729157411
-    3  (  3) -0.495487159854538 -0.630575218275538 -0.284210529100489 -0.394005207299682  0.243829412824131 -0.426368810438983  0.000017569224274 -0.316982847795332  1.182262387796268
-    4  (  4)  0.391977861689502  0.318458435778042  0.410524448216213  0.243871385545647 -0.262605821454379  0.313475558817429 -0.006238164976110  0.146232809940208 -0.404783357267945
-    5  (  5)  0.211677947989569 -0.572946112183618  0.465876094202739 -0.424891649228725  0.310576368667640  0.340119032966648 -0.103399884420596 -0.366027570904681  0.140243317389270
-    6  (  6) -0.083203642949521  0.374758513857944 -0.095474380553338 -0.000848431158077 -0.007011740191065 -0.103456952640946  0.035381526355376  0.100664517850410 -0.224617556800866
-    7  (  7) -0.039824177760467  0.417269525333673 -0.339848279473418 -0.316785009817077  0.144981956006953 -0.366591938133070  0.100487370214345  0.453363803566786 -0.284080848307595
-    8  (  8)  0.058454981179204 -0.209563433448112 -0.187086823104815  1.182437825563613 -0.401897920471953  0.141960153823608 -0.223791716105096 -0.283768269790238 -0.127258563076312
-    9  (  9)  0.176473367868989 -0.113695285962430 -0.191045562239273 -0.466077182834650  0.080353173846381 -0.392419296545826  0.139310719822578  0.097667658130615  0.260382741772322
-   10  ( 10)  0.087511748605763 -0.084525637542731 -0.451433812661641  0.087442027470754 -0.075301055147615  0.128254312442896  0.066832910809452  0.040269698765907  0.083963538620684
-   11  ( 11) -0.256000473516428  0.178934738319287  0.462669412659627  0.336070869572452 -0.226364820740552  0.220661186826050  0.015682276558009 -0.019696413835863 -0.320368477367524
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.177398660643495  0.088413661062507 -0.257047850800415
-    1  (  1) -0.114710761582569 -0.086001542477366  0.179468892454740
-    2  (  2) -0.191402905701337 -0.452554194931555  0.463985875678332
-    3  (  3) -0.467548510382317  0.086605995128391  0.336310348111395
-    4  (  4)  0.080907164839857 -0.077457000042675 -0.231693183962593
-    5  (  5) -0.391713702811823  0.124122145336547  0.233240659481206
-    6  (  6)  0.139727422139028  0.065972550943365  0.014736999139443
-    7  (  7)  0.097438431199858  0.039119593081805 -0.012607893852994
-    8  (  8)  0.258370481571402  0.084693167750785 -0.328679992068142
-    9  (  9) -0.027947875522173 -0.059452680730838  0.039102598209232
-   10  ( 10) -0.061112133253744 -0.042824028656813 -0.176907573001062
-   11  ( 11)  0.036269564126208 -0.174115037047438  0.046562990208638
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.221915567502623  0.240154969163816  0.089524025753548 -0.009891539023461 -0.105352264889997 -0.079728196437896 -0.186918344067447 -0.018609216798882 -0.150218987334760
-    1  (  1)  0.239595861160914  0.097635005536382 -0.020343203465831  0.252497393963625 -0.178770889626966  0.156659860903133  0.042031186852564 -0.226739274781765  0.050354579998016
-    2  (  2)  0.090047283413814 -0.021960432152020 -0.652704165096791 -0.484235858264924  0.265074532283746 -0.870240852693915  0.056963933090132  0.087593695232780 -0.397150344061483
-    3  (  3) -0.008304023565221  0.254514964099576 -0.488668744172267  0.243914942296862 -0.497430549408554 -0.651892044099941 -0.144949354151790  0.009197770416785  0.363155689203458
-    4  (  4) -0.105368055288416 -0.178968402377489  0.265813616023428 -0.498441236963999  0.117807978177016 -0.197938223960627  0.010977461550819  0.054866508200549 -0.633466747483980
-    5  (  5) -0.079092278611567  0.155211327907083 -0.870349858528248 -0.648891955877304 -0.198852995680930  0.056118287010249  0.077393750543525 -0.820063131904850 -0.522591293712200
-    6  (  6) -0.188319262904704  0.043235387216250  0.056704467242807 -0.145342612784415  0.011176054667898  0.077123788010048 -0.017043504447154 -0.229308594149143 -0.061253571825596
-    7  (  7) -0.017449220652026 -0.226052369590475  0.086398229140611  0.009988063298837  0.055257253277244 -0.820894010869112 -0.229107411788767  0.436891114659360  0.154693358924324
-    8  (  8) -0.147652836473568  0.050157233403955 -0.397985593672069  0.364902332737576 -0.632177325650741 -0.523669848989306 -0.060883358066048  0.155008994016302 -0.331322085722016
-    9  (  9) -0.012364053013731 -0.381902018882131  0.730234455154150  0.318717588976828  0.654372705810295  0.234910934996783  0.063436038641434  0.568676727219248  0.116095919775855
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010717409085818
-    1  (  1) -0.381606046587817
-    2  (  2)  0.729520232349256
-    3  (  3)  0.319801359646356
-    4  (  4)  0.655576694394483
-    5  (  5)  0.233766377042350
-    6  (  6)  0.063681628675817
-    7  (  7)  0.569047245691214
-    8  (  8)  0.115234955131862
-    9  (  9) -0.255200733989858
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006756611009239 -0.004812319108707 -0.015155246179453  0.018768861614548  0.003263846230316 -0.029956626691063  0.007768157616613  0.008654952545397 -0.024139771998296
-    1  (  1) -0.000276876655733 -0.007317152277636  0.067126401411285 -0.013873168496829  0.038395392580021 -0.004054864162186 -0.028032553908660  0.014238200673600  0.044802348000681
-    2  (  2)  0.034311733284435  0.014478380463186  0.079037871547464 -0.037480797351928  0.004455235189999  0.068266709703376 -0.020927095140560 -0.000590179941322 -0.116436689576599
-    3  (  3) -0.034781167081690 -0.039999835648210  0.017388947621558  0.117724049135840 -0.062309713575062  0.098214530429882  0.024529272430519  0.026637769905859  0.121592113448416
-    4  (  4) -0.036088452219928  0.018119725898309 -0.181397076074172 -0.381210957896193  0.211295234548894 -0.335046977567969 -0.001001209940803 -0.032788904430710 -0.087406508170972
-    5  (  5)  0.091932999121248  0.163472911292393  0.257039057929667 -0.406986018028708  0.108362880698111  0.483755223010107  0.114747171070721 -0.179816739697054  0.021814542430540
-    6  (  6)  0.102207313652244 -0.075273825473482  0.076700485775484  0.010389199522243 -0.095145363312679 -0.177269643268087  0.339312666537493  0.145893525857585 -0.013352577122472
-    7  (  7) -0.036776384387696 -0.162278963391709  0.362818814892890 -0.043460364327904 -0.026462409718549 -0.199351982461758 -0.104180059013018  0.364628559511404  0.137093791802520
-    8  (  8) -0.054133642075650  0.281937460317668 -0.549118750139198 -0.110766566728388 -0.665283649525633 -0.004014717984651 -0.026030812844979 -0.193249298632007  0.140185869779560
-    9  (  9) -0.149539825936769  0.083496187141563  0.222414359602469  0.086467924966290  0.058519767738283 -0.026610134648035 -0.023639345193443  0.224482305471681  0.335967535114734
-   10  ( 10) -0.342551768791105  0.115343806322270 -0.079695331214451  0.094078531732984  0.012984790263811 -0.052720281866277 -0.089289783188097 -0.003161584461577  0.011520822726607
-   11  ( 11) -0.067948144123858  0.170897803094304 -0.268478044795138 -0.331752793901224  0.110501398686606 -0.120431522039808  0.010421693063374 -0.142909196950524 -0.136584264097857
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.029945709624550
-    1  (  1) -0.003777838622564
-    2  (  2) -0.000494193391228
-    3  (  3) -0.283159255072162
-    4  (  4) -0.002056849846006
-    5  (  5) -0.055491249216550
-    6  (  6)  0.134241443599212
-    7  (  7)  0.294425347600366
-    8  (  8)  0.138732741810037
-    9  (  9) -0.100744739667681
-   10  ( 10) -0.062352827286650
-   11  ( 11)  0.087587602591740
-
-	DPD File2: P*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.016434384667148 -0.059537003054536  0.018382703913455  0.001901473074516 -0.028510164358282 -0.077646279855039 -0.000356251398219 -0.021408373218989 -0.091393977088558
-    1  (  1)  0.005835140019102  0.006847303402179 -0.005801307077118  0.092503110731406  0.040640220398500  0.004476772769023 -0.006707493956919 -0.025598358653730 -0.054742040386929
-    2  (  2)  0.032576552661469  0.022759352669700 -0.015700451044420 -0.017659613283536  0.033691301649134 -0.071320914458495 -0.010810523808367  0.000599142203483 -0.006831611161324
-    3  (  3) -0.028439441517722 -0.025978253338493 -0.005227408482745 -0.004129515933235 -0.042131401342259 -0.005061996623806  0.014819468597155  0.029813444208053 -0.124931870713391
-    4  (  4) -0.026711661740657 -0.065952388204908  0.070397760617197  0.113357837258571 -0.162062952662508  0.007050708037022  0.019958512448364  0.113599468912823 -0.186779858191589
-    5  (  5)  0.054225682429018  0.150592673565962 -0.090221508528394  0.165469278587529  0.105075744052049  0.235926758500148  0.076402735009682  0.065221510888654  0.109078486285223
-    6  (  6) -0.036820767703606  0.045049000362756 -0.022079029118092 -0.038075092578984  0.045448669142688 -0.103567825475646  0.243196158948954  0.024866082639399  0.028667254743547
-    7  (  7)  0.064079984215095  0.104489316033204 -0.208936934850580 -0.011404897999585  0.191297065299167  0.062928087633658 -0.036625785426208  0.182329767369539  0.046827781359629
-    8  (  8)  0.029820488646987  0.037609170202879 -0.184366833470305  0.250608304245861  0.266157936861978  0.003343240964033  0.026232571891440  0.068560106516425 -0.143703222469330
-    9  (  9) -0.097477133499219  0.253919330671861  0.022474002349921  0.091068839306237  0.030773177890121  0.124639301979492  0.057377848460010  0.129428480584789 -0.052503813838482
-   10  ( 10) -0.308102321981415  0.100099264744172  0.103502297395079 -0.030595871425367 -0.027930037535271 -0.082924987589621  0.003621479559882 -0.051467583495009 -0.001729710593298
-   11  ( 11) -0.065171614185219  0.083076013227694 -0.007781121482082  0.129638416743258 -0.025583078029705  0.021102804445382  0.038969277950233  0.054649593445510 -0.156415144250598
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.100574711969240
-    1  (  1)  0.017311198418314
-    2  (  2) -0.099207008690223
-    3  (  3) -0.049312818935542
-    4  (  4) -0.020969683268895
-    5  (  5)  0.168478941844432
-    6  (  6) -0.036633223806040
-    7  (  7)  0.083149987934917
-    8  (  8) -0.054463823630147
-    9  (  9)  0.105100295511211
-   10  ( 10) -0.049112459843749
-   11  ( 11)  0.074285789462190
-
-	DPD File2: P*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000150860459877 -0.171933918231252  0.041419056803072 -0.170616058570147 -0.200856757156520  0.002034169374196 -0.083717100185599 -0.000516882277833  0.000760835570240
-    1  (  1)  0.171458970665860 -0.000052671693709  0.080477211012241  0.158047078345989  0.171611945068556  0.020781553144960  0.081182987020708  0.096111050666912  0.028348265964974
-    2  (  2) -0.041612402589055 -0.080354514984744  0.000394264947173 -0.065176020012681 -0.096961733142428 -0.000557038525025  0.109435480142694 -0.034287451388532  0.031868099666052
-    3  (  3)  0.170115569606579 -0.158386367352469  0.064620104688982 -0.000274195329164 -0.003073114771818 -0.155980931184969  0.002438060010510 -0.075892612616599 -0.118957615446809
-    4  (  4)  0.200436196772240 -0.171813138083843  0.096620398683267  0.002372485388961 -0.000742978447135  0.018013393904637 -0.033369149651403 -0.120720251055992 -0.104550918281167
-    5  (  5) -0.002211117433298 -0.019930957908302  0.000666901496264  0.157204484557621 -0.015901976339486  0.000217821561163 -0.009428657942981  0.039993958187839 -0.071492158249729
-    6  (  6)  0.083537896232863 -0.081216293971867 -0.109652154032100 -0.002769108821106  0.033489275419838  0.010079357840938  0.000064832704676  0.012979883425805  0.022286123614410
-    7  (  7)  0.000446183372454 -0.095595436198971  0.034260265949943  0.076357839284767  0.123056525926531 -0.039576937592408 -0.012836423633655 -0.000276922615353  0.011862614885765
-    8  (  8) -0.000763780194579 -0.028492759060566 -0.031582546116686  0.118324194064185  0.106500675879643  0.072862382850876 -0.022267846900148 -0.011936132807121  0.000309785123822
-    9  (  9) -0.200009372729413  0.049971216489633  0.123430272682259  0.142933103185242  0.066275175614906  0.011400665529444  0.086697488232449  0.026102313931474 -0.001060546754189
-   10  ( 10) -0.021852700751396  0.017163247777288  0.127823592278093 -0.091613120127056 -0.051604501451930 -0.012175072674142  0.083661634147568 -0.068820029767420 -0.010286004757943
-   11  ( 11) -0.114973761942494  0.044704429189879  0.150112248621738  0.031470261050302  0.054465549098901  0.018492073632933  0.052809037569742 -0.018588462631583  0.062465552340744
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.199650432776970  0.021769646283719  0.115014099877643
-    1  (  1) -0.048847979709979 -0.016224624083658 -0.045739997653995
-    2  (  2) -0.121535202952087 -0.127110081169448 -0.150689800369572
-    3  (  3) -0.141534079657396  0.092900464386430 -0.030906929300398
-    4  (  4) -0.064777188331671  0.052294246689992 -0.052576843649814
-    5  (  5) -0.012798646161060  0.011617495484096 -0.021426191620278
-    6  (  6) -0.085439453581865 -0.082177824690696 -0.054044239620785
-    7  (  7) -0.026881359606727  0.069312090513404  0.013578395284128
-    8  (  8)  0.000980665289481  0.011875108407812 -0.069843147407046
-    9  (  9) -0.001396130223525 -0.045043795365458 -0.018886220574768
-   10  ( 10)  0.041412670665906 -0.001872911812120  0.033067578033610
-   11  ( 11)  0.016567946659153 -0.031899396551867 -0.001929777984873
-
-	DPD File2: P*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.001411268359160  0.010548061189878  0.012234985630211 -0.023975313562280  0.023062230820039 -0.045437732948681  0.106872881296076 -0.025944637778051  0.029363485311898
-    1  (  1) -0.014640801150040  0.001773735046594  0.029549963184092 -0.020758435544442 -0.007635590000279 -0.056071060358736 -0.088482364466965 -0.027605241546487  0.020492843216977
-    2  (  2) -0.013184523566191 -0.031261847780049  0.000489474253254 -0.031775189074985 -0.038538471296270  0.038607714449183 -0.007921641905981  0.014600160708699 -0.097026534080847
-    3  (  3)  0.023325695791557  0.021331801923242  0.030636705569878  0.000479373870642 -0.011687430157835  0.060845116281804 -0.009020253210307 -0.020543788213974  0.119533313623190
-    4  (  4) -0.023654300689698  0.009020483406481  0.038301937767707  0.011962372815437  0.000301509800453 -0.037261192743398 -0.029045239001199 -0.041781275442091  0.051627710213779
-    5  (  5)  0.044386181810683  0.057414182896665 -0.038267122468401 -0.061256729128929  0.037800933596037  0.000260698778894  0.001511863535883 -0.016380337639677  0.072487672330699
-    6  (  6) -0.106206323004553  0.087758718377781  0.007560784408469  0.009263545408533  0.028871039692754 -0.002023613184462  0.000132116955283  0.000735561511998  0.010945124965688
-    7  (  7)  0.025425283561814  0.027796807869910 -0.014997640380461  0.020644254386635  0.041827532757913  0.016146444702388 -0.000831333123472 -0.000058581308311  0.017035220679833
-    8  (  8) -0.029580773528628 -0.019460244903885  0.099428018149333 -0.121448802541844 -0.052251959451872 -0.071719334941988 -0.011527870420583 -0.017438360216925  0.000376592607811
-    9  (  9)  0.011323796835811 -0.022846032797884  0.003463845070647 -0.010590766229841  0.093908204414477 -0.097279630619014 -0.016132246312287 -0.052832474295790  0.033804637999018
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.012386803276718
-    1  (  1)  0.025331755243544
-    2  (  2) -0.004701299813181
-    3  (  3)  0.011259859427831
-    4  (  4) -0.092847122914529
-    5  (  5)  0.097092353171668
-    6  (  6)  0.015797039269438
-    7  (  7)  0.052823551833136
-    8  (  8) -0.033708639353932
-    9  (  9)  0.000241834945391
-
-	DPD File2: P*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019875399821365  0.067213072995023 -0.012299941717659 -0.003468875187880  0.030128328426274  0.082822743936825 -0.001897897698354  0.021797662835713  0.095153762344945
-    1  (  1) -0.006451292960481 -0.005754162581844  0.002884034500734 -0.094974935426192 -0.041098451485401 -0.000058064511604  0.008894806239621  0.025485003895974  0.057087471632476
-    2  (  2) -0.026223355242450 -0.024273603088334  0.016292189081393  0.015844039410231 -0.030633853079712  0.077008417539564  0.014788316606733 -0.000243822647885  0.007976439135467
-    3  (  3)  0.025334252850709  0.027648721071750  0.005856451162092  0.011279594978250  0.045220581787047  0.007788112252830 -0.015791844926599 -0.026413664639332  0.132992803966333
-    4  (  4)  0.028858615977169  0.070880006979721 -0.078385497137577 -0.115909817357349  0.170672806468397 -0.002802625270051 -0.018507237940661 -0.116641608428124  0.183930260352482
-    5  (  5) -0.062029310382341 -0.165059238935656  0.096438123628463 -0.170982438012572 -0.101168051978722 -0.247462788062147 -0.078143137508448 -0.065503368874352 -0.123407161852621
-    6  (  6)  0.029868108814055 -0.043826434723281  0.020536879880122  0.040118359069746 -0.047262891605686  0.111204577364818 -0.250427612151989 -0.027185217329734 -0.027972758218343
-    7  (  7) -0.071045843569722 -0.110497052752988  0.212396167514294  0.014472401617176 -0.201746291025428 -0.058726820006450  0.038658609736798 -0.191686821472890 -0.051568740310987
-    8  (  8) -0.030231001314245 -0.039607181613347  0.190237369746058 -0.251586833919896 -0.277372132160808 -0.008690855780340 -0.027285881313233 -0.066231456708385  0.148705440863578
-    9  (  9)  0.119406447574908 -0.267992491845044 -0.024723477609567 -0.092623842023547 -0.035484932702787 -0.135905292178670 -0.058976108500788 -0.137156317198896  0.050622979340015
-   10  ( 10)  0.354731988399122 -0.114731465978240 -0.113605854938311  0.033621899430544  0.024886546894064  0.086388159191061  0.001760250802633  0.054814426010942  0.004266849862045
-   11  ( 11)  0.074987139083159 -0.087839869817099  0.017174937068014 -0.139817452729011  0.030459814346611 -0.019645857821193 -0.042455388198899 -0.058190403006369  0.165317136166192
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.104159520209993
-    1  (  1) -0.017365114579609
-    2  (  2)  0.105508249406411
-    3  (  3)  0.051333283782025
-    4  (  4)  0.026824469147080
-    5  (  5) -0.172355785037806
-    6  (  6)  0.037231897229526
-    7  (  7) -0.092488656033236
-    8  (  8)  0.060576527966250
-    9  (  9) -0.114591221791530
-   10  ( 10)  0.052791324163552
-   11  ( 11) -0.078009502545252
-
-	DPD File2: P*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.013905849892992 -0.105574256292555 -0.058365326510732 -0.011150777040830 -0.004301162141041  0.055780562682692  0.053115864387752  0.011951099406770  0.044340643594202
-    1  (  1) -0.013705956820555  0.025309547841960  0.001538984041734  0.001849504741603 -0.005133976748632  0.012878903904056 -0.096751125536924  0.003812996689903 -0.009632709529968
-    2  (  2)  0.020569845493093  0.032320703460180  0.011944643866745  0.047792544188734 -0.032679729361416  0.019407207672949  0.038230397931919 -0.003676283556944  0.058784384336985
-    3  (  3) -0.071874917867093  0.002631775952960 -0.003539152259809 -0.028170151218425  0.033082337295689 -0.021301963625855  0.050188554745657 -0.011804977856767 -0.016979295260921
-    4  (  4) -0.014914728990396 -0.041337858840349 -0.031774187859112  0.031846901880618  0.020737884741536 -0.009318588686327  0.180587918491444 -0.014608314108616  0.091927794627027
-    5  (  5) -0.043163603381900  0.253570894625469  0.078110646309368  0.060207643631253 -0.083755719198877 -0.160896258343551 -0.127680183234514  0.074831092977117 -0.060961655981049
-    6  (  6)  0.044917686060828  0.074437543040067 -0.066817478801761 -0.141365137531753 -0.114156889702257  0.038201515939482  0.107320317731531  0.348968351908512 -0.116558406175751
-    7  (  7) -0.034184804469893  0.226667134284391  0.206947793731390  0.080987919933847 -0.050884738274657 -0.136027438420489  0.157869432700479 -0.195670168357032 -0.055408723502488
-    8  (  8) -0.031166515249721 -0.045258191750987  0.124213591624855 -0.070497635611886  0.013839913877531  0.080645709057116  0.048975111106761 -0.013846985677438 -0.081456527024621
-    9  (  9) -0.260272045600859 -0.057970015239195 -0.114635559073584 -0.083827066916392  0.094102194410800  0.136997319599706  0.136846202555835  0.093755934766235  0.066197390562813
-   10  ( 10)  0.128170228467008  0.270987976538407  0.063355286850330 -0.080149940628318  0.057123968341669  0.051813056590924 -0.080732658365778  0.110930691434851  0.002284134974517
-   11  ( 11)  0.014638573493894  0.093181336572008 -0.090893348615143  0.060951699754620  0.036152243930201 -0.068685591001865  0.022141424075597  0.054226980293487  0.076820031900454
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.045178917656151
-    1  (  1) -0.000506654263468
-    2  (  2)  0.062622183647669
-    3  (  3)  0.006475863513060
-    4  (  4) -0.009581278166545
-    5  (  5) -0.123788681467482
-    6  (  6) -0.140490962930464
-    7  (  7) -0.012343887711756
-    8  (  8)  0.065924555702067
-    9  (  9)  0.071777365622544
-   10  ( 10)  0.030198414714018
-   11  ( 11) -0.038206097812612
-
-	DPD File2: P*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000441373721971 -0.087271451504254 -0.308356080671030  0.018077607068688 -0.073688004857476  0.153028983755896  0.021375900910730  0.125940926422186 -0.021636449149896
-    1  (  1)  0.086671311731224  0.000204963757277 -0.004083848977647  0.019054726614325 -0.000357076891570  0.008883507874300  0.245817294107565 -0.139613669494547  0.011872389377551
-    2  (  2)  0.307138366785038  0.004537268804354  0.000000947821260  0.032420162338715  0.044765722657128 -0.148620348284250 -0.082511203687099 -0.091836400843881  0.021157739960336
-    3  (  3) -0.018180307170497 -0.018806737266631 -0.032304346608179  0.000164575589082 -0.000048486967076  0.033944617253518 -0.017906518922370  0.039367589983503 -0.041014607610233
-    4  (  4)  0.073708499176395  0.000188579066207 -0.045384824461272 -0.000051244255112  0.000118131709454 -0.009319825672971 -0.005919844337701  0.028188407915503  0.062383088971619
-    5  (  5) -0.153503404134916 -0.008021529263725  0.150851560923171 -0.033683034219721  0.010920406889103 -0.000843675018215  0.002305152210287  0.006419896281910  0.018802686354169
-    6  (  6) -0.021663782224978 -0.245568524819791  0.082607420634013  0.017861578854728  0.005717491537118 -0.001465956881798 -0.000164104368228 -0.019402844307281 -0.008582138264613
-    7  (  7) -0.126272473343725  0.140132379196136  0.093779865985419 -0.039016174646910 -0.027756266123623 -0.008788078328085  0.019927753575961 -0.000986178708271 -0.006276129856304
-    8  (  8)  0.021659942465065 -0.012093240675092 -0.021224721403549  0.041292366946203 -0.063444639030514 -0.018952234899780  0.008805846385022  0.006555018834286 -0.000619883795504
-    9  (  9)  0.110032896200750 -0.071298113833135 -0.163479589536219  0.111444129990912  0.024671365993001  0.003210445766199  0.009378587102769  0.014713425509001 -0.000839110373856
-   10  ( 10) -0.069217830582824  0.088543829220743  0.203682134643279  0.186485128327869  0.053425964853416 -0.063005981229243  0.018184933705949 -0.000540007105749  0.005219687452082
-   11  ( 11) -0.023959189620953  0.030895371890558  0.044769544498433  0.009068900298863  0.130492147876274  0.035762663243292  0.002770335503139 -0.023536235288276 -0.010103727285469
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.109799080219678  0.069203346900770  0.023919903278421
-    1  (  1)  0.071129060568146 -0.087605257548157 -0.030425173883571
-    2  (  2)  0.162026048331677 -0.201435103487415 -0.044723919546572
-    3  (  3) -0.110972252607892 -0.185860701404063 -0.009243336757067
-    4  (  4) -0.024458462243726 -0.052145051182170 -0.130041721565426
-    5  (  5) -0.002181441725954  0.060001657923379 -0.037138509415485
-    6  (  6) -0.007938597292020 -0.017379429117453 -0.002521412739913
-    7  (  7) -0.012919580840703 -0.002428706377795  0.023595862068092
-    8  (  8)  0.000273485582407 -0.005817339116375  0.014280567707235
-    9  (  9) -0.003328589668182  0.017803512680764  0.001063197928266
-   10  ( 10) -0.016699725327030 -0.001798758796680  0.002170763958318
-   11  ( 11) -0.001212933542278 -0.001783778903851 -0.003563107345321
-
-	DPD File2: P*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.002010159634630 -0.000220404084817 -0.003192882122880  0.011052627613533 -0.003562668031365  0.009837814318177 -0.002544312104621  0.035965473851195 -0.038472004952375
-    1  (  1)  0.001452297302852  0.003072719747229 -0.008838287240450 -0.026771929595669  0.046483406284037  0.009889595128182 -0.035422086740367 -0.011912247720366  0.000936796016060
-    2  (  2)  0.004597077371462  0.009797303502342  0.002356759440367 -0.013160928599717  0.036596664601802 -0.014914711645441  0.014591721304407 -0.007418668493650  0.037805835513950
-    3  (  3) -0.010591350137419  0.026807560073439  0.010708663838159  0.000566073142147  0.006877298509595 -0.015806087254090 -0.036616622156539 -0.004527327935437 -0.052470069694755
-    4  (  4)  0.002197180048840 -0.045360469690206 -0.037290055709025 -0.006377690547549  0.000197738244084  0.043135976717434 -0.013927669894978  0.013270906950991  0.034225968512880
-    5  (  5) -0.012223872820757 -0.012276608732166  0.015974082159209  0.014788689444500 -0.043434889585929  0.001241108463199 -0.022259649308453 -0.002776600972090  0.020757469065177
-    6  (  6)  0.002236227833952  0.033698361699947 -0.015413577603851  0.037176700349159  0.013637799368342  0.022481473057898  0.000196461263851  0.066878572107562 -0.012948719456691
-    7  (  7) -0.036159618368672  0.011023728969868  0.006496546324176  0.004756159901056 -0.013088014945893  0.003050957277162 -0.066534588876792  0.000038997802685 -0.018679498186635
-    8  (  8)  0.037272822971437 -0.001025968499180 -0.039463494780131  0.053213044947716 -0.033933492458794 -0.020627554065949  0.012927451364571  0.019084958215300  0.000379158267741
-    9  (  9)  0.044713556544603 -0.031925295057843  0.027454374007067  0.016949911467799 -0.043552787687819  0.029362229767510 -0.013081869754981  0.017575107888422 -0.005208148088787
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.046477985245624
-    1  (  1)  0.031367776651430
-    2  (  2) -0.027386023407765
-    3  (  3) -0.017151073595537
-    4  (  4)  0.043659143705007
-    5  (  5) -0.028276225310864
-    6  (  6)  0.013015371352964
-    7  (  7) -0.017243006711225
-    8  (  8)  0.005600961681940
-    9  (  9)  0.000315129095420
-
-	DPD File2: P*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.016735058692801  0.127427648471711  0.067812616467594  0.013558783551809  0.005269296599083 -0.059347294870606 -0.061177076545679 -0.011973162399102 -0.046187859594365
-    1  (  1)  0.006127975507731 -0.027720789931143 -0.002131386760238 -0.002129686454541  0.005489719844856 -0.015177604183485  0.105071662567975 -0.004089530302215  0.010958371300164
-    2  (  2) -0.014625553671885 -0.033500045224482 -0.010197102842648 -0.049282810089046  0.029146517326401 -0.023890316169967 -0.041396999030433  0.003031629472559 -0.064649337167924
-    3  (  3)  0.059287322502299 -0.004510597912865  0.001550787253983  0.026031838087948 -0.030781241595677  0.028268360125230 -0.056263472143293  0.012481413064923  0.018331852915645
-    4  (  4)  0.010310728455768  0.048004310504315  0.024726014802135 -0.029487545392420 -0.016798380655264  0.006146311288820 -0.193469287289224  0.016404156709459 -0.090545229018770
-    5  (  5)  0.048438874849073 -0.279911055793901 -0.091858080305683 -0.061529389949110  0.086013764646970  0.169909289190226  0.137573811978801 -0.079110070379465  0.068315894389439
-    6  (  6) -0.059086874754328 -0.080452543242778  0.072102486682582  0.152740972704247  0.124804294386305 -0.037562128266895 -0.116816705616042 -0.371092921921504  0.124060147180532
-    7  (  7)  0.029687956296635 -0.256142179942571 -0.224177989138016 -0.089126356257227  0.052538373002914  0.151219359570602 -0.169667778296547  0.210592113990055  0.060100313305223
-    8  (  8)  0.037809640230564  0.049847669441603 -0.131510551596478  0.073995987264147 -0.016613192275803 -0.085953668087854 -0.052289681067999  0.014235003810069  0.085573468377869
-    9  (  9)  0.334054043680738  0.062946651230341  0.131443841559570  0.090838578825240 -0.107669515927940 -0.163692131260888 -0.145222895910058 -0.104796708213769 -0.078942908507754
-   10  ( 10) -0.149544392295761 -0.318224503990855 -0.078211068857457  0.094418507207579 -0.062827781432203 -0.056112671791795  0.092070650285035 -0.118729407251681 -0.005066399630771
-   11  ( 11) -0.017252785597153 -0.111183203080125  0.114995811791783 -0.075235812067226 -0.042976611330520  0.083335038142330 -0.026013221761888 -0.060774659749613 -0.084239808865889
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.046526303364398
-    1  (  1)  0.000196633156806
-    2  (  2) -0.068136524138653
-    3  (  3) -0.003983938855648
-    4  (  4)  0.006861374242241
-    5  (  5)  0.130771416331255
-    6  (  6)  0.153069412317755
-    7  (  7)  0.016354872554726
-    8  (  8) -0.070442312778792
-    9  (  9) -0.084886961073099
-   10  ( 10) -0.034495414084981
-   11  ( 11)  0.039745136609744
-
-	DPD File2: P*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.007512480776319 -0.036140698221162 -0.006614016091629  0.006989344711517 -0.012538055579667 -0.047719007710800  0.011438854389831 -0.001348837643708 -0.043912417866150
-    1  (  1) -0.000217941106815 -0.023674382271911  0.074458985850499 -0.018669991150763  0.024216220760344 -0.026693268127322 -0.030529166464713  0.009220514907509  0.051390413902716
-    2  (  2)  0.018657169402382  0.000504863635670  0.063891633981927 -0.031237660505947 -0.009378378679164  0.057274634026543 -0.010216661924779 -0.007277876487311 -0.107239917659553
-    3  (  3) -0.016066164003828 -0.014293064557711  0.024640166827267  0.100199283130149 -0.053038409095112  0.079899101326132  0.014809180078406  0.008036171971183  0.093693488350467
-    4  (  4) -0.014907654111593  0.000249634614143 -0.129575540220445 -0.265751473143634  0.141781144259113 -0.223368583932083  0.004368931811378 -0.027043226757367 -0.062609693461921
-    5  (  5)  0.041914834745247  0.097616041138947  0.135770321463814 -0.246024098805421  0.106912109293501  0.321253251117319  0.068788844583990 -0.142290197287628  0.046076100892295
-    6  (  6)  0.039123394394723 -0.039408255038257  0.037211012657418  0.010312056024403 -0.060353960942951 -0.114209155992994  0.186728746530896  0.112616911396924 -0.025666796391066
-    7  (  7) -0.018468061945917 -0.067823974613178  0.190104823535190 -0.003755811520253 -0.014064572484241 -0.109658452638694 -0.056630665145805  0.263520506917883  0.064583476374394
-    8  (  8) -0.033210755622659  0.136136968498900 -0.263316618160002 -0.077412830589797 -0.422459728217546 -0.053553377730948 -0.034175715906935 -0.165897217652793  0.074779388344555
-    9  (  9) -0.055036749751630  0.056894038751104  0.107311287797063  0.058290191137784  0.056944188937166  0.005725850016316 -0.009926099968286  0.140696143209114  0.190545524907610
-   10  ( 10) -0.130997705273781  0.090153965609249 -0.007790248268810  0.054524064976066 -0.013947321007330 -0.034280119179197 -0.056585811356156  0.002663395414836 -0.003086708496419
-   11  ( 11) -0.024354529821742  0.002391484587850 -0.132211150437169 -0.155582434877820  0.034543780627935 -0.051588565499349  0.027770703760258 -0.083659992199369 -0.057647900826746
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.055482114656335
-    1  (  1)  0.000101235030463
-    2  (  2) -0.010234508711291
-    3  (  3) -0.213846558445248
-    4  (  4) -0.006630092722992
-    5  (  5) -0.012814259546957
-    6  (  6)  0.078975443650986
-    7  (  7)  0.184930804112230
-    8  (  8)  0.058689588477811
-    9  (  9) -0.044249382467578
-   10  ( 10) -0.036865706935893
-   11  ( 11)  0.030515341975517
-
-	DPD File2: P*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000120442405581 -0.037525975792407 -0.039028837738652 -0.219221358143393  0.183820180818448  0.112972286408530 -0.047240063409728 -0.020414149561154  0.034238085799271
-    1  (  1)  0.037241793728452  0.000047287882243 -0.009729516430168 -0.094202030077235  0.063477866953276 -0.160286164587806  0.109752667557022  0.131207263236284 -0.068887611832074
-    2  (  2)  0.038783295216622  0.009745201912242  0.000258217562465 -0.013038009614076  0.045399222161827  0.081371094984120 -0.019570499748086 -0.076966277295000 -0.058756671783764
-    3  (  3)  0.218771475127948  0.094047631347429  0.012728901107962 -0.000222898647350  0.006965466758731 -0.051483080000543 -0.001032959857400 -0.046617530443310  0.239873280201692
-    4  (  4) -0.183500005674293 -0.063741918250972 -0.045633149570229 -0.007771962048066  0.000752652425378 -0.016686259902744  0.006062931975271 -0.002941130184259 -0.039794941498885
-    5  (  5) -0.112922744463035  0.160447948543053 -0.080839610143832  0.052938181517924  0.014759035093032 -0.001963138533058 -0.004122965199026 -0.030082971847399  0.018688716203396
-    6  (  6)  0.047223957422349 -0.110045906731433  0.018982606895220  0.000425116658999 -0.006190502350060  0.005177802298965 -0.000459941844479  0.006641133881612 -0.015637294529107
-    7  (  7)  0.020258099631627 -0.130980408805956  0.076838250722457  0.047153827019528  0.001697177794538  0.030097214957006 -0.006397035656861  0.000314330689973 -0.000958762971255
-    8  (  8) -0.034242059158271  0.069241386609174  0.058253268615506 -0.239551778865238  0.041466100486767 -0.019183970473991  0.016012586324303  0.000462521772429  0.000639781016008
-    9  (  9) -0.110158178577256  0.043113630563978  0.067267974845207  0.106313996022487 -0.002243251219660  0.021517985932208 -0.002884772712544 -0.010112074041123 -0.004700729741936
-   10  ( 10) -0.070149397127063  0.040299222838292  0.154071817441956 -0.030869069243567  0.038016470293222 -0.011150694193011 -0.007490401305220 -0.020531677805594  0.003859946060401
-   11  ( 11)  0.176636225337744 -0.095095393142691 -0.195177688825668 -0.108802410559496  0.020149361123103  0.001298105635127 -0.020927308070429  0.032058427881699  0.018315736142454
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.110002482243441  0.070133081529118 -0.176505754583752
-    1  (  1) -0.042468765075500 -0.040212942886088  0.096465231599211
-    2  (  2) -0.066618057955858 -0.153916879455284  0.197045228959983
-    3  (  3) -0.105738247971788  0.031572929220209  0.109334469149534
-    4  (  4)  0.002665514835355 -0.037310624735359 -0.021518865524247
-    5  (  5) -0.022104060533187  0.008811719711463  0.005069793238862
-    6  (  6)  0.004143184140488  0.008777342033569  0.020657864679248
-    7  (  7)  0.010048741121033  0.019686189563806 -0.029679561142739
-    8  (  8)  0.004305480816755 -0.003474531743331 -0.021387666942059
-    9  (  9) -0.000592809919997 -0.021935245808500  0.003238719819323
-   10  ( 10)  0.019997593459389 -0.000606363597873 -0.056392578735375
-   11  ( 11) -0.002880485106043  0.055206554617854 -0.001235092281117
-
-	DPD File2: P*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000888157000468 -0.002604640035267 -0.004433898987700 -0.017327910307372  0.010855912598213 -0.001781915278721 -0.008615460934422 -0.004078735474285 -0.032557314773045
-    1  (  1)  0.000573161245420  0.000624628285884 -0.035628999167227  0.001815728764627 -0.008946874115813 -0.029170863803310  0.000115513436505 -0.008856710566910 -0.004031507153659
-    2  (  2)  0.003701039844373  0.036575536539622  0.001091193696307  0.032172216141300 -0.001275865950015 -0.022397487526299 -0.009622303363090 -0.007231877711175 -0.019725778025116
-    3  (  3)  0.016821693036289 -0.002844602963518 -0.032977853684673 -0.000161455575952  0.028542188119355 -0.026304537820681  0.001013466229083  0.013057607695183  0.044876693583426
-    4  (  4) -0.011431384588178  0.009478622864698  0.000774534739031 -0.028965078860221 -0.000058413694986 -0.014596515715548 -0.009143536386555 -0.018007246969037 -0.087822521777407
-    5  (  5)  0.001221856014832  0.030845996389588  0.023077706374501  0.025758114847142  0.014593714027409  0.000250583717006 -0.003873642475734  0.026298757281796 -0.079590541434343
-    6  (  6)  0.009743031224748 -0.000827857567403  0.008744416704428 -0.000735028308095  0.009056595663713  0.003266063160321  0.000168072469286  0.014668639254903 -0.020470938456272
-    7  (  7)  0.003647754834421  0.008460886211306  0.007264440669328 -0.013024018123218  0.017787838957003 -0.026317221009114 -0.014749296379031  0.000019923943455  0.029438703128615
-    8  (  8)  0.031026550181144  0.004477343275687  0.020769831071035 -0.045275173918403  0.088633054403976  0.080566188830968  0.020052483095054 -0.029483325674276 -0.000128037153401
-    9  (  9) -0.012269663364479  0.042319244263402 -0.071429692849981 -0.076602220709806 -0.093629733790147 -0.065554975939979 -0.020165870906458 -0.076547332424074 -0.015636093570251
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.012474935539863
-    1  (  1) -0.041072842913216
-    2  (  2)  0.070651080248399
-    3  (  3)  0.076892460848025
-    4  (  4)  0.093624677134694
-    5  (  5)  0.065506732660539
-    6  (  6)  0.019889038609582
-    7  (  7)  0.076305954221087
-    8  (  8)  0.015612091565202
-    9  (  9)  0.000252880154158
-
-	DPD File2: P*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.009427979504735  0.045069494658558  0.001947285705090 -0.002710338034860  0.015522926834851  0.047663635028120 -0.012944383860693  0.002408628963511  0.046667839995062
-    1  (  1)  0.000029889909955  0.026801338329852 -0.080490862472698  0.019668739880126 -0.025396971257700  0.032890092829257  0.033906444326876 -0.009364690845122 -0.055325390015170
-    2  (  2) -0.013223768231853 -0.001284266713521 -0.066553348308937  0.032573816116206  0.011585258035685 -0.060717975924391  0.011936168857210  0.007853073890483  0.116794956739995
-    3  (  3)  0.012900769345878  0.013623437855550 -0.022570570921494 -0.105173709434029  0.056797034187850 -0.081144841159178 -0.016572432074935 -0.007712189870591 -0.096484218880683
-    4  (  4)  0.015650650711432  0.003889202049455  0.137621535484575  0.283731289627315 -0.151612143157194  0.236884111934266 -0.005136759708167  0.028125482384447  0.063101070821467
-    5  (  5) -0.049233650528213 -0.108628515589384 -0.145433760308553  0.264881634113210 -0.112823478790252 -0.343941453835902 -0.074580579832084  0.152217918461378 -0.050073263216128
-    6  (  6) -0.047771378538329  0.043773249125745 -0.042587468032780 -0.011128298856248  0.066617092775075  0.124136463076967 -0.204572752605319 -0.119847093573235  0.027500955272741
-    7  (  7)  0.017888279952241  0.071752886460858 -0.208298887916757  0.005542743128559  0.016702047381836  0.119479054133457  0.062994319192022 -0.283598496506144 -0.069642269402630
-    8  (  8)  0.037568403528376 -0.148073898852809  0.285205978681411  0.081955004515730  0.456336274750824  0.051315761340278  0.035910751818194  0.176384561285241 -0.080264248689634
-    9  (  9)  0.073735844540901 -0.063193611128899 -0.114658323070558 -0.062815237579419 -0.064185887519018 -0.009313244304943  0.011480973281939 -0.153753080425913 -0.207572044587912
-   10  ( 10)  0.162215796938684 -0.102608816758085  0.007760654943323 -0.059426107703524  0.013639971522339  0.037904077339461  0.064744743002174 -0.002349088500079  0.003377674546375
-   11  ( 11)  0.030714567047902 -0.017149469368505  0.148281723814033  0.168021936553750 -0.043219337814574  0.059348822268391 -0.027602295508655  0.090506279699096  0.064287335914591
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.058979846663424
-    1  (  1) -0.000234151433416
-    2  (  2)  0.011430006640806
-    3  (  3)  0.225608458896205
-    4  (  4)  0.014102875489979
-    5  (  5)  0.012200282245874
-    6  (  6) -0.083455375182168
-    7  (  7) -0.198201250764442
-    8  (  8) -0.062481817545980
-    9  (  9)  0.043390015833605
-   10  ( 10)  0.040973644943399
-   11  ( 11) -0.034098640710675
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.057027762100789 -0.007489633887342  0.036964189813796 -0.021384352100284  0.004867815775604  0.032130235858782 -0.019486973797962 -0.000503926514732 -0.024868986663351
-    1  (  1)  0.007883399599923 -0.007529104506445 -0.013216566770749  0.001554286609489  0.002481002458300  0.003555137440754 -0.020216878378801  0.003435265519663  0.003420680709423
-    2  (  2)  0.005061763911744  0.024005030999464  0.016920245291348 -0.019760528227158 -0.007759414271484  0.029231812106945  0.009559298232843 -0.004745878981161 -0.053662769962019
-    3  (  3)  0.011903086348447 -0.106154395386531 -0.048846797682958  0.038122834717736 -0.042076447151745  0.017515736018254  0.021695004377211  0.017259669010754  0.058953679400153
-    4  (  4) -0.086846706941042  0.161257530089836  0.037361255861875 -0.089905419413410  0.174437646387183 -0.071028892880315 -0.038811212273731 -0.045200518155063 -0.066894551440516
-    5  (  5)  0.295118954821928  0.042171667688274  0.057142717280935 -0.095328920031059  0.118376834610768 -0.017202604507056 -0.038088685926927 -0.015413673756028 -0.019970185142534
-    6  (  6) -0.061695197805604 -0.041447416246154  0.107874329349021 -0.009310856499629 -0.028327062477196 -0.072556054900044  0.031173831746629  0.093673016450942  0.096470656575707
-    7  (  7)  0.040164356283535  0.019606328824315 -0.022514162311588  0.103095269177578 -0.105738125414362  0.000251323240260  0.190667102998226 -0.014251172141516  0.042544347999407
-    8  (  8) -0.209747539729284 -0.026225521984115 -0.065411218317390  0.108576414051802 -0.195951046046893  0.054935351774023 -0.181062671358124  0.048648601818055  0.037403343457353
-    9  (  9)  0.029537922421234 -0.045187174636289  0.013381512217286 -0.049426415359509  0.003411235911782 -0.045265306723710  0.096457278821335  0.006113492494935 -0.044165814974043
-   10  ( 10)  0.026870929841946  0.010513244846490 -0.122411818973730  0.066300236331789 -0.074150921852319 -0.175359501999903 -0.025219490294838  0.031299023505132 -0.032770162927265
-   11  ( 11) -0.076638806040972 -0.048660864910506 -0.054798136469999 -0.067410404189619  0.096042680906718 -0.030077767167195 -0.040609376761651 -0.003350033647470 -0.011069317631493
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007613623485115
-    1  (  1) -0.001053219582711
-    2  (  2)  0.054751844139672
-    3  (  3) -0.021588797011546
-    4  (  4) -0.069416579868176
-    5  (  5) -0.031311068013170
-    6  (  6)  0.060683491342485
-    7  (  7)  0.004937786560826
-    8  (  8)  0.055843386605960
-    9  (  9)  0.053258374332423
-   10  ( 10)  0.029326398375861
-   11  ( 11) -0.027904630917537
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000025015734507  0.010198711087952  0.006474775958448  0.066946051563528 -0.066550206967977 -0.041188873125926  0.023552914991952  0.019202263160422 -0.006942946197737
-    1  (  1) -0.010140605887652 -0.000014394957877  0.022996796061328 -0.067092192493274  0.063685673857393  0.019093615376604 -0.005525180617760 -0.015031464830750  0.005320182556269
-    2  (  2) -0.006534739001904 -0.022969584694137  0.000183457658640 -0.211551326757209  0.218187807438925  0.104132114893528 -0.065436658246811 -0.042103919182146 -0.012243831904844
-    3  (  3) -0.066304931943444  0.066584833979085  0.210703888875489 -0.000394093515089 -0.011258600581601 -0.092530428436357 -0.131881992071255  0.026480578605083  0.063346368194022
-    4  (  4)  0.065779542430873 -0.062822415172501 -0.216601239538476  0.011617389043850  0.000720555249011  0.020159848057855  0.073942431465134  0.001119920964031  0.016120241216710
-    5  (  5)  0.040846799691504 -0.018979734118351 -0.103125251405654  0.092549855601907 -0.021623501291584 -0.000771447754999 -0.234552119202209 -0.000611164043666 -0.101606719343242
-    6  (  6) -0.023326218450828  0.005550385111505  0.065252405074981  0.131681855193961 -0.073575257938565  0.233645237851028  0.000193851682480 -0.255788429172446  0.079072823032341
-    7  (  7) -0.019055068515462  0.014786531642521  0.041539856986611 -0.026353850726780 -0.001700683540838  0.000445480591706  0.255766070671258  0.000118381893033 -0.151562772366571
-    8  (  8)  0.006620321009197 -0.005142966830662  0.011245852682541 -0.062510776113309 -0.015648596901915  0.102272652360209 -0.078381794853266  0.152302821501449 -0.000094469957927
-    9  (  9)  0.045347281960025 -0.040291069791943 -0.085226922335689 -0.018441757598111 -0.027467525239214 -0.004932928889320 -0.020868912898856  0.024483356625930  0.224180460199113
-   10  ( 10)  0.020374790573784 -0.028198954860440 -0.010392111666997 -0.120181326176130  0.060512260831236  0.109015894697222  0.047153104465120  0.043944046420833  0.103069326885495
-   11  ( 11) -0.049408052352300  0.045270280246414  0.110185553685008  0.041594160321979  0.088273360930753 -0.183934249639257  0.003285919080508 -0.178701510068243  0.007505307453433
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.045673042542890 -0.020717466986083  0.050844518832522
-    1  (  1)  0.040043621408487  0.028287827625151 -0.045457031631407
-    2  (  2)  0.084888848710605  0.010052611398803 -0.109898373773783
-    3  (  3)  0.018088362425205  0.120534313520650 -0.041770057803413
-    4  (  4)  0.026789230886550 -0.060849702419905 -0.088673365261613
-    5  (  5)  0.008004711197727 -0.108432873838655  0.185071361149961
-    6  (  6)  0.020116775504235 -0.047889712574718 -0.001523439225442
-    7  (  7) -0.023964360822185 -0.043618854823263  0.177454217319223
-    8  (  8) -0.226734396044438 -0.102481459206944 -0.008115223439087
-    9  (  9)  0.000423083368406  0.309060226547434 -0.090400550219427
-   10  ( 10) -0.308249178857435  0.001017567434936  0.330623886780632
-   11  ( 11)  0.090136758927266 -0.334530610017321 -0.000453348817603
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000379496190680  0.036516557673727 -0.022488411844201 -0.041143099111719  0.015151024607555 -0.009820525598214 -0.001328546168408  0.002719718233480 -0.079787685858295
-    1  (  1) -0.035173743352485 -0.000509376348503  0.021748140811100  0.018984912310085  0.002571720003760 -0.101540537848848 -0.014107119535580 -0.020961802105584 -0.100916916558314
-    2  (  2)  0.024420430259890 -0.020833264343634  0.000589210441902  0.028690810435666 -0.025063562199365 -0.056845698692633 -0.019362765266970 -0.000534124800005 -0.061230653902760
-    3  (  3)  0.039980341452345 -0.019929624233720 -0.028127725164783 -0.000384377200086  0.012223469426354  0.007870420436516  0.021500821930750 -0.002985124038023  0.055850425927213
-    4  (  4) -0.015033200445576 -0.003096204403696  0.023799943458502 -0.011898049659739  0.000036971633887 -0.000277032322295 -0.021239662546675  0.005095064856192 -0.060237805990277
-    5  (  5)  0.010708008535887  0.101587409014600  0.056660431011914 -0.007350368054025 -0.000126941263904 -0.000065704202214  0.008506831299188 -0.011228150905342 -0.011964202302477
-    6  (  6)  0.000469087338482  0.014200163610075  0.019097267233085 -0.021632296910845  0.021392214011008 -0.008495741848254 -0.000109627873962  0.021812533614874  0.020464844726232
-    7  (  7) -0.002889338898616  0.020632474935553  0.000453752095144  0.002975803626006 -0.005037506724376  0.011335159213681 -0.021733393798695  0.000007087204356  0.019955598928897
-    8  (  8)  0.081293710509515  0.100918057466141  0.060971767857812 -0.055875536861090  0.060631757745431  0.011264467031019 -0.020209151997608 -0.020081495210629 -0.000340983773767
-    9  (  9) -0.080516503167305  0.106262951221757  0.031461397073353  0.007056184146683 -0.022432192781915 -0.017093833942137 -0.097099983466552  0.001349018368294 -0.004773736026001
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.079753101670227
-    1  (  1) -0.106710217482987
-    2  (  2) -0.031619499292907
-    3  (  3) -0.007164069356259
-    4  (  4)  0.022223903647397
-    5  (  5)  0.017462464724719
-    6  (  6)  0.096957045420818
-    7  (  7) -0.001243112172754
-    8  (  8)  0.004611313750592
-    9  (  9)  0.000252169760563
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055343853322395  0.005338522209203 -0.036325792187091  0.020411379114398 -0.005004472559017 -0.030883540419705  0.019693764112942  0.000404480716013  0.025396203204216
-    1  (  1) -0.006570683600848  0.008768421568488  0.011573795638563 -0.000009175751903 -0.002770565739659 -0.004931208897901  0.022163570789429 -0.003290104656908 -0.003254936700297
-    2  (  2) -0.001674419203277 -0.021967102120902 -0.025831824909554  0.024758928994745  0.009340908203812 -0.034459015755376 -0.010228225914487  0.005919790861067  0.058115699230390
-    3  (  3) -0.007779977639509  0.106141218473434  0.050482163293278 -0.041812559908941  0.042606909564863 -0.016938249582167 -0.022723831963497 -0.018285942873731 -0.061788101761112
-    4  (  4)  0.087397972334062 -0.164590469335859 -0.035983465272717  0.095460926704216 -0.183399304764373  0.073380967092300  0.038295030471351  0.047026058194857  0.066959437295317
-    5  (  5) -0.293750190777910 -0.042648437038433 -0.056404874075468  0.100193237694056 -0.123782490033077  0.014652582564902  0.036251400704161  0.016769125982848  0.023410414575794
-    6  (  6)  0.063526410041118  0.042202406515953 -0.107158367449000  0.011222400592515  0.032805848689894  0.070775222023081 -0.034269417179590 -0.097599209765295 -0.095048599779477
-    7  (  7) -0.039213631545190 -0.016300797142278  0.022834925899151 -0.106699749704471  0.109813770660251  0.000567880224415 -0.192962587636570  0.013162275101134 -0.042958800457043
-    8  (  8)  0.207671023275567  0.021761663181296  0.066317329893717 -0.113575721461044  0.208505431005016 -0.053139089145086  0.182387663583988 -0.049317657695772 -0.039898751560786
-    9  (  9) -0.031717525025615  0.035452316963842 -0.019040840253717  0.049757955126745 -0.003315672276934  0.048439544916052 -0.094357742781682 -0.007725852797236  0.042206115018339
-   10  ( 10) -0.030723138202058 -0.012685537900520  0.130253036286197 -0.070878549267589  0.073822499716479  0.176856315004232  0.024096584449109 -0.033980770130198  0.029602022179569
-   11  ( 11)  0.076338046412608  0.058007647538535  0.059625157558161  0.072355446358478 -0.100714683926583  0.028164062896195  0.037103331661254  0.004159802100780  0.012336171911566
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007837140573608
-    1  (  1)  0.001271351061977
-    2  (  2) -0.056316152671545
-    3  (  3)  0.023558705106194
-    4  (  4)  0.071677402926291
-    5  (  5)  0.031036091810970
-    6  (  6) -0.060669139129724
-    7  (  7) -0.008329217020035
-    8  (  8) -0.058082899762783
-    9  (  9) -0.050026765138378
-   10  ( 10) -0.030419330923301
-   11  ( 11)  0.028289350786073
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010782784489972 -0.013050845930128 -0.033023155215664  0.015191714992095 -0.005425132814901 -0.026116394662957  0.007256800612108 -0.004570990183776 -0.083505985646911
-    1  (  1)  0.004775248888120  0.019609050610054 -0.043741880650327  0.000073954161324 -0.027319440587928  0.081090619324759  0.046094626593374 -0.004371816989341 -0.079334747598806
-    2  (  2)  0.007829067250874  0.005611745899100  0.069924533643314 -0.039501674728206 -0.000927353784976  0.005421401951033  0.003817544999769 -0.008629946885833 -0.093259618314415
-    3  (  3) -0.018327078243591  0.003795046417131 -0.017900293895817  0.029796535142542 -0.026342994062962 -0.087573876827112 -0.029918989049988  0.054199220040285  0.044809777400716
-    4  (  4) -0.027183503470872 -0.089536481638857 -0.084857160463068  0.036527297001861  0.242538124561929  0.016430382958973  0.030531081573579 -0.170538311757182 -0.261658379411546
-    5  (  5)  0.020462782587523 -0.074168804451800  0.167834230231717 -0.149604127852478  0.243854217657690 -0.044978789492557 -0.032478673883371  0.164731310430024 -0.003040851330374
-    6  (  6)  0.075422914773902 -0.018345498918631 -0.109883881828728  0.119442941495868 -0.084779039670754  0.177672686986939 -0.254932779745392 -0.179910297504286 -0.058420300218360
-    7  (  7)  0.077293940205111  0.171942167313393 -0.155379720343131  0.213627786676900 -0.203405159942268  0.435742440136601  0.116233082588661 -0.403785601702878 -0.048376113482094
-    8  (  8)  0.113887453356696 -0.134815689960008  0.121289875435757  0.381302435842573 -0.140362613154441 -0.094837304770689  0.044125422076338  0.354102164255088 -0.021060221761777
-    9  (  9) -0.010381942177856  0.091513821594073 -0.090489398632436  0.104640269057990 -0.011526746486386  0.174325672883320 -0.095096801177535 -0.162567420891194  0.086584233440007
-   10  ( 10) -0.046140785323826  0.004506559121454  0.092261546126996 -0.049590165687623 -0.056546117609635 -0.023211770714739 -0.114566901687301  0.007355072527000 -0.045260763292278
-   11  ( 11) -0.210277389085871 -0.043479475791959  0.002620356919958  0.027295607176521  0.213582758279457  0.049406759718245 -0.038753842401848  0.045549481042434 -0.106068884747289
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.000588783769111
-    1  (  1) -0.095074877441065
-    2  (  2)  0.094269658052775
-    3  (  3)  0.087042465113366
-    4  (  4) -0.229147969925312
-    5  (  5)  0.037090740492870
-    6  (  6) -0.008539965499391
-    7  (  7) -0.114631280540035
-    8  (  8)  0.035100938386537
-    9  (  9) -0.119410852550345
-   10  ( 10)  0.048938543804445
-   11  ( 11) -0.026842233365654
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000083177655875 -0.020596022225207 -0.023074380682109 -0.123906982660277  0.115856799969175  0.077548996218664 -0.033724258035794 -0.015583195761424  0.055304180213594
-    1  (  1)  0.020496643104719 -0.000177442053919  0.044849161409626  0.200056054082230 -0.192734988239744  0.095810846356379 -0.089592000858118 -0.154865722471105  0.062884487656521
-    2  (  2)  0.022893568520427 -0.044914234916282  0.000286887581780 -0.110147204900385  0.098101481651214 -0.037544614577033  0.063107876559817  0.057867129267241 -0.133662561842804
-    3  (  3)  0.123637708691857 -0.200030347190693  0.110276511900212  0.000067254700333 -0.150932238527093 -0.295587503177329  0.155559256339819  0.250191288225748 -0.068514494250419
-    4  (  4) -0.115217909263092  0.191910599591419 -0.098719023514077  0.150564412486325  0.000108066296459 -0.207017027157466  0.092817557275927  0.119727699718554 -0.027839136386995
-    5  (  5) -0.077201349586182 -0.095637330323257  0.037580888266386  0.296037283435946  0.206488013849544 -0.000677656990837  0.030142059938078  0.107860538698997 -0.317965442908009
-    6  (  6)  0.033520398034563  0.089301712720516 -0.063135446629119 -0.155494983890111 -0.093120397549751 -0.029958661714230 -0.000263665833745 -0.031787895548351 -0.052772032197117
-    7  (  7)  0.015173638148760  0.154650785159269 -0.057964322733043 -0.249885773107303 -0.119546085272213 -0.107827018648257  0.031752436246544 -0.000037065640674 -0.211400361545441
-    8  (  8) -0.055452136609395 -0.063704146851438  0.132109776961381  0.067534716804367  0.027512182553154  0.319330567201196  0.051501501228049  0.211684727134552  0.000062825592229
-    9  (  9) -0.059987775905021  0.059013360455393  0.001731139538261 -0.025602282087959  0.077406198911912 -0.032289392048789  0.044673931971007  0.007013222782529 -0.205272148471903
-   10  ( 10) -0.040816969333319  0.029839999727295  0.097606908985792 -0.012730679444132 -0.052120800982420 -0.047092545087938  0.097199457935824 -0.008100744465293  0.194519063749344
-   11  ( 11)  0.105565276750546 -0.086850909183234 -0.141349531156014 -0.064538795649442 -0.048769909889220  0.098670307723293 -0.132937762954191  0.091749745952861  0.050571681003909
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.059727136016838  0.040967341903913 -0.106287777222309
-    1  (  1) -0.058687758282915 -0.029394471353826  0.086811620398375
-    2  (  2) -0.001293940264555 -0.097641591345113  0.142636172226853
-    3  (  3)  0.025821629306306  0.013207208477272  0.063793857996761
-    4  (  4) -0.076409112526474  0.052575212530451  0.047414860037356
-    5  (  5)  0.032527517350565  0.045632421732577 -0.095160623491729
-    6  (  6) -0.044231942651703 -0.096152133696301  0.132935625343693
-    7  (  7) -0.007372100254253  0.008488811567739 -0.092713079820202
-    8  (  8)  0.206938183650805 -0.192802275414426 -0.052611900153123
-    9  (  9) -0.000608554890156  0.088592533061698 -0.344380743508036
-   10  ( 10) -0.088950131298492 -0.000863284429953 -0.222751022723935
-   11  ( 11)  0.341005102874300  0.224718204882492 -0.000326394311109
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000338557997552  0.011375035743392 -0.029451193209236  0.012043586883828  0.021579660859347 -0.039033326019946  0.009990415550092 -0.009478976983628  0.045907412693585
-    1  (  1) -0.013672223167698  0.000473657715584  0.014851568055555 -0.021895587564371  0.022163590605075 -0.051246172607775 -0.019257625103746 -0.003658602851281  0.019552361048058
-    2  (  2)  0.032608942325713 -0.014402827198054  0.000746991250603  0.029107751732300 -0.054720608245644 -0.057033646383303 -0.001872360780591  0.031698780852448 -0.056602981887733
-    3  (  3) -0.014268935231542  0.021459967996182 -0.030313065636317  0.000730068456009  0.016766656065195  0.058973632357354  0.003002419788061 -0.022431580465626  0.134333948620083
-    4  (  4) -0.022372891038515 -0.021355779916377  0.052959509294565 -0.015751198634933  0.000391938857969  0.016109226068828 -0.004538544158672  0.050308920012661 -0.059340919102150
-    5  (  5)  0.040216234763810  0.051875751817174  0.055849318880052 -0.058120412757832 -0.016460961175898 -0.000645475334216 -0.019024299026328 -0.068804307634402  0.024311188622736
-    6  (  6) -0.009930727984206  0.019074682595569  0.002242770131548 -0.003091320851947  0.004596281406168  0.019032186967740 -0.000074596378968 -0.032870219636189  0.006741182978715
-    7  (  7)  0.009279418369258  0.004264018479381 -0.032087681361723  0.022624894165436 -0.049954824766487  0.068907285150032  0.032867640818893  0.000029995356356  0.011652937852273
-    8  (  8) -0.047260005865874 -0.018493502167014  0.056736132845076 -0.135589678169431  0.059916509278318 -0.024164421049794 -0.007333544303120 -0.011763030881780  0.000264400142459
-    9  (  9)  0.016875007958598 -0.031435494057685  0.089048257959160  0.041017085631602 -0.020420285065562 -0.066513023484078 -0.000739604154969  0.091958006244489 -0.027226933196085
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.016438561460291
-    1  (  1)  0.031819705279686
-    2  (  2) -0.089217438029428
-    3  (  3) -0.040553914705774
-    4  (  4)  0.020554472275814
-    5  (  5)  0.066048736736302
-    6  (  6)  0.000688806170902
-    7  (  7) -0.091248940256931
-    8  (  8)  0.027663919394381
-    9  (  9)  0.000090314260367
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.011888856297006  0.017750932125153  0.030381401096490 -0.012819546160996  0.007239420422718  0.024248756043407 -0.008035757610220  0.005364063357974  0.085646323747472
-    1  (  1) -0.005014728223890 -0.026640078285976  0.053625852742063  0.001580773154934  0.029513947501511 -0.084681976949646 -0.049070075720108  0.003015931693788  0.083533135335069
-    2  (  2) -0.005701802857788 -0.001861436552455 -0.077309348516175  0.039227298256145  0.002806617492516 -0.004668173879327 -0.004051055445085  0.009725469213679  0.098722432349714
-    3  (  3)  0.016358351457124  0.001723600627698  0.021225514928062 -0.039815087581337  0.022808569998795  0.104140287911999  0.033233738030323 -0.056382556071864 -0.046907957767316
-    4  (  4)  0.023138877563353  0.095098707280146  0.087666288227931 -0.037561492255805 -0.255193211004254 -0.015544572331716 -0.030557402755123  0.180093964112144  0.259856355700386
-    5  (  5) -0.024228572043234  0.082834757201086 -0.181139504221043  0.153944959591839 -0.252818375021614  0.048862178579716  0.036094966909273 -0.170640955267472  0.004551713568432
-    6  (  6) -0.085402345559358  0.022737485412840  0.117389155338347 -0.122686430467103  0.089994929534087 -0.186662776489157  0.276334552924253  0.188945818003174  0.062512631958960
-    7  (  7) -0.077377916753636 -0.184413390881742  0.161635032551528 -0.217081818449181  0.216158931990711 -0.452250331823368 -0.121365143499215  0.427486936599919  0.051141830029037
-    8  (  8) -0.109996402529651  0.145159792225805 -0.137471198251747 -0.396423044911114  0.145941263905056  0.104134158957014 -0.041227108112442 -0.369426049626710  0.017681253264412
-    9  (  9)  0.015271329763023 -0.091667642816572  0.093167229349338 -0.105178289783052  0.012072216330151 -0.184888670947420  0.104021366500691  0.173041839821099 -0.089774142402176
-   10  ( 10)  0.051871879465497 -0.004911726396439 -0.095027344602311  0.050235453581707  0.056755121586123  0.023277306660177  0.123771404812450 -0.008953154661311  0.042342746566353
-   11  ( 11)  0.213874614633354  0.038620645156941 -0.003918905035704 -0.027644952213642 -0.227437070959628 -0.047768116418487  0.043243210008693 -0.046251908849224  0.106495755067544
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001231945309971
-    1  (  1)  0.099118498855930
-    2  (  2) -0.099462956417043
-    3  (  3) -0.089788110354890
-    4  (  4)  0.236379406660322
-    5  (  5) -0.043290372964682
-    6  (  6)  0.008471875583563
-    7  (  7)  0.118429426587662
-    8  (  8) -0.041151812398786
-    9  (  9)  0.121668252978460
-   10  ( 10) -0.047795297768532
-   11  ( 11)  0.026000603113831
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.092723408151075  0.057215092134940  0.054154926215137 -0.012957083117559 -0.028122190094715 -0.031179347218855 -0.013645641371598 -0.009921258172339 -0.037242536390232
-    1  (  1) -0.019990430092613  0.002382806987559 -0.016009786257367 -0.011651136664597  0.017212414198990  0.024265249236370 -0.152443472946687  0.006755616148329 -0.024207249541319
-    2  (  2) -0.009030755895234 -0.085216520460363  0.016500441499831  0.009813164947617  0.015713678712422 -0.028373503652355  0.075877310310795 -0.039590492962937 -0.081270933339189
-    3  (  3)  0.075043611755008  0.103608833794547  0.030676505925522  0.013143510199953 -0.006187488557257 -0.045202449901574  0.041605892889482  0.001210820793539  0.045033631139440
-    4  (  4)  0.122337112724117  0.176460576265088  0.085321001863374 -0.041690733440160  0.111448222796030 -0.083092300673138  0.094252463151414 -0.071551603610925 -0.059851091994803
-    5  (  5) -0.372712635775664 -0.109553572239785 -0.087636097688831 -0.161393941368917  0.091711881285738  0.083559837956631 -0.084048684818413  0.114275654348762 -0.004760374961166
-    6  (  6) -0.030431995544059  0.095321795210779 -0.159145740022025 -0.376304340373359 -0.189004479350399  0.100683798175242  0.128902751762968  0.567857709085750  0.002399331341204
-    7  (  7) -0.344039522571259 -0.114279634125077 -0.003626426979965  0.177981236436906  0.027932329764501  0.026442462397652  0.246808699479261 -0.268819164710932  0.106523620842343
-    8  (  8) -0.111643207885322 -0.002836247769573  0.018154026503924  0.097243438328650 -0.121498121615664 -0.006682650130485 -0.107315976978454  0.036939727738377  0.063237979028415
-    9  (  9)  0.063921675215150  0.215994652248761  0.065707412514049 -0.003935136905129 -0.142641982827575 -0.026699050855783  0.056962954862571  0.164747861484427 -0.081509018515780
-   10  ( 10) -0.058030998072116 -0.060474289846612 -0.205628226890442 -0.038897333798042  0.068097699807560  0.116172285533776  0.038858694654200  0.255643829382515 -0.001247633054968
-   11  ( 11) -0.085574013220044 -0.030726962638802 -0.008247473867838 -0.106409310393215  0.064469816287686  0.072180462194277  0.022620356444758  0.070649638629627 -0.098848734288576
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015293746360799
-    1  (  1) -0.020176832366409
-    2  (  2) -0.007468634139779
-    3  (  3)  0.002013486296780
-    4  (  4) -0.055907379643807
-    5  (  5) -0.014548062338959
-    6  (  6) -0.210557719542813
-    7  (  7)  0.107773752705760
-    8  (  8)  0.004939471027833
-    9  (  9) -0.101796072438763
-   10  ( 10) -0.052197801100809
-   11  ( 11)  0.010791942309942
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000245185765728  0.004422769142209  0.195473142624697 -0.067124189998810 -0.027096370068160 -0.099320185873800 -0.032910569428743 -0.079494520674282  0.016762710819247
-    1  (  1) -0.004388313593185  0.000165290846899 -0.188129406432792  0.063756474949075  0.001128748240139  0.126263116741295  0.303817994309096 -0.069854530583820 -0.010310792522154
-    2  (  2) -0.194444327410373  0.187906024270824 -0.000538868177065  0.115697813615881  0.188025580722992  0.063555095149569 -0.109038200896130  0.123360187528163 -0.037347597176070
-    3  (  3)  0.066590814481336 -0.063203632987523 -0.115347217679990  0.000002301796994 -0.034584588669551 -0.038983157581533 -0.229948513873159  0.131721887952800  0.028384936970778
-    4  (  4)  0.026403437308072 -0.000527986476725 -0.186677671985474  0.034818437947430  0.000320297338463 -0.037865478650564 -0.201451121997014  0.109301689008128  0.005643097026329
-    5  (  5)  0.099409584232992 -0.126346592032007 -0.064419008019557  0.039794220656347  0.036855903902447  0.000190318965932 -0.088891480212760  0.056789849447140 -0.091073030281233
-    6  (  6)  0.033050985013878 -0.303259624681304  0.108281756633666  0.230173439372417  0.201331671706094  0.089930560146314  0.000311452672695  0.221067383348441  0.053494283573947
-    7  (  7)  0.079472710309908  0.069297203366025 -0.125033677339702 -0.131451975782708 -0.110125569334720 -0.054839641157466 -0.219945401741596  0.001085047372961 -0.089073871816377
-    8  (  8) -0.016952142014388  0.010421932566239  0.036927801153181 -0.027792238689701 -0.005351459000165  0.090892785458666 -0.052690955519676  0.088985197141446  0.000032698621213
-    9  (  9) -0.149061020700740  0.058621114959186  0.279965277538519  0.021488283829580  0.044200621925698  0.026904718590704  0.074208134755608  0.037354078157659  0.137372829291651
-   10  ( 10)  0.035190315077894 -0.050814828300922 -0.151303785089698  0.062867991520111  0.077053666036856  0.075037906181509 -0.133385625358484  0.006791369727277  0.121764957568739
-   11  ( 11) -0.016457666688676  0.009560970830020  0.030160709068648  0.052615429880776  0.007184814870880 -0.147317585107930 -0.048007656104932 -0.024985856634055  0.107464259465764
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.149527127949477 -0.035025203143730  0.017236912650706
-    1  (  1) -0.058313378902528  0.050420942142557 -0.009474518218355
-    2  (  2) -0.278325755481738  0.150562770304950 -0.029989264213428
-    3  (  3) -0.020585218415975 -0.063268588986747 -0.052977667343551
-    4  (  4) -0.042114256624995 -0.077316775027134 -0.007960467665663
-    5  (  5) -0.031625284755674 -0.074462306356205  0.148447086799088
-    6  (  6) -0.074615124808937  0.133170285550522  0.049651682674137
-    7  (  7) -0.041592449377408 -0.005910763914811  0.024358506166719
-    8  (  8) -0.138294110971387 -0.121744291260784 -0.107918344276425
-    9  (  9)  0.001133592488713 -0.474400799155993 -0.192590673354496
-   10  ( 10)  0.472105353620486  0.001334835966633  0.192285927563244
-   11  ( 11)  0.191497735915320 -0.194932828964948  0.001344945845524
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000738836304181 -0.037293198581408 -0.029451404620807  0.009378792471894 -0.055701113540954  0.035128933511984  0.013954700067714  0.072836702551235 -0.051857122483535
-    1  (  1)  0.032660614374695 -0.002015876922290 -0.074058480716263  0.021479421330690  0.014966422603257  0.166979967788261  0.013073252080067  0.022556560940623  0.170972365950935
-    2  (  2)  0.029165553040464  0.073308940131147 -0.000753195727027  0.033014777438001 -0.000651481686764  0.016615463822703  0.030045410532860  0.013342873064028  0.078343409399381
-    3  (  3) -0.010384415064446 -0.021326871974424 -0.031305865808474 -0.000583541727095  0.005150844265660  0.010972964083321  0.024667426696971 -0.003421011953857  0.027197309287279
-    4  (  4)  0.055501401866642 -0.014297660722118  0.000710544848112 -0.005493793084614  0.000124683940717  0.025126510553785  0.000947638436962  0.017069455654223 -0.023650915169846
-    5  (  5) -0.033803616927021 -0.164339399892725 -0.017068168082329 -0.010030727560507 -0.025241735580020 -0.000735433014139  0.028603795353780 -0.023029380344413 -0.027599055296252
-    6  (  6) -0.013107540346806 -0.012828435687407 -0.030286401438565 -0.024713021163335 -0.001063605161759 -0.029296491836886  0.000025149030498  0.111104514389532 -0.102861376746943
-    7  (  7) -0.072733387901303 -0.022465577956558 -0.013436829086647  0.003433808737295 -0.017048766876852  0.023125015384758 -0.110934303358415 -0.000037875914124 -0.002935696551342
-    8  (  8)  0.053267672687232 -0.170660201820078 -0.076657788504288 -0.028160893222526  0.023606436991553  0.027690933408034  0.102626814241324  0.002887530223588 -0.000373637330912
-    9  (  9) -0.004804828900057 -0.224333052817770 -0.065186758028368 -0.004091068046870 -0.039040275694483  0.042976408882840  0.051197675519228  0.024101682646066  0.000693639807374
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.005026329948406
-    1  (  1)  0.225373696682354
-    2  (  2)  0.064686362479745
-    3  (  3)  0.004567750792129
-    4  (  4)  0.038996417519414
-    5  (  5) -0.043485644851561
-    6  (  6) -0.051601626537389
-    7  (  7) -0.023715023759407
-    8  (  8) -0.001115391080639
-    9  (  9) -0.000048164004682
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.087860740756488 -0.068261038905906 -0.057593788019307  0.011454237083441  0.027305499289367  0.032385982368371  0.018173477269549  0.009363386608796  0.038732450559880
-    1  (  1)  0.013249632151170  0.004184657414979  0.019716507976896  0.014744696478638 -0.016703323694180 -0.027386275287573  0.163732376866413 -0.007136524293248  0.024482820661864
-    2  (  2)  0.007013218896085  0.084657964294727 -0.026004205374563 -0.008076798202963 -0.011641159214614  0.031112856231507 -0.081756432692912  0.043486513055778  0.085001128307205
-    3  (  3) -0.058477500387638 -0.110048615847953 -0.032104075685968 -0.014807417786102  0.004697674213231  0.048123068402958 -0.048143599431998 -0.000645092439839 -0.047260089330542
-    4  (  4) -0.110574498742467 -0.188131348104213 -0.086636459451987  0.041361686502598 -0.118556992954628  0.089270642674348 -0.104552978829704  0.075153301656795  0.057940099039356
-    5  (  5)  0.371487279658724  0.115772941053656  0.094845419594772  0.167070991238391 -0.094497706414686 -0.087134798346335  0.079465840043241 -0.119932858558240  0.004312964076576
-    6  (  6)  0.035255689937620 -0.112028499449997  0.168145842580037  0.392683527257363  0.194284650981365 -0.110254467391126 -0.135773335198962 -0.599025983356266 -0.001116295743642
-    7  (  7)  0.362602042970953  0.115938705836042 -0.002852393959785 -0.186519834338995 -0.026972926522319 -0.023780474127448 -0.271135694461778  0.284033125501378 -0.111247570725030
-    8  (  8)  0.111196944464455  0.001239941376560 -0.021205830532168 -0.101329748088148  0.128975240085324  0.010144197632550  0.108358474715393 -0.037918096280026 -0.066572090545295
-    9  (  9) -0.090967744709768 -0.211201922436275 -0.066377513424381  0.007899083102241  0.154707771160094  0.037980948657754 -0.073559352539101 -0.172041273327275  0.087426840520207
-   10  ( 10)  0.070112475488657  0.079061926736069  0.222919508358954  0.040775801294398 -0.061424635747658 -0.113162621408555 -0.037903862973014 -0.270692474130444  0.009570796789139
-   11  ( 11)  0.090924578792926  0.040585886130445  0.000311072794648  0.117174234675791 -0.063663959894116 -0.077941781302743 -0.027645133174923 -0.073495241874676  0.102137660538697
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015882565008118
-    1  (  1)  0.020403231736073
-    2  (  2)  0.007241270504095
-    3  (  3) -0.003144444710549
-    4  (  4)  0.058793064689134
-    5  (  5)  0.012293150809123
-    6  (  6)  0.215177196230389
-    7  (  7) -0.113635102585609
-    8  (  8) -0.004824845555481
-    9  (  9)  0.113550918048735
-   10  ( 10)  0.063789409560574
-   11  ( 11) -0.007009974437012
-
 	Computing Mu_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        14.646057913664
-	   1        19.900740748221    7.415e-01
-	   2        24.202679156489    3.530e-01
-	   3        24.333910708305    5.786e-02
-	   4        24.386483066105    2.489e-02
-	   5        24.384011165183    7.288e-03
-	   6        24.382065088424    2.366e-03
-	   7        24.382700715455    9.330e-04
-	   8        24.382865717115    3.872e-04
-	   9        24.382703786034    2.028e-04
-	  10        24.382629501640    1.136e-04
-	  11        24.382672663324    5.108e-05
-	  12        24.382725217329    1.491e-05
-	  13        24.382740206450    4.837e-06
-	  14        24.382743815154    2.005e-06
-	  15        24.382743156157    7.537e-07
-	  16        24.382742798204    3.075e-07
-	  17        24.382742886125    1.381e-07
+	   0        14.646057783933
+	   1        19.900740560938    7.415e-01
+	   2        24.202678907650    3.530e-01
+	   3        24.333910457480    5.786e-02
+	   4        24.386482814098    2.489e-02
+	   5        24.384010913035    7.288e-03
+	   6        24.382064836339    2.366e-03
+	   7        24.382700463367    9.330e-04
+	   8        24.382865465020    3.872e-04
+	   9        24.382703533938    2.028e-04
+	  10        24.382629249546    1.136e-04
+	  11        24.382672411233    5.108e-05
+	  12        24.382724965238    1.491e-05
+	  13        24.382739954358    4.837e-06
+	  14        24.382743563062    2.005e-06
+	  15        24.382742904064    7.537e-07
+	  16        24.382742546112    3.075e-07
+	  17        24.382742634033    1.381e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 6.116e-08
 
 	Computing P*_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.559587419784
-	   1         6.095758291437    3.787e-01
-	   2         7.217290798629    1.691e-01
-	   3         7.247452637403    2.602e-02
-	   4         7.257227899801    1.164e-02
-	   5         7.256922198978    4.177e-03
-	   6         7.256609260575    1.602e-03
-	   7         7.256844533117    7.263e-04
-	   8         7.256919105672    2.985e-04
-	   9         7.256885068394    1.147e-04
-	  10         7.256878778916    4.306e-05
-	  11         7.256887853780    1.600e-05
-	  12         7.256896815662    5.459e-06
-	  13         7.256899702075    2.295e-06
-	  14         7.256900465099    1.264e-06
-	  15         7.256900111608    6.854e-07
-	  16         7.256899894116    3.188e-07
-	  17         7.256899906098    1.387e-07
+	   0         4.559587448007
+	   1         6.095758325876    3.787e-01
+	   2         7.217290833134    1.691e-01
+	   3         7.247452671700    2.602e-02
+	   4         7.257227933966    1.164e-02
+	   5         7.256922233102    4.177e-03
+	   6         7.256609294703    1.602e-03
+	   7         7.256844567238    7.263e-04
+	   8         7.256919139790    2.985e-04
+	   9         7.256885102513    1.147e-04
+	  10         7.256878813035    4.306e-05
+	  11         7.256887887898    1.600e-05
+	  12         7.256896849780    5.459e-06
+	  13         7.256899736193    2.295e-06
+	  14         7.256900499217    1.264e-06
+	  15         7.256900145726    6.854e-07
+	  16         7.256899928234    3.188e-07
+	  17         7.256899940216    1.387e-07
 	-----------------------------------------
 	Converged P*_X-Perturbed Wfn to 5.869e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         1.908748848060
-	   1         2.522419107674    2.099e-01
-	   2         2.920051794462    9.194e-02
-	   3         2.941681476796    1.609e-02
-	   4         2.942548695016    4.298e-03
-	   5         2.942363089528    1.619e-03
-	   6         2.942476596522    3.856e-04
-	   7         2.942501377803    1.022e-04
-	   8         2.942496335975    3.516e-05
-	   9         2.942495426078    1.030e-05
-	  10         2.942495389151    3.887e-06
-	  11         2.942495558250    1.223e-06
-	  12         2.942495669318    2.989e-07
+	   0         1.908748836016
+	   1         2.522419088932    2.099e-01
+	   2         2.920051768265    9.194e-02
+	   3         2.941681449791    1.609e-02
+	   4         2.942548667946    4.298e-03
+	   5         2.942363062455    1.619e-03
+	   6         2.942476569443    3.856e-04
+	   7         2.942501350723    1.022e-04
+	   8         2.942496308895    3.516e-05
+	   9         2.942495398998    1.030e-05
+	  10         2.942495362070    3.887e-06
+	  11         2.942495531169    1.223e-06
+	  12         2.942495642238    2.989e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 8.750e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        12.132525424194
-	   1        15.276412075449    5.092e-01
-	   2        17.210437160386    2.109e-01
-	   3        17.286411907319    4.091e-02
-	   4        17.318464424712    1.854e-02
-	   5        17.318141518833    4.833e-03
-	   6        17.317143734080    1.713e-03
-	   7        17.317421323740    6.058e-04
-	   8        17.317472143230    1.907e-04
-	   9        17.317424416210    6.910e-05
-	  10        17.317410508800    2.580e-05
-	  11        17.317418268887    9.916e-06
-	  12        17.317425792174    4.665e-06
-	  13        17.317426840328    1.897e-06
-	  14        17.317426337304    8.194e-07
-	  15        17.317425894162    3.197e-07
-	  16        17.317425811495    1.607e-07
+	   0        12.132525332684
+	   1        15.276411955967    5.092e-01
+	   2        17.210437018418    2.109e-01
+	   3        17.286411764119    4.091e-02
+	   4        17.318464280897    1.854e-02
+	   5        17.318141374969    4.833e-03
+	   6        17.317143590244    1.713e-03
+	   7        17.317421179904    6.058e-04
+	   8        17.317471999391    1.907e-04
+	   9        17.317424272372    6.910e-05
+	  10        17.317410364963    2.580e-05
+	  11        17.317418125049    9.916e-06
+	  12        17.317425648337    4.665e-06
+	  13        17.317426696491    1.897e-06
+	  14        17.317426193466    8.194e-07
+	  15        17.317425750325    3.197e-07
+	  16        17.317425667657    1.607e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 8.766e-08
 
 	Computing P*_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.703792433770
-	   1         5.827598242104    2.961e-01
-	   2         6.469640810218    1.178e-01
-	   3         6.498578696663    2.690e-02
-	   4         6.510083175735    1.303e-02
-	   5         6.510070720098    3.471e-03
-	   6         6.509872205728    1.193e-03
-	   7         6.509973179588    4.063e-04
-	   8         6.509992723310    1.279e-04
-	   9         6.509984909773    5.085e-05
-	  10         6.509981092429    2.163e-05
-	  11         6.509985357189    9.105e-06
-	  12         6.509988975945    4.069e-06
-	  13         6.509989361614    1.578e-06
-	  14         6.509989117506    7.148e-07
-	  15         6.509988904522    3.240e-07
-	  16         6.509988872595    1.663e-07
+	   0         4.703792458819
+	   1         5.827598271322    2.961e-01
+	   2         6.469640839480    1.178e-01
+	   3         6.498578725708    2.690e-02
+	   4         6.510083204617    1.303e-02
+	   5         6.510070748962    3.471e-03
+	   6         6.509872234596    1.193e-03
+	   7         6.509973208454    4.063e-04
+	   8         6.509992752175    1.279e-04
+	   9         6.509984938638    5.085e-05
+	  10         6.509981121294    2.163e-05
+	  11         6.509985386054    9.105e-06
+	  12         6.509989004810    4.069e-06
+	  13         6.509989390479    1.578e-06
+	  14         6.509989146370    7.148e-07
+	  15         6.509988933386    3.240e-07
+	  16         6.509988901460    1.663e-07
 	-----------------------------------------
 	Converged P*_Y-Perturbed Wfn to 8.380e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.555861136875
-	   1         7.177212316115    3.126e-01
-	   2         8.011578153227    1.222e-01
-	   3         8.058975386592    2.985e-02
-	   4         8.062684542750    7.695e-03
-	   5         8.062432115876    2.264e-03
-	   6         8.062541186112    4.903e-04
-	   7         8.062578910302    1.186e-04
-	   8         8.062572201748    3.889e-05
-	   9         8.062569913381    9.756e-06
-	  10         8.062570044441    3.221e-06
-	  11         8.062570332289    1.140e-06
-	  12         8.062570599451    3.217e-07
-	  13         8.062570659305    1.046e-07
+	   0         5.555861106333
+	   1         7.177212270797    3.126e-01
+	   2         8.011578095349    1.222e-01
+	   3         8.058975327010    2.985e-02
+	   4         8.062684482936    7.695e-03
+	   5         8.062432056051    2.264e-03
+	   6         8.062541126281    4.903e-04
+	   7         8.062578850469    1.186e-04
+	   8         8.062572141915    3.889e-05
+	   9         8.062569853548    9.756e-06
+	  10         8.062569984608    3.221e-06
+	  11         8.062570272456    1.140e-06
+	  12         8.062570539618    3.217e-07
+	  13         8.062570599473    1.046e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 3.987e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        12.281082759100
-	   1        16.014852206849    5.396e-01
-	   2        18.149152044303    2.121e-01
-	   3        18.218730734708    3.868e-02
-	   4        18.239340149111    1.507e-02
-	   5        18.237988197076    4.658e-03
-	   6        18.237840034963    1.504e-03
-	   7        18.238212549558    6.648e-04
-	   8        18.238168578145    2.924e-04
-	   9        18.238119678376    1.131e-04
-	  10        18.238112985217    4.594e-05
-	  11        18.238129525742    1.886e-05
-	  12        18.238139425675    5.440e-06
-	  13        18.238141128719    1.853e-06
-	  14        18.238141186246    7.411e-07
-	  15        18.238140962304    2.771e-07
-	  16        18.238140974172    1.229e-07
+	   0        12.281082666430
+	   1        16.014852079418    5.396e-01
+	   2        18.149151891564    2.121e-01
+	   3        18.218730581041    3.868e-02
+	   4        18.239339995036    1.507e-02
+	   5        18.237988042967    4.658e-03
+	   6        18.237839880868    1.504e-03
+	   7        18.238212395457    6.648e-04
+	   8        18.238168424043    2.924e-04
+	   9        18.238119524276    1.131e-04
+	  10        18.238112831118    4.594e-05
+	  11        18.238129371642    1.886e-05
+	  12        18.238139271574    5.440e-06
+	  13        18.238140974619    1.853e-06
+	  14        18.238141032145    7.411e-07
+	  15        18.238140808204    2.771e-07
+	  16        18.238140820071    1.229e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 6.493e-08
 
 	Computing P*_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.052710531877
-	   1         6.556640438095    3.325e-01
-	   2         7.362866810915    1.245e-01
-	   3         7.385505314991    2.390e-02
-	   4         7.392478029351    1.140e-02
-	   5         7.392594978385    4.866e-03
-	   6         7.392847079049    1.545e-03
-	   7         7.393047369457    5.497e-04
-	   8         7.393038460017    2.014e-04
-	   9         7.393028462646    6.716e-05
-	  10         7.393025904479    2.588e-05
-	  11         7.393030599300    1.141e-05
-	  12         7.393034009195    5.006e-06
-	  13         7.393034633094    2.562e-06
-	  14         7.393034367168    1.279e-06
-	  15         7.393034052763    5.844e-07
-	  16         7.393034066786    2.305e-07
-	  17         7.393034129735    1.018e-07
+	   0         5.052710554188
+	   1         6.556640464242    3.325e-01
+	   2         7.362866836593    1.245e-01
+	   3         7.385505340409    2.390e-02
+	   4         7.392478054600    1.140e-02
+	   5         7.392595003582    4.866e-03
+	   6         7.392847104234    1.545e-03
+	   7         7.393047394635    5.497e-04
+	   8         7.393038485194    2.014e-04
+	   9         7.393028487823    6.716e-05
+	  10         7.393025929656    2.588e-05
+	  11         7.393030624478    1.141e-05
+	  12         7.393034034372    5.006e-06
+	  13         7.393034658271    2.562e-06
+	  14         7.393034392346    1.279e-06
+	  15         7.393034077940    5.844e-07
+	  16         7.393034091963    2.305e-07
+	  17         7.393034154913    1.018e-07
 	-----------------------------------------
 	Converged P*_Z-Perturbed Wfn to 4.803e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.460761061417
-	   1         7.037583289127    3.147e-01
-	   2         7.888897856946    1.236e-01
-	   3         7.927306342634    2.188e-02
-	   4         7.929487644358    4.727e-03
-	   5         7.929054857895    1.852e-03
-	   6         7.929123937184    5.650e-04
-	   7         7.929179781307    1.652e-04
-	   8         7.929175406835    5.229e-05
-	   9         7.929174612924    1.264e-05
-	  10         7.929174328030    4.348e-06
-	  11         7.929174923165    1.561e-06
-	  12         7.929175254900    3.990e-07
-	  13         7.929175355364    1.342e-07
+	   0         5.460761031750
+	   1         7.037583245153    3.147e-01
+	   2         7.888897799925    1.236e-01
+	   3         7.927306284430    2.188e-02
+	   4         7.929487586053    4.727e-03
+	   5         7.929054799598    1.852e-03
+	   6         7.929123878882    5.650e-04
+	   7         7.929179723002    1.652e-04
+	   8         7.929175348530    5.229e-05
+	   9         7.929174554619    1.264e-05
+	  10         7.929174269725    4.348e-06
+	  11         7.929174864860    1.561e-06
+	  12         7.929175196595    3.990e-07
+	  13         7.929175297059    1.342e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 4.665e-08
 
@@ -9164,12 +1570,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.180382563837796    -0.231277803091417    -0.067393277098506
-    1     -0.011460339714520     0.093901050002510    -0.240574201477729
-    2     -0.302759284932568     0.322187346703909    -0.246887973979225
+    0      0.180382563931021    -0.231277802328226    -0.067393276664584
+    1     -0.011460339705175     0.093901050342524    -0.240574201690021
+    2     -0.302759285560127     0.322187347251801    -0.246887974136866
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) = -130.56373 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -130.56371 deg/[dm (g/cm^3)]
 
          CCSD Optical Rotation Tensor (Velocity Gauge):
   -------------------------------------------------------------------------
@@ -9178,12 +1584,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.626853571615096     0.026579264162903     0.264461314109701
-    1     -0.002704222895427     0.205427072877583    -1.360524945453503
-    2     -1.431576595918529     1.460380570875453    -0.823772929850462
+    0      0.626853571405274     0.026579259245714     0.264461312410121
+    1     -0.002704223756096     0.205427072281908    -1.360524938977089
+    2     -1.431576592421155     1.460380568022666    -0.823772929067616
 
    Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) = -315.91241 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -315.91237 deg/[dm (g/cm^3)]
 
         CCSD Optical Rotation Tensor (Modified Velocity Gauge):
   -------------------------------------------------------------------------
@@ -9192,12 +1598,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.021563932790953    -0.022161482153058    -0.006612420940727
-    1     -0.001168015542549     0.008796275315561    -0.018642842770238
-    2     -0.033437079384754     0.029512466818215    -0.026955737464166
+    0      0.021563932986890    -0.022161482382887    -0.006612421138756
+    1     -0.001168015625946     0.008796275438191    -0.018642843018040
+    2     -0.033437079613544     0.029512467112302    -0.026955737771790
 
    Specific rotation using modified velocity-gauge Rosenfeld tensor.
-	[alpha]_(0.128) = -126.41639 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -126.41637 deg/[dm (g/cm^3)]
 
    Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.
      Delta_x =  -5.21   Delta_y =   2.23   Delta_z = -11.10
@@ -9209,8 +1615,8 @@ Total time:
     E_h      nm   deg/[dm (g/cm^3)]        deg/[dm (g/cm^3)]/bohr
    -----   ------ ------------------  ----------------------------------
                                           x           y           z      
-   0.072   633.00       -38.80517      -1.53381     0.59448    -3.26954
-   0.128   355.00      -130.56373      -5.20757     2.23400   -11.10365
+   0.072   633.00       -38.80516      -1.53381     0.59448    -3.26954
+   0.128   355.00      -130.56371      -5.20757     2.23400   -11.10364
 
    ------------------------------------------------------
             CCSD Velocity-Gauge Optical Rotation
@@ -9219,17 +1625,10 @@ Total time:
 
     E_h      nm   Velocity-Gauge  Modified Velocity-Gauge
    -----   ------ --------------  -----------------------
-   0.072   633.00   -227.15489           -37.65886
-   0.128   355.00   -315.91241          -126.41639
+   0.072   633.00   -227.15486           -37.65886
+   0.128   355.00   -315.91237          -126.41637
 
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
-Module time:
-	user time   =       6.28 seconds =       0.10 minutes
-	system time =       5.25 seconds =       0.09 minutes
-	total time  =         12 seconds =       0.20 minutes
-Total time:
-	user time   =       7.40 seconds =       0.12 minutes
-	system time =       5.74 seconds =       0.10 minutes
-	total time  =         14 seconds =       0.23 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:24PM
+    Psi4 wall time for execution: 0:00:26.27
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc34/output.ref
+++ b/tests/cc34/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:26PM
 
-    Process ID:  12766
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65906
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -47,21 +60,24 @@ set {
 energy('ccsd')
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:36 2017
+Scratch directory: /tmp/
+
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:26:59 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -75,15 +91,15 @@ energy('ccsd')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.065781240615    15.994914619560
-           H          0.000000000000    -0.755375621709     0.521998012412     1.007825032070
-           H          0.000000000000     0.755375621709     0.521998012412     1.007825032070
+         O            0.000000000000     0.000000000000    -0.065781240624    15.994914619570
+         H            0.000000000000    -0.755375621709     0.521998012403     1.007825032230
+         H            0.000000000000     0.755375621709     0.521998012403     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     27.25827  B =     14.65735  C =      9.53186 [cm^-1]
-  Rotational constants: A = 817182.31131  B = 439416.26664  C = 285758.08273 [MHz]
-  Nuclear repulsion =    9.196442078324043
+  Rotational constants: A = 817182.31742  B = 439416.26992  C = 285758.08487 [MHz]
+  Nuclear repulsion =    9.196442114471857
 
   Charge       = 0
   Multiplicity = 1
@@ -100,30 +116,17 @@ energy('ccsd')
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      24      24       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -142,40 +145,58 @@ energy('ccsd')
   Using 90300 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.4132328758E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.2454299360E-02.
+  Reciprocal condition number of the overlap matrix is 1.0298309542E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -75.89774761657189   -7.58977e+01   1.21427e-01 
-   @RHF iter   1:   -76.00520445878196   -1.07457e-01   1.71025e-02 
-   @RHF iter   2:   -76.02219797712723   -1.69935e-02   8.13340e-03 DIIS
-   @RHF iter   3:   -76.02663696184406   -4.43898e-03   1.19324e-03 DIIS
-   @RHF iter   4:   -76.02679023317005   -1.53271e-04   2.51897e-04 DIIS
-   @RHF iter   5:   -76.02680383117369   -1.35980e-05   5.89471e-05 DIIS
-   @RHF iter   6:   -76.02680478139122   -9.50218e-07   1.08365e-05 DIIS
-   @RHF iter   7:   -76.02680481176277   -3.03716e-08   1.25899e-06 DIIS
-   @RHF iter   8:   -76.02680481213405   -3.71273e-10   2.24504e-07 DIIS
-   @RHF iter   9:   -76.02680481214483   -1.07860e-11   2.53032e-08 DIIS
-   @RHF iter  10:   -76.02680481214490   -7.10543e-14   2.14212e-09 DIIS
+   @RHF iter SAD:   -75.51203931426201   -7.55120e+01   0.00000e+00 
+   @RHF iter   1:   -75.95405523547107   -4.42016e-01   3.03172e-02 DIIS/ADIIS
+   @RHF iter   2:   -76.00735381655032   -5.32986e-02   1.73131e-02 DIIS/ADIIS
+   @RHF iter   3:   -76.02621214226635   -1.88583e-02   2.29991e-03 DIIS/ADIIS
+   @RHF iter   4:   -76.02678454706610   -5.72405e-04   3.69059e-04 DIIS/ADIIS
+   @RHF iter   5:   -76.02680388860790   -1.93415e-05   6.61318e-05 DIIS
+   @RHF iter   6:   -76.02680478703451   -8.98427e-07   1.04412e-05 DIIS
+   @RHF iter   7:   -76.02680481181378   -2.47793e-08   1.42077e-06 DIIS
+   @RHF iter   8:   -76.02680481228461   -4.70834e-10   3.32075e-07 DIIS
+   @RHF iter   9:   -76.02680481231481   -3.01981e-11   5.75280e-08 DIIS
+   @RHF iter  10:   -76.02680481231558   -7.67386e-13   4.72729e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -196,49 +217,44 @@ energy('ccsd')
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.02680481214490
+  @RHF Final Energy:   -76.02680481231558
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1964420783240435
-    One-Electron Energy =                -123.1528618737278578
-    Two-Electron Energy =                  37.9296149832589293
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0268048121448885
+    Nuclear Repulsion Energy =              9.1964421144718571
+    One-Electron Energy =                -123.1528619528479425
+    Two-Electron Energy =                  37.9296150260605174
+    Total Energy =                        -76.0268048123155751
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9784
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.1677
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.8107     Total:     0.8107
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.0606     Total:     2.0606
 
 
-*** tstop() called on psinet at Mon May 15 15:34:36 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:27:00 2022
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.73 seconds =       0.01 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.73 seconds =       0.01 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -252,19 +268,19 @@ Total time:
       Number of basis functions:        24
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  11    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 11683 non-zero two-electron integrals.
+      Computed 11412 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:36 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:27:00 2022
 
 
 	Wfn Parameters:
@@ -289,7 +305,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -325,7 +341,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -61.31659865775317
+	Frozen core energy     =    -61.31659866643020
 
 	Size of irrep 0 of <ab|cd> integrals:      0.013 (MW) /      0.102 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.037 (MB)
@@ -345,34 +361,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.000 (MW) /      0.003 (MB)
 	Total:                                     0.002 (MW) /      0.012 (MB)
 
-	Nuclear Rep. energy          =      9.19644207832404
-	SCF energy                   =    -76.02680481214490
-	One-electron energy          =    -41.62078914354875
-	Two-electron energy          =     17.71414091083302
-	Reference energy             =    -76.02680481214486
+	Nuclear Rep. energy          =      9.19644211447186
+	SCF energy                   =    -76.02680481231558
+	One-electron energy          =    -41.62078919091541
+	Two-electron energy          =     17.71414093055816
+	Reference energy             =    -76.02680481231559
 
-*** tstop() called on psinet at Mon May 15 15:34:37 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:27:00 2022
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.43 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       0.22 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:37 2017
-
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.196442078324043
-    SCF energy          (wfn)     =  -76.026804812144903
-    Reference energy    (file100) =  -76.026804812144860
+    Nuclear Rep. energy (wfn)     =    9.196442114471857
+    SCF energy          (wfn)     =  -76.026804812315575
+    Reference energy    (file100) =  -76.026804812315589
 
     Input parameters:
     -----------------
@@ -401,70 +413,72 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2016450560547201
+MP2 correlation energy -0.2016450556302664
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.201645056054720    0.000e+00    0.000000    0.000000    0.000000    0.109452
-     1        -0.206836947230161    2.658e-02    0.004491    0.008605    0.008605    0.116415
-     2        -0.210781126055819    9.357e-03    0.005320    0.009910    0.009910    0.121737
-     3        -0.211188394707540    2.416e-03    0.005797    0.010711    0.010711    0.122932
-     4        -0.211199634669757    5.559e-04    0.005843    0.010928    0.010928    0.123127
-     5        -0.211210637689748    1.646e-04    0.005869    0.011038    0.011038    0.123160
-     6        -0.211208802399953    5.463e-05    0.005878    0.011083    0.011083    0.123153
-     7        -0.211208579644672    1.476e-05    0.005881    0.011097    0.011097    0.123151
-     8        -0.211208455768539    2.550e-06    0.005882    0.011099    0.011099    0.123151
-     9        -0.211208410007173    6.129e-07    0.005882    0.011099    0.011099    0.123151
-    10        -0.211208424169732    1.239e-07    0.005882    0.011099    0.011099    0.123151
-    11        -0.211208422947632    2.638e-08    0.005882    0.011099    0.011099    0.123151
+     0        -0.201645055630266    0.000e+00    0.000000    0.000000    0.000000    0.109452
+     1        -0.206836946938429    2.658e-02    0.004491    0.008605    0.008605    0.116415
+     2        -0.210781125752042    9.357e-03    0.005320    0.009910    0.009910    0.121737
+     3        -0.211188394469577    2.416e-03    0.005797    0.010711    0.010711    0.122932
+     4        -0.211199634407096    5.559e-04    0.005843    0.010928    0.010928    0.123127
+     5        -0.211210637427756    1.646e-04    0.005869    0.011038    0.011038    0.123160
+     6        -0.211208802135744    5.463e-05    0.005878    0.011083    0.011083    0.123153
+     7        -0.211208579380154    1.476e-05    0.005881    0.011097    0.011097    0.123151
+     8        -0.211208455504045    2.550e-06    0.005882    0.011099    0.011099    0.123151
+     9        -0.211208409742669    6.129e-07    0.005882    0.011099    0.011099    0.123151
+    10        -0.211208423905230    1.239e-07    0.005882    0.011099    0.011099    0.123151
+    11        -0.211208422683130    2.638e-08    0.005882    0.011099    0.011099    0.123151
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              1   0         0.0074294728
-              3  17         0.0073229132
-              3  13        -0.0059853257
-              1   5         0.0049810576
-              3  15         0.0045372485
+              1   0         0.0074294772
+              3  17         0.0073229129
+              3  13        -0.0059853303
+              1   5         0.0049810572
+              3  15         0.0045372481
               0   2         0.0042045397
-              0   0        -0.0038074433
-              2  11        -0.0032788570
-              2  10        -0.0030289147
-              1   1        -0.0029930210
+              0   0        -0.0038074423
+              2  11        -0.0032788568
+              2  10        -0.0030289145
+              1   1        -0.0029930227
 
     Largest TIjAb Amplitudes:
-      2   2  10  10        -0.0514005091
+      2   2  10  10        -0.0514005090
       3   3  14  14        -0.0361095442
-      1   1   2   2        -0.0353039407
+      1   1   2   2        -0.0353039406
       3   3  13  13        -0.0292732854
-      1   2   2  10         0.0285597326
-      2   1  10   2         0.0285597326
-      3   3   1   1        -0.0282565456
-      1   1  14  14        -0.0256830909
-      2   3  10  15        -0.0228210017
-      3   2  15  10        -0.0228210017
+      1   2   2  10         0.0285597325
+      2   1  10   2         0.0285597325
+      3   3   1   1        -0.0282565459
+      1   1  14  14        -0.0256830910
+      2   3  10  15        -0.0228210016
+      3   2  15  10        -0.0228210016
 
-    SCF energy       (wfn)                    =  -76.026804812144903
-    Reference energy (file100)                =  -76.026804812144860
+    SCF energy       (wfn)                    =  -76.026804812315575
+    Reference energy (file100)                =  -76.026804812315589
 
-    Opposite-spin MP2 correlation energy      =   -0.150928502097786
-    Same-spin MP2 correlation energy          =   -0.050716553956934
-    MP2 correlation energy                    =   -0.201645056054720
-      * MP2 total energy                      =  -76.228449868199576
+    Opposite-spin MP2 correlation energy      =   -0.150928501780848
+    Same-spin MP2 correlation energy          =   -0.050716553849418
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.201645055630266
+      * MP2 total energy                      =  -76.228449867945855
 
-    Opposite-spin CCSD correlation energy     =   -0.165898173721301
-    Same-spin CCSD correlation energy         =   -0.045310249285392
-    CCSD correlation energy                   =   -0.211208422947632
-      * CCSD total energy                     =  -76.238013235092495
+    Opposite-spin CCSD correlation energy     =   -0.165898173443881
+    Same-spin CCSD correlation energy         =   -0.045310249239249
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.211208422683130
+      * CCSD total energy                     =  -76.238013234998718
 
     Singlet pair energies
         i       j         MP2             CCSD
       -----   -----   ------------   ------------
         1       1     -0.008981594   -0.010060049
-        2       1     -0.009382404   -0.011432243
-        2       2     -0.017430800   -0.019331898
+        2       1     -0.009382404   -0.011432242
+        2       2     -0.017430799   -0.019331898
         3       1     -0.009038789   -0.010841286
         3       2     -0.009981198   -0.011031465
         3       3     -0.016907536   -0.018624210
@@ -482,20 +496,13 @@ MP2 correlation energy -0.2016450560547201
         3       1     -0.005876787   -0.005029730
         3       2     -0.019823538   -0.018091068
         4       1     -0.005982083   -0.005022623
-        4       2     -0.018914791   -0.016980275
+        4       2     -0.018914791   -0.016980274
         4       3     -0.019883739   -0.018012434
       -------------   ------------   ------------
           Total       -0.076074831   -0.067965374
 
 
-*** tstop() called on psinet at Mon May 15 15:34:37 2017
-Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.51 seconds =       0.01 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:27PM
+    Psi4 wall time for execution: 0:00:01.76
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc36/CMakeLists.txt
+++ b/tests/cc36/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc36 "psi;cc;autotest;cart")
+add_regression_test(cc36 "psi;cc;cart")

--- a/tests/cc36/input.dat
+++ b/tests/cc36/input.dat
@@ -14,3 +14,12 @@ set {
 }
 
 energy('cc2')
+
+enuc =   9.00935422966266 # TEST
+escf = -76.02403851151333 # TEST
+ecc2 = -76.22960579193078 # TEST
+
+compare_values(enuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ecc2, variable("CC2 TOTAL ENERGY"), 7, "CC2 energy") #TEST
+

--- a/tests/cc36/output.ref
+++ b/tests/cc36/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev53 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} d897692 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 February 2022 12:39PM
 
-    Process ID:  12803
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 7130
+    Host:       dhcp189-242.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -44,23 +57,35 @@ set {
 }
 
 energy('cc2')
+
+enuc =   9.00935422966266 # TEST
+escf = -76.02403851151333 # TEST
+ecc2 = -76.22960579193078 # TEST
+
+compare_values(enuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ecc2, variable("CC2 TOTAL ENERGY"), 7, "CC2 energy") #TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:38 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:39:51 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -74,15 +99,15 @@ energy('cc2')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000     0.117499201619    15.994914619560
-           H          0.000000000000    -1.515263000000    -0.932398798381     1.007825032070
-           H         -0.000000000000     1.515263000000    -0.932398798381     1.007825032070
+         O            0.000000000000     0.000000000000     0.117499201635    15.994914619570
+         H            0.000000000000    -1.515263000000    -0.932398798365     1.007825032230
+         H           -0.000000000000     1.515263000000    -0.932398798365     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     30.50916  B =     13.00778  C =      9.11958 [cm^-1]
-  Rotational constants: A = 914641.67040  B = 389963.32063  C = 273398.23581 [MHz]
-  Nuclear repulsion =    9.009354229662666
+  Rotational constants: A = 914641.67005  B = 389963.32048  C = 273398.23570 [MHz]
+  Nuclear repulsion =    9.009354229662664
 
   Charge       = 0
   Multiplicity = 1
@@ -99,30 +124,17 @@ energy('cc2')
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      24      24       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -141,40 +153,58 @@ energy('cc2')
   Using 90300 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6636430474E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.5052171027E-02.
+  Reciprocal condition number of the overlap matrix is 1.1227574483E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -75.96481693085128   -7.59648e+01   1.17112e-01 
-   @RHF iter   1:   -75.98846953043378   -2.36526e-02   2.03294e-02 
-   @RHF iter   2:   -76.01612072821780   -2.76512e-02   1.03196e-02 DIIS
-   @RHF iter   3:   -76.02339909851237   -7.27837e-03   1.76119e-03 DIIS
-   @RHF iter   4:   -76.02397201744562   -5.72919e-04   5.18764e-04 DIIS
-   @RHF iter   5:   -76.02403491860942   -6.29012e-05   1.08027e-04 DIIS
-   @RHF iter   6:   -76.02403842681726   -3.50821e-06   1.67139e-05 DIIS
-   @RHF iter   7:   -76.02403851053356   -8.37163e-08   2.10103e-06 DIIS
-   @RHF iter   8:   -76.02403851148739   -9.53833e-10   3.64606e-07 DIIS
-   @RHF iter   9:   -76.02403851151291   -2.55227e-11   3.38706e-08 DIIS
-   @RHF iter  10:   -76.02403851151308   -1.70530e-13   4.82115e-09 DIIS
+   @RHF iter SAD:   -75.47972672068823   -7.54797e+01   0.00000e+00 
+   @RHF iter   1:   -75.95121718432353   -4.71490e-01   3.02129e-02 ADIIS/DIIS
+   @RHF iter   2:   -76.00403247038633   -5.28153e-02   1.74872e-02 ADIIS/DIIS
+   @RHF iter   3:   -76.02339537533202   -1.93629e-02   2.34988e-03 ADIIS/DIIS
+   @RHF iter   4:   -76.02401414524086   -6.18770e-04   3.90559e-04 ADIIS/DIIS
+   @RHF iter   5:   -76.02403724419413   -2.30990e-05   7.31233e-05 DIIS
+   @RHF iter   6:   -76.02403846458711   -1.22039e-06   1.29395e-05 DIIS
+   @RHF iter   7:   -76.02403851004952   -4.54624e-08   2.25541e-06 DIIS
+   @RHF iter   8:   -76.02403851145485   -1.40533e-09   4.62835e-07 DIIS
+   @RHF iter   9:   -76.02403851151267   -5.78240e-11   5.95475e-08 DIIS
+   @RHF iter  10:   -76.02403851151333   -6.53699e-13   5.38640e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -195,49 +225,44 @@ energy('cc2')
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.02403851151308
+  @RHF Final Energy:   -76.02403851151333
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.0093542296626659
-    One-Electron Energy =                -122.8396184640541975
-    Two-Electron Energy =                  37.8062257228784446
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0240385115130834
+    Nuclear Repulsion Energy =              9.0093542296626641
+    One-Electron Energy =                -122.8396184319122426
+    Two-Electron Energy =                  37.8062256907362482
+    Total Energy =                        -76.0240385115133392
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.9248
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.1472
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.7776     Total:     0.7776
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -1.9765     Total:     1.9765
 
 
-*** tstop() called on psinet at Mon May 15 15:34:38 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:39:52 2022
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.53 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.53 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -251,19 +276,19 @@ Total time:
       Number of basis functions:        24
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  11    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 11669 non-zero two-electron integrals.
+      Computed 11412 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:38 2017
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:39:52 2022
 
 
 	Wfn Parameters:
@@ -288,7 +313,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -344,34 +369,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.005 (MB)
 	Total:                                     0.002 (MW) /      0.020 (MB)
 
-	Nuclear Rep. energy          =      9.00935422966267
-	SCF energy                   =    -76.02403851151308
-	One-electron energy          =   -122.83961835558476
-	Two-electron energy          =     37.80622561440902
-	Reference energy             =    -76.02403851151307
+	Nuclear Rep. energy          =      9.00935422966266
+	SCF energy                   =    -76.02403851151333
+	One-electron energy          =   -122.83961835462445
+	Two-electron energy          =     37.80622561344851
+	Reference energy             =    -76.02403851151327
 
-*** tstop() called on psinet at Mon May 15 15:34:38 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:39:52 2022
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.42 seconds =       0.01 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:38 2017
-
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.009354229662666
-    SCF energy          (wfn)     =  -76.024038511513083
-    Reference energy    (file100) =  -76.024038511513069
+    Nuclear Rep. energy (wfn)     =    9.009354229662664
+    SCF energy          (wfn)     =  -76.024038511513325
+    Reference energy    (file100) =  -76.024038511513268
 
     Input parameters:
     -----------------
@@ -399,69 +420,66 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2046900056774967
+MP2 correlation energy -0.2046900051754240
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.204690005677496    0.000e+00    0.000000    0.000000    0.000000    0.110581
-     1        -0.204682498803763    1.296e-02    0.004097    0.008642    0.008642    0.110581
-     2        -0.205493344383818    3.455e-03    0.004956    0.010294    0.010294    0.111542
-     3        -0.205580695383035    1.234e-03    0.005350    0.011148    0.011148    0.111640
-     4        -0.205565233165356    4.154e-04    0.005428    0.011556    0.011556    0.111628
-     5        -0.205566618351388    1.359e-04    0.005463    0.011732    0.011732    0.111629
-     6        -0.205567276183463    1.878e-05    0.005463    0.011739    0.011739    0.111629
-     7        -0.205567277169338    3.378e-06    0.005463    0.011740    0.011740    0.111629
-     8        -0.205567278488660    6.837e-07    0.005463    0.011740    0.011740    0.111629
-     9        -0.205567280045702    1.343e-07    0.005463    0.011740    0.011740    0.111629
-    10        -0.205567280541746    2.703e-08    0.005463    0.011740    0.011740    0.111629
+     0        -0.204690005175424    0.000e+00    0.000000    0.000000    0.000000    0.110581
+     1        -0.204682498588262    1.296e-02    0.004097    0.008642    0.008642    0.110581
+     2        -0.205493344270209    3.455e-03    0.004956    0.010294    0.010294    0.111542
+     3        -0.205580695241538    1.234e-03    0.005350    0.011148    0.011148    0.111640
+     4        -0.205565233043004    4.154e-04    0.005428    0.011556    0.011556    0.111628
+     5        -0.205566618228271    1.359e-04    0.005463    0.011732    0.011732    0.111629
+     6        -0.205567276059311    1.878e-05    0.005463    0.011739    0.011739    0.111629
+     7        -0.205567277045147    3.378e-06    0.005463    0.011740    0.011740    0.111629
+     8        -0.205567278364433    6.837e-07    0.005463    0.011740    0.011740    0.111629
+     9        -0.205567279921470    1.343e-07    0.005463    0.011740    0.011740    0.111629
+    10        -0.205567280417514    2.703e-08    0.005463    0.011740    0.011740    0.111629
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2   0         0.0089629814
-              4  17         0.0074420145
-              4  13        -0.0059592753
-              2   5         0.0050496347
-              4  15         0.0047108540
-              1   2        -0.0041382117
+              2   0         0.0089629775
+              4  17         0.0074420164
+              4  13        -0.0059592668
+              2   5         0.0050496339
+              4  15         0.0047108597
+              1   2        -0.0041382126
               3  10        -0.0035794542
-              3  11         0.0032944671
-              1   0        -0.0032147076
-              2   3        -0.0028168819
+              3  11         0.0032944680
+              1   0        -0.0032147066
+              2   3        -0.0028168814
 
     Largest TIjAb Amplitudes:
       3   3  10  10        -0.0473652111
-      2   2   2   2        -0.0350775970
+      2   2   2   2        -0.0350775972
       2   3   2  10        -0.0306163633
       3   2  10   2        -0.0306163633
       4   4  14  14        -0.0302856573
-      4   4  13  13        -0.0276354780
-      4   4   1   1        -0.0258309018
-      3   4  10  13        -0.0236598400
-      4   3  13  10        -0.0236598400
-      3   4  10  15        -0.0225643752
+      4   4  13  13        -0.0276354772
+      4   4   1   1        -0.0258309012
+      3   4  10  13        -0.0236598397
+      4   3  13  10        -0.0236598397
+      3   4  10  15        -0.0225643753
 
-    SCF energy       (wfn)                    =  -76.024038511513083
-    Reference energy (file100)                =  -76.024038511513069
+    SCF energy       (wfn)                    =  -76.024038511513325
+    Reference energy (file100)                =  -76.024038511513268
 
-    Opposite-spin MP2 correlation energy      =   -0.153102750701990
-    Same-spin MP2 correlation energy          =   -0.051587254975507
-    MP2 correlation energy                    =   -0.204690005677497
-      * MP2 total energy                      =  -76.228728517190561
-    CC2 correlation energy                    =   -0.205567280541746
-      * CC2 total energy                      =  -76.229605792054812
+    Opposite-spin MP2 correlation energy      =   -0.153102750320796
+    Same-spin MP2 correlation energy          =   -0.051587254854628
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.204690005175424
+      * MP2 total energy                      =  -76.228728516688690
+    CC2 correlation energy                    =   -0.205567280417514
+      * CC2 total energy                      =  -76.229605791930780
 
+    Nuclear repulsion energy..............................................................PASSED
+    SCF energy............................................................................PASSED
+    CC2 energy............................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:39 2017
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+    Psi4 stopped on: Monday, 14 February 2022 12:39PM
+    Psi4 wall time for execution: 0:00:01.57
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc37/CMakeLists.txt
+++ b/tests/cc37/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc37 "psi;cc;autotest;cart;noc1")
+add_regression_test(cc37 "psi;cc;cart;noc1")

--- a/tests/cc37/input.dat
+++ b/tests/cc37/input.dat
@@ -17,3 +17,12 @@ set {
 }
 
 energy('cc2')
+
+enuc =   9.009354229662664 # TEST
+escf = -75.634062420797946 # TEST
+ecc2 = -75.788452383580008 # TEST
+
+compare_values(enuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ecc2, variable("CC2 TOTAL ENERGY"), 7, "CC2 energy") #TEST
+

--- a/tests/cc37/output.ref
+++ b/tests/cc37/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev54 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} a448fdb dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 February 2022 12:49PM
 
-    Process ID:  12802
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 7908
+    Host:       dhcp189-242.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -47,23 +60,35 @@ set {
 }
 
 energy('cc2')
+
+enuc =   9.009354229662664 # TEST
+escf = -75.634062420797946 # TEST
+ecc2 = -75.788452383580008 # TEST
+
+compare_values(enuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ecc2, variable("CC2 TOTAL ENERGY"), 7, "CC2 energy") #TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:38 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:49:21 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -77,15 +102,15 @@ energy('cc2')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000     0.117499201619    15.994914619560
-           H          0.000000000000    -1.515263000000    -0.932398798381     1.007825032070
-           H         -0.000000000000     1.515263000000    -0.932398798381     1.007825032070
+         O            0.000000000000     0.000000000000     0.117499201635    15.994914619570
+         H            0.000000000000    -1.515263000000    -0.932398798365     1.007825032230
+         H           -0.000000000000     1.515263000000    -0.932398798365     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     30.50916  B =     13.00778  C =      9.11958 [cm^-1]
-  Rotational constants: A = 914641.67040  B = 389963.32063  C = 273398.23581 [MHz]
-  Nuclear repulsion =    9.009354229662666
+  Rotational constants: A = 914641.67005  B = 389963.32048  C = 273398.23570 [MHz]
+  Nuclear repulsion =    9.009354229662664
 
   Charge       = 1
   Multiplicity = 2
@@ -99,33 +124,20 @@ energy('cc2')
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       3       3       3       0
-     A2         2       2       0       0       0       0
-     B1         4       4       1       0       0       1
-     B2         7       7       1       1       1       0
-   -------------------------------------------------------
-    Total      24      24       5       4       4       1
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -144,47 +156,66 @@ energy('cc2')
   Using 90300 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.6636430474E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 3.5052171027E-02.
+  Reciprocal condition number of the overlap matrix is 1.1227574483E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter   1:   -74.85013087637024   -7.48501e+01   1.20985e-01 
-   @UHF iter   2:   -75.55213092858813   -7.02000e-01   3.43732e-02 DIIS
-   @UHF iter   3:   -75.62962982053345   -7.74989e-02   6.02496e-03 DIIS
-   @UHF iter   4:   -75.63371972800851   -4.08991e-03   1.42899e-03 DIIS
-   @UHF iter   5:   -75.63403322738742   -3.13499e-04   3.16304e-04 DIIS
-   @UHF iter   6:   -75.63405648370852   -2.32563e-05   1.33962e-04 DIIS
-   @UHF iter   7:   -75.63406187637489   -5.39267e-06   4.03179e-05 DIIS
-   @UHF iter   8:   -75.63406240807953   -5.31705e-07   7.14328e-06 DIIS
-   @UHF iter   9:   -75.63406242067518   -1.25956e-08   8.05608e-07 DIIS
-   @UHF iter  10:   -75.63406242079262   -1.17439e-10   1.62016e-07 DIIS
-   @UHF iter  11:   -75.63406242079755   -4.93117e-12   3.12882e-08 DIIS
-   @UHF iter  12:   -75.63406242079770   -1.56319e-13   6.40457e-09 DIIS
+   @UHF iter SAD:   -75.47972672068823   -7.54797e+01   0.00000e+00 
+   @UHF iter   1:   -75.59614084736920   -1.16414e-01   1.95010e-02 DIIS/ADIIS
+   @UHF iter   2:   -75.63106816722410   -3.49273e-02   5.42905e-03 DIIS/ADIIS
+   @UHF iter   3:   -75.63354568189290   -2.47751e-03   1.95170e-03 DIIS/ADIIS
+   @UHF iter   4:   -75.63395537962593   -4.09698e-04   6.32605e-04 DIIS/ADIIS
+   @UHF iter   5:   -75.63403671977161   -8.13401e-05   2.83616e-04 DIIS/ADIIS
+   @UHF iter   6:   -75.63405986678374   -2.31470e-05   8.77976e-05 DIIS
+   @UHF iter   7:   -75.63406236140899   -2.49463e-06   1.49145e-05 DIIS
+   @UHF iter   8:   -75.63406241961586   -5.82069e-08   2.42742e-06 DIIS
+   @UHF iter   9:   -75.63406242074470   -1.12884e-09   4.96765e-07 DIIS
+   @UHF iter  10:   -75.63406242079648   -5.17844e-11   8.22081e-08 DIIS
+   @UHF iter  11:   -75.63406242079792   -1.43530e-12   1.51734e-08 DIIS
+   @UHF iter  12:   -75.63406242079795   -2.84217e-14   3.83816e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   6.409684670E-03
+   @Spin Contamination Metric:   6.409684317E-03
    @S^2 Expected:                7.500000000E-01
-   @S^2 Observed:                7.564096847E-01
+   @S^2 Observed:                7.564096843E-01
    @S   Expected:                5.000000000E-01
    @S   Observed:                5.000000000E-01
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
@@ -221,21 +252,14 @@ energy('cc2')
     DOCC [     3,    0,    0,    1 ]
     SOCC [     0,    0,    1,    0 ]
 
-  Energy converged.
-
-  @UHF Final Energy:   -75.63406242079770
+  @UHF Final Energy:   -75.63406242079795
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.0093542296626659
-    One-Electron Energy =                -117.8015463974060282
-    Two-Electron Energy =                  33.1581297469456686
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -75.6340624207977044
-
+    Nuclear Repulsion Energy =              9.0093542296626641
+    One-Electron Energy =                -117.8015463773347022
+    Two-Electron Energy =                  33.1581297268741082
+    Total Energy =                        -75.6340624207979317
 
   UHF NO Occupations:
   HONO-2 :    1 B2 1.9991329
@@ -247,33 +271,35 @@ energy('cc2')
   LUNO+3 :    6 A1 0.0000003
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.9248
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.0328
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.9576     Total:     0.9576
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -2.4339     Total:     2.4339
 
 
-*** tstop() called on psinet at Mon May 15 15:34:38 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:49:22 2022
 Module time:
-	user time   =       0.20 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.20 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.58 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -287,19 +313,19 @@ Total time:
       Number of basis functions:        24
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  11    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 11669 non-zero two-electron integrals.
+      Computed 11412 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:38 2017
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:49:22 2022
 
 
 	Wfn Parameters:
@@ -324,7 +350,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -434,37 +460,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.001 (MW) /      0.005 (MB)
 	Total:                                     0.002 (MW) /      0.017 (MB)
 
-	Nuclear Rep. energy          =      9.00935422966267
-	SCF energy                   =    -75.63406242079770
-	One-electron energy          =   -117.80154638874495
-	Two-electron (AA) energy     =      7.85329581102903
-	Two-electron (BB) energy     =      4.64043020519127
-	Two-electron (AB) energy     =     20.66440372206431
-	Two-electron energy          =     33.15812973828461
-	Reference energy             =    -75.63406242079766
+	Nuclear Rep. energy          =      9.00935422966266
+	SCF energy                   =    -75.63406242079795
+	One-electron energy          =   -117.80154637944339
+	Two-electron (AA) energy     =      7.85329580923065
+	Two-electron (BB) energy     =      4.64043020327569
+	Two-electron (AB) energy     =     20.66440371647642
+	Two-electron energy          =     33.15812972898276
+	Reference energy             =    -75.63406242079797
 
-*** tstop() called on psinet at Mon May 15 15:34:38 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:49:22 2022
 Module time:
 	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.27 seconds =       0.00 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:38 2017
-
+	user time   =       0.64 seconds =       0.01 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.009354229662666
-    SCF energy          (wfn)     =  -75.634062420797704
-    Reference energy    (file100) =  -75.634062420797662
+    Nuclear Rep. energy (wfn)     =    9.009354229662664
+    SCF energy          (wfn)     =  -75.634062420797946
+    Reference energy    (file100) =  -75.634062420797974
 
     Input parameters:
     -----------------
@@ -492,105 +514,102 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.1536803298044448
+MP2 correlation energy -0.1536803298520241
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.153680329804445    0.000e+00    0.000000    0.000000    0.000000    0.000000
-     1        -0.153665030990904    1.713e-02    0.005709    0.000000    0.000000    0.000000
-     2        -0.154319296014096    4.207e-03    0.006917    0.000000    0.000000    0.000000
-     3        -0.154396655470093    1.579e-03    0.007523    0.000000    0.000000    0.000000
-     4        -0.154388862198056    4.065e-04    0.007606    0.000000    0.000000    0.000000
-     5        -0.154389783904537    7.499e-05    0.007619    0.000000    0.000000    0.000000
-     6        -0.154389989713595    1.562e-05    0.007618    0.000000    0.000000    0.000000
-     7        -0.154389964951067    3.893e-06    0.007619    0.000000    0.000000    0.000000
-     8        -0.154389960839958    1.280e-06    0.007619    0.000000    0.000000    0.000000
-     9        -0.154389961090279    2.558e-07    0.007619    0.000000    0.000000    0.000000
-    10        -0.154389962613242    7.119e-08    0.007619    0.000000    0.000000    0.000000
+     0        -0.153680329852024    0.000e+00    0.000000    0.000000    0.000000    0.000000
+     1        -0.153665031076787    1.713e-02    0.005709    0.000000    0.000000    0.000000
+     2        -0.154319296158700    4.207e-03    0.006917    0.000000    0.000000    0.000000
+     3        -0.154396655640088    1.579e-03    0.007523    0.000000    0.000000    0.000000
+     4        -0.154388862367779    4.065e-04    0.007606    0.000000    0.000000    0.000000
+     5        -0.154389784073414    7.499e-05    0.007619    0.000000    0.000000    0.000000
+     6        -0.154389989882373    1.562e-05    0.007618    0.000000    0.000000    0.000000
+     7        -0.154389965119863    3.893e-06    0.007619    0.000000    0.000000    0.000000
+     8        -0.154389961008747    1.280e-06    0.007619    0.000000    0.000000    0.000000
+     9        -0.154389961259067    2.558e-07    0.007619    0.000000    0.000000    0.000000
+    10        -0.154389962782028    7.119e-08    0.007619    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2   0        -0.0085529233
-              4  13        -0.0084681013
-              3  10        -0.0080629517
-              1   0         0.0046170778
-              4  17         0.0043086031
-              2   1         0.0042739960
-              4  14        -0.0041604571
-              2   2         0.0038566405
-              2   5        -0.0028039543
-              1   2         0.0025796618
+              2   0        -0.0085528943
+              4  13        -0.0084681146
+              3  10        -0.0080629533
+              1   0         0.0046170750
+              4  17         0.0043085998
+              2   1         0.0042739946
+              4  14        -0.0041604687
+              2   2         0.0038566485
+              2   5        -0.0028039551
+              1   2         0.0025796681
 
     Largest Tia Amplitudes:
-              2   0        -0.0067364407
-              3  18         0.0056707287
-              1   5         0.0048750610
-              1   1         0.0039835341
-              3  14        -0.0036057927
-              2   1         0.0034706125
-              3  16         0.0031313995
-              2   4        -0.0026166006
-              2   3         0.0025311998
-              2   5        -0.0021020047
+              2   0        -0.0067364676
+              3  18         0.0056707345
+              1   5         0.0048750584
+              1   1         0.0039835283
+              3  14        -0.0036057672
+              2   1         0.0034706216
+              3  16         0.0031314121
+              2   4        -0.0026165935
+              2   3         0.0025312057
+              2   5        -0.0021020019
 
     Largest TIJAB Amplitudes:
-      3   2  10   2         0.0232051173
-      4   3  13  10        -0.0192601210
-      4   2  13   2         0.0186862020
-      4   3  15  10        -0.0178445242
+      3   2  10   2         0.0232051176
+      4   3  13  10        -0.0192601213
+      4   2  13   2         0.0186862021
+      4   3  15  10        -0.0178445241
       4   2  14   2         0.0144661575
-      4   2  15   2         0.0130542369
-      3   2  10   1         0.0111933469
-      4   3  14  10        -0.0110676038
-      4   3   8   1        -0.0110013455
-      3   1  10   0         0.0106184618
+      4   2  15   2         0.0130542368
+      3   2  10   1         0.0111933470
+      4   3  14  10        -0.0110676040
+      4   3   8   1        -0.0110013457
+      3   1  10   0         0.0106184619
 
     Largest Tijab Amplitudes:
-      3   2  14   2         0.0193532933
-      3   2  15   2         0.0152645948
-      3   2  16   2         0.0131425483
-      3   2  16   1         0.0094551660
-      2   1   2   0        -0.0092491494
-      3   2  18   2         0.0088073613
-      3   2  15   3         0.0087556254
-      3   1  14   0         0.0086285852
-      2   1  13  10        -0.0084862572
-      3   1  10   8         0.0084782228
+      3   2  14   2         0.0193532930
+      3   2  15   2         0.0152645950
+      3   2  16   2         0.0131425485
+      3   2  16   1         0.0094551655
+      2   1   2   0        -0.0092491491
+      3   2  18   2         0.0088073617
+      3   2  15   3         0.0087556255
+      3   1  14   0         0.0086285844
+      2   1  13  10        -0.0084862570
+      3   1  10   8         0.0084782226
 
     Largest TIjAb Amplitudes:
-      2   2   2   2        -0.0327121996
-      3   2  10   2         0.0279215717
-      4   3  13  14        -0.0253331289
-      4   3  14  15        -0.0246193133
-      3   3  10  14        -0.0217738599
-      3   3  10  16        -0.0207614165
-      4   3   1   1        -0.0206642142
+      2   2   2   2        -0.0327121997
+      3   2  10   2         0.0279215715
+      4   3  13  14        -0.0253331285
+      4   3  14  15        -0.0246193132
+      3   3  10  14        -0.0217738593
+      3   3  10  16        -0.0207614168
+      4   3   1   1        -0.0206642137
       4   3  15  16        -0.0200699119
-      4   2  13   2         0.0195384489
-      2   3   2  14         0.0192232896
+      4   2  13   2         0.0195384491
+      2   3   2  14         0.0192232891
 
-    SCF energy       (wfn)                    =  -75.634062420797704
-    Reference energy (file100)                =  -75.634062420797662
+    SCF energy       (wfn)                    =  -75.634062420797946
+    Reference energy (file100)                =  -75.634062420797974
 
-    Opposite-spin MP2 correlation energy      =   -0.117764907344175
-    Same-spin MP2 correlation energy          =   -0.035915422460268
-    MP2 correlation energy                    =   -0.153680329804445
-      * MP2 total energy                      =  -75.787742750602106
-    CC2 correlation energy                    =   -0.154389962613242
-      * CC2 total energy                      =  -75.788452383410899
+    Opposite-spin MP2 correlation energy      =   -0.117764907371762
+    Same-spin MP2 correlation energy          =   -0.035915422480262
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.153680329852024
+      * MP2 total energy                      =  -75.787742750649997
+    CC2 correlation energy                    =   -0.154389962782028
+      * CC2 total energy                      =  -75.788452383580008
 
+    Nuclear repulsion energy..............................................................PASSED
+    SCF energy............................................................................PASSED
+    CC2 energy............................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:39 2017
-Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+    Psi4 stopped on: Monday, 14 February 2022 12:49PM
+    Psi4 wall time for execution: 0:00:01.63
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc40/output.ref
+++ b/tests/cc40/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:25PM
 
-    Process ID:  12845
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65732
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -46,24 +59,25 @@ set {
   omega [589, 355, nm]
 }
 
-property('cc2',properties=['rotation'])
+properties('cc2',properties=['rotation'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:40 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:11 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 3-4 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1-2 entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3-4 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -77,16 +91,16 @@ property('cc2',properties=['rotation'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000    -0.695000000000    -0.049338350190    15.994914619560
-           O          0.000000000000     0.695000000000    -0.049338350190    15.994914619560
-           H          0.388142264171    -0.895248563098     0.783035421467     1.007825032070
-           H         -0.388142264171     0.895248563098     0.783035421467     1.007825032070
+         O            0.000000000000    -0.695000000000    -0.049338350197    15.994914619570
+         O            0.000000000000     0.695000000000    -0.049338350197    15.994914619570
+         H            0.388142264171    -0.895248563098     0.783035421459     1.007825032230
+         H           -0.388142264171     0.895248563098     0.783035421459     1.007825032230
 
   Running in c2 symmetry.
 
   Rotational constants: A =     10.61423  B =      0.97044  C =      0.91566 [cm^-1]
-  Rotational constants: A = 318206.57462  B =  29093.19738  C =  27450.82444 [MHz]
-  Nuclear repulsion =   38.253968380680327
+  Rotational constants: A = 318206.57700  B =  29093.19760  C =  27450.82465 [MHz]
+  Nuclear repulsion =   38.253968531042538
 
   Charge       = 0
   Multiplicity = 1
@@ -103,28 +117,17 @@ property('cc2',properties=['rotation'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 18
-    Number of basis function: 38
+    Number of basis functions: 38
     Number of Cartesian functions: 40
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         19      19       0       0       0       0
-     B         19      19       0       0       0       0
-   -------------------------------------------------------
-    Total      38      38       9       9       9       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -143,44 +146,60 @@ property('cc2',properties=['rotation'])
   Using 549822 doubles for integral storage.
   We computed 14706 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.1870579153E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.1047221517E-02.
+  Reciprocal condition number of the overlap matrix is 8.7919776090E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+     B         19      19 
+   -------------------------
+    Total      38      38
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -150.83527118424107   -1.50835e+02   7.61669e-02 
-   @RHF iter   1:  -150.75300393196321    8.22673e-02   8.92814e-03 
-   @RHF iter   2:  -150.77674264680306   -2.37387e-02   2.23904e-03 DIIS
-   @RHF iter   3:  -150.77866726940414   -1.92462e-03   8.11583e-04 DIIS
-   @RHF iter   4:  -150.77908304190512   -4.15773e-04   3.09116e-04 DIIS
-   @RHF iter   5:  -150.77917159812225   -8.85562e-05   9.19744e-05 DIIS
-   @RHF iter   6:  -150.77918361494824   -1.20168e-05   1.37015e-05 DIIS
-   @RHF iter   7:  -150.77918386184561   -2.46897e-07   2.97198e-06 DIIS
-   @RHF iter   8:  -150.77918387199861   -1.01530e-08   5.75950e-07 DIIS
-   @RHF iter   9:  -150.77918387232643   -3.27816e-10   1.51394e-07 DIIS
-   @RHF iter  10:  -150.77918387235533   -2.89049e-11   4.48580e-08 DIIS
-   @RHF iter  11:  -150.77918387235832   -2.98428e-12   9.89275e-09 DIIS
-   @RHF iter  12:  -150.77918387235854   -2.27374e-13   1.77899e-09 DIIS
-   @RHF iter  13:  -150.77918387235854    0.00000e+00   2.61633e-10 DIIS
-   @RHF iter  14:  -150.77918387235866   -1.13687e-13   6.83680e-11 DIIS
+   @RHF iter SAD:  -150.13109142562024   -1.50131e+02   0.00000e+00 
+   @RHF iter   1:  -150.72994418505689   -5.98853e-01   1.20798e-02 DIIS/ADIIS
+   @RHF iter   2:  -150.77474437542560   -4.48002e-02   3.93712e-03 DIIS/ADIIS
+   @RHF iter   3:  -150.77872862263547   -3.98425e-03   9.99210e-04 DIIS/ADIIS
+   @RHF iter   4:  -150.77914039140384   -4.11769e-04   2.79341e-04 DIIS/ADIIS
+   @RHF iter   5:  -150.77918120837066   -4.08170e-05   4.89524e-05 DIIS
+   @RHF iter   6:  -150.77918362626531   -2.41789e-06   1.25560e-05 DIIS
+   @RHF iter   7:  -150.77918384927895   -2.23014e-07   3.89300e-06 DIIS
+   @RHF iter   8:  -150.77918387131706   -2.20381e-08   8.16055e-07 DIIS
+   @RHF iter   9:  -150.77918387210650   -7.89441e-10   1.49865e-07 DIIS
+   @RHF iter  10:  -150.77918387212898   -2.24816e-11   3.10868e-08 DIIS
+   @RHF iter  11:  -150.77918387213006   -1.08002e-12   6.61624e-09 DIIS
+   @RHF iter  12:  -150.77918387213001    5.68434e-14   1.38474e-09 DIIS
+   @RHF iter  13:  -150.77918387213003   -2.84217e-14   3.05202e-10 DIIS
+   @RHF iter  14:  -150.77918387213003    0.00000e+00   6.31844e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -205,49 +224,44 @@ property('cc2',properties=['rotation'])
               A     B 
     DOCC [     5,    4 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -150.77918387235866
+  @RHF Final Energy:  -150.77918387213003
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             38.2539683806803268
-    One-Electron Energy =                -284.0698921465231024
-    Two-Electron Energy =                  95.0367398934841106
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -150.7791838723586579
+    Nuclear Repulsion Energy =             38.2539685310425384
+    One-Electron Energy =                -284.0698924306753952
+    Two-Electron Energy =                  95.0367400275028018
+    Total Energy =                       -150.7791838721300337
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.2602
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.2074     Total:     1.2074
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on psinet at Mon May 15 15:34:41 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:13 2022
 Module time:
-	user time   =       0.56 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.22 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.56 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.22 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -261,19 +275,19 @@ Total time:
       Number of basis functions:        38
 
       Number of irreps:                  2
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  19   19 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 117651 non-zero two-electron integrals.
+      Computed 107467 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:13 2022
 
 
 	Wfn Parameters:
@@ -296,7 +310,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -332,7 +346,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -132.27484824295888
+	Frozen core energy     =   -132.27484829822760
 
 	Size of irrep 0 of <ab|cd> integrals:      0.177 (MW) /      1.418 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.176 (MW) /      1.411 (MB)
@@ -346,34 +360,30 @@ Total time:
 	Size of irrep 1 of tijab amplitudes:       0.010 (MW) /      0.081 (MB)
 	Total:                                     0.021 (MW) /      0.165 (MB)
 
-	Nuclear Rep. energy          =     38.25396838068033
-	SCF energy                   =   -150.77918387235866
-	One-electron energy          =   -101.99691957132278
-	Two-electron energy          =     45.23861556124292
-	Reference energy             =   -150.77918387235840
+	Nuclear Rep. energy          =     38.25396853104254
+	SCF energy                   =   -150.77918387213003
+	One-electron energy          =   -101.99691974243427
+	Two-electron energy          =     45.23861563748924
+	Reference energy             =   -150.77918387213009
 
-*** tstop() called on psinet at Mon May 15 15:34:41 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:13 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.22 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.72 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
-
+	user time   =       1.47 seconds =       0.02 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   38.253968380680327
-    SCF energy          (wfn)     = -150.779183872358658
-    Reference energy    (file100) = -150.779183872358402
+    Nuclear Rep. energy (wfn)     =   38.253968531042538
+    SCF energy          (wfn)     = -150.779183872130034
+    Reference energy    (file100) = -150.779183872130091
 
     Input parameters:
     -----------------
@@ -401,76 +411,63 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3802563054135786
+MP2 correlation energy -0.3802563047354116
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.380256305413579    0.000e+00    0.000000    0.000000    0.000000    0.143419
-     1        -0.380254802722191    2.350e-02    0.006281    0.014957    0.014957    0.143419
-     2        -0.382926539245087    6.976e-03    0.007604    0.017580    0.017580    0.146255
-     3        -0.383312067134339    2.742e-03    0.008393    0.018848    0.018848    0.146676
-     4        -0.383283495426499    9.595e-04    0.008568    0.018859    0.018859    0.146729
-     5        -0.383286625218999    3.462e-04    0.008637    0.018841    0.018841    0.146745
-     6        -0.383290105628155    9.323e-05    0.008642    0.018836    0.018836    0.146748
-     7        -0.383289932289577    3.248e-05    0.008643    0.018835    0.018835    0.146748
-     8        -0.383289793502011    1.255e-05    0.008643    0.018835    0.018835    0.146748
-     9        -0.383289823387466    3.458e-06    0.008643    0.018835    0.018835    0.146748
-    10        -0.383289826363972    1.544e-06    0.008643    0.018835    0.018835    0.146748
-    11        -0.383289836414563    4.659e-07    0.008643    0.018835    0.018835    0.146748
-    12        -0.383289840450543    1.935e-07    0.008643    0.018835    0.018835    0.146748
-    13        -0.383289840923771    7.060e-08    0.008643    0.018835    0.018835    0.146748
+     0        -0.380256304735412    0.000e+00    0.000000    0.000000    0.000000    0.143419
+     1        -0.380254802043540    2.350e-02    0.006281    0.014957    0.014957    0.143419
+     2        -0.382926538507049    6.976e-03    0.007604    0.017580    0.017580    0.146255
+     3        -0.383312066377153    2.742e-03    0.008393    0.018848    0.018848    0.146676
+     4        -0.383283494671484    9.595e-04    0.008568    0.018859    0.018859    0.146729
+     5        -0.383286624463608    3.462e-04    0.008637    0.018841    0.018841    0.146745
+     6        -0.383290104872661    9.323e-05    0.008642    0.018836    0.018836    0.146748
+     7        -0.383289931534114    3.248e-05    0.008643    0.018835    0.018835    0.146748
+     8        -0.383289792746542    1.255e-05    0.008643    0.018835    0.018835    0.146748
+     9        -0.383289822631999    3.458e-06    0.008643    0.018835    0.018835    0.146748
+    10        -0.383289825608501    1.544e-06    0.008643    0.018835    0.018835    0.146748
+    11        -0.383289835659091    4.659e-07    0.008643    0.018835    0.018835    0.146748
+    12        -0.383289839695072    1.935e-07    0.008643    0.018835    0.018835    0.146748
+    13        -0.383289840168299    7.060e-08    0.008643    0.018835    0.018835    0.146748
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              5  14        -0.0109554494
-              6  14        -0.0098594082
-              2   7        -0.0085098717
+              5  14        -0.0109554489
+              6  14        -0.0098594077
+              2   7        -0.0085098715
               2   9        -0.0082148274
-              2   4         0.0076053348
-              5  17         0.0075277221
+              2   4         0.0076053346
+              5  17         0.0075277218
               1   0        -0.0069350391
-              1   8        -0.0069268907
+              1   8        -0.0069268906
               1   3         0.0063772897
-              2   3        -0.0057368808
+              2   3        -0.0057368806
 
     Largest TIjAb Amplitudes:
-      2   2  15  15        -0.0557781569
+      2   2  15  15        -0.0557781564
       1   1  15  15        -0.0278636304
-      1   2  15  15         0.0272969982
-      2   1  15  15         0.0272969982
-      2   2  14  15         0.0270427379
-      2   2  15  14         0.0270427379
-      3   3  17  17        -0.0218529151
-      2   3  15  17         0.0214876848
-      3   2  17  15         0.0214876848
-      2   6  15   2         0.0208245684
+      1   2  15  15         0.0272969980
+      2   1  15  15         0.0272969980
+      2   2  14  15         0.0270427369
+      2   2  15  14         0.0270427369
+      3   3  17  17        -0.0218529145
+      2   3  15  17         0.0214876843
+      3   2  17  15         0.0214876843
+      2   6  15   2         0.0208245681
 
-    SCF energy       (wfn)                    = -150.779183872358658
-    Reference energy (file100)                = -150.779183872358402
+    SCF energy       (wfn)                    = -150.779183872130034
+    Reference energy (file100)                = -150.779183872130091
 
-    Opposite-spin MP2 correlation energy      =   -0.282698987529233
-    Same-spin MP2 correlation energy          =   -0.097557317884345
-    MP2 correlation energy                    =   -0.380256305413579
-      * MP2 total energy                      = -151.159440177771984
-    CC2 correlation energy                    =   -0.383289840923771
-      * CC2 total energy                      = -151.162473713282168
-
-
-*** tstop() called on psinet at Mon May 15 15:34:41 2017
-Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.90 seconds =       0.01 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
+    Opposite-spin MP2 correlation energy      =   -0.282698986958674
+    Same-spin MP2 correlation energy          =   -0.097557317776737
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.380256304735412
+      * MP2 total energy                      = -151.159440176865502
+    CC2 correlation energy                    =   -0.383289840168299
+      * CC2 total energy                      = -151.162473712298379
 
 
 			**************************
@@ -480,31 +477,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:41 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.92 seconds =       0.02 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -150.779183872358658
-	Reference energy    (CC_INFO) = -150.779183872358402
-	CC2 energy          (CC_INFO) =   -0.383289840923771
-	Total CC2 energy    (CC_INFO) = -151.162473713282168
+	SCF energy          (wfn)     = -150.779183872130034
+	Reference energy    (CC_INFO) = -150.779183872130091
+	CC2 energy          (CC_INFO) =   -0.383289840168299
+	Total CC2 energy    (CC_INFO) = -151.162473712298379
 
 	Input parameters:
 	-----------------
@@ -517,7 +500,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -530,60 +513,46 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.383295397523610    0.000e+00
-	   1        -0.383120322491645    1.686e-03
-	   2        -0.383118990756196    4.354e-04
-	   3        -0.383116158153779    2.067e-04
-	   4        -0.383115581742905    6.283e-05
-	   5        -0.383115059697210    2.959e-05
-	   6        -0.383114943553522    9.670e-06
-	   7        -0.383114954361295    3.957e-06
-	   8        -0.383114969044349    1.278e-06
-	   9        -0.383114972723801    5.372e-07
-	  10        -0.383114973373712    1.690e-07
-	  11        -0.383114972858115    6.804e-08
+	   0        -0.383295396774544    0.000e+00
+	   1        -0.383120321753058    1.686e-03
+	   2        -0.383118990017498    4.354e-04
+	   3        -0.383116157415033    2.067e-04
+	   4        -0.383115581004172    6.283e-05
+	   5        -0.383115058958540    2.959e-05
+	   6        -0.383114942814858    9.670e-06
+	   7        -0.383114953622620    3.957e-06
+	   8        -0.383114968305673    1.278e-06
+	   9        -0.383114971985125    5.372e-07
+	  10        -0.383114972635039    1.690e-07
+	  11        -0.383114972119443    6.804e-08
 
 	Largest LIA Amplitudes:
-	          5  14        -0.0106325455
-	          6  14        -0.0091021051
-	          2   7        -0.0085623603
+	          5  14        -0.0106325449
+	          6  14        -0.0091021046
+	          2   7        -0.0085623601
 	          2   9        -0.0085246839
-	          2   4         0.0077474301
-	          5  17         0.0076075600
-	          1   8        -0.0069597320
+	          2   4         0.0077474299
+	          5  17         0.0076075597
+	          1   8        -0.0069597319
 	          1   3         0.0064431890
 	          1   0        -0.0061242831
-	          2   3        -0.0058807098
+	          2   3        -0.0058807096
 
 	Largest LIjAb Amplitudes:
-	  2   2  15  15        -0.0557451680
+	  2   2  15  15        -0.0557451675
 	  1   1  15  15        -0.0278670139
-	  1   2  15  15         0.0272995607
-	  2   1  15  15         0.0272995607
-	  2   2  14  15         0.0269850145
-	  2   2  15  14         0.0269850145
-	  3   3  17  17        -0.0218489283
-	  2   3  15  17         0.0214821810
-	  3   2  17  15         0.0214821810
-	  2   6  15   2         0.0208269410
+	  1   2  15  15         0.0272995606
+	  2   1  15  15         0.0272995606
+	  2   2  14  15         0.0269850136
+	  2   2  15  14         0.0269850136
+	  3   3  17  17        -0.0218489277
+	  2   3  15  17         0.0214821805
+	  3   2  17  15         0.0214821805
+	  2   6  15   2         0.0208269408
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.89784269363
-
-*** tstop() called on psinet at Mon May 15 15:34:42 2017
-Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.98 seconds =       0.02 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
-
+	Overlap <L|e^T> =        0.89784269438
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -617,2973 +586,273 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933721  0.015024519180326 -0.027415915569923 -0.162886507397727  0.113254822182230 -0.064023650931695  0.055316304980596  0.030988679956785  0.002674429417476
-    1  (  1)  0.215473680254307  0.146951879885488 -0.277734064030091  0.062883278348033  0.148483123915935  0.181595053380776  0.367001371843723  0.003086313328543  0.095386404339359
-    2  (  2) -0.028492499167413  0.000076506520592 -0.059221747197110  0.071711487991993  0.074053260083109  0.055563200913397 -0.046720222778269  0.241063526706418  0.098194384215293
-    3  (  3) -0.132536698935214 -0.177581639220038 -0.107360746511049 -0.032262815899170  0.006088751294726  0.053657437577810 -0.241466578728657 -0.131962062699396  0.577380042604835
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927831  0.060461893794975 -0.005615477646773 -0.003888920206540  0.016113135271294 -0.008672229740056
-    1  (  1) -0.037058680758827 -0.084686071934137 -0.145302623884175 -0.027760832624305 -0.054555858489407  0.022009727182520
-    2  (  2) -0.087315818129458  0.399047483163755 -0.041723099752479 -0.020041920189961 -0.040600995633870  0.007777357868476
-    3  (  3)  0.035307803556717 -0.050920479686547  0.165550414172803 -0.068091463340346 -0.144062340529092 -0.042051983076333
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356551 -0.081063517853355  0.006129432769008  0.163964563111000  0.188951419459772 -0.080047732466251  0.074988303081870  0.007836242506546 -0.044696302205990
-    1  (  5)  0.348085979138495  0.014814724303192 -0.054134117524112 -0.070406995762186  0.073423358836432 -0.343984245233763  0.389896180591070 -0.295068043464411  0.051928952937999
-    2  (  6)  0.021691230674310 -0.340003625622930 -0.038072452179286 -0.014533847126846 -0.084733391360489 -0.004556444515536  0.201335045135150  0.349717311230196 -0.082620936463629
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932767 -0.007485730843831 -0.029474818409046  0.032209758674478  0.014108652541197
-    1  (  5)  0.209382720135363  0.066996563725017 -0.203801631001167 -0.021994746468443  0.025790645299276
-    2  (  6) -0.188199132187483 -0.086167806666973 -0.070501884768031 -0.051440727873373 -0.127552190835530
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135226960454326 -0.626072128797857  0.189283545408855
-    1  (  1) -0.198601340506735 -0.037544167210710 -0.132449472453123
-    2  (  2)  0.054869769604049  0.126822216303606 -0.064658685102817
-    3  (  3)  0.615161980452153 -0.126204375217762 -0.081927924761016
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135552779706605 -0.198154082714880  0.054851984676121  0.616510373253301
-    1  (  5) -0.625008803021783 -0.037782453643461  0.128063646533814 -0.126279998076325
-    2  (  6)  0.187629167441123 -0.129442737930211 -0.067422044676096 -0.079936634548171
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904639712499439 -0.487488103200078 -0.229076194035628  0.577203417890213 -0.193643876563157 -0.103447604010519 -0.002742470403338 -0.002451788094665 -0.093813724218962
-    1  (  1) -0.150591231752385 -0.132839961398676 -0.684911223766579  0.231736797158491 -0.050522572300056 -0.177494490840237  0.234003342486172  0.124606643062309 -0.128494931356702
-    2  (  2)  0.012679732612823 -0.025746334218930  0.172509146876788 -0.235881170188821 -0.123364008456996 -0.206129657450583 -0.121800673855382 -0.114140784221046 -0.027356216567616
-    3  (  3) -0.420686741899061  0.000223888623800 -0.019382136800409 -0.199660686586704 -0.007228242971196  0.053875733566288 -0.291408914352108  0.275298575094317  0.504737487457471
-    4  (  4) -0.444479349932735 -0.097546029689345 -0.201324076119096 -0.112193453656006 -0.168730295177533  0.009510393466858 -0.073326647656929 -0.314743664834676  0.576679302947966
-    5  (  5) -0.139143305540494  0.035439861017529 -0.250210390538725 -0.395563451554441  0.287109450839755 -0.179399443391463  0.197453518892032  0.283328589948463 -0.108409713739276
-    6  (  6) -0.129858112319467 -0.067528694061781  0.181320447910051  0.198216451549547  0.101434222271457  0.004260476702563 -0.540044484893393  0.047093544204498 -0.240211227858317
-    7  (  7) -0.134029026372179 -0.177806690148740  0.066071255125330 -0.420048245168209  0.282274848902370 -0.347456793165357 -0.074406017626720 -0.307127129684534  0.001639432917262
-    8  (  8) -0.063335732549795 -0.086906710930686  0.269779701592780  0.018783692891969  0.093247017991832  0.136863024113189  0.153892981652101 -0.031577691616059  0.057553836246877
-    9  (  9)  0.014012585179935  0.032071651340400  0.006363849845328 -0.122564599853796  0.077119470960861 -0.029965581352468  0.027046636903361  0.089397837094510 -0.000802529924297
-   10  ( 10)  0.055348506435330 -0.144624122276394  0.060432277066912 -0.048567020795905 -0.074912986944547 -0.098523802539045  0.029250640804257 -0.193836130554804  0.085063532916871
-   11  ( 11) -0.167019155111352 -0.139650558475052  0.283534980836448  0.091894060309814 -0.065838077605570 -0.024336945622802 -0.227843897422647  0.001167201554402 -0.053408806911177
-   12  ( 12) -0.031974022074098  0.367173995466688  0.116713714097486  0.049340092544991  0.015070529788372 -0.072500414701040  0.058353998450087 -0.115184864373280 -0.153182495837634
-   13  ( 13)  0.015928358602531 -0.071164774172966  0.101660897809927 -0.105977026406625  0.126658664034785 -0.065056017101773 -0.035738606034778 -0.004435603298653 -0.059994356828765
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128825974989500 -0.011693877694954 -0.146729379814642 -0.059424684705185 -0.018525365113564  0.062705489025804
-    1  (  1)  0.288526396149451  0.103129875764731  0.289919344105945  0.006241427794517  0.000597805518375 -0.002126961584353
-    2  (  2) -0.124928230102762 -0.010221797026433 -0.056571189755009 -0.103418885736751 -0.082343433199768  0.048808132756783
-    3  (  3)  0.041255915551139 -0.068310001947050 -0.078413018324278  0.150330242984058  0.179548999452874  0.040220285290066
-    4  (  4)  0.222674700983961  0.064061711596252 -0.051112895424355 -0.009318828777664  0.269456744732756  0.059360036713996
-    5  (  5) -0.030199751599663 -0.174896036167204  0.092691422408846  0.028256224393044 -0.095222992765343 -0.000984235427176
-    6  (  6)  0.000100463193802 -0.095109995484187 -0.236670455787582  0.077272409830333 -0.062627657605157 -0.003574021992866
-    7  (  7) -0.071380631315581  0.113168055430653 -0.125965816328837 -0.059330696538416  0.017157541349967  0.045135077260113
-    8  (  8) -0.578000624333806 -0.096150086854235  0.034301394867331  0.008135450733185  0.200641611845458 -0.180371714719453
-    9  (  9) -0.075918662396489  0.004599198141430  0.008112602200919  0.005143287525084  0.000284986477859 -0.012193359543264
-   10  ( 10) -0.010150745998769  0.093962320907848  0.012547284938520 -0.048325478252248  0.058041984098958  0.029299969972018
-   11  ( 11) -0.079273276366054 -0.056402585822244 -0.083755323132190 -0.007973236673633  0.003424691269619 -0.009405123180744
-   12  ( 12) -0.063303823644194  0.041869083940430 -0.019024216633724 -0.031772697856612 -0.042532243078148 -0.051259918656066
-   13  ( 13)  0.241542081048424  0.060829474159102 -0.029241791046112 -0.004754249561527 -0.057213036452327  0.050348392969423
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902374530738008 -0.153219479021394  0.011852929174186 -0.420772110136407 -0.445657281852273 -0.142990081433871 -0.124215890045063 -0.133483278617458 -0.065282671277566
-    1  ( 15) -0.489111175456927 -0.131490362750630 -0.025259277994884  0.001430871050474 -0.096952824968507  0.035534183248507 -0.068855717941579 -0.178542279528997 -0.088180183979091
-    2  ( 16) -0.227418381124775 -0.683144902334135  0.173877572588784 -0.020414541641214 -0.199817592754849 -0.249739904936551  0.179565732929508  0.064581867916811  0.271668362709082
-    3  ( 17)  0.574685513420533  0.230755641765086 -0.236330653993548 -0.198455558262872 -0.112539659295318 -0.393276362435683  0.196125851625034 -0.416930913980347  0.017841111258385
-    4  ( 18) -0.193861200269283 -0.049521286941883 -0.123799353815102 -0.006786264807840 -0.167396168176672  0.285560945535698  0.102872968175062  0.279329859462892  0.092685860122596
-    5  ( 19) -0.103950692672564 -0.178731366743249 -0.207305979104111  0.054759646458592  0.008750479265519 -0.180116361743284  0.005850873308008 -0.346544100781257  0.135656056953786
-    6  ( 20) -0.005630218802764  0.235616494969925 -0.121418775897705 -0.289705308748917 -0.074615700944892  0.197147960229448 -0.541298908627660 -0.074766151907210  0.151080244573408
-    7  ( 21) -0.003422639573222  0.126273883662646 -0.114690954063456  0.273155566178151 -0.312791095371300  0.283606567581999  0.047453631637739 -0.310404476862382 -0.030935364545073
-    8  ( 22) -0.094384208857057 -0.130119390042013 -0.029535782736633  0.507266905754741  0.577412507794778 -0.108469543731760 -0.239044626830659  0.001740919827222  0.057806922411972
-    9  ( 23) -0.126661063777400  0.286542775287411 -0.124995270818101  0.042040769766214  0.222601161131182 -0.031774064783095  0.002289661982458 -0.069973062056327 -0.578237160301569
-   10  ( 24) -0.012316706158686  0.104097860742320 -0.011505288409008 -0.071480242591928  0.067861431955949 -0.174641527191867 -0.093323115387948  0.108845273419867 -0.094609691027843
-   11  ( 25) -0.145222688889768  0.289337733151123 -0.056602400212246 -0.078531799009311 -0.050892925184265  0.092549568885380 -0.236281405460432 -0.125802430135998  0.035465582481709
-   12  ( 26) -0.059239279504452  0.006390267291510 -0.103087074498875  0.150070392220906 -0.009342684455998  0.028289380811622  0.077066678658249 -0.059246681674570  0.008175814399608
-   13  ( 27) -0.018271401982887  0.001173845770897 -0.081596168939430  0.178729785139622  0.269264211536966 -0.095094170813462 -0.063160456524498  0.017032758007931  0.200794357953942
-   14  ( 28)  0.062542890221325 -0.002043353345747  0.048801696637921  0.040072732580050  0.059190323152562 -0.000990742681884 -0.003556361910880  0.045152229102534 -0.180550803638735
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015123588660556  0.055493926114085 -0.169975137829354 -0.032809701818424  0.015002120333843
-    1  ( 15)  0.032575974689070 -0.144334404568215 -0.139389411890768  0.367448169822376 -0.070672349646377
-    2  ( 16)  0.006576811925776  0.060477069258316  0.284097691628269  0.117086244456108  0.102358639196815
-    3  ( 17) -0.124972828077132 -0.049265564522439  0.093111727254423  0.049489377800982 -0.106573762761451
-    4  ( 18)  0.078337257989459 -0.074315417379011 -0.066598566061466  0.015174881916698  0.127229135544765
-    5  ( 19) -0.030091617468876 -0.098524033243499 -0.024929078981087 -0.072709941383628 -0.065547640079017
-    6  ( 20)  0.028642219542830  0.029887343616836 -0.227866902460199  0.058376706970881 -0.035321371844132
-    7  ( 21)  0.087782136491557 -0.193844146817683  0.000960256633727 -0.115246048391406 -0.004217096818016
-    8  ( 22) -0.000480626398773  0.085216781964246 -0.052876715620283 -0.152779703755072 -0.059953833408381
-    9  ( 23) -0.075367737260768 -0.010279381835845 -0.080270644652143 -0.063438855793631  0.241130315879109
-   10  ( 24)  0.001339830230094  0.093599534020443 -0.056909491966952  0.041771584176777  0.060831797189672
-   11  ( 25)  0.008376396051512  0.012488344592189 -0.083677242445135 -0.018943587777835 -0.029225017366590
-   12  ( 26)  0.005096769732663 -0.048366952557414 -0.008003858722236 -0.031797935609827 -0.004752495908712
-   13  ( 27)  0.000291047131524  0.058011237654453  0.003385274769858 -0.042619295059250 -0.057154993286877
-   14  ( 28) -0.012282741908213  0.029296735642713 -0.009480582784425 -0.051319211356103  0.050295534824419
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027700885793089  0.024831013973624 -0.023766237412621 -0.167016603039280  0.109441555361160 -0.067202506902949  0.052695088582618  0.024064411648558  0.006188438734746
-    1  (  1)  0.211348759010706  0.133908962277452 -0.251856181342029  0.050198620344033  0.139035741221497  0.172926066548623  0.339110899470514  0.007367826854061  0.086633467632850
-    2  (  2) -0.033041625132304  0.014036582200115 -0.054189619432055  0.084538537056321  0.066377206996779  0.053646226488692 -0.037306526458897  0.220368264081419  0.092674869094186
-    3  (  3) -0.148568319902249 -0.152791211204357 -0.088570806082634 -0.044321874775512  0.009397298861538  0.049588338511205 -0.223116042687504 -0.123854255485028  0.553492211947823
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031010458886504  0.050729211215458 -0.003248182162606 -0.003208641714201  0.015229535075599 -0.008450459157619
-    1  (  1) -0.026218145702589 -0.073512341998450 -0.129399675880911 -0.023964582987083 -0.050019383975384  0.020539415914054
-    2  (  2) -0.075590807541998  0.365585379125665 -0.036729157945637 -0.016058134590288 -0.036438378068467  0.005536360852375
-    3  (  3)  0.037937313174179 -0.045234909961240  0.147760703126564 -0.060764535561326 -0.127333495556496 -0.038975339991215
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.051048798017957 -0.074362715758785  0.011189550347874  0.166183248293209  0.192475433446917 -0.070879824995188  0.064177194660693  0.010742342939181 -0.040136733536897
-    1  (  5)  0.352033813656896  0.019031583986239 -0.054018125678770 -0.066876079961762  0.060148226317505 -0.330348230405549  0.365124970723493 -0.284795973003397  0.051302526538111
-    2  (  6)  0.016809582021530 -0.311268516971319 -0.037661154101049 -0.006688597064521 -0.076727139945062  0.002675593746505  0.192087236696244  0.332474625249007 -0.065875996007770
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002709655241189 -0.005736834567419 -0.024459935540251  0.027202469191560  0.013148077561852
-    1  (  5)  0.191661619772419  0.061070263266083 -0.180667286312631 -0.019964047997521  0.020757203718357
-    2  (  6) -0.172312444590061 -0.078944608822717 -0.060240884585301 -0.044786922712268 -0.117310123601211
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102369  0.008188589712244 -0.013790999932790 -0.066013267343731 -0.002979179364342  0.115067560152145 -0.029904774000611  0.075658337330168  0.005135342269605
-    1  (  1) -0.415137332088593  0.400791789518608  0.060626653167985 -0.009777722957189  0.182694524485363  0.107591424113193 -0.071470092116897  0.210805299972922 -0.029640655301111
-    2  (  2)  0.731004204598539 -0.977674938020318  0.030910735141457  0.126476447646409  0.160297857646222 -0.115254107794131  0.017919423470240  0.019160269758167  0.056677210805976
-    3  (  3) -0.052710934455977  0.190825342618776 -0.121683764296172  0.058318753384790 -0.051331848225845  0.122833340921058  0.176985596744925 -0.321410474763131  0.015752780623204
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449210 -0.003857954296837  0.001116934481339 -0.006268480889133  0.011819863965878  0.022338641059405
-    1  (  1)  0.026581167918672 -0.003242138995830  0.002209759168115 -0.126256065331463  0.064001666171859  0.019583311633875
-    2  (  2)  0.060541607763315 -0.048685401885033 -0.005324531906372 -0.077364982992391 -0.023160042352107 -0.131997334895639
-    3  (  3)  0.086532549077844 -0.501054912835391 -0.033953281830236 -0.045954160893792  0.007588765668995  0.026055365513595
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407922 -0.003874637131511  0.017573675069951 -0.250000468336235  0.193535227171898 -0.023949830014066 -0.006344215172670 -0.002637721142584  0.025018403626545
-    1  (  5) -0.061066900138162  0.119597101102996  0.077747477731531 -0.181802110874953 -0.105212352540657 -0.191650240311690 -0.067261595147719  0.101033231559073  0.034053487252844
-    2  (  6) -0.129779125650164  0.272168473286843  0.218088904973320 -0.105590817864524  0.170044089806045 -0.413895401404370 -0.204721805057737  0.193774792721795  0.022574107317573
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304095 -0.022619515940241  0.001370551331510 -0.019480287608798 -0.016611790333307
-    1  (  5) -0.015006262168541  0.018557640744949 -0.000086080146176 -0.193359672647774  0.037991057379316
-    2  (  6)  0.020942063740396 -0.276121820896825 -0.020375408054502  0.090755244706106  0.038585932807353
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234755470283494 -0.089757897373023 -0.029226311105254
-    1  (  1)  0.628249611487220  0.562405195056322  1.006567293279198
-    2  (  2) -1.014513658696586  0.324469533164463  0.758540603298639
-    3  (  3)  0.070695571972183 -1.217301397368707  0.544825504539346
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235350713719762  0.628273412467369 -1.016171307500347  0.070820853933145
-    1  (  5) -0.089319079346849  0.558364917857370  0.332433157387864 -1.220987955904315
-    2  (  6) -0.028486683819979  1.000293875862993  0.767362449165297  0.543367325750416
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.804113115082455  0.859865209406016  0.271144212420684  0.233800284186302 -0.124039945960445 -0.010266323749662 -0.092708567501357  0.016778206024757 -0.004458179405400
-    1  (  1)  0.400343044462632 -0.255491137898947  1.725894952211800  0.228060869773307 -0.016813664829461  0.078025484956005 -0.010667432793270  0.508783176705984  0.007215780908165
-    2  (  2) -0.011354346714383 -0.088649218741449 -0.217285460959672 -0.271127696601540 -0.847424926486788 -0.636922641013145  0.167096970483964  0.613137270589854  0.118274978265621
-    3  (  3)  0.794199691903289 -0.188240166832108  0.221783053519910 -0.127263314849167  0.529647578782857 -1.234322959041016  0.503694754515590 -0.716759154325337  0.003713884622648
-    4  (  4) -0.401724672662141  0.338296304392090  0.027696569600321 -1.521982152309948  0.118592993378328  0.737822504259584  0.133024505198198  0.089529285352511  0.037479870573357
-    5  (  5) -0.062644206103430  0.401210407583400 -0.021849381974059 -0.715241456861978 -1.272083761860038  0.501726128250687 -0.443637757248648 -0.893021281361460  0.592660402987478
-    6  (  6) -0.010995449282209  0.203452242512839 -0.137034668384807 -0.113107359606136 -0.481513340581283  0.549194810269333  1.454087044363819 -0.104931286723820 -0.037492008681499
-    7  (  7)  0.128269755499576  0.321618430212563  0.165227456397829  0.036785042290427  0.490368577399842  0.556638814926841 -0.027991830909212  0.572834606710204  0.836617597163351
-    8  (  8)  0.028289154881442 -0.066964202719273 -0.261747148048831 -0.132206243094638 -0.099640531633387  0.125261053712953 -0.191170844521893  0.152462184420592 -0.345612464690994
-    9  (  9) -0.116917200684005  0.677293814759278  0.057457633837347  0.132537898195614 -0.004175807366704 -0.154875636337899 -0.038546773688736 -0.121822888362938 -0.349244520254430
-   10  ( 10) -0.180886604759008 -0.111792204437992  0.370617548329887 -0.010060948397228  0.175897261426766 -0.187416342815094 -0.018902126694376  0.507517994343601 -0.113620600518252
-   11  ( 11) -0.014433403132825  0.015210570936209  0.010143344331716 -0.005691229002329 -0.031059326071826 -0.023288546292954  0.128101332902295 -0.039392944850374 -0.110920114561200
-   12  ( 12) -0.125268954735592 -0.096735894811095  0.052480306210829  0.258243594453865  0.005805250173642  0.145107299027973  0.116452856795825 -0.074374807730489  0.022119923916468
-   13  ( 13) -0.016491827683000 -0.002316794514639 -0.087971851878045 -0.101325911412226 -0.036377238947018  0.195278206944873 -0.010131352705037  0.009611107176448 -0.056274461552982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020619978804339  0.055393926260198  0.016493468301721 -0.100372381621015  0.100626242248391  0.085758294302200
-    1  (  1) -0.158166323997468 -0.302157830906836 -0.003244540958724  0.141116982835093 -0.086717578223975 -0.004480871143071
-    2  (  2)  0.117237563107167 -0.174570847573252 -0.011204345589118 -0.263173432731339  0.005218532196608 -0.028842080195278
-    3  (  3)  0.116941646649193 -0.002586479599460 -0.011231548488137 -0.058984655279782 -0.019822661982992  0.041048882280086
-    4  (  4)  0.050776820640488 -0.220908341720040  0.039982596283608 -0.028513186801397  0.038501560477780 -0.072498198103576
-    5  (  5) -0.020348029264279  0.163764941111662 -0.082946711645309  0.111452654944127  0.037984566239170 -0.107199595569002
-    6  (  6)  0.021256126103386  0.388694787591368  0.114910007821023  0.018804713347355  0.008937619959603 -0.015873506672528
-    7  (  7)  0.297925323013454  0.033191669222593  0.094278199439532 -0.060174035263281  0.021406855727336  0.043089336483833
-    8  (  8)  1.538149876661768  0.255388094594368 -0.163312643003209 -0.034677585072596 -0.142125228818818 -0.045738087971649
-    9  (  9)  0.091443541252255 -0.031128123891514 -0.061982026707814 -0.058678185009605  0.760839955512426  0.950617857124013
-   10  ( 10) -0.067301877513064  0.211057800702034 -0.020603819563629  1.234407038988008 -0.163795705023159  0.167535211420885
-   11  ( 11)  0.163445976328784 -0.060082779666650  1.332811809287809  0.048638214648013 -0.084741484840295  0.093756111599773
-   12  ( 12)  0.205948682024817 -1.200679744036831 -0.135474810029670  0.365861100667199 -0.094093662797895  0.008686523394767
-   13  ( 13) -0.181605938452006 -0.042014918886112  0.112406427108237  0.222953862798683  0.995139187403184 -0.917632565321750
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802008727902655  0.406135528069519 -0.010476316013926  0.784475556802977 -0.394386683091322 -0.066798881058913 -0.011980564813183  0.124376056524346  0.033526134230598
-    1  ( 15)  0.862028914432838 -0.259382739909253 -0.086667305572571 -0.180064784220811  0.329908607377568  0.399964089565239  0.202187771096584  0.330121816685617 -0.071953120874633
-    2  ( 16)  0.271307809960517  1.724790149840174 -0.218446172710917  0.221581282093101  0.027552874986052 -0.019301351758235 -0.136156749402951  0.163711145289538 -0.262315292158509
-    3  ( 17)  0.233832160360253  0.228075923415992 -0.271855585596124 -0.127498943532143 -1.519236751765142 -0.714946933274599 -0.112783303905635  0.035742190545795 -0.131799331720450
-    4  ( 18) -0.125884857507906 -0.016503178327160 -0.848590316809834  0.528676059271022  0.118589942996707 -1.271521009940539 -0.481050683706143  0.489094666232740 -0.100427993377443
-    5  ( 19) -0.011410411929704  0.078504916539328 -0.635756927956291 -1.233330464680219  0.737249034134053  0.499445190730949  0.548364048058951  0.558640131286851  0.124411035854073
-    6  ( 20) -0.091600083261382 -0.011874324392682  0.166095509172920  0.503931355593027  0.132971166339089 -0.442847331045605  1.455101200236642 -0.028340512672194 -0.190421039545480
-    7  ( 21)  0.014506888035501  0.509793857361999  0.613540224928847 -0.716635769138310  0.088503909893924 -0.892421715175117 -0.105643577538643  0.572215069358707  0.150576387127192
-    8  ( 22) -0.004177720337601  0.006709815498338  0.117678875953444  0.003186946250536  0.038303116431661  0.593619431704902 -0.036920385902464  0.835672825510557 -0.345283877638120
-    9  ( 23) -0.021586239236069 -0.156869719857389  0.117889758366713  0.115161423657166  0.052238225817567 -0.022709102194002  0.020562459070758  0.298677779552414  1.538509512042494
-   10  ( 24)  0.054682068155330 -0.300070995804170 -0.172660016100405 -0.004680568559133 -0.221321821680689  0.163619483231767  0.386948477906821  0.033115261343779  0.254769962308421
-   11  ( 25)  0.016488293849114 -0.003235639473042 -0.011174682028047 -0.011243945686262  0.039809588242801 -0.082761513420814  0.114884412151995  0.094200391738432 -0.163393716854442
-   12  ( 26) -0.099231335638981  0.141112668735439 -0.262446613088938 -0.059563147663697 -0.028574452319685  0.111394864273783  0.018513759386770 -0.059760408126185 -0.034040397389902
-   13  ( 27)  0.100244162906019 -0.086825753516515  0.005142496829880 -0.019052879526344  0.037887085038908  0.037954868269094  0.008919579926842  0.021672382001814 -0.142649674386460
-   14  ( 28)  0.086046561377269 -0.004744302368675 -0.028249738219516  0.042030603060936 -0.073561648753544 -0.107720217983973 -0.016217142075139  0.044341471770558 -0.046187444393698
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124233708134536 -0.184518326175237 -0.014667753095384 -0.126540650902716 -0.015843433752182
-    1  ( 15)  0.686899770278225 -0.109692117003667  0.015377495137090 -0.096723489130418 -0.002397757787977
-    2  ( 16)  0.057205529179573  0.372042133273675  0.010210131259620  0.052160697899345 -0.088271643130934
-    3  ( 17)  0.131871345108646 -0.011180948360664 -0.005727193367078  0.259941586635767 -0.101614450210759
-    4  ( 18) -0.005079597151550  0.176830214271493 -0.031032942109530  0.004628941737735 -0.036366477592728
-    5  ( 19) -0.153488339566642 -0.188246645479895 -0.023332293508359  0.145173541284801  0.195552538719571
-    6  ( 20) -0.038666420291800 -0.018333798481472  0.128217423491274  0.116258211557260 -0.010271886085247
-    7  ( 21) -0.121961409061188  0.508144909444712 -0.039497933150400 -0.074911313979374  0.009738174256599
-    8  ( 22) -0.349752281191282 -0.113379050365462 -0.110884161439924  0.022227055299971 -0.056428042287591
-    9  ( 23)  0.091274387643065 -0.068482004342720  0.163392525285683  0.205701365643148 -0.181416453396970
-   10  ( 24) -0.031494844081003  0.210984913522447 -0.060264440706341 -1.201297108840478 -0.041823116964621
-   11  ( 25) -0.061998986866087 -0.020468588707388  1.332808723106093 -0.135556576828281  0.112406197562980
-   12  ( 26) -0.058487448548964  1.234274465594818  0.048631105388868  0.365854082845994  0.222962926250886
-   13  ( 27)  0.761200546740672 -0.163618812251394 -0.084738989433935 -0.094122389252816  0.995165590894080
-   14  ( 28)  0.951772998269778  0.167560207344595  0.093759874796882  0.008708619204364 -0.917569948681331
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062431637468595  0.002416441043494 -0.004633709181854 -0.077570764564634 -0.013832459901085  0.123710471759648 -0.027165779035151  0.071044010954103  0.019658423662051
-    1  (  1) -0.407170389584196  0.333069478291481  0.076649076907709  0.002175328366595  0.197922707135443  0.117656968282733 -0.067757706616656  0.182812175438110 -0.031734247883934
-    2  (  2)  0.673185035517385 -0.888138019247629  0.034358376579761  0.125358507387175  0.172994941404661 -0.106755581181951  0.013852200121288  0.009496870454373  0.036809619943014
-    3  (  3) -0.040742790622452  0.181389056204799 -0.117008669682236  0.012401302848616 -0.022196391591003  0.102862126461673  0.166049221641564 -0.310434511631988  0.017146561969833
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.010530607294135 -0.003710118206636  0.001098184033274 -0.004177259623773  0.010641720243897  0.020819711535909
-    1  (  1)  0.026376312845796 -0.003084063695379  0.001935075690028 -0.112197866496249  0.055637648529160  0.022260912302157
-    2  (  2)  0.054059905057592 -0.043789787513268 -0.004472231165839 -0.071437136436276 -0.024456749693059 -0.126350825107534
-    3  (  3)  0.083331116085326 -0.461426302980745 -0.028171699513189 -0.043194879139585  0.008942983333379  0.024389199674004
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.021216263100624  0.005003175055603  0.013535160841075 -0.263704651382093  0.210918804180330  0.005688291976374  0.005207710700417 -0.000895282201935  0.031550648985107
-    1  (  5) -0.080441383224428  0.123194069685474  0.057717422634392 -0.198323986141407 -0.141861353254421 -0.184709849630275 -0.056481718890527  0.088971412091793  0.030305733467359
-    2  (  6) -0.146541148918465  0.264369470289016  0.161465568338008 -0.083507608614829  0.171726934895341 -0.400382872983893 -0.201596935132327  0.184414767198991  0.015497227351109
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.010467742288235 -0.019463191825822  0.001308339278104 -0.016880359740534 -0.016885157913526
-    1  (  5) -0.009224792466207  0.019323723500933 -0.001197784436253 -0.171358632107000  0.032143333569086
-    2  (  6)  0.022721945593511 -0.245666385556985 -0.017093671892173  0.084713974597816  0.032963157176328
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521802 -0.064555152855138  0.195953381503071 -0.041248493404121 -0.011229686922121 -0.030149441468397 -0.052245051042500 -0.006640144591442 -0.060816046803627
-    1  (  1)  0.618380750339720 -0.527850820452490 -0.215416501468029 -0.157035437820935 -0.069798458053230  0.063297476854259 -0.224803808806348 -0.036770088857866 -0.093292414355442
-    2  (  2)  0.089963765220190  0.016694193855693 -0.049894217028098 -0.224500363636583  0.100545586935572 -0.339808932362447 -0.300486601784948  0.103978674940069  0.003854593986175
-    3  (  3) -0.017912540893907  0.240051544179785  0.016875920141055 -0.019658112757049  0.000950481978189  0.139486307895283 -0.307526295494266 -0.245045411721372  0.038982174459018
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151717 -0.053483299255778  0.001461399819935 -0.009996127160185  0.040844890766481
-    1  (  1)  0.010356156252342  0.045196494943179  0.123149462829327 -0.009608799091533 -0.092775098416550
-    2  (  2)  0.068261626755323 -0.266621644473694  0.090983468547791 -0.007824999539035 -0.015479677414575
-    3  (  3)  0.102991688131894  0.095940846129216  0.235195882789531  0.030438278876705  0.100331913639100
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065248  0.055002400477821 -0.190701615134341 -0.008587073557084 -0.137456634337712 -0.102685174742823 -0.038575707278161  0.049077773985898  0.038775520871497
-    1  (  5)  0.266426121061191  0.201904502527537 -0.404472747743473  0.112355452346505  0.244543383067869  0.203488255110531  0.093346083766348  0.046662175778569  0.162564534078649
-    2  (  6)  0.310200495971193  0.275860886663903 -0.334362481171662  0.111323203428083  0.107269573507973 -0.015396505983549 -0.485347827861583 -0.115211810541078 -0.189399381355351
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661082 -0.010182782856367  0.015536223735828  0.027148068637774  0.019304531582384 -0.012170541889263
-    1  (  5) -0.076359104752409  0.072719944885935 -0.105706045053714 -0.076791075572647 -0.095250630872885  0.044053081318688
-    2  (  6) -0.023401555368538 -0.060789750773995  0.233844071164901 -0.060200608258474 -0.022972229731696  0.078966373846356
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134464733238495 -0.662210405494713 -0.268087036060508 -0.078995101665649
-    1  (  1) -0.664136191142181 -0.208512216408356  0.147227682691113  0.068768195668241
-    2  (  2) -0.267178832853318  0.148347614169084  0.187155712816499  0.001725942570585
-    3  (  3) -0.077975712094611  0.066243031692256  0.004079617492317  0.013944312169831
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274618126592076 -0.278113702179189 -0.671633022270395
-    1  (  5) -0.277949145712571 -0.011863615919940 -0.010374435234634
-    2  (  6) -0.670048686168265 -0.009476206950290  0.097890068097066
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959494414290853 -0.408191876587357 -0.490587797784235  0.038620088951700 -0.077925870525924 -0.487449819239270 -0.107605742375904 -0.396082210854031 -0.237542456199032
-    1  (  1) -0.404346098969045 -1.325089706115921  0.174671472615893  0.248857938939690 -0.197997176299327 -0.317531715369544 -0.251443125493972 -0.030205216051466  0.632709778669897
-    2  (  2) -0.488203594414091  0.174177358170279  0.686637133275405  0.342440322127986 -0.009976595905960  0.483509687591532  0.287263685740954  0.302820486761602 -0.272146504988795
-    3  (  3)  0.037519851932805  0.250891430236009  0.345028453615613 -0.288802596502282  0.242048997261983 -0.302155533583706 -0.510767048111858  0.184742116191470 -0.216988138473832
-    4  (  4) -0.076335128439672 -0.199690457337231 -0.011287590259796  0.242287343472353 -0.131826185478683  0.385784652335332 -0.241579744319177 -0.375155233716578  0.062534851979726
-    5  (  5) -0.485786339572524 -0.319069045647698  0.484028655874806 -0.298894130368480  0.382592029688529 -0.557110750088133  0.333239304019173  0.111824333667390  0.019820080095694
-    6  (  6) -0.105004388042392 -0.251919494300239  0.289657780268581 -0.510934745583711 -0.243423593715530  0.333487274729372 -0.859815579894803 -0.040189411214503  0.015976724219764
-    7  (  7) -0.396742866204424 -0.028527583501407  0.303542401120419  0.181332247012507 -0.373287106593955  0.109028339876178 -0.042483577229034 -0.424450995877431 -0.165337209178978
-    8  (  8) -0.232477111217568  0.628541780993301 -0.273469783503725 -0.217890852518762  0.061988654737611  0.020919866007559  0.015643111904884 -0.165546891359504 -1.139952791754372
-    9  (  9)  0.005546163403788  0.056122031350974  0.162961042742049 -0.082482781173176  0.072908205250705 -0.108799436968506 -0.023533780380763  0.044777427042704 -0.147235448199817
-   10  ( 10) -0.006901975709221  0.054429650490003 -0.040577693872379  0.341755839709641 -0.179734725561057  0.323402736691831  0.128204737160643 -0.274641710567115 -0.052505646555499
-   11  ( 11)  0.095370531310646 -0.102133079874744  0.068438122875481 -0.163729824989548 -0.155636229704619  0.243225496644066 -0.456632637964553 -0.005300419866763 -0.049825612054653
-   12  ( 12) -0.031656876480322  0.049261490140927 -0.071615793822899  0.132066208561311 -0.108599421258561  0.096544859699583  0.079601642520208 -0.086582876221016 -0.054558080822567
-   13  ( 13) -0.055177843918678  0.125972146875380 -0.045925897173266 -0.019932953437884 -0.072414580136129 -0.032514397877208 -0.014074648780379 -0.073540469649060  0.566252900794764
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006844108037316 -0.007417708485432  0.096179215271910 -0.031845351907950 -0.055819107034893
-    1  (  1)  0.055009072408368  0.054764569974464 -0.101360748266653  0.049483066032708  0.126311659941364
-    2  (  2)  0.163126461717698 -0.041474056730500  0.069773970511476 -0.071604513134715 -0.045921679797628
-    3  (  3) -0.081145867550905  0.339512714763515 -0.164814632361134  0.131963409806745 -0.019701057447438
-    4  (  4)  0.071392957638912 -0.177541925322310 -0.155855587434795 -0.108549913772827 -0.072788709838572
-    5  (  5) -0.105620913909822  0.324570384536927  0.243426148668895  0.096676164465064 -0.032493241135614
-    6  (  6) -0.022622971576109  0.128555788054587 -0.457558865820421  0.079424640656331 -0.014304063550757
-    7  (  7)  0.043872369029022 -0.277428590499647 -0.005167508600307 -0.086808599804733 -0.073543295023506
-    8  (  8) -0.147656701585277 -0.051770671721882 -0.049464276722928 -0.054622357068254  0.565518286432935
-    9  (  9)  0.072058098581742  0.045414939179585  0.010276622684317  0.009607329011721  0.026546654266791
-   10  ( 10)  0.047972578248005 -0.139091273135494 -0.006969817312947 -0.101924439794115 -0.021963395913839
-   11  ( 11)  0.010225949518788 -0.006903254834441 -0.093461448932077 -0.006458623521929  0.037408632154760
-   12  ( 12)  0.009659072763447 -0.101989750292789 -0.006543886552567  0.055499957258902  0.004536647288290
-   13  ( 13)  0.026525022859865 -0.022073627181823  0.037503294944017  0.004573821056444 -0.064450805660396
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.531729549886298 -0.787699013260720 -0.218007437963128  0.182768764967664  0.602768885926166 -0.199812958118043  0.029032839745447 -0.008774056556998 -0.142478600997401
-    1  ( 15) -0.793340915328517 -0.320131124132658 -0.162653978535470  0.058649157291279  0.020639907683325 -0.223525268439384  0.107699068558594 -0.353783645623560 -0.095871343640248
-    2  ( 16) -0.212191388052984 -0.164888118017376 -1.296946785661574  0.042300146112888  0.273826728839772 -0.438781481182649 -0.122091204716307  0.097191959045013 -0.140871391153761
-    3  ( 17)  0.179719553134882  0.058669914491584  0.044506714025066  0.293003077614788  0.349110568675561  0.303215667162415  0.076915097449125  0.005807473711893  0.013837821466959
-    4  ( 18)  0.599360800493389  0.022132908209793  0.274035423937454  0.351223850237582  0.210864723099932  0.044675310303669 -0.438675626813712 -0.490920343842293 -0.399212333009898
-    5  ( 19) -0.200407898503595 -0.221431932840884 -0.440102897905219  0.305762109212930  0.044881546181386 -0.117472965844391 -0.191665223291112 -0.319783714572633 -0.359452162382383
-    6  ( 20)  0.032165821117663  0.105941691907443 -0.123879210125571  0.078979233990532 -0.440650088275931 -0.189889145121382 -1.110705925194965  0.246906737793529  0.255259757334091
-    7  ( 21) -0.008321241705301 -0.354528191467815  0.096628486245053  0.006334262611059 -0.491255100347711 -0.318969662674625  0.247541587785850 -1.005004062277651  0.329386657154236
-    8  ( 22) -0.142962699223549 -0.097023037413528 -0.141097052846351  0.015166149438974 -0.401326717044885 -0.359426368361956  0.255258622579679  0.329097335449224  0.052132117322127
-    9  ( 23) -0.219955098740470 -0.249965476004888  0.576414624728282  0.098982863369388 -0.020508824733516  0.097549190747056 -0.059941456738217  0.014715712854346  0.155030958604429
-   10  ( 24) -0.078889746445523  0.108239301318901  0.027162587747041  0.046514963820434  0.091370815063922  0.113422647703502 -0.170202961400924  0.302110584863860 -0.032804637243887
-   11  ( 25)  0.043306270957027  0.032344455295716 -0.179576712827774  0.107307667430455 -0.187560546689596 -0.097222488608903 -0.510712264729794 -0.080025590477581  0.081254866792350
-   12  ( 26) -0.068084805818490  0.217394768160197  0.162482224135859  0.182198793902305 -0.078588038008549 -0.138375144701551  0.045964808967526 -0.318369645237611 -0.094340949188752
-   13  ( 27)  0.012776338365641 -0.163304628586287  0.065170181095058  0.076353862354929 -0.116471236774223 -0.057100568669610  0.002733328139540  0.275543901650406 -0.101218272889531
-   14  ( 28)  0.072542900570950  0.116082117753812 -0.039461901860534 -0.060056679393757 -0.063442716501334 -0.039954821491188 -0.007431183194756  0.061660754619171  0.127196734189506
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223424944652175 -0.079375640508209  0.044559638332806 -0.069603179695813  0.011608492724559  0.073681298891794
-    1  ( 15) -0.252190810534109  0.107773105664069  0.031929727381883  0.217773765514458 -0.162942254516907  0.115583488493230
-    2  ( 16)  0.579669499848572  0.028398284174960 -0.180764151357438  0.163082238678493  0.065318137383570 -0.039861277950844
-    3  ( 17)  0.098419070380212  0.045497640187139  0.108888066901844  0.182679251676257  0.077063420292881 -0.060270475148200
-    4  ( 18) -0.021657152218140  0.091391477818874 -0.188694941835346 -0.078654463993081 -0.116917635244861 -0.063687461311382
-    5  ( 19)  0.097200061293784  0.112946819841968 -0.096557046310004 -0.138722208764674 -0.057492822647748 -0.039657945432933
-    6  ( 20) -0.058061983715355 -0.170140847494679 -0.511516651549454  0.046153385708922  0.002608094185221 -0.007424017797985
-    7  ( 21)  0.014898598107636  0.302204656416843 -0.080604696411276 -0.318409184220291  0.275439068186170  0.061680442175982
-    8  ( 22)  0.155158381420859 -0.033182129585361  0.080993013335593 -0.094077880752320 -0.101045740908378  0.127069446713633
-    9  ( 23) -1.153500606432346 -0.223848574870748  0.084940142762255 -0.000172697505726  0.401118128913118 -0.346039941954413
-   10  ( 24) -0.224004522828874 -0.014993374950352 -0.013190820033296  0.067266852084063 -0.009898419000703 -0.084301934906622
-   11  ( 25)  0.084246516406413 -0.012971453666467 -0.099638608783543  0.005049425073667 -0.012239639402272  0.023058100761842
-   12  ( 26)  0.000190360752639  0.067412521796062  0.005072007098540  0.014663156532778 -0.012615786454218 -0.021995005158486
-   13  ( 27)  0.401506800485801 -0.009668467136188 -0.012313296328671 -0.012645382168417 -0.008180220628733  0.091135079144531
-   14  ( 28) -0.346436667192436 -0.084407881559669  0.023159285170777 -0.022057721310468  0.091092458906097  0.040126683454997
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057778460125475 -0.058621598376446  0.204961973610432 -0.030014886957110 -0.012702201238060 -0.012361806840330 -0.042464722570104  0.000589178332867 -0.053783176425629
-    1  (  1)  0.588150716074137 -0.466021636272279 -0.203183245475023 -0.148450737716195 -0.057365952908272  0.049828198627789 -0.211650340717459 -0.033709163320874 -0.066014023276537
-    2  (  2)  0.097096715428347  0.013316869335681 -0.075592001791495 -0.184144455632612  0.076454331448179 -0.322693901417475 -0.283033300411638  0.095787940086230  0.009135557725685
-    3  (  3) -0.012585457310361  0.213693355283451  0.008392879074051 -0.006477176275207  0.025095812734804  0.122050564721351 -0.287478867298026 -0.227752050770288  0.025535574433447
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004343658462411 -0.045416781087739  0.000353809954909 -0.008814420994644  0.038608153091639
-    1  (  1)  0.012371345270913  0.037357699916558  0.110010051271466 -0.008428651261314 -0.087698412018737
-    2  (  2)  0.059734573261687 -0.241104936943560  0.080654968743397 -0.004302203609171 -0.010690545484549
-    3  (  3)  0.093269555935928  0.087251850932645  0.210582632378020  0.029543407964615  0.092601662289167
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.096268685878252  0.067598109905929 -0.171831816211843 -0.019892225326929 -0.151432830345500 -0.102828613678797 -0.031328453208209  0.054857782228203  0.045391983457330
-    1  (  5)  0.259548823811749  0.185158249821502 -0.361847535039713  0.121706180799369  0.214912924418826  0.198674927692087  0.082249065771639  0.046754216202725  0.144894234011997
-    2  (  6)  0.316675644828390  0.241534850892177 -0.298024592816788  0.095120602156143  0.117908244615295 -0.011781114685658 -0.451417780640774 -0.113394265201560 -0.193663841427194
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.075217766018102 -0.009009066779015  0.013059078733354  0.023267742031503  0.019382631456237 -0.010439549922317
-    1  (  5) -0.055615787731083  0.073750137089776 -0.094740835467127 -0.066906556461946 -0.087569521638086  0.039832146294914
-    2  (  6) -0.007989421944926 -0.055545532554458  0.206332460425461 -0.056516118698094 -0.025725290779719  0.073743491663518
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016118777276715  0.076689387067910 -0.125264792267213  0.007931013310159 -0.098301937535619 -0.089040062536403 -0.042653189503990  0.143650549015434  0.062698356849217
-    1  (  1) -0.038523460792185  0.325926212074866 -0.217436403108304  0.076210929079487  0.124956744969463  0.049869905306287 -0.256022567536771  0.049219148025203 -0.025163660677627
-    2  (  2) -0.015460259327543  0.182364499530151 -0.081021447104334  0.065186772706427  0.193628085224658  0.090709199284724 -0.144227288852916  0.007154481293509 -0.060483347873691
-    3  (  3) -0.069494321441897 -0.016013992178315  0.169506236224075 -0.050547669997934 -0.177140340538951 -0.181255025833236 -0.201077665225237 -0.109139777586652 -0.215083611892000
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159361864611552 -0.056476108299593  0.034334354535920 -0.068420323850568  0.100698715800717 -0.049820592017766
-    1  (  1) -0.121041364374108 -0.003994619377140  0.190684428167186  0.052070114913538 -0.189028662705267  0.205096915582724
-    2  (  2)  0.013836799939815 -0.073875918803128  0.147901928532515 -0.343158528114240  0.053056478393310  0.086736758175874
-    3  (  3)  0.065392768372813 -0.072388535495375  0.365788807268936  0.156911353062530  0.184439406967998 -0.043117455907282
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095080611028905 -0.132974666952795  0.233475927910152 -0.109077700761869 -0.033619328181748 -0.003336619392392 -0.079318686273400 -0.006541773193153 -0.188514066103895
-    1  (  5)  0.133180554197729 -0.220459497770333 -0.122961007604827 -0.144493780528925  0.034530325126889 -0.144382538755407  0.001565508478549  0.179104189145759 -0.084352671049965
-    2  (  6)  0.305369897772518 -0.245966510909105 -0.171589985467989 -0.288954965589194  0.048536799653817 -0.105233271021575 -0.400024803684146 -0.035818012706229 -0.066124321501166
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011358647742861  0.047842821118306  0.011877525445924 -0.012099889406653  0.055702357687979
-    1  (  5) -0.060987538430202 -0.100437160073965 -0.174976176295347 -0.033059202656664 -0.296249624542357
-    2  (  6)  0.156959926194252 -0.053853503787377  0.406665675932450 -0.026462885456155 -0.143060389345544
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.020933994600404 -0.036837370041378 -0.105536213576208
-    1  (  1)  0.298453027380235 -0.115575201783041 -0.255528599615218
-    2  (  2)  0.258793135913458  0.115959940555419  0.442826057795212
-    3  (  3)  0.060024736570876 -0.030098554189578 -0.068752806226696
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019369167440735 -0.299662599013862 -0.261538199445479 -0.060711849430245
-    1  (  5)  0.036904684367183  0.115259605353543 -0.117033018013316  0.032657591929024
-    2  (  6)  0.104769015611943  0.252811001882389 -0.444270078409885  0.069751899589238
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.140264901989732  0.063903836208700 -0.058837720478344  0.099834492513857 -0.059321359064218 -0.159667027697165  0.002087278187167 -0.046204224826828  0.008601023391647
-    1  (  1)  0.090548490120087  0.202601353512529 -0.092021876157049 -0.096539072051997  0.170154281529252  0.083912296322820 -0.509059273187923  0.818772979644953 -0.070828284365805
-    2  (  2) -0.023785290834458  0.356113587695708 -0.273990976839604  0.279080899835211  0.352444630227632 -0.196438091918237 -0.305379232907223  0.066497365309668 -0.201285694555594
-    3  (  3) -0.097000901586888 -0.245927544981666  0.317839114090146 -0.024062116307417  0.214330573426636  0.049574376579035  0.029033713280438  0.054130019251473  0.003096872422278
-    4  (  4)  0.057665969694961  0.180120952217587 -0.233587576454962 -0.044983378670516 -0.207784279042753 -0.114395252588009 -0.123426849025615  0.227078923197653  0.055512731053909
-    5  (  5)  0.215771286107030 -0.314990234779502  0.316883540178318 -0.120867850220805 -0.280144439746019 -0.294187393366266  0.216440287801519  0.200727103538257  0.064432166939554
-    6  (  6)  0.088234371667171 -0.148935506374392  0.366935246390879 -0.011963781822295 -0.214228897418453 -0.110020140834752  0.192637863546305  0.231329350431209 -0.059800681126421
-    7  (  7)  0.046850408793983  0.280155317167401 -0.370918303757555  0.110906122388311 -0.088736250126060  0.146624611249243  0.021132431838010 -0.399622620248811 -0.041122390922456
-    8  (  8)  0.213219122375794  0.108141657808899 -0.632333203738685 -0.072815736912286 -0.035034243651182 -0.162896842787145  0.072787072592861 -0.219123938652931  0.041084573562014
-    9  (  9) -0.053156461400879  0.091068663315954  0.087565530354220 -0.029252405162121  0.135958664144570 -0.072618412616171 -0.001674517036246 -0.447580570679357 -0.046048420321108
-   10  ( 10)  0.217389369502910 -0.434955320268301 -0.409591028918214 -0.322091930890674 -0.032769693001577  0.320487371417213 -0.022524010208258  0.286088771348243  0.028739508255579
-   11  ( 11) -0.043655408036926 -0.078795431314352  0.262179238045961 -0.331516326718921  0.435766491267148  0.063689969335714  0.247099037158840 -0.001834914627209 -0.140224560742040
-   12  ( 12)  0.056091676196034 -0.010888223476595 -0.132073582410596 -0.097444459311643 -0.064913316132981  0.000177701715019 -0.216786241209525  0.136744724942226 -0.129238968566772
-   13  ( 13)  0.037502956248588  0.225853404732460 -0.091597810906137 -0.251988574100658 -0.015208060782076 -0.284415044485819  0.108318027167759 -0.003844624714698  0.367465648248436
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222316043515173 -0.015706219813460  0.082385006687320  0.001598515176512 -0.060473243217402  0.093727480766952
-    1  (  1)  0.559608456549850 -0.123427525882115 -0.153467678522284  0.170334032667751  0.080737466652215 -0.083738891751807
-    2  (  2) -0.169476216588385 -0.033571289044860  0.409164888922149 -0.223598543173697 -0.075034173166616  0.314714537560889
-    3  (  3) -0.116710909315575 -0.019725573527882 -0.283423547853871  0.175125619030608 -0.285157403250322 -0.036616525847335
-    4  (  4)  0.005652624292121 -0.042302085019166 -0.326173261129808 -0.429217689688999 -0.082297928451369  0.119033467524274
-    5  (  5) -0.013435701805306 -0.050340607661298  0.120543829175976  0.018862712789954 -0.153571720838557 -0.076183620287339
-    6  (  6) -0.081289708009932 -0.326406046335021 -0.215268699384055 -0.111421444457992 -0.019027619773786 -0.098888316320541
-    7  (  7)  0.155159820795190  0.099172439421084 -0.073800976886365  0.027692155232139 -0.092694133839456  0.234604646553257
-    8  (  8) -0.037085102415794  0.221081896212581  0.033634728216760 -0.500286732444230  0.749342092540231 -0.380702305205380
-    9  (  9) -0.121604531068668  0.307665948271803  0.063134933207098  0.759313712683884 -0.291120411772461  0.157024245706380
-   10  ( 10)  0.436899181077493  0.180584483336554 -0.427706818265058  0.039319556166566 -0.042977724169066 -0.570262735340494
-   11  ( 11)  0.012744975594815  0.355849153273434  0.014473345977435  0.331011762918559 -0.082407538752018 -0.048301595441145
-   12  ( 12)  0.275248111407273 -0.041018113706040  0.197136817157691  0.114052207324942  0.270934107062801 -0.185007344485080
-   13  ( 13) -0.588095271872920  0.141945816656553  0.099720177389789 -0.418487800295605  0.225864709971283  0.209383142865023
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.136055292355693 -0.095447390079340  0.020092912976452  0.093125301806219 -0.056850399225392 -0.218468169087239 -0.091857234706676 -0.045161486852249 -0.214714486134321
-    1  ( 15) -0.061207776400224 -0.202708633629211 -0.353114471022979  0.245649376419565 -0.180866138364034  0.315320438007598  0.149515492263340 -0.279091224397284 -0.106858935875563
-    2  ( 16)  0.054684214245539  0.094025065222640  0.275943577798546 -0.316343751367895  0.233336305598380 -0.315879985031598 -0.365377908227180  0.369960150477096  0.630562926717977
-    3  ( 17) -0.098691998169988  0.096665834479676 -0.277640044986388  0.024005765248079  0.044522040617490  0.121507599386095  0.010509659584542 -0.111862233831084  0.073060388343816
-    4  ( 18)  0.060773979545201 -0.171895263117941 -0.351151470699367 -0.213576840796575  0.206989754617357  0.279451579746598  0.215385933896301  0.091082110140082  0.034953691198195
-    5  ( 19)  0.161690364133666 -0.086139117701369  0.195608563911810 -0.050196750893508  0.114409300434323  0.293302924591653  0.108870291715961 -0.145705855705827  0.162864209989065
-    6  ( 20) -0.004933077734461  0.509112916459715  0.304189657786525 -0.027011307788378  0.123564513171824 -0.216326146660944 -0.190918994832455 -0.021599458243760 -0.073921971953628
-    7  ( 21)  0.046939300208709 -0.818898745115211 -0.067231269443295 -0.053385434393248 -0.227366778650250 -0.200959323300586 -0.230355491785330  0.400408400878989  0.219890208910709
-    8  ( 22) -0.008875208231344  0.070617448884265  0.201028236092715 -0.001986037102750 -0.055524570746332 -0.064229773357344  0.060955407810699  0.040899342701140 -0.040928237624152
-    9  ( 23)  0.222811666664930 -0.561652381203109  0.169673185845526  0.114995614482537 -0.005558626156127  0.012604855943775  0.079125943676941 -0.154935461007958  0.034774271928076
-   10  ( 24)  0.015658264689237  0.122684274627566  0.033049817652516  0.019053422527839  0.043070830779656  0.050152205966237  0.326697513368317 -0.099443390036459 -0.221198097566915
-   11  ( 25) -0.081038041563999  0.154593341750092 -0.407140318931982  0.281943720612544  0.325675147388131 -0.120351655341255  0.214124337140213  0.074325284613066 -0.033051994607945
-   12  ( 26) -0.003149016432983 -0.169066126704265  0.222974141740581 -0.178167341127558  0.432229982121915 -0.017874255780535  0.111773550217181 -0.031100511775812  0.501206663109520
-   13  ( 27)  0.059358328554799 -0.079903052840446  0.074950199177116  0.286331686497637  0.080924619758545  0.153353900448026  0.018409365441232  0.093462744168473 -0.750750124348698
-   14  ( 28) -0.091958135023802  0.083203421400514 -0.314158605792337  0.035767063530586 -0.118730598661029  0.076122730197956  0.098773188363513 -0.234233392684125  0.381969165301650
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054160915945440 -0.219019011349658  0.045758113327127 -0.056667077142781 -0.042241899582407
-    1  ( 15) -0.090944710506667  0.435278295065980  0.077842273581985  0.010976755804927 -0.224792334219628
-    2  ( 16) -0.088739489380727  0.410297160213689 -0.264172456920594  0.132125091344117  0.093086518366925
-    3  ( 17)  0.030526782846308  0.322820843845164  0.334117022964236  0.097597092001360  0.253965732413055
-    4  ( 18) -0.135352462834400  0.032599183228255 -0.437639446213156  0.064872058901777  0.014497262646719
-    5  ( 19)  0.073899654730442 -0.320885730724610 -0.062344415655754 -0.000276840662850  0.283336476795450
-    6  ( 20)  0.001158784637988  0.022837257389255 -0.248024269025133  0.216907823965295 -0.108098145849829
-    7  ( 21)  0.447481917087611 -0.286161905602590  0.000998969948768 -0.136653733410721  0.003506425728694
-    8  ( 22)  0.045854947627220 -0.028382633755552  0.139989494186330  0.129405417600154 -0.366820033409182
-    9  ( 23)  0.122256207458041 -0.437180402944026 -0.011581755997582 -0.275567866951767  0.586898649032620
-   10  ( 24) -0.308323852677721 -0.180850894824869 -0.356131896237584  0.040945642422104 -0.142574344254184
-   11  ( 25) -0.063098776158328  0.427549053292047 -0.014802143274616 -0.197270506582796 -0.099635293972022
-   12  ( 26) -0.762581095039490 -0.039734172920445 -0.331033022441221 -0.114161465508855  0.418490755826759
-   13  ( 27)  0.291938944356913  0.043222558646275  0.082214356128437 -0.270960148007918 -0.225910263769365
-   14  ( 28) -0.156871086239257  0.569997035340436  0.048467653901954  0.184994394399617 -0.209531521675460
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.009005560415620 -0.070810523176753  0.120067832596330 -0.009073132789057  0.090464498751423  0.086174111119354  0.045794981404383 -0.145874969594551 -0.061668751575064
-    1  (  1)  0.049157751161976 -0.341837336007353  0.225991322214198 -0.079794887273987 -0.129000775913212 -0.051890082528198  0.264098306233452 -0.041882987798608  0.014437873768995
-    2  (  2)  0.004178475304275 -0.176534362212284  0.088484784587547 -0.060893560844785 -0.188770646517540 -0.098157508320685  0.154422738208026 -0.028159762307564  0.056745595914708
-    3  (  3)  0.078632631263391  0.018162490565869 -0.185802179760109  0.047918543127734  0.190222116766280  0.186537019008367  0.211456806958070  0.116264562677776  0.222361952728882
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163744366705646  0.058513889685968 -0.036529339633760  0.074890516703321 -0.101980211526271  0.048987870817682
-    1  (  1)  0.129678391589477  0.003465728257171 -0.197451754644996 -0.065935565415812  0.202740138649240 -0.212710296862521
-    2  (  2) -0.022460564343485  0.084272909470111 -0.151124340943592  0.372643880141893 -0.063147940573273 -0.083681000851943
-    3  (  3) -0.069418152872000  0.077040623108210 -0.377203303892585 -0.165559399244429 -0.189357768189066  0.044737808867399
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.085668830826552  0.137820799821428 -0.214610467959109  0.105542261331575  0.036859097160699  0.000473863191187  0.079606876493940  0.008613359831911  0.198755661758927
-    1  (  5) -0.139412038667804  0.235636886292823  0.125284829879163  0.147970518740863 -0.038362154224395  0.146537444592945 -0.006121389458985 -0.189794595760356  0.090516747843842
-    2  (  6) -0.309048143972667  0.258748687397478  0.168238503241577  0.304764034594830 -0.050456064213686  0.094565768675462  0.416604423570797  0.027331415693002  0.066446598559594
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.012674523904089 -0.052192101234841 -0.013753920669736  0.012760663896321 -0.052741920591878
-    1  (  5)  0.065601509403618  0.098250162685785  0.177768481553462  0.033008693934464  0.305584708162473
-    2  (  6) -0.160962535198804  0.052046626684912 -0.419200543530856  0.024457493928167  0.150587999794571
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002292052292103 -0.001327689025616 -0.000248352651822 -0.007958119616401 -0.006332326100069 -0.018602233716078 -0.068879285117605 -0.007819744108382  0.006538352080531
-    1  (  1) -0.002764164951484  0.002219747844781 -0.018293151832048  0.029668233290910 -0.039848292773073 -0.022489745012597 -0.162281988584096 -0.020804504235237  0.019083175045335
-    2  (  2)  0.011217835122942  0.011598249376099 -0.016968466001430  0.008250037510454  0.006232273271199  0.008766677291355  0.010338243291251  0.010725726663582  0.004470553150490
-    3  (  3)  0.050562851864422  0.047527304873166 -0.078707468856861  0.000484758494314  0.025585059000149  0.011993586441405  0.049963781283820 -0.008029454242805  0.026864587292976
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006805334012410  0.003000362320124  0.002228041038774  0.000013471324712  0.003129940535122 -0.001748281527537
-    1  (  1) -0.013913717596781 -0.013715090430948 -0.022806809849797 -0.002206415430012 -0.006824605289547  0.005086150284378
-    2  (  2) -0.011033408042674  0.021897939524419 -0.000684908130867 -0.006441462755861 -0.002207402072499 -0.000019160522387
-    3  (  3) -0.030996252825103 -0.007986449014412  0.024562077320802 -0.006200249162121 -0.010690383251548 -0.011486173135262
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.008068643711801 -0.010525757489218 -0.001816581937116 -0.014852647204910 -0.016446444650493  0.051123908211814 -0.105303074579265 -0.010186396385182 -0.002604742010165
-    1  (  5) -0.024807027264740  0.041872241876177  0.005357408083722 -0.028564486604489 -0.031353252400093  0.040716482303670 -0.082357809569052 -0.022204595749263  0.028676826310240
-    2  (  6)  0.057433465116021 -0.072910653400311 -0.007950207598684 -0.045866077252401 -0.051478467074881  0.066399959025161 -0.120267838044196  0.002980749702428 -0.024762093508968
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000934050050601  0.000604010149742 -0.003646663045597  0.000033137801782  0.002019175758164
-    1  (  5)  0.015497094356084  0.002871076746167 -0.025548488367170 -0.001995117147543 -0.006447008967147
-    2  (  6) -0.009288606849912 -0.006735078994323 -0.016930923349151 -0.006239987724853 -0.010309885333920
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.002224796248932  0.043809288397668 -0.042786645812817
-    1  (  1)  0.035961652529642  0.375558249507307 -0.229138680808401
-    2  (  2)  0.031482392637318  0.208906969570392 -0.045224347296993
-    3  (  3)  0.099946950247302  0.215409785029960  0.414532197880426
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.002181806445193 -0.035979573047749 -0.031640926892770 -0.100238553322265
-    1  (  5) -0.043671265862196 -0.375015508928976 -0.208917842140980 -0.216574490738358
-    2  (  6)  0.042527296867704  0.228253198541364  0.044456455969980 -0.415218734433247
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.071571831474078  0.044653489385004  0.010701302384521 -0.107261739958166  0.107631207507480  0.021982609216158  0.087555139416088 -0.002428271330290  0.013116395341898
-    1  (  1)  0.000994163831951 -0.002283385696650  0.009683189881167  0.069987093364656 -0.211165412824247 -0.144806549288858 -0.839471629333561 -0.082797629633042  0.083995255816987
-    2  (  2)  0.048029450774152  0.034159151942753  0.005345969743377 -0.362094457083752  0.166955343421217 -0.200138180389859 -0.200325175150546 -0.048097856321736  0.015226624624379
-    3  (  3) -0.099901242333760 -0.066741882163174  0.192006761021434  0.037162207196608  0.149491220617197  0.091957380518235 -0.124661875998661 -0.114474410410770 -0.084751404274498
-    4  (  4) -0.098292057994740 -0.060260709677490  0.234095836344240  0.042527139722405  0.172693635464862  0.110397071373739 -0.184879337331564 -0.074537123570685 -0.084735776692236
-    5  (  5)  0.074314676568805  0.053240577551284 -0.354242764435207  0.039009834260932  0.144962419013306  0.061650919712871 -0.045188344047270 -0.085035282721814  0.173092563485556
-    6  (  6) -0.068641550367955 -0.078242424055456  0.700330832585814 -0.207548816757698 -0.389421892794422 -0.222244858530312  0.109406330044358  0.045457397940437 -0.343867539807075
-    7  (  7)  0.021723320720404  0.016351205203476  0.098413699787287  0.004057278627194  0.006939091834835  0.079051971654245  0.378143817290533  0.122761983444910 -0.057845298080872
-    8  (  8)  0.009573032166809  0.006109372122326 -0.063933429430759  0.085659891507819 -0.069748375065097  0.032412606198411  0.211702458249100  0.046995111806491 -0.044380498011898
-    9  (  9) -0.004993361863043 -0.003634014150995 -0.021315829704565  0.021713795540591 -0.030056681969938 -0.023359631271158 -0.128991093821754 -0.016400014214086 -0.007638043352367
-   10  ( 10)  0.003364468158750  0.005158901374854  0.010157814233361  0.013146135283286 -0.036788603301889 -0.001796925979298 -0.031087735489025 -0.158319551738170 -0.001398916399977
-   11  ( 11) -0.005212014578832 -0.005572219785769  0.129300362837609 -0.009016877484905  0.009416239426444  0.064438058134478  0.026488687258820 -0.021963612194050  0.285489003307810
-   12  ( 12)  0.022889675001499 -0.014028568601137 -0.005258310077958 -0.012614598275049  0.011181538654879  0.041924328606934 -0.003053461905651  0.141650155501189 -0.005090787707422
-   13  ( 13)  0.006246133552104  0.010356570946206  0.013049157750693 -0.012424981952374 -0.009162366348548 -0.014458376447183 -0.062634797746530 -0.024809108873570  0.013232375979099
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.002828230885259 -0.008462795614423  0.005154038879344  0.009706144885118 -0.000351690712204 -0.003016908410820
-    1  (  1) -0.016542909802003 -0.036808232009347 -0.132827410709676  0.012545312927289  0.013603497625073 -0.014243226256359
-    2  (  2) -0.056531888264110  0.026681841564715  0.044472892095955 -0.008316762319552 -0.009818160226072  0.003132505638469
-    3  (  3)  0.065664012413420 -0.084000307061434  0.024123678461565 -0.011516052481207  0.005295212539449  0.009770444853693
-    4  (  4)  0.036042306167929  0.066196882580851 -0.035814283991967  0.000422354014022  0.007346814292352  0.010225200735509
-    5  (  5)  0.148907428019867 -0.109320100217019 -0.041270431698870 -0.008286052492371  0.000171545458770  0.012799874602526
-    6  (  6) -0.267740896585426 -0.203497348994007  0.004880757246495 -0.039144439238699  0.017848850593927 -0.043282221917129
-    7  (  7) -0.072391125356364  0.141340064883945 -0.132216664302783  0.021712276497558 -0.014580212743961  0.003413596406028
-    8  (  8)  0.065338926975322  0.070417584641905  0.663636576046729  0.043614890913083  0.008447529962600 -0.017635456067550
-    9  (  9)  0.053338372051572  0.015608392811416  0.295869564541767  0.007118975871925  0.021727777212874 -0.010944181246410
-   10  ( 10)  0.043778421907192 -0.395589362339912  0.177341233202869  0.145584179195568 -0.046786531122239  0.019085441444645
-   11  ( 11) -0.612579899217924 -0.015866362451336  0.053555820669477 -0.384133045755224 -0.648991284315058  0.223359237845080
-   12  ( 12)  0.089924264835293 -0.149474889068186  0.147998013353447 -0.410950037016040  0.122612685939173 -0.053519931502489
-   13  ( 13) -0.016968386753168 -0.001120736716635  0.667558162177878  0.016648983669680 -0.049072172914969  0.011592992748874
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.071349801352714 -0.001077758689270 -0.047849010758326  0.099049708991045  0.097373218549676 -0.073249702217693  0.066497399663864 -0.021905924000240 -0.009611371244577
-    1  ( 15) -0.044780949738342  0.002559008927919 -0.033951661393688  0.066729312295417  0.060308115101389 -0.053229541901532  0.078046690958424 -0.016360376267857 -0.006154062585818
-    2  ( 16) -0.011020054803348 -0.009639577990268 -0.005659342412167 -0.191466387657639 -0.233770018397514  0.353943104953864 -0.699652203951292 -0.098429630868855  0.064028996133411
-    3  ( 17)  0.107854789786829 -0.070585793426064  0.362141920362757 -0.037292065848127 -0.042427554280204 -0.038929544624314  0.207453249613870 -0.003913287572517 -0.085781111935039
-    4  ( 18) -0.108209449998589  0.211629628691260 -0.166874900133538 -0.149325288082853 -0.172890816462261 -0.144890994778007  0.389082003854745 -0.007000687821959  0.069612637937369
-    5  ( 19) -0.022019034844530  0.144617634612034  0.200192966932155 -0.092059326306506 -0.110737371319811 -0.061364605633156  0.221637061620796 -0.079021140430879 -0.032667339771983
-    6  ( 20) -0.089130158761340  0.839805360702565  0.200387491136600  0.125541335494667  0.184496760040884  0.044995250241868 -0.109402692051630 -0.378035804168224 -0.212908503907275
-    7  ( 21)  0.002178057091036  0.082925436926419  0.048118216149304  0.114730021254923  0.074453346277450  0.084891108935456 -0.045281773316414 -0.122667104662944 -0.047081579488124
-    8  ( 22) -0.013014867453698 -0.083878416356731 -0.015105645463008  0.084649544925904  0.084843093804877 -0.173122296622746  0.343876299664282  0.057834963947671  0.044464266623977
-    9  ( 23)  0.002901775226447  0.016234828173147  0.056359654971911 -0.065872157385184 -0.036362021680569 -0.148332139389866  0.266718078511433  0.072258279284240 -0.065401012908072
-   10  ( 24)  0.008445720197208  0.036804429594076 -0.026642166859464  0.084168947416296 -0.066510758074240  0.109381013548543  0.203196264302595 -0.141165925569768 -0.070499221179176
-   11  ( 25) -0.005377792056995  0.132971363586077 -0.044450134013510 -0.024046237867949  0.035750577264431  0.041236558408713 -0.004898258174407  0.132214673314304 -0.663804812343683
-   12  ( 26) -0.009728994170677 -0.012565610031588  0.008265487183253  0.011507462056025 -0.000390885497569  0.008310505974528  0.039141081466535 -0.021755546401078 -0.043610775840933
-   13  ( 27)  0.000301420723240 -0.013603051175605  0.009758944837902 -0.005201669668069 -0.007344582365292 -0.000240423767516 -0.017707548228131  0.014600989921611 -0.008461166379486
-   14  ( 28)  0.003079753925572  0.014179269497254 -0.003153288832510 -0.009783782056838 -0.010222304053932 -0.012792812982895  0.043303231879505 -0.003407229733486  0.017679792666433
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.005093584579739 -0.003397430557442  0.004751145314811 -0.022993999775599 -0.006406607432759
-    1  ( 15)  0.003664268681973 -0.005140681437481  0.005623137023323  0.014031183819186 -0.010293722738861
-    2  ( 16)  0.021380720709283 -0.010101149193742 -0.129156907046771  0.005327658954335 -0.012995314092573
-    3  ( 17) -0.021888212102979 -0.013219387248743  0.009147784998755  0.012607741489428  0.012451560776458
-    4  ( 18)  0.030283770762202  0.036869387279966 -0.009496744772099 -0.011181780485761  0.009182409552405
-    5  ( 19)  0.023453672116025  0.001799424920848 -0.064551617042567 -0.041960641260944  0.014420118956797
-    6  ( 20)  0.129458546494568  0.031271046054797 -0.026491102279080  0.003035012140173  0.062712336606301
-    7  ( 21)  0.016591446747124  0.158366047016833  0.021959782838746 -0.141640631249085  0.024819174074491
-    8  ( 22)  0.007575701587639  0.001384112156404 -0.285443557719673  0.005092627774539 -0.013202606990523
-    9  ( 23) -0.053335089301781 -0.043785415746453  0.612428033952452 -0.089945127333784  0.016908784258582
-   10  ( 24) -0.015338693676901  0.395633576722136  0.015809806174567  0.149475505805733  0.001108572795382
-   11  ( 25) -0.295832367201873 -0.177313650229223 -0.053561286295896 -0.148004020967956 -0.667548449265010
-   12  ( 26) -0.007157154416058 -0.145586590425994  0.384132810583031  0.410951719442907 -0.016651787670946
-   13  ( 27) -0.021701996830356  0.046797876195804  0.648997652718972 -0.122606232077452  0.049068049852610
-   14  ( 28)  0.010942221777250 -0.019093183683670 -0.223365949415048  0.053520759465633 -0.011602247780488
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002779955261603  0.001692895942305 -0.000296900585249  0.009027308047397  0.005517424530412  0.019392785745096  0.071615718156204  0.008379623734860 -0.006552142468187
-    1  (  1)  0.002104549417692 -0.002248748312386  0.016268779471160 -0.026298614529289  0.037020427510003  0.022919155336995  0.164160248243373  0.021028638082435 -0.018807600972838
-    2  (  2) -0.012197014321068 -0.010749741004112  0.015969423342584 -0.008379419120709 -0.005700661608129 -0.009182078264487 -0.007072493012826 -0.010651845449984 -0.003884546255784
-    3  (  3) -0.055916626202382 -0.044952545452401  0.075693796863108 -0.001117242062951 -0.024281174456382 -0.014619597544438 -0.053283290640730  0.007703747637899 -0.022436578410201
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006982563138735 -0.003194903879745 -0.002336222897234  0.000159319304137 -0.003153288870770  0.001705858583767
-    1  (  1)  0.013922175981332  0.014264739151757  0.027533427644979  0.002422850658312  0.006842699761048 -0.005360945695368
-    2  (  2)  0.010224586423111 -0.021331787446370  0.001728789794737  0.007349416930946  0.001927444504520  0.000065986060579
-    3  (  3)  0.028649073776620  0.008193923965951 -0.026834068422643  0.006433642271155  0.011064478009774  0.011417291735949
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.007713676236593  0.011322134542428  0.003907084678219  0.013398999832291  0.015469012646281 -0.052157960119991  0.107410796770668  0.010366341516334  0.002761603992801
-    1  (  5)  0.025927350683998 -0.036918918076003 -0.006183726668217  0.026765793037022  0.030906551194516 -0.042649472793173  0.084196537695922  0.021256853976094 -0.026253718608666
-    2  (  6) -0.059547667994817  0.071575508753467  0.010792071396252  0.045987434407757  0.051692908853285 -0.069048919754801  0.125623895288436 -0.001752094627181  0.022191347480178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000950352585130 -0.000964031243708  0.004357151868410  0.000282508389387 -0.001887057940293
-    1  (  5) -0.015009418487876 -0.001705110486741  0.029429172036479  0.001075595895759  0.006702102006371
-    2  (  6)  0.007980731926488  0.006589892733093  0.020940438262105  0.005674678855388  0.010940914550878
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440295578  0.058098623160145  0.000062770556734 -0.132305009159611 -0.206845253888058  0.090151367716479 -0.021622993201581 -0.039361663017837  0.081041759541848
-    1  (  1) -0.058446002592383  0.108172168387664  0.020491566069371  0.029038345945870 -0.075256281089891  0.197244333760833 -0.268904698800656 -0.104165934684918  0.067340388337437
-    2  (  2) -0.015395531940673  0.065975044888456  0.020693241252069  0.145278172828421  0.156811977467588  0.026190455409862 -0.072791620600653 -0.106379132149930  0.008110007387645
-    3  (  3)  0.209889648220476  0.051262205346321 -0.016792464687925 -0.095510023534387  0.095336437810918 -0.289116526954893  0.245753636284359 -0.379261907424047  0.084194488967520
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922100177 -0.024147628250431  0.039515998201655  0.082736569420115 -0.047511948424277
-    1  (  1)  0.028213287461099  0.067760885411210  0.238885785807081 -0.125969164479712  0.177609465312039
-    2  (  2)  0.077606300081105 -0.045313543916726  0.093141189396730  0.365274041996187  0.093447143795058
-    3  (  3)  0.414915648100446  0.159852566418800 -0.273568285227138 -0.034618677637943  0.200919751819537
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102681987247 -0.069778483698168  0.053388820632184  0.227201022134102 -0.199230027457495  0.049687576281282 -0.168877445270920 -0.014461225328823 -0.006078045812768
-    1  (  5)  0.058029574787105 -0.323045692563541  0.030451397472046 -0.087822399116244 -0.049669665032409 -0.052839306746917 -0.277652121541251 -0.149775076383341  0.305937155270733
-    2  (  6) -0.084055275470365  0.046073375199285  0.190725804864314 -0.087557818530586 -0.137785527514627 -0.205465571554509 -0.198777590920696 -0.118276962990446 -0.298899363373256
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985616709  0.083163093490794  0.059838819851119  0.009394325001919 -0.030439464329862  0.004211858017357
-    1  (  5)  0.056299326992345 -0.068872084539633  0.330916524068157 -0.053769676104372 -0.184435947376542 -0.103868547783998
-    2  (  6)  0.066328790174083 -0.124449756312359  0.113043685745465  0.144452726551049  0.299204372306590 -0.043729255680777
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000261962805527  0.008184590036916  0.017078206714547 -0.120797444663216
-    1  (  1) -0.008556708940915  0.000310357479341  0.070665159347740 -0.263733240360097
-    2  (  2) -0.016665957640930 -0.070092969568202  0.000658296979419  0.516406140442811
-    3  (  3)  0.119815260993819  0.260397085059189 -0.515923296927157  0.000854850636513
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000399146441393  0.382166830385046 -0.144086395309984
-    1  (  5) -0.378879203373124 -0.000650240992924  0.057572968692994
-    2  (  6)  0.142267704977137 -0.057783925625683  0.001456329094586
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000900630817554  0.057480932301245  0.021776185729722 -0.109986124582383 -0.040974945330873  0.038859091716892 -0.013722976007050  0.027662163358449  0.095856958174055
-    1  (  1) -0.055475653729801  0.000055946423413 -0.161049994133599  0.114708024204161 -0.226365261647007  0.429957047290397 -0.365226817146616 -0.339873184728980 -0.220417191818889
-    2  (  2) -0.021015776391225  0.161427052909876  0.000077274959500  0.056803578516090  0.009014493962561  0.218381032705501 -0.249538253456386 -0.218329398300718  0.109423644471870
-    3  (  3)  0.109912942235435 -0.115891216387226 -0.056027564915087  0.000745943372336  0.462877633738761  0.122572187022543  0.103916786291671  0.116372032296581  0.000178644283986
-    4  (  4)  0.040100257401875  0.225977964738004 -0.007764610803158 -0.462832592343494 -0.000863713188322  0.292983388565633 -0.009504255770613 -0.051881331882898 -0.039789084738632
-    5  (  5) -0.036362528925732 -0.431143684565054 -0.219013710239047 -0.122734678900396 -0.292859375843390 -0.000211534680094  0.380048338834312  0.122563604837503  0.042304270254859
-    6  (  6)  0.010482485700734  0.366095597661643  0.249485788064463 -0.103549341685718  0.008516226169398 -0.379084427040244 -0.000639775867465  0.110614613813807 -0.062004820067381
-    7  (  7) -0.028768402882084  0.339119958859187  0.216813059372753 -0.114011828936208  0.053232451800269 -0.122211769727443 -0.109878960190362 -0.000261733603902 -0.084697348659745
-    8  (  8) -0.095810944695339  0.221328249276198 -0.109105398407016 -0.000872051363332  0.038539628128303 -0.040520833999869  0.059740000698589  0.084693665490196  0.000412317879658
-    9  (  9)  0.014697085572369 -0.105287145446065 -0.107273285124554  0.218858370800790  0.309735125099707 -0.105267325854044 -0.129620026346489  0.117982202893295  0.042502371715710
-   10  ( 10) -0.029182274069824  0.107750482915279 -0.099755873232372  0.053540519729340  0.138357776561313  0.190065661316288 -0.089951321859094 -0.050398080030990 -0.205938711533234
-   11  ( 11) -0.155188100419270  0.443693923193144 -0.328775787595012 -0.218791170588425 -0.215183707581290  0.086687685172567 -0.081438682030110 -0.042661060649417  0.076989743302328
-   12  ( 12)  0.047041819133234  0.056356277723762 -0.091876156457250  0.290703693299404 -0.241933426060854 -0.247197194304072  0.042704222313260  0.092541926182781 -0.274193192866188
-   13  ( 13) -0.050345457187291  0.050309029533973 -0.290248962160651  0.162027268205590  0.213802087129947 -0.103771321970539 -0.033795235497895 -0.045614675872296  0.299788281594492
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015094426489385  0.029115659613983  0.157755053899576 -0.046090500922969  0.051508699260243
-    1  (  1)  0.106870813652794 -0.107133528015315 -0.444981848759502 -0.057242056092260 -0.049852574162924
-    2  (  2)  0.109000377776186  0.100245307552926  0.328735836791228  0.092813183683021  0.291725571255699
-    3  (  3) -0.218950464663642 -0.054805102085229  0.218886888542850 -0.287519470239803 -0.163372131318531
-    4  (  4) -0.309058290561687 -0.137567383239755  0.215197532854542  0.238351393836415 -0.213552990219106
-    5  (  5)  0.105624117972050 -0.189859620690769 -0.086820347884659  0.246317074454971  0.103852569604006
-    6  (  6)  0.128090000856950  0.089849284790687  0.081980995688424 -0.043663325009380  0.033155703031442
-    7  (  7) -0.117989240855164  0.049695249544289  0.043676012478627 -0.088835836027467  0.045632574214248
-    8  (  8) -0.043185512310112  0.206252030230843 -0.075219160600281  0.272504390674221 -0.299099410447325
-    9  (  9) -0.000057792160806  0.416496446259856  0.033591110007553 -1.079044045817673  0.144878189091344
-   10  ( 10) -0.417381448990175 -0.000164005362256 -0.288881720270974 -0.322059475407989 -0.291538277058572
-   11  ( 11) -0.033261524584632  0.288678211108029  0.000120543612153  0.357470920187363 -0.110246704427593
-   12  ( 12)  1.082405304483696  0.322498276514614 -0.357322196019218  0.000062083058686 -0.002512916703852
-   13  ( 13) -0.144912114579266  0.291369916474373  0.110105006775573  0.002446483993983  0.000063534084907
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000175081543235  0.016120371429442  0.025072002498304 -0.062542190001802 -0.021350885611547  0.118270325314463 -0.004836963443515 -0.089308321494225  0.035265121599229
-    1  ( 15) -0.019016581108199 -0.000074621970575  0.073692709803714 -0.220090875517869  0.117001241546735 -0.069843654088595 -0.194734592940075  0.297334325625652 -0.000079679030764
-    2  ( 16) -0.022601123418379 -0.074079137647861 -0.000898075728427 -0.015352523942528 -0.086856492084779 -0.105020764975973 -0.399309885639222 -0.436863382131768  0.175020106394673
-    3  ( 17)  0.059722097345643  0.223919505098562  0.017236939707976  0.001153330835786  0.251337783789024 -0.316047497618501  0.195069502405347  0.070796117852759 -0.376854141068864
-    4  ( 18)  0.020136753535406 -0.119176676580157  0.086690091555957 -0.251646590139027 -0.000253931741203  0.043128862347216  0.031767565075469  0.166618171717943  0.162853353427719
-    5  ( 19) -0.121150060676491  0.070465337136684  0.107141402917482  0.315382260507260 -0.043144844880677 -0.000915299484024  0.084836748925337  0.176704257940108 -0.191804096130314
-    6  ( 20)  0.000227153495196  0.194659284089696  0.399818522753271 -0.193896536829138 -0.032525351177495 -0.085523354347228  0.000313079507665  0.483156326770454 -0.288322768300902
-    7  ( 21)  0.086746307137050 -0.297294170806804  0.437363838809433 -0.070300496686642 -0.166591994782638 -0.177217714676447 -0.482838971708773 -0.000010492293158  0.098273184847418
-    8  ( 22) -0.034845258926463  0.000856544015042 -0.174085542944903  0.374309528502768 -0.160749665940989  0.191624326414423  0.289454904423207 -0.097021267550286 -0.000014930403134
-    9  ( 23) -0.146129839058625  0.053485685235489  0.324250294825688  0.062889229683993  0.055229748354907  0.064112736518454  0.152978751390762  0.139451617186824 -0.103725991413667
-   10  ( 24)  0.228960109301508 -0.607985902209196 -0.190616272123952 -0.232984732345919 -0.097313246050482  0.308149392800304 -0.021807135674588  0.163587870408667  0.316482089556332
-   11  ( 25) -0.113565876404474 -0.174438492287337  0.418980586076638  0.308342622144811 -0.075432621028035  0.339103289288013 -0.159452756259669 -0.028406298387558 -0.098839597099947
-   12  ( 26) -0.037444327267497 -0.021664072112540  0.117362801200428 -0.051936890369174  0.180410685976303  0.010675625355601  0.081438166282141 -0.155940478341525  0.070485054402519
-   13  ( 27)  0.017297506490474 -0.067203074043417  0.031147633780062 -0.363738862057104  0.387270613641932  0.012184715254153  0.015942188037241  0.055059690817384 -0.199296990199252
-   14  ( 28)  0.034092252177280  0.073609066570291 -0.020468002829462 -0.085810470847407  0.016765555515325 -0.112839616184042 -0.014153257364848  0.178002322135800  0.110338785365483
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147095539872376 -0.230933799773572  0.118289772746159  0.038253772767438 -0.016292190599376 -0.035682534667399
-    1  ( 15) -0.054490936726022  0.608135664745132  0.173899591973771  0.021325225109122  0.066354839577593 -0.073331369735504
-    2  ( 16) -0.323391847959362  0.191801489512728 -0.419969130886919 -0.118001273092270 -0.032684795751606  0.020933916119483
-    3  ( 17) -0.062697350486216  0.233350536310731 -0.310310140488106  0.052850324165962  0.365716314917336  0.086296396691588
-    4  ( 18) -0.056488793458209  0.097314229222503  0.076761540605130 -0.181114864878229 -0.388829148158998 -0.017043041264799
-    5  ( 19) -0.064628320787142 -0.308910350912419 -0.338058227371863 -0.010220898623398 -0.011328162399013  0.112362127982886
-    6  ( 20) -0.155379178216757  0.021354195203649  0.159398635050554 -0.081833336858149 -0.016534888228425  0.014163359612815
-    7  ( 21) -0.140544774640631 -0.163930417297838  0.028664595573872  0.155618444233800 -0.055735865052570 -0.178161215640947
-    8  ( 22)  0.103335943311626 -0.315447824318076  0.098508893733054 -0.070643837593413  0.199190551733374 -0.110186805922077
-    9  ( 23)  0.000685205966667 -0.100205727138125 -0.098177984906046  0.175404901290335 -0.218086466804573  0.228138153240994
-   10  ( 24)  0.099957378010052 -0.000114683002834  0.318552989781421 -0.225328174596453 -0.500054658950178 -0.463890214112073
-   11  ( 25)  0.099837194917026 -0.317752725239532 -0.000013072206941  0.325584528982677 -0.211934933711074 -0.064802310197909
-   12  ( 26) -0.174911687089744  0.225249469039813 -0.325644361756676  0.000020583584119 -0.212000345487719  0.097990759740781
-   13  ( 27)  0.218595256276680  0.499626470482130  0.211748903875100  0.211985776866882 -0.000065067673371 -0.140785106097385
-   14  ( 28) -0.228612967389221  0.463548085364371  0.064895093957796 -0.097943745399768  0.140883877569216 -0.000043885507604
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019700182677107 -0.054538984090235  0.000657293183087  0.126059310809811  0.202210998435547 -0.093434338948912  0.024491292826920  0.039730679308171 -0.082949626694246
-    1  (  1)  0.060570767175445 -0.116914550591561 -0.021887147512720 -0.031244847376015  0.072525220228195 -0.201021150446149  0.281719713830611  0.109054645892934 -0.074327440399932
-    2  (  2)  0.019917912309244 -0.073498936617270 -0.021015841735436 -0.144973687437559 -0.148661911932328 -0.032805680200530  0.073267109264718  0.114043301611775 -0.006398273119569
-    3  (  3) -0.203013924377866 -0.061956730055074  0.012687970996344  0.097374198936086 -0.112619147770746  0.293844050008896 -0.262428514093214  0.382217125669607 -0.093448479811714
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009866900732451  0.025414444169079 -0.042903095265212 -0.089054808289042  0.047172870515861
-    1  (  1) -0.029479300283789 -0.071852668133045 -0.250209813738974  0.142668644531379 -0.184582935130086
-    2  (  2) -0.082839864480010  0.055172054044893 -0.094169081580928 -0.401277867082134 -0.092346870950092
-    3  (  3) -0.429785932962397 -0.170247315400433  0.282336698266608  0.039589385431124 -0.207542683133741
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.009866584979611  0.069659389537491 -0.056437231681762 -0.210909857782961  0.193232853181259 -0.044263163299027  0.177086741570330  0.011251791029683  0.005974944716262
-    1  (  5) -0.063966745715496  0.332083812922556 -0.023959233352897  0.077592998716570  0.049685567261429  0.057922845574581  0.292828526996055  0.156611147799579 -0.308189152931942
-    2  (  6)  0.093646243694878 -0.043886805978709 -0.210333087134871  0.092497904993075  0.147507586034143  0.211245402574055  0.209822842363998  0.120370292677794  0.308437245541794
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068407482810996 -0.091070726633549 -0.065843093849225 -0.010412482581374  0.030047987986099 -0.002926817734499
-    1  (  5) -0.052950259935718  0.069489349844532 -0.341748563636018  0.056521413026788  0.185361514981414  0.106113084848256
-    2  (  6) -0.072195900884664  0.125482826256953 -0.118114475628611 -0.149158088490925 -0.308475854808778  0.046262836261962
-
 	Computing Mu_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.958253927724
-	   1         4.677945123999    2.295e-01
-	   2         5.194708704823    1.156e-01
-	   3         5.223843948812    2.586e-02
-	   4         5.226847535403    1.016e-02
-	   5         5.227467838779    2.194e-03
-	   6         5.227668260533    8.875e-04
-	   7         5.227636383659    2.763e-04
-	   8         5.227622132159    1.088e-04
-	   9         5.227613569870    3.847e-05
-	  10         5.227613624358    1.719e-05
-	  11         5.227615206033    3.938e-06
-	  12         5.227616189681    9.343e-07
-	  13         5.227616597313    3.329e-07
-	  14         5.227616779125    1.318e-07
+	   0         3.958253914342
+	   1         4.677945105523    2.295e-01
+	   2         5.194708680543    1.156e-01
+	   3         5.223843923672    2.586e-02
+	   4         5.226847510193    1.016e-02
+	   5         5.227467813531    2.194e-03
+	   6         5.227668235281    8.875e-04
+	   7         5.227636358407    2.763e-04
+	   8         5.227622106907    1.088e-04
+	   9         5.227613544619    3.847e-05
+	  10         5.227613599107    1.719e-05
+	  11         5.227615180782    3.938e-06
+	  12         5.227616164430    9.343e-07
+	  13         5.227616572061    3.329e-07
+	  14         5.227616753873    1.318e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 3.955e-08
 
 	Computing L_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.909269872101
-	   1         6.098499218047    3.500e-01
-	   2         7.261780824711    2.268e-01
-	   3         7.434267586103    6.951e-02
-	   4         7.483209126897    3.985e-02
-	   5         7.496330683077    1.229e-02
-	   6         7.499259495652    7.641e-03
-	   7         7.499885485763    2.891e-03
-	   8         7.500087217193    1.506e-03
-	   9         7.500033617657    6.224e-04
-	  10         7.500090357893    2.277e-04
-	  11         7.500136464518    6.297e-05
-	  12         7.500173475599    2.554e-05
-	  13         7.500190475078    1.065e-05
-	  14         7.500198657741    5.767e-06
-	  15         7.500202873290    2.677e-06
-	  16         7.500206074425    1.296e-06
-	  17         7.500206585889    2.883e-07
-	  18         7.500206868012    1.101e-07
+	   0         4.909269846731
+	   1         6.098499188985    3.500e-01
+	   2         7.261780793355    2.268e-01
+	   3         7.434267551759    6.951e-02
+	   4         7.483209092475    3.985e-02
+	   5         7.496330648248    1.229e-02
+	   6         7.499259460593    7.641e-03
+	   7         7.499885450677    2.891e-03
+	   8         7.500087182080    1.506e-03
+	   9         7.500033582554    6.224e-04
+	  10         7.500090322786    2.277e-04
+	  11         7.500136429410    6.297e-05
+	  12         7.500173440490    2.554e-05
+	  13         7.500190439968    1.065e-05
+	  14         7.500198622631    5.767e-06
+	  15         7.500202838179    2.677e-06
+	  16         7.500206039314    1.296e-06
+	  17         7.500206550779    2.883e-07
+	  18         7.500206832901    1.101e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.441e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.692592322658
-	   1        10.490408346050    3.939e-01
-	   2        12.018989318895    2.063e-01
-	   3        12.236695142072    5.074e-02
-	   4        12.243823613582    1.469e-02
-	   5        12.248391603354    3.641e-03
-	   6        12.248130104407    1.635e-03
-	   7        12.247909955895    4.952e-04
-	   8        12.248046890301    2.222e-04
-	   9        12.248019215060    6.429e-05
-	  10        12.248025404715    1.911e-05
-	  11        12.248027792757    6.466e-06
-	  12        12.248030824745    2.198e-06
-	  13        12.248031891251    5.363e-07
-	  14        12.248032214297    1.460e-07
+	   0         8.692592226045
+	   1        10.490408230041    3.939e-01
+	   2        12.018989179337    2.063e-01
+	   3        12.236694990555    5.074e-02
+	   4        12.243823461844    1.469e-02
+	   5        12.248391451361    3.641e-03
+	   6        12.248129952431    1.635e-03
+	   7        12.247909803926    4.952e-04
+	   8        12.248046738322    2.222e-04
+	   9        12.248019063083    6.429e-05
+	  10        12.248025252738    1.911e-05
+	  11        12.248027640779    6.466e-06
+	  12        12.248030672767    2.198e-06
+	  13        12.248031739273    5.363e-07
+	  14        12.248032062319    1.460e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 5.555e-08
 
 	Computing L_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.280438994803
-	   1         0.371361838663    1.009e-01
-	   2         0.471651547773    6.845e-02
-	   3         0.484364612368    2.032e-02
-	   4         0.489347451485    1.073e-02
-	   5         0.489911804533    2.331e-03
-	   6         0.489834712389    1.420e-03
-	   7         0.489907742765    7.630e-04
-	   8         0.489907746311    2.549e-04
-	   9         0.489906317860    6.078e-05
-	  10         0.489908398321    3.042e-05
-	  11         0.489908751802    8.951e-06
-	  12         0.489909091837    4.525e-06
-	  13         0.489909114282    1.152e-06
-	  14         0.489909255713    6.152e-07
-	  15         0.489909373232    2.200e-07
+	   0         0.280438991009
+	   1         0.371361833245    1.009e-01
+	   2         0.471651539689    6.845e-02
+	   3         0.484364603776    2.032e-02
+	   4         0.489347442754    1.073e-02
+	   5         0.489911795769    2.331e-03
+	   6         0.489834703624    1.420e-03
+	   7         0.489907733988    7.630e-04
+	   8         0.489907737533    2.549e-04
+	   9         0.489906309082    6.078e-05
+	  10         0.489908389542    3.042e-05
+	  11         0.489908743023    8.951e-06
+	  12         0.489909083059    4.525e-06
+	  13         0.489909105503    1.152e-06
+	  14         0.489909246934    6.152e-07
+	  15         0.489909364453    2.200e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 8.192e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.035221686904
-	   1         7.203431615233    3.036e-01
-	   2         8.082456187114    1.437e-01
-	   3         8.136577479984    2.983e-02
-	   4         8.138127889486    1.036e-02
-	   5         8.139238839229    2.346e-03
-	   6         8.139491473949    1.024e-03
-	   7         8.139434659373    2.591e-04
-	   8         8.139430452042    1.022e-04
-	   9         8.139426049199    2.475e-05
-	  10         8.139428164369    7.449e-06
-	  11         8.139428982346    2.414e-06
-	  12         8.139429532985    7.302e-07
-	  13         8.139429746243    2.172e-07
+	   0         6.035221637163
+	   1         7.203431551379    3.036e-01
+	   2         8.082456108041    1.437e-01
+	   3         8.136577399080    2.983e-02
+	   4         8.138127808458    1.036e-02
+	   5         8.139238758159    2.346e-03
+	   6         8.139491392867    1.024e-03
+	   7         8.139434578294    2.591e-04
+	   8         8.139430370963    1.022e-04
+	   9         8.139425968120    2.475e-05
+	  10         8.139428083290    7.449e-06
+	  11         8.139428901268    2.414e-06
+	  12         8.139429451907    7.302e-07
+	  13         8.139429665164    2.172e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 7.344e-08
 
 	Computing L_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.333764813277
-	   1         5.296520310202    3.172e-01
-	   2         6.231001510687    2.287e-01
-	   3         6.496507781226    9.756e-02
-	   4         6.601902855081    5.559e-02
-	   5         6.615164178139    1.513e-02
-	   6         6.618869528813    8.529e-03
-	   7         6.618879535302    2.377e-03
-	   8         6.618572573738    9.321e-04
-	   9         6.618465227605    3.594e-04
-	  10         6.618442424974    1.658e-04
-	  11         6.618451827555    6.184e-05
-	  12         6.618467480938    2.133e-05
-	  13         6.618475922113    8.629e-06
-	  14         6.618483521040    4.974e-06
-	  15         6.618489220104    2.048e-06
-	  16         6.618492250485    9.175e-07
-	  17         6.618493175955    2.370e-07
+	   0         4.333764788838
+	   1         5.296520282068    3.172e-01
+	   2         6.231001480117    2.287e-01
+	   3         6.496507748828    9.756e-02
+	   4         6.601902823335    5.559e-02
+	   5         6.615164146260    1.513e-02
+	   6         6.618869496915    8.529e-03
+	   7         6.618879503388    2.377e-03
+	   8         6.618572541817    9.321e-04
+	   9         6.618465195689    3.594e-04
+	  10         6.618442393058    1.658e-04
+	  11         6.618451795640    6.184e-05
+	  12         6.618467449023    2.133e-05
+	  13         6.618475890198    8.629e-06
+	  14         6.618483489125    4.974e-06
+	  15         6.618489188189    2.048e-06
+	  16         6.618492218570    9.175e-07
+	  17         6.618493144040    2.370e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 6.773e-08
 
 	Computing 1/2 <<Mu;L>>_(0.077) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933721  0.015024519180326 -0.027415915569923 -0.162886507397727  0.113254822182230 -0.064023650931695  0.055316304980596  0.030988679956785  0.002674429417476
-    1  (  1)  0.215473680254307  0.146951879885488 -0.277734064030091  0.062883278348033  0.148483123915935  0.181595053380776  0.367001371843723  0.003086313328543  0.095386404339359
-    2  (  2) -0.028492499167413  0.000076506520592 -0.059221747197110  0.071711487991993  0.074053260083109  0.055563200913397 -0.046720222778269  0.241063526706418  0.098194384215293
-    3  (  3) -0.132536698935214 -0.177581639220038 -0.107360746511049 -0.032262815899170  0.006088751294726  0.053657437577810 -0.241466578728657 -0.131962062699396  0.577380042604835
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927831  0.060461893794975 -0.005615477646773 -0.003888920206540  0.016113135271294 -0.008672229740056
-    1  (  1) -0.037058680758827 -0.084686071934137 -0.145302623884175 -0.027760832624305 -0.054555858489407  0.022009727182520
-    2  (  2) -0.087315818129458  0.399047483163755 -0.041723099752479 -0.020041920189961 -0.040600995633870  0.007777357868476
-    3  (  3)  0.035307803556717 -0.050920479686547  0.165550414172803 -0.068091463340346 -0.144062340529092 -0.042051983076333
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356551 -0.081063517853355  0.006129432769008  0.163964563111000  0.188951419459772 -0.080047732466251  0.074988303081870  0.007836242506546 -0.044696302205990
-    1  (  5)  0.348085979138495  0.014814724303192 -0.054134117524112 -0.070406995762186  0.073423358836432 -0.343984245233763  0.389896180591070 -0.295068043464411  0.051928952937999
-    2  (  6)  0.021691230674310 -0.340003625622930 -0.038072452179286 -0.014533847126846 -0.084733391360489 -0.004556444515536  0.201335045135150  0.349717311230196 -0.082620936463629
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932767 -0.007485730843831 -0.029474818409046  0.032209758674478  0.014108652541197
-    1  (  5)  0.209382720135363  0.066996563725017 -0.203801631001167 -0.021994746468443  0.025790645299276
-    2  (  6) -0.188199132187483 -0.086167806666973 -0.070501884768031 -0.051440727873373 -0.127552190835530
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135226960454326 -0.626072128797857  0.189283545408855
-    1  (  1) -0.198601340506735 -0.037544167210710 -0.132449472453123
-    2  (  2)  0.054869769604049  0.126822216303606 -0.064658685102817
-    3  (  3)  0.615161980452153 -0.126204375217762 -0.081927924761016
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135552779706605 -0.198154082714880  0.054851984676121  0.616510373253301
-    1  (  5) -0.625008803021783 -0.037782453643461  0.128063646533814 -0.126279998076325
-    2  (  6)  0.187629167441123 -0.129442737930211 -0.067422044676096 -0.079936634548171
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904639712499439 -0.487488103200078 -0.229076194035628  0.577203417890213 -0.193643876563157 -0.103447604010519 -0.002742470403338 -0.002451788094665 -0.093813724218962
-    1  (  1) -0.150591231752385 -0.132839961398676 -0.684911223766579  0.231736797158491 -0.050522572300056 -0.177494490840237  0.234003342486172  0.124606643062309 -0.128494931356702
-    2  (  2)  0.012679732612823 -0.025746334218930  0.172509146876788 -0.235881170188821 -0.123364008456996 -0.206129657450583 -0.121800673855382 -0.114140784221046 -0.027356216567616
-    3  (  3) -0.420686741899061  0.000223888623800 -0.019382136800409 -0.199660686586704 -0.007228242971196  0.053875733566288 -0.291408914352108  0.275298575094317  0.504737487457471
-    4  (  4) -0.444479349932735 -0.097546029689345 -0.201324076119096 -0.112193453656006 -0.168730295177533  0.009510393466858 -0.073326647656929 -0.314743664834676  0.576679302947966
-    5  (  5) -0.139143305540494  0.035439861017529 -0.250210390538725 -0.395563451554441  0.287109450839755 -0.179399443391463  0.197453518892032  0.283328589948463 -0.108409713739276
-    6  (  6) -0.129858112319467 -0.067528694061781  0.181320447910051  0.198216451549547  0.101434222271457  0.004260476702563 -0.540044484893393  0.047093544204498 -0.240211227858317
-    7  (  7) -0.134029026372179 -0.177806690148740  0.066071255125330 -0.420048245168209  0.282274848902370 -0.347456793165357 -0.074406017626720 -0.307127129684534  0.001639432917262
-    8  (  8) -0.063335732549795 -0.086906710930686  0.269779701592780  0.018783692891969  0.093247017991832  0.136863024113189  0.153892981652101 -0.031577691616059  0.057553836246877
-    9  (  9)  0.014012585179935  0.032071651340400  0.006363849845328 -0.122564599853796  0.077119470960861 -0.029965581352468  0.027046636903361  0.089397837094510 -0.000802529924297
-   10  ( 10)  0.055348506435330 -0.144624122276394  0.060432277066912 -0.048567020795905 -0.074912986944547 -0.098523802539045  0.029250640804257 -0.193836130554804  0.085063532916871
-   11  ( 11) -0.167019155111352 -0.139650558475052  0.283534980836448  0.091894060309814 -0.065838077605570 -0.024336945622802 -0.227843897422647  0.001167201554402 -0.053408806911177
-   12  ( 12) -0.031974022074098  0.367173995466688  0.116713714097486  0.049340092544991  0.015070529788372 -0.072500414701040  0.058353998450087 -0.115184864373280 -0.153182495837634
-   13  ( 13)  0.015928358602531 -0.071164774172966  0.101660897809927 -0.105977026406625  0.126658664034785 -0.065056017101773 -0.035738606034778 -0.004435603298653 -0.059994356828765
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128825974989500 -0.011693877694954 -0.146729379814642 -0.059424684705185 -0.018525365113564  0.062705489025804
-    1  (  1)  0.288526396149451  0.103129875764731  0.289919344105945  0.006241427794517  0.000597805518375 -0.002126961584353
-    2  (  2) -0.124928230102762 -0.010221797026433 -0.056571189755009 -0.103418885736751 -0.082343433199768  0.048808132756783
-    3  (  3)  0.041255915551139 -0.068310001947050 -0.078413018324278  0.150330242984058  0.179548999452874  0.040220285290066
-    4  (  4)  0.222674700983961  0.064061711596252 -0.051112895424355 -0.009318828777664  0.269456744732756  0.059360036713996
-    5  (  5) -0.030199751599663 -0.174896036167204  0.092691422408846  0.028256224393044 -0.095222992765343 -0.000984235427176
-    6  (  6)  0.000100463193802 -0.095109995484187 -0.236670455787582  0.077272409830333 -0.062627657605157 -0.003574021992866
-    7  (  7) -0.071380631315581  0.113168055430653 -0.125965816328837 -0.059330696538416  0.017157541349967  0.045135077260113
-    8  (  8) -0.578000624333806 -0.096150086854235  0.034301394867331  0.008135450733185  0.200641611845458 -0.180371714719453
-    9  (  9) -0.075918662396489  0.004599198141430  0.008112602200919  0.005143287525084  0.000284986477859 -0.012193359543264
-   10  ( 10) -0.010150745998769  0.093962320907848  0.012547284938520 -0.048325478252248  0.058041984098958  0.029299969972018
-   11  ( 11) -0.079273276366054 -0.056402585822244 -0.083755323132190 -0.007973236673633  0.003424691269619 -0.009405123180744
-   12  ( 12) -0.063303823644194  0.041869083940430 -0.019024216633724 -0.031772697856612 -0.042532243078148 -0.051259918656066
-   13  ( 13)  0.241542081048424  0.060829474159102 -0.029241791046112 -0.004754249561527 -0.057213036452327  0.050348392969423
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902374530738008 -0.153219479021394  0.011852929174186 -0.420772110136407 -0.445657281852273 -0.142990081433871 -0.124215890045063 -0.133483278617458 -0.065282671277566
-    1  ( 15) -0.489111175456927 -0.131490362750630 -0.025259277994884  0.001430871050474 -0.096952824968507  0.035534183248507 -0.068855717941579 -0.178542279528997 -0.088180183979091
-    2  ( 16) -0.227418381124775 -0.683144902334135  0.173877572588784 -0.020414541641214 -0.199817592754849 -0.249739904936551  0.179565732929508  0.064581867916811  0.271668362709082
-    3  ( 17)  0.574685513420533  0.230755641765086 -0.236330653993548 -0.198455558262872 -0.112539659295318 -0.393276362435683  0.196125851625034 -0.416930913980347  0.017841111258385
-    4  ( 18) -0.193861200269283 -0.049521286941883 -0.123799353815102 -0.006786264807840 -0.167396168176672  0.285560945535698  0.102872968175062  0.279329859462892  0.092685860122596
-    5  ( 19) -0.103950692672564 -0.178731366743249 -0.207305979104111  0.054759646458592  0.008750479265519 -0.180116361743284  0.005850873308008 -0.346544100781257  0.135656056953786
-    6  ( 20) -0.005630218802764  0.235616494969925 -0.121418775897705 -0.289705308748917 -0.074615700944892  0.197147960229448 -0.541298908627660 -0.074766151907210  0.151080244573408
-    7  ( 21) -0.003422639573222  0.126273883662646 -0.114690954063456  0.273155566178151 -0.312791095371300  0.283606567581999  0.047453631637739 -0.310404476862382 -0.030935364545073
-    8  ( 22) -0.094384208857057 -0.130119390042013 -0.029535782736633  0.507266905754741  0.577412507794778 -0.108469543731760 -0.239044626830659  0.001740919827222  0.057806922411972
-    9  ( 23) -0.126661063777400  0.286542775287411 -0.124995270818101  0.042040769766214  0.222601161131182 -0.031774064783095  0.002289661982458 -0.069973062056327 -0.578237160301569
-   10  ( 24) -0.012316706158686  0.104097860742320 -0.011505288409008 -0.071480242591928  0.067861431955949 -0.174641527191867 -0.093323115387948  0.108845273419867 -0.094609691027843
-   11  ( 25) -0.145222688889768  0.289337733151123 -0.056602400212246 -0.078531799009311 -0.050892925184265  0.092549568885380 -0.236281405460432 -0.125802430135998  0.035465582481709
-   12  ( 26) -0.059239279504452  0.006390267291510 -0.103087074498875  0.150070392220906 -0.009342684455998  0.028289380811622  0.077066678658249 -0.059246681674570  0.008175814399608
-   13  ( 27) -0.018271401982887  0.001173845770897 -0.081596168939430  0.178729785139622  0.269264211536966 -0.095094170813462 -0.063160456524498  0.017032758007931  0.200794357953942
-   14  ( 28)  0.062542890221325 -0.002043353345747  0.048801696637921  0.040072732580050  0.059190323152562 -0.000990742681884 -0.003556361910880  0.045152229102534 -0.180550803638735
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015123588660556  0.055493926114085 -0.169975137829354 -0.032809701818424  0.015002120333843
-    1  ( 15)  0.032575974689070 -0.144334404568215 -0.139389411890768  0.367448169822376 -0.070672349646377
-    2  ( 16)  0.006576811925776  0.060477069258316  0.284097691628269  0.117086244456108  0.102358639196815
-    3  ( 17) -0.124972828077132 -0.049265564522439  0.093111727254423  0.049489377800982 -0.106573762761451
-    4  ( 18)  0.078337257989459 -0.074315417379011 -0.066598566061466  0.015174881916698  0.127229135544765
-    5  ( 19) -0.030091617468876 -0.098524033243499 -0.024929078981087 -0.072709941383628 -0.065547640079017
-    6  ( 20)  0.028642219542830  0.029887343616836 -0.227866902460199  0.058376706970881 -0.035321371844132
-    7  ( 21)  0.087782136491557 -0.193844146817683  0.000960256633727 -0.115246048391406 -0.004217096818016
-    8  ( 22) -0.000480626398773  0.085216781964246 -0.052876715620283 -0.152779703755072 -0.059953833408381
-    9  ( 23) -0.075367737260768 -0.010279381835845 -0.080270644652143 -0.063438855793631  0.241130315879109
-   10  ( 24)  0.001339830230094  0.093599534020443 -0.056909491966952  0.041771584176777  0.060831797189672
-   11  ( 25)  0.008376396051512  0.012488344592189 -0.083677242445135 -0.018943587777835 -0.029225017366590
-   12  ( 26)  0.005096769732663 -0.048366952557414 -0.008003858722236 -0.031797935609827 -0.004752495908712
-   13  ( 27)  0.000291047131524  0.058011237654453  0.003385274769858 -0.042619295059250 -0.057154993286877
-   14  ( 28) -0.012282741908213  0.029296735642713 -0.009480582784425 -0.051319211356103  0.050295534824419
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027700885793089  0.024831013973624 -0.023766237412621 -0.167016603039280  0.109441555361160 -0.067202506902949  0.052695088582618  0.024064411648558  0.006188438734746
-    1  (  1)  0.211348759010706  0.133908962277452 -0.251856181342029  0.050198620344033  0.139035741221497  0.172926066548623  0.339110899470514  0.007367826854061  0.086633467632850
-    2  (  2) -0.033041625132304  0.014036582200115 -0.054189619432055  0.084538537056321  0.066377206996779  0.053646226488692 -0.037306526458897  0.220368264081419  0.092674869094186
-    3  (  3) -0.148568319902249 -0.152791211204357 -0.088570806082634 -0.044321874775512  0.009397298861538  0.049588338511205 -0.223116042687504 -0.123854255485028  0.553492211947823
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031010458886504  0.050729211215458 -0.003248182162606 -0.003208641714201  0.015229535075599 -0.008450459157619
-    1  (  1) -0.026218145702589 -0.073512341998450 -0.129399675880911 -0.023964582987083 -0.050019383975384  0.020539415914054
-    2  (  2) -0.075590807541998  0.365585379125665 -0.036729157945637 -0.016058134590288 -0.036438378068467  0.005536360852375
-    3  (  3)  0.037937313174179 -0.045234909961240  0.147760703126564 -0.060764535561326 -0.127333495556496 -0.038975339991215
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.051048798017957 -0.074362715758785  0.011189550347874  0.166183248293209  0.192475433446917 -0.070879824995188  0.064177194660693  0.010742342939181 -0.040136733536897
-    1  (  5)  0.352033813656896  0.019031583986239 -0.054018125678770 -0.066876079961762  0.060148226317505 -0.330348230405549  0.365124970723493 -0.284795973003397  0.051302526538111
-    2  (  6)  0.016809582021530 -0.311268516971319 -0.037661154101049 -0.006688597064521 -0.076727139945062  0.002675593746505  0.192087236696244  0.332474625249007 -0.065875996007770
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002709655241189 -0.005736834567419 -0.024459935540251  0.027202469191560  0.013148077561852
-    1  (  5)  0.191661619772419  0.061070263266083 -0.180667286312631 -0.019964047997521  0.020757203718357
-    2  (  6) -0.172312444590061 -0.078944608822717 -0.060240884585301 -0.044786922712268 -0.117310123601211
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102369  0.008188589712244 -0.013790999932790 -0.066013267343731 -0.002979179364342  0.115067560152145 -0.029904774000611  0.075658337330168  0.005135342269605
-    1  (  1) -0.415137332088593  0.400791789518608  0.060626653167985 -0.009777722957189  0.182694524485363  0.107591424113193 -0.071470092116897  0.210805299972922 -0.029640655301111
-    2  (  2)  0.731004204598539 -0.977674938020318  0.030910735141457  0.126476447646409  0.160297857646222 -0.115254107794131  0.017919423470240  0.019160269758167  0.056677210805976
-    3  (  3) -0.052710934455977  0.190825342618776 -0.121683764296172  0.058318753384790 -0.051331848225845  0.122833340921058  0.176985596744925 -0.321410474763131  0.015752780623204
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449210 -0.003857954296837  0.001116934481339 -0.006268480889133  0.011819863965878  0.022338641059405
-    1  (  1)  0.026581167918672 -0.003242138995830  0.002209759168115 -0.126256065331463  0.064001666171859  0.019583311633875
-    2  (  2)  0.060541607763315 -0.048685401885033 -0.005324531906372 -0.077364982992391 -0.023160042352107 -0.131997334895639
-    3  (  3)  0.086532549077844 -0.501054912835391 -0.033953281830236 -0.045954160893792  0.007588765668995  0.026055365513595
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407922 -0.003874637131511  0.017573675069951 -0.250000468336235  0.193535227171898 -0.023949830014066 -0.006344215172670 -0.002637721142584  0.025018403626545
-    1  (  5) -0.061066900138162  0.119597101102996  0.077747477731531 -0.181802110874953 -0.105212352540657 -0.191650240311690 -0.067261595147719  0.101033231559073  0.034053487252844
-    2  (  6) -0.129779125650164  0.272168473286843  0.218088904973320 -0.105590817864524  0.170044089806045 -0.413895401404370 -0.204721805057737  0.193774792721795  0.022574107317573
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304095 -0.022619515940241  0.001370551331510 -0.019480287608798 -0.016611790333307
-    1  (  5) -0.015006262168541  0.018557640744949 -0.000086080146176 -0.193359672647774  0.037991057379316
-    2  (  6)  0.020942063740396 -0.276121820896825 -0.020375408054502  0.090755244706106  0.038585932807353
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234755470283494 -0.089757897373023 -0.029226311105254
-    1  (  1)  0.628249611487220  0.562405195056322  1.006567293279198
-    2  (  2) -1.014513658696586  0.324469533164463  0.758540603298639
-    3  (  3)  0.070695571972183 -1.217301397368707  0.544825504539346
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235350713719762  0.628273412467369 -1.016171307500347  0.070820853933145
-    1  (  5) -0.089319079346849  0.558364917857370  0.332433157387864 -1.220987955904315
-    2  (  6) -0.028486683819979  1.000293875862993  0.767362449165297  0.543367325750416
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.804113115082455  0.859865209406016  0.271144212420684  0.233800284186302 -0.124039945960445 -0.010266323749662 -0.092708567501357  0.016778206024757 -0.004458179405400
-    1  (  1)  0.400343044462632 -0.255491137898947  1.725894952211800  0.228060869773307 -0.016813664829461  0.078025484956005 -0.010667432793270  0.508783176705984  0.007215780908165
-    2  (  2) -0.011354346714383 -0.088649218741449 -0.217285460959672 -0.271127696601540 -0.847424926486788 -0.636922641013145  0.167096970483964  0.613137270589854  0.118274978265621
-    3  (  3)  0.794199691903289 -0.188240166832108  0.221783053519910 -0.127263314849167  0.529647578782857 -1.234322959041016  0.503694754515590 -0.716759154325337  0.003713884622648
-    4  (  4) -0.401724672662141  0.338296304392090  0.027696569600321 -1.521982152309948  0.118592993378328  0.737822504259584  0.133024505198198  0.089529285352511  0.037479870573357
-    5  (  5) -0.062644206103430  0.401210407583400 -0.021849381974059 -0.715241456861978 -1.272083761860038  0.501726128250687 -0.443637757248648 -0.893021281361460  0.592660402987478
-    6  (  6) -0.010995449282209  0.203452242512839 -0.137034668384807 -0.113107359606136 -0.481513340581283  0.549194810269333  1.454087044363819 -0.104931286723820 -0.037492008681499
-    7  (  7)  0.128269755499576  0.321618430212563  0.165227456397829  0.036785042290427  0.490368577399842  0.556638814926841 -0.027991830909212  0.572834606710204  0.836617597163351
-    8  (  8)  0.028289154881442 -0.066964202719273 -0.261747148048831 -0.132206243094638 -0.099640531633387  0.125261053712953 -0.191170844521893  0.152462184420592 -0.345612464690994
-    9  (  9) -0.116917200684005  0.677293814759278  0.057457633837347  0.132537898195614 -0.004175807366704 -0.154875636337899 -0.038546773688736 -0.121822888362938 -0.349244520254430
-   10  ( 10) -0.180886604759008 -0.111792204437992  0.370617548329887 -0.010060948397228  0.175897261426766 -0.187416342815094 -0.018902126694376  0.507517994343601 -0.113620600518252
-   11  ( 11) -0.014433403132825  0.015210570936209  0.010143344331716 -0.005691229002329 -0.031059326071826 -0.023288546292954  0.128101332902295 -0.039392944850374 -0.110920114561200
-   12  ( 12) -0.125268954735592 -0.096735894811095  0.052480306210829  0.258243594453865  0.005805250173642  0.145107299027973  0.116452856795825 -0.074374807730489  0.022119923916468
-   13  ( 13) -0.016491827683000 -0.002316794514639 -0.087971851878045 -0.101325911412226 -0.036377238947018  0.195278206944873 -0.010131352705037  0.009611107176448 -0.056274461552982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020619978804339  0.055393926260198  0.016493468301721 -0.100372381621015  0.100626242248391  0.085758294302200
-    1  (  1) -0.158166323997468 -0.302157830906836 -0.003244540958724  0.141116982835093 -0.086717578223975 -0.004480871143071
-    2  (  2)  0.117237563107167 -0.174570847573252 -0.011204345589118 -0.263173432731339  0.005218532196608 -0.028842080195278
-    3  (  3)  0.116941646649193 -0.002586479599460 -0.011231548488137 -0.058984655279782 -0.019822661982992  0.041048882280086
-    4  (  4)  0.050776820640488 -0.220908341720040  0.039982596283608 -0.028513186801397  0.038501560477780 -0.072498198103576
-    5  (  5) -0.020348029264279  0.163764941111662 -0.082946711645309  0.111452654944127  0.037984566239170 -0.107199595569002
-    6  (  6)  0.021256126103386  0.388694787591368  0.114910007821023  0.018804713347355  0.008937619959603 -0.015873506672528
-    7  (  7)  0.297925323013454  0.033191669222593  0.094278199439532 -0.060174035263281  0.021406855727336  0.043089336483833
-    8  (  8)  1.538149876661768  0.255388094594368 -0.163312643003209 -0.034677585072596 -0.142125228818818 -0.045738087971649
-    9  (  9)  0.091443541252255 -0.031128123891514 -0.061982026707814 -0.058678185009605  0.760839955512426  0.950617857124013
-   10  ( 10) -0.067301877513064  0.211057800702034 -0.020603819563629  1.234407038988008 -0.163795705023159  0.167535211420885
-   11  ( 11)  0.163445976328784 -0.060082779666650  1.332811809287809  0.048638214648013 -0.084741484840295  0.093756111599773
-   12  ( 12)  0.205948682024817 -1.200679744036831 -0.135474810029670  0.365861100667199 -0.094093662797895  0.008686523394767
-   13  ( 13) -0.181605938452006 -0.042014918886112  0.112406427108237  0.222953862798683  0.995139187403184 -0.917632565321750
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802008727902655  0.406135528069519 -0.010476316013926  0.784475556802977 -0.394386683091322 -0.066798881058913 -0.011980564813183  0.124376056524346  0.033526134230598
-    1  ( 15)  0.862028914432838 -0.259382739909253 -0.086667305572571 -0.180064784220811  0.329908607377568  0.399964089565239  0.202187771096584  0.330121816685617 -0.071953120874633
-    2  ( 16)  0.271307809960517  1.724790149840174 -0.218446172710917  0.221581282093101  0.027552874986052 -0.019301351758235 -0.136156749402951  0.163711145289538 -0.262315292158509
-    3  ( 17)  0.233832160360253  0.228075923415992 -0.271855585596124 -0.127498943532143 -1.519236751765142 -0.714946933274599 -0.112783303905635  0.035742190545795 -0.131799331720450
-    4  ( 18) -0.125884857507906 -0.016503178327160 -0.848590316809834  0.528676059271022  0.118589942996707 -1.271521009940539 -0.481050683706143  0.489094666232740 -0.100427993377443
-    5  ( 19) -0.011410411929704  0.078504916539328 -0.635756927956291 -1.233330464680219  0.737249034134053  0.499445190730949  0.548364048058951  0.558640131286851  0.124411035854073
-    6  ( 20) -0.091600083261382 -0.011874324392682  0.166095509172920  0.503931355593027  0.132971166339089 -0.442847331045605  1.455101200236642 -0.028340512672194 -0.190421039545480
-    7  ( 21)  0.014506888035501  0.509793857361999  0.613540224928847 -0.716635769138310  0.088503909893924 -0.892421715175117 -0.105643577538643  0.572215069358707  0.150576387127192
-    8  ( 22) -0.004177720337601  0.006709815498338  0.117678875953444  0.003186946250536  0.038303116431661  0.593619431704902 -0.036920385902464  0.835672825510557 -0.345283877638120
-    9  ( 23) -0.021586239236069 -0.156869719857389  0.117889758366713  0.115161423657166  0.052238225817567 -0.022709102194002  0.020562459070758  0.298677779552414  1.538509512042494
-   10  ( 24)  0.054682068155330 -0.300070995804170 -0.172660016100405 -0.004680568559133 -0.221321821680689  0.163619483231767  0.386948477906821  0.033115261343779  0.254769962308421
-   11  ( 25)  0.016488293849114 -0.003235639473042 -0.011174682028047 -0.011243945686262  0.039809588242801 -0.082761513420814  0.114884412151995  0.094200391738432 -0.163393716854442
-   12  ( 26) -0.099231335638981  0.141112668735439 -0.262446613088938 -0.059563147663697 -0.028574452319685  0.111394864273783  0.018513759386770 -0.059760408126185 -0.034040397389902
-   13  ( 27)  0.100244162906019 -0.086825753516515  0.005142496829880 -0.019052879526344  0.037887085038908  0.037954868269094  0.008919579926842  0.021672382001814 -0.142649674386460
-   14  ( 28)  0.086046561377269 -0.004744302368675 -0.028249738219516  0.042030603060936 -0.073561648753544 -0.107720217983973 -0.016217142075139  0.044341471770558 -0.046187444393698
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124233708134536 -0.184518326175237 -0.014667753095384 -0.126540650902716 -0.015843433752182
-    1  ( 15)  0.686899770278225 -0.109692117003667  0.015377495137090 -0.096723489130418 -0.002397757787977
-    2  ( 16)  0.057205529179573  0.372042133273675  0.010210131259620  0.052160697899345 -0.088271643130934
-    3  ( 17)  0.131871345108646 -0.011180948360664 -0.005727193367078  0.259941586635767 -0.101614450210759
-    4  ( 18) -0.005079597151550  0.176830214271493 -0.031032942109530  0.004628941737735 -0.036366477592728
-    5  ( 19) -0.153488339566642 -0.188246645479895 -0.023332293508359  0.145173541284801  0.195552538719571
-    6  ( 20) -0.038666420291800 -0.018333798481472  0.128217423491274  0.116258211557260 -0.010271886085247
-    7  ( 21) -0.121961409061188  0.508144909444712 -0.039497933150400 -0.074911313979374  0.009738174256599
-    8  ( 22) -0.349752281191282 -0.113379050365462 -0.110884161439924  0.022227055299971 -0.056428042287591
-    9  ( 23)  0.091274387643065 -0.068482004342720  0.163392525285683  0.205701365643148 -0.181416453396970
-   10  ( 24) -0.031494844081003  0.210984913522447 -0.060264440706341 -1.201297108840478 -0.041823116964621
-   11  ( 25) -0.061998986866087 -0.020468588707388  1.332808723106093 -0.135556576828281  0.112406197562980
-   12  ( 26) -0.058487448548964  1.234274465594818  0.048631105388868  0.365854082845994  0.222962926250886
-   13  ( 27)  0.761200546740672 -0.163618812251394 -0.084738989433935 -0.094122389252816  0.995165590894080
-   14  ( 28)  0.951772998269778  0.167560207344595  0.093759874796882  0.008708619204364 -0.917569948681331
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062431637468595  0.002416441043494 -0.004633709181854 -0.077570764564634 -0.013832459901085  0.123710471759648 -0.027165779035151  0.071044010954103  0.019658423662051
-    1  (  1) -0.407170389584196  0.333069478291481  0.076649076907709  0.002175328366595  0.197922707135443  0.117656968282733 -0.067757706616656  0.182812175438110 -0.031734247883934
-    2  (  2)  0.673185035517385 -0.888138019247629  0.034358376579761  0.125358507387175  0.172994941404661 -0.106755581181951  0.013852200121288  0.009496870454373  0.036809619943014
-    3  (  3) -0.040742790622452  0.181389056204799 -0.117008669682236  0.012401302848616 -0.022196391591003  0.102862126461673  0.166049221641564 -0.310434511631988  0.017146561969833
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.010530607294135 -0.003710118206636  0.001098184033274 -0.004177259623773  0.010641720243897  0.020819711535909
-    1  (  1)  0.026376312845796 -0.003084063695379  0.001935075690028 -0.112197866496249  0.055637648529160  0.022260912302157
-    2  (  2)  0.054059905057592 -0.043789787513268 -0.004472231165839 -0.071437136436276 -0.024456749693059 -0.126350825107534
-    3  (  3)  0.083331116085326 -0.461426302980745 -0.028171699513189 -0.043194879139585  0.008942983333379  0.024389199674004
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.021216263100624  0.005003175055603  0.013535160841075 -0.263704651382093  0.210918804180330  0.005688291976374  0.005207710700417 -0.000895282201935  0.031550648985107
-    1  (  5) -0.080441383224428  0.123194069685474  0.057717422634392 -0.198323986141407 -0.141861353254421 -0.184709849630275 -0.056481718890527  0.088971412091793  0.030305733467359
-    2  (  6) -0.146541148918465  0.264369470289016  0.161465568338008 -0.083507608614829  0.171726934895341 -0.400382872983893 -0.201596935132327  0.184414767198991  0.015497227351109
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.010467742288235 -0.019463191825822  0.001308339278104 -0.016880359740534 -0.016885157913526
-    1  (  5) -0.009224792466207  0.019323723500933 -0.001197784436253 -0.171358632107000  0.032143333569086
-    2  (  6)  0.022721945593511 -0.245666385556985 -0.017093671892173  0.084713974597816  0.032963157176328
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521802 -0.064555152855138  0.195953381503071 -0.041248493404121 -0.011229686922121 -0.030149441468397 -0.052245051042500 -0.006640144591442 -0.060816046803627
-    1  (  1)  0.618380750339720 -0.527850820452490 -0.215416501468029 -0.157035437820935 -0.069798458053230  0.063297476854259 -0.224803808806348 -0.036770088857866 -0.093292414355442
-    2  (  2)  0.089963765220190  0.016694193855693 -0.049894217028098 -0.224500363636583  0.100545586935572 -0.339808932362447 -0.300486601784948  0.103978674940069  0.003854593986175
-    3  (  3) -0.017912540893907  0.240051544179785  0.016875920141055 -0.019658112757049  0.000950481978189  0.139486307895283 -0.307526295494266 -0.245045411721372  0.038982174459018
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151717 -0.053483299255778  0.001461399819935 -0.009996127160185  0.040844890766481
-    1  (  1)  0.010356156252342  0.045196494943179  0.123149462829327 -0.009608799091533 -0.092775098416550
-    2  (  2)  0.068261626755323 -0.266621644473694  0.090983468547791 -0.007824999539035 -0.015479677414575
-    3  (  3)  0.102991688131894  0.095940846129216  0.235195882789531  0.030438278876705  0.100331913639100
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065248  0.055002400477821 -0.190701615134341 -0.008587073557084 -0.137456634337712 -0.102685174742823 -0.038575707278161  0.049077773985898  0.038775520871497
-    1  (  5)  0.266426121061191  0.201904502527537 -0.404472747743473  0.112355452346505  0.244543383067869  0.203488255110531  0.093346083766348  0.046662175778569  0.162564534078649
-    2  (  6)  0.310200495971193  0.275860886663903 -0.334362481171662  0.111323203428083  0.107269573507973 -0.015396505983549 -0.485347827861583 -0.115211810541078 -0.189399381355351
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661082 -0.010182782856367  0.015536223735828  0.027148068637774  0.019304531582384 -0.012170541889263
-    1  (  5) -0.076359104752409  0.072719944885935 -0.105706045053714 -0.076791075572647 -0.095250630872885  0.044053081318688
-    2  (  6) -0.023401555368538 -0.060789750773995  0.233844071164901 -0.060200608258474 -0.022972229731696  0.078966373846356
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134464733238495 -0.662210405494713 -0.268087036060508 -0.078995101665649
-    1  (  1) -0.664136191142181 -0.208512216408356  0.147227682691113  0.068768195668241
-    2  (  2) -0.267178832853318  0.148347614169084  0.187155712816499  0.001725942570585
-    3  (  3) -0.077975712094611  0.066243031692256  0.004079617492317  0.013944312169831
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274618126592076 -0.278113702179189 -0.671633022270395
-    1  (  5) -0.277949145712571 -0.011863615919940 -0.010374435234634
-    2  (  6) -0.670048686168265 -0.009476206950290  0.097890068097066
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959494414290853 -0.408191876587357 -0.490587797784235  0.038620088951700 -0.077925870525924 -0.487449819239270 -0.107605742375904 -0.396082210854031 -0.237542456199032
-    1  (  1) -0.404346098969045 -1.325089706115921  0.174671472615893  0.248857938939690 -0.197997176299327 -0.317531715369544 -0.251443125493972 -0.030205216051466  0.632709778669897
-    2  (  2) -0.488203594414091  0.174177358170279  0.686637133275405  0.342440322127986 -0.009976595905960  0.483509687591532  0.287263685740954  0.302820486761602 -0.272146504988795
-    3  (  3)  0.037519851932805  0.250891430236009  0.345028453615613 -0.288802596502282  0.242048997261983 -0.302155533583706 -0.510767048111858  0.184742116191470 -0.216988138473832
-    4  (  4) -0.076335128439672 -0.199690457337231 -0.011287590259796  0.242287343472353 -0.131826185478683  0.385784652335332 -0.241579744319177 -0.375155233716578  0.062534851979726
-    5  (  5) -0.485786339572524 -0.319069045647698  0.484028655874806 -0.298894130368480  0.382592029688529 -0.557110750088133  0.333239304019173  0.111824333667390  0.019820080095694
-    6  (  6) -0.105004388042392 -0.251919494300239  0.289657780268581 -0.510934745583711 -0.243423593715530  0.333487274729372 -0.859815579894803 -0.040189411214503  0.015976724219764
-    7  (  7) -0.396742866204424 -0.028527583501407  0.303542401120419  0.181332247012507 -0.373287106593955  0.109028339876178 -0.042483577229034 -0.424450995877431 -0.165337209178978
-    8  (  8) -0.232477111217568  0.628541780993301 -0.273469783503725 -0.217890852518762  0.061988654737611  0.020919866007559  0.015643111904884 -0.165546891359504 -1.139952791754372
-    9  (  9)  0.005546163403788  0.056122031350974  0.162961042742049 -0.082482781173176  0.072908205250705 -0.108799436968506 -0.023533780380763  0.044777427042704 -0.147235448199817
-   10  ( 10) -0.006901975709221  0.054429650490003 -0.040577693872379  0.341755839709641 -0.179734725561057  0.323402736691831  0.128204737160643 -0.274641710567115 -0.052505646555499
-   11  ( 11)  0.095370531310646 -0.102133079874744  0.068438122875481 -0.163729824989548 -0.155636229704619  0.243225496644066 -0.456632637964553 -0.005300419866763 -0.049825612054653
-   12  ( 12) -0.031656876480322  0.049261490140927 -0.071615793822899  0.132066208561311 -0.108599421258561  0.096544859699583  0.079601642520208 -0.086582876221016 -0.054558080822567
-   13  ( 13) -0.055177843918678  0.125972146875380 -0.045925897173266 -0.019932953437884 -0.072414580136129 -0.032514397877208 -0.014074648780379 -0.073540469649060  0.566252900794764
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006844108037316 -0.007417708485432  0.096179215271910 -0.031845351907950 -0.055819107034893
-    1  (  1)  0.055009072408368  0.054764569974464 -0.101360748266653  0.049483066032708  0.126311659941364
-    2  (  2)  0.163126461717698 -0.041474056730500  0.069773970511476 -0.071604513134715 -0.045921679797628
-    3  (  3) -0.081145867550905  0.339512714763515 -0.164814632361134  0.131963409806745 -0.019701057447438
-    4  (  4)  0.071392957638912 -0.177541925322310 -0.155855587434795 -0.108549913772827 -0.072788709838572
-    5  (  5) -0.105620913909822  0.324570384536927  0.243426148668895  0.096676164465064 -0.032493241135614
-    6  (  6) -0.022622971576109  0.128555788054587 -0.457558865820421  0.079424640656331 -0.014304063550757
-    7  (  7)  0.043872369029022 -0.277428590499647 -0.005167508600307 -0.086808599804733 -0.073543295023506
-    8  (  8) -0.147656701585277 -0.051770671721882 -0.049464276722928 -0.054622357068254  0.565518286432935
-    9  (  9)  0.072058098581742  0.045414939179585  0.010276622684317  0.009607329011721  0.026546654266791
-   10  ( 10)  0.047972578248005 -0.139091273135494 -0.006969817312947 -0.101924439794115 -0.021963395913839
-   11  ( 11)  0.010225949518788 -0.006903254834441 -0.093461448932077 -0.006458623521929  0.037408632154760
-   12  ( 12)  0.009659072763447 -0.101989750292789 -0.006543886552567  0.055499957258902  0.004536647288290
-   13  ( 13)  0.026525022859865 -0.022073627181823  0.037503294944017  0.004573821056444 -0.064450805660396
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.531729549886298 -0.787699013260720 -0.218007437963128  0.182768764967664  0.602768885926166 -0.199812958118043  0.029032839745447 -0.008774056556998 -0.142478600997401
-    1  ( 15) -0.793340915328517 -0.320131124132658 -0.162653978535470  0.058649157291279  0.020639907683325 -0.223525268439384  0.107699068558594 -0.353783645623560 -0.095871343640248
-    2  ( 16) -0.212191388052984 -0.164888118017376 -1.296946785661574  0.042300146112888  0.273826728839772 -0.438781481182649 -0.122091204716307  0.097191959045013 -0.140871391153761
-    3  ( 17)  0.179719553134882  0.058669914491584  0.044506714025066  0.293003077614788  0.349110568675561  0.303215667162415  0.076915097449125  0.005807473711893  0.013837821466959
-    4  ( 18)  0.599360800493389  0.022132908209793  0.274035423937454  0.351223850237582  0.210864723099932  0.044675310303669 -0.438675626813712 -0.490920343842293 -0.399212333009898
-    5  ( 19) -0.200407898503595 -0.221431932840884 -0.440102897905219  0.305762109212930  0.044881546181386 -0.117472965844391 -0.191665223291112 -0.319783714572633 -0.359452162382383
-    6  ( 20)  0.032165821117663  0.105941691907443 -0.123879210125571  0.078979233990532 -0.440650088275931 -0.189889145121382 -1.110705925194965  0.246906737793529  0.255259757334091
-    7  ( 21) -0.008321241705301 -0.354528191467815  0.096628486245053  0.006334262611059 -0.491255100347711 -0.318969662674625  0.247541587785850 -1.005004062277651  0.329386657154236
-    8  ( 22) -0.142962699223549 -0.097023037413528 -0.141097052846351  0.015166149438974 -0.401326717044885 -0.359426368361956  0.255258622579679  0.329097335449224  0.052132117322127
-    9  ( 23) -0.219955098740470 -0.249965476004888  0.576414624728282  0.098982863369388 -0.020508824733516  0.097549190747056 -0.059941456738217  0.014715712854346  0.155030958604429
-   10  ( 24) -0.078889746445523  0.108239301318901  0.027162587747041  0.046514963820434  0.091370815063922  0.113422647703502 -0.170202961400924  0.302110584863860 -0.032804637243887
-   11  ( 25)  0.043306270957027  0.032344455295716 -0.179576712827774  0.107307667430455 -0.187560546689596 -0.097222488608903 -0.510712264729794 -0.080025590477581  0.081254866792350
-   12  ( 26) -0.068084805818490  0.217394768160197  0.162482224135859  0.182198793902305 -0.078588038008549 -0.138375144701551  0.045964808967526 -0.318369645237611 -0.094340949188752
-   13  ( 27)  0.012776338365641 -0.163304628586287  0.065170181095058  0.076353862354929 -0.116471236774223 -0.057100568669610  0.002733328139540  0.275543901650406 -0.101218272889531
-   14  ( 28)  0.072542900570950  0.116082117753812 -0.039461901860534 -0.060056679393757 -0.063442716501334 -0.039954821491188 -0.007431183194756  0.061660754619171  0.127196734189506
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223424944652175 -0.079375640508209  0.044559638332806 -0.069603179695813  0.011608492724559  0.073681298891794
-    1  ( 15) -0.252190810534109  0.107773105664069  0.031929727381883  0.217773765514458 -0.162942254516907  0.115583488493230
-    2  ( 16)  0.579669499848572  0.028398284174960 -0.180764151357438  0.163082238678493  0.065318137383570 -0.039861277950844
-    3  ( 17)  0.098419070380212  0.045497640187139  0.108888066901844  0.182679251676257  0.077063420292881 -0.060270475148200
-    4  ( 18) -0.021657152218140  0.091391477818874 -0.188694941835346 -0.078654463993081 -0.116917635244861 -0.063687461311382
-    5  ( 19)  0.097200061293784  0.112946819841968 -0.096557046310004 -0.138722208764674 -0.057492822647748 -0.039657945432933
-    6  ( 20) -0.058061983715355 -0.170140847494679 -0.511516651549454  0.046153385708922  0.002608094185221 -0.007424017797985
-    7  ( 21)  0.014898598107636  0.302204656416843 -0.080604696411276 -0.318409184220291  0.275439068186170  0.061680442175982
-    8  ( 22)  0.155158381420859 -0.033182129585361  0.080993013335593 -0.094077880752320 -0.101045740908378  0.127069446713633
-    9  ( 23) -1.153500606432346 -0.223848574870748  0.084940142762255 -0.000172697505726  0.401118128913118 -0.346039941954413
-   10  ( 24) -0.224004522828874 -0.014993374950352 -0.013190820033296  0.067266852084063 -0.009898419000703 -0.084301934906622
-   11  ( 25)  0.084246516406413 -0.012971453666467 -0.099638608783543  0.005049425073667 -0.012239639402272  0.023058100761842
-   12  ( 26)  0.000190360752639  0.067412521796062  0.005072007098540  0.014663156532778 -0.012615786454218 -0.021995005158486
-   13  ( 27)  0.401506800485801 -0.009668467136188 -0.012313296328671 -0.012645382168417 -0.008180220628733  0.091135079144531
-   14  ( 28) -0.346436667192436 -0.084407881559669  0.023159285170777 -0.022057721310468  0.091092458906097  0.040126683454997
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057778460125475 -0.058621598376446  0.204961973610432 -0.030014886957110 -0.012702201238060 -0.012361806840330 -0.042464722570104  0.000589178332867 -0.053783176425629
-    1  (  1)  0.588150716074137 -0.466021636272279 -0.203183245475023 -0.148450737716195 -0.057365952908272  0.049828198627789 -0.211650340717459 -0.033709163320874 -0.066014023276537
-    2  (  2)  0.097096715428347  0.013316869335681 -0.075592001791495 -0.184144455632612  0.076454331448179 -0.322693901417475 -0.283033300411638  0.095787940086230  0.009135557725685
-    3  (  3) -0.012585457310361  0.213693355283451  0.008392879074051 -0.006477176275207  0.025095812734804  0.122050564721351 -0.287478867298026 -0.227752050770288  0.025535574433447
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004343658462411 -0.045416781087739  0.000353809954909 -0.008814420994644  0.038608153091639
-    1  (  1)  0.012371345270913  0.037357699916558  0.110010051271466 -0.008428651261314 -0.087698412018737
-    2  (  2)  0.059734573261687 -0.241104936943560  0.080654968743397 -0.004302203609171 -0.010690545484549
-    3  (  3)  0.093269555935928  0.087251850932645  0.210582632378020  0.029543407964615  0.092601662289167
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.096268685878252  0.067598109905929 -0.171831816211843 -0.019892225326929 -0.151432830345500 -0.102828613678797 -0.031328453208209  0.054857782228203  0.045391983457330
-    1  (  5)  0.259548823811749  0.185158249821502 -0.361847535039713  0.121706180799369  0.214912924418826  0.198674927692087  0.082249065771639  0.046754216202725  0.144894234011997
-    2  (  6)  0.316675644828390  0.241534850892177 -0.298024592816788  0.095120602156143  0.117908244615295 -0.011781114685658 -0.451417780640774 -0.113394265201560 -0.193663841427194
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.075217766018102 -0.009009066779015  0.013059078733354  0.023267742031503  0.019382631456237 -0.010439549922317
-    1  (  5) -0.055615787731083  0.073750137089776 -0.094740835467127 -0.066906556461946 -0.087569521638086  0.039832146294914
-    2  (  6) -0.007989421944926 -0.055545532554458  0.206332460425461 -0.056516118698094 -0.025725290779719  0.073743491663518
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.016118777276715 -0.076689387067910  0.125264792267213 -0.007931013310159  0.098301937535619  0.089040062536403  0.042653189503990 -0.143650549015434 -0.062698356849217
-    1  (  1)  0.038523460792185 -0.325926212074866  0.217436403108304 -0.076210929079487 -0.124956744969463 -0.049869905306287  0.256022567536771 -0.049219148025203  0.025163660677627
-    2  (  2)  0.015460259327543 -0.182364499530151  0.081021447104334 -0.065186772706427 -0.193628085224658 -0.090709199284724  0.144227288852916 -0.007154481293509  0.060483347873691
-    3  (  3)  0.069494321441897  0.016013992178315 -0.169506236224075  0.050547669997934  0.177140340538951  0.181255025833236  0.201077665225237  0.109139777586652  0.215083611892000
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.159361864611552  0.056476108299593 -0.034334354535920  0.068420323850568 -0.100698715800717  0.049820592017766
-    1  (  1)  0.121041364374108  0.003994619377140 -0.190684428167186 -0.052070114913538  0.189028662705267 -0.205096915582724
-    2  (  2) -0.013836799939815  0.073875918803128 -0.147901928532515  0.343158528114240 -0.053056478393310 -0.086736758175874
-    3  (  3) -0.065392768372813  0.072388535495375 -0.365788807268936 -0.156911353062530 -0.184439406967998  0.043117455907282
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.095080611028905  0.132974666952795 -0.233475927910152  0.109077700761869  0.033619328181748  0.003336619392392  0.079318686273400  0.006541773193153  0.188514066103895
-    1  (  5) -0.133180554197729  0.220459497770333  0.122961007604827  0.144493780528925 -0.034530325126889  0.144382538755407 -0.001565508478549 -0.179104189145759  0.084352671049965
-    2  (  6) -0.305369897772518  0.245966510909105  0.171589985467989  0.288954965589194 -0.048536799653817  0.105233271021575  0.400024803684146  0.035818012706229  0.066124321501166
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.011358647742861 -0.047842821118306 -0.011877525445924  0.012099889406653 -0.055702357687979
-    1  (  5)  0.060987538430202  0.100437160073965  0.174976176295347  0.033059202656664  0.296249624542357
-    2  (  6) -0.156959926194252  0.053853503787377 -0.406665675932450  0.026462885456155  0.143060389345544
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.020933994600404  0.036837370041378  0.105536213576208
-    1  (  1) -0.298453027380235  0.115575201783041  0.255528599615218
-    2  (  2) -0.258793135913458 -0.115959940555419 -0.442826057795212
-    3  (  3) -0.060024736570876  0.030098554189578  0.068752806226696
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019369167440735  0.299662599013862  0.261538199445479  0.060711849430245
-    1  (  5) -0.036904684367183 -0.115259605353543  0.117033018013316 -0.032657591929024
-    2  (  6) -0.104769015611943 -0.252811001882389  0.444270078409885 -0.069751899589238
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.140264901989732 -0.063903836208700  0.058837720478344 -0.099834492513857  0.059321359064218  0.159667027697165 -0.002087278187167  0.046204224826828 -0.008601023391647
-    1  (  1) -0.090548490120087 -0.202601353512529  0.092021876157049  0.096539072051997 -0.170154281529252 -0.083912296322820  0.509059273187923 -0.818772979644953  0.070828284365805
-    2  (  2)  0.023785290834458 -0.356113587695708  0.273990976839604 -0.279080899835211 -0.352444630227632  0.196438091918237  0.305379232907223 -0.066497365309668  0.201285694555594
-    3  (  3)  0.097000901586888  0.245927544981666 -0.317839114090146  0.024062116307417 -0.214330573426636 -0.049574376579035 -0.029033713280438 -0.054130019251473 -0.003096872422278
-    4  (  4) -0.057665969694961 -0.180120952217587  0.233587576454962  0.044983378670516  0.207784279042753  0.114395252588009  0.123426849025615 -0.227078923197653 -0.055512731053909
-    5  (  5) -0.215771286107030  0.314990234779502 -0.316883540178318  0.120867850220805  0.280144439746019  0.294187393366266 -0.216440287801519 -0.200727103538257 -0.064432166939554
-    6  (  6) -0.088234371667171  0.148935506374392 -0.366935246390879  0.011963781822295  0.214228897418453  0.110020140834752 -0.192637863546305 -0.231329350431209  0.059800681126421
-    7  (  7) -0.046850408793983 -0.280155317167401  0.370918303757555 -0.110906122388311  0.088736250126060 -0.146624611249243 -0.021132431838010  0.399622620248811  0.041122390922456
-    8  (  8) -0.213219122375794 -0.108141657808899  0.632333203738685  0.072815736912286  0.035034243651182  0.162896842787145 -0.072787072592861  0.219123938652931 -0.041084573562014
-    9  (  9)  0.053156461400879 -0.091068663315954 -0.087565530354220  0.029252405162121 -0.135958664144570  0.072618412616171  0.001674517036246  0.447580570679357  0.046048420321108
-   10  ( 10) -0.217389369502910  0.434955320268301  0.409591028918214  0.322091930890674  0.032769693001577 -0.320487371417213  0.022524010208258 -0.286088771348243 -0.028739508255579
-   11  ( 11)  0.043655408036926  0.078795431314352 -0.262179238045961  0.331516326718921 -0.435766491267148 -0.063689969335714 -0.247099037158840  0.001834914627209  0.140224560742040
-   12  ( 12) -0.056091676196034  0.010888223476595  0.132073582410596  0.097444459311643  0.064913316132981 -0.000177701715019  0.216786241209525 -0.136744724942226  0.129238968566772
-   13  ( 13) -0.037502956248588 -0.225853404732460  0.091597810906137  0.251988574100658  0.015208060782076  0.284415044485819 -0.108318027167759  0.003844624714698 -0.367465648248436
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222316043515173  0.015706219813460 -0.082385006687320 -0.001598515176512  0.060473243217402 -0.093727480766952
-    1  (  1) -0.559608456549850  0.123427525882115  0.153467678522284 -0.170334032667751 -0.080737466652215  0.083738891751807
-    2  (  2)  0.169476216588385  0.033571289044860 -0.409164888922149  0.223598543173697  0.075034173166616 -0.314714537560889
-    3  (  3)  0.116710909315575  0.019725573527882  0.283423547853871 -0.175125619030608  0.285157403250322  0.036616525847335
-    4  (  4) -0.005652624292121  0.042302085019166  0.326173261129808  0.429217689688999  0.082297928451369 -0.119033467524274
-    5  (  5)  0.013435701805306  0.050340607661298 -0.120543829175976 -0.018862712789954  0.153571720838557  0.076183620287339
-    6  (  6)  0.081289708009932  0.326406046335021  0.215268699384055  0.111421444457992  0.019027619773786  0.098888316320541
-    7  (  7) -0.155159820795190 -0.099172439421084  0.073800976886365 -0.027692155232139  0.092694133839456 -0.234604646553257
-    8  (  8)  0.037085102415794 -0.221081896212581 -0.033634728216760  0.500286732444230 -0.749342092540231  0.380702305205380
-    9  (  9)  0.121604531068668 -0.307665948271803 -0.063134933207098 -0.759313712683884  0.291120411772461 -0.157024245706380
-   10  ( 10) -0.436899181077493 -0.180584483336554  0.427706818265058 -0.039319556166566  0.042977724169066  0.570262735340494
-   11  ( 11) -0.012744975594815 -0.355849153273434 -0.014473345977435 -0.331011762918559  0.082407538752018  0.048301595441145
-   12  ( 12) -0.275248111407273  0.041018113706040 -0.197136817157691 -0.114052207324942 -0.270934107062801  0.185007344485080
-   13  ( 13)  0.588095271872920 -0.141945816656553 -0.099720177389789  0.418487800295605 -0.225864709971283 -0.209383142865023
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.136055292355693  0.095447390079340 -0.020092912976452 -0.093125301806219  0.056850399225392  0.218468169087239  0.091857234706676  0.045161486852249  0.214714486134321
-    1  ( 15)  0.061207776400224  0.202708633629211  0.353114471022979 -0.245649376419565  0.180866138364034 -0.315320438007598 -0.149515492263340  0.279091224397284  0.106858935875563
-    2  ( 16) -0.054684214245539 -0.094025065222640 -0.275943577798546  0.316343751367895 -0.233336305598380  0.315879985031598  0.365377908227180 -0.369960150477096 -0.630562926717977
-    3  ( 17)  0.098691998169988 -0.096665834479676  0.277640044986388 -0.024005765248079 -0.044522040617490 -0.121507599386095 -0.010509659584542  0.111862233831084 -0.073060388343816
-    4  ( 18) -0.060773979545201  0.171895263117941  0.351151470699367  0.213576840796575 -0.206989754617357 -0.279451579746598 -0.215385933896301 -0.091082110140082 -0.034953691198195
-    5  ( 19) -0.161690364133666  0.086139117701369 -0.195608563911810  0.050196750893508 -0.114409300434323 -0.293302924591653 -0.108870291715961  0.145705855705827 -0.162864209989065
-    6  ( 20)  0.004933077734461 -0.509112916459715 -0.304189657786525  0.027011307788378 -0.123564513171824  0.216326146660944  0.190918994832455  0.021599458243760  0.073921971953628
-    7  ( 21) -0.046939300208709  0.818898745115211  0.067231269443295  0.053385434393248  0.227366778650250  0.200959323300586  0.230355491785330 -0.400408400878989 -0.219890208910709
-    8  ( 22)  0.008875208231344 -0.070617448884265 -0.201028236092715  0.001986037102750  0.055524570746332  0.064229773357344 -0.060955407810699 -0.040899342701140  0.040928237624152
-    9  ( 23) -0.222811666664930  0.561652381203109 -0.169673185845526 -0.114995614482537  0.005558626156127 -0.012604855943775 -0.079125943676941  0.154935461007958 -0.034774271928076
-   10  ( 24) -0.015658264689237 -0.122684274627566 -0.033049817652516 -0.019053422527839 -0.043070830779656 -0.050152205966237 -0.326697513368317  0.099443390036459  0.221198097566915
-   11  ( 25)  0.081038041563999 -0.154593341750092  0.407140318931982 -0.281943720612544 -0.325675147388131  0.120351655341255 -0.214124337140213 -0.074325284613066  0.033051994607945
-   12  ( 26)  0.003149016432983  0.169066126704265 -0.222974141740581  0.178167341127558 -0.432229982121915  0.017874255780535 -0.111773550217181  0.031100511775812 -0.501206663109520
-   13  ( 27) -0.059358328554799  0.079903052840446 -0.074950199177116 -0.286331686497637 -0.080924619758545 -0.153353900448026 -0.018409365441232 -0.093462744168473  0.750750124348698
-   14  ( 28)  0.091958135023802 -0.083203421400514  0.314158605792337 -0.035767063530586  0.118730598661029 -0.076122730197956 -0.098773188363513  0.234233392684125 -0.381969165301650
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054160915945440  0.219019011349658 -0.045758113327127  0.056667077142781  0.042241899582407
-    1  ( 15)  0.090944710506667 -0.435278295065980 -0.077842273581985 -0.010976755804927  0.224792334219628
-    2  ( 16)  0.088739489380727 -0.410297160213689  0.264172456920594 -0.132125091344117 -0.093086518366925
-    3  ( 17) -0.030526782846308 -0.322820843845164 -0.334117022964236 -0.097597092001360 -0.253965732413055
-    4  ( 18)  0.135352462834400 -0.032599183228255  0.437639446213156 -0.064872058901777 -0.014497262646719
-    5  ( 19) -0.073899654730442  0.320885730724610  0.062344415655754  0.000276840662850 -0.283336476795450
-    6  ( 20) -0.001158784637988 -0.022837257389255  0.248024269025133 -0.216907823965295  0.108098145849829
-    7  ( 21) -0.447481917087611  0.286161905602590 -0.000998969948768  0.136653733410721 -0.003506425728694
-    8  ( 22) -0.045854947627220  0.028382633755552 -0.139989494186330 -0.129405417600154  0.366820033409182
-    9  ( 23) -0.122256207458041  0.437180402944026  0.011581755997582  0.275567866951767 -0.586898649032620
-   10  ( 24)  0.308323852677721  0.180850894824869  0.356131896237584 -0.040945642422104  0.142574344254184
-   11  ( 25)  0.063098776158328 -0.427549053292047  0.014802143274616  0.197270506582796  0.099635293972022
-   12  ( 26)  0.762581095039490  0.039734172920445  0.331033022441221  0.114161465508855 -0.418490755826759
-   13  ( 27) -0.291938944356913 -0.043222558646275 -0.082214356128437  0.270960148007918  0.225910263769365
-   14  ( 28)  0.156871086239257 -0.569997035340436 -0.048467653901954 -0.184994394399617  0.209531521675460
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.009005560415620  0.070810523176753 -0.120067832596330  0.009073132789057 -0.090464498751423 -0.086174111119354 -0.045794981404383  0.145874969594551  0.061668751575064
-    1  (  1) -0.049157751161976  0.341837336007353 -0.225991322214198  0.079794887273987  0.129000775913212  0.051890082528198 -0.264098306233452  0.041882987798608 -0.014437873768995
-    2  (  2) -0.004178475304275  0.176534362212284 -0.088484784587547  0.060893560844785  0.188770646517540  0.098157508320685 -0.154422738208026  0.028159762307564 -0.056745595914708
-    3  (  3) -0.078632631263391 -0.018162490565869  0.185802179760109 -0.047918543127734 -0.190222116766280 -0.186537019008367 -0.211456806958070 -0.116264562677776 -0.222361952728882
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.163744366705646 -0.058513889685968  0.036529339633760 -0.074890516703321  0.101980211526271 -0.048987870817682
-    1  (  1) -0.129678391589477 -0.003465728257171  0.197451754644996  0.065935565415812 -0.202740138649240  0.212710296862521
-    2  (  2)  0.022460564343485 -0.084272909470111  0.151124340943592 -0.372643880141893  0.063147940573273  0.083681000851943
-    3  (  3)  0.069418152872000 -0.077040623108210  0.377203303892585  0.165559399244429  0.189357768189066 -0.044737808867399
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.085668830826552 -0.137820799821428  0.214610467959109 -0.105542261331575 -0.036859097160699 -0.000473863191187 -0.079606876493940 -0.008613359831911 -0.198755661758927
-    1  (  5)  0.139412038667804 -0.235636886292823 -0.125284829879163 -0.147970518740863  0.038362154224395 -0.146537444592945  0.006121389458985  0.189794595760356 -0.090516747843842
-    2  (  6)  0.309048143972667 -0.258748687397478 -0.168238503241577 -0.304764034594830  0.050456064213686 -0.094565768675462 -0.416604423570797 -0.027331415693002 -0.066446598559594
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.012674523904089  0.052192101234841  0.013753920669736 -0.012760663896321  0.052741920591878
-    1  (  5) -0.065601509403618 -0.098250162685785 -0.177768481553462 -0.033008693934464 -0.305584708162473
-    2  (  6)  0.160962535198804 -0.052046626684912  0.419200543530856 -0.024457493928167 -0.150587999794571
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002292052292103  0.001327689025616  0.000248352651822  0.007958119616401  0.006332326100069  0.018602233716078  0.068879285117605  0.007819744108382 -0.006538352080531
-    1  (  1)  0.002764164951484 -0.002219747844781  0.018293151832048 -0.029668233290910  0.039848292773073  0.022489745012597  0.162281988584096  0.020804504235237 -0.019083175045335
-    2  (  2) -0.011217835122942 -0.011598249376099  0.016968466001430 -0.008250037510454 -0.006232273271199 -0.008766677291355 -0.010338243291251 -0.010725726663582 -0.004470553150490
-    3  (  3) -0.050562851864422 -0.047527304873166  0.078707468856861 -0.000484758494314 -0.025585059000149 -0.011993586441405 -0.049963781283820  0.008029454242805 -0.026864587292976
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006805334012410 -0.003000362320124 -0.002228041038774 -0.000013471324712 -0.003129940535122  0.001748281527537
-    1  (  1)  0.013913717596781  0.013715090430948  0.022806809849797  0.002206415430012  0.006824605289547 -0.005086150284378
-    2  (  2)  0.011033408042674 -0.021897939524419  0.000684908130867  0.006441462755861  0.002207402072499  0.000019160522387
-    3  (  3)  0.030996252825103  0.007986449014412 -0.024562077320802  0.006200249162121  0.010690383251548  0.011486173135262
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.008068643711801  0.010525757489218  0.001816581937116  0.014852647204910  0.016446444650493 -0.051123908211814  0.105303074579265  0.010186396385182  0.002604742010165
-    1  (  5)  0.024807027264740 -0.041872241876177 -0.005357408083722  0.028564486604489  0.031353252400093 -0.040716482303670  0.082357809569052  0.022204595749263 -0.028676826310240
-    2  (  6) -0.057433465116021  0.072910653400311  0.007950207598684  0.045866077252401  0.051478467074881 -0.066399959025161  0.120267838044196 -0.002980749702428  0.024762093508968
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000934050050601 -0.000604010149742  0.003646663045597 -0.000033137801782 -0.002019175758164
-    1  (  5) -0.015497094356084 -0.002871076746167  0.025548488367170  0.001995117147543  0.006447008967147
-    2  (  6)  0.009288606849912  0.006735078994323  0.016930923349151  0.006239987724853  0.010309885333920
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.002224796248932 -0.043809288397668  0.042786645812817
-    1  (  1) -0.035961652529642 -0.375558249507307  0.229138680808401
-    2  (  2) -0.031482392637318 -0.208906969570392  0.045224347296993
-    3  (  3) -0.099946950247302 -0.215409785029960 -0.414532197880426
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.002181806445193  0.035979573047749  0.031640926892770  0.100238553322265
-    1  (  5)  0.043671265862196  0.375015508928976  0.208917842140980  0.216574490738358
-    2  (  6) -0.042527296867704 -0.228253198541364 -0.044456455969980  0.415218734433247
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.071571831474078 -0.044653489385004 -0.010701302384521  0.107261739958166 -0.107631207507480 -0.021982609216158 -0.087555139416088  0.002428271330290 -0.013116395341898
-    1  (  1) -0.000994163831951  0.002283385696650 -0.009683189881167 -0.069987093364656  0.211165412824247  0.144806549288858  0.839471629333561  0.082797629633042 -0.083995255816987
-    2  (  2) -0.048029450774152 -0.034159151942753 -0.005345969743377  0.362094457083752 -0.166955343421217  0.200138180389859  0.200325175150546  0.048097856321736 -0.015226624624379
-    3  (  3)  0.099901242333760  0.066741882163174 -0.192006761021434 -0.037162207196608 -0.149491220617197 -0.091957380518235  0.124661875998661  0.114474410410770  0.084751404274498
-    4  (  4)  0.098292057994740  0.060260709677490 -0.234095836344240 -0.042527139722405 -0.172693635464862 -0.110397071373739  0.184879337331564  0.074537123570685  0.084735776692236
-    5  (  5) -0.074314676568805 -0.053240577551284  0.354242764435207 -0.039009834260932 -0.144962419013306 -0.061650919712871  0.045188344047270  0.085035282721814 -0.173092563485556
-    6  (  6)  0.068641550367955  0.078242424055456 -0.700330832585814  0.207548816757698  0.389421892794422  0.222244858530312 -0.109406330044358 -0.045457397940437  0.343867539807075
-    7  (  7) -0.021723320720404 -0.016351205203476 -0.098413699787287 -0.004057278627194 -0.006939091834835 -0.079051971654245 -0.378143817290533 -0.122761983444910  0.057845298080872
-    8  (  8) -0.009573032166809 -0.006109372122326  0.063933429430759 -0.085659891507819  0.069748375065097 -0.032412606198411 -0.211702458249100 -0.046995111806491  0.044380498011898
-    9  (  9)  0.004993361863043  0.003634014150995  0.021315829704565 -0.021713795540591  0.030056681969938  0.023359631271158  0.128991093821754  0.016400014214086  0.007638043352367
-   10  ( 10) -0.003364468158750 -0.005158901374854 -0.010157814233361 -0.013146135283286  0.036788603301889  0.001796925979298  0.031087735489025  0.158319551738170  0.001398916399977
-   11  ( 11)  0.005212014578832  0.005572219785769 -0.129300362837609  0.009016877484905 -0.009416239426444 -0.064438058134478 -0.026488687258820  0.021963612194050 -0.285489003307810
-   12  ( 12) -0.022889675001499  0.014028568601137  0.005258310077958  0.012614598275049 -0.011181538654879 -0.041924328606934  0.003053461905651 -0.141650155501189  0.005090787707422
-   13  ( 13) -0.006246133552104 -0.010356570946206 -0.013049157750693  0.012424981952374  0.009162366348548  0.014458376447183  0.062634797746530  0.024809108873570 -0.013232375979099
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.002828230885259  0.008462795614423 -0.005154038879344 -0.009706144885118  0.000351690712204  0.003016908410820
-    1  (  1)  0.016542909802003  0.036808232009347  0.132827410709676 -0.012545312927289 -0.013603497625073  0.014243226256359
-    2  (  2)  0.056531888264110 -0.026681841564715 -0.044472892095955  0.008316762319552  0.009818160226072 -0.003132505638469
-    3  (  3) -0.065664012413420  0.084000307061434 -0.024123678461565  0.011516052481207 -0.005295212539449 -0.009770444853693
-    4  (  4) -0.036042306167929 -0.066196882580851  0.035814283991967 -0.000422354014022 -0.007346814292352 -0.010225200735509
-    5  (  5) -0.148907428019867  0.109320100217019  0.041270431698870  0.008286052492371 -0.000171545458770 -0.012799874602526
-    6  (  6)  0.267740896585426  0.203497348994007 -0.004880757246495  0.039144439238699 -0.017848850593927  0.043282221917129
-    7  (  7)  0.072391125356364 -0.141340064883945  0.132216664302783 -0.021712276497558  0.014580212743961 -0.003413596406028
-    8  (  8) -0.065338926975322 -0.070417584641905 -0.663636576046729 -0.043614890913083 -0.008447529962600  0.017635456067550
-    9  (  9) -0.053338372051572 -0.015608392811416 -0.295869564541767 -0.007118975871925 -0.021727777212874  0.010944181246410
-   10  ( 10) -0.043778421907192  0.395589362339912 -0.177341233202869 -0.145584179195568  0.046786531122239 -0.019085441444645
-   11  ( 11)  0.612579899217924  0.015866362451336 -0.053555820669477  0.384133045755224  0.648991284315058 -0.223359237845080
-   12  ( 12) -0.089924264835293  0.149474889068186 -0.147998013353447  0.410950037016040 -0.122612685939173  0.053519931502489
-   13  ( 13)  0.016968386753168  0.001120736716635 -0.667558162177878 -0.016648983669680  0.049072172914969 -0.011592992748874
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.071349801352714  0.001077758689270  0.047849010758326 -0.099049708991045 -0.097373218549676  0.073249702217693 -0.066497399663864  0.021905924000240  0.009611371244577
-    1  ( 15)  0.044780949738342 -0.002559008927919  0.033951661393688 -0.066729312295417 -0.060308115101389  0.053229541901532 -0.078046690958424  0.016360376267857  0.006154062585818
-    2  ( 16)  0.011020054803348  0.009639577990268  0.005659342412167  0.191466387657639  0.233770018397514 -0.353943104953864  0.699652203951292  0.098429630868855 -0.064028996133411
-    3  ( 17) -0.107854789786829  0.070585793426064 -0.362141920362757  0.037292065848127  0.042427554280204  0.038929544624314 -0.207453249613870  0.003913287572517  0.085781111935039
-    4  ( 18)  0.108209449998589 -0.211629628691260  0.166874900133538  0.149325288082853  0.172890816462261  0.144890994778007 -0.389082003854745  0.007000687821959 -0.069612637937369
-    5  ( 19)  0.022019034844530 -0.144617634612034 -0.200192966932155  0.092059326306506  0.110737371319811  0.061364605633156 -0.221637061620796  0.079021140430879  0.032667339771983
-    6  ( 20)  0.089130158761340 -0.839805360702565 -0.200387491136600 -0.125541335494667 -0.184496760040884 -0.044995250241868  0.109402692051630  0.378035804168224  0.212908503907275
-    7  ( 21) -0.002178057091036 -0.082925436926419 -0.048118216149304 -0.114730021254923 -0.074453346277450 -0.084891108935456  0.045281773316414  0.122667104662944  0.047081579488124
-    8  ( 22)  0.013014867453698  0.083878416356731  0.015105645463008 -0.084649544925904 -0.084843093804877  0.173122296622746 -0.343876299664282 -0.057834963947671 -0.044464266623977
-    9  ( 23) -0.002901775226447 -0.016234828173147 -0.056359654971911  0.065872157385184  0.036362021680569  0.148332139389866 -0.266718078511433 -0.072258279284240  0.065401012908072
-   10  ( 24) -0.008445720197208 -0.036804429594076  0.026642166859464 -0.084168947416296  0.066510758074240 -0.109381013548543 -0.203196264302595  0.141165925569768  0.070499221179176
-   11  ( 25)  0.005377792056995 -0.132971363586077  0.044450134013510  0.024046237867949 -0.035750577264431 -0.041236558408713  0.004898258174407 -0.132214673314304  0.663804812343683
-   12  ( 26)  0.009728994170677  0.012565610031588 -0.008265487183253 -0.011507462056025  0.000390885497569 -0.008310505974528 -0.039141081466535  0.021755546401078  0.043610775840933
-   13  ( 27) -0.000301420723240  0.013603051175605 -0.009758944837902  0.005201669668069  0.007344582365292  0.000240423767516  0.017707548228131 -0.014600989921611  0.008461166379486
-   14  ( 28) -0.003079753925572 -0.014179269497254  0.003153288832510  0.009783782056838  0.010222304053932  0.012792812982895 -0.043303231879505  0.003407229733486 -0.017679792666433
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.005093584579739  0.003397430557442 -0.004751145314811  0.022993999775599  0.006406607432759
-    1  ( 15) -0.003664268681973  0.005140681437481 -0.005623137023323 -0.014031183819186  0.010293722738861
-    2  ( 16) -0.021380720709283  0.010101149193742  0.129156907046771 -0.005327658954335  0.012995314092573
-    3  ( 17)  0.021888212102979  0.013219387248743 -0.009147784998755 -0.012607741489428 -0.012451560776458
-    4  ( 18) -0.030283770762202 -0.036869387279966  0.009496744772099  0.011181780485761 -0.009182409552405
-    5  ( 19) -0.023453672116025 -0.001799424920848  0.064551617042567  0.041960641260944 -0.014420118956797
-    6  ( 20) -0.129458546494568 -0.031271046054797  0.026491102279080 -0.003035012140173 -0.062712336606301
-    7  ( 21) -0.016591446747124 -0.158366047016833 -0.021959782838746  0.141640631249085 -0.024819174074491
-    8  ( 22) -0.007575701587639 -0.001384112156404  0.285443557719673 -0.005092627774539  0.013202606990523
-    9  ( 23)  0.053335089301781  0.043785415746453 -0.612428033952452  0.089945127333784 -0.016908784258582
-   10  ( 24)  0.015338693676901 -0.395633576722136 -0.015809806174567 -0.149475505805733 -0.001108572795382
-   11  ( 25)  0.295832367201873  0.177313650229223  0.053561286295896  0.148004020967956  0.667548449265010
-   12  ( 26)  0.007157154416058  0.145586590425994 -0.384132810583031 -0.410951719442907  0.016651787670946
-   13  ( 27)  0.021701996830356 -0.046797876195804 -0.648997652718972  0.122606232077452 -0.049068049852610
-   14  ( 28) -0.010942221777250  0.019093183683670  0.223365949415048 -0.053520759465633  0.011602247780488
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002779955261603 -0.001692895942305  0.000296900585249 -0.009027308047397 -0.005517424530412 -0.019392785745096 -0.071615718156204 -0.008379623734860  0.006552142468187
-    1  (  1) -0.002104549417692  0.002248748312386 -0.016268779471160  0.026298614529289 -0.037020427510003 -0.022919155336995 -0.164160248243373 -0.021028638082435  0.018807600972838
-    2  (  2)  0.012197014321068  0.010749741004112 -0.015969423342584  0.008379419120709  0.005700661608129  0.009182078264487  0.007072493012826  0.010651845449984  0.003884546255784
-    3  (  3)  0.055916626202382  0.044952545452401 -0.075693796863108  0.001117242062951  0.024281174456382  0.014619597544438  0.053283290640730 -0.007703747637899  0.022436578410201
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006982563138735  0.003194903879745  0.002336222897234 -0.000159319304137  0.003153288870770 -0.001705858583767
-    1  (  1) -0.013922175981332 -0.014264739151757 -0.027533427644979 -0.002422850658312 -0.006842699761048  0.005360945695368
-    2  (  2) -0.010224586423111  0.021331787446370 -0.001728789794737 -0.007349416930946 -0.001927444504520 -0.000065986060579
-    3  (  3) -0.028649073776620 -0.008193923965951  0.026834068422643 -0.006433642271155 -0.011064478009774 -0.011417291735949
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.007713676236593 -0.011322134542428 -0.003907084678219 -0.013398999832291 -0.015469012646281  0.052157960119991 -0.107410796770668 -0.010366341516334 -0.002761603992801
-    1  (  5) -0.025927350683998  0.036918918076003  0.006183726668217 -0.026765793037022 -0.030906551194516  0.042649472793173 -0.084196537695922 -0.021256853976094  0.026253718608666
-    2  (  6)  0.059547667994817 -0.071575508753467 -0.010792071396252 -0.045987434407757 -0.051692908853285  0.069048919754801 -0.125623895288436  0.001752094627181 -0.022191347480178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000950352585130  0.000964031243708 -0.004357151868410 -0.000282508389387  0.001887057940293
-    1  (  5)  0.015009418487876  0.001705110486741 -0.029429172036479 -0.001075595895759 -0.006702102006371
-    2  (  6) -0.007980731926488 -0.006589892733093 -0.020940438262105 -0.005674678855388 -0.010940914550878
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.022503440295578 -0.058098623160145 -0.000062770556734  0.132305009159611  0.206845253888058 -0.090151367716479  0.021622993201581  0.039361663017837 -0.081041759541848
-    1  (  1)  0.058446002592383 -0.108172168387664 -0.020491566069371 -0.029038345945870  0.075256281089891 -0.197244333760833  0.268904698800656  0.104165934684918 -0.067340388337437
-    2  (  2)  0.015395531940673 -0.065975044888456 -0.020693241252069 -0.145278172828421 -0.156811977467588 -0.026190455409862  0.072791620600653  0.106379132149930 -0.008110007387645
-    3  (  3) -0.209889648220476 -0.051262205346321  0.016792464687925  0.095510023534387 -0.095336437810918  0.289116526954893 -0.245753636284359  0.379261907424047 -0.084194488967520
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009235922100177  0.024147628250431 -0.039515998201655 -0.082736569420115  0.047511948424277
-    1  (  1) -0.028213287461099 -0.067760885411210 -0.238885785807081  0.125969164479712 -0.177609465312039
-    2  (  2) -0.077606300081105  0.045313543916726 -0.093141189396730 -0.365274041996187 -0.093447143795058
-    3  (  3) -0.414915648100446 -0.159852566418800  0.273568285227138  0.034618677637943 -0.200919751819537
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.016102681987247  0.069778483698168 -0.053388820632184 -0.227201022134102  0.199230027457495 -0.049687576281282  0.168877445270920  0.014461225328823  0.006078045812768
-    1  (  5) -0.058029574787105  0.323045692563541 -0.030451397472046  0.087822399116244  0.049669665032409  0.052839306746917  0.277652121541251  0.149775076383341 -0.305937155270733
-    2  (  6)  0.084055275470365 -0.046073375199285 -0.190725804864314  0.087557818530586  0.137785527514627  0.205465571554509  0.198777590920696  0.118276962990446  0.298899363373256
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.065173985616709 -0.083163093490794 -0.059838819851119 -0.009394325001919  0.030439464329862 -0.004211858017357
-    1  (  5) -0.056299326992345  0.068872084539633 -0.330916524068157  0.053769676104372  0.184435947376542  0.103868547783998
-    2  (  6) -0.066328790174083  0.124449756312359 -0.113043685745465 -0.144452726551049 -0.299204372306590  0.043729255680777
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.000261962805527 -0.008184590036916 -0.017078206714547  0.120797444663216
-    1  (  1)  0.008556708940915 -0.000310357479341 -0.070665159347740  0.263733240360097
-    2  (  2)  0.016665957640930  0.070092969568202 -0.000658296979419 -0.516406140442811
-    3  (  3) -0.119815260993819 -0.260397085059189  0.515923296927157 -0.000854850636513
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.000399146441393 -0.382166830385046  0.144086395309984
-    1  (  5)  0.378879203373124  0.000650240992924 -0.057572968692994
-    2  (  6) -0.142267704977137  0.057783925625683 -0.001456329094586
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000900630817554 -0.057480932301245 -0.021776185729722  0.109986124582383  0.040974945330873 -0.038859091716892  0.013722976007050 -0.027662163358449 -0.095856958174055
-    1  (  1)  0.055475653729801 -0.000055946423413  0.161049994133599 -0.114708024204161  0.226365261647007 -0.429957047290397  0.365226817146616  0.339873184728980  0.220417191818889
-    2  (  2)  0.021015776391225 -0.161427052909876 -0.000077274959500 -0.056803578516090 -0.009014493962561 -0.218381032705501  0.249538253456386  0.218329398300718 -0.109423644471870
-    3  (  3) -0.109912942235435  0.115891216387226  0.056027564915087 -0.000745943372336 -0.462877633738761 -0.122572187022543 -0.103916786291671 -0.116372032296581 -0.000178644283986
-    4  (  4) -0.040100257401875 -0.225977964738004  0.007764610803158  0.462832592343494  0.000863713188322 -0.292983388565633  0.009504255770613  0.051881331882898  0.039789084738632
-    5  (  5)  0.036362528925732  0.431143684565054  0.219013710239047  0.122734678900396  0.292859375843390  0.000211534680094 -0.380048338834312 -0.122563604837503 -0.042304270254859
-    6  (  6) -0.010482485700734 -0.366095597661643 -0.249485788064463  0.103549341685718 -0.008516226169398  0.379084427040244  0.000639775867465 -0.110614613813807  0.062004820067381
-    7  (  7)  0.028768402882084 -0.339119958859187 -0.216813059372753  0.114011828936208 -0.053232451800269  0.122211769727443  0.109878960190362  0.000261733603902  0.084697348659745
-    8  (  8)  0.095810944695339 -0.221328249276198  0.109105398407016  0.000872051363332 -0.038539628128303  0.040520833999869 -0.059740000698589 -0.084693665490196 -0.000412317879658
-    9  (  9) -0.014697085572369  0.105287145446065  0.107273285124554 -0.218858370800790 -0.309735125099707  0.105267325854044  0.129620026346489 -0.117982202893295 -0.042502371715710
-   10  ( 10)  0.029182274069824 -0.107750482915279  0.099755873232372 -0.053540519729340 -0.138357776561313 -0.190065661316288  0.089951321859094  0.050398080030990  0.205938711533234
-   11  ( 11)  0.155188100419270 -0.443693923193144  0.328775787595012  0.218791170588425  0.215183707581290 -0.086687685172567  0.081438682030110  0.042661060649417 -0.076989743302328
-   12  ( 12) -0.047041819133234 -0.056356277723762  0.091876156457250 -0.290703693299404  0.241933426060854  0.247197194304072 -0.042704222313260 -0.092541926182781  0.274193192866188
-   13  ( 13)  0.050345457187291 -0.050309029533973  0.290248962160651 -0.162027268205590 -0.213802087129947  0.103771321970539  0.033795235497895  0.045614675872296 -0.299788281594492
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015094426489385 -0.029115659613983 -0.157755053899576  0.046090500922969 -0.051508699260243
-    1  (  1) -0.106870813652794  0.107133528015315  0.444981848759502  0.057242056092260  0.049852574162924
-    2  (  2) -0.109000377776186 -0.100245307552926 -0.328735836791228 -0.092813183683021 -0.291725571255699
-    3  (  3)  0.218950464663642  0.054805102085229 -0.218886888542850  0.287519470239803  0.163372131318531
-    4  (  4)  0.309058290561687  0.137567383239755 -0.215197532854542 -0.238351393836415  0.213552990219106
-    5  (  5) -0.105624117972050  0.189859620690769  0.086820347884659 -0.246317074454971 -0.103852569604006
-    6  (  6) -0.128090000856950 -0.089849284790687 -0.081980995688424  0.043663325009380 -0.033155703031442
-    7  (  7)  0.117989240855164 -0.049695249544289 -0.043676012478627  0.088835836027467 -0.045632574214248
-    8  (  8)  0.043185512310112 -0.206252030230843  0.075219160600281 -0.272504390674221  0.299099410447325
-    9  (  9)  0.000057792160806 -0.416496446259856 -0.033591110007553  1.079044045817673 -0.144878189091344
-   10  ( 10)  0.417381448990175  0.000164005362256  0.288881720270974  0.322059475407989  0.291538277058572
-   11  ( 11)  0.033261524584632 -0.288678211108029 -0.000120543612153 -0.357470920187363  0.110246704427593
-   12  ( 12) -1.082405304483696 -0.322498276514614  0.357322196019218 -0.000062083058686  0.002512916703852
-   13  ( 13)  0.144912114579266 -0.291369916474373 -0.110105006775573 -0.002446483993983 -0.000063534084907
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000175081543235 -0.016120371429442 -0.025072002498304  0.062542190001802  0.021350885611547 -0.118270325314463  0.004836963443515  0.089308321494225 -0.035265121599229
-    1  ( 15)  0.019016581108199  0.000074621970575 -0.073692709803714  0.220090875517869 -0.117001241546735  0.069843654088595  0.194734592940075 -0.297334325625652  0.000079679030764
-    2  ( 16)  0.022601123418379  0.074079137647861  0.000898075728427  0.015352523942528  0.086856492084779  0.105020764975973  0.399309885639222  0.436863382131768 -0.175020106394673
-    3  ( 17) -0.059722097345643 -0.223919505098562 -0.017236939707976 -0.001153330835786 -0.251337783789024  0.316047497618501 -0.195069502405347 -0.070796117852759  0.376854141068864
-    4  ( 18) -0.020136753535406  0.119176676580157 -0.086690091555957  0.251646590139027  0.000253931741203 -0.043128862347216 -0.031767565075469 -0.166618171717943 -0.162853353427719
-    5  ( 19)  0.121150060676491 -0.070465337136684 -0.107141402917482 -0.315382260507260  0.043144844880677  0.000915299484024 -0.084836748925337 -0.176704257940108  0.191804096130314
-    6  ( 20) -0.000227153495196 -0.194659284089696 -0.399818522753271  0.193896536829138  0.032525351177495  0.085523354347228 -0.000313079507665 -0.483156326770454  0.288322768300902
-    7  ( 21) -0.086746307137050  0.297294170806804 -0.437363838809433  0.070300496686642  0.166591994782638  0.177217714676447  0.482838971708773  0.000010492293158 -0.098273184847418
-    8  ( 22)  0.034845258926463 -0.000856544015042  0.174085542944903 -0.374309528502768  0.160749665940989 -0.191624326414423 -0.289454904423207  0.097021267550286  0.000014930403134
-    9  ( 23)  0.146129839058625 -0.053485685235489 -0.324250294825688 -0.062889229683993 -0.055229748354907 -0.064112736518454 -0.152978751390762 -0.139451617186824  0.103725991413667
-   10  ( 24) -0.228960109301508  0.607985902209196  0.190616272123952  0.232984732345919  0.097313246050482 -0.308149392800304  0.021807135674588 -0.163587870408667 -0.316482089556332
-   11  ( 25)  0.113565876404474  0.174438492287337 -0.418980586076638 -0.308342622144811  0.075432621028035 -0.339103289288013  0.159452756259669  0.028406298387558  0.098839597099947
-   12  ( 26)  0.037444327267497  0.021664072112540 -0.117362801200428  0.051936890369174 -0.180410685976303 -0.010675625355601 -0.081438166282141  0.155940478341525 -0.070485054402519
-   13  ( 27) -0.017297506490474  0.067203074043417 -0.031147633780062  0.363738862057104 -0.387270613641932 -0.012184715254153 -0.015942188037241 -0.055059690817384  0.199296990199252
-   14  ( 28) -0.034092252177280 -0.073609066570291  0.020468002829462  0.085810470847407 -0.016765555515325  0.112839616184042  0.014153257364848 -0.178002322135800 -0.110338785365483
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147095539872376  0.230933799773572 -0.118289772746159 -0.038253772767438  0.016292190599376  0.035682534667399
-    1  ( 15)  0.054490936726022 -0.608135664745132 -0.173899591973771 -0.021325225109122 -0.066354839577593  0.073331369735504
-    2  ( 16)  0.323391847959362 -0.191801489512728  0.419969130886919  0.118001273092270  0.032684795751606 -0.020933916119483
-    3  ( 17)  0.062697350486216 -0.233350536310731  0.310310140488106 -0.052850324165962 -0.365716314917336 -0.086296396691588
-    4  ( 18)  0.056488793458209 -0.097314229222503 -0.076761540605130  0.181114864878229  0.388829148158998  0.017043041264799
-    5  ( 19)  0.064628320787142  0.308910350912419  0.338058227371863  0.010220898623398  0.011328162399013 -0.112362127982886
-    6  ( 20)  0.155379178216757 -0.021354195203649 -0.159398635050554  0.081833336858149  0.016534888228425 -0.014163359612815
-    7  ( 21)  0.140544774640631  0.163930417297838 -0.028664595573872 -0.155618444233800  0.055735865052570  0.178161215640947
-    8  ( 22) -0.103335943311626  0.315447824318076 -0.098508893733054  0.070643837593413 -0.199190551733374  0.110186805922077
-    9  ( 23) -0.000685205966667  0.100205727138125  0.098177984906046 -0.175404901290335  0.218086466804573 -0.228138153240994
-   10  ( 24) -0.099957378010052  0.000114683002834 -0.318552989781421  0.225328174596453  0.500054658950178  0.463890214112073
-   11  ( 25) -0.099837194917026  0.317752725239532  0.000013072206941 -0.325584528982677  0.211934933711074  0.064802310197909
-   12  ( 26)  0.174911687089744 -0.225249469039813  0.325644361756676 -0.000020583584119  0.212000345487719 -0.097990759740781
-   13  ( 27) -0.218595256276680 -0.499626470482130 -0.211748903875100 -0.211985776866882  0.000065067673371  0.140785106097385
-   14  ( 28)  0.228612967389221 -0.463548085364371 -0.064895093957796  0.097943745399768 -0.140883877569216  0.000043885507604
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019700182677107  0.054538984090235 -0.000657293183087 -0.126059310809811 -0.202210998435547  0.093434338948912 -0.024491292826920 -0.039730679308171  0.082949626694246
-    1  (  1) -0.060570767175445  0.116914550591561  0.021887147512720  0.031244847376015 -0.072525220228195  0.201021150446149 -0.281719713830611 -0.109054645892934  0.074327440399932
-    2  (  2) -0.019917912309244  0.073498936617270  0.021015841735436  0.144973687437559  0.148661911932328  0.032805680200530 -0.073267109264718 -0.114043301611775  0.006398273119569
-    3  (  3)  0.203013924377866  0.061956730055074 -0.012687970996344 -0.097374198936086  0.112619147770746 -0.293844050008896  0.262428514093214 -0.382217125669607  0.093448479811714
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009866900732451 -0.025414444169079  0.042903095265212  0.089054808289042 -0.047172870515861
-    1  (  1)  0.029479300283789  0.071852668133045  0.250209813738974 -0.142668644531379  0.184582935130086
-    2  (  2)  0.082839864480010 -0.055172054044893  0.094169081580928  0.401277867082134  0.092346870950092
-    3  (  3)  0.429785932962397  0.170247315400433 -0.282336698266608 -0.039589385431124  0.207542683133741
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.009866584979611 -0.069659389537491  0.056437231681762  0.210909857782961 -0.193232853181259  0.044263163299027 -0.177086741570330 -0.011251791029683 -0.005974944716262
-    1  (  5)  0.063966745715496 -0.332083812922556  0.023959233352897 -0.077592998716570 -0.049685567261429 -0.057922845574581 -0.292828526996055 -0.156611147799579  0.308189152931942
-    2  (  6) -0.093646243694878  0.043886805978709  0.210333087134871 -0.092497904993075 -0.147507586034143 -0.211245402574055 -0.209822842363998 -0.120370292677794 -0.308437245541794
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.068407482810996  0.091070726633549  0.065843093849225  0.010412482581374 -0.030047987986099  0.002926817734499
-    1  (  5)  0.052950259935718 -0.069489349844532  0.341748563636018 -0.056521413026788 -0.185361514981414 -0.106113084848256
-    2  (  6)  0.072195900884664 -0.125482826256953  0.118114475628611  0.149158088490925  0.308475854808778 -0.046262836261962
-
 	Computing Mu_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.375799332377
-	   1         5.296859595086    3.096e-01
-	   2         6.160547161060    1.889e-01
-	   3         6.261605992749    5.683e-02
-	   4         6.288911116024    2.841e-02
-	   5         6.293219867196    9.327e-03
-	   6         6.295001984788    4.895e-03
-	   7         6.294804800934    2.214e-03
-	   8         6.294697863019    1.065e-03
-	   9         6.294565693243    5.236e-04
-	  10         6.294593758840    2.339e-04
-	  11         6.294619975942    5.184e-05
-	  12         6.294638606832    1.755e-05
-	  13         6.294647194102    7.981e-06
-	  14         6.294652317588    3.968e-06
-	  15         6.294654523159    1.440e-06
-	  16         6.294655328244    5.885e-07
-	  17         6.294655419782    1.479e-07
+	   0         4.375799322300
+	   1         5.296859580919    3.096e-01
+	   2         6.160547142252    1.889e-01
+	   3         6.261605972756    5.683e-02
+	   4         6.288911096112    2.841e-02
+	   5         6.293219847131    9.327e-03
+	   6         6.295001964725    4.895e-03
+	   7         6.294804780862    2.214e-03
+	   8         6.294697842944    1.065e-03
+	   9         6.294565673175    5.236e-04
+	  10         6.294593738769    2.339e-04
+	  11         6.294619955871    5.184e-05
+	  12         6.294638586760    1.755e-05
+	  13         6.294647174029    7.981e-06
+	  14         6.294652297516    3.968e-06
+	  15         6.294654503086    1.440e-06
+	  16         6.294655308171    5.885e-07
+	  17         6.294655399709    1.479e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.886e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.439398874095
-	   1         5.371293204264    2.594e-01
-	   2         6.076617273373    1.387e-01
-	   3         6.119138911669    3.100e-02
-	   4         6.127598203786    1.467e-02
-	   5         6.129699936149    3.204e-03
-	   6         6.130036210635    1.681e-03
-	   7         6.130049865879    4.765e-04
-	   8         6.130060297181    1.704e-04
-	   9         6.130049043146    6.134e-05
-	  10         6.130053995384    1.861e-05
-	  11         6.130057803553    4.494e-06
-	  12         6.130060157243    1.399e-06
-	  13         6.130061264132    5.305e-07
-	  14         6.130061602091    2.079e-07
+	   0         4.439398845487
+	   1         5.371293170025    2.594e-01
+	   2         6.076617232969    1.387e-01
+	   3         6.119138869419    3.100e-02
+	   4         6.127598161318    1.467e-02
+	   5         6.129699893574    3.204e-03
+	   6         6.130036168029    1.681e-03
+	   7         6.130049823274    4.765e-04
+	   8         6.130060254574    1.704e-04
+	   9         6.130049000540    6.134e-05
+	  10         6.130053952778    1.861e-05
+	  11         6.130057760947    4.494e-06
+	  12         6.130060114637    1.399e-06
+	  13         6.130061221526    5.305e-07
+	  14         6.130061559485    2.079e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 7.568e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.046333557452
-	   1        12.442227680470    5.227e-01
-	   2        14.864939955441    3.202e-01
-	   3        15.429117008258    9.656e-02
-	   4        15.470238268066    3.649e-02
-	   5        15.489124886185    1.247e-02
-	   6        15.489391069277    6.942e-03
-	   7        15.487859478399    3.096e-03
-	   8        15.489514226158    1.635e-03
-	   9        15.489187856558    6.258e-04
-	  10        15.489248974295    2.963e-04
-	  11        15.489272487987    1.114e-04
-	  12        15.489341020156    3.327e-05
-	  13        15.489369668837    8.608e-06
-	  14        15.489381485873    3.758e-06
-	  15        15.489386092445    1.725e-06
-	  16        15.489386987137    6.803e-07
-	  17        15.489386387659    2.201e-07
-	  18        15.489386272899    1.091e-07
+	   0        10.046333454849
+	   1        12.442227557130    5.227e-01
+	   2        14.864939808708    3.202e-01
+	   3        15.429116835827    9.656e-02
+	   4        15.470238094959    3.649e-02
+	   5        15.489124712215    1.247e-02
+	   6        15.489390895336    6.942e-03
+	   7        15.487859304466    3.096e-03
+	   8        15.489514052123    1.635e-03
+	   9        15.489187682538    6.258e-04
+	  10        15.489248800273    2.963e-04
+	  11        15.489272313966    1.114e-04
+	  12        15.489340846132    3.327e-05
+	  13        15.489369494813    8.608e-06
+	  14        15.489381311848    3.758e-06
+	  15        15.489385918420    1.725e-06
+	  16        15.489386813112    6.803e-07
+	  17        15.489386213634    2.201e-07
+	  18        15.489386098874    1.091e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 3.554e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.252621959256
-	   1         0.324103642800    7.375e-02
-	   2         0.381905556661    4.092e-02
-	   3         0.384055317728    8.396e-03
-	   4         0.384878293300    3.789e-03
-	   5         0.384947270287    4.893e-04
-	   6         0.384933279475    2.098e-04
-	   7         0.384935359547    7.052e-05
-	   8         0.384934890925    3.136e-05
-	   9         0.384934809142    6.904e-06
-	  10         0.384934961278    2.363e-06
-	  11         0.384935042979    5.761e-07
-	  12         0.384935082790    2.231e-07
+	   0         0.252621955661
+	   1         0.324103637822    7.375e-02
+	   2         0.381905549941    4.092e-02
+	   3         0.384055310874    8.396e-03
+	   4         0.384878286410    3.789e-03
+	   5         0.384947263393    4.893e-04
+	   6         0.384933272582    2.098e-04
+	   7         0.384935352653    7.052e-05
+	   8         0.384934884031    3.136e-05
+	   9         0.384934802248    6.904e-06
+	  10         0.384934954384    2.363e-06
+	  11         0.384935036085    5.761e-07
+	  12         0.384935075896    2.231e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 3.189e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.821161588437
-	   1         8.349288795591    4.037e-01
-	   2         9.783177391714    2.271e-01
-	   3         9.931957521415    5.931e-02
-	   4         9.951293369120    2.642e-02
-	   5         9.956872385170    7.970e-03
-	   6         9.958275001707    4.187e-03
-	   7         9.958051262575    1.433e-03
-	   8         9.958083725945    6.311e-04
-	   9         9.958056525014    1.750e-04
-	  10         9.958081775558    6.638e-05
-	  11         9.958084675327    3.195e-05
-	  12         9.958089432948    1.455e-05
-	  13         9.958091732727    7.828e-06
-	  14         9.958094312640    3.705e-06
-	  15         9.958095869157    1.468e-06
-	  16         9.958096412692    6.359e-07
-	  17         9.958096483400    2.878e-07
-	  18         9.958096428897    1.575e-07
+	   0         6.821161539097
+	   1         8.349288731365    4.037e-01
+	   2         9.783177309502    2.271e-01
+	   3         9.931957436080    5.931e-02
+	   4         9.951293283494    2.642e-02
+	   5         9.956872299430    7.970e-03
+	   6         9.958274915925    4.187e-03
+	   7         9.958051176803    1.433e-03
+	   8         9.958083640170    6.311e-04
+	   9         9.958056439241    1.750e-04
+	  10         9.958081689784    6.638e-05
+	  11         9.958084589553    3.195e-05
+	  12         9.958089347174    1.455e-05
+	  13         9.958091646953    7.828e-06
+	  14         9.958094226866    3.705e-06
+	  15         9.958095783383    1.468e-06
+	  16         9.958096326918    6.359e-07
+	  17         9.958096397627    2.878e-07
+	  18         9.958096343123    1.575e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 6.046e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.974039174967
-	   1         4.741444632544    2.312e-01
-	   2         5.312770350415    1.345e-01
-	   3         5.367746351153    3.797e-02
-	   4         5.383237423570    1.742e-02
-	   5         5.384022465788    3.055e-03
-	   6         5.384259935227    1.514e-03
-	   7         5.384211934459    3.426e-04
-	   8         5.384189956466    1.023e-04
-	   9         5.384179383688    2.823e-05
-	  10         5.384178994033    9.138e-06
-	  11         5.384180034462    3.103e-06
-	  12         5.384180685105    1.140e-06
-	  13         5.384181018266    4.324e-07
-	  14         5.384181202611    1.822e-07
+	   0         3.974039147813
+	   1         4.741444600123    2.312e-01
+	   2         5.312770312389    1.345e-01
+	   3         5.367746311024    3.797e-02
+	   4         5.383237383031    1.742e-02
+	   5         5.384022425187    3.055e-03
+	   6         5.384259894609    1.514e-03
+	   7         5.384211893840    3.426e-04
+	   8         5.384189915847    1.023e-04
+	   9         5.384179343069    2.823e-05
+	  10         5.384178953415    9.138e-06
+	  11         5.384179993843    3.103e-06
+	  12         5.384180644486    1.140e-06
+	  13         5.384180977648    4.324e-07
+	  14         5.384181161993    1.822e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 5.700e-08
 
@@ -3596,2987 +865,287 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.158728295592418    -0.066346095137328     0.000000000000000
-    1     -0.272773167947183    -0.014108130749903     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.127667934489882
+    0      0.158728294539562    -0.066346094594683     0.000000000000000
+    1     -0.272773167749082    -0.014108130360601     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.127667932423499
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
 	[alpha]_(0.077) =  -83.11386 deg/[dm (g/cm^3)]
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933721  0.015024519180326 -0.027415915569923 -0.162886507397727  0.113254822182230 -0.064023650931695  0.055316304980596  0.030988679956785  0.002674429417476
-    1  (  1)  0.215473680254307  0.146951879885488 -0.277734064030091  0.062883278348033  0.148483123915935  0.181595053380776  0.367001371843723  0.003086313328543  0.095386404339359
-    2  (  2) -0.028492499167413  0.000076506520592 -0.059221747197110  0.071711487991993  0.074053260083109  0.055563200913397 -0.046720222778269  0.241063526706418  0.098194384215293
-    3  (  3) -0.132536698935214 -0.177581639220038 -0.107360746511049 -0.032262815899170  0.006088751294726  0.053657437577810 -0.241466578728657 -0.131962062699396  0.577380042604835
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927831  0.060461893794975 -0.005615477646773 -0.003888920206540  0.016113135271294 -0.008672229740056
-    1  (  1) -0.037058680758827 -0.084686071934137 -0.145302623884175 -0.027760832624305 -0.054555858489407  0.022009727182520
-    2  (  2) -0.087315818129458  0.399047483163755 -0.041723099752479 -0.020041920189961 -0.040600995633870  0.007777357868476
-    3  (  3)  0.035307803556717 -0.050920479686547  0.165550414172803 -0.068091463340346 -0.144062340529092 -0.042051983076333
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356551 -0.081063517853355  0.006129432769008  0.163964563111000  0.188951419459772 -0.080047732466251  0.074988303081870  0.007836242506546 -0.044696302205990
-    1  (  5)  0.348085979138495  0.014814724303192 -0.054134117524112 -0.070406995762186  0.073423358836432 -0.343984245233763  0.389896180591070 -0.295068043464411  0.051928952937999
-    2  (  6)  0.021691230674310 -0.340003625622930 -0.038072452179286 -0.014533847126846 -0.084733391360489 -0.004556444515536  0.201335045135150  0.349717311230196 -0.082620936463629
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932767 -0.007485730843831 -0.029474818409046  0.032209758674478  0.014108652541197
-    1  (  5)  0.209382720135363  0.066996563725017 -0.203801631001167 -0.021994746468443  0.025790645299276
-    2  (  6) -0.188199132187483 -0.086167806666973 -0.070501884768031 -0.051440727873373 -0.127552190835530
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135226960454326 -0.626072128797857  0.189283545408855
-    1  (  1) -0.198601340506735 -0.037544167210710 -0.132449472453123
-    2  (  2)  0.054869769604049  0.126822216303606 -0.064658685102817
-    3  (  3)  0.615161980452153 -0.126204375217762 -0.081927924761016
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135552779706605 -0.198154082714880  0.054851984676121  0.616510373253301
-    1  (  5) -0.625008803021783 -0.037782453643461  0.128063646533814 -0.126279998076325
-    2  (  6)  0.187629167441123 -0.129442737930211 -0.067422044676096 -0.079936634548171
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904639712499439 -0.487488103200078 -0.229076194035628  0.577203417890213 -0.193643876563157 -0.103447604010519 -0.002742470403338 -0.002451788094665 -0.093813724218962
-    1  (  1) -0.150591231752385 -0.132839961398676 -0.684911223766579  0.231736797158491 -0.050522572300056 -0.177494490840237  0.234003342486172  0.124606643062309 -0.128494931356702
-    2  (  2)  0.012679732612823 -0.025746334218930  0.172509146876788 -0.235881170188821 -0.123364008456996 -0.206129657450583 -0.121800673855382 -0.114140784221046 -0.027356216567616
-    3  (  3) -0.420686741899061  0.000223888623800 -0.019382136800409 -0.199660686586704 -0.007228242971196  0.053875733566288 -0.291408914352108  0.275298575094317  0.504737487457471
-    4  (  4) -0.444479349932735 -0.097546029689345 -0.201324076119096 -0.112193453656006 -0.168730295177533  0.009510393466858 -0.073326647656929 -0.314743664834676  0.576679302947966
-    5  (  5) -0.139143305540494  0.035439861017529 -0.250210390538725 -0.395563451554441  0.287109450839755 -0.179399443391463  0.197453518892032  0.283328589948463 -0.108409713739276
-    6  (  6) -0.129858112319467 -0.067528694061781  0.181320447910051  0.198216451549547  0.101434222271457  0.004260476702563 -0.540044484893393  0.047093544204498 -0.240211227858317
-    7  (  7) -0.134029026372179 -0.177806690148740  0.066071255125330 -0.420048245168209  0.282274848902370 -0.347456793165357 -0.074406017626720 -0.307127129684534  0.001639432917262
-    8  (  8) -0.063335732549795 -0.086906710930686  0.269779701592780  0.018783692891969  0.093247017991832  0.136863024113189  0.153892981652101 -0.031577691616059  0.057553836246877
-    9  (  9)  0.014012585179935  0.032071651340400  0.006363849845328 -0.122564599853796  0.077119470960861 -0.029965581352468  0.027046636903361  0.089397837094510 -0.000802529924297
-   10  ( 10)  0.055348506435330 -0.144624122276394  0.060432277066912 -0.048567020795905 -0.074912986944547 -0.098523802539045  0.029250640804257 -0.193836130554804  0.085063532916871
-   11  ( 11) -0.167019155111352 -0.139650558475052  0.283534980836448  0.091894060309814 -0.065838077605570 -0.024336945622802 -0.227843897422647  0.001167201554402 -0.053408806911177
-   12  ( 12) -0.031974022074098  0.367173995466688  0.116713714097486  0.049340092544991  0.015070529788372 -0.072500414701040  0.058353998450087 -0.115184864373280 -0.153182495837634
-   13  ( 13)  0.015928358602531 -0.071164774172966  0.101660897809927 -0.105977026406625  0.126658664034785 -0.065056017101773 -0.035738606034778 -0.004435603298653 -0.059994356828765
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128825974989500 -0.011693877694954 -0.146729379814642 -0.059424684705185 -0.018525365113564  0.062705489025804
-    1  (  1)  0.288526396149451  0.103129875764731  0.289919344105945  0.006241427794517  0.000597805518375 -0.002126961584353
-    2  (  2) -0.124928230102762 -0.010221797026433 -0.056571189755009 -0.103418885736751 -0.082343433199768  0.048808132756783
-    3  (  3)  0.041255915551139 -0.068310001947050 -0.078413018324278  0.150330242984058  0.179548999452874  0.040220285290066
-    4  (  4)  0.222674700983961  0.064061711596252 -0.051112895424355 -0.009318828777664  0.269456744732756  0.059360036713996
-    5  (  5) -0.030199751599663 -0.174896036167204  0.092691422408846  0.028256224393044 -0.095222992765343 -0.000984235427176
-    6  (  6)  0.000100463193802 -0.095109995484187 -0.236670455787582  0.077272409830333 -0.062627657605157 -0.003574021992866
-    7  (  7) -0.071380631315581  0.113168055430653 -0.125965816328837 -0.059330696538416  0.017157541349967  0.045135077260113
-    8  (  8) -0.578000624333806 -0.096150086854235  0.034301394867331  0.008135450733185  0.200641611845458 -0.180371714719453
-    9  (  9) -0.075918662396489  0.004599198141430  0.008112602200919  0.005143287525084  0.000284986477859 -0.012193359543264
-   10  ( 10) -0.010150745998769  0.093962320907848  0.012547284938520 -0.048325478252248  0.058041984098958  0.029299969972018
-   11  ( 11) -0.079273276366054 -0.056402585822244 -0.083755323132190 -0.007973236673633  0.003424691269619 -0.009405123180744
-   12  ( 12) -0.063303823644194  0.041869083940430 -0.019024216633724 -0.031772697856612 -0.042532243078148 -0.051259918656066
-   13  ( 13)  0.241542081048424  0.060829474159102 -0.029241791046112 -0.004754249561527 -0.057213036452327  0.050348392969423
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902374530738008 -0.153219479021394  0.011852929174186 -0.420772110136407 -0.445657281852273 -0.142990081433871 -0.124215890045063 -0.133483278617458 -0.065282671277566
-    1  ( 15) -0.489111175456927 -0.131490362750630 -0.025259277994884  0.001430871050474 -0.096952824968507  0.035534183248507 -0.068855717941579 -0.178542279528997 -0.088180183979091
-    2  ( 16) -0.227418381124775 -0.683144902334135  0.173877572588784 -0.020414541641214 -0.199817592754849 -0.249739904936551  0.179565732929508  0.064581867916811  0.271668362709082
-    3  ( 17)  0.574685513420533  0.230755641765086 -0.236330653993548 -0.198455558262872 -0.112539659295318 -0.393276362435683  0.196125851625034 -0.416930913980347  0.017841111258385
-    4  ( 18) -0.193861200269283 -0.049521286941883 -0.123799353815102 -0.006786264807840 -0.167396168176672  0.285560945535698  0.102872968175062  0.279329859462892  0.092685860122596
-    5  ( 19) -0.103950692672564 -0.178731366743249 -0.207305979104111  0.054759646458592  0.008750479265519 -0.180116361743284  0.005850873308008 -0.346544100781257  0.135656056953786
-    6  ( 20) -0.005630218802764  0.235616494969925 -0.121418775897705 -0.289705308748917 -0.074615700944892  0.197147960229448 -0.541298908627660 -0.074766151907210  0.151080244573408
-    7  ( 21) -0.003422639573222  0.126273883662646 -0.114690954063456  0.273155566178151 -0.312791095371300  0.283606567581999  0.047453631637739 -0.310404476862382 -0.030935364545073
-    8  ( 22) -0.094384208857057 -0.130119390042013 -0.029535782736633  0.507266905754741  0.577412507794778 -0.108469543731760 -0.239044626830659  0.001740919827222  0.057806922411972
-    9  ( 23) -0.126661063777400  0.286542775287411 -0.124995270818101  0.042040769766214  0.222601161131182 -0.031774064783095  0.002289661982458 -0.069973062056327 -0.578237160301569
-   10  ( 24) -0.012316706158686  0.104097860742320 -0.011505288409008 -0.071480242591928  0.067861431955949 -0.174641527191867 -0.093323115387948  0.108845273419867 -0.094609691027843
-   11  ( 25) -0.145222688889768  0.289337733151123 -0.056602400212246 -0.078531799009311 -0.050892925184265  0.092549568885380 -0.236281405460432 -0.125802430135998  0.035465582481709
-   12  ( 26) -0.059239279504452  0.006390267291510 -0.103087074498875  0.150070392220906 -0.009342684455998  0.028289380811622  0.077066678658249 -0.059246681674570  0.008175814399608
-   13  ( 27) -0.018271401982887  0.001173845770897 -0.081596168939430  0.178729785139622  0.269264211536966 -0.095094170813462 -0.063160456524498  0.017032758007931  0.200794357953942
-   14  ( 28)  0.062542890221325 -0.002043353345747  0.048801696637921  0.040072732580050  0.059190323152562 -0.000990742681884 -0.003556361910880  0.045152229102534 -0.180550803638735
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015123588660556  0.055493926114085 -0.169975137829354 -0.032809701818424  0.015002120333843
-    1  ( 15)  0.032575974689070 -0.144334404568215 -0.139389411890768  0.367448169822376 -0.070672349646377
-    2  ( 16)  0.006576811925776  0.060477069258316  0.284097691628269  0.117086244456108  0.102358639196815
-    3  ( 17) -0.124972828077132 -0.049265564522439  0.093111727254423  0.049489377800982 -0.106573762761451
-    4  ( 18)  0.078337257989459 -0.074315417379011 -0.066598566061466  0.015174881916698  0.127229135544765
-    5  ( 19) -0.030091617468876 -0.098524033243499 -0.024929078981087 -0.072709941383628 -0.065547640079017
-    6  ( 20)  0.028642219542830  0.029887343616836 -0.227866902460199  0.058376706970881 -0.035321371844132
-    7  ( 21)  0.087782136491557 -0.193844146817683  0.000960256633727 -0.115246048391406 -0.004217096818016
-    8  ( 22) -0.000480626398773  0.085216781964246 -0.052876715620283 -0.152779703755072 -0.059953833408381
-    9  ( 23) -0.075367737260768 -0.010279381835845 -0.080270644652143 -0.063438855793631  0.241130315879109
-   10  ( 24)  0.001339830230094  0.093599534020443 -0.056909491966952  0.041771584176777  0.060831797189672
-   11  ( 25)  0.008376396051512  0.012488344592189 -0.083677242445135 -0.018943587777835 -0.029225017366590
-   12  ( 26)  0.005096769732663 -0.048366952557414 -0.008003858722236 -0.031797935609827 -0.004752495908712
-   13  ( 27)  0.000291047131524  0.058011237654453  0.003385274769858 -0.042619295059250 -0.057154993286877
-   14  ( 28) -0.012282741908213  0.029296735642713 -0.009480582784425 -0.051319211356103  0.050295534824419
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027700885793089  0.024831013973624 -0.023766237412621 -0.167016603039280  0.109441555361160 -0.067202506902949  0.052695088582618  0.024064411648558  0.006188438734746
-    1  (  1)  0.211348759010706  0.133908962277452 -0.251856181342029  0.050198620344033  0.139035741221497  0.172926066548623  0.339110899470514  0.007367826854061  0.086633467632850
-    2  (  2) -0.033041625132304  0.014036582200115 -0.054189619432055  0.084538537056321  0.066377206996779  0.053646226488692 -0.037306526458897  0.220368264081419  0.092674869094186
-    3  (  3) -0.148568319902249 -0.152791211204357 -0.088570806082634 -0.044321874775512  0.009397298861538  0.049588338511205 -0.223116042687504 -0.123854255485028  0.553492211947823
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031010458886504  0.050729211215458 -0.003248182162606 -0.003208641714201  0.015229535075599 -0.008450459157619
-    1  (  1) -0.026218145702589 -0.073512341998450 -0.129399675880911 -0.023964582987083 -0.050019383975384  0.020539415914054
-    2  (  2) -0.075590807541998  0.365585379125665 -0.036729157945637 -0.016058134590288 -0.036438378068467  0.005536360852375
-    3  (  3)  0.037937313174179 -0.045234909961240  0.147760703126564 -0.060764535561326 -0.127333495556496 -0.038975339991215
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.051048798017957 -0.074362715758785  0.011189550347874  0.166183248293209  0.192475433446917 -0.070879824995188  0.064177194660693  0.010742342939181 -0.040136733536897
-    1  (  5)  0.352033813656896  0.019031583986239 -0.054018125678770 -0.066876079961762  0.060148226317505 -0.330348230405549  0.365124970723493 -0.284795973003397  0.051302526538111
-    2  (  6)  0.016809582021530 -0.311268516971319 -0.037661154101049 -0.006688597064521 -0.076727139945062  0.002675593746505  0.192087236696244  0.332474625249007 -0.065875996007770
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002709655241189 -0.005736834567419 -0.024459935540251  0.027202469191560  0.013148077561852
-    1  (  5)  0.191661619772419  0.061070263266083 -0.180667286312631 -0.019964047997521  0.020757203718357
-    2  (  6) -0.172312444590061 -0.078944608822717 -0.060240884585301 -0.044786922712268 -0.117310123601211
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102369  0.008188589712244 -0.013790999932790 -0.066013267343731 -0.002979179364342  0.115067560152145 -0.029904774000611  0.075658337330168  0.005135342269605
-    1  (  1) -0.415137332088593  0.400791789518608  0.060626653167985 -0.009777722957189  0.182694524485363  0.107591424113193 -0.071470092116897  0.210805299972922 -0.029640655301111
-    2  (  2)  0.731004204598539 -0.977674938020318  0.030910735141457  0.126476447646409  0.160297857646222 -0.115254107794131  0.017919423470240  0.019160269758167  0.056677210805976
-    3  (  3) -0.052710934455977  0.190825342618776 -0.121683764296172  0.058318753384790 -0.051331848225845  0.122833340921058  0.176985596744925 -0.321410474763131  0.015752780623204
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449210 -0.003857954296837  0.001116934481339 -0.006268480889133  0.011819863965878  0.022338641059405
-    1  (  1)  0.026581167918672 -0.003242138995830  0.002209759168115 -0.126256065331463  0.064001666171859  0.019583311633875
-    2  (  2)  0.060541607763315 -0.048685401885033 -0.005324531906372 -0.077364982992391 -0.023160042352107 -0.131997334895639
-    3  (  3)  0.086532549077844 -0.501054912835391 -0.033953281830236 -0.045954160893792  0.007588765668995  0.026055365513595
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407922 -0.003874637131511  0.017573675069951 -0.250000468336235  0.193535227171898 -0.023949830014066 -0.006344215172670 -0.002637721142584  0.025018403626545
-    1  (  5) -0.061066900138162  0.119597101102996  0.077747477731531 -0.181802110874953 -0.105212352540657 -0.191650240311690 -0.067261595147719  0.101033231559073  0.034053487252844
-    2  (  6) -0.129779125650164  0.272168473286843  0.218088904973320 -0.105590817864524  0.170044089806045 -0.413895401404370 -0.204721805057737  0.193774792721795  0.022574107317573
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304095 -0.022619515940241  0.001370551331510 -0.019480287608798 -0.016611790333307
-    1  (  5) -0.015006262168541  0.018557640744949 -0.000086080146176 -0.193359672647774  0.037991057379316
-    2  (  6)  0.020942063740396 -0.276121820896825 -0.020375408054502  0.090755244706106  0.038585932807353
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234755470283494 -0.089757897373023 -0.029226311105254
-    1  (  1)  0.628249611487220  0.562405195056322  1.006567293279198
-    2  (  2) -1.014513658696586  0.324469533164463  0.758540603298639
-    3  (  3)  0.070695571972183 -1.217301397368707  0.544825504539346
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235350713719762  0.628273412467369 -1.016171307500347  0.070820853933145
-    1  (  5) -0.089319079346849  0.558364917857370  0.332433157387864 -1.220987955904315
-    2  (  6) -0.028486683819979  1.000293875862993  0.767362449165297  0.543367325750416
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.804113115082455  0.859865209406016  0.271144212420684  0.233800284186302 -0.124039945960445 -0.010266323749662 -0.092708567501357  0.016778206024757 -0.004458179405400
-    1  (  1)  0.400343044462632 -0.255491137898947  1.725894952211800  0.228060869773307 -0.016813664829461  0.078025484956005 -0.010667432793270  0.508783176705984  0.007215780908165
-    2  (  2) -0.011354346714383 -0.088649218741449 -0.217285460959672 -0.271127696601540 -0.847424926486788 -0.636922641013145  0.167096970483964  0.613137270589854  0.118274978265621
-    3  (  3)  0.794199691903289 -0.188240166832108  0.221783053519910 -0.127263314849167  0.529647578782857 -1.234322959041016  0.503694754515590 -0.716759154325337  0.003713884622648
-    4  (  4) -0.401724672662141  0.338296304392090  0.027696569600321 -1.521982152309948  0.118592993378328  0.737822504259584  0.133024505198198  0.089529285352511  0.037479870573357
-    5  (  5) -0.062644206103430  0.401210407583400 -0.021849381974059 -0.715241456861978 -1.272083761860038  0.501726128250687 -0.443637757248648 -0.893021281361460  0.592660402987478
-    6  (  6) -0.010995449282209  0.203452242512839 -0.137034668384807 -0.113107359606136 -0.481513340581283  0.549194810269333  1.454087044363819 -0.104931286723820 -0.037492008681499
-    7  (  7)  0.128269755499576  0.321618430212563  0.165227456397829  0.036785042290427  0.490368577399842  0.556638814926841 -0.027991830909212  0.572834606710204  0.836617597163351
-    8  (  8)  0.028289154881442 -0.066964202719273 -0.261747148048831 -0.132206243094638 -0.099640531633387  0.125261053712953 -0.191170844521893  0.152462184420592 -0.345612464690994
-    9  (  9) -0.116917200684005  0.677293814759278  0.057457633837347  0.132537898195614 -0.004175807366704 -0.154875636337899 -0.038546773688736 -0.121822888362938 -0.349244520254430
-   10  ( 10) -0.180886604759008 -0.111792204437992  0.370617548329887 -0.010060948397228  0.175897261426766 -0.187416342815094 -0.018902126694376  0.507517994343601 -0.113620600518252
-   11  ( 11) -0.014433403132825  0.015210570936209  0.010143344331716 -0.005691229002329 -0.031059326071826 -0.023288546292954  0.128101332902295 -0.039392944850374 -0.110920114561200
-   12  ( 12) -0.125268954735592 -0.096735894811095  0.052480306210829  0.258243594453865  0.005805250173642  0.145107299027973  0.116452856795825 -0.074374807730489  0.022119923916468
-   13  ( 13) -0.016491827683000 -0.002316794514639 -0.087971851878045 -0.101325911412226 -0.036377238947018  0.195278206944873 -0.010131352705037  0.009611107176448 -0.056274461552982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020619978804339  0.055393926260198  0.016493468301721 -0.100372381621015  0.100626242248391  0.085758294302200
-    1  (  1) -0.158166323997468 -0.302157830906836 -0.003244540958724  0.141116982835093 -0.086717578223975 -0.004480871143071
-    2  (  2)  0.117237563107167 -0.174570847573252 -0.011204345589118 -0.263173432731339  0.005218532196608 -0.028842080195278
-    3  (  3)  0.116941646649193 -0.002586479599460 -0.011231548488137 -0.058984655279782 -0.019822661982992  0.041048882280086
-    4  (  4)  0.050776820640488 -0.220908341720040  0.039982596283608 -0.028513186801397  0.038501560477780 -0.072498198103576
-    5  (  5) -0.020348029264279  0.163764941111662 -0.082946711645309  0.111452654944127  0.037984566239170 -0.107199595569002
-    6  (  6)  0.021256126103386  0.388694787591368  0.114910007821023  0.018804713347355  0.008937619959603 -0.015873506672528
-    7  (  7)  0.297925323013454  0.033191669222593  0.094278199439532 -0.060174035263281  0.021406855727336  0.043089336483833
-    8  (  8)  1.538149876661768  0.255388094594368 -0.163312643003209 -0.034677585072596 -0.142125228818818 -0.045738087971649
-    9  (  9)  0.091443541252255 -0.031128123891514 -0.061982026707814 -0.058678185009605  0.760839955512426  0.950617857124013
-   10  ( 10) -0.067301877513064  0.211057800702034 -0.020603819563629  1.234407038988008 -0.163795705023159  0.167535211420885
-   11  ( 11)  0.163445976328784 -0.060082779666650  1.332811809287809  0.048638214648013 -0.084741484840295  0.093756111599773
-   12  ( 12)  0.205948682024817 -1.200679744036831 -0.135474810029670  0.365861100667199 -0.094093662797895  0.008686523394767
-   13  ( 13) -0.181605938452006 -0.042014918886112  0.112406427108237  0.222953862798683  0.995139187403184 -0.917632565321750
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802008727902655  0.406135528069519 -0.010476316013926  0.784475556802977 -0.394386683091322 -0.066798881058913 -0.011980564813183  0.124376056524346  0.033526134230598
-    1  ( 15)  0.862028914432838 -0.259382739909253 -0.086667305572571 -0.180064784220811  0.329908607377568  0.399964089565239  0.202187771096584  0.330121816685617 -0.071953120874633
-    2  ( 16)  0.271307809960517  1.724790149840174 -0.218446172710917  0.221581282093101  0.027552874986052 -0.019301351758235 -0.136156749402951  0.163711145289538 -0.262315292158509
-    3  ( 17)  0.233832160360253  0.228075923415992 -0.271855585596124 -0.127498943532143 -1.519236751765142 -0.714946933274599 -0.112783303905635  0.035742190545795 -0.131799331720450
-    4  ( 18) -0.125884857507906 -0.016503178327160 -0.848590316809834  0.528676059271022  0.118589942996707 -1.271521009940539 -0.481050683706143  0.489094666232740 -0.100427993377443
-    5  ( 19) -0.011410411929704  0.078504916539328 -0.635756927956291 -1.233330464680219  0.737249034134053  0.499445190730949  0.548364048058951  0.558640131286851  0.124411035854073
-    6  ( 20) -0.091600083261382 -0.011874324392682  0.166095509172920  0.503931355593027  0.132971166339089 -0.442847331045605  1.455101200236642 -0.028340512672194 -0.190421039545480
-    7  ( 21)  0.014506888035501  0.509793857361999  0.613540224928847 -0.716635769138310  0.088503909893924 -0.892421715175117 -0.105643577538643  0.572215069358707  0.150576387127192
-    8  ( 22) -0.004177720337601  0.006709815498338  0.117678875953444  0.003186946250536  0.038303116431661  0.593619431704902 -0.036920385902464  0.835672825510557 -0.345283877638120
-    9  ( 23) -0.021586239236069 -0.156869719857389  0.117889758366713  0.115161423657166  0.052238225817567 -0.022709102194002  0.020562459070758  0.298677779552414  1.538509512042494
-   10  ( 24)  0.054682068155330 -0.300070995804170 -0.172660016100405 -0.004680568559133 -0.221321821680689  0.163619483231767  0.386948477906821  0.033115261343779  0.254769962308421
-   11  ( 25)  0.016488293849114 -0.003235639473042 -0.011174682028047 -0.011243945686262  0.039809588242801 -0.082761513420814  0.114884412151995  0.094200391738432 -0.163393716854442
-   12  ( 26) -0.099231335638981  0.141112668735439 -0.262446613088938 -0.059563147663697 -0.028574452319685  0.111394864273783  0.018513759386770 -0.059760408126185 -0.034040397389902
-   13  ( 27)  0.100244162906019 -0.086825753516515  0.005142496829880 -0.019052879526344  0.037887085038908  0.037954868269094  0.008919579926842  0.021672382001814 -0.142649674386460
-   14  ( 28)  0.086046561377269 -0.004744302368675 -0.028249738219516  0.042030603060936 -0.073561648753544 -0.107720217983973 -0.016217142075139  0.044341471770558 -0.046187444393698
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124233708134536 -0.184518326175237 -0.014667753095384 -0.126540650902716 -0.015843433752182
-    1  ( 15)  0.686899770278225 -0.109692117003667  0.015377495137090 -0.096723489130418 -0.002397757787977
-    2  ( 16)  0.057205529179573  0.372042133273675  0.010210131259620  0.052160697899345 -0.088271643130934
-    3  ( 17)  0.131871345108646 -0.011180948360664 -0.005727193367078  0.259941586635767 -0.101614450210759
-    4  ( 18) -0.005079597151550  0.176830214271493 -0.031032942109530  0.004628941737735 -0.036366477592728
-    5  ( 19) -0.153488339566642 -0.188246645479895 -0.023332293508359  0.145173541284801  0.195552538719571
-    6  ( 20) -0.038666420291800 -0.018333798481472  0.128217423491274  0.116258211557260 -0.010271886085247
-    7  ( 21) -0.121961409061188  0.508144909444712 -0.039497933150400 -0.074911313979374  0.009738174256599
-    8  ( 22) -0.349752281191282 -0.113379050365462 -0.110884161439924  0.022227055299971 -0.056428042287591
-    9  ( 23)  0.091274387643065 -0.068482004342720  0.163392525285683  0.205701365643148 -0.181416453396970
-   10  ( 24) -0.031494844081003  0.210984913522447 -0.060264440706341 -1.201297108840478 -0.041823116964621
-   11  ( 25) -0.061998986866087 -0.020468588707388  1.332808723106093 -0.135556576828281  0.112406197562980
-   12  ( 26) -0.058487448548964  1.234274465594818  0.048631105388868  0.365854082845994  0.222962926250886
-   13  ( 27)  0.761200546740672 -0.163618812251394 -0.084738989433935 -0.094122389252816  0.995165590894080
-   14  ( 28)  0.951772998269778  0.167560207344595  0.093759874796882  0.008708619204364 -0.917569948681331
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062431637468595  0.002416441043494 -0.004633709181854 -0.077570764564634 -0.013832459901085  0.123710471759648 -0.027165779035151  0.071044010954103  0.019658423662051
-    1  (  1) -0.407170389584196  0.333069478291481  0.076649076907709  0.002175328366595  0.197922707135443  0.117656968282733 -0.067757706616656  0.182812175438110 -0.031734247883934
-    2  (  2)  0.673185035517385 -0.888138019247629  0.034358376579761  0.125358507387175  0.172994941404661 -0.106755581181951  0.013852200121288  0.009496870454373  0.036809619943014
-    3  (  3) -0.040742790622452  0.181389056204799 -0.117008669682236  0.012401302848616 -0.022196391591003  0.102862126461673  0.166049221641564 -0.310434511631988  0.017146561969833
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.010530607294135 -0.003710118206636  0.001098184033274 -0.004177259623773  0.010641720243897  0.020819711535909
-    1  (  1)  0.026376312845796 -0.003084063695379  0.001935075690028 -0.112197866496249  0.055637648529160  0.022260912302157
-    2  (  2)  0.054059905057592 -0.043789787513268 -0.004472231165839 -0.071437136436276 -0.024456749693059 -0.126350825107534
-    3  (  3)  0.083331116085326 -0.461426302980745 -0.028171699513189 -0.043194879139585  0.008942983333379  0.024389199674004
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.021216263100624  0.005003175055603  0.013535160841075 -0.263704651382093  0.210918804180330  0.005688291976374  0.005207710700417 -0.000895282201935  0.031550648985107
-    1  (  5) -0.080441383224428  0.123194069685474  0.057717422634392 -0.198323986141407 -0.141861353254421 -0.184709849630275 -0.056481718890527  0.088971412091793  0.030305733467359
-    2  (  6) -0.146541148918465  0.264369470289016  0.161465568338008 -0.083507608614829  0.171726934895341 -0.400382872983893 -0.201596935132327  0.184414767198991  0.015497227351109
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.010467742288235 -0.019463191825822  0.001308339278104 -0.016880359740534 -0.016885157913526
-    1  (  5) -0.009224792466207  0.019323723500933 -0.001197784436253 -0.171358632107000  0.032143333569086
-    2  (  6)  0.022721945593511 -0.245666385556985 -0.017093671892173  0.084713974597816  0.032963157176328
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521802 -0.064555152855138  0.195953381503071 -0.041248493404121 -0.011229686922121 -0.030149441468397 -0.052245051042500 -0.006640144591442 -0.060816046803627
-    1  (  1)  0.618380750339720 -0.527850820452490 -0.215416501468029 -0.157035437820935 -0.069798458053230  0.063297476854259 -0.224803808806348 -0.036770088857866 -0.093292414355442
-    2  (  2)  0.089963765220190  0.016694193855693 -0.049894217028098 -0.224500363636583  0.100545586935572 -0.339808932362447 -0.300486601784948  0.103978674940069  0.003854593986175
-    3  (  3) -0.017912540893907  0.240051544179785  0.016875920141055 -0.019658112757049  0.000950481978189  0.139486307895283 -0.307526295494266 -0.245045411721372  0.038982174459018
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151717 -0.053483299255778  0.001461399819935 -0.009996127160185  0.040844890766481
-    1  (  1)  0.010356156252342  0.045196494943179  0.123149462829327 -0.009608799091533 -0.092775098416550
-    2  (  2)  0.068261626755323 -0.266621644473694  0.090983468547791 -0.007824999539035 -0.015479677414575
-    3  (  3)  0.102991688131894  0.095940846129216  0.235195882789531  0.030438278876705  0.100331913639100
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065248  0.055002400477821 -0.190701615134341 -0.008587073557084 -0.137456634337712 -0.102685174742823 -0.038575707278161  0.049077773985898  0.038775520871497
-    1  (  5)  0.266426121061191  0.201904502527537 -0.404472747743473  0.112355452346505  0.244543383067869  0.203488255110531  0.093346083766348  0.046662175778569  0.162564534078649
-    2  (  6)  0.310200495971193  0.275860886663903 -0.334362481171662  0.111323203428083  0.107269573507973 -0.015396505983549 -0.485347827861583 -0.115211810541078 -0.189399381355351
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661082 -0.010182782856367  0.015536223735828  0.027148068637774  0.019304531582384 -0.012170541889263
-    1  (  5) -0.076359104752409  0.072719944885935 -0.105706045053714 -0.076791075572647 -0.095250630872885  0.044053081318688
-    2  (  6) -0.023401555368538 -0.060789750773995  0.233844071164901 -0.060200608258474 -0.022972229731696  0.078966373846356
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134464733238495 -0.662210405494713 -0.268087036060508 -0.078995101665649
-    1  (  1) -0.664136191142181 -0.208512216408356  0.147227682691113  0.068768195668241
-    2  (  2) -0.267178832853318  0.148347614169084  0.187155712816499  0.001725942570585
-    3  (  3) -0.077975712094611  0.066243031692256  0.004079617492317  0.013944312169831
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274618126592076 -0.278113702179189 -0.671633022270395
-    1  (  5) -0.277949145712571 -0.011863615919940 -0.010374435234634
-    2  (  6) -0.670048686168265 -0.009476206950290  0.097890068097066
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959494414290853 -0.408191876587357 -0.490587797784235  0.038620088951700 -0.077925870525924 -0.487449819239270 -0.107605742375904 -0.396082210854031 -0.237542456199032
-    1  (  1) -0.404346098969045 -1.325089706115921  0.174671472615893  0.248857938939690 -0.197997176299327 -0.317531715369544 -0.251443125493972 -0.030205216051466  0.632709778669897
-    2  (  2) -0.488203594414091  0.174177358170279  0.686637133275405  0.342440322127986 -0.009976595905960  0.483509687591532  0.287263685740954  0.302820486761602 -0.272146504988795
-    3  (  3)  0.037519851932805  0.250891430236009  0.345028453615613 -0.288802596502282  0.242048997261983 -0.302155533583706 -0.510767048111858  0.184742116191470 -0.216988138473832
-    4  (  4) -0.076335128439672 -0.199690457337231 -0.011287590259796  0.242287343472353 -0.131826185478683  0.385784652335332 -0.241579744319177 -0.375155233716578  0.062534851979726
-    5  (  5) -0.485786339572524 -0.319069045647698  0.484028655874806 -0.298894130368480  0.382592029688529 -0.557110750088133  0.333239304019173  0.111824333667390  0.019820080095694
-    6  (  6) -0.105004388042392 -0.251919494300239  0.289657780268581 -0.510934745583711 -0.243423593715530  0.333487274729372 -0.859815579894803 -0.040189411214503  0.015976724219764
-    7  (  7) -0.396742866204424 -0.028527583501407  0.303542401120419  0.181332247012507 -0.373287106593955  0.109028339876178 -0.042483577229034 -0.424450995877431 -0.165337209178978
-    8  (  8) -0.232477111217568  0.628541780993301 -0.273469783503725 -0.217890852518762  0.061988654737611  0.020919866007559  0.015643111904884 -0.165546891359504 -1.139952791754372
-    9  (  9)  0.005546163403788  0.056122031350974  0.162961042742049 -0.082482781173176  0.072908205250705 -0.108799436968506 -0.023533780380763  0.044777427042704 -0.147235448199817
-   10  ( 10) -0.006901975709221  0.054429650490003 -0.040577693872379  0.341755839709641 -0.179734725561057  0.323402736691831  0.128204737160643 -0.274641710567115 -0.052505646555499
-   11  ( 11)  0.095370531310646 -0.102133079874744  0.068438122875481 -0.163729824989548 -0.155636229704619  0.243225496644066 -0.456632637964553 -0.005300419866763 -0.049825612054653
-   12  ( 12) -0.031656876480322  0.049261490140927 -0.071615793822899  0.132066208561311 -0.108599421258561  0.096544859699583  0.079601642520208 -0.086582876221016 -0.054558080822567
-   13  ( 13) -0.055177843918678  0.125972146875380 -0.045925897173266 -0.019932953437884 -0.072414580136129 -0.032514397877208 -0.014074648780379 -0.073540469649060  0.566252900794764
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006844108037316 -0.007417708485432  0.096179215271910 -0.031845351907950 -0.055819107034893
-    1  (  1)  0.055009072408368  0.054764569974464 -0.101360748266653  0.049483066032708  0.126311659941364
-    2  (  2)  0.163126461717698 -0.041474056730500  0.069773970511476 -0.071604513134715 -0.045921679797628
-    3  (  3) -0.081145867550905  0.339512714763515 -0.164814632361134  0.131963409806745 -0.019701057447438
-    4  (  4)  0.071392957638912 -0.177541925322310 -0.155855587434795 -0.108549913772827 -0.072788709838572
-    5  (  5) -0.105620913909822  0.324570384536927  0.243426148668895  0.096676164465064 -0.032493241135614
-    6  (  6) -0.022622971576109  0.128555788054587 -0.457558865820421  0.079424640656331 -0.014304063550757
-    7  (  7)  0.043872369029022 -0.277428590499647 -0.005167508600307 -0.086808599804733 -0.073543295023506
-    8  (  8) -0.147656701585277 -0.051770671721882 -0.049464276722928 -0.054622357068254  0.565518286432935
-    9  (  9)  0.072058098581742  0.045414939179585  0.010276622684317  0.009607329011721  0.026546654266791
-   10  ( 10)  0.047972578248005 -0.139091273135494 -0.006969817312947 -0.101924439794115 -0.021963395913839
-   11  ( 11)  0.010225949518788 -0.006903254834441 -0.093461448932077 -0.006458623521929  0.037408632154760
-   12  ( 12)  0.009659072763447 -0.101989750292789 -0.006543886552567  0.055499957258902  0.004536647288290
-   13  ( 13)  0.026525022859865 -0.022073627181823  0.037503294944017  0.004573821056444 -0.064450805660396
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.531729549886298 -0.787699013260720 -0.218007437963128  0.182768764967664  0.602768885926166 -0.199812958118043  0.029032839745447 -0.008774056556998 -0.142478600997401
-    1  ( 15) -0.793340915328517 -0.320131124132658 -0.162653978535470  0.058649157291279  0.020639907683325 -0.223525268439384  0.107699068558594 -0.353783645623560 -0.095871343640248
-    2  ( 16) -0.212191388052984 -0.164888118017376 -1.296946785661574  0.042300146112888  0.273826728839772 -0.438781481182649 -0.122091204716307  0.097191959045013 -0.140871391153761
-    3  ( 17)  0.179719553134882  0.058669914491584  0.044506714025066  0.293003077614788  0.349110568675561  0.303215667162415  0.076915097449125  0.005807473711893  0.013837821466959
-    4  ( 18)  0.599360800493389  0.022132908209793  0.274035423937454  0.351223850237582  0.210864723099932  0.044675310303669 -0.438675626813712 -0.490920343842293 -0.399212333009898
-    5  ( 19) -0.200407898503595 -0.221431932840884 -0.440102897905219  0.305762109212930  0.044881546181386 -0.117472965844391 -0.191665223291112 -0.319783714572633 -0.359452162382383
-    6  ( 20)  0.032165821117663  0.105941691907443 -0.123879210125571  0.078979233990532 -0.440650088275931 -0.189889145121382 -1.110705925194965  0.246906737793529  0.255259757334091
-    7  ( 21) -0.008321241705301 -0.354528191467815  0.096628486245053  0.006334262611059 -0.491255100347711 -0.318969662674625  0.247541587785850 -1.005004062277651  0.329386657154236
-    8  ( 22) -0.142962699223549 -0.097023037413528 -0.141097052846351  0.015166149438974 -0.401326717044885 -0.359426368361956  0.255258622579679  0.329097335449224  0.052132117322127
-    9  ( 23) -0.219955098740470 -0.249965476004888  0.576414624728282  0.098982863369388 -0.020508824733516  0.097549190747056 -0.059941456738217  0.014715712854346  0.155030958604429
-   10  ( 24) -0.078889746445523  0.108239301318901  0.027162587747041  0.046514963820434  0.091370815063922  0.113422647703502 -0.170202961400924  0.302110584863860 -0.032804637243887
-   11  ( 25)  0.043306270957027  0.032344455295716 -0.179576712827774  0.107307667430455 -0.187560546689596 -0.097222488608903 -0.510712264729794 -0.080025590477581  0.081254866792350
-   12  ( 26) -0.068084805818490  0.217394768160197  0.162482224135859  0.182198793902305 -0.078588038008549 -0.138375144701551  0.045964808967526 -0.318369645237611 -0.094340949188752
-   13  ( 27)  0.012776338365641 -0.163304628586287  0.065170181095058  0.076353862354929 -0.116471236774223 -0.057100568669610  0.002733328139540  0.275543901650406 -0.101218272889531
-   14  ( 28)  0.072542900570950  0.116082117753812 -0.039461901860534 -0.060056679393757 -0.063442716501334 -0.039954821491188 -0.007431183194756  0.061660754619171  0.127196734189506
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223424944652175 -0.079375640508209  0.044559638332806 -0.069603179695813  0.011608492724559  0.073681298891794
-    1  ( 15) -0.252190810534109  0.107773105664069  0.031929727381883  0.217773765514458 -0.162942254516907  0.115583488493230
-    2  ( 16)  0.579669499848572  0.028398284174960 -0.180764151357438  0.163082238678493  0.065318137383570 -0.039861277950844
-    3  ( 17)  0.098419070380212  0.045497640187139  0.108888066901844  0.182679251676257  0.077063420292881 -0.060270475148200
-    4  ( 18) -0.021657152218140  0.091391477818874 -0.188694941835346 -0.078654463993081 -0.116917635244861 -0.063687461311382
-    5  ( 19)  0.097200061293784  0.112946819841968 -0.096557046310004 -0.138722208764674 -0.057492822647748 -0.039657945432933
-    6  ( 20) -0.058061983715355 -0.170140847494679 -0.511516651549454  0.046153385708922  0.002608094185221 -0.007424017797985
-    7  ( 21)  0.014898598107636  0.302204656416843 -0.080604696411276 -0.318409184220291  0.275439068186170  0.061680442175982
-    8  ( 22)  0.155158381420859 -0.033182129585361  0.080993013335593 -0.094077880752320 -0.101045740908378  0.127069446713633
-    9  ( 23) -1.153500606432346 -0.223848574870748  0.084940142762255 -0.000172697505726  0.401118128913118 -0.346039941954413
-   10  ( 24) -0.224004522828874 -0.014993374950352 -0.013190820033296  0.067266852084063 -0.009898419000703 -0.084301934906622
-   11  ( 25)  0.084246516406413 -0.012971453666467 -0.099638608783543  0.005049425073667 -0.012239639402272  0.023058100761842
-   12  ( 26)  0.000190360752639  0.067412521796062  0.005072007098540  0.014663156532778 -0.012615786454218 -0.021995005158486
-   13  ( 27)  0.401506800485801 -0.009668467136188 -0.012313296328671 -0.012645382168417 -0.008180220628733  0.091135079144531
-   14  ( 28) -0.346436667192436 -0.084407881559669  0.023159285170777 -0.022057721310468  0.091092458906097  0.040126683454997
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057778460125475 -0.058621598376446  0.204961973610432 -0.030014886957110 -0.012702201238060 -0.012361806840330 -0.042464722570104  0.000589178332867 -0.053783176425629
-    1  (  1)  0.588150716074137 -0.466021636272279 -0.203183245475023 -0.148450737716195 -0.057365952908272  0.049828198627789 -0.211650340717459 -0.033709163320874 -0.066014023276537
-    2  (  2)  0.097096715428347  0.013316869335681 -0.075592001791495 -0.184144455632612  0.076454331448179 -0.322693901417475 -0.283033300411638  0.095787940086230  0.009135557725685
-    3  (  3) -0.012585457310361  0.213693355283451  0.008392879074051 -0.006477176275207  0.025095812734804  0.122050564721351 -0.287478867298026 -0.227752050770288  0.025535574433447
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004343658462411 -0.045416781087739  0.000353809954909 -0.008814420994644  0.038608153091639
-    1  (  1)  0.012371345270913  0.037357699916558  0.110010051271466 -0.008428651261314 -0.087698412018737
-    2  (  2)  0.059734573261687 -0.241104936943560  0.080654968743397 -0.004302203609171 -0.010690545484549
-    3  (  3)  0.093269555935928  0.087251850932645  0.210582632378020  0.029543407964615  0.092601662289167
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.096268685878252  0.067598109905929 -0.171831816211843 -0.019892225326929 -0.151432830345500 -0.102828613678797 -0.031328453208209  0.054857782228203  0.045391983457330
-    1  (  5)  0.259548823811749  0.185158249821502 -0.361847535039713  0.121706180799369  0.214912924418826  0.198674927692087  0.082249065771639  0.046754216202725  0.144894234011997
-    2  (  6)  0.316675644828390  0.241534850892177 -0.298024592816788  0.095120602156143  0.117908244615295 -0.011781114685658 -0.451417780640774 -0.113394265201560 -0.193663841427194
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.075217766018102 -0.009009066779015  0.013059078733354  0.023267742031503  0.019382631456237 -0.010439549922317
-    1  (  5) -0.055615787731083  0.073750137089776 -0.094740835467127 -0.066906556461946 -0.087569521638086  0.039832146294914
-    2  (  6) -0.007989421944926 -0.055545532554458  0.206332460425461 -0.056516118698094 -0.025725290779719  0.073743491663518
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016118777276715  0.076689387067910 -0.125264792267213  0.007931013310159 -0.098301937535619 -0.089040062536403 -0.042653189503990  0.143650549015434  0.062698356849217
-    1  (  1) -0.038523460792185  0.325926212074866 -0.217436403108304  0.076210929079487  0.124956744969463  0.049869905306287 -0.256022567536771  0.049219148025203 -0.025163660677627
-    2  (  2) -0.015460259327543  0.182364499530151 -0.081021447104334  0.065186772706427  0.193628085224658  0.090709199284724 -0.144227288852916  0.007154481293509 -0.060483347873691
-    3  (  3) -0.069494321441897 -0.016013992178315  0.169506236224075 -0.050547669997934 -0.177140340538951 -0.181255025833236 -0.201077665225237 -0.109139777586652 -0.215083611892000
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159361864611552 -0.056476108299593  0.034334354535920 -0.068420323850568  0.100698715800717 -0.049820592017766
-    1  (  1) -0.121041364374108 -0.003994619377140  0.190684428167186  0.052070114913538 -0.189028662705267  0.205096915582724
-    2  (  2)  0.013836799939815 -0.073875918803128  0.147901928532515 -0.343158528114240  0.053056478393310  0.086736758175874
-    3  (  3)  0.065392768372813 -0.072388535495375  0.365788807268936  0.156911353062530  0.184439406967998 -0.043117455907282
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095080611028905 -0.132974666952795  0.233475927910152 -0.109077700761869 -0.033619328181748 -0.003336619392392 -0.079318686273400 -0.006541773193153 -0.188514066103895
-    1  (  5)  0.133180554197729 -0.220459497770333 -0.122961007604827 -0.144493780528925  0.034530325126889 -0.144382538755407  0.001565508478549  0.179104189145759 -0.084352671049965
-    2  (  6)  0.305369897772518 -0.245966510909105 -0.171589985467989 -0.288954965589194  0.048536799653817 -0.105233271021575 -0.400024803684146 -0.035818012706229 -0.066124321501166
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011358647742861  0.047842821118306  0.011877525445924 -0.012099889406653  0.055702357687979
-    1  (  5) -0.060987538430202 -0.100437160073965 -0.174976176295347 -0.033059202656664 -0.296249624542357
-    2  (  6)  0.156959926194252 -0.053853503787377  0.406665675932450 -0.026462885456155 -0.143060389345544
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.020933994600404 -0.036837370041378 -0.105536213576208
-    1  (  1)  0.298453027380235 -0.115575201783041 -0.255528599615218
-    2  (  2)  0.258793135913458  0.115959940555419  0.442826057795212
-    3  (  3)  0.060024736570876 -0.030098554189578 -0.068752806226696
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019369167440735 -0.299662599013862 -0.261538199445479 -0.060711849430245
-    1  (  5)  0.036904684367183  0.115259605353543 -0.117033018013316  0.032657591929024
-    2  (  6)  0.104769015611943  0.252811001882389 -0.444270078409885  0.069751899589238
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.140264901989732  0.063903836208700 -0.058837720478344  0.099834492513857 -0.059321359064218 -0.159667027697165  0.002087278187167 -0.046204224826828  0.008601023391647
-    1  (  1)  0.090548490120087  0.202601353512529 -0.092021876157049 -0.096539072051997  0.170154281529252  0.083912296322820 -0.509059273187923  0.818772979644953 -0.070828284365805
-    2  (  2) -0.023785290834458  0.356113587695708 -0.273990976839604  0.279080899835211  0.352444630227632 -0.196438091918237 -0.305379232907223  0.066497365309668 -0.201285694555594
-    3  (  3) -0.097000901586888 -0.245927544981666  0.317839114090146 -0.024062116307417  0.214330573426636  0.049574376579035  0.029033713280438  0.054130019251473  0.003096872422278
-    4  (  4)  0.057665969694961  0.180120952217587 -0.233587576454962 -0.044983378670516 -0.207784279042753 -0.114395252588009 -0.123426849025615  0.227078923197653  0.055512731053909
-    5  (  5)  0.215771286107030 -0.314990234779502  0.316883540178318 -0.120867850220805 -0.280144439746019 -0.294187393366266  0.216440287801519  0.200727103538257  0.064432166939554
-    6  (  6)  0.088234371667171 -0.148935506374392  0.366935246390879 -0.011963781822295 -0.214228897418453 -0.110020140834752  0.192637863546305  0.231329350431209 -0.059800681126421
-    7  (  7)  0.046850408793983  0.280155317167401 -0.370918303757555  0.110906122388311 -0.088736250126060  0.146624611249243  0.021132431838010 -0.399622620248811 -0.041122390922456
-    8  (  8)  0.213219122375794  0.108141657808899 -0.632333203738685 -0.072815736912286 -0.035034243651182 -0.162896842787145  0.072787072592861 -0.219123938652931  0.041084573562014
-    9  (  9) -0.053156461400879  0.091068663315954  0.087565530354220 -0.029252405162121  0.135958664144570 -0.072618412616171 -0.001674517036246 -0.447580570679357 -0.046048420321108
-   10  ( 10)  0.217389369502910 -0.434955320268301 -0.409591028918214 -0.322091930890674 -0.032769693001577  0.320487371417213 -0.022524010208258  0.286088771348243  0.028739508255579
-   11  ( 11) -0.043655408036926 -0.078795431314352  0.262179238045961 -0.331516326718921  0.435766491267148  0.063689969335714  0.247099037158840 -0.001834914627209 -0.140224560742040
-   12  ( 12)  0.056091676196034 -0.010888223476595 -0.132073582410596 -0.097444459311643 -0.064913316132981  0.000177701715019 -0.216786241209525  0.136744724942226 -0.129238968566772
-   13  ( 13)  0.037502956248588  0.225853404732460 -0.091597810906137 -0.251988574100658 -0.015208060782076 -0.284415044485819  0.108318027167759 -0.003844624714698  0.367465648248436
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222316043515173 -0.015706219813460  0.082385006687320  0.001598515176512 -0.060473243217402  0.093727480766952
-    1  (  1)  0.559608456549850 -0.123427525882115 -0.153467678522284  0.170334032667751  0.080737466652215 -0.083738891751807
-    2  (  2) -0.169476216588385 -0.033571289044860  0.409164888922149 -0.223598543173697 -0.075034173166616  0.314714537560889
-    3  (  3) -0.116710909315575 -0.019725573527882 -0.283423547853871  0.175125619030608 -0.285157403250322 -0.036616525847335
-    4  (  4)  0.005652624292121 -0.042302085019166 -0.326173261129808 -0.429217689688999 -0.082297928451369  0.119033467524274
-    5  (  5) -0.013435701805306 -0.050340607661298  0.120543829175976  0.018862712789954 -0.153571720838557 -0.076183620287339
-    6  (  6) -0.081289708009932 -0.326406046335021 -0.215268699384055 -0.111421444457992 -0.019027619773786 -0.098888316320541
-    7  (  7)  0.155159820795190  0.099172439421084 -0.073800976886365  0.027692155232139 -0.092694133839456  0.234604646553257
-    8  (  8) -0.037085102415794  0.221081896212581  0.033634728216760 -0.500286732444230  0.749342092540231 -0.380702305205380
-    9  (  9) -0.121604531068668  0.307665948271803  0.063134933207098  0.759313712683884 -0.291120411772461  0.157024245706380
-   10  ( 10)  0.436899181077493  0.180584483336554 -0.427706818265058  0.039319556166566 -0.042977724169066 -0.570262735340494
-   11  ( 11)  0.012744975594815  0.355849153273434  0.014473345977435  0.331011762918559 -0.082407538752018 -0.048301595441145
-   12  ( 12)  0.275248111407273 -0.041018113706040  0.197136817157691  0.114052207324942  0.270934107062801 -0.185007344485080
-   13  ( 13) -0.588095271872920  0.141945816656553  0.099720177389789 -0.418487800295605  0.225864709971283  0.209383142865023
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.136055292355693 -0.095447390079340  0.020092912976452  0.093125301806219 -0.056850399225392 -0.218468169087239 -0.091857234706676 -0.045161486852249 -0.214714486134321
-    1  ( 15) -0.061207776400224 -0.202708633629211 -0.353114471022979  0.245649376419565 -0.180866138364034  0.315320438007598  0.149515492263340 -0.279091224397284 -0.106858935875563
-    2  ( 16)  0.054684214245539  0.094025065222640  0.275943577798546 -0.316343751367895  0.233336305598380 -0.315879985031598 -0.365377908227180  0.369960150477096  0.630562926717977
-    3  ( 17) -0.098691998169988  0.096665834479676 -0.277640044986388  0.024005765248079  0.044522040617490  0.121507599386095  0.010509659584542 -0.111862233831084  0.073060388343816
-    4  ( 18)  0.060773979545201 -0.171895263117941 -0.351151470699367 -0.213576840796575  0.206989754617357  0.279451579746598  0.215385933896301  0.091082110140082  0.034953691198195
-    5  ( 19)  0.161690364133666 -0.086139117701369  0.195608563911810 -0.050196750893508  0.114409300434323  0.293302924591653  0.108870291715961 -0.145705855705827  0.162864209989065
-    6  ( 20) -0.004933077734461  0.509112916459715  0.304189657786525 -0.027011307788378  0.123564513171824 -0.216326146660944 -0.190918994832455 -0.021599458243760 -0.073921971953628
-    7  ( 21)  0.046939300208709 -0.818898745115211 -0.067231269443295 -0.053385434393248 -0.227366778650250 -0.200959323300586 -0.230355491785330  0.400408400878989  0.219890208910709
-    8  ( 22) -0.008875208231344  0.070617448884265  0.201028236092715 -0.001986037102750 -0.055524570746332 -0.064229773357344  0.060955407810699  0.040899342701140 -0.040928237624152
-    9  ( 23)  0.222811666664930 -0.561652381203109  0.169673185845526  0.114995614482537 -0.005558626156127  0.012604855943775  0.079125943676941 -0.154935461007958  0.034774271928076
-   10  ( 24)  0.015658264689237  0.122684274627566  0.033049817652516  0.019053422527839  0.043070830779656  0.050152205966237  0.326697513368317 -0.099443390036459 -0.221198097566915
-   11  ( 25) -0.081038041563999  0.154593341750092 -0.407140318931982  0.281943720612544  0.325675147388131 -0.120351655341255  0.214124337140213  0.074325284613066 -0.033051994607945
-   12  ( 26) -0.003149016432983 -0.169066126704265  0.222974141740581 -0.178167341127558  0.432229982121915 -0.017874255780535  0.111773550217181 -0.031100511775812  0.501206663109520
-   13  ( 27)  0.059358328554799 -0.079903052840446  0.074950199177116  0.286331686497637  0.080924619758545  0.153353900448026  0.018409365441232  0.093462744168473 -0.750750124348698
-   14  ( 28) -0.091958135023802  0.083203421400514 -0.314158605792337  0.035767063530586 -0.118730598661029  0.076122730197956  0.098773188363513 -0.234233392684125  0.381969165301650
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054160915945440 -0.219019011349658  0.045758113327127 -0.056667077142781 -0.042241899582407
-    1  ( 15) -0.090944710506667  0.435278295065980  0.077842273581985  0.010976755804927 -0.224792334219628
-    2  ( 16) -0.088739489380727  0.410297160213689 -0.264172456920594  0.132125091344117  0.093086518366925
-    3  ( 17)  0.030526782846308  0.322820843845164  0.334117022964236  0.097597092001360  0.253965732413055
-    4  ( 18) -0.135352462834400  0.032599183228255 -0.437639446213156  0.064872058901777  0.014497262646719
-    5  ( 19)  0.073899654730442 -0.320885730724610 -0.062344415655754 -0.000276840662850  0.283336476795450
-    6  ( 20)  0.001158784637988  0.022837257389255 -0.248024269025133  0.216907823965295 -0.108098145849829
-    7  ( 21)  0.447481917087611 -0.286161905602590  0.000998969948768 -0.136653733410721  0.003506425728694
-    8  ( 22)  0.045854947627220 -0.028382633755552  0.139989494186330  0.129405417600154 -0.366820033409182
-    9  ( 23)  0.122256207458041 -0.437180402944026 -0.011581755997582 -0.275567866951767  0.586898649032620
-   10  ( 24) -0.308323852677721 -0.180850894824869 -0.356131896237584  0.040945642422104 -0.142574344254184
-   11  ( 25) -0.063098776158328  0.427549053292047 -0.014802143274616 -0.197270506582796 -0.099635293972022
-   12  ( 26) -0.762581095039490 -0.039734172920445 -0.331033022441221 -0.114161465508855  0.418490755826759
-   13  ( 27)  0.291938944356913  0.043222558646275  0.082214356128437 -0.270960148007918 -0.225910263769365
-   14  ( 28) -0.156871086239257  0.569997035340436  0.048467653901954  0.184994394399617 -0.209531521675460
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.009005560415620 -0.070810523176753  0.120067832596330 -0.009073132789057  0.090464498751423  0.086174111119354  0.045794981404383 -0.145874969594551 -0.061668751575064
-    1  (  1)  0.049157751161976 -0.341837336007353  0.225991322214198 -0.079794887273987 -0.129000775913212 -0.051890082528198  0.264098306233452 -0.041882987798608  0.014437873768995
-    2  (  2)  0.004178475304275 -0.176534362212284  0.088484784587547 -0.060893560844785 -0.188770646517540 -0.098157508320685  0.154422738208026 -0.028159762307564  0.056745595914708
-    3  (  3)  0.078632631263391  0.018162490565869 -0.185802179760109  0.047918543127734  0.190222116766280  0.186537019008367  0.211456806958070  0.116264562677776  0.222361952728882
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163744366705646  0.058513889685968 -0.036529339633760  0.074890516703321 -0.101980211526271  0.048987870817682
-    1  (  1)  0.129678391589477  0.003465728257171 -0.197451754644996 -0.065935565415812  0.202740138649240 -0.212710296862521
-    2  (  2) -0.022460564343485  0.084272909470111 -0.151124340943592  0.372643880141893 -0.063147940573273 -0.083681000851943
-    3  (  3) -0.069418152872000  0.077040623108210 -0.377203303892585 -0.165559399244429 -0.189357768189066  0.044737808867399
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.085668830826552  0.137820799821428 -0.214610467959109  0.105542261331575  0.036859097160699  0.000473863191187  0.079606876493940  0.008613359831911  0.198755661758927
-    1  (  5) -0.139412038667804  0.235636886292823  0.125284829879163  0.147970518740863 -0.038362154224395  0.146537444592945 -0.006121389458985 -0.189794595760356  0.090516747843842
-    2  (  6) -0.309048143972667  0.258748687397478  0.168238503241577  0.304764034594830 -0.050456064213686  0.094565768675462  0.416604423570797  0.027331415693002  0.066446598559594
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.012674523904089 -0.052192101234841 -0.013753920669736  0.012760663896321 -0.052741920591878
-    1  (  5)  0.065601509403618  0.098250162685785  0.177768481553462  0.033008693934464  0.305584708162473
-    2  (  6) -0.160962535198804  0.052046626684912 -0.419200543530856  0.024457493928167  0.150587999794571
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002292052292103 -0.001327689025616 -0.000248352651822 -0.007958119616401 -0.006332326100069 -0.018602233716078 -0.068879285117605 -0.007819744108382  0.006538352080531
-    1  (  1) -0.002764164951484  0.002219747844781 -0.018293151832048  0.029668233290910 -0.039848292773073 -0.022489745012597 -0.162281988584096 -0.020804504235237  0.019083175045335
-    2  (  2)  0.011217835122942  0.011598249376099 -0.016968466001430  0.008250037510454  0.006232273271199  0.008766677291355  0.010338243291251  0.010725726663582  0.004470553150490
-    3  (  3)  0.050562851864422  0.047527304873166 -0.078707468856861  0.000484758494314  0.025585059000149  0.011993586441405  0.049963781283820 -0.008029454242805  0.026864587292976
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006805334012410  0.003000362320124  0.002228041038774  0.000013471324712  0.003129940535122 -0.001748281527537
-    1  (  1) -0.013913717596781 -0.013715090430948 -0.022806809849797 -0.002206415430012 -0.006824605289547  0.005086150284378
-    2  (  2) -0.011033408042674  0.021897939524419 -0.000684908130867 -0.006441462755861 -0.002207402072499 -0.000019160522387
-    3  (  3) -0.030996252825103 -0.007986449014412  0.024562077320802 -0.006200249162121 -0.010690383251548 -0.011486173135262
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.008068643711801 -0.010525757489218 -0.001816581937116 -0.014852647204910 -0.016446444650493  0.051123908211814 -0.105303074579265 -0.010186396385182 -0.002604742010165
-    1  (  5) -0.024807027264740  0.041872241876177  0.005357408083722 -0.028564486604489 -0.031353252400093  0.040716482303670 -0.082357809569052 -0.022204595749263  0.028676826310240
-    2  (  6)  0.057433465116021 -0.072910653400311 -0.007950207598684 -0.045866077252401 -0.051478467074881  0.066399959025161 -0.120267838044196  0.002980749702428 -0.024762093508968
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000934050050601  0.000604010149742 -0.003646663045597  0.000033137801782  0.002019175758164
-    1  (  5)  0.015497094356084  0.002871076746167 -0.025548488367170 -0.001995117147543 -0.006447008967147
-    2  (  6) -0.009288606849912 -0.006735078994323 -0.016930923349151 -0.006239987724853 -0.010309885333920
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.002224796248932  0.043809288397668 -0.042786645812817
-    1  (  1)  0.035961652529642  0.375558249507307 -0.229138680808401
-    2  (  2)  0.031482392637318  0.208906969570392 -0.045224347296993
-    3  (  3)  0.099946950247302  0.215409785029960  0.414532197880426
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.002181806445193 -0.035979573047749 -0.031640926892770 -0.100238553322265
-    1  (  5) -0.043671265862196 -0.375015508928976 -0.208917842140980 -0.216574490738358
-    2  (  6)  0.042527296867704  0.228253198541364  0.044456455969980 -0.415218734433247
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.071571831474078  0.044653489385004  0.010701302384521 -0.107261739958166  0.107631207507480  0.021982609216158  0.087555139416088 -0.002428271330290  0.013116395341898
-    1  (  1)  0.000994163831951 -0.002283385696650  0.009683189881167  0.069987093364656 -0.211165412824247 -0.144806549288858 -0.839471629333561 -0.082797629633042  0.083995255816987
-    2  (  2)  0.048029450774152  0.034159151942753  0.005345969743377 -0.362094457083752  0.166955343421217 -0.200138180389859 -0.200325175150546 -0.048097856321736  0.015226624624379
-    3  (  3) -0.099901242333760 -0.066741882163174  0.192006761021434  0.037162207196608  0.149491220617197  0.091957380518235 -0.124661875998661 -0.114474410410770 -0.084751404274498
-    4  (  4) -0.098292057994740 -0.060260709677490  0.234095836344240  0.042527139722405  0.172693635464862  0.110397071373739 -0.184879337331564 -0.074537123570685 -0.084735776692236
-    5  (  5)  0.074314676568805  0.053240577551284 -0.354242764435207  0.039009834260932  0.144962419013306  0.061650919712871 -0.045188344047270 -0.085035282721814  0.173092563485556
-    6  (  6) -0.068641550367955 -0.078242424055456  0.700330832585814 -0.207548816757698 -0.389421892794422 -0.222244858530312  0.109406330044358  0.045457397940437 -0.343867539807075
-    7  (  7)  0.021723320720404  0.016351205203476  0.098413699787287  0.004057278627194  0.006939091834835  0.079051971654245  0.378143817290533  0.122761983444910 -0.057845298080872
-    8  (  8)  0.009573032166809  0.006109372122326 -0.063933429430759  0.085659891507819 -0.069748375065097  0.032412606198411  0.211702458249100  0.046995111806491 -0.044380498011898
-    9  (  9) -0.004993361863043 -0.003634014150995 -0.021315829704565  0.021713795540591 -0.030056681969938 -0.023359631271158 -0.128991093821754 -0.016400014214086 -0.007638043352367
-   10  ( 10)  0.003364468158750  0.005158901374854  0.010157814233361  0.013146135283286 -0.036788603301889 -0.001796925979298 -0.031087735489025 -0.158319551738170 -0.001398916399977
-   11  ( 11) -0.005212014578832 -0.005572219785769  0.129300362837609 -0.009016877484905  0.009416239426444  0.064438058134478  0.026488687258820 -0.021963612194050  0.285489003307810
-   12  ( 12)  0.022889675001499 -0.014028568601137 -0.005258310077958 -0.012614598275049  0.011181538654879  0.041924328606934 -0.003053461905651  0.141650155501189 -0.005090787707422
-   13  ( 13)  0.006246133552104  0.010356570946206  0.013049157750693 -0.012424981952374 -0.009162366348548 -0.014458376447183 -0.062634797746530 -0.024809108873570  0.013232375979099
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.002828230885259 -0.008462795614423  0.005154038879344  0.009706144885118 -0.000351690712204 -0.003016908410820
-    1  (  1) -0.016542909802003 -0.036808232009347 -0.132827410709676  0.012545312927289  0.013603497625073 -0.014243226256359
-    2  (  2) -0.056531888264110  0.026681841564715  0.044472892095955 -0.008316762319552 -0.009818160226072  0.003132505638469
-    3  (  3)  0.065664012413420 -0.084000307061434  0.024123678461565 -0.011516052481207  0.005295212539449  0.009770444853693
-    4  (  4)  0.036042306167929  0.066196882580851 -0.035814283991967  0.000422354014022  0.007346814292352  0.010225200735509
-    5  (  5)  0.148907428019867 -0.109320100217019 -0.041270431698870 -0.008286052492371  0.000171545458770  0.012799874602526
-    6  (  6) -0.267740896585426 -0.203497348994007  0.004880757246495 -0.039144439238699  0.017848850593927 -0.043282221917129
-    7  (  7) -0.072391125356364  0.141340064883945 -0.132216664302783  0.021712276497558 -0.014580212743961  0.003413596406028
-    8  (  8)  0.065338926975322  0.070417584641905  0.663636576046729  0.043614890913083  0.008447529962600 -0.017635456067550
-    9  (  9)  0.053338372051572  0.015608392811416  0.295869564541767  0.007118975871925  0.021727777212874 -0.010944181246410
-   10  ( 10)  0.043778421907192 -0.395589362339912  0.177341233202869  0.145584179195568 -0.046786531122239  0.019085441444645
-   11  ( 11) -0.612579899217924 -0.015866362451336  0.053555820669477 -0.384133045755224 -0.648991284315058  0.223359237845080
-   12  ( 12)  0.089924264835293 -0.149474889068186  0.147998013353447 -0.410950037016040  0.122612685939173 -0.053519931502489
-   13  ( 13) -0.016968386753168 -0.001120736716635  0.667558162177878  0.016648983669680 -0.049072172914969  0.011592992748874
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.071349801352714 -0.001077758689270 -0.047849010758326  0.099049708991045  0.097373218549676 -0.073249702217693  0.066497399663864 -0.021905924000240 -0.009611371244577
-    1  ( 15) -0.044780949738342  0.002559008927919 -0.033951661393688  0.066729312295417  0.060308115101389 -0.053229541901532  0.078046690958424 -0.016360376267857 -0.006154062585818
-    2  ( 16) -0.011020054803348 -0.009639577990268 -0.005659342412167 -0.191466387657639 -0.233770018397514  0.353943104953864 -0.699652203951292 -0.098429630868855  0.064028996133411
-    3  ( 17)  0.107854789786829 -0.070585793426064  0.362141920362757 -0.037292065848127 -0.042427554280204 -0.038929544624314  0.207453249613870 -0.003913287572517 -0.085781111935039
-    4  ( 18) -0.108209449998589  0.211629628691260 -0.166874900133538 -0.149325288082853 -0.172890816462261 -0.144890994778007  0.389082003854745 -0.007000687821959  0.069612637937369
-    5  ( 19) -0.022019034844530  0.144617634612034  0.200192966932155 -0.092059326306506 -0.110737371319811 -0.061364605633156  0.221637061620796 -0.079021140430879 -0.032667339771983
-    6  ( 20) -0.089130158761340  0.839805360702565  0.200387491136600  0.125541335494667  0.184496760040884  0.044995250241868 -0.109402692051630 -0.378035804168224 -0.212908503907275
-    7  ( 21)  0.002178057091036  0.082925436926419  0.048118216149304  0.114730021254923  0.074453346277450  0.084891108935456 -0.045281773316414 -0.122667104662944 -0.047081579488124
-    8  ( 22) -0.013014867453698 -0.083878416356731 -0.015105645463008  0.084649544925904  0.084843093804877 -0.173122296622746  0.343876299664282  0.057834963947671  0.044464266623977
-    9  ( 23)  0.002901775226447  0.016234828173147  0.056359654971911 -0.065872157385184 -0.036362021680569 -0.148332139389866  0.266718078511433  0.072258279284240 -0.065401012908072
-   10  ( 24)  0.008445720197208  0.036804429594076 -0.026642166859464  0.084168947416296 -0.066510758074240  0.109381013548543  0.203196264302595 -0.141165925569768 -0.070499221179176
-   11  ( 25) -0.005377792056995  0.132971363586077 -0.044450134013510 -0.024046237867949  0.035750577264431  0.041236558408713 -0.004898258174407  0.132214673314304 -0.663804812343683
-   12  ( 26) -0.009728994170677 -0.012565610031588  0.008265487183253  0.011507462056025 -0.000390885497569  0.008310505974528  0.039141081466535 -0.021755546401078 -0.043610775840933
-   13  ( 27)  0.000301420723240 -0.013603051175605  0.009758944837902 -0.005201669668069 -0.007344582365292 -0.000240423767516 -0.017707548228131  0.014600989921611 -0.008461166379486
-   14  ( 28)  0.003079753925572  0.014179269497254 -0.003153288832510 -0.009783782056838 -0.010222304053932 -0.012792812982895  0.043303231879505 -0.003407229733486  0.017679792666433
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.005093584579739 -0.003397430557442  0.004751145314811 -0.022993999775599 -0.006406607432759
-    1  ( 15)  0.003664268681973 -0.005140681437481  0.005623137023323  0.014031183819186 -0.010293722738861
-    2  ( 16)  0.021380720709283 -0.010101149193742 -0.129156907046771  0.005327658954335 -0.012995314092573
-    3  ( 17) -0.021888212102979 -0.013219387248743  0.009147784998755  0.012607741489428  0.012451560776458
-    4  ( 18)  0.030283770762202  0.036869387279966 -0.009496744772099 -0.011181780485761  0.009182409552405
-    5  ( 19)  0.023453672116025  0.001799424920848 -0.064551617042567 -0.041960641260944  0.014420118956797
-    6  ( 20)  0.129458546494568  0.031271046054797 -0.026491102279080  0.003035012140173  0.062712336606301
-    7  ( 21)  0.016591446747124  0.158366047016833  0.021959782838746 -0.141640631249085  0.024819174074491
-    8  ( 22)  0.007575701587639  0.001384112156404 -0.285443557719673  0.005092627774539 -0.013202606990523
-    9  ( 23) -0.053335089301781 -0.043785415746453  0.612428033952452 -0.089945127333784  0.016908784258582
-   10  ( 24) -0.015338693676901  0.395633576722136  0.015809806174567  0.149475505805733  0.001108572795382
-   11  ( 25) -0.295832367201873 -0.177313650229223 -0.053561286295896 -0.148004020967956 -0.667548449265010
-   12  ( 26) -0.007157154416058 -0.145586590425994  0.384132810583031  0.410951719442907 -0.016651787670946
-   13  ( 27) -0.021701996830356  0.046797876195804  0.648997652718972 -0.122606232077452  0.049068049852610
-   14  ( 28)  0.010942221777250 -0.019093183683670 -0.223365949415048  0.053520759465633 -0.011602247780488
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002779955261603  0.001692895942305 -0.000296900585249  0.009027308047397  0.005517424530412  0.019392785745096  0.071615718156204  0.008379623734860 -0.006552142468187
-    1  (  1)  0.002104549417692 -0.002248748312386  0.016268779471160 -0.026298614529289  0.037020427510003  0.022919155336995  0.164160248243373  0.021028638082435 -0.018807600972838
-    2  (  2) -0.012197014321068 -0.010749741004112  0.015969423342584 -0.008379419120709 -0.005700661608129 -0.009182078264487 -0.007072493012826 -0.010651845449984 -0.003884546255784
-    3  (  3) -0.055916626202382 -0.044952545452401  0.075693796863108 -0.001117242062951 -0.024281174456382 -0.014619597544438 -0.053283290640730  0.007703747637899 -0.022436578410201
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006982563138735 -0.003194903879745 -0.002336222897234  0.000159319304137 -0.003153288870770  0.001705858583767
-    1  (  1)  0.013922175981332  0.014264739151757  0.027533427644979  0.002422850658312  0.006842699761048 -0.005360945695368
-    2  (  2)  0.010224586423111 -0.021331787446370  0.001728789794737  0.007349416930946  0.001927444504520  0.000065986060579
-    3  (  3)  0.028649073776620  0.008193923965951 -0.026834068422643  0.006433642271155  0.011064478009774  0.011417291735949
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.007713676236593  0.011322134542428  0.003907084678219  0.013398999832291  0.015469012646281 -0.052157960119991  0.107410796770668  0.010366341516334  0.002761603992801
-    1  (  5)  0.025927350683998 -0.036918918076003 -0.006183726668217  0.026765793037022  0.030906551194516 -0.042649472793173  0.084196537695922  0.021256853976094 -0.026253718608666
-    2  (  6) -0.059547667994817  0.071575508753467  0.010792071396252  0.045987434407757  0.051692908853285 -0.069048919754801  0.125623895288436 -0.001752094627181  0.022191347480178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000950352585130 -0.000964031243708  0.004357151868410  0.000282508389387 -0.001887057940293
-    1  (  5) -0.015009418487876 -0.001705110486741  0.029429172036479  0.001075595895759  0.006702102006371
-    2  (  6)  0.007980731926488  0.006589892733093  0.020940438262105  0.005674678855388  0.010940914550878
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440295578  0.058098623160145  0.000062770556734 -0.132305009159611 -0.206845253888058  0.090151367716479 -0.021622993201581 -0.039361663017837  0.081041759541848
-    1  (  1) -0.058446002592383  0.108172168387664  0.020491566069371  0.029038345945870 -0.075256281089891  0.197244333760833 -0.268904698800656 -0.104165934684918  0.067340388337437
-    2  (  2) -0.015395531940673  0.065975044888456  0.020693241252069  0.145278172828421  0.156811977467588  0.026190455409862 -0.072791620600653 -0.106379132149930  0.008110007387645
-    3  (  3)  0.209889648220476  0.051262205346321 -0.016792464687925 -0.095510023534387  0.095336437810918 -0.289116526954893  0.245753636284359 -0.379261907424047  0.084194488967520
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922100177 -0.024147628250431  0.039515998201655  0.082736569420115 -0.047511948424277
-    1  (  1)  0.028213287461099  0.067760885411210  0.238885785807081 -0.125969164479712  0.177609465312039
-    2  (  2)  0.077606300081105 -0.045313543916726  0.093141189396730  0.365274041996187  0.093447143795058
-    3  (  3)  0.414915648100446  0.159852566418800 -0.273568285227138 -0.034618677637943  0.200919751819537
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102681987247 -0.069778483698168  0.053388820632184  0.227201022134102 -0.199230027457495  0.049687576281282 -0.168877445270920 -0.014461225328823 -0.006078045812768
-    1  (  5)  0.058029574787105 -0.323045692563541  0.030451397472046 -0.087822399116244 -0.049669665032409 -0.052839306746917 -0.277652121541251 -0.149775076383341  0.305937155270733
-    2  (  6) -0.084055275470365  0.046073375199285  0.190725804864314 -0.087557818530586 -0.137785527514627 -0.205465571554509 -0.198777590920696 -0.118276962990446 -0.298899363373256
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985616709  0.083163093490794  0.059838819851119  0.009394325001919 -0.030439464329862  0.004211858017357
-    1  (  5)  0.056299326992345 -0.068872084539633  0.330916524068157 -0.053769676104372 -0.184435947376542 -0.103868547783998
-    2  (  6)  0.066328790174083 -0.124449756312359  0.113043685745465  0.144452726551049  0.299204372306590 -0.043729255680777
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000261962805527  0.008184590036916  0.017078206714547 -0.120797444663216
-    1  (  1) -0.008556708940915  0.000310357479341  0.070665159347740 -0.263733240360097
-    2  (  2) -0.016665957640930 -0.070092969568202  0.000658296979419  0.516406140442811
-    3  (  3)  0.119815260993819  0.260397085059189 -0.515923296927157  0.000854850636513
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000399146441393  0.382166830385046 -0.144086395309984
-    1  (  5) -0.378879203373124 -0.000650240992924  0.057572968692994
-    2  (  6)  0.142267704977137 -0.057783925625683  0.001456329094586
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000900630817554  0.057480932301245  0.021776185729722 -0.109986124582383 -0.040974945330873  0.038859091716892 -0.013722976007050  0.027662163358449  0.095856958174055
-    1  (  1) -0.055475653729801  0.000055946423413 -0.161049994133599  0.114708024204161 -0.226365261647007  0.429957047290397 -0.365226817146616 -0.339873184728980 -0.220417191818889
-    2  (  2) -0.021015776391225  0.161427052909876  0.000077274959500  0.056803578516090  0.009014493962561  0.218381032705501 -0.249538253456386 -0.218329398300718  0.109423644471870
-    3  (  3)  0.109912942235435 -0.115891216387226 -0.056027564915087  0.000745943372336  0.462877633738761  0.122572187022543  0.103916786291671  0.116372032296581  0.000178644283986
-    4  (  4)  0.040100257401875  0.225977964738004 -0.007764610803158 -0.462832592343494 -0.000863713188322  0.292983388565633 -0.009504255770613 -0.051881331882898 -0.039789084738632
-    5  (  5) -0.036362528925732 -0.431143684565054 -0.219013710239047 -0.122734678900396 -0.292859375843390 -0.000211534680094  0.380048338834312  0.122563604837503  0.042304270254859
-    6  (  6)  0.010482485700734  0.366095597661643  0.249485788064463 -0.103549341685718  0.008516226169398 -0.379084427040244 -0.000639775867465  0.110614613813807 -0.062004820067381
-    7  (  7) -0.028768402882084  0.339119958859187  0.216813059372753 -0.114011828936208  0.053232451800269 -0.122211769727443 -0.109878960190362 -0.000261733603902 -0.084697348659745
-    8  (  8) -0.095810944695339  0.221328249276198 -0.109105398407016 -0.000872051363332  0.038539628128303 -0.040520833999869  0.059740000698589  0.084693665490196  0.000412317879658
-    9  (  9)  0.014697085572369 -0.105287145446065 -0.107273285124554  0.218858370800790  0.309735125099707 -0.105267325854044 -0.129620026346489  0.117982202893295  0.042502371715710
-   10  ( 10) -0.029182274069824  0.107750482915279 -0.099755873232372  0.053540519729340  0.138357776561313  0.190065661316288 -0.089951321859094 -0.050398080030990 -0.205938711533234
-   11  ( 11) -0.155188100419270  0.443693923193144 -0.328775787595012 -0.218791170588425 -0.215183707581290  0.086687685172567 -0.081438682030110 -0.042661060649417  0.076989743302328
-   12  ( 12)  0.047041819133234  0.056356277723762 -0.091876156457250  0.290703693299404 -0.241933426060854 -0.247197194304072  0.042704222313260  0.092541926182781 -0.274193192866188
-   13  ( 13) -0.050345457187291  0.050309029533973 -0.290248962160651  0.162027268205590  0.213802087129947 -0.103771321970539 -0.033795235497895 -0.045614675872296  0.299788281594492
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015094426489385  0.029115659613983  0.157755053899576 -0.046090500922969  0.051508699260243
-    1  (  1)  0.106870813652794 -0.107133528015315 -0.444981848759502 -0.057242056092260 -0.049852574162924
-    2  (  2)  0.109000377776186  0.100245307552926  0.328735836791228  0.092813183683021  0.291725571255699
-    3  (  3) -0.218950464663642 -0.054805102085229  0.218886888542850 -0.287519470239803 -0.163372131318531
-    4  (  4) -0.309058290561687 -0.137567383239755  0.215197532854542  0.238351393836415 -0.213552990219106
-    5  (  5)  0.105624117972050 -0.189859620690769 -0.086820347884659  0.246317074454971  0.103852569604006
-    6  (  6)  0.128090000856950  0.089849284790687  0.081980995688424 -0.043663325009380  0.033155703031442
-    7  (  7) -0.117989240855164  0.049695249544289  0.043676012478627 -0.088835836027467  0.045632574214248
-    8  (  8) -0.043185512310112  0.206252030230843 -0.075219160600281  0.272504390674221 -0.299099410447325
-    9  (  9) -0.000057792160806  0.416496446259856  0.033591110007553 -1.079044045817673  0.144878189091344
-   10  ( 10) -0.417381448990175 -0.000164005362256 -0.288881720270974 -0.322059475407989 -0.291538277058572
-   11  ( 11) -0.033261524584632  0.288678211108029  0.000120543612153  0.357470920187363 -0.110246704427593
-   12  ( 12)  1.082405304483696  0.322498276514614 -0.357322196019218  0.000062083058686 -0.002512916703852
-   13  ( 13) -0.144912114579266  0.291369916474373  0.110105006775573  0.002446483993983  0.000063534084907
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000175081543235  0.016120371429442  0.025072002498304 -0.062542190001802 -0.021350885611547  0.118270325314463 -0.004836963443515 -0.089308321494225  0.035265121599229
-    1  ( 15) -0.019016581108199 -0.000074621970575  0.073692709803714 -0.220090875517869  0.117001241546735 -0.069843654088595 -0.194734592940075  0.297334325625652 -0.000079679030764
-    2  ( 16) -0.022601123418379 -0.074079137647861 -0.000898075728427 -0.015352523942528 -0.086856492084779 -0.105020764975973 -0.399309885639222 -0.436863382131768  0.175020106394673
-    3  ( 17)  0.059722097345643  0.223919505098562  0.017236939707976  0.001153330835786  0.251337783789024 -0.316047497618501  0.195069502405347  0.070796117852759 -0.376854141068864
-    4  ( 18)  0.020136753535406 -0.119176676580157  0.086690091555957 -0.251646590139027 -0.000253931741203  0.043128862347216  0.031767565075469  0.166618171717943  0.162853353427719
-    5  ( 19) -0.121150060676491  0.070465337136684  0.107141402917482  0.315382260507260 -0.043144844880677 -0.000915299484024  0.084836748925337  0.176704257940108 -0.191804096130314
-    6  ( 20)  0.000227153495196  0.194659284089696  0.399818522753271 -0.193896536829138 -0.032525351177495 -0.085523354347228  0.000313079507665  0.483156326770454 -0.288322768300902
-    7  ( 21)  0.086746307137050 -0.297294170806804  0.437363838809433 -0.070300496686642 -0.166591994782638 -0.177217714676447 -0.482838971708773 -0.000010492293158  0.098273184847418
-    8  ( 22) -0.034845258926463  0.000856544015042 -0.174085542944903  0.374309528502768 -0.160749665940989  0.191624326414423  0.289454904423207 -0.097021267550286 -0.000014930403134
-    9  ( 23) -0.146129839058625  0.053485685235489  0.324250294825688  0.062889229683993  0.055229748354907  0.064112736518454  0.152978751390762  0.139451617186824 -0.103725991413667
-   10  ( 24)  0.228960109301508 -0.607985902209196 -0.190616272123952 -0.232984732345919 -0.097313246050482  0.308149392800304 -0.021807135674588  0.163587870408667  0.316482089556332
-   11  ( 25) -0.113565876404474 -0.174438492287337  0.418980586076638  0.308342622144811 -0.075432621028035  0.339103289288013 -0.159452756259669 -0.028406298387558 -0.098839597099947
-   12  ( 26) -0.037444327267497 -0.021664072112540  0.117362801200428 -0.051936890369174  0.180410685976303  0.010675625355601  0.081438166282141 -0.155940478341525  0.070485054402519
-   13  ( 27)  0.017297506490474 -0.067203074043417  0.031147633780062 -0.363738862057104  0.387270613641932  0.012184715254153  0.015942188037241  0.055059690817384 -0.199296990199252
-   14  ( 28)  0.034092252177280  0.073609066570291 -0.020468002829462 -0.085810470847407  0.016765555515325 -0.112839616184042 -0.014153257364848  0.178002322135800  0.110338785365483
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147095539872376 -0.230933799773572  0.118289772746159  0.038253772767438 -0.016292190599376 -0.035682534667399
-    1  ( 15) -0.054490936726022  0.608135664745132  0.173899591973771  0.021325225109122  0.066354839577593 -0.073331369735504
-    2  ( 16) -0.323391847959362  0.191801489512728 -0.419969130886919 -0.118001273092270 -0.032684795751606  0.020933916119483
-    3  ( 17) -0.062697350486216  0.233350536310731 -0.310310140488106  0.052850324165962  0.365716314917336  0.086296396691588
-    4  ( 18) -0.056488793458209  0.097314229222503  0.076761540605130 -0.181114864878229 -0.388829148158998 -0.017043041264799
-    5  ( 19) -0.064628320787142 -0.308910350912419 -0.338058227371863 -0.010220898623398 -0.011328162399013  0.112362127982886
-    6  ( 20) -0.155379178216757  0.021354195203649  0.159398635050554 -0.081833336858149 -0.016534888228425  0.014163359612815
-    7  ( 21) -0.140544774640631 -0.163930417297838  0.028664595573872  0.155618444233800 -0.055735865052570 -0.178161215640947
-    8  ( 22)  0.103335943311626 -0.315447824318076  0.098508893733054 -0.070643837593413  0.199190551733374 -0.110186805922077
-    9  ( 23)  0.000685205966667 -0.100205727138125 -0.098177984906046  0.175404901290335 -0.218086466804573  0.228138153240994
-   10  ( 24)  0.099957378010052 -0.000114683002834  0.318552989781421 -0.225328174596453 -0.500054658950178 -0.463890214112073
-   11  ( 25)  0.099837194917026 -0.317752725239532 -0.000013072206941  0.325584528982677 -0.211934933711074 -0.064802310197909
-   12  ( 26) -0.174911687089744  0.225249469039813 -0.325644361756676  0.000020583584119 -0.212000345487719  0.097990759740781
-   13  ( 27)  0.218595256276680  0.499626470482130  0.211748903875100  0.211985776866882 -0.000065067673371 -0.140785106097385
-   14  ( 28) -0.228612967389221  0.463548085364371  0.064895093957796 -0.097943745399768  0.140883877569216 -0.000043885507604
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019700182677107 -0.054538984090235  0.000657293183087  0.126059310809811  0.202210998435547 -0.093434338948912  0.024491292826920  0.039730679308171 -0.082949626694246
-    1  (  1)  0.060570767175445 -0.116914550591561 -0.021887147512720 -0.031244847376015  0.072525220228195 -0.201021150446149  0.281719713830611  0.109054645892934 -0.074327440399932
-    2  (  2)  0.019917912309244 -0.073498936617270 -0.021015841735436 -0.144973687437559 -0.148661911932328 -0.032805680200530  0.073267109264718  0.114043301611775 -0.006398273119569
-    3  (  3) -0.203013924377866 -0.061956730055074  0.012687970996344  0.097374198936086 -0.112619147770746  0.293844050008896 -0.262428514093214  0.382217125669607 -0.093448479811714
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009866900732451  0.025414444169079 -0.042903095265212 -0.089054808289042  0.047172870515861
-    1  (  1) -0.029479300283789 -0.071852668133045 -0.250209813738974  0.142668644531379 -0.184582935130086
-    2  (  2) -0.082839864480010  0.055172054044893 -0.094169081580928 -0.401277867082134 -0.092346870950092
-    3  (  3) -0.429785932962397 -0.170247315400433  0.282336698266608  0.039589385431124 -0.207542683133741
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.009866584979611  0.069659389537491 -0.056437231681762 -0.210909857782961  0.193232853181259 -0.044263163299027  0.177086741570330  0.011251791029683  0.005974944716262
-    1  (  5) -0.063966745715496  0.332083812922556 -0.023959233352897  0.077592998716570  0.049685567261429  0.057922845574581  0.292828526996055  0.156611147799579 -0.308189152931942
-    2  (  6)  0.093646243694878 -0.043886805978709 -0.210333087134871  0.092497904993075  0.147507586034143  0.211245402574055  0.209822842363998  0.120370292677794  0.308437245541794
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068407482810996 -0.091070726633549 -0.065843093849225 -0.010412482581374  0.030047987986099 -0.002926817734499
-    1  (  5) -0.052950259935718  0.069489349844532 -0.341748563636018  0.056521413026788  0.185361514981414  0.106113084848256
-    2  (  6) -0.072195900884664  0.125482826256953 -0.118114475628611 -0.149158088490925 -0.308475854808778  0.046262836261962
-
 	Computing Mu_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.841616280598
-	   1         4.511795705571    2.109e-01
-	   2         4.959050111723    1.004e-01
-	   3         4.980051362351    2.096e-02
-	   4         4.981320179484    7.724e-03
-	   5         4.981712301022    1.504e-03
-	   6         4.981835231534    5.699e-04
-	   7         4.981819356707    1.580e-04
-	   8         4.981812139647    5.884e-05
-	   9         4.981808242510    1.860e-05
-	  10         4.981808168486    8.098e-06
-	  11         4.981808837701    2.000e-06
-	  12         4.981809266352    4.488e-07
-	  13         4.981809436467    1.498e-07
+	   0         3.841616266483
+	   1         4.511795686270    2.109e-01
+	   2         4.959050086804    1.004e-01
+	   3         4.980051336735    2.096e-02
+	   4         4.981320153822    7.724e-03
+	   5         4.981712275335    1.504e-03
+	   6         4.981835205844    5.699e-04
+	   7         4.981819331017    1.580e-04
+	   8         4.981812113957    5.884e-05
+	   9         4.981808216821    1.860e-05
+	  10         4.981808142797    8.098e-06
+	  11         4.981808812011    2.000e-06
+	  12         4.981809240662    4.488e-07
+	  13         4.981809410777    1.498e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.562e-08
 
 	Computing L_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.095996289782
-	   1         6.401596951212    3.937e-01
-	   2         7.797672748548    2.746e-01
-	   3         8.105509880086    9.848e-02
-	   4         8.202475872992    6.039e-02
-	   5         8.232003385578    2.167e-02
-	   6         8.240339701422    1.437e-02
-	   7         8.242815228230    6.444e-03
-	   8         8.243750371709    3.872e-03
-	   9         8.243811218558    1.729e-03
-	  10         8.244025976019    6.964e-04
-	  11         8.244145019707    2.164e-04
-	  12         8.244270446726    1.004e-04
-	  13         8.244319437498    4.431e-05
-	  14         8.244354784931    2.740e-05
-	  15         8.244377042272    1.336e-05
-	  16         8.244393992810    5.930e-06
-	  17         8.244396855967    1.275e-06
-	  18         8.244398212127    4.908e-07
-	  19         8.244398122576    2.569e-07
-	  20         8.244398166129    1.002e-07
+	   0         5.095996266154
+	   1         6.401596925248    3.937e-01
+	   2         7.797672723860    2.746e-01
+	   3         8.105509853867    9.848e-02
+	   4         8.202475847793    6.039e-02
+	   5         8.232003359838    2.167e-02
+	   6         8.240339675148    1.437e-02
+	   7         8.242815201852    6.444e-03
+	   8         8.243750345219    3.872e-03
+	   9         8.243811192088    1.729e-03
+	  10         8.244025949533    6.964e-04
+	  11         8.244144993224    2.164e-04
+	  12         8.244270420239    1.004e-04
+	  13         8.244319411009    4.431e-05
+	  14         8.244354758443    2.740e-05
+	  15         8.244377015783    1.336e-05
+	  16         8.244393966320    5.930e-06
+	  17         8.244396829477    1.275e-06
+	  18         8.244398185637    4.908e-07
+	  19         8.244398096086    2.569e-07
+	  20         8.244398139640    1.002e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 4.203e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.329380164115
-	   1         9.982622912399    3.629e-01
-	   2        11.316565097793    1.815e-01
-	   3        11.483610038950    4.249e-02
-	   4        11.487719401060    1.145e-02
-	   5        11.490868056764    2.611e-03
-	   6        11.490678794860    1.109e-03
-	   7        11.490551310701    3.019e-04
-	   8        11.490621874917    1.299e-04
-	   9        11.490607272896    3.636e-05
-	  10        11.490610763466    9.668e-06
-	  11        11.490612036643    2.944e-06
-	  12        11.490613344936    9.958e-07
-	  13        11.490613800255    2.559e-07
+	   0         8.329380069571
+	   1         9.982622799105    3.629e-01
+	   2        11.316564962112    1.815e-01
+	   3        11.483609893762    4.249e-02
+	   4        11.487719255728    1.145e-02
+	   5        11.490867911252    2.611e-03
+	   6        11.490678649360    1.109e-03
+	   7        11.490551165206    3.019e-04
+	   8        11.490621729416    1.299e-04
+	   9        11.490607127396    3.636e-05
+	  10        11.490610617966    9.668e-06
+	  11        11.490611891143    2.944e-06
+	  12        11.490613199435    9.958e-07
+	  13        11.490613654755    2.559e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.332e-08
 
 	Computing L_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.291582245314
-	   1         0.391360792165    1.143e-01
-	   2         0.514608664360    8.375e-02
-	   3         0.540629484353    3.014e-02
-	   4         0.551092090644    1.684e-02
-	   5         0.552549053313    4.703e-03
-	   6         0.552460440102    3.209e-03
-	   7         0.552807688285    1.921e-03
-	   8         0.552828305284    6.241e-04
-	   9         0.552824586002    1.739e-04
-	  10         0.552831493610    1.022e-04
-	  11         0.552830688522    3.442e-05
-	  12         0.552831290252    1.883e-05
-	  13         0.552831270170    6.104e-06
-	  14         0.552832487454    3.439e-06
-	  15         0.552833334194    1.199e-06
-	  16         0.552833945135    5.391e-07
-	  17         0.552834170620    1.869e-07
+	   0         0.291582241455
+	   1         0.391360786593    1.143e-01
+	   2         0.514608655744    8.375e-02
+	   3         0.540629474944    3.014e-02
+	   4         0.551092081033    1.684e-02
+	   5         0.552549043629    4.703e-03
+	   6         0.552460430401    3.209e-03
+	   7         0.552807678538    1.921e-03
+	   8         0.552828295532    6.241e-04
+	   9         0.552824576250    1.739e-04
+	  10         0.552831483857    1.022e-04
+	  11         0.552830678770    3.442e-05
+	  12         0.552831280500    1.883e-05
+	  13         0.552831260418    6.104e-06
+	  14         0.552832477702    3.439e-06
+	  15         0.552833324442    1.199e-06
+	  16         0.552833935383    5.391e-07
+	  17         0.552834160868    1.869e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 6.600e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.819681087960
-	   1         6.899835155239    2.798e-01
-	   2         7.664038983693    1.259e-01
-	   3         7.705339789575    2.470e-02
-	   4         7.705610751208    7.996e-03
-	   5         7.706340128198    1.678e-03
-	   6         7.706507735661    6.930e-04
-	   7         7.706472063356    1.633e-04
-	   8         7.706469048057    6.155e-05
-	   9         7.706466402851    1.459e-05
-	  10         7.706467448390    4.167e-06
-	  11         7.706467926070    1.273e-06
-	  12         7.706468214800    3.747e-07
-	  13         7.706468324110    1.051e-07
+	   0         5.819681038435
+	   1         6.899835092030    2.798e-01
+	   2         7.664038906396    1.259e-01
+	   3         7.705339710771    2.470e-02
+	   4         7.705610672325    7.996e-03
+	   5         7.706340049284    1.678e-03
+	   6         7.706507656739    6.930e-04
+	   7         7.706471984436    1.633e-04
+	   8         7.706468969137    6.155e-05
+	   9         7.706466323931    1.459e-05
+	  10         7.706467369470    4.167e-06
+	  11         7.706467847150    1.273e-06
+	  12         7.706468135880    3.747e-07
+	  13         7.706468245191    1.051e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 3.397e-08
 
 	Computing L_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.474769876147
-	   1         5.526295847669    3.606e-01
-	   2         6.609530180555    2.826e-01
-	   3         7.125831101786    1.487e-01
-	   4         7.367086459667    9.337e-02
-	   5         7.417232111235    3.155e-02
-	   6         7.433498205025    1.839e-02
-	   7         7.435046902193    5.844e-03
-	   8         7.434207112168    2.565e-03
-	   9         7.433995521881    1.114e-03
-	  10         7.433956521439    5.405e-04
-	  11         7.433940521986    2.026e-04
-	  12         7.434010604710    7.193e-05
-	  13         7.434031997663    2.958e-05
-	  14         7.434067355257    1.772e-05
-	  15         7.434091951598    6.997e-06
-	  16         7.434104173139    2.786e-06
-	  17         7.434107868770    7.688e-07
-	  18         7.434108079734    2.424e-07
-	  19         7.434108081302    1.112e-07
+	   0         4.474769853145
+	   1         5.526295822132    3.606e-01
+	   2         6.609530153650    2.826e-01
+	   3         7.125831079300    1.487e-01
+	   4         7.367086443196    9.337e-02
+	   5         7.417232095929    3.155e-02
+	   6         7.433498190198    1.839e-02
+	   7         7.435046887357    5.844e-03
+	   8         7.434207097286    2.565e-03
+	   9         7.433995507019    1.114e-03
+	  10         7.433956506573    5.405e-04
+	  11         7.433940507125    2.026e-04
+	  12         7.434010589849    7.193e-05
+	  13         7.434031982802    2.958e-05
+	  14         7.434067340395    1.772e-05
+	  15         7.434091936735    6.997e-06
+	  16         7.434104158276    2.786e-06
+	  17         7.434107853907    7.688e-07
+	  18         7.434108064871    2.424e-07
+	  19         7.434108066439    1.112e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 6.199e-08
 
 	Computing 1/2 <<Mu;L>>_(0.128) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933721  0.015024519180326 -0.027415915569923 -0.162886507397727  0.113254822182230 -0.064023650931695  0.055316304980596  0.030988679956785  0.002674429417476
-    1  (  1)  0.215473680254307  0.146951879885488 -0.277734064030091  0.062883278348033  0.148483123915935  0.181595053380776  0.367001371843723  0.003086313328543  0.095386404339359
-    2  (  2) -0.028492499167413  0.000076506520592 -0.059221747197110  0.071711487991993  0.074053260083109  0.055563200913397 -0.046720222778269  0.241063526706418  0.098194384215293
-    3  (  3) -0.132536698935214 -0.177581639220038 -0.107360746511049 -0.032262815899170  0.006088751294726  0.053657437577810 -0.241466578728657 -0.131962062699396  0.577380042604835
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927831  0.060461893794975 -0.005615477646773 -0.003888920206540  0.016113135271294 -0.008672229740056
-    1  (  1) -0.037058680758827 -0.084686071934137 -0.145302623884175 -0.027760832624305 -0.054555858489407  0.022009727182520
-    2  (  2) -0.087315818129458  0.399047483163755 -0.041723099752479 -0.020041920189961 -0.040600995633870  0.007777357868476
-    3  (  3)  0.035307803556717 -0.050920479686547  0.165550414172803 -0.068091463340346 -0.144062340529092 -0.042051983076333
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356551 -0.081063517853355  0.006129432769008  0.163964563111000  0.188951419459772 -0.080047732466251  0.074988303081870  0.007836242506546 -0.044696302205990
-    1  (  5)  0.348085979138495  0.014814724303192 -0.054134117524112 -0.070406995762186  0.073423358836432 -0.343984245233763  0.389896180591070 -0.295068043464411  0.051928952937999
-    2  (  6)  0.021691230674310 -0.340003625622930 -0.038072452179286 -0.014533847126846 -0.084733391360489 -0.004556444515536  0.201335045135150  0.349717311230196 -0.082620936463629
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932767 -0.007485730843831 -0.029474818409046  0.032209758674478  0.014108652541197
-    1  (  5)  0.209382720135363  0.066996563725017 -0.203801631001167 -0.021994746468443  0.025790645299276
-    2  (  6) -0.188199132187483 -0.086167806666973 -0.070501884768031 -0.051440727873373 -0.127552190835530
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135226960454326 -0.626072128797857  0.189283545408855
-    1  (  1) -0.198601340506735 -0.037544167210710 -0.132449472453123
-    2  (  2)  0.054869769604049  0.126822216303606 -0.064658685102817
-    3  (  3)  0.615161980452153 -0.126204375217762 -0.081927924761016
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135552779706605 -0.198154082714880  0.054851984676121  0.616510373253301
-    1  (  5) -0.625008803021783 -0.037782453643461  0.128063646533814 -0.126279998076325
-    2  (  6)  0.187629167441123 -0.129442737930211 -0.067422044676096 -0.079936634548171
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904639712499439 -0.487488103200078 -0.229076194035628  0.577203417890213 -0.193643876563157 -0.103447604010519 -0.002742470403338 -0.002451788094665 -0.093813724218962
-    1  (  1) -0.150591231752385 -0.132839961398676 -0.684911223766579  0.231736797158491 -0.050522572300056 -0.177494490840237  0.234003342486172  0.124606643062309 -0.128494931356702
-    2  (  2)  0.012679732612823 -0.025746334218930  0.172509146876788 -0.235881170188821 -0.123364008456996 -0.206129657450583 -0.121800673855382 -0.114140784221046 -0.027356216567616
-    3  (  3) -0.420686741899061  0.000223888623800 -0.019382136800409 -0.199660686586704 -0.007228242971196  0.053875733566288 -0.291408914352108  0.275298575094317  0.504737487457471
-    4  (  4) -0.444479349932735 -0.097546029689345 -0.201324076119096 -0.112193453656006 -0.168730295177533  0.009510393466858 -0.073326647656929 -0.314743664834676  0.576679302947966
-    5  (  5) -0.139143305540494  0.035439861017529 -0.250210390538725 -0.395563451554441  0.287109450839755 -0.179399443391463  0.197453518892032  0.283328589948463 -0.108409713739276
-    6  (  6) -0.129858112319467 -0.067528694061781  0.181320447910051  0.198216451549547  0.101434222271457  0.004260476702563 -0.540044484893393  0.047093544204498 -0.240211227858317
-    7  (  7) -0.134029026372179 -0.177806690148740  0.066071255125330 -0.420048245168209  0.282274848902370 -0.347456793165357 -0.074406017626720 -0.307127129684534  0.001639432917262
-    8  (  8) -0.063335732549795 -0.086906710930686  0.269779701592780  0.018783692891969  0.093247017991832  0.136863024113189  0.153892981652101 -0.031577691616059  0.057553836246877
-    9  (  9)  0.014012585179935  0.032071651340400  0.006363849845328 -0.122564599853796  0.077119470960861 -0.029965581352468  0.027046636903361  0.089397837094510 -0.000802529924297
-   10  ( 10)  0.055348506435330 -0.144624122276394  0.060432277066912 -0.048567020795905 -0.074912986944547 -0.098523802539045  0.029250640804257 -0.193836130554804  0.085063532916871
-   11  ( 11) -0.167019155111352 -0.139650558475052  0.283534980836448  0.091894060309814 -0.065838077605570 -0.024336945622802 -0.227843897422647  0.001167201554402 -0.053408806911177
-   12  ( 12) -0.031974022074098  0.367173995466688  0.116713714097486  0.049340092544991  0.015070529788372 -0.072500414701040  0.058353998450087 -0.115184864373280 -0.153182495837634
-   13  ( 13)  0.015928358602531 -0.071164774172966  0.101660897809927 -0.105977026406625  0.126658664034785 -0.065056017101773 -0.035738606034778 -0.004435603298653 -0.059994356828765
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128825974989500 -0.011693877694954 -0.146729379814642 -0.059424684705185 -0.018525365113564  0.062705489025804
-    1  (  1)  0.288526396149451  0.103129875764731  0.289919344105945  0.006241427794517  0.000597805518375 -0.002126961584353
-    2  (  2) -0.124928230102762 -0.010221797026433 -0.056571189755009 -0.103418885736751 -0.082343433199768  0.048808132756783
-    3  (  3)  0.041255915551139 -0.068310001947050 -0.078413018324278  0.150330242984058  0.179548999452874  0.040220285290066
-    4  (  4)  0.222674700983961  0.064061711596252 -0.051112895424355 -0.009318828777664  0.269456744732756  0.059360036713996
-    5  (  5) -0.030199751599663 -0.174896036167204  0.092691422408846  0.028256224393044 -0.095222992765343 -0.000984235427176
-    6  (  6)  0.000100463193802 -0.095109995484187 -0.236670455787582  0.077272409830333 -0.062627657605157 -0.003574021992866
-    7  (  7) -0.071380631315581  0.113168055430653 -0.125965816328837 -0.059330696538416  0.017157541349967  0.045135077260113
-    8  (  8) -0.578000624333806 -0.096150086854235  0.034301394867331  0.008135450733185  0.200641611845458 -0.180371714719453
-    9  (  9) -0.075918662396489  0.004599198141430  0.008112602200919  0.005143287525084  0.000284986477859 -0.012193359543264
-   10  ( 10) -0.010150745998769  0.093962320907848  0.012547284938520 -0.048325478252248  0.058041984098958  0.029299969972018
-   11  ( 11) -0.079273276366054 -0.056402585822244 -0.083755323132190 -0.007973236673633  0.003424691269619 -0.009405123180744
-   12  ( 12) -0.063303823644194  0.041869083940430 -0.019024216633724 -0.031772697856612 -0.042532243078148 -0.051259918656066
-   13  ( 13)  0.241542081048424  0.060829474159102 -0.029241791046112 -0.004754249561527 -0.057213036452327  0.050348392969423
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902374530738008 -0.153219479021394  0.011852929174186 -0.420772110136407 -0.445657281852273 -0.142990081433871 -0.124215890045063 -0.133483278617458 -0.065282671277566
-    1  ( 15) -0.489111175456927 -0.131490362750630 -0.025259277994884  0.001430871050474 -0.096952824968507  0.035534183248507 -0.068855717941579 -0.178542279528997 -0.088180183979091
-    2  ( 16) -0.227418381124775 -0.683144902334135  0.173877572588784 -0.020414541641214 -0.199817592754849 -0.249739904936551  0.179565732929508  0.064581867916811  0.271668362709082
-    3  ( 17)  0.574685513420533  0.230755641765086 -0.236330653993548 -0.198455558262872 -0.112539659295318 -0.393276362435683  0.196125851625034 -0.416930913980347  0.017841111258385
-    4  ( 18) -0.193861200269283 -0.049521286941883 -0.123799353815102 -0.006786264807840 -0.167396168176672  0.285560945535698  0.102872968175062  0.279329859462892  0.092685860122596
-    5  ( 19) -0.103950692672564 -0.178731366743249 -0.207305979104111  0.054759646458592  0.008750479265519 -0.180116361743284  0.005850873308008 -0.346544100781257  0.135656056953786
-    6  ( 20) -0.005630218802764  0.235616494969925 -0.121418775897705 -0.289705308748917 -0.074615700944892  0.197147960229448 -0.541298908627660 -0.074766151907210  0.151080244573408
-    7  ( 21) -0.003422639573222  0.126273883662646 -0.114690954063456  0.273155566178151 -0.312791095371300  0.283606567581999  0.047453631637739 -0.310404476862382 -0.030935364545073
-    8  ( 22) -0.094384208857057 -0.130119390042013 -0.029535782736633  0.507266905754741  0.577412507794778 -0.108469543731760 -0.239044626830659  0.001740919827222  0.057806922411972
-    9  ( 23) -0.126661063777400  0.286542775287411 -0.124995270818101  0.042040769766214  0.222601161131182 -0.031774064783095  0.002289661982458 -0.069973062056327 -0.578237160301569
-   10  ( 24) -0.012316706158686  0.104097860742320 -0.011505288409008 -0.071480242591928  0.067861431955949 -0.174641527191867 -0.093323115387948  0.108845273419867 -0.094609691027843
-   11  ( 25) -0.145222688889768  0.289337733151123 -0.056602400212246 -0.078531799009311 -0.050892925184265  0.092549568885380 -0.236281405460432 -0.125802430135998  0.035465582481709
-   12  ( 26) -0.059239279504452  0.006390267291510 -0.103087074498875  0.150070392220906 -0.009342684455998  0.028289380811622  0.077066678658249 -0.059246681674570  0.008175814399608
-   13  ( 27) -0.018271401982887  0.001173845770897 -0.081596168939430  0.178729785139622  0.269264211536966 -0.095094170813462 -0.063160456524498  0.017032758007931  0.200794357953942
-   14  ( 28)  0.062542890221325 -0.002043353345747  0.048801696637921  0.040072732580050  0.059190323152562 -0.000990742681884 -0.003556361910880  0.045152229102534 -0.180550803638735
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015123588660556  0.055493926114085 -0.169975137829354 -0.032809701818424  0.015002120333843
-    1  ( 15)  0.032575974689070 -0.144334404568215 -0.139389411890768  0.367448169822376 -0.070672349646377
-    2  ( 16)  0.006576811925776  0.060477069258316  0.284097691628269  0.117086244456108  0.102358639196815
-    3  ( 17) -0.124972828077132 -0.049265564522439  0.093111727254423  0.049489377800982 -0.106573762761451
-    4  ( 18)  0.078337257989459 -0.074315417379011 -0.066598566061466  0.015174881916698  0.127229135544765
-    5  ( 19) -0.030091617468876 -0.098524033243499 -0.024929078981087 -0.072709941383628 -0.065547640079017
-    6  ( 20)  0.028642219542830  0.029887343616836 -0.227866902460199  0.058376706970881 -0.035321371844132
-    7  ( 21)  0.087782136491557 -0.193844146817683  0.000960256633727 -0.115246048391406 -0.004217096818016
-    8  ( 22) -0.000480626398773  0.085216781964246 -0.052876715620283 -0.152779703755072 -0.059953833408381
-    9  ( 23) -0.075367737260768 -0.010279381835845 -0.080270644652143 -0.063438855793631  0.241130315879109
-   10  ( 24)  0.001339830230094  0.093599534020443 -0.056909491966952  0.041771584176777  0.060831797189672
-   11  ( 25)  0.008376396051512  0.012488344592189 -0.083677242445135 -0.018943587777835 -0.029225017366590
-   12  ( 26)  0.005096769732663 -0.048366952557414 -0.008003858722236 -0.031797935609827 -0.004752495908712
-   13  ( 27)  0.000291047131524  0.058011237654453  0.003385274769858 -0.042619295059250 -0.057154993286877
-   14  ( 28) -0.012282741908213  0.029296735642713 -0.009480582784425 -0.051319211356103  0.050295534824419
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027700885793089  0.024831013973624 -0.023766237412621 -0.167016603039280  0.109441555361160 -0.067202506902949  0.052695088582618  0.024064411648558  0.006188438734746
-    1  (  1)  0.211348759010706  0.133908962277452 -0.251856181342029  0.050198620344033  0.139035741221497  0.172926066548623  0.339110899470514  0.007367826854061  0.086633467632850
-    2  (  2) -0.033041625132304  0.014036582200115 -0.054189619432055  0.084538537056321  0.066377206996779  0.053646226488692 -0.037306526458897  0.220368264081419  0.092674869094186
-    3  (  3) -0.148568319902249 -0.152791211204357 -0.088570806082634 -0.044321874775512  0.009397298861538  0.049588338511205 -0.223116042687504 -0.123854255485028  0.553492211947823
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031010458886504  0.050729211215458 -0.003248182162606 -0.003208641714201  0.015229535075599 -0.008450459157619
-    1  (  1) -0.026218145702589 -0.073512341998450 -0.129399675880911 -0.023964582987083 -0.050019383975384  0.020539415914054
-    2  (  2) -0.075590807541998  0.365585379125665 -0.036729157945637 -0.016058134590288 -0.036438378068467  0.005536360852375
-    3  (  3)  0.037937313174179 -0.045234909961240  0.147760703126564 -0.060764535561326 -0.127333495556496 -0.038975339991215
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.051048798017957 -0.074362715758785  0.011189550347874  0.166183248293209  0.192475433446917 -0.070879824995188  0.064177194660693  0.010742342939181 -0.040136733536897
-    1  (  5)  0.352033813656896  0.019031583986239 -0.054018125678770 -0.066876079961762  0.060148226317505 -0.330348230405549  0.365124970723493 -0.284795973003397  0.051302526538111
-    2  (  6)  0.016809582021530 -0.311268516971319 -0.037661154101049 -0.006688597064521 -0.076727139945062  0.002675593746505  0.192087236696244  0.332474625249007 -0.065875996007770
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002709655241189 -0.005736834567419 -0.024459935540251  0.027202469191560  0.013148077561852
-    1  (  5)  0.191661619772419  0.061070263266083 -0.180667286312631 -0.019964047997521  0.020757203718357
-    2  (  6) -0.172312444590061 -0.078944608822717 -0.060240884585301 -0.044786922712268 -0.117310123601211
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102369  0.008188589712244 -0.013790999932790 -0.066013267343731 -0.002979179364342  0.115067560152145 -0.029904774000611  0.075658337330168  0.005135342269605
-    1  (  1) -0.415137332088593  0.400791789518608  0.060626653167985 -0.009777722957189  0.182694524485363  0.107591424113193 -0.071470092116897  0.210805299972922 -0.029640655301111
-    2  (  2)  0.731004204598539 -0.977674938020318  0.030910735141457  0.126476447646409  0.160297857646222 -0.115254107794131  0.017919423470240  0.019160269758167  0.056677210805976
-    3  (  3) -0.052710934455977  0.190825342618776 -0.121683764296172  0.058318753384790 -0.051331848225845  0.122833340921058  0.176985596744925 -0.321410474763131  0.015752780623204
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449210 -0.003857954296837  0.001116934481339 -0.006268480889133  0.011819863965878  0.022338641059405
-    1  (  1)  0.026581167918672 -0.003242138995830  0.002209759168115 -0.126256065331463  0.064001666171859  0.019583311633875
-    2  (  2)  0.060541607763315 -0.048685401885033 -0.005324531906372 -0.077364982992391 -0.023160042352107 -0.131997334895639
-    3  (  3)  0.086532549077844 -0.501054912835391 -0.033953281830236 -0.045954160893792  0.007588765668995  0.026055365513595
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407922 -0.003874637131511  0.017573675069951 -0.250000468336235  0.193535227171898 -0.023949830014066 -0.006344215172670 -0.002637721142584  0.025018403626545
-    1  (  5) -0.061066900138162  0.119597101102996  0.077747477731531 -0.181802110874953 -0.105212352540657 -0.191650240311690 -0.067261595147719  0.101033231559073  0.034053487252844
-    2  (  6) -0.129779125650164  0.272168473286843  0.218088904973320 -0.105590817864524  0.170044089806045 -0.413895401404370 -0.204721805057737  0.193774792721795  0.022574107317573
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304095 -0.022619515940241  0.001370551331510 -0.019480287608798 -0.016611790333307
-    1  (  5) -0.015006262168541  0.018557640744949 -0.000086080146176 -0.193359672647774  0.037991057379316
-    2  (  6)  0.020942063740396 -0.276121820896825 -0.020375408054502  0.090755244706106  0.038585932807353
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234755470283494 -0.089757897373023 -0.029226311105254
-    1  (  1)  0.628249611487220  0.562405195056322  1.006567293279198
-    2  (  2) -1.014513658696586  0.324469533164463  0.758540603298639
-    3  (  3)  0.070695571972183 -1.217301397368707  0.544825504539346
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235350713719762  0.628273412467369 -1.016171307500347  0.070820853933145
-    1  (  5) -0.089319079346849  0.558364917857370  0.332433157387864 -1.220987955904315
-    2  (  6) -0.028486683819979  1.000293875862993  0.767362449165297  0.543367325750416
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.804113115082455  0.859865209406016  0.271144212420684  0.233800284186302 -0.124039945960445 -0.010266323749662 -0.092708567501357  0.016778206024757 -0.004458179405400
-    1  (  1)  0.400343044462632 -0.255491137898947  1.725894952211800  0.228060869773307 -0.016813664829461  0.078025484956005 -0.010667432793270  0.508783176705984  0.007215780908165
-    2  (  2) -0.011354346714383 -0.088649218741449 -0.217285460959672 -0.271127696601540 -0.847424926486788 -0.636922641013145  0.167096970483964  0.613137270589854  0.118274978265621
-    3  (  3)  0.794199691903289 -0.188240166832108  0.221783053519910 -0.127263314849167  0.529647578782857 -1.234322959041016  0.503694754515590 -0.716759154325337  0.003713884622648
-    4  (  4) -0.401724672662141  0.338296304392090  0.027696569600321 -1.521982152309948  0.118592993378328  0.737822504259584  0.133024505198198  0.089529285352511  0.037479870573357
-    5  (  5) -0.062644206103430  0.401210407583400 -0.021849381974059 -0.715241456861978 -1.272083761860038  0.501726128250687 -0.443637757248648 -0.893021281361460  0.592660402987478
-    6  (  6) -0.010995449282209  0.203452242512839 -0.137034668384807 -0.113107359606136 -0.481513340581283  0.549194810269333  1.454087044363819 -0.104931286723820 -0.037492008681499
-    7  (  7)  0.128269755499576  0.321618430212563  0.165227456397829  0.036785042290427  0.490368577399842  0.556638814926841 -0.027991830909212  0.572834606710204  0.836617597163351
-    8  (  8)  0.028289154881442 -0.066964202719273 -0.261747148048831 -0.132206243094638 -0.099640531633387  0.125261053712953 -0.191170844521893  0.152462184420592 -0.345612464690994
-    9  (  9) -0.116917200684005  0.677293814759278  0.057457633837347  0.132537898195614 -0.004175807366704 -0.154875636337899 -0.038546773688736 -0.121822888362938 -0.349244520254430
-   10  ( 10) -0.180886604759008 -0.111792204437992  0.370617548329887 -0.010060948397228  0.175897261426766 -0.187416342815094 -0.018902126694376  0.507517994343601 -0.113620600518252
-   11  ( 11) -0.014433403132825  0.015210570936209  0.010143344331716 -0.005691229002329 -0.031059326071826 -0.023288546292954  0.128101332902295 -0.039392944850374 -0.110920114561200
-   12  ( 12) -0.125268954735592 -0.096735894811095  0.052480306210829  0.258243594453865  0.005805250173642  0.145107299027973  0.116452856795825 -0.074374807730489  0.022119923916468
-   13  ( 13) -0.016491827683000 -0.002316794514639 -0.087971851878045 -0.101325911412226 -0.036377238947018  0.195278206944873 -0.010131352705037  0.009611107176448 -0.056274461552982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020619978804339  0.055393926260198  0.016493468301721 -0.100372381621015  0.100626242248391  0.085758294302200
-    1  (  1) -0.158166323997468 -0.302157830906836 -0.003244540958724  0.141116982835093 -0.086717578223975 -0.004480871143071
-    2  (  2)  0.117237563107167 -0.174570847573252 -0.011204345589118 -0.263173432731339  0.005218532196608 -0.028842080195278
-    3  (  3)  0.116941646649193 -0.002586479599460 -0.011231548488137 -0.058984655279782 -0.019822661982992  0.041048882280086
-    4  (  4)  0.050776820640488 -0.220908341720040  0.039982596283608 -0.028513186801397  0.038501560477780 -0.072498198103576
-    5  (  5) -0.020348029264279  0.163764941111662 -0.082946711645309  0.111452654944127  0.037984566239170 -0.107199595569002
-    6  (  6)  0.021256126103386  0.388694787591368  0.114910007821023  0.018804713347355  0.008937619959603 -0.015873506672528
-    7  (  7)  0.297925323013454  0.033191669222593  0.094278199439532 -0.060174035263281  0.021406855727336  0.043089336483833
-    8  (  8)  1.538149876661768  0.255388094594368 -0.163312643003209 -0.034677585072596 -0.142125228818818 -0.045738087971649
-    9  (  9)  0.091443541252255 -0.031128123891514 -0.061982026707814 -0.058678185009605  0.760839955512426  0.950617857124013
-   10  ( 10) -0.067301877513064  0.211057800702034 -0.020603819563629  1.234407038988008 -0.163795705023159  0.167535211420885
-   11  ( 11)  0.163445976328784 -0.060082779666650  1.332811809287809  0.048638214648013 -0.084741484840295  0.093756111599773
-   12  ( 12)  0.205948682024817 -1.200679744036831 -0.135474810029670  0.365861100667199 -0.094093662797895  0.008686523394767
-   13  ( 13) -0.181605938452006 -0.042014918886112  0.112406427108237  0.222953862798683  0.995139187403184 -0.917632565321750
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802008727902655  0.406135528069519 -0.010476316013926  0.784475556802977 -0.394386683091322 -0.066798881058913 -0.011980564813183  0.124376056524346  0.033526134230598
-    1  ( 15)  0.862028914432838 -0.259382739909253 -0.086667305572571 -0.180064784220811  0.329908607377568  0.399964089565239  0.202187771096584  0.330121816685617 -0.071953120874633
-    2  ( 16)  0.271307809960517  1.724790149840174 -0.218446172710917  0.221581282093101  0.027552874986052 -0.019301351758235 -0.136156749402951  0.163711145289538 -0.262315292158509
-    3  ( 17)  0.233832160360253  0.228075923415992 -0.271855585596124 -0.127498943532143 -1.519236751765142 -0.714946933274599 -0.112783303905635  0.035742190545795 -0.131799331720450
-    4  ( 18) -0.125884857507906 -0.016503178327160 -0.848590316809834  0.528676059271022  0.118589942996707 -1.271521009940539 -0.481050683706143  0.489094666232740 -0.100427993377443
-    5  ( 19) -0.011410411929704  0.078504916539328 -0.635756927956291 -1.233330464680219  0.737249034134053  0.499445190730949  0.548364048058951  0.558640131286851  0.124411035854073
-    6  ( 20) -0.091600083261382 -0.011874324392682  0.166095509172920  0.503931355593027  0.132971166339089 -0.442847331045605  1.455101200236642 -0.028340512672194 -0.190421039545480
-    7  ( 21)  0.014506888035501  0.509793857361999  0.613540224928847 -0.716635769138310  0.088503909893924 -0.892421715175117 -0.105643577538643  0.572215069358707  0.150576387127192
-    8  ( 22) -0.004177720337601  0.006709815498338  0.117678875953444  0.003186946250536  0.038303116431661  0.593619431704902 -0.036920385902464  0.835672825510557 -0.345283877638120
-    9  ( 23) -0.021586239236069 -0.156869719857389  0.117889758366713  0.115161423657166  0.052238225817567 -0.022709102194002  0.020562459070758  0.298677779552414  1.538509512042494
-   10  ( 24)  0.054682068155330 -0.300070995804170 -0.172660016100405 -0.004680568559133 -0.221321821680689  0.163619483231767  0.386948477906821  0.033115261343779  0.254769962308421
-   11  ( 25)  0.016488293849114 -0.003235639473042 -0.011174682028047 -0.011243945686262  0.039809588242801 -0.082761513420814  0.114884412151995  0.094200391738432 -0.163393716854442
-   12  ( 26) -0.099231335638981  0.141112668735439 -0.262446613088938 -0.059563147663697 -0.028574452319685  0.111394864273783  0.018513759386770 -0.059760408126185 -0.034040397389902
-   13  ( 27)  0.100244162906019 -0.086825753516515  0.005142496829880 -0.019052879526344  0.037887085038908  0.037954868269094  0.008919579926842  0.021672382001814 -0.142649674386460
-   14  ( 28)  0.086046561377269 -0.004744302368675 -0.028249738219516  0.042030603060936 -0.073561648753544 -0.107720217983973 -0.016217142075139  0.044341471770558 -0.046187444393698
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124233708134536 -0.184518326175237 -0.014667753095384 -0.126540650902716 -0.015843433752182
-    1  ( 15)  0.686899770278225 -0.109692117003667  0.015377495137090 -0.096723489130418 -0.002397757787977
-    2  ( 16)  0.057205529179573  0.372042133273675  0.010210131259620  0.052160697899345 -0.088271643130934
-    3  ( 17)  0.131871345108646 -0.011180948360664 -0.005727193367078  0.259941586635767 -0.101614450210759
-    4  ( 18) -0.005079597151550  0.176830214271493 -0.031032942109530  0.004628941737735 -0.036366477592728
-    5  ( 19) -0.153488339566642 -0.188246645479895 -0.023332293508359  0.145173541284801  0.195552538719571
-    6  ( 20) -0.038666420291800 -0.018333798481472  0.128217423491274  0.116258211557260 -0.010271886085247
-    7  ( 21) -0.121961409061188  0.508144909444712 -0.039497933150400 -0.074911313979374  0.009738174256599
-    8  ( 22) -0.349752281191282 -0.113379050365462 -0.110884161439924  0.022227055299971 -0.056428042287591
-    9  ( 23)  0.091274387643065 -0.068482004342720  0.163392525285683  0.205701365643148 -0.181416453396970
-   10  ( 24) -0.031494844081003  0.210984913522447 -0.060264440706341 -1.201297108840478 -0.041823116964621
-   11  ( 25) -0.061998986866087 -0.020468588707388  1.332808723106093 -0.135556576828281  0.112406197562980
-   12  ( 26) -0.058487448548964  1.234274465594818  0.048631105388868  0.365854082845994  0.222962926250886
-   13  ( 27)  0.761200546740672 -0.163618812251394 -0.084738989433935 -0.094122389252816  0.995165590894080
-   14  ( 28)  0.951772998269778  0.167560207344595  0.093759874796882  0.008708619204364 -0.917569948681331
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062431637468595  0.002416441043494 -0.004633709181854 -0.077570764564634 -0.013832459901085  0.123710471759648 -0.027165779035151  0.071044010954103  0.019658423662051
-    1  (  1) -0.407170389584196  0.333069478291481  0.076649076907709  0.002175328366595  0.197922707135443  0.117656968282733 -0.067757706616656  0.182812175438110 -0.031734247883934
-    2  (  2)  0.673185035517385 -0.888138019247629  0.034358376579761  0.125358507387175  0.172994941404661 -0.106755581181951  0.013852200121288  0.009496870454373  0.036809619943014
-    3  (  3) -0.040742790622452  0.181389056204799 -0.117008669682236  0.012401302848616 -0.022196391591003  0.102862126461673  0.166049221641564 -0.310434511631988  0.017146561969833
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.010530607294135 -0.003710118206636  0.001098184033274 -0.004177259623773  0.010641720243897  0.020819711535909
-    1  (  1)  0.026376312845796 -0.003084063695379  0.001935075690028 -0.112197866496249  0.055637648529160  0.022260912302157
-    2  (  2)  0.054059905057592 -0.043789787513268 -0.004472231165839 -0.071437136436276 -0.024456749693059 -0.126350825107534
-    3  (  3)  0.083331116085326 -0.461426302980745 -0.028171699513189 -0.043194879139585  0.008942983333379  0.024389199674004
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.021216263100624  0.005003175055603  0.013535160841075 -0.263704651382093  0.210918804180330  0.005688291976374  0.005207710700417 -0.000895282201935  0.031550648985107
-    1  (  5) -0.080441383224428  0.123194069685474  0.057717422634392 -0.198323986141407 -0.141861353254421 -0.184709849630275 -0.056481718890527  0.088971412091793  0.030305733467359
-    2  (  6) -0.146541148918465  0.264369470289016  0.161465568338008 -0.083507608614829  0.171726934895341 -0.400382872983893 -0.201596935132327  0.184414767198991  0.015497227351109
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.010467742288235 -0.019463191825822  0.001308339278104 -0.016880359740534 -0.016885157913526
-    1  (  5) -0.009224792466207  0.019323723500933 -0.001197784436253 -0.171358632107000  0.032143333569086
-    2  (  6)  0.022721945593511 -0.245666385556985 -0.017093671892173  0.084713974597816  0.032963157176328
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521802 -0.064555152855138  0.195953381503071 -0.041248493404121 -0.011229686922121 -0.030149441468397 -0.052245051042500 -0.006640144591442 -0.060816046803627
-    1  (  1)  0.618380750339720 -0.527850820452490 -0.215416501468029 -0.157035437820935 -0.069798458053230  0.063297476854259 -0.224803808806348 -0.036770088857866 -0.093292414355442
-    2  (  2)  0.089963765220190  0.016694193855693 -0.049894217028098 -0.224500363636583  0.100545586935572 -0.339808932362447 -0.300486601784948  0.103978674940069  0.003854593986175
-    3  (  3) -0.017912540893907  0.240051544179785  0.016875920141055 -0.019658112757049  0.000950481978189  0.139486307895283 -0.307526295494266 -0.245045411721372  0.038982174459018
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151717 -0.053483299255778  0.001461399819935 -0.009996127160185  0.040844890766481
-    1  (  1)  0.010356156252342  0.045196494943179  0.123149462829327 -0.009608799091533 -0.092775098416550
-    2  (  2)  0.068261626755323 -0.266621644473694  0.090983468547791 -0.007824999539035 -0.015479677414575
-    3  (  3)  0.102991688131894  0.095940846129216  0.235195882789531  0.030438278876705  0.100331913639100
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065248  0.055002400477821 -0.190701615134341 -0.008587073557084 -0.137456634337712 -0.102685174742823 -0.038575707278161  0.049077773985898  0.038775520871497
-    1  (  5)  0.266426121061191  0.201904502527537 -0.404472747743473  0.112355452346505  0.244543383067869  0.203488255110531  0.093346083766348  0.046662175778569  0.162564534078649
-    2  (  6)  0.310200495971193  0.275860886663903 -0.334362481171662  0.111323203428083  0.107269573507973 -0.015396505983549 -0.485347827861583 -0.115211810541078 -0.189399381355351
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661082 -0.010182782856367  0.015536223735828  0.027148068637774  0.019304531582384 -0.012170541889263
-    1  (  5) -0.076359104752409  0.072719944885935 -0.105706045053714 -0.076791075572647 -0.095250630872885  0.044053081318688
-    2  (  6) -0.023401555368538 -0.060789750773995  0.233844071164901 -0.060200608258474 -0.022972229731696  0.078966373846356
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134464733238495 -0.662210405494713 -0.268087036060508 -0.078995101665649
-    1  (  1) -0.664136191142181 -0.208512216408356  0.147227682691113  0.068768195668241
-    2  (  2) -0.267178832853318  0.148347614169084  0.187155712816499  0.001725942570585
-    3  (  3) -0.077975712094611  0.066243031692256  0.004079617492317  0.013944312169831
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274618126592076 -0.278113702179189 -0.671633022270395
-    1  (  5) -0.277949145712571 -0.011863615919940 -0.010374435234634
-    2  (  6) -0.670048686168265 -0.009476206950290  0.097890068097066
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959494414290853 -0.408191876587357 -0.490587797784235  0.038620088951700 -0.077925870525924 -0.487449819239270 -0.107605742375904 -0.396082210854031 -0.237542456199032
-    1  (  1) -0.404346098969045 -1.325089706115921  0.174671472615893  0.248857938939690 -0.197997176299327 -0.317531715369544 -0.251443125493972 -0.030205216051466  0.632709778669897
-    2  (  2) -0.488203594414091  0.174177358170279  0.686637133275405  0.342440322127986 -0.009976595905960  0.483509687591532  0.287263685740954  0.302820486761602 -0.272146504988795
-    3  (  3)  0.037519851932805  0.250891430236009  0.345028453615613 -0.288802596502282  0.242048997261983 -0.302155533583706 -0.510767048111858  0.184742116191470 -0.216988138473832
-    4  (  4) -0.076335128439672 -0.199690457337231 -0.011287590259796  0.242287343472353 -0.131826185478683  0.385784652335332 -0.241579744319177 -0.375155233716578  0.062534851979726
-    5  (  5) -0.485786339572524 -0.319069045647698  0.484028655874806 -0.298894130368480  0.382592029688529 -0.557110750088133  0.333239304019173  0.111824333667390  0.019820080095694
-    6  (  6) -0.105004388042392 -0.251919494300239  0.289657780268581 -0.510934745583711 -0.243423593715530  0.333487274729372 -0.859815579894803 -0.040189411214503  0.015976724219764
-    7  (  7) -0.396742866204424 -0.028527583501407  0.303542401120419  0.181332247012507 -0.373287106593955  0.109028339876178 -0.042483577229034 -0.424450995877431 -0.165337209178978
-    8  (  8) -0.232477111217568  0.628541780993301 -0.273469783503725 -0.217890852518762  0.061988654737611  0.020919866007559  0.015643111904884 -0.165546891359504 -1.139952791754372
-    9  (  9)  0.005546163403788  0.056122031350974  0.162961042742049 -0.082482781173176  0.072908205250705 -0.108799436968506 -0.023533780380763  0.044777427042704 -0.147235448199817
-   10  ( 10) -0.006901975709221  0.054429650490003 -0.040577693872379  0.341755839709641 -0.179734725561057  0.323402736691831  0.128204737160643 -0.274641710567115 -0.052505646555499
-   11  ( 11)  0.095370531310646 -0.102133079874744  0.068438122875481 -0.163729824989548 -0.155636229704619  0.243225496644066 -0.456632637964553 -0.005300419866763 -0.049825612054653
-   12  ( 12) -0.031656876480322  0.049261490140927 -0.071615793822899  0.132066208561311 -0.108599421258561  0.096544859699583  0.079601642520208 -0.086582876221016 -0.054558080822567
-   13  ( 13) -0.055177843918678  0.125972146875380 -0.045925897173266 -0.019932953437884 -0.072414580136129 -0.032514397877208 -0.014074648780379 -0.073540469649060  0.566252900794764
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006844108037316 -0.007417708485432  0.096179215271910 -0.031845351907950 -0.055819107034893
-    1  (  1)  0.055009072408368  0.054764569974464 -0.101360748266653  0.049483066032708  0.126311659941364
-    2  (  2)  0.163126461717698 -0.041474056730500  0.069773970511476 -0.071604513134715 -0.045921679797628
-    3  (  3) -0.081145867550905  0.339512714763515 -0.164814632361134  0.131963409806745 -0.019701057447438
-    4  (  4)  0.071392957638912 -0.177541925322310 -0.155855587434795 -0.108549913772827 -0.072788709838572
-    5  (  5) -0.105620913909822  0.324570384536927  0.243426148668895  0.096676164465064 -0.032493241135614
-    6  (  6) -0.022622971576109  0.128555788054587 -0.457558865820421  0.079424640656331 -0.014304063550757
-    7  (  7)  0.043872369029022 -0.277428590499647 -0.005167508600307 -0.086808599804733 -0.073543295023506
-    8  (  8) -0.147656701585277 -0.051770671721882 -0.049464276722928 -0.054622357068254  0.565518286432935
-    9  (  9)  0.072058098581742  0.045414939179585  0.010276622684317  0.009607329011721  0.026546654266791
-   10  ( 10)  0.047972578248005 -0.139091273135494 -0.006969817312947 -0.101924439794115 -0.021963395913839
-   11  ( 11)  0.010225949518788 -0.006903254834441 -0.093461448932077 -0.006458623521929  0.037408632154760
-   12  ( 12)  0.009659072763447 -0.101989750292789 -0.006543886552567  0.055499957258902  0.004536647288290
-   13  ( 13)  0.026525022859865 -0.022073627181823  0.037503294944017  0.004573821056444 -0.064450805660396
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.531729549886298 -0.787699013260720 -0.218007437963128  0.182768764967664  0.602768885926166 -0.199812958118043  0.029032839745447 -0.008774056556998 -0.142478600997401
-    1  ( 15) -0.793340915328517 -0.320131124132658 -0.162653978535470  0.058649157291279  0.020639907683325 -0.223525268439384  0.107699068558594 -0.353783645623560 -0.095871343640248
-    2  ( 16) -0.212191388052984 -0.164888118017376 -1.296946785661574  0.042300146112888  0.273826728839772 -0.438781481182649 -0.122091204716307  0.097191959045013 -0.140871391153761
-    3  ( 17)  0.179719553134882  0.058669914491584  0.044506714025066  0.293003077614788  0.349110568675561  0.303215667162415  0.076915097449125  0.005807473711893  0.013837821466959
-    4  ( 18)  0.599360800493389  0.022132908209793  0.274035423937454  0.351223850237582  0.210864723099932  0.044675310303669 -0.438675626813712 -0.490920343842293 -0.399212333009898
-    5  ( 19) -0.200407898503595 -0.221431932840884 -0.440102897905219  0.305762109212930  0.044881546181386 -0.117472965844391 -0.191665223291112 -0.319783714572633 -0.359452162382383
-    6  ( 20)  0.032165821117663  0.105941691907443 -0.123879210125571  0.078979233990532 -0.440650088275931 -0.189889145121382 -1.110705925194965  0.246906737793529  0.255259757334091
-    7  ( 21) -0.008321241705301 -0.354528191467815  0.096628486245053  0.006334262611059 -0.491255100347711 -0.318969662674625  0.247541587785850 -1.005004062277651  0.329386657154236
-    8  ( 22) -0.142962699223549 -0.097023037413528 -0.141097052846351  0.015166149438974 -0.401326717044885 -0.359426368361956  0.255258622579679  0.329097335449224  0.052132117322127
-    9  ( 23) -0.219955098740470 -0.249965476004888  0.576414624728282  0.098982863369388 -0.020508824733516  0.097549190747056 -0.059941456738217  0.014715712854346  0.155030958604429
-   10  ( 24) -0.078889746445523  0.108239301318901  0.027162587747041  0.046514963820434  0.091370815063922  0.113422647703502 -0.170202961400924  0.302110584863860 -0.032804637243887
-   11  ( 25)  0.043306270957027  0.032344455295716 -0.179576712827774  0.107307667430455 -0.187560546689596 -0.097222488608903 -0.510712264729794 -0.080025590477581  0.081254866792350
-   12  ( 26) -0.068084805818490  0.217394768160197  0.162482224135859  0.182198793902305 -0.078588038008549 -0.138375144701551  0.045964808967526 -0.318369645237611 -0.094340949188752
-   13  ( 27)  0.012776338365641 -0.163304628586287  0.065170181095058  0.076353862354929 -0.116471236774223 -0.057100568669610  0.002733328139540  0.275543901650406 -0.101218272889531
-   14  ( 28)  0.072542900570950  0.116082117753812 -0.039461901860534 -0.060056679393757 -0.063442716501334 -0.039954821491188 -0.007431183194756  0.061660754619171  0.127196734189506
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223424944652175 -0.079375640508209  0.044559638332806 -0.069603179695813  0.011608492724559  0.073681298891794
-    1  ( 15) -0.252190810534109  0.107773105664069  0.031929727381883  0.217773765514458 -0.162942254516907  0.115583488493230
-    2  ( 16)  0.579669499848572  0.028398284174960 -0.180764151357438  0.163082238678493  0.065318137383570 -0.039861277950844
-    3  ( 17)  0.098419070380212  0.045497640187139  0.108888066901844  0.182679251676257  0.077063420292881 -0.060270475148200
-    4  ( 18) -0.021657152218140  0.091391477818874 -0.188694941835346 -0.078654463993081 -0.116917635244861 -0.063687461311382
-    5  ( 19)  0.097200061293784  0.112946819841968 -0.096557046310004 -0.138722208764674 -0.057492822647748 -0.039657945432933
-    6  ( 20) -0.058061983715355 -0.170140847494679 -0.511516651549454  0.046153385708922  0.002608094185221 -0.007424017797985
-    7  ( 21)  0.014898598107636  0.302204656416843 -0.080604696411276 -0.318409184220291  0.275439068186170  0.061680442175982
-    8  ( 22)  0.155158381420859 -0.033182129585361  0.080993013335593 -0.094077880752320 -0.101045740908378  0.127069446713633
-    9  ( 23) -1.153500606432346 -0.223848574870748  0.084940142762255 -0.000172697505726  0.401118128913118 -0.346039941954413
-   10  ( 24) -0.224004522828874 -0.014993374950352 -0.013190820033296  0.067266852084063 -0.009898419000703 -0.084301934906622
-   11  ( 25)  0.084246516406413 -0.012971453666467 -0.099638608783543  0.005049425073667 -0.012239639402272  0.023058100761842
-   12  ( 26)  0.000190360752639  0.067412521796062  0.005072007098540  0.014663156532778 -0.012615786454218 -0.021995005158486
-   13  ( 27)  0.401506800485801 -0.009668467136188 -0.012313296328671 -0.012645382168417 -0.008180220628733  0.091135079144531
-   14  ( 28) -0.346436667192436 -0.084407881559669  0.023159285170777 -0.022057721310468  0.091092458906097  0.040126683454997
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057778460125475 -0.058621598376446  0.204961973610432 -0.030014886957110 -0.012702201238060 -0.012361806840330 -0.042464722570104  0.000589178332867 -0.053783176425629
-    1  (  1)  0.588150716074137 -0.466021636272279 -0.203183245475023 -0.148450737716195 -0.057365952908272  0.049828198627789 -0.211650340717459 -0.033709163320874 -0.066014023276537
-    2  (  2)  0.097096715428347  0.013316869335681 -0.075592001791495 -0.184144455632612  0.076454331448179 -0.322693901417475 -0.283033300411638  0.095787940086230  0.009135557725685
-    3  (  3) -0.012585457310361  0.213693355283451  0.008392879074051 -0.006477176275207  0.025095812734804  0.122050564721351 -0.287478867298026 -0.227752050770288  0.025535574433447
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004343658462411 -0.045416781087739  0.000353809954909 -0.008814420994644  0.038608153091639
-    1  (  1)  0.012371345270913  0.037357699916558  0.110010051271466 -0.008428651261314 -0.087698412018737
-    2  (  2)  0.059734573261687 -0.241104936943560  0.080654968743397 -0.004302203609171 -0.010690545484549
-    3  (  3)  0.093269555935928  0.087251850932645  0.210582632378020  0.029543407964615  0.092601662289167
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.096268685878252  0.067598109905929 -0.171831816211843 -0.019892225326929 -0.151432830345500 -0.102828613678797 -0.031328453208209  0.054857782228203  0.045391983457330
-    1  (  5)  0.259548823811749  0.185158249821502 -0.361847535039713  0.121706180799369  0.214912924418826  0.198674927692087  0.082249065771639  0.046754216202725  0.144894234011997
-    2  (  6)  0.316675644828390  0.241534850892177 -0.298024592816788  0.095120602156143  0.117908244615295 -0.011781114685658 -0.451417780640774 -0.113394265201560 -0.193663841427194
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.075217766018102 -0.009009066779015  0.013059078733354  0.023267742031503  0.019382631456237 -0.010439549922317
-    1  (  5) -0.055615787731083  0.073750137089776 -0.094740835467127 -0.066906556461946 -0.087569521638086  0.039832146294914
-    2  (  6) -0.007989421944926 -0.055545532554458  0.206332460425461 -0.056516118698094 -0.025725290779719  0.073743491663518
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.016118777276715 -0.076689387067910  0.125264792267213 -0.007931013310159  0.098301937535619  0.089040062536403  0.042653189503990 -0.143650549015434 -0.062698356849217
-    1  (  1)  0.038523460792185 -0.325926212074866  0.217436403108304 -0.076210929079487 -0.124956744969463 -0.049869905306287  0.256022567536771 -0.049219148025203  0.025163660677627
-    2  (  2)  0.015460259327543 -0.182364499530151  0.081021447104334 -0.065186772706427 -0.193628085224658 -0.090709199284724  0.144227288852916 -0.007154481293509  0.060483347873691
-    3  (  3)  0.069494321441897  0.016013992178315 -0.169506236224075  0.050547669997934  0.177140340538951  0.181255025833236  0.201077665225237  0.109139777586652  0.215083611892000
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.159361864611552  0.056476108299593 -0.034334354535920  0.068420323850568 -0.100698715800717  0.049820592017766
-    1  (  1)  0.121041364374108  0.003994619377140 -0.190684428167186 -0.052070114913538  0.189028662705267 -0.205096915582724
-    2  (  2) -0.013836799939815  0.073875918803128 -0.147901928532515  0.343158528114240 -0.053056478393310 -0.086736758175874
-    3  (  3) -0.065392768372813  0.072388535495375 -0.365788807268936 -0.156911353062530 -0.184439406967998  0.043117455907282
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.095080611028905  0.132974666952795 -0.233475927910152  0.109077700761869  0.033619328181748  0.003336619392392  0.079318686273400  0.006541773193153  0.188514066103895
-    1  (  5) -0.133180554197729  0.220459497770333  0.122961007604827  0.144493780528925 -0.034530325126889  0.144382538755407 -0.001565508478549 -0.179104189145759  0.084352671049965
-    2  (  6) -0.305369897772518  0.245966510909105  0.171589985467989  0.288954965589194 -0.048536799653817  0.105233271021575  0.400024803684146  0.035818012706229  0.066124321501166
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.011358647742861 -0.047842821118306 -0.011877525445924  0.012099889406653 -0.055702357687979
-    1  (  5)  0.060987538430202  0.100437160073965  0.174976176295347  0.033059202656664  0.296249624542357
-    2  (  6) -0.156959926194252  0.053853503787377 -0.406665675932450  0.026462885456155  0.143060389345544
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.020933994600404  0.036837370041378  0.105536213576208
-    1  (  1) -0.298453027380235  0.115575201783041  0.255528599615218
-    2  (  2) -0.258793135913458 -0.115959940555419 -0.442826057795212
-    3  (  3) -0.060024736570876  0.030098554189578  0.068752806226696
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019369167440735  0.299662599013862  0.261538199445479  0.060711849430245
-    1  (  5) -0.036904684367183 -0.115259605353543  0.117033018013316 -0.032657591929024
-    2  (  6) -0.104769015611943 -0.252811001882389  0.444270078409885 -0.069751899589238
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.140264901989732 -0.063903836208700  0.058837720478344 -0.099834492513857  0.059321359064218  0.159667027697165 -0.002087278187167  0.046204224826828 -0.008601023391647
-    1  (  1) -0.090548490120087 -0.202601353512529  0.092021876157049  0.096539072051997 -0.170154281529252 -0.083912296322820  0.509059273187923 -0.818772979644953  0.070828284365805
-    2  (  2)  0.023785290834458 -0.356113587695708  0.273990976839604 -0.279080899835211 -0.352444630227632  0.196438091918237  0.305379232907223 -0.066497365309668  0.201285694555594
-    3  (  3)  0.097000901586888  0.245927544981666 -0.317839114090146  0.024062116307417 -0.214330573426636 -0.049574376579035 -0.029033713280438 -0.054130019251473 -0.003096872422278
-    4  (  4) -0.057665969694961 -0.180120952217587  0.233587576454962  0.044983378670516  0.207784279042753  0.114395252588009  0.123426849025615 -0.227078923197653 -0.055512731053909
-    5  (  5) -0.215771286107030  0.314990234779502 -0.316883540178318  0.120867850220805  0.280144439746019  0.294187393366266 -0.216440287801519 -0.200727103538257 -0.064432166939554
-    6  (  6) -0.088234371667171  0.148935506374392 -0.366935246390879  0.011963781822295  0.214228897418453  0.110020140834752 -0.192637863546305 -0.231329350431209  0.059800681126421
-    7  (  7) -0.046850408793983 -0.280155317167401  0.370918303757555 -0.110906122388311  0.088736250126060 -0.146624611249243 -0.021132431838010  0.399622620248811  0.041122390922456
-    8  (  8) -0.213219122375794 -0.108141657808899  0.632333203738685  0.072815736912286  0.035034243651182  0.162896842787145 -0.072787072592861  0.219123938652931 -0.041084573562014
-    9  (  9)  0.053156461400879 -0.091068663315954 -0.087565530354220  0.029252405162121 -0.135958664144570  0.072618412616171  0.001674517036246  0.447580570679357  0.046048420321108
-   10  ( 10) -0.217389369502910  0.434955320268301  0.409591028918214  0.322091930890674  0.032769693001577 -0.320487371417213  0.022524010208258 -0.286088771348243 -0.028739508255579
-   11  ( 11)  0.043655408036926  0.078795431314352 -0.262179238045961  0.331516326718921 -0.435766491267148 -0.063689969335714 -0.247099037158840  0.001834914627209  0.140224560742040
-   12  ( 12) -0.056091676196034  0.010888223476595  0.132073582410596  0.097444459311643  0.064913316132981 -0.000177701715019  0.216786241209525 -0.136744724942226  0.129238968566772
-   13  ( 13) -0.037502956248588 -0.225853404732460  0.091597810906137  0.251988574100658  0.015208060782076  0.284415044485819 -0.108318027167759  0.003844624714698 -0.367465648248436
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222316043515173  0.015706219813460 -0.082385006687320 -0.001598515176512  0.060473243217402 -0.093727480766952
-    1  (  1) -0.559608456549850  0.123427525882115  0.153467678522284 -0.170334032667751 -0.080737466652215  0.083738891751807
-    2  (  2)  0.169476216588385  0.033571289044860 -0.409164888922149  0.223598543173697  0.075034173166616 -0.314714537560889
-    3  (  3)  0.116710909315575  0.019725573527882  0.283423547853871 -0.175125619030608  0.285157403250322  0.036616525847335
-    4  (  4) -0.005652624292121  0.042302085019166  0.326173261129808  0.429217689688999  0.082297928451369 -0.119033467524274
-    5  (  5)  0.013435701805306  0.050340607661298 -0.120543829175976 -0.018862712789954  0.153571720838557  0.076183620287339
-    6  (  6)  0.081289708009932  0.326406046335021  0.215268699384055  0.111421444457992  0.019027619773786  0.098888316320541
-    7  (  7) -0.155159820795190 -0.099172439421084  0.073800976886365 -0.027692155232139  0.092694133839456 -0.234604646553257
-    8  (  8)  0.037085102415794 -0.221081896212581 -0.033634728216760  0.500286732444230 -0.749342092540231  0.380702305205380
-    9  (  9)  0.121604531068668 -0.307665948271803 -0.063134933207098 -0.759313712683884  0.291120411772461 -0.157024245706380
-   10  ( 10) -0.436899181077493 -0.180584483336554  0.427706818265058 -0.039319556166566  0.042977724169066  0.570262735340494
-   11  ( 11) -0.012744975594815 -0.355849153273434 -0.014473345977435 -0.331011762918559  0.082407538752018  0.048301595441145
-   12  ( 12) -0.275248111407273  0.041018113706040 -0.197136817157691 -0.114052207324942 -0.270934107062801  0.185007344485080
-   13  ( 13)  0.588095271872920 -0.141945816656553 -0.099720177389789  0.418487800295605 -0.225864709971283 -0.209383142865023
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.136055292355693  0.095447390079340 -0.020092912976452 -0.093125301806219  0.056850399225392  0.218468169087239  0.091857234706676  0.045161486852249  0.214714486134321
-    1  ( 15)  0.061207776400224  0.202708633629211  0.353114471022979 -0.245649376419565  0.180866138364034 -0.315320438007598 -0.149515492263340  0.279091224397284  0.106858935875563
-    2  ( 16) -0.054684214245539 -0.094025065222640 -0.275943577798546  0.316343751367895 -0.233336305598380  0.315879985031598  0.365377908227180 -0.369960150477096 -0.630562926717977
-    3  ( 17)  0.098691998169988 -0.096665834479676  0.277640044986388 -0.024005765248079 -0.044522040617490 -0.121507599386095 -0.010509659584542  0.111862233831084 -0.073060388343816
-    4  ( 18) -0.060773979545201  0.171895263117941  0.351151470699367  0.213576840796575 -0.206989754617357 -0.279451579746598 -0.215385933896301 -0.091082110140082 -0.034953691198195
-    5  ( 19) -0.161690364133666  0.086139117701369 -0.195608563911810  0.050196750893508 -0.114409300434323 -0.293302924591653 -0.108870291715961  0.145705855705827 -0.162864209989065
-    6  ( 20)  0.004933077734461 -0.509112916459715 -0.304189657786525  0.027011307788378 -0.123564513171824  0.216326146660944  0.190918994832455  0.021599458243760  0.073921971953628
-    7  ( 21) -0.046939300208709  0.818898745115211  0.067231269443295  0.053385434393248  0.227366778650250  0.200959323300586  0.230355491785330 -0.400408400878989 -0.219890208910709
-    8  ( 22)  0.008875208231344 -0.070617448884265 -0.201028236092715  0.001986037102750  0.055524570746332  0.064229773357344 -0.060955407810699 -0.040899342701140  0.040928237624152
-    9  ( 23) -0.222811666664930  0.561652381203109 -0.169673185845526 -0.114995614482537  0.005558626156127 -0.012604855943775 -0.079125943676941  0.154935461007958 -0.034774271928076
-   10  ( 24) -0.015658264689237 -0.122684274627566 -0.033049817652516 -0.019053422527839 -0.043070830779656 -0.050152205966237 -0.326697513368317  0.099443390036459  0.221198097566915
-   11  ( 25)  0.081038041563999 -0.154593341750092  0.407140318931982 -0.281943720612544 -0.325675147388131  0.120351655341255 -0.214124337140213 -0.074325284613066  0.033051994607945
-   12  ( 26)  0.003149016432983  0.169066126704265 -0.222974141740581  0.178167341127558 -0.432229982121915  0.017874255780535 -0.111773550217181  0.031100511775812 -0.501206663109520
-   13  ( 27) -0.059358328554799  0.079903052840446 -0.074950199177116 -0.286331686497637 -0.080924619758545 -0.153353900448026 -0.018409365441232 -0.093462744168473  0.750750124348698
-   14  ( 28)  0.091958135023802 -0.083203421400514  0.314158605792337 -0.035767063530586  0.118730598661029 -0.076122730197956 -0.098773188363513  0.234233392684125 -0.381969165301650
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054160915945440  0.219019011349658 -0.045758113327127  0.056667077142781  0.042241899582407
-    1  ( 15)  0.090944710506667 -0.435278295065980 -0.077842273581985 -0.010976755804927  0.224792334219628
-    2  ( 16)  0.088739489380727 -0.410297160213689  0.264172456920594 -0.132125091344117 -0.093086518366925
-    3  ( 17) -0.030526782846308 -0.322820843845164 -0.334117022964236 -0.097597092001360 -0.253965732413055
-    4  ( 18)  0.135352462834400 -0.032599183228255  0.437639446213156 -0.064872058901777 -0.014497262646719
-    5  ( 19) -0.073899654730442  0.320885730724610  0.062344415655754  0.000276840662850 -0.283336476795450
-    6  ( 20) -0.001158784637988 -0.022837257389255  0.248024269025133 -0.216907823965295  0.108098145849829
-    7  ( 21) -0.447481917087611  0.286161905602590 -0.000998969948768  0.136653733410721 -0.003506425728694
-    8  ( 22) -0.045854947627220  0.028382633755552 -0.139989494186330 -0.129405417600154  0.366820033409182
-    9  ( 23) -0.122256207458041  0.437180402944026  0.011581755997582  0.275567866951767 -0.586898649032620
-   10  ( 24)  0.308323852677721  0.180850894824869  0.356131896237584 -0.040945642422104  0.142574344254184
-   11  ( 25)  0.063098776158328 -0.427549053292047  0.014802143274616  0.197270506582796  0.099635293972022
-   12  ( 26)  0.762581095039490  0.039734172920445  0.331033022441221  0.114161465508855 -0.418490755826759
-   13  ( 27) -0.291938944356913 -0.043222558646275 -0.082214356128437  0.270960148007918  0.225910263769365
-   14  ( 28)  0.156871086239257 -0.569997035340436 -0.048467653901954 -0.184994394399617  0.209531521675460
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.009005560415620  0.070810523176753 -0.120067832596330  0.009073132789057 -0.090464498751423 -0.086174111119354 -0.045794981404383  0.145874969594551  0.061668751575064
-    1  (  1) -0.049157751161976  0.341837336007353 -0.225991322214198  0.079794887273987  0.129000775913212  0.051890082528198 -0.264098306233452  0.041882987798608 -0.014437873768995
-    2  (  2) -0.004178475304275  0.176534362212284 -0.088484784587547  0.060893560844785  0.188770646517540  0.098157508320685 -0.154422738208026  0.028159762307564 -0.056745595914708
-    3  (  3) -0.078632631263391 -0.018162490565869  0.185802179760109 -0.047918543127734 -0.190222116766280 -0.186537019008367 -0.211456806958070 -0.116264562677776 -0.222361952728882
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.163744366705646 -0.058513889685968  0.036529339633760 -0.074890516703321  0.101980211526271 -0.048987870817682
-    1  (  1) -0.129678391589477 -0.003465728257171  0.197451754644996  0.065935565415812 -0.202740138649240  0.212710296862521
-    2  (  2)  0.022460564343485 -0.084272909470111  0.151124340943592 -0.372643880141893  0.063147940573273  0.083681000851943
-    3  (  3)  0.069418152872000 -0.077040623108210  0.377203303892585  0.165559399244429  0.189357768189066 -0.044737808867399
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.085668830826552 -0.137820799821428  0.214610467959109 -0.105542261331575 -0.036859097160699 -0.000473863191187 -0.079606876493940 -0.008613359831911 -0.198755661758927
-    1  (  5)  0.139412038667804 -0.235636886292823 -0.125284829879163 -0.147970518740863  0.038362154224395 -0.146537444592945  0.006121389458985  0.189794595760356 -0.090516747843842
-    2  (  6)  0.309048143972667 -0.258748687397478 -0.168238503241577 -0.304764034594830  0.050456064213686 -0.094565768675462 -0.416604423570797 -0.027331415693002 -0.066446598559594
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.012674523904089  0.052192101234841  0.013753920669736 -0.012760663896321  0.052741920591878
-    1  (  5) -0.065601509403618 -0.098250162685785 -0.177768481553462 -0.033008693934464 -0.305584708162473
-    2  (  6)  0.160962535198804 -0.052046626684912  0.419200543530856 -0.024457493928167 -0.150587999794571
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002292052292103  0.001327689025616  0.000248352651822  0.007958119616401  0.006332326100069  0.018602233716078  0.068879285117605  0.007819744108382 -0.006538352080531
-    1  (  1)  0.002764164951484 -0.002219747844781  0.018293151832048 -0.029668233290910  0.039848292773073  0.022489745012597  0.162281988584096  0.020804504235237 -0.019083175045335
-    2  (  2) -0.011217835122942 -0.011598249376099  0.016968466001430 -0.008250037510454 -0.006232273271199 -0.008766677291355 -0.010338243291251 -0.010725726663582 -0.004470553150490
-    3  (  3) -0.050562851864422 -0.047527304873166  0.078707468856861 -0.000484758494314 -0.025585059000149 -0.011993586441405 -0.049963781283820  0.008029454242805 -0.026864587292976
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006805334012410 -0.003000362320124 -0.002228041038774 -0.000013471324712 -0.003129940535122  0.001748281527537
-    1  (  1)  0.013913717596781  0.013715090430948  0.022806809849797  0.002206415430012  0.006824605289547 -0.005086150284378
-    2  (  2)  0.011033408042674 -0.021897939524419  0.000684908130867  0.006441462755861  0.002207402072499  0.000019160522387
-    3  (  3)  0.030996252825103  0.007986449014412 -0.024562077320802  0.006200249162121  0.010690383251548  0.011486173135262
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.008068643711801  0.010525757489218  0.001816581937116  0.014852647204910  0.016446444650493 -0.051123908211814  0.105303074579265  0.010186396385182  0.002604742010165
-    1  (  5)  0.024807027264740 -0.041872241876177 -0.005357408083722  0.028564486604489  0.031353252400093 -0.040716482303670  0.082357809569052  0.022204595749263 -0.028676826310240
-    2  (  6) -0.057433465116021  0.072910653400311  0.007950207598684  0.045866077252401  0.051478467074881 -0.066399959025161  0.120267838044196 -0.002980749702428  0.024762093508968
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000934050050601 -0.000604010149742  0.003646663045597 -0.000033137801782 -0.002019175758164
-    1  (  5) -0.015497094356084 -0.002871076746167  0.025548488367170  0.001995117147543  0.006447008967147
-    2  (  6)  0.009288606849912  0.006735078994323  0.016930923349151  0.006239987724853  0.010309885333920
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.002224796248932 -0.043809288397668  0.042786645812817
-    1  (  1) -0.035961652529642 -0.375558249507307  0.229138680808401
-    2  (  2) -0.031482392637318 -0.208906969570392  0.045224347296993
-    3  (  3) -0.099946950247302 -0.215409785029960 -0.414532197880426
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.002181806445193  0.035979573047749  0.031640926892770  0.100238553322265
-    1  (  5)  0.043671265862196  0.375015508928976  0.208917842140980  0.216574490738358
-    2  (  6) -0.042527296867704 -0.228253198541364 -0.044456455969980  0.415218734433247
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.071571831474078 -0.044653489385004 -0.010701302384521  0.107261739958166 -0.107631207507480 -0.021982609216158 -0.087555139416088  0.002428271330290 -0.013116395341898
-    1  (  1) -0.000994163831951  0.002283385696650 -0.009683189881167 -0.069987093364656  0.211165412824247  0.144806549288858  0.839471629333561  0.082797629633042 -0.083995255816987
-    2  (  2) -0.048029450774152 -0.034159151942753 -0.005345969743377  0.362094457083752 -0.166955343421217  0.200138180389859  0.200325175150546  0.048097856321736 -0.015226624624379
-    3  (  3)  0.099901242333760  0.066741882163174 -0.192006761021434 -0.037162207196608 -0.149491220617197 -0.091957380518235  0.124661875998661  0.114474410410770  0.084751404274498
-    4  (  4)  0.098292057994740  0.060260709677490 -0.234095836344240 -0.042527139722405 -0.172693635464862 -0.110397071373739  0.184879337331564  0.074537123570685  0.084735776692236
-    5  (  5) -0.074314676568805 -0.053240577551284  0.354242764435207 -0.039009834260932 -0.144962419013306 -0.061650919712871  0.045188344047270  0.085035282721814 -0.173092563485556
-    6  (  6)  0.068641550367955  0.078242424055456 -0.700330832585814  0.207548816757698  0.389421892794422  0.222244858530312 -0.109406330044358 -0.045457397940437  0.343867539807075
-    7  (  7) -0.021723320720404 -0.016351205203476 -0.098413699787287 -0.004057278627194 -0.006939091834835 -0.079051971654245 -0.378143817290533 -0.122761983444910  0.057845298080872
-    8  (  8) -0.009573032166809 -0.006109372122326  0.063933429430759 -0.085659891507819  0.069748375065097 -0.032412606198411 -0.211702458249100 -0.046995111806491  0.044380498011898
-    9  (  9)  0.004993361863043  0.003634014150995  0.021315829704565 -0.021713795540591  0.030056681969938  0.023359631271158  0.128991093821754  0.016400014214086  0.007638043352367
-   10  ( 10) -0.003364468158750 -0.005158901374854 -0.010157814233361 -0.013146135283286  0.036788603301889  0.001796925979298  0.031087735489025  0.158319551738170  0.001398916399977
-   11  ( 11)  0.005212014578832  0.005572219785769 -0.129300362837609  0.009016877484905 -0.009416239426444 -0.064438058134478 -0.026488687258820  0.021963612194050 -0.285489003307810
-   12  ( 12) -0.022889675001499  0.014028568601137  0.005258310077958  0.012614598275049 -0.011181538654879 -0.041924328606934  0.003053461905651 -0.141650155501189  0.005090787707422
-   13  ( 13) -0.006246133552104 -0.010356570946206 -0.013049157750693  0.012424981952374  0.009162366348548  0.014458376447183  0.062634797746530  0.024809108873570 -0.013232375979099
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.002828230885259  0.008462795614423 -0.005154038879344 -0.009706144885118  0.000351690712204  0.003016908410820
-    1  (  1)  0.016542909802003  0.036808232009347  0.132827410709676 -0.012545312927289 -0.013603497625073  0.014243226256359
-    2  (  2)  0.056531888264110 -0.026681841564715 -0.044472892095955  0.008316762319552  0.009818160226072 -0.003132505638469
-    3  (  3) -0.065664012413420  0.084000307061434 -0.024123678461565  0.011516052481207 -0.005295212539449 -0.009770444853693
-    4  (  4) -0.036042306167929 -0.066196882580851  0.035814283991967 -0.000422354014022 -0.007346814292352 -0.010225200735509
-    5  (  5) -0.148907428019867  0.109320100217019  0.041270431698870  0.008286052492371 -0.000171545458770 -0.012799874602526
-    6  (  6)  0.267740896585426  0.203497348994007 -0.004880757246495  0.039144439238699 -0.017848850593927  0.043282221917129
-    7  (  7)  0.072391125356364 -0.141340064883945  0.132216664302783 -0.021712276497558  0.014580212743961 -0.003413596406028
-    8  (  8) -0.065338926975322 -0.070417584641905 -0.663636576046729 -0.043614890913083 -0.008447529962600  0.017635456067550
-    9  (  9) -0.053338372051572 -0.015608392811416 -0.295869564541767 -0.007118975871925 -0.021727777212874  0.010944181246410
-   10  ( 10) -0.043778421907192  0.395589362339912 -0.177341233202869 -0.145584179195568  0.046786531122239 -0.019085441444645
-   11  ( 11)  0.612579899217924  0.015866362451336 -0.053555820669477  0.384133045755224  0.648991284315058 -0.223359237845080
-   12  ( 12) -0.089924264835293  0.149474889068186 -0.147998013353447  0.410950037016040 -0.122612685939173  0.053519931502489
-   13  ( 13)  0.016968386753168  0.001120736716635 -0.667558162177878 -0.016648983669680  0.049072172914969 -0.011592992748874
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.071349801352714  0.001077758689270  0.047849010758326 -0.099049708991045 -0.097373218549676  0.073249702217693 -0.066497399663864  0.021905924000240  0.009611371244577
-    1  ( 15)  0.044780949738342 -0.002559008927919  0.033951661393688 -0.066729312295417 -0.060308115101389  0.053229541901532 -0.078046690958424  0.016360376267857  0.006154062585818
-    2  ( 16)  0.011020054803348  0.009639577990268  0.005659342412167  0.191466387657639  0.233770018397514 -0.353943104953864  0.699652203951292  0.098429630868855 -0.064028996133411
-    3  ( 17) -0.107854789786829  0.070585793426064 -0.362141920362757  0.037292065848127  0.042427554280204  0.038929544624314 -0.207453249613870  0.003913287572517  0.085781111935039
-    4  ( 18)  0.108209449998589 -0.211629628691260  0.166874900133538  0.149325288082853  0.172890816462261  0.144890994778007 -0.389082003854745  0.007000687821959 -0.069612637937369
-    5  ( 19)  0.022019034844530 -0.144617634612034 -0.200192966932155  0.092059326306506  0.110737371319811  0.061364605633156 -0.221637061620796  0.079021140430879  0.032667339771983
-    6  ( 20)  0.089130158761340 -0.839805360702565 -0.200387491136600 -0.125541335494667 -0.184496760040884 -0.044995250241868  0.109402692051630  0.378035804168224  0.212908503907275
-    7  ( 21) -0.002178057091036 -0.082925436926419 -0.048118216149304 -0.114730021254923 -0.074453346277450 -0.084891108935456  0.045281773316414  0.122667104662944  0.047081579488124
-    8  ( 22)  0.013014867453698  0.083878416356731  0.015105645463008 -0.084649544925904 -0.084843093804877  0.173122296622746 -0.343876299664282 -0.057834963947671 -0.044464266623977
-    9  ( 23) -0.002901775226447 -0.016234828173147 -0.056359654971911  0.065872157385184  0.036362021680569  0.148332139389866 -0.266718078511433 -0.072258279284240  0.065401012908072
-   10  ( 24) -0.008445720197208 -0.036804429594076  0.026642166859464 -0.084168947416296  0.066510758074240 -0.109381013548543 -0.203196264302595  0.141165925569768  0.070499221179176
-   11  ( 25)  0.005377792056995 -0.132971363586077  0.044450134013510  0.024046237867949 -0.035750577264431 -0.041236558408713  0.004898258174407 -0.132214673314304  0.663804812343683
-   12  ( 26)  0.009728994170677  0.012565610031588 -0.008265487183253 -0.011507462056025  0.000390885497569 -0.008310505974528 -0.039141081466535  0.021755546401078  0.043610775840933
-   13  ( 27) -0.000301420723240  0.013603051175605 -0.009758944837902  0.005201669668069  0.007344582365292  0.000240423767516  0.017707548228131 -0.014600989921611  0.008461166379486
-   14  ( 28) -0.003079753925572 -0.014179269497254  0.003153288832510  0.009783782056838  0.010222304053932  0.012792812982895 -0.043303231879505  0.003407229733486 -0.017679792666433
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.005093584579739  0.003397430557442 -0.004751145314811  0.022993999775599  0.006406607432759
-    1  ( 15) -0.003664268681973  0.005140681437481 -0.005623137023323 -0.014031183819186  0.010293722738861
-    2  ( 16) -0.021380720709283  0.010101149193742  0.129156907046771 -0.005327658954335  0.012995314092573
-    3  ( 17)  0.021888212102979  0.013219387248743 -0.009147784998755 -0.012607741489428 -0.012451560776458
-    4  ( 18) -0.030283770762202 -0.036869387279966  0.009496744772099  0.011181780485761 -0.009182409552405
-    5  ( 19) -0.023453672116025 -0.001799424920848  0.064551617042567  0.041960641260944 -0.014420118956797
-    6  ( 20) -0.129458546494568 -0.031271046054797  0.026491102279080 -0.003035012140173 -0.062712336606301
-    7  ( 21) -0.016591446747124 -0.158366047016833 -0.021959782838746  0.141640631249085 -0.024819174074491
-    8  ( 22) -0.007575701587639 -0.001384112156404  0.285443557719673 -0.005092627774539  0.013202606990523
-    9  ( 23)  0.053335089301781  0.043785415746453 -0.612428033952452  0.089945127333784 -0.016908784258582
-   10  ( 24)  0.015338693676901 -0.395633576722136 -0.015809806174567 -0.149475505805733 -0.001108572795382
-   11  ( 25)  0.295832367201873  0.177313650229223  0.053561286295896  0.148004020967956  0.667548449265010
-   12  ( 26)  0.007157154416058  0.145586590425994 -0.384132810583031 -0.410951719442907  0.016651787670946
-   13  ( 27)  0.021701996830356 -0.046797876195804 -0.648997652718972  0.122606232077452 -0.049068049852610
-   14  ( 28) -0.010942221777250  0.019093183683670  0.223365949415048 -0.053520759465633  0.011602247780488
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002779955261603 -0.001692895942305  0.000296900585249 -0.009027308047397 -0.005517424530412 -0.019392785745096 -0.071615718156204 -0.008379623734860  0.006552142468187
-    1  (  1) -0.002104549417692  0.002248748312386 -0.016268779471160  0.026298614529289 -0.037020427510003 -0.022919155336995 -0.164160248243373 -0.021028638082435  0.018807600972838
-    2  (  2)  0.012197014321068  0.010749741004112 -0.015969423342584  0.008379419120709  0.005700661608129  0.009182078264487  0.007072493012826  0.010651845449984  0.003884546255784
-    3  (  3)  0.055916626202382  0.044952545452401 -0.075693796863108  0.001117242062951  0.024281174456382  0.014619597544438  0.053283290640730 -0.007703747637899  0.022436578410201
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006982563138735  0.003194903879745  0.002336222897234 -0.000159319304137  0.003153288870770 -0.001705858583767
-    1  (  1) -0.013922175981332 -0.014264739151757 -0.027533427644979 -0.002422850658312 -0.006842699761048  0.005360945695368
-    2  (  2) -0.010224586423111  0.021331787446370 -0.001728789794737 -0.007349416930946 -0.001927444504520 -0.000065986060579
-    3  (  3) -0.028649073776620 -0.008193923965951  0.026834068422643 -0.006433642271155 -0.011064478009774 -0.011417291735949
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.007713676236593 -0.011322134542428 -0.003907084678219 -0.013398999832291 -0.015469012646281  0.052157960119991 -0.107410796770668 -0.010366341516334 -0.002761603992801
-    1  (  5) -0.025927350683998  0.036918918076003  0.006183726668217 -0.026765793037022 -0.030906551194516  0.042649472793173 -0.084196537695922 -0.021256853976094  0.026253718608666
-    2  (  6)  0.059547667994817 -0.071575508753467 -0.010792071396252 -0.045987434407757 -0.051692908853285  0.069048919754801 -0.125623895288436  0.001752094627181 -0.022191347480178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000950352585130  0.000964031243708 -0.004357151868410 -0.000282508389387  0.001887057940293
-    1  (  5)  0.015009418487876  0.001705110486741 -0.029429172036479 -0.001075595895759 -0.006702102006371
-    2  (  6) -0.007980731926488 -0.006589892733093 -0.020940438262105 -0.005674678855388 -0.010940914550878
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.022503440295578 -0.058098623160145 -0.000062770556734  0.132305009159611  0.206845253888058 -0.090151367716479  0.021622993201581  0.039361663017837 -0.081041759541848
-    1  (  1)  0.058446002592383 -0.108172168387664 -0.020491566069371 -0.029038345945870  0.075256281089891 -0.197244333760833  0.268904698800656  0.104165934684918 -0.067340388337437
-    2  (  2)  0.015395531940673 -0.065975044888456 -0.020693241252069 -0.145278172828421 -0.156811977467588 -0.026190455409862  0.072791620600653  0.106379132149930 -0.008110007387645
-    3  (  3) -0.209889648220476 -0.051262205346321  0.016792464687925  0.095510023534387 -0.095336437810918  0.289116526954893 -0.245753636284359  0.379261907424047 -0.084194488967520
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009235922100177  0.024147628250431 -0.039515998201655 -0.082736569420115  0.047511948424277
-    1  (  1) -0.028213287461099 -0.067760885411210 -0.238885785807081  0.125969164479712 -0.177609465312039
-    2  (  2) -0.077606300081105  0.045313543916726 -0.093141189396730 -0.365274041996187 -0.093447143795058
-    3  (  3) -0.414915648100446 -0.159852566418800  0.273568285227138  0.034618677637943 -0.200919751819537
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.016102681987247  0.069778483698168 -0.053388820632184 -0.227201022134102  0.199230027457495 -0.049687576281282  0.168877445270920  0.014461225328823  0.006078045812768
-    1  (  5) -0.058029574787105  0.323045692563541 -0.030451397472046  0.087822399116244  0.049669665032409  0.052839306746917  0.277652121541251  0.149775076383341 -0.305937155270733
-    2  (  6)  0.084055275470365 -0.046073375199285 -0.190725804864314  0.087557818530586  0.137785527514627  0.205465571554509  0.198777590920696  0.118276962990446  0.298899363373256
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.065173985616709 -0.083163093490794 -0.059838819851119 -0.009394325001919  0.030439464329862 -0.004211858017357
-    1  (  5) -0.056299326992345  0.068872084539633 -0.330916524068157  0.053769676104372  0.184435947376542  0.103868547783998
-    2  (  6) -0.066328790174083  0.124449756312359 -0.113043685745465 -0.144452726551049 -0.299204372306590  0.043729255680777
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.000261962805527 -0.008184590036916 -0.017078206714547  0.120797444663216
-    1  (  1)  0.008556708940915 -0.000310357479341 -0.070665159347740  0.263733240360097
-    2  (  2)  0.016665957640930  0.070092969568202 -0.000658296979419 -0.516406140442811
-    3  (  3) -0.119815260993819 -0.260397085059189  0.515923296927157 -0.000854850636513
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.000399146441393 -0.382166830385046  0.144086395309984
-    1  (  5)  0.378879203373124  0.000650240992924 -0.057572968692994
-    2  (  6) -0.142267704977137  0.057783925625683 -0.001456329094586
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000900630817554 -0.057480932301245 -0.021776185729722  0.109986124582383  0.040974945330873 -0.038859091716892  0.013722976007050 -0.027662163358449 -0.095856958174055
-    1  (  1)  0.055475653729801 -0.000055946423413  0.161049994133599 -0.114708024204161  0.226365261647007 -0.429957047290397  0.365226817146616  0.339873184728980  0.220417191818889
-    2  (  2)  0.021015776391225 -0.161427052909876 -0.000077274959500 -0.056803578516090 -0.009014493962561 -0.218381032705501  0.249538253456386  0.218329398300718 -0.109423644471870
-    3  (  3) -0.109912942235435  0.115891216387226  0.056027564915087 -0.000745943372336 -0.462877633738761 -0.122572187022543 -0.103916786291671 -0.116372032296581 -0.000178644283986
-    4  (  4) -0.040100257401875 -0.225977964738004  0.007764610803158  0.462832592343494  0.000863713188322 -0.292983388565633  0.009504255770613  0.051881331882898  0.039789084738632
-    5  (  5)  0.036362528925732  0.431143684565054  0.219013710239047  0.122734678900396  0.292859375843390  0.000211534680094 -0.380048338834312 -0.122563604837503 -0.042304270254859
-    6  (  6) -0.010482485700734 -0.366095597661643 -0.249485788064463  0.103549341685718 -0.008516226169398  0.379084427040244  0.000639775867465 -0.110614613813807  0.062004820067381
-    7  (  7)  0.028768402882084 -0.339119958859187 -0.216813059372753  0.114011828936208 -0.053232451800269  0.122211769727443  0.109878960190362  0.000261733603902  0.084697348659745
-    8  (  8)  0.095810944695339 -0.221328249276198  0.109105398407016  0.000872051363332 -0.038539628128303  0.040520833999869 -0.059740000698589 -0.084693665490196 -0.000412317879658
-    9  (  9) -0.014697085572369  0.105287145446065  0.107273285124554 -0.218858370800790 -0.309735125099707  0.105267325854044  0.129620026346489 -0.117982202893295 -0.042502371715710
-   10  ( 10)  0.029182274069824 -0.107750482915279  0.099755873232372 -0.053540519729340 -0.138357776561313 -0.190065661316288  0.089951321859094  0.050398080030990  0.205938711533234
-   11  ( 11)  0.155188100419270 -0.443693923193144  0.328775787595012  0.218791170588425  0.215183707581290 -0.086687685172567  0.081438682030110  0.042661060649417 -0.076989743302328
-   12  ( 12) -0.047041819133234 -0.056356277723762  0.091876156457250 -0.290703693299404  0.241933426060854  0.247197194304072 -0.042704222313260 -0.092541926182781  0.274193192866188
-   13  ( 13)  0.050345457187291 -0.050309029533973  0.290248962160651 -0.162027268205590 -0.213802087129947  0.103771321970539  0.033795235497895  0.045614675872296 -0.299788281594492
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015094426489385 -0.029115659613983 -0.157755053899576  0.046090500922969 -0.051508699260243
-    1  (  1) -0.106870813652794  0.107133528015315  0.444981848759502  0.057242056092260  0.049852574162924
-    2  (  2) -0.109000377776186 -0.100245307552926 -0.328735836791228 -0.092813183683021 -0.291725571255699
-    3  (  3)  0.218950464663642  0.054805102085229 -0.218886888542850  0.287519470239803  0.163372131318531
-    4  (  4)  0.309058290561687  0.137567383239755 -0.215197532854542 -0.238351393836415  0.213552990219106
-    5  (  5) -0.105624117972050  0.189859620690769  0.086820347884659 -0.246317074454971 -0.103852569604006
-    6  (  6) -0.128090000856950 -0.089849284790687 -0.081980995688424  0.043663325009380 -0.033155703031442
-    7  (  7)  0.117989240855164 -0.049695249544289 -0.043676012478627  0.088835836027467 -0.045632574214248
-    8  (  8)  0.043185512310112 -0.206252030230843  0.075219160600281 -0.272504390674221  0.299099410447325
-    9  (  9)  0.000057792160806 -0.416496446259856 -0.033591110007553  1.079044045817673 -0.144878189091344
-   10  ( 10)  0.417381448990175  0.000164005362256  0.288881720270974  0.322059475407989  0.291538277058572
-   11  ( 11)  0.033261524584632 -0.288678211108029 -0.000120543612153 -0.357470920187363  0.110246704427593
-   12  ( 12) -1.082405304483696 -0.322498276514614  0.357322196019218 -0.000062083058686  0.002512916703852
-   13  ( 13)  0.144912114579266 -0.291369916474373 -0.110105006775573 -0.002446483993983 -0.000063534084907
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000175081543235 -0.016120371429442 -0.025072002498304  0.062542190001802  0.021350885611547 -0.118270325314463  0.004836963443515  0.089308321494225 -0.035265121599229
-    1  ( 15)  0.019016581108199  0.000074621970575 -0.073692709803714  0.220090875517869 -0.117001241546735  0.069843654088595  0.194734592940075 -0.297334325625652  0.000079679030764
-    2  ( 16)  0.022601123418379  0.074079137647861  0.000898075728427  0.015352523942528  0.086856492084779  0.105020764975973  0.399309885639222  0.436863382131768 -0.175020106394673
-    3  ( 17) -0.059722097345643 -0.223919505098562 -0.017236939707976 -0.001153330835786 -0.251337783789024  0.316047497618501 -0.195069502405347 -0.070796117852759  0.376854141068864
-    4  ( 18) -0.020136753535406  0.119176676580157 -0.086690091555957  0.251646590139027  0.000253931741203 -0.043128862347216 -0.031767565075469 -0.166618171717943 -0.162853353427719
-    5  ( 19)  0.121150060676491 -0.070465337136684 -0.107141402917482 -0.315382260507260  0.043144844880677  0.000915299484024 -0.084836748925337 -0.176704257940108  0.191804096130314
-    6  ( 20) -0.000227153495196 -0.194659284089696 -0.399818522753271  0.193896536829138  0.032525351177495  0.085523354347228 -0.000313079507665 -0.483156326770454  0.288322768300902
-    7  ( 21) -0.086746307137050  0.297294170806804 -0.437363838809433  0.070300496686642  0.166591994782638  0.177217714676447  0.482838971708773  0.000010492293158 -0.098273184847418
-    8  ( 22)  0.034845258926463 -0.000856544015042  0.174085542944903 -0.374309528502768  0.160749665940989 -0.191624326414423 -0.289454904423207  0.097021267550286  0.000014930403134
-    9  ( 23)  0.146129839058625 -0.053485685235489 -0.324250294825688 -0.062889229683993 -0.055229748354907 -0.064112736518454 -0.152978751390762 -0.139451617186824  0.103725991413667
-   10  ( 24) -0.228960109301508  0.607985902209196  0.190616272123952  0.232984732345919  0.097313246050482 -0.308149392800304  0.021807135674588 -0.163587870408667 -0.316482089556332
-   11  ( 25)  0.113565876404474  0.174438492287337 -0.418980586076638 -0.308342622144811  0.075432621028035 -0.339103289288013  0.159452756259669  0.028406298387558  0.098839597099947
-   12  ( 26)  0.037444327267497  0.021664072112540 -0.117362801200428  0.051936890369174 -0.180410685976303 -0.010675625355601 -0.081438166282141  0.155940478341525 -0.070485054402519
-   13  ( 27) -0.017297506490474  0.067203074043417 -0.031147633780062  0.363738862057104 -0.387270613641932 -0.012184715254153 -0.015942188037241 -0.055059690817384  0.199296990199252
-   14  ( 28) -0.034092252177280 -0.073609066570291  0.020468002829462  0.085810470847407 -0.016765555515325  0.112839616184042  0.014153257364848 -0.178002322135800 -0.110338785365483
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147095539872376  0.230933799773572 -0.118289772746159 -0.038253772767438  0.016292190599376  0.035682534667399
-    1  ( 15)  0.054490936726022 -0.608135664745132 -0.173899591973771 -0.021325225109122 -0.066354839577593  0.073331369735504
-    2  ( 16)  0.323391847959362 -0.191801489512728  0.419969130886919  0.118001273092270  0.032684795751606 -0.020933916119483
-    3  ( 17)  0.062697350486216 -0.233350536310731  0.310310140488106 -0.052850324165962 -0.365716314917336 -0.086296396691588
-    4  ( 18)  0.056488793458209 -0.097314229222503 -0.076761540605130  0.181114864878229  0.388829148158998  0.017043041264799
-    5  ( 19)  0.064628320787142  0.308910350912419  0.338058227371863  0.010220898623398  0.011328162399013 -0.112362127982886
-    6  ( 20)  0.155379178216757 -0.021354195203649 -0.159398635050554  0.081833336858149  0.016534888228425 -0.014163359612815
-    7  ( 21)  0.140544774640631  0.163930417297838 -0.028664595573872 -0.155618444233800  0.055735865052570  0.178161215640947
-    8  ( 22) -0.103335943311626  0.315447824318076 -0.098508893733054  0.070643837593413 -0.199190551733374  0.110186805922077
-    9  ( 23) -0.000685205966667  0.100205727138125  0.098177984906046 -0.175404901290335  0.218086466804573 -0.228138153240994
-   10  ( 24) -0.099957378010052  0.000114683002834 -0.318552989781421  0.225328174596453  0.500054658950178  0.463890214112073
-   11  ( 25) -0.099837194917026  0.317752725239532  0.000013072206941 -0.325584528982677  0.211934933711074  0.064802310197909
-   12  ( 26)  0.174911687089744 -0.225249469039813  0.325644361756676 -0.000020583584119  0.212000345487719 -0.097990759740781
-   13  ( 27) -0.218595256276680 -0.499626470482130 -0.211748903875100 -0.211985776866882  0.000065067673371  0.140785106097385
-   14  ( 28)  0.228612967389221 -0.463548085364371 -0.064895093957796  0.097943745399768 -0.140883877569216  0.000043885507604
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019700182677107  0.054538984090235 -0.000657293183087 -0.126059310809811 -0.202210998435547  0.093434338948912 -0.024491292826920 -0.039730679308171  0.082949626694246
-    1  (  1) -0.060570767175445  0.116914550591561  0.021887147512720  0.031244847376015 -0.072525220228195  0.201021150446149 -0.281719713830611 -0.109054645892934  0.074327440399932
-    2  (  2) -0.019917912309244  0.073498936617270  0.021015841735436  0.144973687437559  0.148661911932328  0.032805680200530 -0.073267109264718 -0.114043301611775  0.006398273119569
-    3  (  3)  0.203013924377866  0.061956730055074 -0.012687970996344 -0.097374198936086  0.112619147770746 -0.293844050008896  0.262428514093214 -0.382217125669607  0.093448479811714
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009866900732451 -0.025414444169079  0.042903095265212  0.089054808289042 -0.047172870515861
-    1  (  1)  0.029479300283789  0.071852668133045  0.250209813738974 -0.142668644531379  0.184582935130086
-    2  (  2)  0.082839864480010 -0.055172054044893  0.094169081580928  0.401277867082134  0.092346870950092
-    3  (  3)  0.429785932962397  0.170247315400433 -0.282336698266608 -0.039589385431124  0.207542683133741
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.009866584979611 -0.069659389537491  0.056437231681762  0.210909857782961 -0.193232853181259  0.044263163299027 -0.177086741570330 -0.011251791029683 -0.005974944716262
-    1  (  5)  0.063966745715496 -0.332083812922556  0.023959233352897 -0.077592998716570 -0.049685567261429 -0.057922845574581 -0.292828526996055 -0.156611147799579  0.308189152931942
-    2  (  6) -0.093646243694878  0.043886805978709  0.210333087134871 -0.092497904993075 -0.147507586034143 -0.211245402574055 -0.209822842363998 -0.120370292677794 -0.308437245541794
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.068407482810996  0.091070726633549  0.065843093849225  0.010412482581374 -0.030047987986099  0.002926817734499
-    1  (  5)  0.052950259935718 -0.069489349844532  0.341748563636018 -0.056521413026788 -0.185361514981414 -0.106113084848256
-    2  (  6)  0.072195900884664 -0.125482826256953  0.118114475628611  0.149158088490925  0.308475854808778 -0.046262836261962
-
 	Computing Mu_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.540697431193
-	   1         5.552916117478    3.480e-01
-	   2         6.604958020371    2.284e-01
-	   3         6.775215300811    7.934e-02
-	   4         6.834035245668    4.394e-02
-	   5         6.845160672783    1.738e-02
-	   6         6.850503279364    1.025e-02
-	   7         6.850632769023    5.347e-03
-	   8         6.850566640390    2.859e-03
-	   9         6.850241817246    1.566e-03
-	  10         6.850405195016    6.971e-04
-	  11         6.850478753078    1.698e-04
-	  12         6.850543404313    7.065e-05
-	  13         6.850571882241    3.674e-05
-	  14         6.850594686286    1.964e-05
-	  15         6.850605491784    7.311e-06
-	  16         6.850609755845    2.877e-06
-	  17         6.850610013933    7.266e-07
-	  18         6.850609678966    3.402e-07
-	  19         6.850609542810    1.219e-07
+	   0         4.540697422749
+	   1         5.552916105745    3.480e-01
+	   2         6.604958005788    2.284e-01
+	   3         6.775215285821    7.934e-02
+	   4         6.834035231501    4.394e-02
+	   5         6.845160658466    1.738e-02
+	   6         6.850503265133    1.025e-02
+	   7         6.850632754759    5.347e-03
+	   8         6.850566626109    2.859e-03
+	   9         6.850241802983    1.566e-03
+	  10         6.850405180741    6.971e-04
+	  11         6.850478738804    1.698e-04
+	  12         6.850543390036    7.065e-05
+	  13         6.850571867964    3.674e-05
+	  14         6.850594672009    1.964e-05
+	  15         6.850605477506    7.311e-06
+	  16         6.850609741567    2.877e-06
+	  17         6.850609999654    7.266e-07
+	  18         6.850609664687    3.402e-07
+	  19         6.850609528531    1.219e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.325e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.308774510044
-	   1         5.177251147516    2.385e-01
-	   2         5.788144734198    1.206e-01
-	   3         5.817401245271    2.506e-02
-	   4         5.822428669112    1.120e-02
-	   5         5.823746001128    2.243e-03
-	   6         5.823954312245    1.112e-03
-	   7         5.823956740112    3.004e-04
-	   8         5.823962111139    9.653e-05
-	   9         5.823955533594    3.317e-05
-	  10         5.823958206449    9.554e-06
-	  11         5.823960101372    2.275e-06
-	  12         5.823961215410    6.655e-07
-	  13         5.823961727557    2.438e-07
+	   0         4.308774480793
+	   1         5.177251112373    2.385e-01
+	   2         5.788144692758    1.206e-01
+	   3         5.817401202381    2.506e-02
+	   4         5.822428626061    1.120e-02
+	   5         5.823745958006    2.243e-03
+	   6         5.823954269104    1.112e-03
+	   7         5.823956696972    3.004e-04
+	   8         5.823962067999    9.653e-05
+	   9         5.823955490454    3.317e-05
+	  10         5.823958163309    9.554e-06
+	  11         5.823960058231    2.275e-06
+	  12         5.823961172270    6.655e-07
+	  13         5.823961684417    2.438e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 8.940e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.602235857657
-	   1        13.271677057014    5.821e-01
-	   2        16.135822785319    3.780e-01
-	   3        16.959451373770    1.255e-01
-	   4        17.038031086023    5.281e-02
-	   5        17.073133975370    2.081e-02
-	   6        17.076161098532    1.277e-02
-	   7        17.073021378674    6.659e-03
-	   8        17.077922418366    3.883e-03
-	   9        17.076962153451    1.776e-03
-	  10        17.077205376846    9.815e-04
-	  11        17.077267411913    3.595e-04
-	  12        17.077514625868    1.084e-04
-	  13        17.077629152400    3.194e-05
-	  14        17.077680905589    1.733e-05
-	  15        17.077702717659    9.195e-06
-	  16        17.077704067073    4.270e-06
-	  17        17.077698484866    1.559e-06
-	  18        17.077697685415    6.697e-07
-	  19        17.077697400523    2.714e-07
+	   0        10.602235753425
+	   1        13.271676932128    5.821e-01
+	   2        16.135822640251    3.780e-01
+	   3        16.959451195178    1.255e-01
+	   4        17.038030906681    5.281e-02
+	   5        17.073133794699    2.081e-02
+	   6        17.076160917884    1.277e-02
+	   7        17.073021197998    6.659e-03
+	   8        17.077922237410    3.883e-03
+	   9        17.076961972524    1.776e-03
+	  10        17.077205195910    9.815e-04
+	  11        17.077267230982    3.595e-04
+	  12        17.077514444931    1.084e-04
+	  13        17.077628971462    3.194e-05
+	  14        17.077680724650    1.733e-05
+	  15        17.077702536719    9.195e-06
+	  16        17.077703886132    4.270e-06
+	  17        17.077698303925    1.559e-06
+	  18        17.077697504474    6.697e-07
+	  19        17.077697219582    2.714e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 9.713e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.244930554509
-	   1         0.311636624039    6.760e-02
-	   2         0.361199110032    3.539e-02
-	   3         0.362499590815    6.680e-03
-	   4         0.362993605803    2.873e-03
-	   5         0.363033480938    3.354e-04
-	   6         0.363025221809    1.308e-04
-	   7         0.363026115518    3.393e-05
-	   8         0.363025851986    1.573e-05
-	   9         0.363025808831    3.876e-06
-	  10         0.363025880342    1.247e-06
-	  11         0.363025925513    2.950e-07
-	  12         0.363025946102    1.072e-07
+	   0         0.244930550976
+	   1         0.311636619191    6.760e-02
+	   2         0.361199103660    3.539e-02
+	   3         0.362499584351    6.680e-03
+	   4         0.362993599316    2.873e-03
+	   5         0.363033474449    3.354e-04
+	   6         0.363025215320    1.308e-04
+	   7         0.363026109029    3.393e-05
+	   8         0.363025845497    1.573e-05
+	   9         0.363025802342    3.876e-06
+	  10         0.363025873854    1.247e-06
+	  11         0.363025919025    2.950e-07
+	  12         0.363025939613    1.072e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 1.612e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.136885453445
-	   1         8.827959964632    4.504e-01
-	   2        10.556417242071    2.704e-01
-	   3        10.782604403022    7.855e-02
-	   4        10.823407882015    3.852e-02
-	   5        10.834692997361    1.311e-02
-	   6        10.837906126725    7.418e-03
-	   7        10.837673587110    2.897e-03
-	   8        10.837862221434    1.321e-03
-	   9        10.837807614417    4.095e-04
-	  10        10.837877551051    1.842e-04
-	  11        10.837874871307    1.127e-04
-	  12        10.837880350125    6.643e-05
-	  13        10.837882578520    3.884e-05
-	  14        10.837896108461    1.776e-05
-	  15        10.837905201770    6.583e-06
-	  16        10.837910723726    3.571e-06
-	  17        10.837912086926    1.677e-06
-	  18        10.837912427624    9.968e-07
-	  19        10.837912585503    4.166e-07
-	  20        10.837912731788    1.603e-07
+	   0         7.136885404839
+	   1         8.827959901316    4.504e-01
+	   2        10.556417160848    2.704e-01
+	   3        10.782604318565    7.855e-02
+	   4        10.823407797411    3.852e-02
+	   5        10.834692912643    1.311e-02
+	   6        10.837906041941    7.418e-03
+	   7        10.837673502344    2.897e-03
+	   8        10.837862136659    1.321e-03
+	   9        10.837807529645    4.095e-04
+	  10        10.837877466278    1.842e-04
+	  11        10.837874786533    1.127e-04
+	  12        10.837880265350    6.643e-05
+	  13        10.837882493744    3.884e-05
+	  14        10.837896023688    1.776e-05
+	  15        10.837905116999    6.583e-06
+	  16        10.837910638957    3.571e-06
+	  17        10.837912002158    1.677e-06
+	  18        10.837912342856    9.968e-07
+	  19        10.837912500735    4.166e-07
+	  20        10.837912647019    1.603e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 7.150e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.872510404753
-	   1         4.591669370067    2.120e-01
-	   2         5.085547488762    1.160e-01
-	   3         5.121987048699    2.992e-02
-	   4         5.131210468924    1.294e-02
-	   5         5.131618039119    2.045e-03
-	   6         5.131761970312    9.597e-04
-	   7         5.131734102928    2.100e-04
-	   8         5.131723837644    5.883e-05
-	   9         5.131718337669    1.520e-05
-	  10         5.131718484323    4.160e-06
-	  11         5.131719052295    1.198e-06
-	  12         5.131719331290    4.377e-07
-	  13         5.131719470515    1.751e-07
+	   0         3.872510377042
+	   1         4.591669336887    2.120e-01
+	   2         5.085547449875    1.160e-01
+	   3         5.121987008165    2.992e-02
+	   4         5.131210428081    1.294e-02
+	   5         5.131617998237    2.045e-03
+	   6         5.131761929419    9.597e-04
+	   7         5.131734062034    2.100e-04
+	   8         5.131723796750    5.883e-05
+	   9         5.131718296775    1.520e-05
+	  10         5.131718443429    4.160e-06
+	  11         5.131719011401    1.198e-06
+	  12         5.131719290397    4.377e-07
+	  13         5.131719429622    1.751e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 6.824e-08
 
@@ -6589,9 +1158,9 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.279315258737979    -0.123252237132555     0.000000000000000
-    1     -0.488104243387048    -0.028164898887982     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.221999670108385
+    0      0.279315257111821    -0.123252236365221     0.000000000000000
+    1     -0.488104244070402    -0.028164898177226     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.221999666119615
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
 	[alpha]_(0.128) = -237.12775 deg/[dm (g/cm^3)]
@@ -6605,14 +1174,7 @@ Total time:
    0.077   589.00       -83.11386
    0.128   355.00      -237.12775
 
-*** tstop() called on psinet at Mon May 15 15:34:46 2017
-Module time:
-	user time   =       1.89 seconds =       0.03 minutes
-	system time =       1.96 seconds =       0.03 minutes
-	total time  =          4 seconds =       0.07 minutes
-Total time:
-	user time   =       2.87 seconds =       0.05 minutes
-	system time =       2.33 seconds =       0.04 minutes
-	total time  =          6 seconds =       0.10 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
+    Psi4 wall time for execution: 0:00:13.15
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc41/output.ref
+++ b/tests/cc41/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:24PM
 
-    Process ID:  12846
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65687
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -46,24 +59,25 @@ set {
   omega [589, 355, nm]
 }
 
-property('cc2',properties=['rotation'])
+properties('cc2',properties=['rotation'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:40 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:05 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 3-4 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1-2 entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3-4 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -77,16 +91,16 @@ property('cc2',properties=['rotation'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000    -0.695000000000    -0.049338350190    15.994914619560
-           O          0.000000000000     0.695000000000    -0.049338350190    15.994914619560
-           H          0.388142264171    -0.895248563098     0.783035421467     1.007825032070
-           H         -0.388142264171     0.895248563098     0.783035421467     1.007825032070
+         O            0.000000000000    -0.695000000000    -0.049338350197    15.994914619570
+         O            0.000000000000     0.695000000000    -0.049338350197    15.994914619570
+         H            0.388142264171    -0.895248563098     0.783035421459     1.007825032230
+         H           -0.388142264171     0.895248563098     0.783035421459     1.007825032230
 
   Running in c2 symmetry.
 
   Rotational constants: A =     10.61423  B =      0.97044  C =      0.91566 [cm^-1]
-  Rotational constants: A = 318206.57462  B =  29093.19738  C =  27450.82444 [MHz]
-  Nuclear repulsion =   38.253968380680327
+  Rotational constants: A = 318206.57700  B =  29093.19760  C =  27450.82465 [MHz]
+  Nuclear repulsion =   38.253968531042538
 
   Charge       = 0
   Multiplicity = 1
@@ -103,28 +117,17 @@ property('cc2',properties=['rotation'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 18
-    Number of basis function: 38
+    Number of basis functions: 38
     Number of Cartesian functions: 40
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         19      19       0       0       0       0
-     B         19      19       0       0       0       0
-   -------------------------------------------------------
-    Total      38      38       9       9       9       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -143,44 +146,60 @@ property('cc2',properties=['rotation'])
   Using 549822 doubles for integral storage.
   We computed 14706 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.1870579153E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.1047221517E-02.
+  Reciprocal condition number of the overlap matrix is 8.7919776090E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+     B         19      19 
+   -------------------------
+    Total      38      38
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -150.83527118424107   -1.50835e+02   7.61669e-02 
-   @RHF iter   1:  -150.75300393196321    8.22673e-02   8.92814e-03 
-   @RHF iter   2:  -150.77674264680306   -2.37387e-02   2.23904e-03 DIIS
-   @RHF iter   3:  -150.77866726940405   -1.92462e-03   8.11583e-04 DIIS
-   @RHF iter   4:  -150.77908304190501   -4.15773e-04   3.09116e-04 DIIS
-   @RHF iter   5:  -150.77917159812222   -8.85562e-05   9.19744e-05 DIIS
-   @RHF iter   6:  -150.77918361494829   -1.20168e-05   1.37015e-05 DIIS
-   @RHF iter   7:  -150.77918386184567   -2.46897e-07   2.97198e-06 DIIS
-   @RHF iter   8:  -150.77918387199867   -1.01530e-08   5.75950e-07 DIIS
-   @RHF iter   9:  -150.77918387232646   -3.27788e-10   1.51394e-07 DIIS
-   @RHF iter  10:  -150.77918387235519   -2.87343e-11   4.48580e-08 DIIS
-   @RHF iter  11:  -150.77918387235863   -3.43903e-12   9.89275e-09 DIIS
-   @RHF iter  12:  -150.77918387235860    2.84217e-14   1.77899e-09 DIIS
-   @RHF iter  13:  -150.77918387235860    0.00000e+00   2.61634e-10 DIIS
-   @RHF iter  14:  -150.77918387235857    2.84217e-14   6.83680e-11 DIIS
+   @RHF iter SAD:  -150.13109142562024   -1.50131e+02   0.00000e+00 
+   @RHF iter   1:  -150.72994418505689   -5.98853e-01   1.20798e-02 DIIS/ADIIS
+   @RHF iter   2:  -150.77474437542560   -4.48002e-02   3.93712e-03 DIIS/ADIIS
+   @RHF iter   3:  -150.77872862263547   -3.98425e-03   9.99210e-04 DIIS/ADIIS
+   @RHF iter   4:  -150.77914039140384   -4.11769e-04   2.79341e-04 DIIS/ADIIS
+   @RHF iter   5:  -150.77918120837066   -4.08170e-05   4.89524e-05 DIIS
+   @RHF iter   6:  -150.77918362626531   -2.41789e-06   1.25560e-05 DIIS
+   @RHF iter   7:  -150.77918384927895   -2.23014e-07   3.89300e-06 DIIS
+   @RHF iter   8:  -150.77918387131706   -2.20381e-08   8.16055e-07 DIIS
+   @RHF iter   9:  -150.77918387210650   -7.89441e-10   1.49865e-07 DIIS
+   @RHF iter  10:  -150.77918387212898   -2.24816e-11   3.10868e-08 DIIS
+   @RHF iter  11:  -150.77918387213006   -1.08002e-12   6.61624e-09 DIIS
+   @RHF iter  12:  -150.77918387213001    5.68434e-14   1.38474e-09 DIIS
+   @RHF iter  13:  -150.77918387213003   -2.84217e-14   3.05202e-10 DIIS
+   @RHF iter  14:  -150.77918387213003    0.00000e+00   6.31844e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -205,49 +224,44 @@ property('cc2',properties=['rotation'])
               A     B 
     DOCC [     5,    4 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -150.77918387235857
+  @RHF Final Energy:  -150.77918387213003
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             38.2539683806803268
-    One-Electron Energy =                -284.0698921465228750
-    Two-Electron Energy =                  95.0367398934839827
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -150.7791838723585442
+    Nuclear Repulsion Energy =             38.2539685310425384
+    One-Electron Energy =                -284.0698924306753952
+    Two-Electron Energy =                  95.0367400275028018
+    Total Energy =                       -150.7791838721300337
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.2602
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.2074     Total:     1.2074
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on psinet at Mon May 15 15:34:41 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:07 2022
 Module time:
-	user time   =       0.58 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.21 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.58 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.21 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -261,19 +275,19 @@ Total time:
       Number of basis functions:        38
 
       Number of irreps:                  2
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  19   19 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 117651 non-zero two-electron integrals.
+      Computed 107467 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:07 2022
 
 
 	Wfn Parameters:
@@ -296,7 +310,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -332,7 +346,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -132.27484824295880
+	Frozen core energy     =   -132.27484829822760
 
 	Size of irrep 0 of <ab|cd> integrals:      0.177 (MW) /      1.418 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.176 (MW) /      1.411 (MB)
@@ -346,34 +360,30 @@ Total time:
 	Size of irrep 1 of tijab amplitudes:       0.010 (MW) /      0.081 (MB)
 	Total:                                     0.021 (MW) /      0.165 (MB)
 
-	Nuclear Rep. energy          =     38.25396838068033
-	SCF energy                   =   -150.77918387235857
-	One-electron energy          =   -101.99691957132272
-	Two-electron energy          =     45.23861556124288
-	Reference energy             =   -150.77918387235832
+	Nuclear Rep. energy          =     38.25396853104254
+	SCF energy                   =   -150.77918387213003
+	One-electron energy          =   -101.99691974243427
+	Two-electron energy          =     45.23861563748924
+	Reference energy             =   -150.77918387213009
 
-*** tstop() called on psinet at Mon May 15 15:34:41 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:08 2022
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.79 seconds =       0.01 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       0.10 seconds =       0.00 minutes
+	system time =       0.22 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
-
+Total time:
+	user time   =       1.44 seconds =       0.02 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   38.253968380680327
-    SCF energy          (wfn)     = -150.779183872358573
-    Reference energy    (file100) = -150.779183872358317
+    Nuclear Rep. energy (wfn)     =   38.253968531042538
+    SCF energy          (wfn)     = -150.779183872130034
+    Reference energy    (file100) = -150.779183872130091
 
     Input parameters:
     -----------------
@@ -401,76 +411,63 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3802563054135771
+MP2 correlation energy -0.3802563047354116
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.380256305413577    0.000e+00    0.000000    0.000000    0.000000    0.143419
-     1        -0.380254802722190    2.350e-02    0.006281    0.014957    0.014957    0.143419
-     2        -0.382926539245088    6.976e-03    0.007604    0.017580    0.017580    0.146255
-     3        -0.383312067134338    2.742e-03    0.008393    0.018848    0.018848    0.146676
-     4        -0.383283495426498    9.595e-04    0.008568    0.018859    0.018859    0.146729
-     5        -0.383286625219000    3.462e-04    0.008637    0.018841    0.018841    0.146745
-     6        -0.383290105628155    9.323e-05    0.008642    0.018836    0.018836    0.146748
-     7        -0.383289932289575    3.248e-05    0.008643    0.018835    0.018835    0.146748
-     8        -0.383289793502011    1.255e-05    0.008643    0.018835    0.018835    0.146748
-     9        -0.383289823387463    3.458e-06    0.008643    0.018835    0.018835    0.146748
-    10        -0.383289826363972    1.544e-06    0.008643    0.018835    0.018835    0.146748
-    11        -0.383289836414563    4.659e-07    0.008643    0.018835    0.018835    0.146748
-    12        -0.383289840450544    1.935e-07    0.008643    0.018835    0.018835    0.146748
-    13        -0.383289840923771    7.060e-08    0.008643    0.018835    0.018835    0.146748
+     0        -0.380256304735412    0.000e+00    0.000000    0.000000    0.000000    0.143419
+     1        -0.380254802043540    2.350e-02    0.006281    0.014957    0.014957    0.143419
+     2        -0.382926538507049    6.976e-03    0.007604    0.017580    0.017580    0.146255
+     3        -0.383312066377153    2.742e-03    0.008393    0.018848    0.018848    0.146676
+     4        -0.383283494671484    9.595e-04    0.008568    0.018859    0.018859    0.146729
+     5        -0.383286624463608    3.462e-04    0.008637    0.018841    0.018841    0.146745
+     6        -0.383290104872661    9.323e-05    0.008642    0.018836    0.018836    0.146748
+     7        -0.383289931534114    3.248e-05    0.008643    0.018835    0.018835    0.146748
+     8        -0.383289792746542    1.255e-05    0.008643    0.018835    0.018835    0.146748
+     9        -0.383289822631999    3.458e-06    0.008643    0.018835    0.018835    0.146748
+    10        -0.383289825608501    1.544e-06    0.008643    0.018835    0.018835    0.146748
+    11        -0.383289835659091    4.659e-07    0.008643    0.018835    0.018835    0.146748
+    12        -0.383289839695072    1.935e-07    0.008643    0.018835    0.018835    0.146748
+    13        -0.383289840168299    7.060e-08    0.008643    0.018835    0.018835    0.146748
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              5  14        -0.0109554494
-              6  14        -0.0098594082
-              2   7        -0.0085098717
+              5  14        -0.0109554489
+              6  14        -0.0098594077
+              2   7        -0.0085098715
               2   9        -0.0082148274
-              2   4         0.0076053348
-              5  17         0.0075277221
+              2   4         0.0076053346
+              5  17         0.0075277218
               1   0        -0.0069350391
-              1   8        -0.0069268907
+              1   8        -0.0069268906
               1   3         0.0063772897
-              2   3        -0.0057368808
+              2   3        -0.0057368806
 
     Largest TIjAb Amplitudes:
-      2   2  15  15        -0.0557781569
+      2   2  15  15        -0.0557781564
       1   1  15  15        -0.0278636304
-      1   2  15  15         0.0272969982
-      2   1  15  15         0.0272969982
-      2   2  14  15         0.0270427379
-      2   2  15  14         0.0270427379
-      3   3  17  17        -0.0218529151
-      2   3  15  17         0.0214876848
-      3   2  17  15         0.0214876848
-      2   6  15   2         0.0208245684
+      1   2  15  15         0.0272969980
+      2   1  15  15         0.0272969980
+      2   2  14  15         0.0270427369
+      2   2  15  14         0.0270427369
+      3   3  17  17        -0.0218529145
+      2   3  15  17         0.0214876843
+      3   2  17  15         0.0214876843
+      2   6  15   2         0.0208245681
 
-    SCF energy       (wfn)                    = -150.779183872358573
-    Reference energy (file100)                = -150.779183872358317
+    SCF energy       (wfn)                    = -150.779183872130034
+    Reference energy (file100)                = -150.779183872130091
 
-    Opposite-spin MP2 correlation energy      =   -0.282698987529232
-    Same-spin MP2 correlation energy          =   -0.097557317884345
-    MP2 correlation energy                    =   -0.380256305413577
-      * MP2 total energy                      = -151.159440177771899
-    CC2 correlation energy                    =   -0.383289840923771
-      * CC2 total energy                      = -151.162473713282083
-
-
-*** tstop() called on psinet at Mon May 15 15:34:41 2017
-Module time:
-	user time   =       0.17 seconds =       0.00 minutes
-	system time =       0.28 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.96 seconds =       0.02 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
+    Opposite-spin MP2 correlation energy      =   -0.282698986958674
+    Same-spin MP2 correlation energy          =   -0.097557317776737
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.380256304735412
+      * MP2 total energy                      = -151.159440176865502
+    CC2 correlation energy                    =   -0.383289840168299
+      * CC2 total energy                      = -151.162473712298379
 
 
 			**************************
@@ -480,31 +477,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:42 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.98 seconds =       0.02 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -150.779183872358573
-	Reference energy    (CC_INFO) = -150.779183872358317
-	CC2 energy          (CC_INFO) =   -0.383289840923771
-	Total CC2 energy    (CC_INFO) = -151.162473713282083
+	SCF energy          (wfn)     = -150.779183872130034
+	Reference energy    (CC_INFO) = -150.779183872130091
+	CC2 energy          (CC_INFO) =   -0.383289840168299
+	Total CC2 energy    (CC_INFO) = -151.162473712298379
 
 	Input parameters:
 	-----------------
@@ -517,7 +500,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -530,60 +513,46 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.383295397523609    0.000e+00
-	   1        -0.383120322491644    1.686e-03
-	   2        -0.383118990756195    4.354e-04
-	   3        -0.383116158153778    2.067e-04
-	   4        -0.383115581742903    6.283e-05
-	   5        -0.383115059697210    2.959e-05
-	   6        -0.383114943553521    9.670e-06
-	   7        -0.383114954361293    3.957e-06
-	   8        -0.383114969044348    1.278e-06
-	   9        -0.383114972723800    5.372e-07
-	  10        -0.383114973373711    1.690e-07
-	  11        -0.383114972858116    6.804e-08
+	   0        -0.383295396774544    0.000e+00
+	   1        -0.383120321753058    1.686e-03
+	   2        -0.383118990017498    4.354e-04
+	   3        -0.383116157415033    2.067e-04
+	   4        -0.383115581004172    6.283e-05
+	   5        -0.383115058958540    2.959e-05
+	   6        -0.383114942814858    9.670e-06
+	   7        -0.383114953622620    3.957e-06
+	   8        -0.383114968305673    1.278e-06
+	   9        -0.383114971985125    5.372e-07
+	  10        -0.383114972635039    1.690e-07
+	  11        -0.383114972119443    6.804e-08
 
 	Largest LIA Amplitudes:
-	          5  14        -0.0106325455
-	          6  14        -0.0091021051
-	          2   7        -0.0085623603
+	          5  14        -0.0106325449
+	          6  14        -0.0091021046
+	          2   7        -0.0085623601
 	          2   9        -0.0085246839
-	          2   4         0.0077474301
-	          5  17         0.0076075600
-	          1   8        -0.0069597320
+	          2   4         0.0077474299
+	          5  17         0.0076075597
+	          1   8        -0.0069597319
 	          1   3         0.0064431890
 	          1   0        -0.0061242831
-	          2   3        -0.0058807098
+	          2   3        -0.0058807096
 
 	Largest LIjAb Amplitudes:
-	  2   2  15  15        -0.0557451680
+	  2   2  15  15        -0.0557451675
 	  1   1  15  15        -0.0278670139
-	  1   2  15  15         0.0272995607
-	  2   1  15  15         0.0272995607
-	  2   2  14  15         0.0269850145
-	  2   2  15  14         0.0269850145
-	  3   3  17  17        -0.0218489283
-	  2   3  15  17         0.0214821810
-	  3   2  17  15         0.0214821810
-	  2   6  15   2         0.0208269410
+	  1   2  15  15         0.0272995606
+	  2   1  15  15         0.0272995606
+	  2   2  14  15         0.0269850136
+	  2   2  15  14         0.0269850136
+	  3   3  17  17        -0.0218489277
+	  2   3  15  17         0.0214821805
+	  3   2  17  15         0.0214821805
+	  2   6  15   2         0.0208269408
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.89784269363
-
-*** tstop() called on psinet at Mon May 15 15:34:42 2017
-Module time:
-	user time   =       0.05 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.03 seconds =       0.02 minutes
-	system time =       0.47 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
-
+	Overlap <L|e^T> =        0.89784269438
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -617,1485 +586,135 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.034398581574139 -0.022991789103343  0.034442469541574  0.330456382558595 -0.233180601662081  0.129080132683952 -0.099470500295552 -0.033215263141241 -0.017533788887759
-    1  (  1) -0.125193963201420 -0.094056863638828  0.250103765613866 -0.112936578244967 -0.149788194818876 -0.227437707997397 -0.485204338670596  0.001668370995162 -0.115356975205661
-    2  (  2)  0.012233240715705  0.002368950907699  0.032425209658723 -0.111084203408140 -0.039672156088148 -0.068595430902717  0.075952847158656 -0.294199045975953 -0.119345992966551
-    3  (  3)  0.102558388937001  0.078769752966251  0.070643800093594  0.002465923506388 -0.048634367995697 -0.013847332731639  0.279588501721531  0.161409573415975 -0.750269595437933
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.124162189892697 -0.147322676383198  0.023215723712951  0.018481088431889 -0.062726537287574  0.032176124900128
-    1  (  1)  0.077900000614672  0.192270763412161  0.391012068764259  0.097598573976617  0.208812184695007 -0.131278202406216
-    2  (  2)  0.138682144513485 -0.743794268000919  0.082765968014440  0.105416894706173  0.124502895186539 -0.026640226681012
-    3  (  3) -0.046377167184700  0.100266413297349 -0.419637942135347  0.187251279348108  0.523906963118894  0.155125602890936
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.041912647030473  0.112025419050593  0.015709063071357 -0.296474982770456 -0.369528478363753  0.133936885862951 -0.093834818402243 -0.023683854572816  0.145081231878617
-    1  (  5) -0.197308914804751 -0.009979277982960  0.032584585136142  0.110675051536769 -0.043528206747949  0.380347857156503 -0.467872633414304  0.360690381381106 -0.081727457648454
-    2  (  6)  0.017175555719515  0.257070166950214  0.064576654101859  0.063636492651100  0.124214525851134  0.043707573882425 -0.279300768930124 -0.436090246737450  0.143049583009588
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000746191936210  0.015117415730589  0.105376277097060 -0.086551013225984 -0.048055402355572
-    1  (  5) -0.421110018244562 -0.132676872543725  0.513327593087781  0.036293567607712 -0.089362635661765
-    2  (  6)  0.356450473386590  0.161425142060580  0.191834100484274  0.123847982073522  0.439997591973663
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.029996182749086  0.414832297711576 -0.157003165507011
-    1  (  1) -0.055478735634457  0.002196588374944  0.023132699054813
-    2  (  2)  0.030157480407918 -0.003965129810969  0.011365271034479
-    3  (  3)  0.379654970672918 -0.026306776079243 -0.008208478993038
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.031312576109208  0.054324731747600 -0.030004942403624 -0.379837271496892
-    1  (  5) -0.410777629523562  0.000546200526033  0.004395778687124  0.022468424749377
-    2  (  6)  0.155134874665963 -0.021960972132954 -0.010503724381488  0.005891989839471
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.041599393589885  0.048291903336677  0.117743150821259  0.017705215406280 -0.102750295559090  0.051687934108131 -0.132725758102637  0.024528471901836 -0.009589411271459
-    1  (  1) -0.072748330347250 -0.064838255172247  0.046249888316539  0.094886169756313 -0.054353256296636 -0.001900039815832 -0.496484885699642 -0.156782601344965  0.027727244644896
-    2  (  2)  0.003177839573369 -0.021969851213782  0.169948604805852 -0.034169379981814 -0.096419218256700 -0.054353168415603 -0.268581512702098 -0.051387229616377 -0.132183241821031
-    3  (  3) -0.006137248486677  0.083042433269493  0.145748994350269 -0.009514642471795 -0.083396174376552  0.050339592310292 -0.147508653266551  0.025994438523140  0.274243623684456
-    4  (  4)  0.041743411936218  0.025314466729841  0.109116009514395 -0.054695145126701 -0.041005429820194  0.040692158860824 -0.089212628083091 -0.089778026874393  0.379559976718284
-    5  (  5) -0.144052404015687  0.020202343348371 -0.250448180839798  0.333938875810814  0.025165926872358  0.198674007872287  0.028751096000422 -0.150673278776424  0.071892589434733
-    6  (  6)  0.035008068923664  0.061157292133481  0.423122850397629 -0.168586232676417 -0.215300951076719 -0.176816011547681  0.082786884188413  0.107997254201703 -0.322302818265947
-    7  (  7) -0.040302039339094 -0.134662805884699  0.074305590729076  0.347285947244785 -0.297150726695267  0.120577275637125  0.158244548193724  0.221247160594885 -0.027161970952188
-    8  (  8) -0.102303986757075 -0.083520013523575  0.381308184856285 -0.143001282615579  0.075527648534131  0.132398234942646  0.075131991247111 -0.046753082020740 -0.011707789197025
-    9  (  9)  0.017637489191487  0.048428952825929  0.034610320117865 -0.459992261564512  0.414982694469193 -0.130318968246814 -0.031074590688744  0.007719514803475  0.025148594805028
-   10  ( 10)  0.073180570141060 -0.217870134214265  0.063234912206834 -0.261216160873510  0.027363003829309  0.069320876175761 -0.042163326174403 -0.184139514400861  0.015591773535866
-   11  ( 11) -0.219122634582937 -0.188385339460405  0.640855359878310  0.491678336416958 -0.065767561519751  0.413066703397514 -0.291084239981445 -0.093425757726901 -0.193265915162178
-   12  ( 12) -0.256885363420365  0.713325451456200  0.225955555841318  0.439590507884674  0.345303095230338 -0.616947103758895  0.172377723246676 -0.152457697169388 -0.041630471494425
-   13  ( 13) -0.012167367476476 -0.157114215675033  0.156454629287810 -0.271295067840173  0.465831347294122  0.087124608448573 -0.001414398542050 -0.117289965933426 -0.301481262964454
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.150893623694895  0.070181619718899  0.231121270771796  0.047212329811452  0.038360068214684 -0.065024101530573
-    1  (  1) -0.459608701558993 -0.017988718780734 -0.620163221664037 -0.047501992394079  0.054935480129094  0.084306620301789
-    2  (  2)  0.170353437709830 -0.137438184253801  0.448066510819233  0.273677026815508  0.394525740926135 -0.158445088257267
-    3  (  3) -0.027380670374415  0.505626164435732  0.414944314617527 -0.268646310616022 -0.386727191221954 -0.113140672337300
-    4  (  4) -0.013445627632877 -0.536383433584967  0.308426011289951 -0.080146650927920 -0.587918144857996 -0.127182537475191
-    5  (  5)  0.035132080582143 -0.167243745339779 -0.093457222254525 -0.023174375055702  0.241438836836271 -0.025034069681694
-    6  (  6) -0.086275759818652 -0.157794617049890  0.091627759449496 -0.100678024828998  0.039930496632404  0.039747117277017
-    7  (  7) -0.064055657553950  0.320525847624377  0.102126662685902  0.025362375541365 -0.011829791315064 -0.091201427043929
-    8  (  8)  0.004186527107181 -0.116906210612177 -0.371187985035768 -0.069143142950027 -0.337550034775452  0.350111866606547
-    9  (  9) -0.075561519107680  0.174471452153015 -0.018361558412792  0.007353276651567  0.041439267169245  0.006958189017632
-   10  ( 10) -0.027806429179180  0.167045135107807 -0.001907984997949  0.011283070546443 -0.060669265876427 -0.055774837261520
-   11  ( 11)  0.242522311612009  0.043113021308048 -0.036594154697736  0.051685667595428 -0.018454723698115 -0.000828881346793
-   12  ( 12) -0.005035323729735  0.080726831317060 -0.052335499542956  0.044973984976305  0.061396486662391  0.099208229191671
-   13  ( 13)  0.438941651704024  0.153468022162067 -0.023659734102045  0.002885107851831 -0.071809885174399 -0.077694612962715
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.044666447845943  0.075416998324096 -0.002009211971351  0.008745765947599 -0.041041980388066  0.148478826412725 -0.043148497905126  0.040061402921621  0.101604386418633
-    1  ( 15) -0.049162162504633  0.064892835130685  0.021916980092655 -0.084534607702244 -0.027746026910093 -0.020171890051146 -0.060412253106789  0.135461490072396  0.083108283525263
-    2  ( 16) -0.115794665664267 -0.047097729608731 -0.169526813418150 -0.148848835873427 -0.110367886513380  0.250308022536814 -0.421430914373290 -0.072716285234647 -0.379882079141591
-    3  ( 17) -0.016234704461670 -0.093143898198671  0.032604929784834  0.008570214748756  0.053618454434530 -0.336390621280297  0.171051246725478 -0.351382500390790  0.144302708365158
-    4  ( 18)  0.099685614405052  0.053576457156830  0.096408379043871  0.083491653355765  0.040031855455092 -0.023231985357187  0.214146456651999  0.299411639286517 -0.077061465722781
-    5  ( 19) -0.053256491006665  0.003075384449121  0.053515222726753 -0.048399268191864 -0.040795198256978 -0.198132545540493  0.175051498642490 -0.121535923725232 -0.133335441765840
-    6  ( 20)  0.128712692365555  0.496870742485916  0.268871209763746  0.149658569303091  0.086711112842081 -0.028977130072006 -0.083484855541891 -0.156340017572166 -0.079418276499146
-    7  ( 21) -0.026401094602506  0.157512598855912  0.050672592676314 -0.027957891435237  0.092269588876111  0.151809482826698 -0.107865561412261 -0.222862187720663  0.046783186727291
-    8  ( 22)  0.009612639390837 -0.030421923009696  0.129146467815306 -0.272344846639473 -0.379884587515890 -0.072760001001148  0.325598038741842  0.027479294568787  0.012294936872080
-    9  ( 23) -0.149880437140593  0.460631247362792 -0.169664291741312  0.027589402289004  0.011349753598096 -0.033685842546708  0.083139401924745  0.064655346261025 -0.002952710962413
-   10  ( 24) -0.073162117570193  0.020016390706408  0.135536511029942 -0.511692353689708  0.542889881863847  0.170172745263858  0.158312356422075 -0.326976851708720  0.119792799568885
-   11  ( 25) -0.227319331530806  0.618159967248025 -0.448267162037961 -0.415380348389647 -0.307673615218558  0.093264262201907 -0.090383721735685 -0.101137463170207  0.374119595658697
-   12  ( 26) -0.046325835806633  0.048013260965168 -0.272519638024099  0.267929097643861  0.079599126690116  0.023217992764788  0.099878544648145 -0.024929139459656  0.069393891025270
-   13  ( 27) -0.037489883688669 -0.053493928653226 -0.391870980933739  0.384400627963214  0.588279019279798 -0.241045539088516 -0.041562667530972  0.011794273471007  0.337810411804872
-   14  ( 28)  0.063867435849832 -0.083549153123607  0.158471290677241  0.113540200875422  0.127048928726566  0.025106714900888 -0.040372191298617  0.090932947916166 -0.351148385967210
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.018436133716857 -0.072929640795625  0.226474353889952  0.258554501885766  0.015629581468102
-    1  ( 15) -0.048844627710976  0.217699525631316  0.187612863297424 -0.714214561739857  0.155652904029163
-    2  ( 16) -0.036504178760377 -0.064141704639546 -0.642298500392749 -0.226999184132633 -0.158883513257702
-    3  ( 17)  0.464003802662343  0.262951360765947 -0.494608205306355 -0.439690590633845  0.272979507733357
-    4  ( 18) -0.417911613304926 -0.028340434910992  0.067656000741894 -0.345749519725828 -0.467548326168384
-    5  ( 19)  0.131287835524258 -0.068639225223597 -0.411512073768996  0.617585289861537 -0.085587328981715
-    6  ( 20)  0.031740361337335  0.042325765757491  0.290709707718165 -0.172790703648515  0.000532545780898
-    7  ( 21) -0.011558038421621  0.183385354532032  0.093657523746171  0.152317012205746  0.116530260167129
-    8  ( 22) -0.024591234247673 -0.015437963416840  0.192723206306395  0.041545920874624  0.300722952291357
-    9  ( 23)  0.076860307291410  0.028222730174457 -0.239744246838648  0.005401314981702 -0.437602472364683
-   10  ( 24) -0.182325175721446 -0.168262818970868 -0.041985084407523 -0.080814437382504 -0.153682650364464
-   11  ( 25)  0.018251396178258  0.001487318511567  0.036744565685453  0.052466578072734  0.023330767494251
-   12  ( 26) -0.006994832022894 -0.011312050265967 -0.051710399870511 -0.045052170184275 -0.002799991775595
-   13  ( 27) -0.042051003701905  0.060322036458563  0.018224376602008 -0.061574434209411  0.071889000854515
-   14  ( 28) -0.006898519418229  0.055936666673248  0.000904652270607 -0.099150038783025  0.077924550244227
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.024746315003693  0.016019947683600 -0.033657454181441 -0.314697310181057  0.226266938924475 -0.124444118187600  0.100976019942115  0.040776992946741  0.016684212809041
-    1  (  1)  0.134389185453098  0.111083358436336 -0.277285327152191  0.119300944830562  0.165892793225342  0.243843028361365  0.522257860139305 -0.003856507813829  0.130032133651498
-    2  (  2) -0.005712363782982 -0.008727960227379 -0.039141212770465  0.103639199943747  0.051337772042530  0.071715964883614 -0.083650082880478  0.323814625304121  0.126954317090625
-    3  (  3) -0.081293710540179 -0.115829551524333 -0.096804246842583  0.012689929096652  0.055158220665324  0.020215225885504 -0.309792669510693 -0.175501033742058  0.786497084573792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.131346722870458  0.163299814747146 -0.027069647322617 -0.020320497257903  0.063430953058875 -0.031962758863077
-    1  (  1) -0.087630835970581 -0.216123500984143 -0.418559649023597 -0.101182356933807 -0.219334050753127  0.138730916232525
-    2  (  2) -0.150883742374018  0.808729391001562 -0.082068044594556 -0.109718430012718 -0.126065481544348  0.025072338478445
-    3  (  3)  0.037377902285561 -0.112570729969231  0.441791115721159 -0.197182836023279 -0.548068009411335 -0.161473931329561
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.035230659308422 -0.106839323325161 -0.014678428381540  0.286556627519623  0.361604275339255 -0.140599935526212  0.104171301624044  0.023270847691008 -0.152469667501182
-    1  (  5)  0.205844940105254  0.013703890486825 -0.030101864871895 -0.113405292167378  0.067278306831822 -0.396432225285843  0.507639566286884 -0.374194080683992  0.087133202725049
-    2  (  6) -0.008020887713167 -0.297537793700841 -0.070946233356648 -0.062333784651526 -0.130550836206602 -0.053406231056288  0.297352200120301  0.465262963875225 -0.160837314824145
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001388437190181 -0.015460041565487 -0.116558611446075  0.083788280005113  0.046694291841919
-    1  (  5)  0.445165309099416  0.139286068687201 -0.540190784438892 -0.030841865046205  0.087779833305208
-    2  (  6) -0.377644271326903 -0.173431493737049 -0.206412471480948 -0.122708702224090 -0.459634387384366
-
 	Computing P_X-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.303506851349
-	   1         9.193848226845    2.084e-01
-	   2         9.636843399963    9.790e-02
-	   3         9.678481341515    3.741e-02
-	   4         9.680529587949    1.626e-02
-	   5         9.682153195858    4.818e-03
-	   6         9.682771899405    2.297e-03
-	   7         9.682666052203    8.525e-04
-	   8         9.682666234373    3.434e-04
-	   9         9.682641166919    1.111e-04
-	  10         9.682657337986    4.506e-05
-	  11         9.682662571258    1.191e-05
-	  12         9.682664918531    2.896e-06
-	  13         9.682666055423    1.103e-06
-	  14         9.682666500679    4.728e-07
-	  15         9.682666695629    1.708e-07
+	   0         8.303506865909
+	   1         9.193848241282    2.084e-01
+	   2         9.636843414583    9.790e-02
+	   3         9.678481355666    3.741e-02
+	   4         9.680529602047    1.626e-02
+	   5         9.682153209915    4.818e-03
+	   6         9.682771913446    2.297e-03
+	   7         9.682666066239    8.525e-04
+	   8         9.682666248411    3.434e-04
+	   9         9.682641180957    1.111e-04
+	  10         9.682657352023    4.506e-05
+	  11         9.682662585296    1.191e-05
+	  12         9.682664932568    2.896e-06
+	  13         9.682666069460    1.103e-06
+	  14         9.682666514716    4.728e-07
+	  15         9.682666709666    1.708e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 8.248e-08
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016118777276718  0.076689387067913 -0.125264792267221  0.007931013310217 -0.098301937535593 -0.089040062536424 -0.042653189503994  0.143650549015436  0.062698356849212
-    1  (  1) -0.038523460792179  0.325926212074865 -0.217436403108293  0.076210929079432  0.124956744969497  0.049869905306322 -0.256022567536767  0.049219148025195 -0.025163660677602
-    2  (  2) -0.015460259327547  0.182364499530156 -0.081021447104321  0.065186772706330  0.193628085224677  0.090709199284776 -0.144227288852923  0.007154481293498 -0.060483347873675
-    3  (  3) -0.069494321441893 -0.016013992178317  0.169506236224066 -0.050547669997832 -0.177140340538940 -0.181255025833280 -0.201077665225234 -0.109139777586644 -0.215083611892043
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159361864611547 -0.056476108299595  0.034334354535918 -0.068420323850582  0.100698715800708 -0.049820592017770
-    1  (  1) -0.121041364374114 -0.003994619377141  0.190684428167188  0.052070114913576 -0.189028662705244  0.205096915582729
-    2  (  2)  0.013836799939810 -0.073875918803127  0.147901928532532 -0.343158528114237  0.053056478393270  0.086736758175874
-    3  (  3)  0.065392768372805 -0.072388535495378  0.365788807268921  0.156911353062510  0.184439406968008 -0.043117455907294
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095080611028908 -0.132974666952804  0.233475927910161 -0.109077700761846 -0.033619328181737 -0.003336619392380 -0.079318686273404 -0.006541773193158 -0.188514066103897
-    1  (  5)  0.133180554197727 -0.220459497770331 -0.122961007604824 -0.144493780528946  0.034530325126907 -0.144382538755413  0.001565508478524  0.179104189145753 -0.084352671049968
-    2  (  6)  0.305369897772513 -0.245966510909099 -0.171589985467973 -0.288954965589218  0.048536799653855 -0.105233271021501 -0.400024803684154 -0.035818012706252 -0.066124321501178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011358647742863  0.047842821118303  0.011877525445924 -0.012099889406653  0.055702357687979
-    1  (  5) -0.060987538430201 -0.100437160073965 -0.174976176295347 -0.033059202656665 -0.296249624542352
-    2  (  6)  0.156959926194247 -0.053853503787388  0.406665675932452 -0.026462885456154 -0.143060389345537
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.020933994600407 -0.036837370041379 -0.105536213576206
-    1  (  1)  0.298453027380229 -0.115575201783048 -0.255528599615226
-    2  (  2)  0.258793135913466  0.115959940555419  0.442826057795207
-    3  (  3)  0.060024736570871 -0.030098554189580 -0.068752806226701
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019369167440737 -0.299662599013855 -0.261538199445486 -0.060711849430240
-    1  (  5)  0.036904684367184  0.115259605353545 -0.117033018013317  0.032657591929025
-    2  (  6)  0.104769015611942  0.252811001882398 -0.444270078409878  0.069751899589244
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.140264901989733  0.063903836208699 -0.058837720478352  0.099834492513907 -0.059321359064120 -0.159667027697165  0.002087278187155 -0.046204224826822  0.008601023391654
-    1  (  1)  0.090548490120094  0.202601353512521 -0.092021876157039 -0.096539072052076  0.170154281529190  0.083912296322856 -0.509059273187919  0.818772979644944 -0.070828284365831
-    2  (  2) -0.023785290834440  0.356113587695746 -0.273990976839633  0.279080899835077  0.352444630227807 -0.196438091918127 -0.305379232907246  0.066497365309673 -0.201285694555553
-    3  (  3) -0.097000901586890 -0.245927544981609  0.317839114090104 -0.024062116307509  0.214330573426622  0.049574376579038  0.029033713280387  0.054130019251520  0.003096872422290
-    4  (  4)  0.057665969694975  0.180120952217609 -0.233587576455003 -0.044983378670389 -0.207784279042752 -0.114395252588051 -0.123426849025620  0.227078923197640  0.055512731053919
-    5  (  5)  0.215771286107017 -0.314990234779514  0.316883540178273 -0.120867850220651 -0.280144439745990 -0.294187393366344  0.216440287801491  0.200727103538268  0.064432166939549
-    6  (  6)  0.088234371667199 -0.148935506374453  0.366935246390926 -0.011963781822206 -0.214228897418480 -0.110020140834853  0.192637863546336  0.231329350431262 -0.059800681126411
-    7  (  7)  0.046850408794017  0.280155317167354 -0.370918303757493  0.110906122388338 -0.088736250126073  0.146624611249212  0.021132431838050 -0.399622620248781 -0.041122390922446
-    8  (  8)  0.213219122375795  0.108141657808912 -0.632333203738691 -0.072815736912248 -0.035034243651177 -0.162896842787152  0.072787072592851 -0.219123938652928  0.041084573561980
-    9  (  9) -0.053156461400872  0.091068663315953  0.087565530354209 -0.029252405162185  0.135958664144556 -0.072618412616147 -0.001674517036243 -0.447580570679361 -0.046048420321104
-   10  ( 10)  0.217389369502915 -0.434955320268289 -0.409591028918221 -0.322091930890678 -0.032769693001793  0.320487371417185 -0.022524010208261  0.286088771348247  0.028739508255570
-   11  ( 11) -0.043655408036923 -0.078795431314355  0.262179238045958 -0.331516326719145  0.435766491266973  0.063689969335775  0.247099037158842 -0.001834914627208 -0.140224560742036
-   12  ( 12)  0.056091676196041 -0.010888223476601 -0.132073582410605 -0.097444459311610 -0.064913316133021  0.000177701715007 -0.216786241209526  0.136744724942230 -0.129238968566818
-   13  ( 13)  0.037502956248588  0.225853404732459 -0.091597810906130 -0.251988574100633 -0.015208060782166 -0.284415044485862  0.108318027167763 -0.003844624714701  0.367465648248442
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222316043515167 -0.015706219813463  0.082385006687323  0.001598515176526 -0.060473243217389  0.093727480766949
-    1  (  1)  0.559608456549858 -0.123427525882107 -0.153467678522300  0.170334032667733  0.080737466652229 -0.083738891751815
-    2  (  2) -0.169476216588372 -0.033571289044868  0.409164888922183 -0.223598543173703 -0.075034173166592  0.314714537560898
-    3  (  3) -0.116710909315587 -0.019725573527899 -0.283423547853851  0.175125619030571 -0.285157403250330 -0.036616525847272
-    4  (  4)  0.005652624292139 -0.042302085019157 -0.326173261129769 -0.429217689689009 -0.082297928451406  0.119033467524284
-    5  (  5) -0.013435701805302 -0.050340607661262  0.120543829176020  0.018862712789976 -0.153571720838539 -0.076183620287342
-    6  (  6) -0.081289708009931 -0.326406046335036 -0.215268699384039 -0.111421444458008 -0.019027619773839 -0.098888316320561
-    7  (  7)  0.155159820795191  0.099172439421062 -0.073800976886369  0.027692155232150 -0.092694133839465  0.234604646553242
-    8  (  8) -0.037085102415804  0.221081896212579  0.033634728216750 -0.500286732444351  0.749342092540156 -0.380702305205404
-    9  (  9) -0.121604531068674  0.307665948271799  0.063134933207080  0.759313712683920 -0.291120411772340  0.157024245706381
-   10  ( 10)  0.436899181077485  0.180584483336558 -0.427706818265059  0.039319556166540 -0.042977724169090 -0.570262735340486
-   11  ( 11)  0.012744975594807  0.355849153273437  0.014473345977422  0.331011762918571 -0.082407538751978 -0.048301595441151
-   12  ( 12)  0.275248111407278 -0.041018113706033  0.197136817157671  0.114052207324907  0.270934107062802 -0.185007344485103
-   13  ( 13) -0.588095271872907  0.141945816656544  0.099720177389796 -0.418487800295615  0.225864709971247  0.209383142865026
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.136055292355694 -0.095447390079347  0.020092912976434  0.093125301806220 -0.056850399225407 -0.218468169087224 -0.091857234706707 -0.045161486852285 -0.214714486134322
-    1  ( 15) -0.061207776400221 -0.202708633629203 -0.353114471023019  0.245649376419509 -0.180866138364055  0.315320438007609  0.149515492263402 -0.279091224397235 -0.106858935875576
-    2  ( 16)  0.054684214245548  0.094025065222631  0.275943577798576 -0.316343751367853  0.233336305598421 -0.315879985031554 -0.365377908227226  0.369960150477034  0.630562926717983
-    3  ( 17) -0.098691998170038  0.096665834479755 -0.277640044986255  0.024005765248171  0.044522040617363  0.121507599385942  0.010509659584452 -0.111862233831111  0.073060388343777
-    4  ( 18)  0.060773979545103 -0.171895263117879 -0.351151470699543 -0.213576840796561  0.206989754617355  0.279451579746568  0.215385933896327  0.091082110140094  0.034953691198189
-    5  ( 19)  0.161690364133666 -0.086139117701405  0.195608563911700 -0.050196750893511  0.114409300434365  0.293302924591731  0.108870291716062 -0.145705855705796  0.162864209989072
-    6  ( 20) -0.004933077734451  0.509112916459710  0.304189657786548 -0.027011307788327  0.123564513171828 -0.216326146660916 -0.190918994832488 -0.021599458243800 -0.073921971953618
-    7  ( 21)  0.046939300208702 -0.818898745115203 -0.067231269443300 -0.053385434393296 -0.227366778650237 -0.200959323300597 -0.230355491785385  0.400408400878960  0.219890208910705
-    8  ( 22) -0.008875208231352  0.070617448884289  0.201028236092674 -0.001986037102761 -0.055524570746341 -0.064229773357339  0.060955407810688  0.040899342701131 -0.040928237624119
-    9  ( 23)  0.222811666664924 -0.561652381203117  0.169673185845513  0.114995614482548 -0.005558626156144  0.012604855943771  0.079125943676940 -0.154935461007958  0.034774271928086
-   10  ( 24)  0.015658264689240  0.122684274627557  0.033049817652525  0.019053422527856  0.043070830779647  0.050152205966201  0.326697513368332 -0.099443390036437 -0.221198097566913
-   11  ( 25) -0.081038041563998  0.154593341750109 -0.407140318932015  0.281943720612524  0.325675147388091 -0.120351655341300  0.214124337140198  0.074325284613070 -0.033051994607934
-   12  ( 26) -0.003149016432995 -0.169066126704247  0.222974141740589 -0.178167341127522  0.432229982121926 -0.017874255780557  0.111773550217198 -0.031100511775823  0.501206663109641
-   13  ( 27)  0.059358328554787 -0.079903052840459  0.074950199177092  0.286331686497645  0.080924619758582  0.153353900448008  0.018409365441285  0.093462744168481 -0.750750124348623
-   14  ( 28) -0.091958135023799  0.083203421400522 -0.314158605792346  0.035767063530523 -0.118730598661038  0.076122730197959  0.098773188363533 -0.234233392684110  0.381969165301674
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054160915945435 -0.219019011349662  0.045758113327127 -0.056667077142789 -0.042241899582406
-    1  ( 15) -0.090944710506667  0.435278295065967  0.077842273581986  0.010976755804933 -0.224792334219630
-    2  ( 16) -0.088739489380716  0.410297160213696 -0.264172456920591  0.132125091344127  0.093086518366917
-    3  ( 17)  0.030526782846372  0.322820843845168  0.334117022964461  0.097597092001327  0.253965732413029
-    4  ( 18) -0.135352462834385  0.032599183228470 -0.437639446212980  0.064872058901817  0.014497262646809
-    5  ( 19)  0.073899654730418 -0.320885730724582 -0.062344415655815 -0.000276840662838  0.283336476795494
-    6  ( 20)  0.001158784637986  0.022837257389258 -0.248024269025134  0.216907823965295 -0.108098145849832
-    7  ( 21)  0.447481917087615 -0.286161905602593  0.000998969948768 -0.136653733410725  0.003506425728696
-    8  ( 22)  0.045854947627217 -0.028382633755544  0.139989494186326  0.129405417600200 -0.366820033409189
-    9  ( 23)  0.122256207458047 -0.437180402944018 -0.011581755997574 -0.275567866951771  0.586898649032607
-   10  ( 24) -0.308323852677716 -0.180850894824874 -0.356131896237587  0.040945642422097 -0.142574344254175
-   11  ( 25) -0.063098776158311  0.427549053292048 -0.014802143274602 -0.197270506582776 -0.099635293972029
-   12  ( 26) -0.762581095039526 -0.039734172920420 -0.331033022441233 -0.114161465508821  0.418490755826768
-   13  ( 27)  0.291938944356791  0.043222558646299  0.082214356128397 -0.270960148007918 -0.225910263769329
-   14  ( 28) -0.156871086239258  0.569997035340427  0.048467653901961  0.184994394399640 -0.209531521675463
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.009005560415623 -0.070810523176756  0.120067832596336 -0.009073132789111  0.090464498751398  0.086174111119373  0.045794981404386 -0.145874969594553 -0.061668751575060
-    1  (  1)  0.049157751161972 -0.341837336007350  0.225991322214187 -0.079794887273929 -0.129000775913247 -0.051890082528236  0.264098306233448 -0.041882987798599  0.014437873768970
-    2  (  2)  0.004178475304277 -0.176534362212289  0.088484784587537 -0.060893560844690 -0.188770646517555 -0.098157508320735  0.154422738208034 -0.028159762307555  0.056745595914693
-    3  (  3)  0.078632631263388  0.018162490565873 -0.185802179760100  0.047918543127627  0.190222116766269  0.186537019008413  0.211456806958065  0.116264562677772  0.222361952728926
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163744366705642  0.058513889685970 -0.036529339633759  0.074890516703334 -0.101980211526259  0.048987870817685
-    1  (  1)  0.129678391589482  0.003465728257172 -0.197451754644998 -0.065935565415855  0.202740138649215 -0.212710296862526
-    2  (  2) -0.022460564343481  0.084272909470110 -0.151124340943610  0.372643880141893 -0.063147940573229 -0.083681000851943
-    3  (  3) -0.069418152871991  0.077040623108211 -0.377203303892570 -0.165559399244409 -0.189357768189075  0.044737808867411
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.085668830826553  0.137820799821437 -0.214610467959115  0.105542261331556  0.036859097160689  0.000473863191174  0.079606876493944  0.008613359831916  0.198755661758929
-    1  (  5) -0.139412038667802  0.235636886292819  0.125284829879155  0.147970518740886 -0.038362154224415  0.146537444592957 -0.006121389458957 -0.189794595760352  0.090516747843845
-    2  (  6) -0.309048143972662  0.258748687397471  0.168238503241560  0.304764034594855 -0.050456064213728  0.094565768675384  0.416604423570803  0.027331415693024  0.066446598559605
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.012674523904092 -0.052192101234842 -0.013753920669735  0.012760663896321 -0.052741920591875
-    1  (  5)  0.065601509403616  0.098250162685792  0.177768481553462  0.033008693934466  0.305584708162464
-    2  (  6) -0.160962535198798  0.052046626684920 -0.419200543530858  0.024457493928166  0.150587999794565
 
 	Computing L_X-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.658665831463
-	   1         5.704690093791    2.985e-01
-	   2         6.599421155196    1.748e-01
-	   3         6.680295220430    4.474e-02
-	   4         6.699746582028    2.323e-02
-	   5         6.704527611233    5.924e-03
-	   6         6.705370887113    3.380e-03
-	   7         6.705465968510    1.070e-03
-	   8         6.705502286498    4.580e-04
-	   9         6.705475558665    1.760e-04
-	  10         6.705489968409    5.804e-05
-	  11         6.705502212499    1.459e-05
-	  12         6.705510528016    5.077e-06
-	  13         6.705514495090    2.013e-06
-	  14         6.705515917988    9.032e-07
-	  15         6.705516478457    3.695e-07
-	  16         6.705516830802    1.819e-07
+	   0         4.658665804176
+	   1         5.704690061557    2.985e-01
+	   2         6.599421117785    1.748e-01
+	   3         6.680295180427    4.474e-02
+	   4         6.699746541730    2.323e-02
+	   5         6.704527570729    5.924e-03
+	   6         6.705370846533    3.380e-03
+	   7         6.705465927926    1.070e-03
+	   8         6.705502245909    4.580e-04
+	   9         6.705475518080    1.760e-04
+	  10         6.705489927823    5.804e-05
+	  11         6.705502171913    1.459e-05
+	  12         6.705510487429    5.077e-06
+	  13         6.705514454503    2.013e-06
+	  14         6.705515877401    9.032e-07
+	  15         6.705516437869    3.695e-07
+	  16         6.705516790215    1.819e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 4.561e-08
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.059484933862835 -0.014840374750558  0.035360338576360  0.173310409629633  0.059725101605321 -0.257184966477164  0.063490095178001 -0.155623028848452  0.002426177597214
-    1  (  1)  0.228582316542215 -0.259588493824183 -0.059979506895381 -0.002310310036236 -0.214166554941788 -0.116943892441225  0.108842892801007 -0.344598351692938  0.046446999584419
-    2  (  2) -0.320448650163398  0.500204746721717 -0.049266542548722 -0.152597804353277 -0.167277822949482  0.193147703880440 -0.032524845682255 -0.036762728768834 -0.080681033267355
-    3  (  3)  0.009703572292968 -0.082952949000966  0.090825897592600 -0.068137067278425  0.068002795336981 -0.155982720923085 -0.189371220312700  0.353775834732784 -0.023853285599523
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.026559166873629  0.005391969117388 -0.002011264512932  0.046870885231393  0.012715635371485  0.026571877043427
-    1  (  1) -0.038988897688016  0.019721374639789 -0.014060753119275  0.430701935913609 -0.259024740507495 -0.161810701507464
-    2  (  2) -0.100083737029750  0.093431068521730  0.015885697887836  0.259560607774115  0.146766142473160  0.593605654650708
-    3  (  3) -0.130235873557485  0.844890867177988  0.085670264124908  0.093010825973034 -0.012325537516171 -0.119484996772910
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.011411967833044  0.019523193555091 -0.029394421691951  0.441924368380274 -0.383516159929503  0.004430337133144 -0.015018368377510  0.081006354989878 -0.100709067945280
-    1  (  5)  0.015106432068076 -0.115430718880751 -0.094613417260511  0.153153896682510  0.130891773654437  0.255513104617105  0.100481979342603 -0.182641502384039 -0.046231419137374
-    2  (  6)  0.045469725116844 -0.216512507684084 -0.240553163844151  0.059703803473819 -0.128799103778847  0.466867168048645  0.230376363698085 -0.268754231533815 -0.029632489718661
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.031283386269007  0.083595055179233 -0.003915100351561  0.081115225653286  0.074158142938438
-    1  (  5)  0.011556443169135 -0.036659881745781  0.006532048558871  0.596174583603508 -0.114916319653540
-    2  (  6) -0.066233849453724  0.593708066141070  0.047160183567134 -0.205443006234017 -0.123500019606919
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.278545233415530  0.059599409615732  0.026034432106375
-    1  (  1)  0.187007295905470 -0.038238309701257 -0.175982197292767
-    2  (  2) -0.431926204916829  0.006084496586666 -0.049694339002754
-    3  (  3)  0.039723645794201 -0.196249784920444  0.036043663433459
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.275546881197932 -0.180389519378317  0.425074243400924 -0.037767422186350
-    1  (  5) -0.058081529209830  0.037390441931729 -0.000516662884118  0.195055591570635
-    2  (  6) -0.026038612826744  0.173019988726883  0.056080139617911 -0.032715759186560
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062756867817297 -0.201112023907446 -0.056048025131715  0.046055783450926  0.033806686060762 -0.171722205176695  0.081098506544458 -0.087289620763258  0.042152324091961
-    1  (  1)  0.113018477232488 -0.112319744349513 -0.016834583533921 -0.057284464999085 -0.226208700821363 -0.112272688334417  0.062097026682019 -0.556436717149114 -0.098351092785228
-    2  (  2)  0.050464428261919 -0.043116595966000 -0.019513144045664 -0.037294003656203 -0.049535289314410  0.026512882856009  0.020955734915841 -0.396348457994657 -0.049143039709126
-    3  (  3)  0.026907740943173 -0.173985640449646 -0.354309597307579 -0.088737881833013  0.026690278443481  0.192249138616519 -0.023099922234093 -0.151104956103080 -0.187993798800110
-    4  (  4)  0.028814397262738  0.124011423960611  0.200563657745864  0.022231046170139 -0.001789869716556 -0.223408416821475  0.102318476102237 -0.153384891973446  0.236674672698061
-    5  (  5) -0.088145317682978  0.132491290238854 -0.182899281954052  0.186746219907929  0.187197714495176  0.005898923884498  0.002120811015656 -0.021990162397056  0.123551537605536
-    6  (  6) -0.024460586881498  0.068797047909759 -0.142150384104535  0.131743429120178  0.105639058982537  0.045294852609385 -0.029270704887015  0.020804211601159  0.117878860256254
-    7  (  7) -0.033776769859701  0.354245094845972  0.243166450499757 -0.029612149638602 -0.008896656564269 -0.116804879825504 -0.018695560701790  0.326627365972202 -0.206018976643332
-    8  (  8)  0.143077917661487 -0.151560533054490 -0.301409236473389 -0.100740265108897 -0.039290343645488  0.041763953575394 -0.058170430215780  0.076845206100452  0.024633152032860
-    9  (  9) -0.347018728951025  1.079771981804557  0.078138529282464  0.501451378510505  0.195061660317550 -0.758451032278065  0.096995118436252 -0.075303195155611 -0.028459788963157
-   10  ( 10) -0.223810118885824 -0.056979536028989  0.716810245770532 -0.128868097994349  0.539754687175803  0.113296255679437 -0.098974782607496  0.009049828893309 -0.202384864538250
-   11  ( 11) -0.022769270154477  0.034674358156828  0.014405983056596  0.017571848532967  0.048691998407531 -0.015583395228223  0.114409081561630 -0.021951676689174 -0.044426938305339
-   12  ( 12) -0.135981286187464 -0.120998241259176  0.262301521327982  0.750392323278277 -0.334209910038890  0.448078191688466  0.024767148532186  0.115571945209708 -0.066264929381116
-   13  ( 13)  0.080577472282162 -0.105823730084873 -0.089794541855267 -0.254940117418226 -0.138440117204762  0.236499087990863 -0.038859436706735  0.192105181610312  0.090975801731982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.032425074737930 -0.078425462405257 -0.011344832045570  0.197456331002049 -0.134718406025863 -0.096409404413494
-    1  (  1)  0.173273250041635  0.433566222378215  0.007405001112899 -0.457114065135928  0.172943454488407 -0.008895375735183
-    2  (  2) -0.109774013784441  0.217911727490325  0.003528460413992  0.763520159635318 -0.225537275802117  0.118975501733302
-    3  (  3)  0.036378102698420 -0.454361087703980 -0.077915823523940 -0.013309796680696 -0.234332299564134 -0.507177620624500
-    4  (  4)  0.092551473116606 -0.475045168698850 -0.084968775693714 -0.026919469339922  0.202750989391175  0.617924078766471
-    5  (  5)  0.097554141145429  0.018018586167576  0.079671555600775  0.092305854243185  0.173736284561078  0.411194160500052
-    6  (  6)  0.003414072729569  0.093327360188558 -0.085627914021145  0.078229939466915  0.111156480724274  0.178796621382799
-    7  (  7) -0.114277067577274 -0.105960426671338 -0.044841696220246 -0.134585263057439 -0.180631730229559 -0.229243957069555
-    8  (  8) -0.037886837147022  0.102808395063350  0.069798483920400 -0.254580996722497  0.401920559110064  0.147751839658310
-    9  (  9)  0.010988821514225 -0.007410444750660  0.002972535589617  0.025318418426566 -0.448643260566270 -0.804372772080077
-   10  ( 10)  0.261244020497494  0.038064665016323 -0.048636140959014 -0.326624772892826 -0.029954423230419 -0.215793554756145
-   11  ( 11)  0.048015789596366  0.069114116273897 -0.007572832400964  0.004238339483900  0.020816591473394 -0.043178136132549
-   12  ( 12)  0.214695948487578 -0.274288590232604  0.016230298683875 -0.029548384872336 -0.038140072907363 -0.033057792945377
-   13  ( 13) -0.275326653840915 -0.061284883995154  0.041285946542463  0.084706584831174  0.090480508761559  0.181791085214834
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.063850422313355 -0.115683680262588 -0.054827490001665 -0.028354117168169 -0.025100127178731  0.096410771095777  0.028664016097217  0.026051889825173 -0.141339706448534
-    1  ( 15)  0.201263187433031  0.111831464020197  0.045175609028392  0.180549663650845 -0.130383086147566 -0.135646922045465 -0.070781303898657 -0.348002287778712  0.148260195426479
-    2  ( 16)  0.055113649368610  0.018738606654586  0.020705966421020  0.355086450538750 -0.201294850701097  0.180112010383658  0.140523266780582 -0.241544163680772  0.300925921088622
-    3  ( 17) -0.045920336133779  0.057784764027644  0.035886357056501  0.088932856294833 -0.024235675752436 -0.187147654830588 -0.131361762793480  0.029658114101546  0.101263553912617
-    4  ( 18) -0.035958486319751  0.227134777791688  0.048687972069102 -0.024933262428833  0.002173989672721 -0.187305076269607 -0.105829902417925  0.008056867875506  0.037853803971042
-    5  ( 19)  0.171149922579415  0.110039862501994 -0.026813452459140 -0.190061024816887  0.222174491954054 -0.004093825553016 -0.044188302806112  0.116881315421755 -0.043225291916047
-    6  ( 20) -0.080019590838700 -0.062262232462848 -0.021096034332220  0.023057305471526 -0.101639862804641 -0.003152213311187  0.029422735136868  0.019240780036951  0.059315335454636
-    7  ( 21)  0.083510548402123  0.557993066791473  0.397235243356208  0.151190399349717  0.153637137534004  0.021828958802507 -0.022025876078118 -0.327175118374607 -0.079618949429238
-    8  ( 22) -0.042227049954364  0.098944758472646  0.049249083184483  0.187848524484403 -0.236611254443533 -0.124376089369001 -0.118097176171872  0.206089300936335 -0.024158581021498
-    9  ( 23)  0.032033977750932 -0.174724865726956  0.107565757409839 -0.033957075679687 -0.093408693176877 -0.094735950835808 -0.001596176802057  0.112245900387886  0.037372397271166
-   10  ( 24)  0.077636129797919 -0.430853371998705 -0.215233761055940  0.452386714098273  0.474453371679467 -0.016809820271846 -0.095741323886920  0.105100659091080 -0.104107445539310
-   11  ( 25)  0.011149970874610 -0.007035579685386 -0.003127573400518  0.077702883164627  0.084954198370187 -0.079818042644370  0.085248456841504  0.044951104587653 -0.070017705668783
-   12  ( 26) -0.193344086617498  0.456776432013422 -0.761441366858404  0.011910497712878  0.026326742647963 -0.092364226349286 -0.078937949371178  0.136041391718326  0.256815257193465
-   13  ( 27)  0.133610614090005 -0.173243160128294  0.225605563113523  0.236498022568823 -0.204477528431671 -0.174386164144365 -0.111604362943586  0.182311312483583 -0.403964555885563
-   14  ( 28)  0.098101278195306  0.007008756260166 -0.117389775367317  0.511914224685440 -0.622957281459333 -0.412506446069418 -0.179820830724467  0.234600868408507 -0.150158824761841
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.343234558725567  0.228637063726269  0.023307266959502  0.140382240172792 -0.083235444793760
-    1  ( 15) -1.074711095873744  0.056336734854343 -0.034809000083236  0.121348785991751  0.106814989655091
-    2  ( 16) -0.078219304152202 -0.719658957943986 -0.014720519366158 -0.261816502529916  0.090881991750144
-    3  ( 17) -0.502805356071942  0.131166561688672 -0.017463933389579 -0.755157521149267  0.255568620797102
-    4  ( 18) -0.195634688856887 -0.541360385537898 -0.048854453075291  0.337587696841954  0.138455603989787
-    5  ( 19)  0.760143596830987 -0.110879995008927  0.015821843299894 -0.447903356003643 -0.237096867164475
-    6  ( 20) -0.097106884263887  0.097545405975693 -0.114437354251730 -0.024000531999102  0.039042927829059
-    7  ( 21)  0.075531866838301 -0.009858499302833  0.021730854579213 -0.114681897686178 -0.191988442177111
-    8  ( 22)  0.027711318590147  0.201621760195186  0.044350251642364  0.065874285776240 -0.090522977876112
-    9  ( 23) -0.011879012685435 -0.258606547469066 -0.047776074363499 -0.213401932184194  0.274704590606944
-   10  ( 24)  0.006858605937754 -0.038088449389244 -0.069395356141264  0.275242327171399  0.061260041265231
-   11  ( 25) -0.002890089589219  0.048355005791387  0.007521454792553 -0.016094295989108 -0.041236148462184
-   12  ( 26) -0.024624287461246  0.326411349050862 -0.004226520020176  0.029493735437593 -0.084692672982552
-   13  ( 27)  0.450726956342698  0.030201266401628 -0.020823649440091  0.038233714612970 -0.090500946858406
-   14  ( 28)  0.809945076459086  0.216752990291181  0.043269372622044  0.033145255679139 -0.181828971805248
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.063013364696514  0.044010513010140 -0.033832526224211 -0.162024471696236 -0.051333545713143  0.246461238669107 -0.063609486603270  0.159478583547076 -0.006207989114076
-    1  (  1) -0.226546037179395  0.291390639777102  0.048328229754705 -0.000396116910678  0.216137862922779  0.115706811352044 -0.113227048986677  0.363481206263983 -0.049424206162689
-    2  (  2)  0.353995982753623 -0.570067383955282  0.052742449525010  0.144888216829452  0.158139021131471 -0.195548321941560  0.035681653601236  0.044365181477906  0.094047723024953
-    3  (  3) -0.014909685853208  0.093363165202933 -0.099368126188753  0.092807318931361 -0.081502054050149  0.166990973951771  0.201832262285607 -0.375763253843030  0.022961121211245
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.027461792188467 -0.004811887789740  0.001758716793345 -0.052146222606019 -0.015489645876144 -0.034542443930348
-    1  (  1)  0.038878540290940 -0.018432422578327  0.015238310520594 -0.445890608944474  0.276103308767449  0.178613718171164
-    2  (  2)  0.112212317864169 -0.097070429592677 -0.017583930410099 -0.264050273165228 -0.167988430449652 -0.635838792277428
-    3  (  3)  0.134391135826268 -0.880500790171335 -0.088985519620608 -0.095884376650580  0.014499630081693  0.127955545332533
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.037904901187616 -0.025077601146789  0.027398631479947 -0.443691662113588  0.381793026485785 -0.022010734273084  0.009578999727395 -0.091037438378063  0.103637073384889
-    1  (  5) -0.010563786544947  0.113947073526168  0.106465996568323 -0.155511131041724 -0.116554544974583 -0.262895686214063 -0.105092877292920  0.193457955253204  0.048498356991785
-    2  (  6) -0.044887612702522  0.228580277279931  0.273604650547313 -0.078952413042729  0.139355988549377 -0.486362168413732 -0.239519122057504  0.286842566968737  0.031193390212920
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.028779621541873 -0.090907914561767  0.003460105941843 -0.087167181054995 -0.071921470779774
-    1  (  5) -0.003930295039018  0.035914981429889 -0.006741878538669 -0.611390099224952  0.116946571666512
-    2  (  6)  0.076298500757009 -0.614894877751711 -0.048926788565139  0.209608637563865  0.127192306297029
 
 	Computing P_Y-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.534960053042
-	   1         9.662955035451    2.594e-01
-	   2        10.311216700447    1.272e-01
-	   3        10.453780821475    3.858e-02
-	   4        10.453181153787    1.193e-02
-	   5        10.455159090576    2.811e-03
-	   6        10.455095687319    1.211e-03
-	   7        10.455078023636    3.142e-04
-	   8        10.455107721746    1.311e-04
-	   9        10.455078212276    6.280e-05
-	  10        10.455091270940    2.849e-05
-	  11        10.455092413809    1.062e-05
-	  12        10.455096248258    4.054e-06
-	  13        10.455096709747    1.529e-06
-	  14        10.455096969108    3.897e-07
-	  15        10.455096883482    1.244e-07
+	   0         8.534960061095
+	   1         9.662955048795    2.594e-01
+	   2        10.311216717373    1.272e-01
+	   3        10.453780834696    3.858e-02
+	   4        10.453181167033    1.193e-02
+	   5        10.455159103781    2.811e-03
+	   6        10.455095700525    1.211e-03
+	   7        10.455078036839    3.142e-04
+	   8        10.455107734949    1.311e-04
+	   9        10.455078225479    6.280e-05
+	  10        10.455091284143    2.849e-05
+	  11        10.455092427013    1.062e-05
+	  12        10.455096261461    4.054e-06
+	  13        10.455096722950    1.529e-06
+	  14        10.455096982311    3.897e-07
+	  15        10.455096896685    1.244e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 4.187e-08
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002292052292102 -0.001327689025616 -0.000248352651822 -0.007958119616396 -0.006332326100070 -0.018602233716079 -0.068879285117607 -0.007819744108382  0.006538352080530
-    1  (  1) -0.002764164951481  0.002219747844780 -0.018293151832047  0.029668233290932 -0.039848292773056 -0.022489745012599 -0.162281988584092 -0.020804504235237  0.019083175045333
-    2  (  2)  0.011217835122943  0.011598249376099 -0.016968466001430  0.008250037510452  0.006232273271200  0.008766677291359  0.010338243291249  0.010725726663582  0.004470553150491
-    3  (  3)  0.050562851864420  0.047527304873166 -0.078707468856856  0.000484758494300  0.025585059000145  0.011993586441410  0.049963781283816 -0.008029454242806  0.026864587292980
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006805334012410  0.003000362320124  0.002228041038775  0.000013471324712  0.003129940535122 -0.001748281527537
-    1  (  1) -0.013913717596781 -0.013715090430948 -0.022806809849796 -0.002206415430011 -0.006824605289547  0.005086150284379
-    2  (  2) -0.011033408042675  0.021897939524418 -0.000684908130867 -0.006441462755861 -0.002207402072499 -0.000019160522387
-    3  (  3) -0.030996252825103 -0.007986449014412  0.024562077320802 -0.006200249162118 -0.010690383251547 -0.011486173135262
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.008068643711801 -0.010525757489217 -0.001816581937116 -0.014852647204911 -0.016446444650489  0.051123908211829 -0.105303074579255 -0.010186396385181 -0.002604742010165
-    1  (  5) -0.024807027264736  0.041872241876176  0.005357408083722 -0.028564486604491 -0.031353252400090  0.040716482303683 -0.082357809569043 -0.022204595749263  0.028676826310240
-    2  (  6)  0.057433465116018 -0.072910653400307 -0.007950207598680 -0.045866077252406 -0.051478467074873  0.066399959025177 -0.120267838044182  0.002980749702429 -0.024762093508970
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000934050050601  0.000604010149742 -0.003646663045597  0.000033137801782  0.002019175758165
-    1  (  5)  0.015497094356084  0.002871076746167 -0.025548488367169 -0.001995117147543 -0.006447008967148
-    2  (  6) -0.009288606849912 -0.006735078994323 -0.016930923349151 -0.006239987724853 -0.010309885333920
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.002224796248932  0.043809288397671 -0.042786645812819
-    1  (  1)  0.035961652529642  0.375558249507302 -0.229138680808403
-    2  (  2)  0.031482392637320  0.208906969570401 -0.045224347296993
-    3  (  3)  0.099946950247304  0.215409785029959  0.414532197880427
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.002181806445193 -0.035979573047748 -0.031640926892772 -0.100238553322267
-    1  (  5) -0.043671265862198 -0.375015508928970 -0.208917842140989 -0.216574490738357
-    2  (  6)  0.042527296867706  0.228253198541367  0.044456455969980 -0.415218734433248
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.071571831474078  0.044653489385004  0.010701302384523 -0.107261739958220  0.107631207507425  0.021982609216167  0.087555139416076 -0.002428271330292  0.013116395341904
-    1  (  1)  0.000994163831951 -0.002283385696650  0.009683189881161  0.069987093364780 -0.211165412824198 -0.144806549288885 -0.839471629333555 -0.082797629633041  0.083995255816967
-    2  (  2)  0.048029450774166  0.034159151942760  0.005345969743360 -0.362094457083817  0.166955343421057 -0.200138180389873 -0.200325175150560 -0.048097856321723  0.015226624624379
-    3  (  3) -0.099901242333767 -0.066741882163175  0.192006761021459  0.037162207196483  0.149491220617225  0.091957380518256 -0.124661875998717 -0.114474410410791 -0.084751404274494
-    4  (  4) -0.098292057994736 -0.060260709677483  0.234095836344223  0.042527139722308  0.172693635464839  0.110397071373777 -0.184879337331547 -0.074537123570678 -0.084735776692218
-    5  (  5)  0.074314676568813  0.053240577551294 -0.354242764435309  0.039009834260888  0.144962419013369  0.061650919712934 -0.045188344047315 -0.085035282721835  0.173092563485620
-    6  (  6) -0.068641550367940 -0.078242424055450  0.700330832585738 -0.207548816757483 -0.389421892794459 -0.222244858530413  0.109406330044345  0.045457397940435 -0.343867539807074
-    7  (  7)  0.021723320720408  0.016351205203477  0.098413699787284  0.004057278627183  0.006939091834822  0.079051971654245  0.378143817290545  0.122761983444906 -0.057845298080862
-    8  (  8)  0.009573032166807  0.006109372122326 -0.063933429430759  0.085659891507852 -0.069748375065056  0.032412606198403  0.211702458249096  0.046995111806493 -0.044380498011908
-    9  (  9) -0.004993361863042 -0.003634014150995 -0.021315829704567  0.021713795540608 -0.030056681969923 -0.023359631271160 -0.128991093821748 -0.016400014214086 -0.007638043352379
-   10  ( 10)  0.003364468158750  0.005158901374854  0.010157814233360  0.013146135283302 -0.036788603301885 -0.001796925979308 -0.031087735489024 -0.158319551738172 -0.001398916399981
-   11  ( 11) -0.005212014578835 -0.005572219785769  0.129300362837610 -0.009016877484923  0.009416239426417  0.064438058134476  0.026488687258818 -0.021963612194052  0.285489003307896
-   12  ( 12)  0.022889675001499 -0.014028568601137 -0.005258310077958 -0.012614598275054  0.011181538654869  0.041924328606938 -0.003053461905652  0.141650155501185 -0.005090787707419
-   13  ( 13)  0.006246133552104  0.010356570946206  0.013049157750693 -0.012424981952369 -0.009162366348552 -0.014458376447183 -0.062634797746517 -0.024809108873564  0.013232375979096
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.002828230885257 -0.008462795614422  0.005154038879345  0.009706144885120 -0.000351690712200 -0.003016908410820
-    1  (  1) -0.016542909801999 -0.036808232009347 -0.132827410709679  0.012545312927284  0.013603497625073 -0.014243226256360
-    2  (  2) -0.056531888264120  0.026681841564725  0.044472892095947 -0.008316762319548 -0.009818160226073  0.003132505638468
-    3  (  3)  0.065664012413416 -0.084000307061427  0.024123678461562 -0.011516052481209  0.005295212539445  0.009770444853693
-    4  (  4)  0.036042306167921  0.066196882580862 -0.035814283991972  0.000422354014022  0.007346814292348  0.010225200735508
-    5  (  5)  0.148907428019918 -0.109320100216994 -0.041270431698859 -0.008286052492360  0.000171545458785  0.012799874602531
-    6  (  6) -0.267740896585406 -0.203497348994038  0.004880757246489 -0.039144439238724  0.017848850593881 -0.043282221917125
-    7  (  7) -0.072391125356366  0.141340064883921 -0.132216664302808  0.021712276497551 -0.014580212743968  0.003413596406031
-    8  (  8)  0.065338926975319  0.070417584641912  0.663636576046729  0.043614890913103  0.008447529962627 -0.017635456067555
-    9  (  9)  0.053338372051575  0.015608392811417  0.295869564541774  0.007118975871935  0.021727777212887 -0.010944181246414
-   10  ( 10)  0.043778421907204 -0.395589362339910  0.177341233202875  0.145584179195590 -0.046786531122207  0.019085441444643
-   11  ( 11) -0.612579899217910 -0.015866362451346  0.053555820669517 -0.384133045755119 -0.648991284315080  0.223359237845109
-   12  ( 12)  0.089924264835296 -0.149474889068188  0.147998013353456 -0.410950037016053  0.122612685939115 -0.053519931502491
-   13  ( 13) -0.016968386753172 -0.001120736716630  0.667558162177866  0.016648983669703 -0.049072172914944  0.011592992748873
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.071349801352714 -0.001077758689270 -0.047849010758340  0.099049708991052  0.097373218549672 -0.073249702217701  0.066497399663850 -0.021905924000244 -0.009611371244576
-    1  ( 15) -0.044780949738342  0.002559008927920 -0.033951661393695  0.066729312295418  0.060308115101382 -0.053229541901542  0.078046690958419 -0.016360376267858 -0.006154062585816
-    2  ( 16) -0.011020054803350 -0.009639577990263 -0.005659342412151 -0.191466387657664 -0.233770018397497  0.353943104953966 -0.699652203951216 -0.098429630868852  0.064028996133412
-    3  ( 17)  0.107854789786884 -0.070585793426189  0.362141920362822 -0.037292065848003 -0.042427554280107 -0.038929544624269  0.207453249613655 -0.003913287572505 -0.085781111935072
-    4  ( 18) -0.108209449998533  0.211629628691212 -0.166874900133377 -0.149325288082881 -0.172890816462238 -0.144890994778070  0.389082003854782 -0.007000687821947  0.069612637937327
-    5  ( 19) -0.022019034844539  0.144617634612061  0.200192966932170 -0.092059326306527 -0.110737371319849 -0.061364605633219  0.221637061620898 -0.079021140430878 -0.032667339771975
-    6  ( 20) -0.089130158761328  0.839805360702557  0.200387491136614  0.125541335494723  0.184496760040866  0.044995250241913 -0.109402692051618 -0.378035804168236 -0.212908503907272
-    7  ( 21)  0.002178057091038  0.082925436926418  0.048118216149291  0.114730021254943  0.074453346277443  0.084891108935477 -0.045281773316412 -0.122667104662941 -0.047081579488126
-    8  ( 22) -0.013014867453703 -0.083878416356711 -0.015105645463008  0.084649544925900  0.084843093804859 -0.173122296622810  0.343876299664282  0.057834963947660  0.044464266623987
-    9  ( 23)  0.002901775226444  0.016234828173143  0.056359654971922 -0.065872157385180 -0.036362021680561 -0.148332139389917  0.266718078511413  0.072258279284242 -0.065401012908070
-   10  ( 24)  0.008445720197207  0.036804429594076 -0.026642166859473  0.084168947416289 -0.066510758074250  0.109381013548519  0.203196264302626 -0.141165925569744 -0.070499221179183
-   11  ( 25) -0.005377792056996  0.132971363586081 -0.044450134013502 -0.024046237867946  0.035750577264436  0.041236558408702 -0.004898258174401  0.132214673314328 -0.663804812343684
-   12  ( 26) -0.009728994170679 -0.012565610031584  0.008265487183249  0.011507462056027 -0.000390885497570  0.008310505974517  0.039141081466560 -0.021755546401072 -0.043610775840953
-   13  ( 27)  0.000301420723236 -0.013603051175605  0.009758944837903 -0.005201669668065 -0.007344582365288 -0.000240423767531 -0.017707548228084  0.014600989921618 -0.008461166379513
-   14  ( 28)  0.003079753925572  0.014179269497255 -0.003153288832508 -0.009783782056838 -0.010222304053931 -0.012792812982900  0.043303231879501 -0.003407229733488  0.017679792666437
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.005093584579739 -0.003397430557442  0.004751145314814 -0.022993999775599 -0.006406607432760
-    1  ( 15)  0.003664268681973 -0.005140681437481  0.005623137023323  0.014031183819186 -0.010293722738862
-    2  ( 16)  0.021380720709285 -0.010101149193740 -0.129156907046771  0.005327658954335 -0.012995314092573
-    3  ( 17) -0.021888212102997 -0.013219387248758  0.009147784998772  0.012607741489433  0.012451560776453
-    4  ( 18)  0.030283770762187  0.036869387279963 -0.009496744772073 -0.011181780485751  0.009182409552409
-    5  ( 19)  0.023453672116028  0.001799424920857 -0.064551617042565 -0.041960641260948  0.014420118956798
-    6  ( 20)  0.129458546494562  0.031271046054797 -0.026491102279077  0.003035012140173  0.062712336606288
-    7  ( 21)  0.016591446747124  0.158366047016835  0.021959782838748 -0.141640631249081  0.024819174074486
-    8  ( 22)  0.007575701587651  0.001384112156408 -0.285443557719759  0.005092627774536 -0.013202606990520
-    9  ( 23) -0.053335089301784 -0.043785415746465  0.612428033952438 -0.089945127333786  0.016908784258587
-   10  ( 24) -0.015338693676902  0.395633576722134  0.015809806174577  0.149475505805735  0.001108572795377
-   11  ( 25) -0.295832367201880 -0.177313650229228 -0.053561286295937 -0.148004020967965 -0.667548449264998
-   12  ( 26) -0.007157154416068 -0.145586590426015  0.384132810582926  0.410951719442920 -0.016651787670969
-   13  ( 27) -0.021701996830369  0.046797876195772  0.648997652718994 -0.122606232077394  0.049068049852585
-   14  ( 28)  0.010942221777254 -0.019093183683669 -0.223365949415077  0.053520759465635 -0.011602247780486
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002779955261603  0.001692895942304 -0.000296900585249  0.009027308047393  0.005517424530413  0.019392785745098  0.071615718156204  0.008379623734860 -0.006552142468186
-    1  (  1)  0.002104549417694 -0.002248748312389  0.016268779471159 -0.026298614529309  0.037020427509987  0.022919155336998  0.164160248243371  0.021028638082436 -0.018807600972837
-    2  (  2) -0.012197014321068 -0.010749741004113  0.015969423342584 -0.008379419120707 -0.005700661608131 -0.009182078264489 -0.007072493012824 -0.010651845449983 -0.003884546255787
-    3  (  3) -0.055916626202381 -0.044952545452401  0.075693796863105 -0.001117242062940 -0.024281174456380 -0.014619597544444 -0.053283290640729  0.007703747637900 -0.022436578410207
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006982563138735 -0.003194903879745 -0.002336222897235  0.000159319304138 -0.003153288870770  0.001705858583767
-    1  (  1)  0.013922175981332  0.014264739151757  0.027533427644978  0.002422850658312  0.006842699761048 -0.005360945695369
-    2  (  2)  0.010224586423112 -0.021331787446369  0.001728789794737  0.007349416930945  0.001927444504520  0.000065986060579
-    3  (  3)  0.028649073776619  0.008193923965952 -0.026834068422643  0.006433642271152  0.011064478009773  0.011417291735948
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.007713676236592  0.011322134542428  0.003907084678219  0.013398999832293  0.015469012646278 -0.052157960120007  0.107410796770658  0.010366341516333  0.002761603992801
-    1  (  5)  0.025927350683997 -0.036918918076002 -0.006183726668218  0.026765793037023  0.030906551194513 -0.042649472793187  0.084196537695915  0.021256853976094 -0.026253718608666
-    2  (  6) -0.059547667994813  0.071575508753465  0.010792071396250  0.045987434407762  0.051692908853277 -0.069048919754819  0.125623895288423 -0.001752094627183  0.022191347480180
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000950352585130 -0.000964031243708  0.004357151868409  0.000282508389387 -0.001887057940293
-    1  (  5) -0.015009418487876 -0.001705110486742  0.029429172036478  0.001075595895759  0.006702102006371
-    2  (  6)  0.007980731926488  0.006589892733093  0.020940438262106  0.005674678855389  0.010940914550877
 
 	Computing L_Y-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.265569212629
-	   1         0.345655468983    8.536e-02
-	   2         0.420530811453    5.209e-02
-	   3         0.425461908890    1.249e-02
-	   4         0.427365324545    6.088e-03
-	   5         0.427542620649    9.749e-04
-	   6         0.427509617017    4.969e-04
-	   7         0.427519927472    2.217e-04
-	   8         0.427518929995    8.525e-05
-	   9         0.427518635350    1.809e-05
-	  10         0.427519139719    7.296e-06
-	  11         0.427519339002    1.886e-06
-	  12         0.427519452465    8.257e-07
-	  13         0.427519456278    1.342e-07
+	   0         0.265569208935
+	   1         0.345655463792    8.536e-02
+	   2         0.420530804111    5.209e-02
+	   3         0.425461901293    1.249e-02
+	   4         0.427365316877    6.088e-03
+	   5         0.427542612971    9.749e-04
+	   6         0.427509609339    4.969e-04
+	   7         0.427519919793    2.217e-04
+	   8         0.427518922315    8.525e-05
+	   9         0.427518627670    1.809e-05
+	  10         0.427519132039    7.296e-06
+	  11         0.427519331322    1.886e-06
+	  12         0.427519444785    8.257e-07
+	  13         0.427519448598    1.342e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 5.740e-08
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.068337016677695  0.096446452026756 -0.360475449331991  0.092239288371853  0.026203678917511  0.022509846886799  0.073478827117419  0.022464061625998  0.227372488621395
-    1  (  1) -0.348245092774866  0.473201941683207  0.285296343579762  0.183481268326088  0.077575420562874 -0.072099125969722  0.272473569856386  0.064219415204321  0.197165880719729
-    2  (  2) -0.067585908335283 -0.050372922133506  0.060758167744452  0.207525430642987 -0.124589544508062  0.366296688963713  0.319501792505756 -0.144609263799336 -0.034557292153017
-    3  (  3) -0.003490778097580 -0.176771187112973 -0.057522831103622 -0.000116418648382 -0.000778288019112 -0.154495740627781  0.307263828587522  0.311985415435969 -0.072067405458553
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009055593070151  0.169294476018032 -0.004376707873729  0.043035427357302 -0.152530590698355
-    1  (  1) -0.043732146257221 -0.133230210157229 -0.321492959581682  0.026647195860165  0.380687102934580
-    2  (  2) -0.166530147628729  0.613643715672385 -0.216790209047481  0.084469048804484  0.070950252851931
-    3  (  3) -0.193623455804687 -0.188085387663198 -0.577128561869679 -0.079182256640786 -0.329374829305157
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.094184605186671 -0.056664612816556  0.249611394657184 -0.001240336497952  0.251113263182976  0.167204841127316  0.053738355395826 -0.110451910693142 -0.110225244293220
-    1  (  5) -0.138889396111012 -0.115961679782817  0.323179744158626 -0.121252123207265 -0.292076432419815 -0.241576686510115 -0.062989099171507 -0.028273376478118 -0.195878521271564
-    2  (  6) -0.158880157678560 -0.136139940912615  0.265648578874291 -0.093877387268260 -0.142453752235908 -0.054140913517762  0.560779480954688  0.138233927899815  0.254132036688695
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.293992892729715  0.040800750956591 -0.057675088119180 -0.076602392465323 -0.065335333102758  0.026360508286139
-    1  (  5)  0.140101157166617 -0.119683195321807  0.266691635597033  0.245738117504136  0.344104644828940 -0.220704301441665
-    2  (  6)  0.056921768258958  0.103403744090827 -0.598429877431589  0.146214200734754  0.059974751023664 -0.323525482450488
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.001194434516926  0.365406825873877  0.191112170654786  0.072953190005452
-    1  (  1) -0.363385965896555  0.001278838882578 -0.019794428206453 -0.015546405496121
-    2  (  2) -0.188455836576036  0.023464280272920  0.001313653362102 -0.003971811529941
-    3  (  3) -0.071937190909342  0.014204649752708  0.004012943205250  0.001742183215196
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.002207002387747  0.099036313248809  0.350070270006789
-    1  (  5) -0.099717351351760  0.002187155419577  0.000406257568929
-    2  (  6) -0.350175744645045  0.003726626970778  0.004104233297166
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002966254715231  0.240855988266728 -0.015168347488530  0.064366755524788  0.058337095528916  0.095917557609408  0.080552351010748  0.173850272969471  0.326738509325595
-    1  (  1) -0.236928751733350 -0.000606734226053 -0.349434191365712 -0.093200906311076  0.041406943350823 -0.069404274429693  0.288704930708582 -0.111892041376425 -0.888816026581642
-    2  (  2)  0.015227164699160  0.348726210567974  0.001624946372493  0.082520881475572  0.073422056547723  0.232856655438329  0.287989353510736  0.229619697744185  0.234594833443005
-    3  (  3) -0.060136079807310  0.090244643623410 -0.083460850918858  0.000190675057493  0.021666820127845 -0.049054167667433 -0.003318783332088 -0.014942478625699  0.184116482215884
-    4  (  4) -0.058810580653892 -0.039254180139711 -0.072185299720667 -0.023983542956374  0.001162617768289  0.085082802307878  0.048921193420164 -0.153382943802422 -0.107278309526120
-    5  (  5) -0.094673430029074  0.068328286783388 -0.231594556891859  0.051852594552707 -0.087895099396058 -0.001022706922957  0.009481397805757  0.039804866070152 -0.148588908121843
-    6  (  6) -0.077478276137780 -0.287498549855759 -0.285112820054957  0.001996885796048 -0.050199534762013 -0.010169007281739 -0.001566818575017  0.173488828459951 -0.045840640430952
-    7  (  7) -0.174574943301410  0.112673533261648 -0.229919171659831  0.014304085765577  0.153548872211132 -0.035649109336757 -0.172043564633104 -0.001747195829410  0.038631522766057
-    8  (  8) -0.326784468679605  0.892435693037357 -0.233569726528789 -0.184065381075518  0.108484932678938  0.147374626265501  0.046903987933936 -0.038178109185914  0.001735751957207
-    9  (  9) -0.006821679719377  0.058926743509393  0.208367267805622 -0.285685508477399  0.014180918165163 -0.077838258063458  0.021878341498618  0.053464078274748 -0.072201437911745
-   10  ( 10)  0.009056199429691  0.188962532231488 -0.202934615692329  0.587329922811144 -0.635977084568857  0.025679043651857 -0.020098430100480  0.176535847273173 -0.134249054850628
-   11  ( 11)  0.122433619087449 -0.184482339508693  0.564618465141536 -0.437678405523193 -0.566648296764866  0.293188916460713 -0.283810265313721 -0.077678717328954 -0.171076053515931
-   12  ( 12) -0.036292153208947  0.108484898349320 -0.145104583947026  0.147429251741648 -0.198788533301527  0.103598496618116  0.121175312167554 -0.030985473315147 -0.001761958158343
-   13  ( 13) -0.133923970852792  0.204871678949702 -0.411285239061003 -0.299554669797709 -0.284169606525854 -0.162383457794127  0.004545044711178 -0.249571768159739  1.096350485902953
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006556329110841 -0.006088586386751 -0.124678079831954  0.037126112155215  0.136830700261450
-    1  (  1) -0.060788036015694 -0.191479282295534  0.182968697985886 -0.108878994177096 -0.206615313543699
-    2  (  2) -0.210374331017044  0.203724330933666 -0.567874430260769  0.145071803402332  0.411903076822992
-    3  (  3)  0.286917147696723 -0.581979187814224  0.440566780256406 -0.146724205480600  0.298411655566699
-    4  (  4) -0.014298727005834  0.630110791185791  0.567066919718617  0.198113213886521  0.285451610676776
-    5  (  5)  0.081474334265114 -0.027014198849763 -0.293476840962639 -0.103773751793710  0.162461435377736
-    6  (  6) -0.019534299275936  0.018969452720832  0.285789804049686 -0.121256569831033 -0.003481312727309
-    7  (  7) -0.056370622889280 -0.170673347832600  0.077097071581232  0.031742893248721  0.249704021902801
-    8  (  8)  0.071994852203822  0.132015517717158  0.170148143024151  0.001951350044678 -1.093751141653295
-    9  (  9) -0.000953866523975 -0.167467737198046 -0.013767962244439 -0.007434218290124  0.054780735052675
-   10  ( 10)  0.173318734659126  0.000810695586467  0.044701276287093  0.097338149388905  0.081237613430460
-   11  ( 11)  0.013895240641951 -0.044282356293427  0.000179785703801  0.004575065369641 -0.075680209341763
-   12  ( 12)  0.008279323048061 -0.097099690667968 -0.004296013685779  0.000048011111236 -0.035877871824266
-   13  ( 13) -0.055107661683376 -0.081651595745875  0.075682651530469  0.035936424072868 -0.000029147707292
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.002983283073552  0.069963597569041  0.177874917667998 -0.062698638146301 -0.106213761198913  0.103906931767555  0.039245016352398 -0.108223517603678 -0.012203119212599
-    1  ( 15) -0.072298870307035  0.000296799608796  0.117346282403810 -0.011865025714908  0.081057312629942  0.082184434890961 -0.047411637016207  0.318551609279607  0.030383483166489
-    2  ( 16) -0.171245613988674 -0.116654951277647 -0.001073144643332  0.130649581927528  0.144907410540790  0.208150327953063  0.198240370201554 -0.179277720823411 -0.001547973613629
-    3  ( 17)  0.060703226947660  0.012583282832888 -0.130776798167377  0.000627586286590  0.018993088317931 -0.044159196655903  0.007932945197872  0.099780861993881  0.079859961463087
-    4  ( 18)  0.100987762729975 -0.079245986001353 -0.141690159528846 -0.016637213332155 -0.000279400820895 -0.188760521966200 -0.218195531933535  0.080299124518616 -0.270793478609675
-    5  ( 19) -0.108074704635216 -0.081590264498889 -0.205498810382318  0.045801307693771  0.187063236245240 -0.000710419758875 -0.073671862989187 -0.043877487134678  0.003892010725365
-    6  ( 20) -0.034177446867522  0.046254597520027 -0.201430745227679 -0.005427131993230  0.216675775592057  0.075812938142253 -0.001274951349149 -0.134520130532184  0.103162147021421
-    7  ( 21)  0.109552512569813 -0.319375904304575  0.177972755772711 -0.099543500716481 -0.081539270937629  0.043994632054622  0.133148819770476 -0.000136132680380  0.101451568181800
-    8  ( 22)  0.012932579381132 -0.031214135384490 -0.000281145990656 -0.077687686709702  0.270019497869643 -0.002445122305778 -0.104445784052100 -0.102366601596632 -0.000293374111723
-    9  ( 23) -0.258661075798788 -0.226451306397380  0.883677423513705  0.031877470630129 -0.145903964590500  0.329887844134728 -0.092796308819851 -0.020328633409678 -0.044508005290364
-   10  ( 24) -0.092756800530096  0.166962776711625  0.090732033242854 -0.033047276838485  0.181047632927145 -0.062682569832297 -0.131253772479093  0.125666164674422  0.010098556627625
-   11  ( 25)  0.085247662084319  0.052988724588725 -0.426265235226709  0.453475536447167 -0.668253171471624 -0.144399850217273 -0.422325162892048  0.144483844450738  0.151429271642033
-   12  ( 26) -0.279045843991891  0.538081255792683  0.338024638087139  0.681172358850588  0.181070323444015 -0.460341461990372  0.046122199431924 -0.472432043418077 -0.099681899420099
-   13  ( 27)  0.031769949568578 -0.364837871962491  0.009792757368435  0.264546010179783 -0.131321500070479  0.369805258593067 -0.160328386436444  0.216930526986653 -0.408555062086236
-   14  ( 28)  0.069122236052376  0.228562041286249 -0.181966055883684 -0.129261778712552 -0.172738024644993 -0.293166654576352  0.081465083951240  0.165047538527886  0.415612188545544
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.259003180995999  0.092034359732091 -0.088092444988971  0.283228839847223 -0.027238337345788 -0.074809429137092
-    1  ( 15)  0.226401057047801 -0.167244181564770 -0.051680013843725 -0.539247725941338  0.363958831235579 -0.227197833049861
-    2  ( 16) -0.880204617361986 -0.090080695403138  0.428803021300672 -0.339354335014476 -0.011073919861198  0.184183385405081
-    3  ( 17) -0.032548488106633  0.034116564240178 -0.457440817331429 -0.682846299872809 -0.267172551643223  0.129975094303440
-    4  ( 18)  0.146446220661130 -0.182273160793426  0.671045144484618 -0.180560000424842  0.132242486336168  0.172542944677419
-    5  ( 19) -0.329935957691708  0.062440148449723  0.142514523618445  0.461407225484117 -0.369136535324331  0.291356141625179
-    6  ( 20)  0.095137293654559  0.130985936102436  0.423469417337729 -0.046319908681962  0.160102833893605 -0.080585118835760
-    7  ( 21)  0.020207238092615 -0.126147064104969 -0.143168454940269  0.472622130455173 -0.216404140117317 -0.164767679261412
-    8  ( 22)  0.044837771622786 -0.010451598353546 -0.151184144406440  0.098993252397369  0.407878413312189 -0.414658535507476
-    9  ( 23)  0.001737606134934  0.018616595639929  0.107543267833085 -0.163017051753013 -0.647726175645918  0.636571415515610
-   10  ( 24) -0.017899922228044 -0.000213602824426  0.053374660165807 -0.073998998716505 -0.058121913122542  0.162859588181722
-   11  ( 25) -0.109492695348190 -0.053011202690733  0.000327739740203 -0.000312768703591  0.053080921470257 -0.055086051279352
-   12  ( 26)  0.164160765816315  0.074526437813364  0.000205041264621 -0.000008221388086 -0.003647906535196  0.023090840612045
-   13  ( 27)  0.648519944554920  0.058749585422481 -0.052822010998177  0.003709251683372  0.000103802664845 -0.203134785839326
-   14  ( 28) -0.638592033397192 -0.163371069122125  0.055018466584646 -0.022957117292923  0.203277611770653 -0.000205390113949
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.050918463672837 -0.088577095911626  0.347792606459412 -0.095753675403874 -0.021868934225380 -0.033922841975857 -0.081457049638017 -0.022670295387980 -0.235434049572332
-    1  (  1)  0.382949048662791 -0.528689769706688 -0.299634584086346 -0.202752933016224 -0.082733390999563  0.092422540316925 -0.290813237500084 -0.058004392324892 -0.224615068405588
-    2  (  2)  0.072432527585316  0.056118386776062 -0.040222186558432 -0.242175264454298  0.146547807338018 -0.390266206867364 -0.347025142548880  0.162810044865207  0.041509720616448
-    3  (  3) -0.002509556424329  0.208248007860462  0.062422901369848 -0.007679044749759 -0.008571630545112  0.174062990005658 -0.334967725932269 -0.336081407145288  0.081599082536296
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.010892131457533 -0.184129002689570  0.006516359878994 -0.045872381230752  0.153258318093946
-    1  (  1)  0.044796011029196  0.153644284644512  0.339325263566756 -0.025646141032274 -0.405174708389161
-    2  (  2)  0.178039316366764 -0.664464704148233  0.224969390534104 -0.089440380756525 -0.066874687913745
-    3  (  3)  0.205823412452233  0.203327440636405  0.607212535172871  0.084515912728930  0.343929939556071
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.078798727127085  0.050234519025036 -0.245209481862661  0.005696954168209 -0.236120915868886 -0.165120845160626 -0.059294811018549  0.108390851582836  0.111673906302634
-    1  (  5)  0.155915068579220  0.141324548768777 -0.367116438384255  0.121574775208674  0.314513424545348  0.257608736751094  0.074849697192160  0.032932966046337  0.220860722558199
-    2  (  6)  0.156801606542398  0.183207885627035 -0.298465110849382  0.100930243056436  0.131083210552854  0.050444928584622 -0.606210604165772 -0.146614859921357 -0.248216540567658
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.311128511448673 -0.042835689156568  0.063170810110215  0.070842689432729  0.064570105984912 -0.023339590654715
-    1  (  5) -0.156644000440875  0.124669553061406 -0.274932589468273 -0.248710717987319 -0.361639916876500  0.231627984560414
-    2  (  6) -0.060874079553630 -0.108175278252638  0.629356829293933 -0.147027352951220 -0.067479673265597  0.339908703023576
 
 	Computing P_Z-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.900528715016
-	   1         9.878642351650    2.427e-01
-	   2        10.457896556207    1.085e-01
-	   3        10.517749213971    3.202e-02
-	   4        10.515790486169    1.234e-02
-	   5        10.517078539517    3.286e-03
-	   6        10.517568503277    1.572e-03
-	   7        10.517522641618    5.148e-04
-	   8        10.517520986540    1.968e-04
-	   9        10.517504363405    6.432e-05
-	  10        10.517514797375    1.919e-05
-	  11        10.517517835826    8.747e-06
-	  12        10.517519919966    3.414e-06
-	  13        10.517520553313    1.629e-06
-	  14        10.517520557358    5.276e-07
-	  15        10.517520632001    1.984e-07
+	   0         8.900528728441
+	   1         9.878642365640    2.427e-01
+	   2        10.457896569397    1.085e-01
+	   3        10.517749226166    3.202e-02
+	   4        10.515790498340    1.234e-02
+	   5        10.517078551668    3.286e-03
+	   6        10.517568515415    1.572e-03
+	   7        10.517522653756    5.148e-04
+	   8        10.517520998679    1.968e-04
+	   9        10.517504375544    6.432e-05
+	  10        10.517514809513    1.919e-05
+	  11        10.517517847965    8.747e-06
+	  12        10.517519932105    3.414e-06
+	  13        10.517520565451    1.629e-06
+	  14        10.517520569496    5.276e-07
+	  15        10.517520644140    1.984e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 7.864e-08
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440295579  0.058098623160149  0.000062770556748 -0.132305009159629 -0.206845253888047  0.090151367716489 -0.021622993201571 -0.039361663017831  0.081041759541844
-    1  (  1) -0.058446002592381  0.108172168387665  0.020491566069368  0.029038345945867 -0.075256281089894  0.197244333760875 -0.268904698800623 -0.104165934684913  0.067340388337437
-    2  (  2) -0.015395531940668  0.065975044888453  0.020693241252053  0.145278172828441  0.156811977467575  0.026190455409877 -0.072791620600644 -0.106379132149940  0.008110007387647
-    3  (  3)  0.209889648220478  0.051262205346318 -0.016792464687917 -0.095510023534389  0.095336437810925 -0.289116526954890  0.245753636284337 -0.379261907424074  0.084194488967514
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922100177 -0.024147628250432  0.039515998201657  0.082736569420113 -0.047511948424277
-    1  (  1)  0.028213287461096  0.067760885411213  0.238885785807082 -0.125969164479716  0.177609465312033
-    2  (  2)  0.077606300081110 -0.045313543916728  0.093141189396729  0.365274041996181  0.093447143795063
-    3  (  3)  0.414915648100444  0.159852566418804 -0.273568285227133 -0.034618677637948  0.200919751819526
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102681987247 -0.069778483698171  0.053388820632185  0.227201022134194 -0.199230027457400  0.049687576281265 -0.168877445270916 -0.014461225328824 -0.006078045812775
-    1  (  5)  0.058029574787099 -0.323045692563543  0.030451397472044 -0.087822399116233 -0.049669665032459 -0.052839306746938 -0.277652121541255 -0.149775076383338  0.305937155270736
-    2  (  6) -0.084055275470361  0.046073375199290  0.190725804864306 -0.087557818530500 -0.137785527514624 -0.205465571554547 -0.198777590920688 -0.118276962990440 -0.298899363373310
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985616706  0.083163093490792  0.059838819851121  0.009394325001926 -0.030439464329859  0.004211858017358
-    1  (  5)  0.056299326992358 -0.068872084539624  0.330916524068169 -0.053769676104327 -0.184435947376520 -0.103868547783993
-    2  (  6)  0.066328790174072 -0.124449756312364  0.113043685745447  0.144452726550998  0.299204372306587 -0.043729255680790
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000261962805528  0.008184590036915  0.017078206714546 -0.120797444663216
-    1  (  1) -0.008556708940913  0.000310357479341  0.070665159347735 -0.263733240360107
-    2  (  2) -0.016665957640930 -0.070092969568198  0.000658296979419  0.516406140442807
-    3  (  3)  0.119815260993819  0.260397085059199 -0.515923296927153  0.000854850636510
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000399146441393  0.382166830385042 -0.144086395309985
-    1  (  5) -0.378879203373120 -0.000650240992922  0.057572968692994
-    2  (  6)  0.142267704977138 -0.057783925625685  0.001456329094587
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000900630817553  0.057480932301248  0.021776185729735 -0.109986124582381 -0.040974945330860  0.038859091716901 -0.013722976007051  0.027662163358443  0.095856958174051
-    1  (  1) -0.055475653729802  0.000055946423413 -0.161049994133622  0.114708024204125 -0.226365261647020  0.429957047290467 -0.365226817146534 -0.339873184728948 -0.220417191818894
-    2  (  2) -0.021015776391238  0.161427052909899  0.000077274959500  0.056803578516095  0.009014493962493  0.218381032705550 -0.249538253456372 -0.218329398300741  0.109423644471862
-    3  (  3)  0.109912942235432 -0.115891216387191 -0.056027564915092  0.000745943372337  0.462877633738750  0.122572187022588  0.103916786291663  0.116372032296575  0.000178644283993
-    4  (  4)  0.040100257401862  0.225977964738017 -0.007764610803091 -0.462832592343483 -0.000863713188323  0.292983388565641 -0.009504255770576 -0.051881331882871 -0.039789084738637
-    5  (  5) -0.036362528925743 -0.431143684565124 -0.219013710239096 -0.122734678900441 -0.292859375843399 -0.000211534680093  0.380048338834318  0.122563604837507  0.042304270254871
-    6  (  6)  0.010482485700737  0.366095597661562  0.249485788064450 -0.103549341685710  0.008516226169361 -0.379084427040252 -0.000639775867465  0.110614613813780 -0.062004820067370
-    7  (  7) -0.028768402882082  0.339119958859154  0.216813059372775 -0.114011828936202  0.053232451800242 -0.122211769727445 -0.109878960190336 -0.000261733603901 -0.084697348659745
-    8  (  8) -0.095810944695334  0.221328249276204 -0.109105398407007 -0.000872051363339  0.038539628128307 -0.040520833999881  0.059740000698578  0.084693665490196  0.000412317879658
-    9  (  9)  0.014697085572369 -0.105287145446058 -0.107273285124578  0.218858370800804  0.309735125099696 -0.105267325854039 -0.129620026346504  0.117982202893285  0.042502371715711
-   10  ( 10) -0.029182274069823  0.107750482915279 -0.099755873232373  0.053540519729348  0.138357776561317  0.190065661316311 -0.089951321859060 -0.050398080030964 -0.205938711533222
-   11  ( 11) -0.155188100419269  0.443693923193159 -0.328775787594980 -0.218791170588477 -0.215183707581260  0.086687685172586 -0.081438682030100 -0.042661060649411  0.076989743302322
-   12  ( 12)  0.047041819133236  0.056356277723761 -0.091876156457291  0.290703693299362 -0.241933426060878 -0.247197194304100  0.042704222313214  0.092541926182743 -0.274193192866205
-   13  ( 13) -0.050345457187286  0.050309029533978 -0.290248962160664  0.162027268205565  0.213802087129928 -0.103771321970540 -0.033795235497894 -0.045614675872296  0.299788281594493
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015094426489382  0.029115659613984  0.157755053899573 -0.046090500922971  0.051508699260239
-    1  (  1)  0.106870813652789 -0.107133528015314 -0.444981848759519 -0.057242056092259 -0.049852574162928
-    2  (  2)  0.109000377776210  0.100245307552928  0.328735836791196  0.092813183683061  0.291725571255713
-    3  (  3) -0.218950464663657 -0.054805102085238  0.218886888542902 -0.287519470239761 -0.163372131318506
-    4  (  4) -0.309058290561676 -0.137567383239759  0.215197532854513  0.238351393836438 -0.213552990219087
-    5  (  5)  0.105624117972044 -0.189859620690792 -0.086820347884678  0.246317074454998  0.103852569604008
-    6  (  6)  0.128090000856966  0.089849284790653  0.081980995688413 -0.043663325009335  0.033155703031441
-    7  (  7) -0.117989240855155  0.049695249544262  0.043676012478621 -0.088835836027429  0.045632574214248
-    8  (  8) -0.043185512310113  0.206252030230831 -0.075219160600274  0.272504390674237 -0.299099410447326
-    9  (  9) -0.000057792160807  0.416496446259873  0.033591110007561 -1.079044045817668  0.144878189091330
-   10  ( 10) -0.417381448990192 -0.000164005362256 -0.288881720270970 -0.322059475407983 -0.291538277058570
-   11  ( 11) -0.033261524584639  0.288678211108026  0.000120543612153  0.357470920187357 -0.110246704427599
-   12  ( 12)  1.082405304483691  0.322498276514608 -0.357322196019213  0.000062083058686 -0.002512916703858
-   13  ( 13) -0.144912114579253  0.291369916474370  0.110105006775579  0.002446483993989  0.000063534084907
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000175081543235  0.016120371429445  0.025072002498307 -0.062542190001810 -0.021350885611608  0.118270325314450 -0.004836963443519 -0.089308321494217  0.035265121599228
-    1  ( 15) -0.019016581108200 -0.000074621970578  0.073692709803711 -0.220090875517914  0.117001241546639 -0.069843654088588 -0.194734592940078  0.297334325625656 -0.000079679030782
-    2  ( 16) -0.022601123418381 -0.074079137647858 -0.000898075728427 -0.015352523942492 -0.086856492084776 -0.105020764975991 -0.399309885639210 -0.436863382131761  0.175020106394679
-    3  ( 17)  0.059722097345652  0.223919505098606  0.017236939707940  0.001153330835786  0.251337783789116 -0.316047497618471  0.195069502405311  0.070796117852672 -0.376854141068940
-    4  ( 18)  0.020136753535465 -0.119176676580060  0.086690091555956 -0.251646590139118 -0.000253931741203  0.043128862347025  0.031767565075530  0.166618171717967  0.162853353427601
-    5  ( 19) -0.121150060676480  0.070465337136678  0.107141402917501  0.315382260507230 -0.043144844880487 -0.000915299484024  0.084836748925369  0.176704257940149 -0.191804096130299
-    6  ( 20)  0.000227153495201  0.194659284089699  0.399818522753260 -0.193896536829102 -0.032525351177556 -0.085523354347259  0.000313079507664  0.483156326770458 -0.288322768300912
-    7  ( 21)  0.086746307137042 -0.297294170806809  0.437363838809426 -0.070300496686555 -0.166591994782662 -0.177217714676487 -0.482838971708778 -0.000010492293158  0.098273184847402
-    8  ( 22) -0.034845258926466  0.000856544015064 -0.174085542944908  0.374309528502842 -0.160749665940872  0.191624326414407  0.289454904423216 -0.097021267550271 -0.000014930403133
-    9  ( 23) -0.146129839058632  0.053485685235498  0.324250294825684  0.062889229683982  0.055229748354918  0.064112736518466  0.152978751390774  0.139451617186818 -0.103725991413656
-   10  ( 24)  0.228960109301500 -0.607985902209189 -0.190616272123952 -0.232984732345903 -0.097313246050666  0.308149392800276 -0.021807135674585  0.163587870408675  0.316482089556363
-   11  ( 25) -0.113565876404484 -0.174438492287332  0.418980586076642  0.308342622144823 -0.075432621027986  0.339103289288024 -0.159452756259661 -0.028406298387555 -0.098839597099930
-   12  ( 26) -0.037444327267505 -0.021664072112537  0.117362801200434 -0.051936890369197  0.180410685976209  0.010675625355649  0.081438166282149 -0.155940478341532  0.070485054402575
-   13  ( 27)  0.017297506490468 -0.067203074043419  0.031147633780082 -0.363738862057262  0.387270613641776  0.012184715254227  0.015942188037276  0.055059690817367 -0.199296990199261
-   14  ( 28)  0.034092252177278  0.073609066570293 -0.020468002829466 -0.085810470847391  0.016765555515284 -0.112839616184051 -0.014153257364854  0.178002322135800  0.110338785365484
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147095539872383 -0.230933799773564  0.118289772746167  0.038253772767447 -0.016292190599368 -0.035682534667396
-    1  ( 15) -0.054490936726031  0.608135664745124  0.173899591973767  0.021325225109119  0.066354839577592 -0.073331369735506
-    2  ( 16) -0.323391847959358  0.191801489512728 -0.419969130886923 -0.118001273092276 -0.032684795751626  0.020933916119487
-    3  ( 17) -0.062697350486204  0.233350536310715 -0.310310140488118  0.052850324165985  0.365716314917495  0.086296396691572
-    4  ( 18) -0.056488793458219  0.097314229222686  0.076761540605080 -0.181114864878134 -0.388829148158841 -0.017043041264758
-    5  ( 19) -0.064628320787155 -0.308910350912390 -0.338058227371875 -0.010220898623446 -0.011328162399087  0.112362127982896
-    6  ( 20) -0.155379178216769  0.021354195203646  0.159398635050546 -0.081833336858156 -0.016534888228459  0.014163359612821
-    7  ( 21) -0.140544774640624 -0.163930417297846  0.028664595573870  0.155618444233808 -0.055735865052552 -0.178161215640947
-    8  ( 22)  0.103335943311615 -0.315447824318108  0.098508893733037 -0.070643837593468  0.199190551733382 -0.110186805922078
-    9  ( 23)  0.000685205966667 -0.100205727138143 -0.098177984906045  0.175404901290359 -0.218086466804531  0.228138153241008
-   10  ( 24)  0.099957378010069 -0.000114683002834  0.318552989781446 -0.225328174596363 -0.500054658950197 -0.463890214112047
-   11  ( 25)  0.099837194917025 -0.317752725239556 -0.000013072206941  0.325584528982697 -0.211934933711027 -0.064802310197898
-   12  ( 26) -0.174911687089768  0.225249469039723 -0.325644361756696  0.000020583584119 -0.212000345487721  0.097990759740804
-   13  ( 27)  0.218595256276638  0.499626470482149  0.211748903875054  0.211985776866883 -0.000065067673371 -0.140785106097381
-   14  ( 28) -0.228612967389234  0.463548085364345  0.064895093957785 -0.097943745399791  0.140883877569212 -0.000043885507604
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019700182677109 -0.054538984090237  0.000657293183073  0.126059310809830  0.202210998435536 -0.093434338948922  0.024491292826910  0.039730679308164 -0.082949626694243
-    1  (  1)  0.060570767175444 -0.116914550591559 -0.021887147512717 -0.031244847376016  0.072525220228198 -0.201021150446193  0.281719713830578  0.109054645892929 -0.074327440399931
-    2  (  2)  0.019917912309235 -0.073498936617270 -0.021015841735422 -0.144973687437576 -0.148661911932313 -0.032805680200546  0.073267109264708  0.114043301611785 -0.006398273119572
-    3  (  3) -0.203013924377868 -0.061956730055068  0.012687970996334  0.097374198936088 -0.112619147770757  0.293844050008894 -0.262428514093194  0.382217125669632 -0.093448479811708
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009866900732451  0.025414444169080 -0.042903095265214 -0.089054808289041  0.047172870515859
-    1  (  1) -0.029479300283787 -0.071852668133049 -0.250209813738974  0.142668644531385 -0.184582935130079
-    2  (  2) -0.082839864480014  0.055172054044896 -0.094169081580928 -0.401277867082131 -0.092346870950097
-    3  (  3) -0.429785932962393 -0.170247315400438  0.282336698266602  0.039589385431130 -0.207542683133729
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.009866584979615  0.069659389537491 -0.056437231681763 -0.210909857783049  0.193232853181170 -0.044263163299008  0.177086741570328  0.011251791029684  0.005974944716268
-    1  (  5) -0.063966745715490  0.332083812922557 -0.023959233352896  0.077592998716556  0.049685567261474  0.057922845574600  0.292828526996057  0.156611147799580 -0.308189152931944
-    2  (  6)  0.093646243694873 -0.043886805978712 -0.210333087134862  0.092497904992983  0.147507586034141  0.211245402574096  0.209822842363991  0.120370292677788  0.308437245541850
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068407482810993 -0.091070726633550 -0.065843093849228 -0.010412482581381  0.030047987986095 -0.002926817734499
-    1  (  5) -0.052950259935732  0.069489349844531 -0.341748563636028  0.056521413026742  0.185361514981393  0.106113084848249
-    2  (  6) -0.072195900884652  0.125482826256955 -0.118114475628592 -0.149158088490872 -0.308475854808773  0.046262836261975
 
 	Computing L_Z-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.142894969348
-	   1         4.996917142622    2.678e-01
-	   2         5.722970185202    1.723e-01
-	   3         5.835413495549    5.784e-02
-	   4         5.872583738861    2.932e-02
-	   5         5.875284459509    6.235e-03
-	   6         5.875993522503    3.318e-03
-	   7         5.875898052773    8.112e-04
-	   8         5.875822573716    2.735e-04
-	   9         5.875790908834    8.796e-05
-	  10         5.875786504789    3.553e-05
-	  11         5.875789838851    1.320e-05
-	  12         5.875792731268    4.578e-06
-	  13         5.875794377628    1.752e-06
-	  14         5.875795474126    8.775e-07
-	  15         5.875796175101    3.241e-07
-	  16         5.875796558971    1.552e-07
+	   0         4.142894943314
+	   1         4.996917111862    2.678e-01
+	   2         5.722970149733    1.723e-01
+	   3         5.835413457273    5.784e-02
+	   4         5.872583700101    2.932e-02
+	   5         5.875284420619    6.235e-03
+	   6         5.875993483580    3.318e-03
+	   7         5.875898013846    8.112e-04
+	   8         5.875822534789    2.735e-04
+	   9         5.875790869909    8.796e-05
+	  10         5.875786465863    3.553e-05
+	  11         5.875789799925    1.320e-05
+	  12         5.875792692343    4.578e-06
+	  13         5.875794338702    1.752e-06
+	  14         5.875795435200    8.775e-07
+	  15         5.875796136175    3.241e-07
+	  16         5.875796520045    1.552e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 4.151e-08
 
@@ -2108,4463 +727,413 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.361359068213073    -0.343963063756748     0.000000000000000
-    1     -0.055701201616850    -0.006113948015631     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.373861236690088
-
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933719  0.015024519180328 -0.027415915569927 -0.162886507397778  0.113254822182172 -0.064023650931690  0.055316304980596  0.030988679956786  0.002674429417477
-    1  (  1)  0.215473680254303  0.146951879885484 -0.277734064030081  0.062883278347954  0.148483123915935  0.181595053380814  0.367001371843722  0.003086313328534  0.095386404339393
-    2  (  2) -0.028492499167414  0.000076506520592 -0.059221747197113  0.071711487991955  0.074053260083134  0.055563200913425 -0.046720222778269  0.241063526706415  0.098194384215310
-    3  (  3) -0.132536698935225 -0.177581639220036 -0.107360746511047 -0.032262815899199  0.006088751294667  0.053657437577797 -0.241466578728664 -0.131962062699398  0.577380042604837
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927832  0.060461893794974 -0.005615477646775 -0.003888920206542  0.016113135271293 -0.008672229740057
-    1  (  1) -0.037058680758818 -0.084686071934143 -0.145302623884171 -0.027760832624295 -0.054555858489399  0.022009727182523
-    2  (  2) -0.087315818129461  0.399047483163753 -0.041723099752478 -0.020041920189952 -0.040600995633868  0.007777357868478
-    3  (  3)  0.035307803556741 -0.050920479686544  0.165550414172814 -0.068091463340302 -0.144062340529055 -0.042051983076328
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356551 -0.081063517853362  0.006129432768986  0.163964563111019  0.188951419459760 -0.080047732466264  0.074988303081860  0.007836242506545 -0.044696302205990
-    1  (  5)  0.348085979138498  0.014814724303187 -0.054134117524106 -0.070406995762195  0.073423358836442 -0.343984245233778  0.389896180591041 -0.295068043464420  0.051928952937995
-    2  (  6)  0.021691230674299 -0.340003625622924 -0.038072452179293 -0.014533847126865 -0.084733391360494 -0.004556444515594  0.201335045135129  0.349717311230211 -0.082620936463628
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932767 -0.007485730843830 -0.029474818409048  0.032209758674475  0.014108652541198
-    1  (  5)  0.209382720135360  0.066996563725018 -0.203801631001162 -0.021994746468443  0.025790645299269
-    2  (  6) -0.188199132187482 -0.086167806666975 -0.070501884768036 -0.051440727873375 -0.127552190835519
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135226960454329 -0.626072128797856  0.189283545408859
-    1  (  1) -0.198601340506734 -0.037544167210706 -0.132449472453120
-    2  (  2)  0.054869769604055  0.126822216303605 -0.064658685102821
-    3  (  3)  0.615161980452155 -0.126204375217765 -0.081927924761018
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135552779706607 -0.198154082714879  0.054851984676127  0.616510373253303
-    1  (  5) -0.625008803021780 -0.037782453643458  0.128063646533814 -0.126279998076331
-    2  (  6)  0.187629167441129 -0.129442737930206 -0.067422044676100 -0.079936634548172
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904639712499451 -0.487488103200076 -0.229076194035639  0.577203417890310 -0.193643876562866 -0.103447604010490 -0.002742470403339 -0.002451788094673 -0.093813724218951
-    1  (  1) -0.150591231752366 -0.132839961398672 -0.684911223766594  0.231736797158550 -0.050522572299863 -0.177494490840206  0.234003342486174  0.124606643062300 -0.128494931356720
-    2  (  2)  0.012679732612875 -0.025746334218933  0.172509146876756 -0.235881170188724 -0.123364008457064 -0.206129657450651 -0.121800673855344 -0.114140784221077 -0.027356216567683
-    3  (  3) -0.420686741899109  0.000223888623798 -0.019382136800427 -0.199660686586779 -0.007228242971357  0.053875733566216 -0.291408914352131  0.275298575094287  0.504737487457482
-    4  (  4) -0.444479349932693 -0.097546029689334 -0.201324076119099 -0.112193453655926 -0.168730295177634  0.009510393466796 -0.073326647656899 -0.314743664834695  0.576679302947873
-    5  (  5) -0.139143305540458  0.035439861017558 -0.250210390538763 -0.395563451554525  0.287109450839577 -0.179399443391397  0.197453518892115  0.283328589948476 -0.108409713739241
-    6  (  6) -0.129858112319494 -0.067528694061774  0.181320447910016  0.198216451549469  0.101434222271579  0.004260476702610 -0.540044484893358  0.047093544204538 -0.240211227858318
-    7  (  7) -0.134029026372210 -0.177806690148742  0.066071255125305 -0.420048245168344  0.282274848902259 -0.347456793165350 -0.074406017626731 -0.307127129684507  0.001639432917235
-    8  (  8) -0.063335732549803 -0.086906710930682  0.269779701592786  0.018783692891885  0.093247017991791  0.136863024113204  0.153892981652107 -0.031577691616058  0.057553836246905
-    9  (  9)  0.014012585179935  0.032071651340396  0.006363849845329 -0.122564599853837  0.077119470960815 -0.029965581352467  0.027046636903364  0.089397837094507 -0.000802529924293
-   10  ( 10)  0.055348506435332 -0.144624122276400  0.060432277066905 -0.048567020795871 -0.074912986944558 -0.098523802539065  0.029250640804258 -0.193836130554797  0.085063532916863
-   11  ( 11) -0.167019155111356 -0.139650558475056  0.283534980836447  0.091894060309841 -0.065838077605531 -0.024336945622807 -0.227843897422644  0.001167201554402 -0.053408806911177
-   12  ( 12) -0.031974022074094  0.367173995466684  0.116713714097489  0.049340092544995  0.015070529788415 -0.072500414701037  0.058353998450091 -0.115184864373284 -0.153182495837622
-   13  ( 13)  0.015928358602524 -0.071164774172970  0.101660897809921 -0.105977026406682  0.126658664034758 -0.065056017101762 -0.035738606034781 -0.004435603298656 -0.059994356828778
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128825974989509 -0.011693877694956 -0.146729379814636 -0.059424684705193 -0.018525365113581  0.062705489025799
-    1  (  1)  0.288526396149447  0.103129875764739  0.289919344105948  0.006241427794524  0.000597805518378 -0.002126961584359
-    2  (  2) -0.124928230102748 -0.010221797026422 -0.056571189754990 -0.103418885736763 -0.082343433199812  0.048808132756786
-    3  (  3)  0.041255915551182 -0.068310001947041 -0.078413018324291  0.150330242984032  0.179548999452936  0.040220285290074
-    4  (  4)  0.222674700983985  0.064061711596271 -0.051112895424348 -0.009318828777699  0.269456744732776  0.059360036713982
-    5  (  5) -0.030199751599662 -0.174896036167204  0.092691422408890  0.028256224393045 -0.095222992765338 -0.000984235427179
-    6  (  6)  0.000100463193790 -0.095109995484221 -0.236670455787565  0.077272409830334 -0.062627657605178 -0.003574021992867
-    7  (  7) -0.071380631315585  0.113168055430629 -0.125965816328841 -0.059330696538415  0.017157541349944  0.045135077260112
-    8  (  8) -0.578000624333793 -0.096150086854243  0.034301394867322  0.008135450733159  0.200641611845460 -0.180371714719462
-    9  (  9) -0.075918662396497  0.004599198141429  0.008112602200918  0.005143287525083  0.000284986477862 -0.012193359543266
-   10  ( 10) -0.010150745998766  0.093962320907848  0.012547284938522 -0.048325478252251  0.058041984098958  0.029299969972017
-   11  ( 11) -0.079273276366059 -0.056402585822246 -0.083755323132189 -0.007973236673640  0.003424691269612 -0.009405123180745
-   12  ( 12) -0.063303823644203  0.041869083940428 -0.019024216633724 -0.031772697856612 -0.042532243078164 -0.051259918656063
-   13  ( 13)  0.241542081048425  0.060829474159106 -0.029241791046113 -0.004754249561521 -0.057213036452335  0.050348392969429
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902374530738022 -0.153219479021377  0.011852929174237 -0.420772110136454 -0.445657281852233 -0.142990081433834 -0.124215890045092 -0.133483278617486 -0.065282671277575
-    1  ( 15) -0.489111175456921 -0.131490362750624 -0.025259277994888  0.001430871050471 -0.096952824968496  0.035534183248533 -0.068855717941569 -0.178542279529003 -0.088180183979087
-    2  ( 16) -0.227418381124785 -0.683144902334149  0.173877572588752 -0.020414541641232 -0.199817592754852 -0.249739904936588  0.179565732929473  0.064581867916785  0.271668362709088
-    3  ( 17)  0.574685513420631  0.230755641765144 -0.236330653993451 -0.198455558262947 -0.112539659295239 -0.393276362435767  0.196125851624956 -0.416930913980481  0.017841111258302
-    4  ( 18) -0.193861200268992 -0.049521286941690 -0.123799353815169 -0.006786264808002 -0.167396168176774  0.285560945535521  0.102872968175184  0.279329859462782  0.092685860122555
-    5  ( 19) -0.103950692672536 -0.178731366743218 -0.207305979104179  0.054759646458521  0.008750479265458 -0.180116361743218  0.005850873308053 -0.346544100781250  0.135656056953800
-    6  ( 20) -0.005630218802764  0.235616494969928 -0.121418775897667 -0.289705308748940 -0.074615700944863  0.197147960229531 -0.541298908627625 -0.074766151907221  0.151080244573413
-    7  ( 21) -0.003422639573229  0.126273883662637 -0.114690954063485  0.273155566178120 -0.312791095371318  0.283606567582012  0.047453631637779 -0.310404476862355 -0.030935364545071
-    8  ( 22) -0.094384208857050 -0.130119390042033 -0.029535782736702  0.507266905754751  0.577412507794685 -0.108469543731725 -0.239044626830660  0.001740919827196  0.057806922411999
-    9  ( 23) -0.126661063777409  0.286542775287408 -0.124995270818088  0.042040769766258  0.222601161131206 -0.031774064783095  0.002289661982445 -0.069973062056331 -0.578237160301556
-   10  ( 24) -0.012316706158688  0.104097860742328 -0.011505288408996 -0.071480242591920  0.067861431955970 -0.174641527191865 -0.093323115387981  0.108845273419844 -0.094609691027850
-   11  ( 25) -0.145222688889763  0.289337733151126 -0.056602400212228 -0.078531799009324 -0.050892925184258  0.092549568885425 -0.236281405460416 -0.125802430136002  0.035465582481700
-   12  ( 26) -0.059239279504459  0.006390267291517 -0.103087074498887  0.150070392220881 -0.009342684456032  0.028289380811624  0.077066678658251 -0.059246681674569  0.008175814399583
-   13  ( 27) -0.018271401982902  0.001173845770900 -0.081596168939475  0.178729785139683  0.269264211536985 -0.095094170813457 -0.063160456524518  0.017032758007907  0.200794357953944
-   14  ( 28)  0.062542890221320 -0.002043353345753  0.048801696637924  0.040072732580057  0.059190323152548 -0.000990742681887 -0.003556361910882  0.045152229102533 -0.180550803638744
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015123588660554  0.055493926114086 -0.169975137829357 -0.032809701818419  0.015002120333835
-    1  ( 15)  0.032575974689068 -0.144334404568220 -0.139389411890772  0.367448169822372 -0.070672349646380
-    2  ( 16)  0.006576811925777  0.060477069258309  0.284097691628268  0.117086244456111  0.102358639196809
-    3  ( 17) -0.124972828077174 -0.049265564522405  0.093111727254450  0.049489377800986 -0.106573762761508
-    4  ( 18)  0.078337257989412 -0.074315417379022 -0.066598566061427  0.015174881916742  0.127229135544739
-    5  ( 19) -0.030091617468876 -0.098524033243520 -0.024929078981092 -0.072709941383626 -0.065547640079006
-    6  ( 20)  0.028642219542832  0.029887343616837 -0.227866902460195  0.058376706970884 -0.035321371844135
-    7  ( 21)  0.087782136491553 -0.193844146817677  0.000960256633726 -0.115246048391410 -0.004217096818020
-    8  ( 22) -0.000480626398768  0.085216781964239 -0.052876715620283 -0.152779703755060 -0.059953833408394
-    9  ( 23) -0.075367737260776 -0.010279381835842 -0.080270644652149 -0.063438855793640  0.241130315879110
-   10  ( 24)  0.001339830230092  0.093599534020443 -0.056909491966955  0.041771584176774  0.060831797189675
-   11  ( 25)  0.008376396051511  0.012488344592190 -0.083677242445135 -0.018943587777834 -0.029225017366591
-   12  ( 26)  0.005096769732662 -0.048366952557418 -0.008003858722242 -0.031797935609827 -0.004752495908706
-   13  ( 27)  0.000291047131527  0.058011237654453  0.003385274769851 -0.042619295059266 -0.057154993286885
-   14  ( 28) -0.012282741908214  0.029296735642711 -0.009480582784426 -0.051319211356101  0.050295534824424
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027700885793090  0.024831013973620 -0.023766237412625 -0.167016603039327  0.109441555361099 -0.067202506902943  0.052695088582618  0.024064411648558  0.006188438734744
-    1  (  1)  0.211348759010705  0.133908962277450 -0.251856181342018  0.050198620343957  0.139035741221492  0.172926066548658  0.339110899470513  0.007367826854054  0.086633467632879
-    2  (  2) -0.033041625132306  0.014036582200115 -0.054189619432057  0.084538537056286  0.066377206996811  0.053646226488719 -0.037306526458897  0.220368264081415  0.092674869094203
-    3  (  3) -0.148568319902254 -0.152791211204353 -0.088570806082631 -0.044321874775550  0.009397298861476  0.049588338511193 -0.223116042687511 -0.123854255485030  0.553492211947825
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031010458886505  0.050729211215458 -0.003248182162608 -0.003208641714203  0.015229535075598 -0.008450459157620
-    1  (  1) -0.026218145702581 -0.073512341998455 -0.129399675880907 -0.023964582987074 -0.050019383975377  0.020539415914057
-    2  (  2) -0.075590807542000  0.365585379125664 -0.036729157945636 -0.016058134590280 -0.036438378068464  0.005536360852376
-    3  (  3)  0.037937313174203 -0.045234909961237  0.147760703126575 -0.060764535561285 -0.127333495556462 -0.038975339991211
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.051048798017959 -0.074362715758791  0.011189550347852  0.166183248293228  0.192475433446903 -0.070879824995202  0.064177194660685  0.010742342939179 -0.040136733536896
-    1  (  5)  0.352033813656898  0.019031583986232 -0.054018125678766 -0.066876079961775  0.060148226317511 -0.330348230405564  0.365124970723465 -0.284795973003407  0.051302526538107
-    2  (  6)  0.016809582021521 -0.311268516971315 -0.037661154101055 -0.006688597064538 -0.076727139945066  0.002675593746451  0.192087236696226  0.332474625249023 -0.065875996007769
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002709655241188 -0.005736834567419 -0.024459935540253  0.027202469191560  0.013148077561853
-    1  (  5)  0.191661619772415  0.061070263266085 -0.180667286312627 -0.019964047997524  0.020757203718351
-    2  (  6) -0.172312444590060 -0.078944608822718 -0.060240884585305 -0.044786922712268 -0.117310123601201
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102371  0.008188589712253 -0.013790999932786 -0.066013267343743 -0.002979179364400  0.115067560152139 -0.029904774000612  0.075658337330171  0.005135342269600
-    1  (  1) -0.415137332088601  0.400791789518638  0.060626653167993 -0.009777722957293  0.182694524485328  0.107591424113232 -0.071470092116899  0.210805299972914 -0.029640655301113
-    2  (  2)  0.731004204598520 -0.977674938020327  0.030910735141464  0.126476447646343  0.160297857646314 -0.115254107794063  0.017919423470237  0.019160269758155  0.056677210806000
-    3  (  3) -0.052710934455990  0.190825342618795 -0.121683764296164  0.058318753384800 -0.051331848225844  0.122833340921047  0.176985596744929 -0.321410474763129  0.015752780623213
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449213 -0.003857954296837  0.001116934481339 -0.006268480889136  0.011819863965877  0.022338641059405
-    1  (  1)  0.026581167918671 -0.003242138995827  0.002209759168118 -0.126256065331473  0.064001666171839  0.019583311633873
-    2  (  2)  0.060541607763312 -0.048685401885036 -0.005324531906369 -0.077364982992387 -0.023160042352107 -0.131997334895641
-    3  (  3)  0.086532549077855 -0.501054912835389 -0.033953281830232 -0.045954160893793  0.007588765668991  0.026055365513597
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407922 -0.003874637131508  0.017573675069981 -0.250000468336213  0.193535227171919 -0.023949830014063 -0.006344215172670 -0.002637721142585  0.025018403626543
-    1  (  5) -0.061066900138168  0.119597101102997  0.077747477731561 -0.181802110874954 -0.105212352540637 -0.191650240311696 -0.067261595147758  0.101033231559049  0.034053487252848
-    2  (  6) -0.129779125650155  0.272168473286835  0.218088904973350 -0.105590817864479  0.170044089806049 -0.413895401404366 -0.204721805057804  0.193774792721739  0.022574107317581
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304092 -0.022619515940244  0.001370551331509 -0.019480287608797 -0.016611790333304
-    1  (  5) -0.015006262168536  0.018557640744952 -0.000086080146175 -0.193359672647774  0.037991057379311
-    2  (  6)  0.020942063740395 -0.276121820896827 -0.020375408054503  0.090755244706104  0.038585932807349
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234755470283494 -0.089757897373020 -0.029226311105252
-    1  (  1)  0.628249611487235  0.562405195056318  1.006567293279179
-    2  (  2) -1.014513658696574  0.324469533164471  0.758540603298664
-    3  (  3)  0.070695571972197 -1.217301397368710  0.544825504539347
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235350713719763  0.628273412467382 -1.016171307500330  0.070820853933159
-    1  (  5) -0.089319079346847  0.558364917857372  0.332433157387859 -1.220987955904316
-    2  (  6) -0.028486683819977  1.000293875862972  0.767362449165329  0.543367325750415
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.804113115082476  0.859865209405978  0.271144212420722  0.233800284186400 -0.124039945960302 -0.010266323749701 -0.092708567501353  0.016778206024767 -0.004458179405382
-    1  (  1)  0.400343044462577 -0.255491137898964  1.725894952211806  0.228060869773276 -0.016813664829395  0.078025484956049 -0.010667432793276  0.508783176705980  0.007215780908188
-    2  (  2) -0.011354346714470 -0.088649218741431 -0.217285460959696 -0.271127696601060 -0.847424926486828 -0.636922641013174  0.167096970483907  0.613137270589982  0.118274978265568
-    3  (  3)  0.794199691903238 -0.188240166832123  0.221783053519905 -0.127263314849504  0.529647578782938 -1.234322959040903  0.503694754515607 -0.716759154325272  0.003713884622693
-    4  (  4) -0.401724672662203  0.338296304392140  0.027696569600284 -1.521982152310056  0.118592993377401  0.737822504259554  0.133024505198137  0.089529285352600  0.037479870573311
-    5  (  5) -0.062644206103431  0.401210407583383 -0.021849381974102 -0.715241456861441 -1.272083761860537  0.501726128250219 -0.443637757248850 -0.893021281361452  0.592660402987318
-    6  (  6) -0.010995449282209  0.203452242512905 -0.137034668384831 -0.113107359606073 -0.481513340581640  0.549194810269266  1.454087044363765 -0.104931286723953 -0.037492008681457
-    7  (  7)  0.128269755499557  0.321618430212614  0.165227456397847  0.036785042290031  0.490368577399565  0.556638814927009 -0.027991830909201  0.572834606710096  0.836617597163443
-    8  (  8)  0.028289154881459 -0.066964202719289 -0.261747148048837 -0.132206243094573 -0.099640531633427  0.125261053712928 -0.191170844521896  0.152462184420595 -0.345612464691053
-    9  (  9) -0.116917200683994  0.677293814759277  0.057457633837352  0.132537898195641 -0.004175807366595 -0.154875636337893 -0.038546773688736 -0.121822888362931 -0.349244520254478
-   10  ( 10) -0.180886604759012 -0.111792204438004  0.370617548329878 -0.010060948397306  0.175897261426789 -0.187416342815067 -0.018902126694380  0.507517994343604 -0.113620600518286
-   11  ( 11) -0.014433403132825  0.015210570936209  0.010143344331716 -0.005691229002309 -0.031059326071816 -0.023288546292970  0.128101332902295 -0.039392944850365 -0.110920114561223
-   12  ( 12) -0.125268954735601 -0.096735894811095  0.052480306210840  0.258243594453840  0.005805250173734  0.145107299027993  0.116452856795828 -0.074374807730486  0.022119923916482
-   13  ( 13) -0.016491827683000 -0.002316794514604 -0.087971851878040 -0.101325911412249 -0.036377238947136  0.195278206944885 -0.010131352705033  0.009611107176441 -0.056274461553023
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020619978804336  0.055393926260187  0.016493468301721 -0.100372381621025  0.100626242248385  0.085758294302206
-    1  (  1) -0.158166323997471 -0.302157830906837 -0.003244540958725  0.141116982835112 -0.086717578223953 -0.004480871143073
-    2  (  2)  0.117237563107159 -0.174570847573259 -0.011204345589108 -0.263173432731341  0.005218532196564 -0.028842080195291
-    3  (  3)  0.116941646649189 -0.002586479599499 -0.011231548488132 -0.058984655279808 -0.019822661982984  0.041048882280058
-    4  (  4)  0.050776820640492 -0.220908341720040  0.039982596283606 -0.028513186801397  0.038501560477761 -0.072498198103566
-    5  (  5) -0.020348029264266  0.163764941111612 -0.082946711645337  0.111452654944128  0.037984566239181 -0.107199595568986
-    6  (  6)  0.021256126103379  0.388694787591390  0.114910007821006  0.018804713347374  0.008937619959600 -0.015873506672536
-    7  (  7)  0.297925323013482  0.033191669222652  0.094278199439545 -0.060174035263233  0.021406855727383  0.043089336483829
-    8  (  8)  1.538149876661748  0.255388094594388 -0.163312643003206 -0.034677585072596 -0.142125228818852 -0.045738087971663
-    9  (  9)  0.091443541252263 -0.031128123891510 -0.061982026707845 -0.058678185009713  0.760839955512426  0.950617857123983
-   10  ( 10) -0.067301877513073  0.211057800702045 -0.020603819563676  1.234407038988020 -0.163795705022985  0.167535211420867
-   11  ( 11)  0.163445976328785 -0.060082779666638  1.332811809287810  0.048638214648072 -0.084741484840249  0.093756111599780
-   12  ( 12)  0.205948682024844 -1.200679744036826 -0.135474810029670  0.365861100667224 -0.094093662797851  0.008686523394777
-   13  ( 13) -0.181605938452019 -0.042014918886121  0.112406427108198  0.222953862798531  0.995139187403178 -0.917632565321793
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802008727902676  0.406135528069464 -0.010476316014009  0.784475556802925 -0.394386683091379 -0.066798881058913 -0.011980564813184  0.124376056524327  0.033526134230615
-    1  ( 15)  0.862028914432798 -0.259382739909270 -0.086667305572556 -0.180064784220824  0.329908607377610  0.399964089565218  0.202187771096648  0.330121816685668 -0.071953120874649
-    2  ( 16)  0.271307809960556  1.724790149840180 -0.218446172710940  0.221581282093097  0.027552874986014 -0.019301351758279 -0.136156749402974  0.163711145289557 -0.262315292158515
-    3  ( 17)  0.233832160360352  0.228075923415961 -0.271855585595643 -0.127498943532479 -1.519236751765249 -0.714946933274063 -0.112783303905572  0.035742190545400 -0.131799331720385
-    4  ( 18) -0.125884857507763 -0.016503178327094 -0.848590316809874  0.528676059271103  0.118589942995782 -1.271521009941038 -0.481050683706501  0.489094666232462 -0.100427993377482
-    5  ( 19) -0.011410411929745  0.078504916539371 -0.635756927956321 -1.233330464680106  0.737249034134023  0.499445190730480  0.548364048058884  0.558640131287018  0.124411035854046
-    6  ( 20) -0.091600083261379 -0.011874324392688  0.166095509172862  0.503931355593045  0.132971166339029 -0.442847331045808  1.455101200236588 -0.028340512672182 -0.190421039545484
-    7  ( 21)  0.014506888035513  0.509793857361997  0.613540224928976 -0.716635769138246  0.088503909894013 -0.892421715175110 -0.105643577538776  0.572215069358599  0.150576387127195
-    8  ( 22) -0.004177720337585  0.006709815498361  0.117678875953393  0.003186946250580  0.038303116431615  0.593619431704741 -0.036920385902422  0.835672825510649 -0.345283877638179
-    9  ( 23) -0.021586239236066 -0.156869719857391  0.117889758366706  0.115161423657162  0.052238225817572 -0.022709102193988  0.020562459070751  0.298677779552442  1.538509512042474
-   10  ( 24)  0.054682068155322 -0.300070995804169 -0.172660016100411 -0.004680568559172 -0.221321821680690  0.163619483231716  0.386948477906845  0.033115261343835  0.254769962308442
-   11  ( 25)  0.016488293849114 -0.003235639473042 -0.011174682028037 -0.011243945686257  0.039809588242799 -0.082761513420842  0.114884412151977  0.094200391738445 -0.163393716854439
-   12  ( 26) -0.099231335638990  0.141112668735458 -0.262446613088940 -0.059563147663723 -0.028574452319685  0.111394864273785  0.018513759386789 -0.059760408126138 -0.034040397389902
-   13  ( 27)  0.100244162906012 -0.086825753516494  0.005142496829835 -0.019052879526336  0.037887085038889  0.037954868269104  0.008919579926839  0.021672382001860 -0.142649674386495
-   14  ( 28)  0.086046561377276 -0.004744302368676 -0.028249738219529  0.042030603060909 -0.073561648753534 -0.107720217983957 -0.016217142075148  0.044341471770554 -0.046187444393712
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124233708134524 -0.184518326175241 -0.014667753095383 -0.126540650902724 -0.015843433752182
-    1  ( 15)  0.686899770278225 -0.109692117003678  0.015377495137089 -0.096723489130419 -0.002397757787942
-    2  ( 16)  0.057205529179578  0.372042133273666  0.010210131259620  0.052160697899357 -0.088271643130929
-    3  ( 17)  0.131871345108673 -0.011180948360743 -0.005727193367058  0.259941586635743 -0.101614450210782
-    4  ( 18) -0.005079597151441  0.176830214271515 -0.031032942109520  0.004628941737829 -0.036366477592845
-    5  ( 19) -0.153488339566637 -0.188246645479869 -0.023332293508375  0.145173541284822  0.195552538719584
-    6  ( 20) -0.038666420291799 -0.018333798481476  0.128217423491274  0.116258211557263 -0.010271886085243
-    7  ( 21) -0.121961409061181  0.508144909444715 -0.039497933150391 -0.074911313979370  0.009738174256592
-    8  ( 22) -0.349752281191330 -0.113379050365496 -0.110884161439947  0.022227055299984 -0.056428042287631
-    9  ( 23)  0.091274387643073 -0.068482004342729  0.163392525285683  0.205701365643175 -0.181416453396984
-   10  ( 24) -0.031494844080999  0.210984913522458 -0.060264440706329 -1.201297108840472 -0.041823116964630
-   11  ( 25) -0.061998986866118 -0.020468588707436  1.332808723106094 -0.135556576828281  0.112406197562940
-   12  ( 26) -0.058487448549072  1.234274465594829  0.048631105388928  0.365854082846019  0.222962926250735
-   13  ( 27)  0.761200546740672 -0.163618812251219 -0.084738989433889 -0.094122389252772  0.995165590894077
-   14  ( 28)  0.951772998269747  0.167560207344577  0.093759874796889  0.008708619204375 -0.917569948681374
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062431637468593  0.002416441043502 -0.004633709181853 -0.077570764564644 -0.013832459901153  0.123710471759642 -0.027165779035152  0.071044010954106  0.019658423662045
-    1  (  1) -0.407170389584207  0.333069478291504  0.076649076907715  0.002175328366486  0.197922707135412  0.117656968282773 -0.067757706616657  0.182812175438104 -0.031734247883933
-    2  (  2)  0.673185035517364 -0.888138019247633  0.034358376579768  0.125358507387098  0.172994941404750 -0.106755581181878  0.013852200121285  0.009496870454365  0.036809619943040
-    3  (  3) -0.040742790622464  0.181389056204803 -0.117008669682237  0.012401302848610 -0.022196391591020  0.102862126461667  0.166049221641567 -0.310434511631989  0.017146561969842
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.010530607294137 -0.003710118206635  0.001098184033274 -0.004177259623775  0.010641720243898  0.020819711535909
-    1  (  1)  0.026376312845794 -0.003084063695378  0.001935075690030 -0.112197866496257  0.055637648529143  0.022260912302157
-    2  (  2)  0.054059905057588 -0.043789787513272 -0.004472231165835 -0.071437136436271 -0.024456749693059 -0.126350825107537
-    3  (  3)  0.083331116085336 -0.461426302980743 -0.028171699513186 -0.043194879139585  0.008942983333376  0.024389199674006
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.021216263100624  0.005003175055611  0.013535160841110 -0.263704651382069  0.210918804180354  0.005688291976377  0.005207710700420 -0.000895282201931  0.031550648985105
-    1  (  5) -0.080441383224434  0.123194069685476  0.057717422634421 -0.198323986141409 -0.141861353254402 -0.184709849630280 -0.056481718890564  0.088971412091769  0.030305733467363
-    2  (  6) -0.146541148918456  0.264369470289011  0.161465568338032 -0.083507608614794  0.171726934895348 -0.400382872983885 -0.201596935132391  0.184414767198936  0.015497227351117
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.010467742288235 -0.019463191825823  0.001308339278104 -0.016880359740534 -0.016885157913524
-    1  (  5) -0.009224792466209  0.019323723500934 -0.001197784436253 -0.171358632107000  0.032143333569082
-    2  (  6)  0.022721945593511 -0.245666385556987 -0.017093671892173  0.084713974597813  0.032963157176325
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521806 -0.064555152855150  0.195953381503074 -0.041248493404101 -0.011229686922118 -0.030149441468389 -0.052245051042507 -0.006640144591450 -0.060816046803629
-    1  (  1)  0.618380750339701 -0.527850820452489 -0.215416501468042 -0.157035437820978 -0.069798458053206  0.063297476854315 -0.224803808806328 -0.036770088857857 -0.093292414355450
-    2  (  2)  0.089963765220201  0.016694193855691 -0.049894217028077 -0.224500363636593  0.100545586935602 -0.339808932362407 -0.300486601785008  0.103978674940020  0.003854593986179
-    3  (  3) -0.017912540893906  0.240051544179780  0.016875920141062 -0.019658112757037  0.000950481978191  0.139486307895354 -0.307526295494235 -0.245045411721377  0.038982174459016
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151715 -0.053483299255778  0.001461399819935 -0.009996127160186  0.040844890766482
-    1  (  1)  0.010356156252337  0.045196494943178  0.123149462829325 -0.009608799091532 -0.092775098416542
-    2  (  2)  0.068261626755321 -0.266621644473694  0.090983468547793 -0.007824999539039 -0.015479677414574
-    3  (  3)  0.102991688131891  0.095940846129218  0.235195882789532  0.030438278876707  0.100331913639094
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065252  0.055002400477820 -0.190701615134350 -0.008587073556999 -0.137456634337686 -0.102685174742854 -0.038575707278163  0.049077773985903  0.038775520871493
-    1  (  5)  0.266426121061197  0.201904502527540 -0.404472747743452  0.112355452346377  0.244543383067891  0.203488255110601  0.093346083766343  0.046662175778558  0.162564534078692
-    2  (  6)  0.310200495971193  0.275860886663895 -0.334362481171644  0.111323203428054  0.107269573508054 -0.015396505983498 -0.485347827861586 -0.115211810541092 -0.189399381355332
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661083 -0.010182782856370  0.015536223735827  0.027148068637771  0.019304531582391 -0.012170541889264
-    1  (  5) -0.076359104752405  0.072719944885937 -0.105706045053704 -0.076791075572625 -0.095250630872875  0.044053081318692
-    2  (  6) -0.023401555368550 -0.060789750773997  0.233844071164904 -0.060200608258467 -0.022972229731698  0.078966373846355
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134464733238505 -0.662210405494710 -0.268087036060520 -0.078995101665645
-    1  (  1) -0.664136191142175 -0.208512216408344  0.147227682691111  0.068768195668233
-    2  (  2) -0.267178832853329  0.148347614169083  0.187155712816505  0.001725942570582
-    3  (  3) -0.077975712094607  0.066243031692251  0.004079617492315  0.013944312169831
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274618126592083 -0.278113702179192 -0.671633022270393
-    1  (  5) -0.277949145712574 -0.011863615919937 -0.010374435234627
-    2  (  6) -0.670048686168263 -0.009476206950281  0.097890068097075
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959494414290863 -0.408191876587327 -0.490587797784240  0.038620088951639 -0.077925870525908 -0.487449819239226 -0.107605742375965 -0.396082210854085 -0.237542456199032
-    1  (  1) -0.404346098969015 -1.325089706115945  0.174671472615795  0.248857938939654 -0.197997176299344 -0.317531715369510 -0.251443125494019 -0.030205216051526  0.632709778669922
-    2  (  2) -0.488203594414096  0.174177358170181  0.686637133275358  0.342440322128134 -0.009976595906060  0.483509687591480  0.287263685741040  0.302820486761619 -0.272146504988732
-    3  (  3)  0.037519851932744  0.250891430235972  0.345028453615760 -0.288802596502157  0.242048997262005 -0.302155533583566 -0.510767048111895  0.184742116191421 -0.216988138473829
-    4  (  4) -0.076335128439655 -0.199690457337249 -0.011287590259897  0.242287343472375 -0.131826185478723  0.385784652335424 -0.241579744319049 -0.375155233716569  0.062534851979750
-    5  (  5) -0.485786339572480 -0.319069045647666  0.484028655874751 -0.298894130368339  0.382592029688619 -0.557110750088232  0.333239304019222  0.111824333667385  0.019820080095697
-    6  (  6) -0.105004388042450 -0.251919494300284  0.289657780268665 -0.510934745583747 -0.243423593715404  0.333487274729421 -0.859815579894716 -0.040189411214490  0.015976724219770
-    7  (  7) -0.396742866204475 -0.028527583501468  0.303542401120437  0.181332247012458 -0.373287106593945  0.109028339876173 -0.042483577229020 -0.424450995877430 -0.165337209178976
-    8  (  8) -0.232477111217568  0.628541780993326 -0.273469783503661 -0.217890852518759  0.061988654737634  0.020919866007563  0.015643111904890 -0.165546891359501 -1.139952791754352
-    9  (  9)  0.005546163403777  0.056122031350978  0.162961042742066 -0.082482781173148  0.072908205250711 -0.108799436968507 -0.023533780380778  0.044777427042681 -0.147235448199837
-   10  ( 10) -0.006901975709222  0.054429650490004 -0.040577693872421  0.341755839709625 -0.179734725561089  0.323402736691826  0.128204737160702 -0.274641710567075 -0.052505646555500
-   11  ( 11)  0.095370531310643 -0.102133079874740  0.068438122875491 -0.163729824989551 -0.155636229704599  0.243225496644137 -0.456632637964522 -0.005300419866762 -0.049825612054664
-   12  ( 12) -0.031656876480324  0.049261490140928 -0.071615793822912  0.132066208561300 -0.108599421258577  0.096544859699582  0.079601642520223 -0.086582876221009 -0.054558080822574
-   13  ( 13) -0.055177843918689  0.125972146875366 -0.045925897173261 -0.019932953437905 -0.072414580136130 -0.032514397877207 -0.014074648780379 -0.073540469649077  0.566252900794774
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006844108037305 -0.007417708485432  0.096179215271909 -0.031845351907952 -0.055819107034905
-    1  (  1)  0.055009072408372  0.054764569974465 -0.101360748266647  0.049483066032708  0.126311659941349
-    2  (  2)  0.163126461717715 -0.041474056730542  0.069773970511485 -0.071604513134729 -0.045921679797623
-    3  (  3) -0.081145867550878  0.339512714763498 -0.164814632361136  0.131963409806733 -0.019701057447459
-    4  (  4)  0.071392957638917 -0.177541925322340 -0.155855587434776 -0.108549913772844 -0.072788709838574
-    5  (  5) -0.105620913909823  0.324570384536922  0.243426148668966  0.096676164465062 -0.032493241135613
-    6  (  6) -0.022622971576123  0.128555788054646 -0.457558865820389  0.079424640656347 -0.014304063550758
-    7  (  7)  0.043872369029000 -0.277428590499607 -0.005167508600307 -0.086808599804727 -0.073543295023523
-    8  (  8) -0.147656701585296 -0.051770671721883 -0.049464276722939 -0.054622357068261  0.565518286432945
-    9  (  9)  0.072058098581738  0.045414939179581  0.010276622684317  0.009607329011719  0.026546654266797
-   10  ( 10)  0.047972578248001 -0.139091273135487 -0.006969817312947 -0.101924439794117 -0.021963395913837
-   11  ( 11)  0.010225949518788 -0.006903254834441 -0.093461448932079 -0.006458623521931  0.037408632154768
-   12  ( 12)  0.009659072763445 -0.101989750292791 -0.006543886552569  0.055499957258899  0.004536647288292
-   13  ( 13)  0.026525022859872 -0.022073627181822  0.037503294944025  0.004573821056446 -0.064450805660415
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.531729549886336 -0.787699013260711 -0.218007437963115  0.182768764967355  0.602768885926282 -0.199812958117875  0.029032839745446 -0.008774056557020 -0.142478600997377
-    1  ( 15) -0.793340915328507 -0.320131124132642 -0.162653978535479  0.058649157291271  0.020639907683380 -0.223525268439364  0.107699068558597 -0.353783645623565 -0.095871343640249
-    2  ( 16) -0.212191388052973 -0.164888118017383 -1.296946785661586  0.042300146112855  0.273826728839961 -0.438781481182550 -0.122091204716331  0.097191959044978 -0.140871391153818
-    3  ( 17)  0.179719553134575  0.058669914491576  0.044506714025033  0.293003077614387  0.349110568675538  0.303215667162520  0.076915097449359  0.005807473712119  0.013837821467220
-    4  ( 18)  0.599360800493505  0.022132908209847  0.274035423937645  0.351223850237559  0.210864723100271  0.044675310303964 -0.438675626813631 -0.490920343842280 -0.399212333009756
-    5  ( 19) -0.200407898503427 -0.221431932840866 -0.440102897905119  0.305762109213035  0.044881546181680 -0.117472965844256 -0.191665223291193 -0.319783714572763 -0.359452162382458
-    6  ( 20)  0.032165821117665  0.105941691907444 -0.123879210125596  0.078979233990767 -0.440650088275849 -0.189889145121464 -1.110705925194973  0.246906737793532  0.255259757334054
-    7  ( 21) -0.008321241705322 -0.354528191467819  0.096628486245017  0.006334262611286 -0.491255100347697 -0.318969662674755  0.247541587785853 -1.005004062277624  0.329386657154203
-    8  ( 22) -0.142962699223523 -0.097023037413530 -0.141097052846409  0.015166149439238 -0.401326717044742 -0.359426368362030  0.255258622579642  0.329097335449191  0.052132117322068
-    9  ( 23) -0.219955098740499 -0.249965476004892  0.576414624728276  0.098982863369343 -0.020508824733562  0.097549190747026 -0.059941456738195  0.014715712854362  0.155030958604457
-   10  ( 24) -0.078889746445527  0.108239301318897  0.027162587747058  0.046514963820383  0.091370815063919  0.113422647703527 -0.170202961400925  0.302110584863863 -0.032804637243869
-   11  ( 25)  0.043306270957026  0.032344455295712 -0.179576712827780  0.107307667430552 -0.187560546689518 -0.097222488608923 -0.510712264729798 -0.080025590477581  0.081254866792341
-   12  ( 26) -0.068084805818493  0.217394768160213  0.162482224135843  0.182198793902355 -0.078588038008432 -0.138375144701558  0.045964808967518 -0.318369645237641 -0.094340949188741
-   13  ( 27)  0.012776338365628 -0.163304628586267  0.065170181095061  0.076353862355042 -0.116471236774195 -0.057100568669669  0.002733328139538  0.275543901650377 -0.101218272889569
-   14  ( 28)  0.072542900570939  0.116082117753815 -0.039461901860544 -0.060056679393734 -0.063442716501357 -0.039954821491213 -0.007431183194753  0.061660754619166  0.127196734189517
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223424944652205 -0.079375640508214  0.044559638332807 -0.069603179695816  0.011608492724546  0.073681298891784
-    1  ( 15) -0.252190810534113  0.107773105664066  0.031929727381877  0.217773765514473 -0.162942254516887  0.115583488493233
-    2  ( 16)  0.579669499848566  0.028398284174976 -0.180764151357445  0.163082238678478  0.065318137383573 -0.039861277950853
-    3  ( 17)  0.098419070380167  0.045497640187089  0.108888066901941  0.182679251676306  0.077063420292993 -0.060270475148176
-    4  ( 18) -0.021657152218187  0.091391477818870 -0.188694941835267 -0.078654463992964 -0.116917635244834 -0.063687461311406
-    5  ( 19)  0.097200061293753  0.112946819841992 -0.096557046310024 -0.138722208764681 -0.057492822647808 -0.039657945432959
-    6  ( 20) -0.058061983715333 -0.170140847494680 -0.511516651549457  0.046153385708912  0.002608094185220 -0.007424017797983
-    7  ( 21)  0.014898598107653  0.302204656416846 -0.080604696411276 -0.318409184220321  0.275439068186140  0.061680442175976
-    8  ( 22)  0.155158381420886 -0.033182129585344  0.080993013335585 -0.094077880752310 -0.101045740908416  0.127069446713644
-    9  ( 23) -1.153500606432321 -0.223848574870770  0.084940142762237 -0.000172697505786  0.401118128913110 -0.346039941954426
-   10  ( 24) -0.224004522828896 -0.014993374950362 -0.013190820033297  0.067266852084061 -0.009898419000692 -0.084301934906628
-   11  ( 25)  0.084246516406395 -0.012971453666469 -0.099638608783541  0.005049425073667 -0.012239639402266  0.023058100761840
-   12  ( 26)  0.000190360752578  0.067412521796060  0.005072007098540  0.014663156532777 -0.012615786454228 -0.021995005158495
-   13  ( 27)  0.401506800485792 -0.009668467136178 -0.012313296328665 -0.012645382168427 -0.008180220628749  0.091135079144539
-   14  ( 28) -0.346436667192449 -0.084407881559674  0.023159285170774 -0.022057721310478  0.091092458906105  0.040126683454989
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057778460125472 -0.058621598376460  0.204961973610432 -0.030014886957090 -0.012702201238060 -0.012361806840327 -0.042464722570110  0.000589178332859 -0.053783176425630
-    1  (  1)  0.588150716074127 -0.466021636272277 -0.203183245475034 -0.148450737716235 -0.057365952908249  0.049828198627842 -0.211650340717439 -0.033709163320866 -0.066014023276544
-    2  (  2)  0.097096715428359  0.013316869335678 -0.075592001791479 -0.184144455632625  0.076454331448205 -0.322693901417435 -0.283033300411692  0.095787940086183  0.009135557725688
-    3  (  3) -0.012585457310347  0.213693355283453  0.008392879074061 -0.006477176275196  0.025095812734807  0.122050564721420 -0.287478867297995 -0.227752050770291  0.025535574433445
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004343658462411 -0.045416781087738  0.000353809954908 -0.008814420994646  0.038608153091639
-    1  (  1)  0.012371345270909  0.037357699916557  0.110010051271464 -0.008428651261313 -0.087698412018729
-    2  (  2)  0.059734573261686 -0.241104936943562  0.080654968743400 -0.004302203609175 -0.010690545484548
-    3  (  3)  0.093269555935925  0.087251850932647  0.210582632378021  0.029543407964617  0.092601662289161
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.096268685878254  0.067598109905927 -0.171831816211853 -0.019892225326838 -0.151432830345480 -0.102828613678833 -0.031328453208212  0.054857782228207  0.045391983457322
-    1  (  5)  0.259548823811751  0.185158249821503 -0.361847535039694  0.121706180799256  0.214912924418858  0.198674927692151  0.082249065771632  0.046754216202716  0.144894234012036
-    2  (  6)  0.316675644828396  0.241534850892174 -0.298024592816770  0.095120602156107  0.117908244615366 -0.011781114685607 -0.451417780640775 -0.113394265201573 -0.193663841427175
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.075217766018101 -0.009009066779016  0.013059078733353  0.023267742031501  0.019382631456242 -0.010439549922317
-    1  (  5) -0.055615787731079  0.073750137089777 -0.094740835467118 -0.066906556461928 -0.087569521638075  0.039832146294917
-    2  (  6) -0.007989421944937 -0.055545532554459  0.206332460425464 -0.056516118698086 -0.025725290779723  0.073743491663517
-
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.034398581574139 -0.022991789103343  0.034442469541574  0.330456382558595 -0.233180601662081  0.129080132683952 -0.099470500295552 -0.033215263141241 -0.017533788887759
-    1  (  1) -0.125193963201420 -0.094056863638828  0.250103765613866 -0.112936578244967 -0.149788194818876 -0.227437707997397 -0.485204338670596  0.001668370995162 -0.115356975205661
-    2  (  2)  0.012233240715705  0.002368950907699  0.032425209658723 -0.111084203408140 -0.039672156088148 -0.068595430902717  0.075952847158656 -0.294199045975953 -0.119345992966551
-    3  (  3)  0.102558388937001  0.078769752966251  0.070643800093594  0.002465923506388 -0.048634367995697 -0.013847332731639  0.279588501721531  0.161409573415975 -0.750269595437933
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.124162189892697 -0.147322676383198  0.023215723712951  0.018481088431889 -0.062726537287574  0.032176124900128
-    1  (  1)  0.077900000614672  0.192270763412161  0.391012068764259  0.097598573976617  0.208812184695007 -0.131278202406216
-    2  (  2)  0.138682144513485 -0.743794268000919  0.082765968014440  0.105416894706173  0.124502895186539 -0.026640226681012
-    3  (  3) -0.046377167184700  0.100266413297349 -0.419637942135347  0.187251279348108  0.523906963118894  0.155125602890936
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.041912647030473  0.112025419050593  0.015709063071357 -0.296474982770456 -0.369528478363753  0.133936885862951 -0.093834818402243 -0.023683854572816  0.145081231878617
-    1  (  5) -0.197308914804751 -0.009979277982960  0.032584585136142  0.110675051536769 -0.043528206747949  0.380347857156503 -0.467872633414304  0.360690381381106 -0.081727457648454
-    2  (  6)  0.017175555719515  0.257070166950214  0.064576654101859  0.063636492651100  0.124214525851134  0.043707573882425 -0.279300768930124 -0.436090246737450  0.143049583009588
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000746191936210  0.015117415730589  0.105376277097060 -0.086551013225984 -0.048055402355572
-    1  (  5) -0.421110018244562 -0.132676872543725  0.513327593087781  0.036293567607712 -0.089362635661765
-    2  (  6)  0.356450473386590  0.161425142060580  0.191834100484274  0.123847982073522  0.439997591973663
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.029996182749086  0.414832297711576 -0.157003165507011
-    1  (  1) -0.055478735634457  0.002196588374944  0.023132699054813
-    2  (  2)  0.030157480407918 -0.003965129810969  0.011365271034479
-    3  (  3)  0.379654970672918 -0.026306776079243 -0.008208478993038
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.031312576109208  0.054324731747600 -0.030004942403624 -0.379837271496892
-    1  (  5) -0.410777629523562  0.000546200526033  0.004395778687124  0.022468424749377
-    2  (  6)  0.155134874665963 -0.021960972132954 -0.010503724381488  0.005891989839471
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.041599393589885  0.048291903336677  0.117743150821259  0.017705215406280 -0.102750295559090  0.051687934108131 -0.132725758102637  0.024528471901836 -0.009589411271459
-    1  (  1) -0.072748330347250 -0.064838255172247  0.046249888316539  0.094886169756313 -0.054353256296636 -0.001900039815832 -0.496484885699642 -0.156782601344965  0.027727244644896
-    2  (  2)  0.003177839573369 -0.021969851213782  0.169948604805852 -0.034169379981814 -0.096419218256700 -0.054353168415603 -0.268581512702098 -0.051387229616377 -0.132183241821031
-    3  (  3) -0.006137248486677  0.083042433269493  0.145748994350269 -0.009514642471795 -0.083396174376552  0.050339592310292 -0.147508653266551  0.025994438523140  0.274243623684456
-    4  (  4)  0.041743411936218  0.025314466729841  0.109116009514395 -0.054695145126701 -0.041005429820194  0.040692158860824 -0.089212628083091 -0.089778026874393  0.379559976718284
-    5  (  5) -0.144052404015687  0.020202343348371 -0.250448180839798  0.333938875810814  0.025165926872358  0.198674007872287  0.028751096000422 -0.150673278776424  0.071892589434733
-    6  (  6)  0.035008068923664  0.061157292133481  0.423122850397629 -0.168586232676417 -0.215300951076719 -0.176816011547681  0.082786884188413  0.107997254201703 -0.322302818265947
-    7  (  7) -0.040302039339094 -0.134662805884699  0.074305590729076  0.347285947244785 -0.297150726695267  0.120577275637125  0.158244548193724  0.221247160594885 -0.027161970952188
-    8  (  8) -0.102303986757075 -0.083520013523575  0.381308184856285 -0.143001282615579  0.075527648534131  0.132398234942646  0.075131991247111 -0.046753082020740 -0.011707789197025
-    9  (  9)  0.017637489191487  0.048428952825929  0.034610320117865 -0.459992261564512  0.414982694469193 -0.130318968246814 -0.031074590688744  0.007719514803475  0.025148594805028
-   10  ( 10)  0.073180570141060 -0.217870134214265  0.063234912206834 -0.261216160873510  0.027363003829309  0.069320876175761 -0.042163326174403 -0.184139514400861  0.015591773535866
-   11  ( 11) -0.219122634582937 -0.188385339460405  0.640855359878310  0.491678336416958 -0.065767561519751  0.413066703397514 -0.291084239981445 -0.093425757726901 -0.193265915162178
-   12  ( 12) -0.256885363420365  0.713325451456200  0.225955555841318  0.439590507884674  0.345303095230338 -0.616947103758895  0.172377723246676 -0.152457697169388 -0.041630471494425
-   13  ( 13) -0.012167367476476 -0.157114215675033  0.156454629287810 -0.271295067840173  0.465831347294122  0.087124608448573 -0.001414398542050 -0.117289965933426 -0.301481262964454
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.150893623694895  0.070181619718899  0.231121270771796  0.047212329811452  0.038360068214684 -0.065024101530573
-    1  (  1) -0.459608701558993 -0.017988718780734 -0.620163221664037 -0.047501992394079  0.054935480129094  0.084306620301789
-    2  (  2)  0.170353437709830 -0.137438184253801  0.448066510819233  0.273677026815508  0.394525740926135 -0.158445088257267
-    3  (  3) -0.027380670374415  0.505626164435732  0.414944314617527 -0.268646310616022 -0.386727191221954 -0.113140672337300
-    4  (  4) -0.013445627632877 -0.536383433584967  0.308426011289951 -0.080146650927920 -0.587918144857996 -0.127182537475191
-    5  (  5)  0.035132080582143 -0.167243745339779 -0.093457222254525 -0.023174375055702  0.241438836836271 -0.025034069681694
-    6  (  6) -0.086275759818652 -0.157794617049890  0.091627759449496 -0.100678024828998  0.039930496632404  0.039747117277017
-    7  (  7) -0.064055657553950  0.320525847624377  0.102126662685902  0.025362375541365 -0.011829791315064 -0.091201427043929
-    8  (  8)  0.004186527107181 -0.116906210612177 -0.371187985035768 -0.069143142950027 -0.337550034775452  0.350111866606547
-    9  (  9) -0.075561519107680  0.174471452153015 -0.018361558412792  0.007353276651567  0.041439267169245  0.006958189017632
-   10  ( 10) -0.027806429179180  0.167045135107807 -0.001907984997949  0.011283070546443 -0.060669265876427 -0.055774837261520
-   11  ( 11)  0.242522311612009  0.043113021308048 -0.036594154697736  0.051685667595428 -0.018454723698115 -0.000828881346793
-   12  ( 12) -0.005035323729735  0.080726831317060 -0.052335499542956  0.044973984976305  0.061396486662391  0.099208229191671
-   13  ( 13)  0.438941651704024  0.153468022162067 -0.023659734102045  0.002885107851831 -0.071809885174399 -0.077694612962715
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.044666447845943  0.075416998324096 -0.002009211971351  0.008745765947599 -0.041041980388066  0.148478826412725 -0.043148497905126  0.040061402921621  0.101604386418633
-    1  ( 15) -0.049162162504633  0.064892835130685  0.021916980092655 -0.084534607702244 -0.027746026910093 -0.020171890051146 -0.060412253106789  0.135461490072396  0.083108283525263
-    2  ( 16) -0.115794665664267 -0.047097729608731 -0.169526813418150 -0.148848835873427 -0.110367886513380  0.250308022536814 -0.421430914373290 -0.072716285234647 -0.379882079141591
-    3  ( 17) -0.016234704461670 -0.093143898198671  0.032604929784834  0.008570214748756  0.053618454434530 -0.336390621280297  0.171051246725478 -0.351382500390790  0.144302708365158
-    4  ( 18)  0.099685614405052  0.053576457156830  0.096408379043871  0.083491653355765  0.040031855455092 -0.023231985357187  0.214146456651999  0.299411639286517 -0.077061465722781
-    5  ( 19) -0.053256491006665  0.003075384449121  0.053515222726753 -0.048399268191864 -0.040795198256978 -0.198132545540493  0.175051498642490 -0.121535923725232 -0.133335441765840
-    6  ( 20)  0.128712692365555  0.496870742485916  0.268871209763746  0.149658569303091  0.086711112842081 -0.028977130072006 -0.083484855541891 -0.156340017572166 -0.079418276499146
-    7  ( 21) -0.026401094602506  0.157512598855912  0.050672592676314 -0.027957891435237  0.092269588876111  0.151809482826698 -0.107865561412261 -0.222862187720663  0.046783186727291
-    8  ( 22)  0.009612639390837 -0.030421923009696  0.129146467815306 -0.272344846639473 -0.379884587515890 -0.072760001001148  0.325598038741842  0.027479294568787  0.012294936872080
-    9  ( 23) -0.149880437140593  0.460631247362792 -0.169664291741312  0.027589402289004  0.011349753598096 -0.033685842546708  0.083139401924745  0.064655346261025 -0.002952710962413
-   10  ( 24) -0.073162117570193  0.020016390706408  0.135536511029942 -0.511692353689708  0.542889881863847  0.170172745263858  0.158312356422075 -0.326976851708720  0.119792799568885
-   11  ( 25) -0.227319331530806  0.618159967248025 -0.448267162037961 -0.415380348389647 -0.307673615218558  0.093264262201907 -0.090383721735685 -0.101137463170207  0.374119595658697
-   12  ( 26) -0.046325835806633  0.048013260965168 -0.272519638024099  0.267929097643861  0.079599126690116  0.023217992764788  0.099878544648145 -0.024929139459656  0.069393891025270
-   13  ( 27) -0.037489883688669 -0.053493928653226 -0.391870980933739  0.384400627963214  0.588279019279798 -0.241045539088516 -0.041562667530972  0.011794273471007  0.337810411804872
-   14  ( 28)  0.063867435849832 -0.083549153123607  0.158471290677241  0.113540200875422  0.127048928726566  0.025106714900888 -0.040372191298617  0.090932947916166 -0.351148385967210
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.018436133716857 -0.072929640795625  0.226474353889952  0.258554501885766  0.015629581468102
-    1  ( 15) -0.048844627710976  0.217699525631316  0.187612863297424 -0.714214561739857  0.155652904029163
-    2  ( 16) -0.036504178760377 -0.064141704639546 -0.642298500392749 -0.226999184132633 -0.158883513257702
-    3  ( 17)  0.464003802662343  0.262951360765947 -0.494608205306355 -0.439690590633845  0.272979507733357
-    4  ( 18) -0.417911613304926 -0.028340434910992  0.067656000741894 -0.345749519725828 -0.467548326168384
-    5  ( 19)  0.131287835524258 -0.068639225223597 -0.411512073768996  0.617585289861537 -0.085587328981715
-    6  ( 20)  0.031740361337335  0.042325765757491  0.290709707718165 -0.172790703648515  0.000532545780898
-    7  ( 21) -0.011558038421621  0.183385354532032  0.093657523746171  0.152317012205746  0.116530260167129
-    8  ( 22) -0.024591234247673 -0.015437963416840  0.192723206306395  0.041545920874624  0.300722952291357
-    9  ( 23)  0.076860307291410  0.028222730174457 -0.239744246838648  0.005401314981702 -0.437602472364683
-   10  ( 24) -0.182325175721446 -0.168262818970868 -0.041985084407523 -0.080814437382504 -0.153682650364464
-   11  ( 25)  0.018251396178258  0.001487318511567  0.036744565685453  0.052466578072734  0.023330767494251
-   12  ( 26) -0.006994832022894 -0.011312050265967 -0.051710399870511 -0.045052170184275 -0.002799991775595
-   13  ( 27) -0.042051003701905  0.060322036458563  0.018224376602008 -0.061574434209411  0.071889000854515
-   14  ( 28) -0.006898519418229  0.055936666673248  0.000904652270607 -0.099150038783025  0.077924550244227
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.024746315003693  0.016019947683600 -0.033657454181441 -0.314697310181057  0.226266938924475 -0.124444118187600  0.100976019942115  0.040776992946741  0.016684212809041
-    1  (  1)  0.134389185453098  0.111083358436336 -0.277285327152191  0.119300944830562  0.165892793225342  0.243843028361365  0.522257860139305 -0.003856507813829  0.130032133651498
-    2  (  2) -0.005712363782982 -0.008727960227379 -0.039141212770465  0.103639199943747  0.051337772042530  0.071715964883614 -0.083650082880478  0.323814625304121  0.126954317090625
-    3  (  3) -0.081293710540179 -0.115829551524333 -0.096804246842583  0.012689929096652  0.055158220665324  0.020215225885504 -0.309792669510693 -0.175501033742058  0.786497084573792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.131346722870458  0.163299814747146 -0.027069647322617 -0.020320497257903  0.063430953058875 -0.031962758863077
-    1  (  1) -0.087630835970581 -0.216123500984143 -0.418559649023597 -0.101182356933807 -0.219334050753127  0.138730916232525
-    2  (  2) -0.150883742374018  0.808729391001562 -0.082068044594556 -0.109718430012718 -0.126065481544348  0.025072338478445
-    3  (  3)  0.037377902285561 -0.112570729969231  0.441791115721159 -0.197182836023279 -0.548068009411335 -0.161473931329561
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.035230659308422 -0.106839323325161 -0.014678428381540  0.286556627519623  0.361604275339255 -0.140599935526212  0.104171301624044  0.023270847691008 -0.152469667501182
-    1  (  5)  0.205844940105254  0.013703890486825 -0.030101864871895 -0.113405292167378  0.067278306831822 -0.396432225285843  0.507639566286884 -0.374194080683992  0.087133202725049
-    2  (  6) -0.008020887713167 -0.297537793700841 -0.070946233356648 -0.062333784651526 -0.130550836206602 -0.053406231056288  0.297352200120301  0.465262963875225 -0.160837314824145
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001388437190181 -0.015460041565487 -0.116558611446075  0.083788280005113  0.046694291841919
-    1  (  5)  0.445165309099416  0.139286068687201 -0.540190784438892 -0.030841865046205  0.087779833305208
-    2  (  6) -0.377644271326903 -0.173431493737049 -0.206412471480948 -0.122708702224090 -0.459634387384366
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.059484933862835 -0.014840374750558  0.035360338576360  0.173310409629633  0.059725101605321 -0.257184966477164  0.063490095178001 -0.155623028848452  0.002426177597214
-    1  (  1)  0.228582316542215 -0.259588493824183 -0.059979506895381 -0.002310310036236 -0.214166554941788 -0.116943892441225  0.108842892801007 -0.344598351692938  0.046446999584419
-    2  (  2) -0.320448650163398  0.500204746721717 -0.049266542548722 -0.152597804353277 -0.167277822949482  0.193147703880440 -0.032524845682255 -0.036762728768834 -0.080681033267355
-    3  (  3)  0.009703572292968 -0.082952949000966  0.090825897592600 -0.068137067278425  0.068002795336981 -0.155982720923085 -0.189371220312700  0.353775834732784 -0.023853285599523
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.026559166873629  0.005391969117388 -0.002011264512932  0.046870885231393  0.012715635371485  0.026571877043427
-    1  (  1) -0.038988897688016  0.019721374639789 -0.014060753119275  0.430701935913609 -0.259024740507495 -0.161810701507464
-    2  (  2) -0.100083737029750  0.093431068521730  0.015885697887836  0.259560607774115  0.146766142473160  0.593605654650708
-    3  (  3) -0.130235873557485  0.844890867177988  0.085670264124908  0.093010825973034 -0.012325537516171 -0.119484996772910
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.011411967833044  0.019523193555091 -0.029394421691951  0.441924368380274 -0.383516159929503  0.004430337133144 -0.015018368377510  0.081006354989878 -0.100709067945280
-    1  (  5)  0.015106432068076 -0.115430718880751 -0.094613417260511  0.153153896682510  0.130891773654437  0.255513104617105  0.100481979342603 -0.182641502384039 -0.046231419137374
-    2  (  6)  0.045469725116844 -0.216512507684084 -0.240553163844151  0.059703803473819 -0.128799103778847  0.466867168048645  0.230376363698085 -0.268754231533815 -0.029632489718661
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.031283386269007  0.083595055179233 -0.003915100351561  0.081115225653286  0.074158142938438
-    1  (  5)  0.011556443169135 -0.036659881745781  0.006532048558871  0.596174583603508 -0.114916319653540
-    2  (  6) -0.066233849453724  0.593708066141070  0.047160183567134 -0.205443006234017 -0.123500019606919
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.278545233415530  0.059599409615732  0.026034432106375
-    1  (  1)  0.187007295905470 -0.038238309701257 -0.175982197292767
-    2  (  2) -0.431926204916829  0.006084496586666 -0.049694339002754
-    3  (  3)  0.039723645794201 -0.196249784920444  0.036043663433459
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.275546881197932 -0.180389519378317  0.425074243400924 -0.037767422186350
-    1  (  5) -0.058081529209830  0.037390441931729 -0.000516662884118  0.195055591570635
-    2  (  6) -0.026038612826744  0.173019988726883  0.056080139617911 -0.032715759186560
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062756867817297 -0.201112023907446 -0.056048025131715  0.046055783450926  0.033806686060762 -0.171722205176695  0.081098506544458 -0.087289620763258  0.042152324091961
-    1  (  1)  0.113018477232488 -0.112319744349513 -0.016834583533921 -0.057284464999085 -0.226208700821363 -0.112272688334417  0.062097026682019 -0.556436717149114 -0.098351092785228
-    2  (  2)  0.050464428261919 -0.043116595966000 -0.019513144045664 -0.037294003656203 -0.049535289314410  0.026512882856009  0.020955734915841 -0.396348457994657 -0.049143039709126
-    3  (  3)  0.026907740943173 -0.173985640449646 -0.354309597307579 -0.088737881833013  0.026690278443481  0.192249138616519 -0.023099922234093 -0.151104956103080 -0.187993798800110
-    4  (  4)  0.028814397262738  0.124011423960611  0.200563657745864  0.022231046170139 -0.001789869716556 -0.223408416821475  0.102318476102237 -0.153384891973446  0.236674672698061
-    5  (  5) -0.088145317682978  0.132491290238854 -0.182899281954052  0.186746219907929  0.187197714495176  0.005898923884498  0.002120811015656 -0.021990162397056  0.123551537605536
-    6  (  6) -0.024460586881498  0.068797047909759 -0.142150384104535  0.131743429120178  0.105639058982537  0.045294852609385 -0.029270704887015  0.020804211601159  0.117878860256254
-    7  (  7) -0.033776769859701  0.354245094845972  0.243166450499757 -0.029612149638602 -0.008896656564269 -0.116804879825504 -0.018695560701790  0.326627365972202 -0.206018976643332
-    8  (  8)  0.143077917661487 -0.151560533054490 -0.301409236473389 -0.100740265108897 -0.039290343645488  0.041763953575394 -0.058170430215780  0.076845206100452  0.024633152032860
-    9  (  9) -0.347018728951025  1.079771981804557  0.078138529282464  0.501451378510505  0.195061660317550 -0.758451032278065  0.096995118436252 -0.075303195155611 -0.028459788963157
-   10  ( 10) -0.223810118885824 -0.056979536028989  0.716810245770532 -0.128868097994349  0.539754687175803  0.113296255679437 -0.098974782607496  0.009049828893309 -0.202384864538250
-   11  ( 11) -0.022769270154477  0.034674358156828  0.014405983056596  0.017571848532967  0.048691998407531 -0.015583395228223  0.114409081561630 -0.021951676689174 -0.044426938305339
-   12  ( 12) -0.135981286187464 -0.120998241259176  0.262301521327982  0.750392323278277 -0.334209910038890  0.448078191688466  0.024767148532186  0.115571945209708 -0.066264929381116
-   13  ( 13)  0.080577472282162 -0.105823730084873 -0.089794541855267 -0.254940117418226 -0.138440117204762  0.236499087990863 -0.038859436706735  0.192105181610312  0.090975801731982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.032425074737930 -0.078425462405257 -0.011344832045570  0.197456331002049 -0.134718406025863 -0.096409404413494
-    1  (  1)  0.173273250041635  0.433566222378215  0.007405001112899 -0.457114065135928  0.172943454488407 -0.008895375735183
-    2  (  2) -0.109774013784441  0.217911727490325  0.003528460413992  0.763520159635318 -0.225537275802117  0.118975501733302
-    3  (  3)  0.036378102698420 -0.454361087703980 -0.077915823523940 -0.013309796680696 -0.234332299564134 -0.507177620624500
-    4  (  4)  0.092551473116606 -0.475045168698850 -0.084968775693714 -0.026919469339922  0.202750989391175  0.617924078766471
-    5  (  5)  0.097554141145429  0.018018586167576  0.079671555600775  0.092305854243185  0.173736284561078  0.411194160500052
-    6  (  6)  0.003414072729569  0.093327360188558 -0.085627914021145  0.078229939466915  0.111156480724274  0.178796621382799
-    7  (  7) -0.114277067577274 -0.105960426671338 -0.044841696220246 -0.134585263057439 -0.180631730229559 -0.229243957069555
-    8  (  8) -0.037886837147022  0.102808395063350  0.069798483920400 -0.254580996722497  0.401920559110064  0.147751839658310
-    9  (  9)  0.010988821514225 -0.007410444750660  0.002972535589617  0.025318418426566 -0.448643260566270 -0.804372772080077
-   10  ( 10)  0.261244020497494  0.038064665016323 -0.048636140959014 -0.326624772892826 -0.029954423230419 -0.215793554756145
-   11  ( 11)  0.048015789596366  0.069114116273897 -0.007572832400964  0.004238339483900  0.020816591473394 -0.043178136132549
-   12  ( 12)  0.214695948487578 -0.274288590232604  0.016230298683875 -0.029548384872336 -0.038140072907363 -0.033057792945377
-   13  ( 13) -0.275326653840915 -0.061284883995154  0.041285946542463  0.084706584831174  0.090480508761559  0.181791085214834
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.063850422313355 -0.115683680262588 -0.054827490001665 -0.028354117168169 -0.025100127178731  0.096410771095777  0.028664016097217  0.026051889825173 -0.141339706448534
-    1  ( 15)  0.201263187433031  0.111831464020197  0.045175609028392  0.180549663650845 -0.130383086147566 -0.135646922045465 -0.070781303898657 -0.348002287778712  0.148260195426479
-    2  ( 16)  0.055113649368610  0.018738606654586  0.020705966421020  0.355086450538750 -0.201294850701097  0.180112010383658  0.140523266780582 -0.241544163680772  0.300925921088622
-    3  ( 17) -0.045920336133779  0.057784764027644  0.035886357056501  0.088932856294833 -0.024235675752436 -0.187147654830588 -0.131361762793480  0.029658114101546  0.101263553912617
-    4  ( 18) -0.035958486319751  0.227134777791688  0.048687972069102 -0.024933262428833  0.002173989672721 -0.187305076269607 -0.105829902417925  0.008056867875506  0.037853803971042
-    5  ( 19)  0.171149922579415  0.110039862501994 -0.026813452459140 -0.190061024816887  0.222174491954054 -0.004093825553016 -0.044188302806112  0.116881315421755 -0.043225291916047
-    6  ( 20) -0.080019590838700 -0.062262232462848 -0.021096034332220  0.023057305471526 -0.101639862804641 -0.003152213311187  0.029422735136868  0.019240780036951  0.059315335454636
-    7  ( 21)  0.083510548402123  0.557993066791473  0.397235243356208  0.151190399349717  0.153637137534004  0.021828958802507 -0.022025876078118 -0.327175118374607 -0.079618949429238
-    8  ( 22) -0.042227049954364  0.098944758472646  0.049249083184483  0.187848524484403 -0.236611254443533 -0.124376089369001 -0.118097176171872  0.206089300936335 -0.024158581021498
-    9  ( 23)  0.032033977750932 -0.174724865726956  0.107565757409839 -0.033957075679687 -0.093408693176877 -0.094735950835808 -0.001596176802057  0.112245900387886  0.037372397271166
-   10  ( 24)  0.077636129797919 -0.430853371998705 -0.215233761055940  0.452386714098273  0.474453371679467 -0.016809820271846 -0.095741323886920  0.105100659091080 -0.104107445539310
-   11  ( 25)  0.011149970874610 -0.007035579685386 -0.003127573400518  0.077702883164627  0.084954198370187 -0.079818042644370  0.085248456841504  0.044951104587653 -0.070017705668783
-   12  ( 26) -0.193344086617498  0.456776432013422 -0.761441366858404  0.011910497712878  0.026326742647963 -0.092364226349286 -0.078937949371178  0.136041391718326  0.256815257193465
-   13  ( 27)  0.133610614090005 -0.173243160128294  0.225605563113523  0.236498022568823 -0.204477528431671 -0.174386164144365 -0.111604362943586  0.182311312483583 -0.403964555885563
-   14  ( 28)  0.098101278195306  0.007008756260166 -0.117389775367317  0.511914224685440 -0.622957281459333 -0.412506446069418 -0.179820830724467  0.234600868408507 -0.150158824761841
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.343234558725567  0.228637063726269  0.023307266959502  0.140382240172792 -0.083235444793760
-    1  ( 15) -1.074711095873744  0.056336734854343 -0.034809000083236  0.121348785991751  0.106814989655091
-    2  ( 16) -0.078219304152202 -0.719658957943986 -0.014720519366158 -0.261816502529916  0.090881991750144
-    3  ( 17) -0.502805356071942  0.131166561688672 -0.017463933389579 -0.755157521149267  0.255568620797102
-    4  ( 18) -0.195634688856887 -0.541360385537898 -0.048854453075291  0.337587696841954  0.138455603989787
-    5  ( 19)  0.760143596830987 -0.110879995008927  0.015821843299894 -0.447903356003643 -0.237096867164475
-    6  ( 20) -0.097106884263887  0.097545405975693 -0.114437354251730 -0.024000531999102  0.039042927829059
-    7  ( 21)  0.075531866838301 -0.009858499302833  0.021730854579213 -0.114681897686178 -0.191988442177111
-    8  ( 22)  0.027711318590147  0.201621760195186  0.044350251642364  0.065874285776240 -0.090522977876112
-    9  ( 23) -0.011879012685435 -0.258606547469066 -0.047776074363499 -0.213401932184194  0.274704590606944
-   10  ( 24)  0.006858605937754 -0.038088449389244 -0.069395356141264  0.275242327171399  0.061260041265231
-   11  ( 25) -0.002890089589219  0.048355005791387  0.007521454792553 -0.016094295989108 -0.041236148462184
-   12  ( 26) -0.024624287461246  0.326411349050862 -0.004226520020176  0.029493735437593 -0.084692672982552
-   13  ( 27)  0.450726956342698  0.030201266401628 -0.020823649440091  0.038233714612970 -0.090500946858406
-   14  ( 28)  0.809945076459086  0.216752990291181  0.043269372622044  0.033145255679139 -0.181828971805248
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.063013364696514  0.044010513010140 -0.033832526224211 -0.162024471696236 -0.051333545713143  0.246461238669107 -0.063609486603270  0.159478583547076 -0.006207989114076
-    1  (  1) -0.226546037179395  0.291390639777102  0.048328229754705 -0.000396116910678  0.216137862922779  0.115706811352044 -0.113227048986677  0.363481206263983 -0.049424206162689
-    2  (  2)  0.353995982753623 -0.570067383955282  0.052742449525010  0.144888216829452  0.158139021131471 -0.195548321941560  0.035681653601236  0.044365181477906  0.094047723024953
-    3  (  3) -0.014909685853208  0.093363165202933 -0.099368126188753  0.092807318931361 -0.081502054050149  0.166990973951771  0.201832262285607 -0.375763253843030  0.022961121211245
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.027461792188467 -0.004811887789740  0.001758716793345 -0.052146222606019 -0.015489645876144 -0.034542443930348
-    1  (  1)  0.038878540290940 -0.018432422578327  0.015238310520594 -0.445890608944474  0.276103308767449  0.178613718171164
-    2  (  2)  0.112212317864169 -0.097070429592677 -0.017583930410099 -0.264050273165228 -0.167988430449652 -0.635838792277428
-    3  (  3)  0.134391135826268 -0.880500790171335 -0.088985519620608 -0.095884376650580  0.014499630081693  0.127955545332533
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.037904901187616 -0.025077601146789  0.027398631479947 -0.443691662113588  0.381793026485785 -0.022010734273084  0.009578999727395 -0.091037438378063  0.103637073384889
-    1  (  5) -0.010563786544947  0.113947073526168  0.106465996568323 -0.155511131041724 -0.116554544974583 -0.262895686214063 -0.105092877292920  0.193457955253204  0.048498356991785
-    2  (  6) -0.044887612702522  0.228580277279931  0.273604650547313 -0.078952413042729  0.139355988549377 -0.486362168413732 -0.239519122057504  0.286842566968737  0.031193390212920
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.028779621541873 -0.090907914561767  0.003460105941843 -0.087167181054995 -0.071921470779774
-    1  (  5) -0.003930295039018  0.035914981429889 -0.006741878538669 -0.611390099224952  0.116946571666512
-    2  (  6)  0.076298500757009 -0.614894877751711 -0.048926788565139  0.209608637563865  0.127192306297029
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.068337016677695  0.096446452026756 -0.360475449331991  0.092239288371853  0.026203678917511  0.022509846886799  0.073478827117419  0.022464061625998  0.227372488621395
-    1  (  1) -0.348245092774866  0.473201941683207  0.285296343579762  0.183481268326088  0.077575420562874 -0.072099125969722  0.272473569856386  0.064219415204321  0.197165880719729
-    2  (  2) -0.067585908335283 -0.050372922133506  0.060758167744452  0.207525430642987 -0.124589544508062  0.366296688963713  0.319501792505756 -0.144609263799336 -0.034557292153017
-    3  (  3) -0.003490778097580 -0.176771187112973 -0.057522831103622 -0.000116418648382 -0.000778288019112 -0.154495740627781  0.307263828587522  0.311985415435969 -0.072067405458553
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009055593070151  0.169294476018032 -0.004376707873729  0.043035427357302 -0.152530590698355
-    1  (  1) -0.043732146257221 -0.133230210157229 -0.321492959581682  0.026647195860165  0.380687102934580
-    2  (  2) -0.166530147628729  0.613643715672385 -0.216790209047481  0.084469048804484  0.070950252851931
-    3  (  3) -0.193623455804687 -0.188085387663198 -0.577128561869679 -0.079182256640786 -0.329374829305157
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.094184605186671 -0.056664612816556  0.249611394657184 -0.001240336497952  0.251113263182976  0.167204841127316  0.053738355395826 -0.110451910693142 -0.110225244293220
-    1  (  5) -0.138889396111012 -0.115961679782817  0.323179744158626 -0.121252123207265 -0.292076432419815 -0.241576686510115 -0.062989099171507 -0.028273376478118 -0.195878521271564
-    2  (  6) -0.158880157678560 -0.136139940912615  0.265648578874291 -0.093877387268260 -0.142453752235908 -0.054140913517762  0.560779480954688  0.138233927899815  0.254132036688695
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.293992892729715  0.040800750956591 -0.057675088119180 -0.076602392465323 -0.065335333102758  0.026360508286139
-    1  (  5)  0.140101157166617 -0.119683195321807  0.266691635597033  0.245738117504136  0.344104644828940 -0.220704301441665
-    2  (  6)  0.056921768258958  0.103403744090827 -0.598429877431589  0.146214200734754  0.059974751023664 -0.323525482450488
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.001194434516926  0.365406825873877  0.191112170654786  0.072953190005452
-    1  (  1) -0.363385965896555  0.001278838882578 -0.019794428206453 -0.015546405496121
-    2  (  2) -0.188455836576036  0.023464280272920  0.001313653362102 -0.003971811529941
-    3  (  3) -0.071937190909342  0.014204649752708  0.004012943205250  0.001742183215196
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.002207002387747  0.099036313248809  0.350070270006789
-    1  (  5) -0.099717351351760  0.002187155419577  0.000406257568929
-    2  (  6) -0.350175744645045  0.003726626970778  0.004104233297166
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002966254715231  0.240855988266728 -0.015168347488530  0.064366755524788  0.058337095528916  0.095917557609408  0.080552351010748  0.173850272969471  0.326738509325595
-    1  (  1) -0.236928751733350 -0.000606734226053 -0.349434191365712 -0.093200906311076  0.041406943350823 -0.069404274429693  0.288704930708582 -0.111892041376425 -0.888816026581642
-    2  (  2)  0.015227164699160  0.348726210567974  0.001624946372493  0.082520881475572  0.073422056547723  0.232856655438329  0.287989353510736  0.229619697744185  0.234594833443005
-    3  (  3) -0.060136079807310  0.090244643623410 -0.083460850918858  0.000190675057493  0.021666820127845 -0.049054167667433 -0.003318783332088 -0.014942478625699  0.184116482215884
-    4  (  4) -0.058810580653892 -0.039254180139711 -0.072185299720667 -0.023983542956374  0.001162617768289  0.085082802307878  0.048921193420164 -0.153382943802422 -0.107278309526120
-    5  (  5) -0.094673430029074  0.068328286783388 -0.231594556891859  0.051852594552707 -0.087895099396058 -0.001022706922957  0.009481397805757  0.039804866070152 -0.148588908121843
-    6  (  6) -0.077478276137780 -0.287498549855759 -0.285112820054957  0.001996885796048 -0.050199534762013 -0.010169007281739 -0.001566818575017  0.173488828459951 -0.045840640430952
-    7  (  7) -0.174574943301410  0.112673533261648 -0.229919171659831  0.014304085765577  0.153548872211132 -0.035649109336757 -0.172043564633104 -0.001747195829410  0.038631522766057
-    8  (  8) -0.326784468679605  0.892435693037357 -0.233569726528789 -0.184065381075518  0.108484932678938  0.147374626265501  0.046903987933936 -0.038178109185914  0.001735751957207
-    9  (  9) -0.006821679719377  0.058926743509393  0.208367267805622 -0.285685508477399  0.014180918165163 -0.077838258063458  0.021878341498618  0.053464078274748 -0.072201437911745
-   10  ( 10)  0.009056199429691  0.188962532231488 -0.202934615692329  0.587329922811144 -0.635977084568857  0.025679043651857 -0.020098430100480  0.176535847273173 -0.134249054850628
-   11  ( 11)  0.122433619087449 -0.184482339508693  0.564618465141536 -0.437678405523193 -0.566648296764866  0.293188916460713 -0.283810265313721 -0.077678717328954 -0.171076053515931
-   12  ( 12) -0.036292153208947  0.108484898349320 -0.145104583947026  0.147429251741648 -0.198788533301527  0.103598496618116  0.121175312167554 -0.030985473315147 -0.001761958158343
-   13  ( 13) -0.133923970852792  0.204871678949702 -0.411285239061003 -0.299554669797709 -0.284169606525854 -0.162383457794127  0.004545044711178 -0.249571768159739  1.096350485902953
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006556329110841 -0.006088586386751 -0.124678079831954  0.037126112155215  0.136830700261450
-    1  (  1) -0.060788036015694 -0.191479282295534  0.182968697985886 -0.108878994177096 -0.206615313543699
-    2  (  2) -0.210374331017044  0.203724330933666 -0.567874430260769  0.145071803402332  0.411903076822992
-    3  (  3)  0.286917147696723 -0.581979187814224  0.440566780256406 -0.146724205480600  0.298411655566699
-    4  (  4) -0.014298727005834  0.630110791185791  0.567066919718617  0.198113213886521  0.285451610676776
-    5  (  5)  0.081474334265114 -0.027014198849763 -0.293476840962639 -0.103773751793710  0.162461435377736
-    6  (  6) -0.019534299275936  0.018969452720832  0.285789804049686 -0.121256569831033 -0.003481312727309
-    7  (  7) -0.056370622889280 -0.170673347832600  0.077097071581232  0.031742893248721  0.249704021902801
-    8  (  8)  0.071994852203822  0.132015517717158  0.170148143024151  0.001951350044678 -1.093751141653295
-    9  (  9) -0.000953866523975 -0.167467737198046 -0.013767962244439 -0.007434218290124  0.054780735052675
-   10  ( 10)  0.173318734659126  0.000810695586467  0.044701276287093  0.097338149388905  0.081237613430460
-   11  ( 11)  0.013895240641951 -0.044282356293427  0.000179785703801  0.004575065369641 -0.075680209341763
-   12  ( 12)  0.008279323048061 -0.097099690667968 -0.004296013685779  0.000048011111236 -0.035877871824266
-   13  ( 13) -0.055107661683376 -0.081651595745875  0.075682651530469  0.035936424072868 -0.000029147707292
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.002983283073552  0.069963597569041  0.177874917667998 -0.062698638146301 -0.106213761198913  0.103906931767555  0.039245016352398 -0.108223517603678 -0.012203119212599
-    1  ( 15) -0.072298870307035  0.000296799608796  0.117346282403810 -0.011865025714908  0.081057312629942  0.082184434890961 -0.047411637016207  0.318551609279607  0.030383483166489
-    2  ( 16) -0.171245613988674 -0.116654951277647 -0.001073144643332  0.130649581927528  0.144907410540790  0.208150327953063  0.198240370201554 -0.179277720823411 -0.001547973613629
-    3  ( 17)  0.060703226947660  0.012583282832888 -0.130776798167377  0.000627586286590  0.018993088317931 -0.044159196655903  0.007932945197872  0.099780861993881  0.079859961463087
-    4  ( 18)  0.100987762729975 -0.079245986001353 -0.141690159528846 -0.016637213332155 -0.000279400820895 -0.188760521966200 -0.218195531933535  0.080299124518616 -0.270793478609675
-    5  ( 19) -0.108074704635216 -0.081590264498889 -0.205498810382318  0.045801307693771  0.187063236245240 -0.000710419758875 -0.073671862989187 -0.043877487134678  0.003892010725365
-    6  ( 20) -0.034177446867522  0.046254597520027 -0.201430745227679 -0.005427131993230  0.216675775592057  0.075812938142253 -0.001274951349149 -0.134520130532184  0.103162147021421
-    7  ( 21)  0.109552512569813 -0.319375904304575  0.177972755772711 -0.099543500716481 -0.081539270937629  0.043994632054622  0.133148819770476 -0.000136132680380  0.101451568181800
-    8  ( 22)  0.012932579381132 -0.031214135384490 -0.000281145990656 -0.077687686709702  0.270019497869643 -0.002445122305778 -0.104445784052100 -0.102366601596632 -0.000293374111723
-    9  ( 23) -0.258661075798788 -0.226451306397380  0.883677423513705  0.031877470630129 -0.145903964590500  0.329887844134728 -0.092796308819851 -0.020328633409678 -0.044508005290364
-   10  ( 24) -0.092756800530096  0.166962776711625  0.090732033242854 -0.033047276838485  0.181047632927145 -0.062682569832297 -0.131253772479093  0.125666164674422  0.010098556627625
-   11  ( 25)  0.085247662084319  0.052988724588725 -0.426265235226709  0.453475536447167 -0.668253171471624 -0.144399850217273 -0.422325162892048  0.144483844450738  0.151429271642033
-   12  ( 26) -0.279045843991891  0.538081255792683  0.338024638087139  0.681172358850588  0.181070323444015 -0.460341461990372  0.046122199431924 -0.472432043418077 -0.099681899420099
-   13  ( 27)  0.031769949568578 -0.364837871962491  0.009792757368435  0.264546010179783 -0.131321500070479  0.369805258593067 -0.160328386436444  0.216930526986653 -0.408555062086236
-   14  ( 28)  0.069122236052376  0.228562041286249 -0.181966055883684 -0.129261778712552 -0.172738024644993 -0.293166654576352  0.081465083951240  0.165047538527886  0.415612188545544
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.259003180995999  0.092034359732091 -0.088092444988971  0.283228839847223 -0.027238337345788 -0.074809429137092
-    1  ( 15)  0.226401057047801 -0.167244181564770 -0.051680013843725 -0.539247725941338  0.363958831235579 -0.227197833049861
-    2  ( 16) -0.880204617361986 -0.090080695403138  0.428803021300672 -0.339354335014476 -0.011073919861198  0.184183385405081
-    3  ( 17) -0.032548488106633  0.034116564240178 -0.457440817331429 -0.682846299872809 -0.267172551643223  0.129975094303440
-    4  ( 18)  0.146446220661130 -0.182273160793426  0.671045144484618 -0.180560000424842  0.132242486336168  0.172542944677419
-    5  ( 19) -0.329935957691708  0.062440148449723  0.142514523618445  0.461407225484117 -0.369136535324331  0.291356141625179
-    6  ( 20)  0.095137293654559  0.130985936102436  0.423469417337729 -0.046319908681962  0.160102833893605 -0.080585118835760
-    7  ( 21)  0.020207238092615 -0.126147064104969 -0.143168454940269  0.472622130455173 -0.216404140117317 -0.164767679261412
-    8  ( 22)  0.044837771622786 -0.010451598353546 -0.151184144406440  0.098993252397369  0.407878413312189 -0.414658535507476
-    9  ( 23)  0.001737606134934  0.018616595639929  0.107543267833085 -0.163017051753013 -0.647726175645918  0.636571415515610
-   10  ( 24) -0.017899922228044 -0.000213602824426  0.053374660165807 -0.073998998716505 -0.058121913122542  0.162859588181722
-   11  ( 25) -0.109492695348190 -0.053011202690733  0.000327739740203 -0.000312768703591  0.053080921470257 -0.055086051279352
-   12  ( 26)  0.164160765816315  0.074526437813364  0.000205041264621 -0.000008221388086 -0.003647906535196  0.023090840612045
-   13  ( 27)  0.648519944554920  0.058749585422481 -0.052822010998177  0.003709251683372  0.000103802664845 -0.203134785839326
-   14  ( 28) -0.638592033397192 -0.163371069122125  0.055018466584646 -0.022957117292923  0.203277611770653 -0.000205390113949
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.050918463672837 -0.088577095911626  0.347792606459412 -0.095753675403874 -0.021868934225380 -0.033922841975857 -0.081457049638017 -0.022670295387980 -0.235434049572332
-    1  (  1)  0.382949048662791 -0.528689769706688 -0.299634584086346 -0.202752933016224 -0.082733390999563  0.092422540316925 -0.290813237500084 -0.058004392324892 -0.224615068405588
-    2  (  2)  0.072432527585316  0.056118386776062 -0.040222186558432 -0.242175264454298  0.146547807338018 -0.390266206867364 -0.347025142548880  0.162810044865207  0.041509720616448
-    3  (  3) -0.002509556424329  0.208248007860462  0.062422901369848 -0.007679044749759 -0.008571630545112  0.174062990005658 -0.334967725932269 -0.336081407145288  0.081599082536296
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.010892131457533 -0.184129002689570  0.006516359878994 -0.045872381230752  0.153258318093946
-    1  (  1)  0.044796011029196  0.153644284644512  0.339325263566756 -0.025646141032274 -0.405174708389161
-    2  (  2)  0.178039316366764 -0.664464704148233  0.224969390534104 -0.089440380756525 -0.066874687913745
-    3  (  3)  0.205823412452233  0.203327440636405  0.607212535172871  0.084515912728930  0.343929939556071
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.078798727127085  0.050234519025036 -0.245209481862661  0.005696954168209 -0.236120915868886 -0.165120845160626 -0.059294811018549  0.108390851582836  0.111673906302634
-    1  (  5)  0.155915068579220  0.141324548768777 -0.367116438384255  0.121574775208674  0.314513424545348  0.257608736751094  0.074849697192160  0.032932966046337  0.220860722558199
-    2  (  6)  0.156801606542398  0.183207885627035 -0.298465110849382  0.100930243056436  0.131083210552854  0.050444928584622 -0.606210604165772 -0.146614859921357 -0.248216540567658
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.311128511448673 -0.042835689156568  0.063170810110215  0.070842689432729  0.064570105984912 -0.023339590654715
-    1  (  5) -0.156644000440875  0.124669553061406 -0.274932589468273 -0.248710717987319 -0.361639916876500  0.231627984560414
-    2  (  6) -0.060874079553630 -0.108175278252638  0.629356829293933 -0.147027352951220 -0.067479673265597  0.339908703023576
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016118777276718  0.076689387067913 -0.125264792267221  0.007931013310217 -0.098301937535593 -0.089040062536424 -0.042653189503994  0.143650549015436  0.062698356849212
-    1  (  1) -0.038523460792179  0.325926212074865 -0.217436403108293  0.076210929079432  0.124956744969497  0.049869905306322 -0.256022567536767  0.049219148025195 -0.025163660677602
-    2  (  2) -0.015460259327547  0.182364499530156 -0.081021447104321  0.065186772706330  0.193628085224677  0.090709199284776 -0.144227288852923  0.007154481293498 -0.060483347873675
-    3  (  3) -0.069494321441893 -0.016013992178317  0.169506236224066 -0.050547669997832 -0.177140340538940 -0.181255025833280 -0.201077665225234 -0.109139777586644 -0.215083611892043
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159361864611547 -0.056476108299595  0.034334354535918 -0.068420323850582  0.100698715800708 -0.049820592017770
-    1  (  1) -0.121041364374114 -0.003994619377141  0.190684428167188  0.052070114913576 -0.189028662705244  0.205096915582729
-    2  (  2)  0.013836799939810 -0.073875918803127  0.147901928532532 -0.343158528114237  0.053056478393270  0.086736758175874
-    3  (  3)  0.065392768372805 -0.072388535495378  0.365788807268921  0.156911353062510  0.184439406968008 -0.043117455907294
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095080611028908 -0.132974666952804  0.233475927910161 -0.109077700761846 -0.033619328181737 -0.003336619392380 -0.079318686273404 -0.006541773193158 -0.188514066103897
-    1  (  5)  0.133180554197727 -0.220459497770331 -0.122961007604824 -0.144493780528946  0.034530325126907 -0.144382538755413  0.001565508478524  0.179104189145753 -0.084352671049968
-    2  (  6)  0.305369897772513 -0.245966510909099 -0.171589985467973 -0.288954965589218  0.048536799653855 -0.105233271021501 -0.400024803684154 -0.035818012706252 -0.066124321501178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011358647742863  0.047842821118303  0.011877525445924 -0.012099889406653  0.055702357687979
-    1  (  5) -0.060987538430201 -0.100437160073965 -0.174976176295347 -0.033059202656665 -0.296249624542352
-    2  (  6)  0.156959926194247 -0.053853503787388  0.406665675932452 -0.026462885456154 -0.143060389345537
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.020933994600407 -0.036837370041379 -0.105536213576206
-    1  (  1)  0.298453027380229 -0.115575201783048 -0.255528599615226
-    2  (  2)  0.258793135913466  0.115959940555419  0.442826057795207
-    3  (  3)  0.060024736570871 -0.030098554189580 -0.068752806226701
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019369167440737 -0.299662599013855 -0.261538199445486 -0.060711849430240
-    1  (  5)  0.036904684367184  0.115259605353545 -0.117033018013317  0.032657591929025
-    2  (  6)  0.104769015611942  0.252811001882398 -0.444270078409878  0.069751899589244
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.140264901989733  0.063903836208699 -0.058837720478352  0.099834492513907 -0.059321359064120 -0.159667027697165  0.002087278187155 -0.046204224826822  0.008601023391654
-    1  (  1)  0.090548490120094  0.202601353512521 -0.092021876157039 -0.096539072052076  0.170154281529190  0.083912296322856 -0.509059273187919  0.818772979644944 -0.070828284365831
-    2  (  2) -0.023785290834440  0.356113587695746 -0.273990976839633  0.279080899835077  0.352444630227807 -0.196438091918127 -0.305379232907246  0.066497365309673 -0.201285694555553
-    3  (  3) -0.097000901586890 -0.245927544981609  0.317839114090104 -0.024062116307509  0.214330573426622  0.049574376579038  0.029033713280387  0.054130019251520  0.003096872422290
-    4  (  4)  0.057665969694975  0.180120952217609 -0.233587576455003 -0.044983378670389 -0.207784279042752 -0.114395252588051 -0.123426849025620  0.227078923197640  0.055512731053919
-    5  (  5)  0.215771286107017 -0.314990234779514  0.316883540178273 -0.120867850220651 -0.280144439745990 -0.294187393366344  0.216440287801491  0.200727103538268  0.064432166939549
-    6  (  6)  0.088234371667199 -0.148935506374453  0.366935246390926 -0.011963781822206 -0.214228897418480 -0.110020140834853  0.192637863546336  0.231329350431262 -0.059800681126411
-    7  (  7)  0.046850408794017  0.280155317167354 -0.370918303757493  0.110906122388338 -0.088736250126073  0.146624611249212  0.021132431838050 -0.399622620248781 -0.041122390922446
-    8  (  8)  0.213219122375795  0.108141657808912 -0.632333203738691 -0.072815736912248 -0.035034243651177 -0.162896842787152  0.072787072592851 -0.219123938652928  0.041084573561980
-    9  (  9) -0.053156461400872  0.091068663315953  0.087565530354209 -0.029252405162185  0.135958664144556 -0.072618412616147 -0.001674517036243 -0.447580570679361 -0.046048420321104
-   10  ( 10)  0.217389369502915 -0.434955320268289 -0.409591028918221 -0.322091930890678 -0.032769693001793  0.320487371417185 -0.022524010208261  0.286088771348247  0.028739508255570
-   11  ( 11) -0.043655408036923 -0.078795431314355  0.262179238045958 -0.331516326719145  0.435766491266973  0.063689969335775  0.247099037158842 -0.001834914627208 -0.140224560742036
-   12  ( 12)  0.056091676196041 -0.010888223476601 -0.132073582410605 -0.097444459311610 -0.064913316133021  0.000177701715007 -0.216786241209526  0.136744724942230 -0.129238968566818
-   13  ( 13)  0.037502956248588  0.225853404732459 -0.091597810906130 -0.251988574100633 -0.015208060782166 -0.284415044485862  0.108318027167763 -0.003844624714701  0.367465648248442
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222316043515167 -0.015706219813463  0.082385006687323  0.001598515176526 -0.060473243217389  0.093727480766949
-    1  (  1)  0.559608456549858 -0.123427525882107 -0.153467678522300  0.170334032667733  0.080737466652229 -0.083738891751815
-    2  (  2) -0.169476216588372 -0.033571289044868  0.409164888922183 -0.223598543173703 -0.075034173166592  0.314714537560898
-    3  (  3) -0.116710909315587 -0.019725573527899 -0.283423547853851  0.175125619030571 -0.285157403250330 -0.036616525847272
-    4  (  4)  0.005652624292139 -0.042302085019157 -0.326173261129769 -0.429217689689009 -0.082297928451406  0.119033467524284
-    5  (  5) -0.013435701805302 -0.050340607661262  0.120543829176020  0.018862712789976 -0.153571720838539 -0.076183620287342
-    6  (  6) -0.081289708009931 -0.326406046335036 -0.215268699384039 -0.111421444458008 -0.019027619773839 -0.098888316320561
-    7  (  7)  0.155159820795191  0.099172439421062 -0.073800976886369  0.027692155232150 -0.092694133839465  0.234604646553242
-    8  (  8) -0.037085102415804  0.221081896212579  0.033634728216750 -0.500286732444351  0.749342092540156 -0.380702305205404
-    9  (  9) -0.121604531068674  0.307665948271799  0.063134933207080  0.759313712683920 -0.291120411772340  0.157024245706381
-   10  ( 10)  0.436899181077485  0.180584483336558 -0.427706818265059  0.039319556166540 -0.042977724169090 -0.570262735340486
-   11  ( 11)  0.012744975594807  0.355849153273437  0.014473345977422  0.331011762918571 -0.082407538751978 -0.048301595441151
-   12  ( 12)  0.275248111407278 -0.041018113706033  0.197136817157671  0.114052207324907  0.270934107062802 -0.185007344485103
-   13  ( 13) -0.588095271872907  0.141945816656544  0.099720177389796 -0.418487800295615  0.225864709971247  0.209383142865026
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.136055292355694 -0.095447390079347  0.020092912976434  0.093125301806220 -0.056850399225407 -0.218468169087224 -0.091857234706707 -0.045161486852285 -0.214714486134322
-    1  ( 15) -0.061207776400221 -0.202708633629203 -0.353114471023019  0.245649376419509 -0.180866138364055  0.315320438007609  0.149515492263402 -0.279091224397235 -0.106858935875576
-    2  ( 16)  0.054684214245548  0.094025065222631  0.275943577798576 -0.316343751367853  0.233336305598421 -0.315879985031554 -0.365377908227226  0.369960150477034  0.630562926717983
-    3  ( 17) -0.098691998170038  0.096665834479755 -0.277640044986255  0.024005765248171  0.044522040617363  0.121507599385942  0.010509659584452 -0.111862233831111  0.073060388343777
-    4  ( 18)  0.060773979545103 -0.171895263117879 -0.351151470699543 -0.213576840796561  0.206989754617355  0.279451579746568  0.215385933896327  0.091082110140094  0.034953691198189
-    5  ( 19)  0.161690364133666 -0.086139117701405  0.195608563911700 -0.050196750893511  0.114409300434365  0.293302924591731  0.108870291716062 -0.145705855705796  0.162864209989072
-    6  ( 20) -0.004933077734451  0.509112916459710  0.304189657786548 -0.027011307788327  0.123564513171828 -0.216326146660916 -0.190918994832488 -0.021599458243800 -0.073921971953618
-    7  ( 21)  0.046939300208702 -0.818898745115203 -0.067231269443300 -0.053385434393296 -0.227366778650237 -0.200959323300597 -0.230355491785385  0.400408400878960  0.219890208910705
-    8  ( 22) -0.008875208231352  0.070617448884289  0.201028236092674 -0.001986037102761 -0.055524570746341 -0.064229773357339  0.060955407810688  0.040899342701131 -0.040928237624119
-    9  ( 23)  0.222811666664924 -0.561652381203117  0.169673185845513  0.114995614482548 -0.005558626156144  0.012604855943771  0.079125943676940 -0.154935461007958  0.034774271928086
-   10  ( 24)  0.015658264689240  0.122684274627557  0.033049817652525  0.019053422527856  0.043070830779647  0.050152205966201  0.326697513368332 -0.099443390036437 -0.221198097566913
-   11  ( 25) -0.081038041563998  0.154593341750109 -0.407140318932015  0.281943720612524  0.325675147388091 -0.120351655341300  0.214124337140198  0.074325284613070 -0.033051994607934
-   12  ( 26) -0.003149016432995 -0.169066126704247  0.222974141740589 -0.178167341127522  0.432229982121926 -0.017874255780557  0.111773550217198 -0.031100511775823  0.501206663109641
-   13  ( 27)  0.059358328554787 -0.079903052840459  0.074950199177092  0.286331686497645  0.080924619758582  0.153353900448008  0.018409365441285  0.093462744168481 -0.750750124348623
-   14  ( 28) -0.091958135023799  0.083203421400522 -0.314158605792346  0.035767063530523 -0.118730598661038  0.076122730197959  0.098773188363533 -0.234233392684110  0.381969165301674
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054160915945435 -0.219019011349662  0.045758113327127 -0.056667077142789 -0.042241899582406
-    1  ( 15) -0.090944710506667  0.435278295065967  0.077842273581986  0.010976755804933 -0.224792334219630
-    2  ( 16) -0.088739489380716  0.410297160213696 -0.264172456920591  0.132125091344127  0.093086518366917
-    3  ( 17)  0.030526782846372  0.322820843845168  0.334117022964461  0.097597092001327  0.253965732413029
-    4  ( 18) -0.135352462834385  0.032599183228470 -0.437639446212980  0.064872058901817  0.014497262646809
-    5  ( 19)  0.073899654730418 -0.320885730724582 -0.062344415655815 -0.000276840662838  0.283336476795494
-    6  ( 20)  0.001158784637986  0.022837257389258 -0.248024269025134  0.216907823965295 -0.108098145849832
-    7  ( 21)  0.447481917087615 -0.286161905602593  0.000998969948768 -0.136653733410725  0.003506425728696
-    8  ( 22)  0.045854947627217 -0.028382633755544  0.139989494186326  0.129405417600200 -0.366820033409189
-    9  ( 23)  0.122256207458047 -0.437180402944018 -0.011581755997574 -0.275567866951771  0.586898649032607
-   10  ( 24) -0.308323852677716 -0.180850894824874 -0.356131896237587  0.040945642422097 -0.142574344254175
-   11  ( 25) -0.063098776158311  0.427549053292048 -0.014802143274602 -0.197270506582776 -0.099635293972029
-   12  ( 26) -0.762581095039526 -0.039734172920420 -0.331033022441233 -0.114161465508821  0.418490755826768
-   13  ( 27)  0.291938944356791  0.043222558646299  0.082214356128397 -0.270960148007918 -0.225910263769329
-   14  ( 28) -0.156871086239258  0.569997035340427  0.048467653901961  0.184994394399640 -0.209531521675463
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.009005560415623 -0.070810523176756  0.120067832596336 -0.009073132789111  0.090464498751398  0.086174111119373  0.045794981404386 -0.145874969594553 -0.061668751575060
-    1  (  1)  0.049157751161972 -0.341837336007350  0.225991322214187 -0.079794887273929 -0.129000775913247 -0.051890082528236  0.264098306233448 -0.041882987798599  0.014437873768970
-    2  (  2)  0.004178475304277 -0.176534362212289  0.088484784587537 -0.060893560844690 -0.188770646517555 -0.098157508320735  0.154422738208034 -0.028159762307555  0.056745595914693
-    3  (  3)  0.078632631263388  0.018162490565873 -0.185802179760100  0.047918543127627  0.190222116766269  0.186537019008413  0.211456806958065  0.116264562677772  0.222361952728926
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163744366705642  0.058513889685970 -0.036529339633759  0.074890516703334 -0.101980211526259  0.048987870817685
-    1  (  1)  0.129678391589482  0.003465728257172 -0.197451754644998 -0.065935565415855  0.202740138649215 -0.212710296862526
-    2  (  2) -0.022460564343481  0.084272909470110 -0.151124340943610  0.372643880141893 -0.063147940573229 -0.083681000851943
-    3  (  3) -0.069418152871991  0.077040623108211 -0.377203303892570 -0.165559399244409 -0.189357768189075  0.044737808867411
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.085668830826553  0.137820799821437 -0.214610467959115  0.105542261331556  0.036859097160689  0.000473863191174  0.079606876493944  0.008613359831916  0.198755661758929
-    1  (  5) -0.139412038667802  0.235636886292819  0.125284829879155  0.147970518740886 -0.038362154224415  0.146537444592957 -0.006121389458957 -0.189794595760352  0.090516747843845
-    2  (  6) -0.309048143972662  0.258748687397471  0.168238503241560  0.304764034594855 -0.050456064213728  0.094565768675384  0.416604423570803  0.027331415693024  0.066446598559605
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.012674523904092 -0.052192101234842 -0.013753920669735  0.012760663896321 -0.052741920591875
-    1  (  5)  0.065601509403616  0.098250162685792  0.177768481553462  0.033008693934466  0.305584708162464
-    2  (  6) -0.160962535198798  0.052046626684920 -0.419200543530858  0.024457493928166  0.150587999794565
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002292052292102 -0.001327689025616 -0.000248352651822 -0.007958119616396 -0.006332326100070 -0.018602233716079 -0.068879285117607 -0.007819744108382  0.006538352080530
-    1  (  1) -0.002764164951481  0.002219747844780 -0.018293151832047  0.029668233290932 -0.039848292773056 -0.022489745012599 -0.162281988584092 -0.020804504235237  0.019083175045333
-    2  (  2)  0.011217835122943  0.011598249376099 -0.016968466001430  0.008250037510452  0.006232273271200  0.008766677291359  0.010338243291249  0.010725726663582  0.004470553150491
-    3  (  3)  0.050562851864420  0.047527304873166 -0.078707468856856  0.000484758494300  0.025585059000145  0.011993586441410  0.049963781283816 -0.008029454242806  0.026864587292980
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006805334012410  0.003000362320124  0.002228041038775  0.000013471324712  0.003129940535122 -0.001748281527537
-    1  (  1) -0.013913717596781 -0.013715090430948 -0.022806809849796 -0.002206415430011 -0.006824605289547  0.005086150284379
-    2  (  2) -0.011033408042675  0.021897939524418 -0.000684908130867 -0.006441462755861 -0.002207402072499 -0.000019160522387
-    3  (  3) -0.030996252825103 -0.007986449014412  0.024562077320802 -0.006200249162118 -0.010690383251547 -0.011486173135262
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.008068643711801 -0.010525757489217 -0.001816581937116 -0.014852647204911 -0.016446444650489  0.051123908211829 -0.105303074579255 -0.010186396385181 -0.002604742010165
-    1  (  5) -0.024807027264736  0.041872241876176  0.005357408083722 -0.028564486604491 -0.031353252400090  0.040716482303683 -0.082357809569043 -0.022204595749263  0.028676826310240
-    2  (  6)  0.057433465116018 -0.072910653400307 -0.007950207598680 -0.045866077252406 -0.051478467074873  0.066399959025177 -0.120267838044182  0.002980749702429 -0.024762093508970
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000934050050601  0.000604010149742 -0.003646663045597  0.000033137801782  0.002019175758165
-    1  (  5)  0.015497094356084  0.002871076746167 -0.025548488367169 -0.001995117147543 -0.006447008967148
-    2  (  6) -0.009288606849912 -0.006735078994323 -0.016930923349151 -0.006239987724853 -0.010309885333920
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.002224796248932  0.043809288397671 -0.042786645812819
-    1  (  1)  0.035961652529642  0.375558249507302 -0.229138680808403
-    2  (  2)  0.031482392637320  0.208906969570401 -0.045224347296993
-    3  (  3)  0.099946950247304  0.215409785029959  0.414532197880427
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.002181806445193 -0.035979573047748 -0.031640926892772 -0.100238553322267
-    1  (  5) -0.043671265862198 -0.375015508928970 -0.208917842140989 -0.216574490738357
-    2  (  6)  0.042527296867706  0.228253198541367  0.044456455969980 -0.415218734433248
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.071571831474078  0.044653489385004  0.010701302384523 -0.107261739958220  0.107631207507425  0.021982609216167  0.087555139416076 -0.002428271330292  0.013116395341904
-    1  (  1)  0.000994163831951 -0.002283385696650  0.009683189881161  0.069987093364780 -0.211165412824198 -0.144806549288885 -0.839471629333555 -0.082797629633041  0.083995255816967
-    2  (  2)  0.048029450774166  0.034159151942760  0.005345969743360 -0.362094457083817  0.166955343421057 -0.200138180389873 -0.200325175150560 -0.048097856321723  0.015226624624379
-    3  (  3) -0.099901242333767 -0.066741882163175  0.192006761021459  0.037162207196483  0.149491220617225  0.091957380518256 -0.124661875998717 -0.114474410410791 -0.084751404274494
-    4  (  4) -0.098292057994736 -0.060260709677483  0.234095836344223  0.042527139722308  0.172693635464839  0.110397071373777 -0.184879337331547 -0.074537123570678 -0.084735776692218
-    5  (  5)  0.074314676568813  0.053240577551294 -0.354242764435309  0.039009834260888  0.144962419013369  0.061650919712934 -0.045188344047315 -0.085035282721835  0.173092563485620
-    6  (  6) -0.068641550367940 -0.078242424055450  0.700330832585738 -0.207548816757483 -0.389421892794459 -0.222244858530413  0.109406330044345  0.045457397940435 -0.343867539807074
-    7  (  7)  0.021723320720408  0.016351205203477  0.098413699787284  0.004057278627183  0.006939091834822  0.079051971654245  0.378143817290545  0.122761983444906 -0.057845298080862
-    8  (  8)  0.009573032166807  0.006109372122326 -0.063933429430759  0.085659891507852 -0.069748375065056  0.032412606198403  0.211702458249096  0.046995111806493 -0.044380498011908
-    9  (  9) -0.004993361863042 -0.003634014150995 -0.021315829704567  0.021713795540608 -0.030056681969923 -0.023359631271160 -0.128991093821748 -0.016400014214086 -0.007638043352379
-   10  ( 10)  0.003364468158750  0.005158901374854  0.010157814233360  0.013146135283302 -0.036788603301885 -0.001796925979308 -0.031087735489024 -0.158319551738172 -0.001398916399981
-   11  ( 11) -0.005212014578835 -0.005572219785769  0.129300362837610 -0.009016877484923  0.009416239426417  0.064438058134476  0.026488687258818 -0.021963612194052  0.285489003307896
-   12  ( 12)  0.022889675001499 -0.014028568601137 -0.005258310077958 -0.012614598275054  0.011181538654869  0.041924328606938 -0.003053461905652  0.141650155501185 -0.005090787707419
-   13  ( 13)  0.006246133552104  0.010356570946206  0.013049157750693 -0.012424981952369 -0.009162366348552 -0.014458376447183 -0.062634797746517 -0.024809108873564  0.013232375979096
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.002828230885257 -0.008462795614422  0.005154038879345  0.009706144885120 -0.000351690712200 -0.003016908410820
-    1  (  1) -0.016542909801999 -0.036808232009347 -0.132827410709679  0.012545312927284  0.013603497625073 -0.014243226256360
-    2  (  2) -0.056531888264120  0.026681841564725  0.044472892095947 -0.008316762319548 -0.009818160226073  0.003132505638468
-    3  (  3)  0.065664012413416 -0.084000307061427  0.024123678461562 -0.011516052481209  0.005295212539445  0.009770444853693
-    4  (  4)  0.036042306167921  0.066196882580862 -0.035814283991972  0.000422354014022  0.007346814292348  0.010225200735508
-    5  (  5)  0.148907428019918 -0.109320100216994 -0.041270431698859 -0.008286052492360  0.000171545458785  0.012799874602531
-    6  (  6) -0.267740896585406 -0.203497348994038  0.004880757246489 -0.039144439238724  0.017848850593881 -0.043282221917125
-    7  (  7) -0.072391125356366  0.141340064883921 -0.132216664302808  0.021712276497551 -0.014580212743968  0.003413596406031
-    8  (  8)  0.065338926975319  0.070417584641912  0.663636576046729  0.043614890913103  0.008447529962627 -0.017635456067555
-    9  (  9)  0.053338372051575  0.015608392811417  0.295869564541774  0.007118975871935  0.021727777212887 -0.010944181246414
-   10  ( 10)  0.043778421907204 -0.395589362339910  0.177341233202875  0.145584179195590 -0.046786531122207  0.019085441444643
-   11  ( 11) -0.612579899217910 -0.015866362451346  0.053555820669517 -0.384133045755119 -0.648991284315080  0.223359237845109
-   12  ( 12)  0.089924264835296 -0.149474889068188  0.147998013353456 -0.410950037016053  0.122612685939115 -0.053519931502491
-   13  ( 13) -0.016968386753172 -0.001120736716630  0.667558162177866  0.016648983669703 -0.049072172914944  0.011592992748873
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.071349801352714 -0.001077758689270 -0.047849010758340  0.099049708991052  0.097373218549672 -0.073249702217701  0.066497399663850 -0.021905924000244 -0.009611371244576
-    1  ( 15) -0.044780949738342  0.002559008927920 -0.033951661393695  0.066729312295418  0.060308115101382 -0.053229541901542  0.078046690958419 -0.016360376267858 -0.006154062585816
-    2  ( 16) -0.011020054803350 -0.009639577990263 -0.005659342412151 -0.191466387657664 -0.233770018397497  0.353943104953966 -0.699652203951216 -0.098429630868852  0.064028996133412
-    3  ( 17)  0.107854789786884 -0.070585793426189  0.362141920362822 -0.037292065848003 -0.042427554280107 -0.038929544624269  0.207453249613655 -0.003913287572505 -0.085781111935072
-    4  ( 18) -0.108209449998533  0.211629628691212 -0.166874900133377 -0.149325288082881 -0.172890816462238 -0.144890994778070  0.389082003854782 -0.007000687821947  0.069612637937327
-    5  ( 19) -0.022019034844539  0.144617634612061  0.200192966932170 -0.092059326306527 -0.110737371319849 -0.061364605633219  0.221637061620898 -0.079021140430878 -0.032667339771975
-    6  ( 20) -0.089130158761328  0.839805360702557  0.200387491136614  0.125541335494723  0.184496760040866  0.044995250241913 -0.109402692051618 -0.378035804168236 -0.212908503907272
-    7  ( 21)  0.002178057091038  0.082925436926418  0.048118216149291  0.114730021254943  0.074453346277443  0.084891108935477 -0.045281773316412 -0.122667104662941 -0.047081579488126
-    8  ( 22) -0.013014867453703 -0.083878416356711 -0.015105645463008  0.084649544925900  0.084843093804859 -0.173122296622810  0.343876299664282  0.057834963947660  0.044464266623987
-    9  ( 23)  0.002901775226444  0.016234828173143  0.056359654971922 -0.065872157385180 -0.036362021680561 -0.148332139389917  0.266718078511413  0.072258279284242 -0.065401012908070
-   10  ( 24)  0.008445720197207  0.036804429594076 -0.026642166859473  0.084168947416289 -0.066510758074250  0.109381013548519  0.203196264302626 -0.141165925569744 -0.070499221179183
-   11  ( 25) -0.005377792056996  0.132971363586081 -0.044450134013502 -0.024046237867946  0.035750577264436  0.041236558408702 -0.004898258174401  0.132214673314328 -0.663804812343684
-   12  ( 26) -0.009728994170679 -0.012565610031584  0.008265487183249  0.011507462056027 -0.000390885497570  0.008310505974517  0.039141081466560 -0.021755546401072 -0.043610775840953
-   13  ( 27)  0.000301420723236 -0.013603051175605  0.009758944837903 -0.005201669668065 -0.007344582365288 -0.000240423767531 -0.017707548228084  0.014600989921618 -0.008461166379513
-   14  ( 28)  0.003079753925572  0.014179269497255 -0.003153288832508 -0.009783782056838 -0.010222304053931 -0.012792812982900  0.043303231879501 -0.003407229733488  0.017679792666437
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.005093584579739 -0.003397430557442  0.004751145314814 -0.022993999775599 -0.006406607432760
-    1  ( 15)  0.003664268681973 -0.005140681437481  0.005623137023323  0.014031183819186 -0.010293722738862
-    2  ( 16)  0.021380720709285 -0.010101149193740 -0.129156907046771  0.005327658954335 -0.012995314092573
-    3  ( 17) -0.021888212102997 -0.013219387248758  0.009147784998772  0.012607741489433  0.012451560776453
-    4  ( 18)  0.030283770762187  0.036869387279963 -0.009496744772073 -0.011181780485751  0.009182409552409
-    5  ( 19)  0.023453672116028  0.001799424920857 -0.064551617042565 -0.041960641260948  0.014420118956798
-    6  ( 20)  0.129458546494562  0.031271046054797 -0.026491102279077  0.003035012140173  0.062712336606288
-    7  ( 21)  0.016591446747124  0.158366047016835  0.021959782838748 -0.141640631249081  0.024819174074486
-    8  ( 22)  0.007575701587651  0.001384112156408 -0.285443557719759  0.005092627774536 -0.013202606990520
-    9  ( 23) -0.053335089301784 -0.043785415746465  0.612428033952438 -0.089945127333786  0.016908784258587
-   10  ( 24) -0.015338693676902  0.395633576722134  0.015809806174577  0.149475505805735  0.001108572795377
-   11  ( 25) -0.295832367201880 -0.177313650229228 -0.053561286295937 -0.148004020967965 -0.667548449264998
-   12  ( 26) -0.007157154416068 -0.145586590426015  0.384132810582926  0.410951719442920 -0.016651787670969
-   13  ( 27) -0.021701996830369  0.046797876195772  0.648997652718994 -0.122606232077394  0.049068049852585
-   14  ( 28)  0.010942221777254 -0.019093183683669 -0.223365949415077  0.053520759465635 -0.011602247780486
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002779955261603  0.001692895942304 -0.000296900585249  0.009027308047393  0.005517424530413  0.019392785745098  0.071615718156204  0.008379623734860 -0.006552142468186
-    1  (  1)  0.002104549417694 -0.002248748312389  0.016268779471159 -0.026298614529309  0.037020427509987  0.022919155336998  0.164160248243371  0.021028638082436 -0.018807600972837
-    2  (  2) -0.012197014321068 -0.010749741004113  0.015969423342584 -0.008379419120707 -0.005700661608131 -0.009182078264489 -0.007072493012824 -0.010651845449983 -0.003884546255787
-    3  (  3) -0.055916626202381 -0.044952545452401  0.075693796863105 -0.001117242062940 -0.024281174456380 -0.014619597544444 -0.053283290640729  0.007703747637900 -0.022436578410207
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006982563138735 -0.003194903879745 -0.002336222897235  0.000159319304138 -0.003153288870770  0.001705858583767
-    1  (  1)  0.013922175981332  0.014264739151757  0.027533427644978  0.002422850658312  0.006842699761048 -0.005360945695369
-    2  (  2)  0.010224586423112 -0.021331787446369  0.001728789794737  0.007349416930945  0.001927444504520  0.000065986060579
-    3  (  3)  0.028649073776619  0.008193923965952 -0.026834068422643  0.006433642271152  0.011064478009773  0.011417291735948
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.007713676236592  0.011322134542428  0.003907084678219  0.013398999832293  0.015469012646278 -0.052157960120007  0.107410796770658  0.010366341516333  0.002761603992801
-    1  (  5)  0.025927350683997 -0.036918918076002 -0.006183726668218  0.026765793037023  0.030906551194513 -0.042649472793187  0.084196537695915  0.021256853976094 -0.026253718608666
-    2  (  6) -0.059547667994813  0.071575508753465  0.010792071396250  0.045987434407762  0.051692908853277 -0.069048919754819  0.125623895288423 -0.001752094627183  0.022191347480180
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000950352585130 -0.000964031243708  0.004357151868409  0.000282508389387 -0.001887057940293
-    1  (  5) -0.015009418487876 -0.001705110486742  0.029429172036478  0.001075595895759  0.006702102006371
-    2  (  6)  0.007980731926488  0.006589892733093  0.020940438262106  0.005674678855389  0.010940914550877
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440295579  0.058098623160149  0.000062770556748 -0.132305009159629 -0.206845253888047  0.090151367716489 -0.021622993201571 -0.039361663017831  0.081041759541844
-    1  (  1) -0.058446002592381  0.108172168387665  0.020491566069368  0.029038345945867 -0.075256281089894  0.197244333760875 -0.268904698800623 -0.104165934684913  0.067340388337437
-    2  (  2) -0.015395531940668  0.065975044888453  0.020693241252053  0.145278172828441  0.156811977467575  0.026190455409877 -0.072791620600644 -0.106379132149940  0.008110007387647
-    3  (  3)  0.209889648220478  0.051262205346318 -0.016792464687917 -0.095510023534389  0.095336437810925 -0.289116526954890  0.245753636284337 -0.379261907424074  0.084194488967514
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922100177 -0.024147628250432  0.039515998201657  0.082736569420113 -0.047511948424277
-    1  (  1)  0.028213287461096  0.067760885411213  0.238885785807082 -0.125969164479716  0.177609465312033
-    2  (  2)  0.077606300081110 -0.045313543916728  0.093141189396729  0.365274041996181  0.093447143795063
-    3  (  3)  0.414915648100444  0.159852566418804 -0.273568285227133 -0.034618677637948  0.200919751819526
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102681987247 -0.069778483698171  0.053388820632185  0.227201022134194 -0.199230027457400  0.049687576281265 -0.168877445270916 -0.014461225328824 -0.006078045812775
-    1  (  5)  0.058029574787099 -0.323045692563543  0.030451397472044 -0.087822399116233 -0.049669665032459 -0.052839306746938 -0.277652121541255 -0.149775076383338  0.305937155270736
-    2  (  6) -0.084055275470361  0.046073375199290  0.190725804864306 -0.087557818530500 -0.137785527514624 -0.205465571554547 -0.198777590920688 -0.118276962990440 -0.298899363373310
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985616706  0.083163093490792  0.059838819851121  0.009394325001926 -0.030439464329859  0.004211858017358
-    1  (  5)  0.056299326992358 -0.068872084539624  0.330916524068169 -0.053769676104327 -0.184435947376520 -0.103868547783993
-    2  (  6)  0.066328790174072 -0.124449756312364  0.113043685745447  0.144452726550998  0.299204372306587 -0.043729255680790
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000261962805528  0.008184590036915  0.017078206714546 -0.120797444663216
-    1  (  1) -0.008556708940913  0.000310357479341  0.070665159347735 -0.263733240360107
-    2  (  2) -0.016665957640930 -0.070092969568198  0.000658296979419  0.516406140442807
-    3  (  3)  0.119815260993819  0.260397085059199 -0.515923296927153  0.000854850636510
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000399146441393  0.382166830385042 -0.144086395309985
-    1  (  5) -0.378879203373120 -0.000650240992922  0.057572968692994
-    2  (  6)  0.142267704977138 -0.057783925625685  0.001456329094587
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000900630817553  0.057480932301248  0.021776185729735 -0.109986124582381 -0.040974945330860  0.038859091716901 -0.013722976007051  0.027662163358443  0.095856958174051
-    1  (  1) -0.055475653729802  0.000055946423413 -0.161049994133622  0.114708024204125 -0.226365261647020  0.429957047290467 -0.365226817146534 -0.339873184728948 -0.220417191818894
-    2  (  2) -0.021015776391238  0.161427052909899  0.000077274959500  0.056803578516095  0.009014493962493  0.218381032705550 -0.249538253456372 -0.218329398300741  0.109423644471862
-    3  (  3)  0.109912942235432 -0.115891216387191 -0.056027564915092  0.000745943372337  0.462877633738750  0.122572187022588  0.103916786291663  0.116372032296575  0.000178644283993
-    4  (  4)  0.040100257401862  0.225977964738017 -0.007764610803091 -0.462832592343483 -0.000863713188323  0.292983388565641 -0.009504255770576 -0.051881331882871 -0.039789084738637
-    5  (  5) -0.036362528925743 -0.431143684565124 -0.219013710239096 -0.122734678900441 -0.292859375843399 -0.000211534680093  0.380048338834318  0.122563604837507  0.042304270254871
-    6  (  6)  0.010482485700737  0.366095597661562  0.249485788064450 -0.103549341685710  0.008516226169361 -0.379084427040252 -0.000639775867465  0.110614613813780 -0.062004820067370
-    7  (  7) -0.028768402882082  0.339119958859154  0.216813059372775 -0.114011828936202  0.053232451800242 -0.122211769727445 -0.109878960190336 -0.000261733603901 -0.084697348659745
-    8  (  8) -0.095810944695334  0.221328249276204 -0.109105398407007 -0.000872051363339  0.038539628128307 -0.040520833999881  0.059740000698578  0.084693665490196  0.000412317879658
-    9  (  9)  0.014697085572369 -0.105287145446058 -0.107273285124578  0.218858370800804  0.309735125099696 -0.105267325854039 -0.129620026346504  0.117982202893285  0.042502371715711
-   10  ( 10) -0.029182274069823  0.107750482915279 -0.099755873232373  0.053540519729348  0.138357776561317  0.190065661316311 -0.089951321859060 -0.050398080030964 -0.205938711533222
-   11  ( 11) -0.155188100419269  0.443693923193159 -0.328775787594980 -0.218791170588477 -0.215183707581260  0.086687685172586 -0.081438682030100 -0.042661060649411  0.076989743302322
-   12  ( 12)  0.047041819133236  0.056356277723761 -0.091876156457291  0.290703693299362 -0.241933426060878 -0.247197194304100  0.042704222313214  0.092541926182743 -0.274193192866205
-   13  ( 13) -0.050345457187286  0.050309029533978 -0.290248962160664  0.162027268205565  0.213802087129928 -0.103771321970540 -0.033795235497894 -0.045614675872296  0.299788281594493
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015094426489382  0.029115659613984  0.157755053899573 -0.046090500922971  0.051508699260239
-    1  (  1)  0.106870813652789 -0.107133528015314 -0.444981848759519 -0.057242056092259 -0.049852574162928
-    2  (  2)  0.109000377776210  0.100245307552928  0.328735836791196  0.092813183683061  0.291725571255713
-    3  (  3) -0.218950464663657 -0.054805102085238  0.218886888542902 -0.287519470239761 -0.163372131318506
-    4  (  4) -0.309058290561676 -0.137567383239759  0.215197532854513  0.238351393836438 -0.213552990219087
-    5  (  5)  0.105624117972044 -0.189859620690792 -0.086820347884678  0.246317074454998  0.103852569604008
-    6  (  6)  0.128090000856966  0.089849284790653  0.081980995688413 -0.043663325009335  0.033155703031441
-    7  (  7) -0.117989240855155  0.049695249544262  0.043676012478621 -0.088835836027429  0.045632574214248
-    8  (  8) -0.043185512310113  0.206252030230831 -0.075219160600274  0.272504390674237 -0.299099410447326
-    9  (  9) -0.000057792160807  0.416496446259873  0.033591110007561 -1.079044045817668  0.144878189091330
-   10  ( 10) -0.417381448990192 -0.000164005362256 -0.288881720270970 -0.322059475407983 -0.291538277058570
-   11  ( 11) -0.033261524584639  0.288678211108026  0.000120543612153  0.357470920187357 -0.110246704427599
-   12  ( 12)  1.082405304483691  0.322498276514608 -0.357322196019213  0.000062083058686 -0.002512916703858
-   13  ( 13) -0.144912114579253  0.291369916474370  0.110105006775579  0.002446483993989  0.000063534084907
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000175081543235  0.016120371429445  0.025072002498307 -0.062542190001810 -0.021350885611608  0.118270325314450 -0.004836963443519 -0.089308321494217  0.035265121599228
-    1  ( 15) -0.019016581108200 -0.000074621970578  0.073692709803711 -0.220090875517914  0.117001241546639 -0.069843654088588 -0.194734592940078  0.297334325625656 -0.000079679030782
-    2  ( 16) -0.022601123418381 -0.074079137647858 -0.000898075728427 -0.015352523942492 -0.086856492084776 -0.105020764975991 -0.399309885639210 -0.436863382131761  0.175020106394679
-    3  ( 17)  0.059722097345652  0.223919505098606  0.017236939707940  0.001153330835786  0.251337783789116 -0.316047497618471  0.195069502405311  0.070796117852672 -0.376854141068940
-    4  ( 18)  0.020136753535465 -0.119176676580060  0.086690091555956 -0.251646590139118 -0.000253931741203  0.043128862347025  0.031767565075530  0.166618171717967  0.162853353427601
-    5  ( 19) -0.121150060676480  0.070465337136678  0.107141402917501  0.315382260507230 -0.043144844880487 -0.000915299484024  0.084836748925369  0.176704257940149 -0.191804096130299
-    6  ( 20)  0.000227153495201  0.194659284089699  0.399818522753260 -0.193896536829102 -0.032525351177556 -0.085523354347259  0.000313079507664  0.483156326770458 -0.288322768300912
-    7  ( 21)  0.086746307137042 -0.297294170806809  0.437363838809426 -0.070300496686555 -0.166591994782662 -0.177217714676487 -0.482838971708778 -0.000010492293158  0.098273184847402
-    8  ( 22) -0.034845258926466  0.000856544015064 -0.174085542944908  0.374309528502842 -0.160749665940872  0.191624326414407  0.289454904423216 -0.097021267550271 -0.000014930403133
-    9  ( 23) -0.146129839058632  0.053485685235498  0.324250294825684  0.062889229683982  0.055229748354918  0.064112736518466  0.152978751390774  0.139451617186818 -0.103725991413656
-   10  ( 24)  0.228960109301500 -0.607985902209189 -0.190616272123952 -0.232984732345903 -0.097313246050666  0.308149392800276 -0.021807135674585  0.163587870408675  0.316482089556363
-   11  ( 25) -0.113565876404484 -0.174438492287332  0.418980586076642  0.308342622144823 -0.075432621027986  0.339103289288024 -0.159452756259661 -0.028406298387555 -0.098839597099930
-   12  ( 26) -0.037444327267505 -0.021664072112537  0.117362801200434 -0.051936890369197  0.180410685976209  0.010675625355649  0.081438166282149 -0.155940478341532  0.070485054402575
-   13  ( 27)  0.017297506490468 -0.067203074043419  0.031147633780082 -0.363738862057262  0.387270613641776  0.012184715254227  0.015942188037276  0.055059690817367 -0.199296990199261
-   14  ( 28)  0.034092252177278  0.073609066570293 -0.020468002829466 -0.085810470847391  0.016765555515284 -0.112839616184051 -0.014153257364854  0.178002322135800  0.110338785365484
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147095539872383 -0.230933799773564  0.118289772746167  0.038253772767447 -0.016292190599368 -0.035682534667396
-    1  ( 15) -0.054490936726031  0.608135664745124  0.173899591973767  0.021325225109119  0.066354839577592 -0.073331369735506
-    2  ( 16) -0.323391847959358  0.191801489512728 -0.419969130886923 -0.118001273092276 -0.032684795751626  0.020933916119487
-    3  ( 17) -0.062697350486204  0.233350536310715 -0.310310140488118  0.052850324165985  0.365716314917495  0.086296396691572
-    4  ( 18) -0.056488793458219  0.097314229222686  0.076761540605080 -0.181114864878134 -0.388829148158841 -0.017043041264758
-    5  ( 19) -0.064628320787155 -0.308910350912390 -0.338058227371875 -0.010220898623446 -0.011328162399087  0.112362127982896
-    6  ( 20) -0.155379178216769  0.021354195203646  0.159398635050546 -0.081833336858156 -0.016534888228459  0.014163359612821
-    7  ( 21) -0.140544774640624 -0.163930417297846  0.028664595573870  0.155618444233808 -0.055735865052552 -0.178161215640947
-    8  ( 22)  0.103335943311615 -0.315447824318108  0.098508893733037 -0.070643837593468  0.199190551733382 -0.110186805922078
-    9  ( 23)  0.000685205966667 -0.100205727138143 -0.098177984906045  0.175404901290359 -0.218086466804531  0.228138153241008
-   10  ( 24)  0.099957378010069 -0.000114683002834  0.318552989781446 -0.225328174596363 -0.500054658950197 -0.463890214112047
-   11  ( 25)  0.099837194917025 -0.317752725239556 -0.000013072206941  0.325584528982697 -0.211934933711027 -0.064802310197898
-   12  ( 26) -0.174911687089768  0.225249469039723 -0.325644361756696  0.000020583584119 -0.212000345487721  0.097990759740804
-   13  ( 27)  0.218595256276638  0.499626470482149  0.211748903875054  0.211985776866883 -0.000065067673371 -0.140785106097381
-   14  ( 28) -0.228612967389234  0.463548085364345  0.064895093957785 -0.097943745399791  0.140883877569212 -0.000043885507604
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019700182677109 -0.054538984090237  0.000657293183073  0.126059310809830  0.202210998435536 -0.093434338948922  0.024491292826910  0.039730679308164 -0.082949626694243
-    1  (  1)  0.060570767175444 -0.116914550591559 -0.021887147512717 -0.031244847376016  0.072525220228198 -0.201021150446193  0.281719713830578  0.109054645892929 -0.074327440399931
-    2  (  2)  0.019917912309235 -0.073498936617270 -0.021015841735422 -0.144973687437576 -0.148661911932313 -0.032805680200546  0.073267109264708  0.114043301611785 -0.006398273119572
-    3  (  3) -0.203013924377868 -0.061956730055068  0.012687970996334  0.097374198936088 -0.112619147770757  0.293844050008894 -0.262428514093194  0.382217125669632 -0.093448479811708
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009866900732451  0.025414444169080 -0.042903095265214 -0.089054808289041  0.047172870515859
-    1  (  1) -0.029479300283787 -0.071852668133049 -0.250209813738974  0.142668644531385 -0.184582935130079
-    2  (  2) -0.082839864480014  0.055172054044896 -0.094169081580928 -0.401277867082131 -0.092346870950097
-    3  (  3) -0.429785932962393 -0.170247315400438  0.282336698266602  0.039589385431130 -0.207542683133729
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.009866584979615  0.069659389537491 -0.056437231681763 -0.210909857783049  0.193232853181170 -0.044263163299008  0.177086741570328  0.011251791029684  0.005974944716268
-    1  (  5) -0.063966745715490  0.332083812922557 -0.023959233352896  0.077592998716556  0.049685567261474  0.057922845574600  0.292828526996057  0.156611147799580 -0.308189152931944
-    2  (  6)  0.093646243694873 -0.043886805978712 -0.210333087134862  0.092497904992983  0.147507586034141  0.211245402574096  0.209822842363991  0.120370292677788  0.308437245541850
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068407482810993 -0.091070726633550 -0.065843093849228 -0.010412482581381  0.030047987986095 -0.002926817734499
-    1  (  5) -0.052950259935732  0.069489349844531 -0.341748563636028  0.056521413026742  0.185361514981393  0.106113084848249
-    2  (  6) -0.072195900884652  0.125482826256955 -0.118114475628592 -0.149158088490872 -0.308475854808773  0.046262836261975
+    0      0.361359066372195    -0.343963060886476     0.000000000000000
+    1     -0.055701201381726    -0.006113947782746     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.373861234746697
 
 	Computing Mu_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.958253927724
-	   1         4.677945123999    2.295e-01
-	   2         5.194708704823    1.156e-01
-	   3         5.223843948812    2.586e-02
-	   4         5.226847535403    1.016e-02
-	   5         5.227467838779    2.194e-03
-	   6         5.227668260533    8.875e-04
-	   7         5.227636383659    2.763e-04
-	   8         5.227622132159    1.088e-04
-	   9         5.227613569870    3.847e-05
-	  10         5.227613624358    1.719e-05
-	  11         5.227615206033    3.938e-06
-	  12         5.227616189681    9.343e-07
-	  13         5.227616597313    3.329e-07
-	  14         5.227616779125    1.318e-07
+	   0         3.958253914342
+	   1         4.677945105523    2.295e-01
+	   2         5.194708680543    1.156e-01
+	   3         5.223843923672    2.586e-02
+	   4         5.226847510193    1.016e-02
+	   5         5.227467813531    2.194e-03
+	   6         5.227668235281    8.875e-04
+	   7         5.227636358407    2.763e-04
+	   8         5.227622106907    1.088e-04
+	   9         5.227613544619    3.847e-05
+	  10         5.227613599107    1.719e-05
+	  11         5.227615180782    3.938e-06
+	  12         5.227616164430    9.343e-07
+	  13         5.227616572061    3.329e-07
+	  14         5.227616753873    1.318e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 3.955e-08
 
 	Computing P_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.040020325202
-	   1         8.863945638608    1.867e-01
-	   2         9.238808929968    7.879e-02
-	   3         9.264717395230    2.650e-02
-	   4         9.263643132806    1.048e-02
-	   5         9.264423439704    2.642e-03
-	   6         9.264672268296    1.147e-03
-	   7         9.264630131748    3.812e-04
-	   8         9.264627527403    1.363e-04
-	   9         9.264617824041    3.912e-05
-	  10         9.264623347094    1.402e-05
-	  11         9.264625201830    3.784e-06
-	  12         9.264625968828    8.798e-07
-	  13         9.264626297765    3.029e-07
-	  14         9.264626411988    1.198e-07
+	   0         8.040020335898
+	   1         8.863945648367    1.867e-01
+	   2         9.238808939095    7.879e-02
+	   3         9.264717403907    2.650e-02
+	   4         9.263643141448    1.048e-02
+	   5         9.264423448324    2.642e-03
+	   6         9.264672276907    1.147e-03
+	   7         9.264630140358    3.812e-04
+	   8         9.264627536013    1.363e-04
+	   9         9.264617832652    3.912e-05
+	  10         9.264623355705    1.402e-05
+	  11         9.264625210441    3.784e-06
+	  12         9.264625977439    8.798e-07
+	  13         9.264626306376    3.029e-07
+	  14         9.264626420598    1.198e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 4.121e-08
 
 	Computing L_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.909269872101
-	   1         6.098499218047    3.500e-01
-	   2         7.261780824711    2.268e-01
-	   3         7.434267586103    6.951e-02
-	   4         7.483209126897    3.985e-02
-	   5         7.496330683077    1.229e-02
-	   6         7.499259495652    7.641e-03
-	   7         7.499885485763    2.891e-03
-	   8         7.500087217193    1.506e-03
-	   9         7.500033617657    6.224e-04
-	  10         7.500090357893    2.277e-04
-	  11         7.500136464518    6.297e-05
-	  12         7.500173475599    2.554e-05
-	  13         7.500190475078    1.065e-05
-	  14         7.500198657741    5.767e-06
-	  15         7.500202873290    2.677e-06
-	  16         7.500206074425    1.296e-06
-	  17         7.500206585889    2.883e-07
-	  18         7.500206868012    1.101e-07
+	   0         4.909269846731
+	   1         6.098499188985    3.500e-01
+	   2         7.261780793355    2.268e-01
+	   3         7.434267551759    6.951e-02
+	   4         7.483209092475    3.985e-02
+	   5         7.496330648248    1.229e-02
+	   6         7.499259460593    7.641e-03
+	   7         7.499885450677    2.891e-03
+	   8         7.500087182080    1.506e-03
+	   9         7.500033582554    6.224e-04
+	  10         7.500090322786    2.277e-04
+	  11         7.500136429410    6.297e-05
+	  12         7.500173440490    2.554e-05
+	  13         7.500190439968    1.065e-05
+	  14         7.500198622631    5.767e-06
+	  15         7.500202838179    2.677e-06
+	  16         7.500206039314    1.296e-06
+	  17         7.500206550779    2.883e-07
+	  18         7.500206832901    1.101e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.441e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.692592322658
-	   1        10.490408346050    3.939e-01
-	   2        12.018989318895    2.063e-01
-	   3        12.236695142072    5.074e-02
-	   4        12.243823613582    1.469e-02
-	   5        12.248391603354    3.641e-03
-	   6        12.248130104407    1.635e-03
-	   7        12.247909955895    4.952e-04
-	   8        12.248046890301    2.222e-04
-	   9        12.248019215060    6.429e-05
-	  10        12.248025404715    1.911e-05
-	  11        12.248027792757    6.466e-06
-	  12        12.248030824745    2.198e-06
-	  13        12.248031891251    5.363e-07
-	  14        12.248032214296    1.460e-07
+	   0         8.692592226045
+	   1        10.490408230041    3.939e-01
+	   2        12.018989179337    2.063e-01
+	   3        12.236694990555    5.074e-02
+	   4        12.243823461844    1.469e-02
+	   5        12.248391451361    3.641e-03
+	   6        12.248129952431    1.635e-03
+	   7        12.247909803926    4.952e-04
+	   8        12.248046738322    2.222e-04
+	   9        12.248019063083    6.429e-05
+	  10        12.248025252738    1.911e-05
+	  11        12.248027640779    6.466e-06
+	  12        12.248030672767    2.198e-06
+	  13        12.248031739273    5.363e-07
+	  14        12.248032062319    1.460e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 5.555e-08
 
 	Computing P_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.168849911504
-	   1         9.199498391740    2.323e-01
-	   2         9.751285328650    1.044e-01
-	   3         9.849582072709    2.886e-02
-	   4         9.847891004385    8.152e-03
-	   5         9.848966207036    1.673e-03
-	   6         9.848921172386    6.489e-04
-	   7         9.848917704271    1.569e-04
-	   8         9.848928302562    5.212e-05
-	   9         9.848919156375    2.225e-05
-	  10         9.848922958016    9.841e-06
-	  11         9.848923572725    2.998e-06
-	  12         9.848924615205    9.961e-07
-	  13         9.848924818252    3.861e-07
-	  14         9.848924898821    1.054e-07
+	   0         8.168849915416
+	   1         9.199498399334    2.323e-01
+	   2         9.751285338020    1.044e-01
+	   3         9.849582079196    2.886e-02
+	   4         9.847891010901    8.152e-03
+	   5         9.848966213526    1.673e-03
+	   6         9.848921178876    6.489e-04
+	   7         9.848917710760    1.569e-04
+	   8         9.848928309052    5.212e-05
+	   9         9.848919162865    2.225e-05
+	  10         9.848922964506    9.841e-06
+	  11         9.848923579215    2.998e-06
+	  12         9.848924621695    9.961e-07
+	  13         9.848924824741    3.861e-07
+	  14         9.848924905311    1.054e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 2.869e-08
 
 	Computing L_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.280438994803
-	   1         0.371361838663    1.009e-01
-	   2         0.471651547773    6.845e-02
-	   3         0.484364612368    2.032e-02
-	   4         0.489347451485    1.073e-02
-	   5         0.489911804533    2.331e-03
-	   6         0.489834712389    1.420e-03
-	   7         0.489907742765    7.630e-04
-	   8         0.489907746311    2.549e-04
-	   9         0.489906317860    6.078e-05
-	  10         0.489908398321    3.042e-05
-	  11         0.489908751802    8.951e-06
-	  12         0.489909091837    4.525e-06
-	  13         0.489909114281    1.152e-06
-	  14         0.489909255713    6.152e-07
-	  15         0.489909373231    2.200e-07
+	   0         0.280438991009
+	   1         0.371361833245    1.009e-01
+	   2         0.471651539689    6.845e-02
+	   3         0.484364603776    2.032e-02
+	   4         0.489347442754    1.073e-02
+	   5         0.489911795769    2.331e-03
+	   6         0.489834703624    1.420e-03
+	   7         0.489907733988    7.630e-04
+	   8         0.489907737533    2.549e-04
+	   9         0.489906309082    6.078e-05
+	  10         0.489908389542    3.042e-05
+	  11         0.489908743023    8.951e-06
+	  12         0.489909083059    4.525e-06
+	  13         0.489909105503    1.152e-06
+	  14         0.489909246934    6.152e-07
+	  15         0.489909364453    2.200e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 8.192e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.035221686904
-	   1         7.203431615233    3.036e-01
-	   2         8.082456187114    1.437e-01
-	   3         8.136577479984    2.983e-02
-	   4         8.138127889486    1.036e-02
-	   5         8.139238839229    2.346e-03
-	   6         8.139491473949    1.024e-03
-	   7         8.139434659373    2.591e-04
-	   8         8.139430452042    1.022e-04
-	   9         8.139426049199    2.475e-05
-	  10         8.139428164368    7.449e-06
-	  11         8.139428982346    2.414e-06
-	  12         8.139429532985    7.302e-07
-	  13         8.139429746243    2.172e-07
+	   0         6.035221637163
+	   1         7.203431551379    3.036e-01
+	   2         8.082456108041    1.437e-01
+	   3         8.136577399080    2.983e-02
+	   4         8.138127808458    1.036e-02
+	   5         8.139238758159    2.346e-03
+	   6         8.139491392867    1.024e-03
+	   7         8.139434578294    2.591e-04
+	   8         8.139430370963    1.022e-04
+	   9         8.139425968120    2.475e-05
+	  10         8.139428083290    7.449e-06
+	  11         8.139428901268    2.414e-06
+	  12         8.139429451907    7.302e-07
+	  13         8.139429665164    2.172e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 7.344e-08
 
 	Computing P_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.560298655846
-	   1         9.452235201987    2.172e-01
-	   2         9.939009704757    8.863e-02
-	   3         9.979824019808    2.356e-02
-	   4         9.977126647569    8.216e-03
-	   5         9.977792532634    1.942e-03
-	   6         9.978033679699    8.294e-04
-	   7         9.978013810798    2.481e-04
-	   8         9.978013707439    8.154e-05
-	   9         9.978007066326    2.459e-05
-	  10         9.978010579468    6.088e-06
-	  11         9.978011699417    2.188e-06
-	  12         9.978012321807    7.244e-07
-	  13         9.978012546253    3.194e-07
+	   0         8.560298665088
+	   1         9.452235210903    2.172e-01
+	   2         9.939009712159    8.863e-02
+	   3         9.979824026367    2.356e-02
+	   4         9.977126654125    8.216e-03
+	   5         9.977792539176    1.942e-03
+	   6         9.978033686233    8.294e-04
+	   7         9.978013817332    2.481e-04
+	   8         9.978013713973    8.154e-05
+	   9         9.978007072860    2.459e-05
+	  10         9.978010586002    6.088e-06
+	  11         9.978011705951    2.188e-06
+	  12         9.978012328342    7.244e-07
+	  13         9.978012552787    3.194e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 9.966e-08
 
 	Computing L_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.333764813277
-	   1         5.296520310202    3.172e-01
-	   2         6.231001510687    2.287e-01
-	   3         6.496507781226    9.756e-02
-	   4         6.601902855081    5.559e-02
-	   5         6.615164178139    1.513e-02
-	   6         6.618869528813    8.529e-03
-	   7         6.618879535302    2.377e-03
-	   8         6.618572573738    9.321e-04
-	   9         6.618465227605    3.594e-04
-	  10         6.618442424974    1.658e-04
-	  11         6.618451827555    6.184e-05
-	  12         6.618467480938    2.133e-05
-	  13         6.618475922113    8.629e-06
-	  14         6.618483521040    4.974e-06
-	  15         6.618489220105    2.048e-06
-	  16         6.618492250485    9.175e-07
-	  17         6.618493175955    2.370e-07
+	   0         4.333764788838
+	   1         5.296520282068    3.172e-01
+	   2         6.231001480117    2.287e-01
+	   3         6.496507748828    9.756e-02
+	   4         6.601902823335    5.559e-02
+	   5         6.615164146260    1.513e-02
+	   6         6.618869496915    8.529e-03
+	   7         6.618879503388    2.377e-03
+	   8         6.618572541817    9.321e-04
+	   9         6.618465195689    3.594e-04
+	  10         6.618442393058    1.658e-04
+	  11         6.618451795640    6.184e-05
+	  12         6.618467449023    2.133e-05
+	  13         6.618475890198    8.629e-06
+	  14         6.618483489125    4.974e-06
+	  15         6.618489188189    2.048e-06
+	  16         6.618492218570    9.175e-07
+	  17         6.618493144040    2.370e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 6.773e-08
 
 	Computing 1/2 <<Mu;L>>_(0.077) tensor.
 	Computing 1/2 <<P;L>>_(0.077) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933719  0.015024519180328 -0.027415915569927 -0.162886507397778  0.113254822182172 -0.064023650931690  0.055316304980596  0.030988679956786  0.002674429417477
-    1  (  1)  0.215473680254303  0.146951879885484 -0.277734064030081  0.062883278347954  0.148483123915935  0.181595053380814  0.367001371843722  0.003086313328534  0.095386404339393
-    2  (  2) -0.028492499167414  0.000076506520592 -0.059221747197113  0.071711487991955  0.074053260083134  0.055563200913425 -0.046720222778269  0.241063526706415  0.098194384215310
-    3  (  3) -0.132536698935225 -0.177581639220036 -0.107360746511047 -0.032262815899199  0.006088751294667  0.053657437577797 -0.241466578728664 -0.131962062699398  0.577380042604837
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927832  0.060461893794974 -0.005615477646775 -0.003888920206542  0.016113135271293 -0.008672229740057
-    1  (  1) -0.037058680758818 -0.084686071934143 -0.145302623884171 -0.027760832624295 -0.054555858489399  0.022009727182523
-    2  (  2) -0.087315818129461  0.399047483163753 -0.041723099752478 -0.020041920189952 -0.040600995633868  0.007777357868478
-    3  (  3)  0.035307803556741 -0.050920479686544  0.165550414172814 -0.068091463340302 -0.144062340529055 -0.042051983076328
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356551 -0.081063517853362  0.006129432768986  0.163964563111019  0.188951419459760 -0.080047732466264  0.074988303081860  0.007836242506545 -0.044696302205990
-    1  (  5)  0.348085979138498  0.014814724303187 -0.054134117524106 -0.070406995762195  0.073423358836442 -0.343984245233778  0.389896180591041 -0.295068043464420  0.051928952937995
-    2  (  6)  0.021691230674299 -0.340003625622924 -0.038072452179293 -0.014533847126865 -0.084733391360494 -0.004556444515594  0.201335045135129  0.349717311230211 -0.082620936463628
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932767 -0.007485730843830 -0.029474818409048  0.032209758674475  0.014108652541198
-    1  (  5)  0.209382720135360  0.066996563725018 -0.203801631001162 -0.021994746468443  0.025790645299269
-    2  (  6) -0.188199132187482 -0.086167806666975 -0.070501884768036 -0.051440727873375 -0.127552190835519
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135226960454329 -0.626072128797856  0.189283545408859
-    1  (  1) -0.198601340506734 -0.037544167210706 -0.132449472453120
-    2  (  2)  0.054869769604055  0.126822216303605 -0.064658685102821
-    3  (  3)  0.615161980452155 -0.126204375217765 -0.081927924761018
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135552779706607 -0.198154082714879  0.054851984676127  0.616510373253303
-    1  (  5) -0.625008803021780 -0.037782453643458  0.128063646533814 -0.126279998076331
-    2  (  6)  0.187629167441129 -0.129442737930206 -0.067422044676100 -0.079936634548172
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904639712499451 -0.487488103200076 -0.229076194035639  0.577203417890310 -0.193643876562866 -0.103447604010490 -0.002742470403339 -0.002451788094673 -0.093813724218951
-    1  (  1) -0.150591231752366 -0.132839961398672 -0.684911223766594  0.231736797158550 -0.050522572299863 -0.177494490840206  0.234003342486174  0.124606643062300 -0.128494931356720
-    2  (  2)  0.012679732612875 -0.025746334218933  0.172509146876756 -0.235881170188724 -0.123364008457064 -0.206129657450651 -0.121800673855344 -0.114140784221077 -0.027356216567683
-    3  (  3) -0.420686741899109  0.000223888623798 -0.019382136800427 -0.199660686586779 -0.007228242971357  0.053875733566216 -0.291408914352131  0.275298575094287  0.504737487457482
-    4  (  4) -0.444479349932693 -0.097546029689334 -0.201324076119099 -0.112193453655926 -0.168730295177634  0.009510393466796 -0.073326647656899 -0.314743664834695  0.576679302947873
-    5  (  5) -0.139143305540458  0.035439861017558 -0.250210390538763 -0.395563451554525  0.287109450839577 -0.179399443391397  0.197453518892115  0.283328589948476 -0.108409713739241
-    6  (  6) -0.129858112319494 -0.067528694061774  0.181320447910016  0.198216451549469  0.101434222271579  0.004260476702610 -0.540044484893358  0.047093544204538 -0.240211227858318
-    7  (  7) -0.134029026372210 -0.177806690148742  0.066071255125305 -0.420048245168344  0.282274848902259 -0.347456793165350 -0.074406017626731 -0.307127129684507  0.001639432917235
-    8  (  8) -0.063335732549803 -0.086906710930682  0.269779701592786  0.018783692891885  0.093247017991791  0.136863024113204  0.153892981652107 -0.031577691616058  0.057553836246905
-    9  (  9)  0.014012585179935  0.032071651340396  0.006363849845329 -0.122564599853837  0.077119470960815 -0.029965581352467  0.027046636903364  0.089397837094507 -0.000802529924293
-   10  ( 10)  0.055348506435332 -0.144624122276400  0.060432277066905 -0.048567020795871 -0.074912986944558 -0.098523802539065  0.029250640804258 -0.193836130554797  0.085063532916863
-   11  ( 11) -0.167019155111356 -0.139650558475056  0.283534980836447  0.091894060309841 -0.065838077605531 -0.024336945622807 -0.227843897422644  0.001167201554402 -0.053408806911177
-   12  ( 12) -0.031974022074094  0.367173995466684  0.116713714097489  0.049340092544995  0.015070529788415 -0.072500414701037  0.058353998450091 -0.115184864373284 -0.153182495837622
-   13  ( 13)  0.015928358602524 -0.071164774172970  0.101660897809921 -0.105977026406682  0.126658664034758 -0.065056017101762 -0.035738606034781 -0.004435603298656 -0.059994356828778
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128825974989509 -0.011693877694956 -0.146729379814636 -0.059424684705193 -0.018525365113581  0.062705489025799
-    1  (  1)  0.288526396149447  0.103129875764739  0.289919344105948  0.006241427794524  0.000597805518378 -0.002126961584359
-    2  (  2) -0.124928230102748 -0.010221797026422 -0.056571189754990 -0.103418885736763 -0.082343433199812  0.048808132756786
-    3  (  3)  0.041255915551182 -0.068310001947041 -0.078413018324291  0.150330242984032  0.179548999452936  0.040220285290074
-    4  (  4)  0.222674700983985  0.064061711596271 -0.051112895424348 -0.009318828777699  0.269456744732776  0.059360036713982
-    5  (  5) -0.030199751599662 -0.174896036167204  0.092691422408890  0.028256224393045 -0.095222992765338 -0.000984235427179
-    6  (  6)  0.000100463193790 -0.095109995484221 -0.236670455787565  0.077272409830334 -0.062627657605178 -0.003574021992867
-    7  (  7) -0.071380631315585  0.113168055430629 -0.125965816328841 -0.059330696538415  0.017157541349944  0.045135077260112
-    8  (  8) -0.578000624333793 -0.096150086854243  0.034301394867322  0.008135450733159  0.200641611845460 -0.180371714719462
-    9  (  9) -0.075918662396497  0.004599198141429  0.008112602200918  0.005143287525083  0.000284986477862 -0.012193359543266
-   10  ( 10) -0.010150745998766  0.093962320907848  0.012547284938522 -0.048325478252251  0.058041984098958  0.029299969972017
-   11  ( 11) -0.079273276366059 -0.056402585822246 -0.083755323132189 -0.007973236673640  0.003424691269612 -0.009405123180745
-   12  ( 12) -0.063303823644203  0.041869083940428 -0.019024216633724 -0.031772697856612 -0.042532243078164 -0.051259918656063
-   13  ( 13)  0.241542081048425  0.060829474159106 -0.029241791046113 -0.004754249561521 -0.057213036452335  0.050348392969429
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902374530738022 -0.153219479021377  0.011852929174237 -0.420772110136454 -0.445657281852233 -0.142990081433834 -0.124215890045092 -0.133483278617486 -0.065282671277575
-    1  ( 15) -0.489111175456921 -0.131490362750624 -0.025259277994888  0.001430871050471 -0.096952824968496  0.035534183248533 -0.068855717941569 -0.178542279529003 -0.088180183979087
-    2  ( 16) -0.227418381124785 -0.683144902334149  0.173877572588752 -0.020414541641232 -0.199817592754852 -0.249739904936588  0.179565732929473  0.064581867916785  0.271668362709088
-    3  ( 17)  0.574685513420631  0.230755641765144 -0.236330653993451 -0.198455558262947 -0.112539659295239 -0.393276362435767  0.196125851624956 -0.416930913980481  0.017841111258302
-    4  ( 18) -0.193861200268992 -0.049521286941690 -0.123799353815169 -0.006786264808002 -0.167396168176774  0.285560945535521  0.102872968175184  0.279329859462782  0.092685860122555
-    5  ( 19) -0.103950692672536 -0.178731366743218 -0.207305979104179  0.054759646458521  0.008750479265458 -0.180116361743218  0.005850873308053 -0.346544100781250  0.135656056953800
-    6  ( 20) -0.005630218802764  0.235616494969928 -0.121418775897667 -0.289705308748940 -0.074615700944863  0.197147960229531 -0.541298908627625 -0.074766151907221  0.151080244573413
-    7  ( 21) -0.003422639573229  0.126273883662637 -0.114690954063485  0.273155566178120 -0.312791095371318  0.283606567582012  0.047453631637779 -0.310404476862355 -0.030935364545071
-    8  ( 22) -0.094384208857050 -0.130119390042033 -0.029535782736702  0.507266905754751  0.577412507794685 -0.108469543731725 -0.239044626830660  0.001740919827196  0.057806922411999
-    9  ( 23) -0.126661063777409  0.286542775287408 -0.124995270818088  0.042040769766258  0.222601161131206 -0.031774064783095  0.002289661982445 -0.069973062056331 -0.578237160301556
-   10  ( 24) -0.012316706158688  0.104097860742328 -0.011505288408996 -0.071480242591920  0.067861431955970 -0.174641527191865 -0.093323115387981  0.108845273419844 -0.094609691027850
-   11  ( 25) -0.145222688889763  0.289337733151126 -0.056602400212228 -0.078531799009324 -0.050892925184258  0.092549568885425 -0.236281405460416 -0.125802430136002  0.035465582481700
-   12  ( 26) -0.059239279504459  0.006390267291517 -0.103087074498887  0.150070392220881 -0.009342684456032  0.028289380811624  0.077066678658251 -0.059246681674569  0.008175814399583
-   13  ( 27) -0.018271401982902  0.001173845770900 -0.081596168939475  0.178729785139683  0.269264211536985 -0.095094170813457 -0.063160456524518  0.017032758007907  0.200794357953944
-   14  ( 28)  0.062542890221320 -0.002043353345753  0.048801696637924  0.040072732580057  0.059190323152548 -0.000990742681887 -0.003556361910882  0.045152229102533 -0.180550803638744
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015123588660554  0.055493926114086 -0.169975137829357 -0.032809701818419  0.015002120333835
-    1  ( 15)  0.032575974689068 -0.144334404568220 -0.139389411890772  0.367448169822372 -0.070672349646380
-    2  ( 16)  0.006576811925777  0.060477069258309  0.284097691628268  0.117086244456111  0.102358639196809
-    3  ( 17) -0.124972828077174 -0.049265564522405  0.093111727254450  0.049489377800986 -0.106573762761508
-    4  ( 18)  0.078337257989412 -0.074315417379022 -0.066598566061427  0.015174881916742  0.127229135544739
-    5  ( 19) -0.030091617468876 -0.098524033243520 -0.024929078981092 -0.072709941383626 -0.065547640079006
-    6  ( 20)  0.028642219542832  0.029887343616837 -0.227866902460195  0.058376706970884 -0.035321371844135
-    7  ( 21)  0.087782136491553 -0.193844146817677  0.000960256633726 -0.115246048391410 -0.004217096818020
-    8  ( 22) -0.000480626398768  0.085216781964239 -0.052876715620283 -0.152779703755060 -0.059953833408394
-    9  ( 23) -0.075367737260776 -0.010279381835842 -0.080270644652149 -0.063438855793640  0.241130315879110
-   10  ( 24)  0.001339830230092  0.093599534020443 -0.056909491966955  0.041771584176774  0.060831797189675
-   11  ( 25)  0.008376396051511  0.012488344592190 -0.083677242445135 -0.018943587777834 -0.029225017366591
-   12  ( 26)  0.005096769732662 -0.048366952557418 -0.008003858722242 -0.031797935609827 -0.004752495908706
-   13  ( 27)  0.000291047131527  0.058011237654453  0.003385274769851 -0.042619295059266 -0.057154993286885
-   14  ( 28) -0.012282741908214  0.029296735642711 -0.009480582784426 -0.051319211356101  0.050295534824424
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027700885793090  0.024831013973620 -0.023766237412625 -0.167016603039327  0.109441555361099 -0.067202506902943  0.052695088582618  0.024064411648558  0.006188438734744
-    1  (  1)  0.211348759010705  0.133908962277450 -0.251856181342018  0.050198620343957  0.139035741221492  0.172926066548658  0.339110899470513  0.007367826854054  0.086633467632879
-    2  (  2) -0.033041625132306  0.014036582200115 -0.054189619432057  0.084538537056286  0.066377206996811  0.053646226488719 -0.037306526458897  0.220368264081415  0.092674869094203
-    3  (  3) -0.148568319902254 -0.152791211204353 -0.088570806082631 -0.044321874775550  0.009397298861476  0.049588338511193 -0.223116042687511 -0.123854255485030  0.553492211947825
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031010458886505  0.050729211215458 -0.003248182162608 -0.003208641714203  0.015229535075598 -0.008450459157620
-    1  (  1) -0.026218145702581 -0.073512341998455 -0.129399675880907 -0.023964582987074 -0.050019383975377  0.020539415914057
-    2  (  2) -0.075590807542000  0.365585379125664 -0.036729157945636 -0.016058134590280 -0.036438378068464  0.005536360852376
-    3  (  3)  0.037937313174203 -0.045234909961237  0.147760703126575 -0.060764535561285 -0.127333495556462 -0.038975339991211
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.051048798017959 -0.074362715758791  0.011189550347852  0.166183248293228  0.192475433446903 -0.070879824995202  0.064177194660685  0.010742342939179 -0.040136733536896
-    1  (  5)  0.352033813656898  0.019031583986232 -0.054018125678766 -0.066876079961775  0.060148226317511 -0.330348230405564  0.365124970723465 -0.284795973003407  0.051302526538107
-    2  (  6)  0.016809582021521 -0.311268516971315 -0.037661154101055 -0.006688597064538 -0.076727139945066  0.002675593746451  0.192087236696226  0.332474625249023 -0.065875996007769
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002709655241188 -0.005736834567419 -0.024459935540253  0.027202469191560  0.013148077561853
-    1  (  5)  0.191661619772415  0.061070263266085 -0.180667286312627 -0.019964047997524  0.020757203718351
-    2  (  6) -0.172312444590060 -0.078944608822718 -0.060240884585305 -0.044786922712268 -0.117310123601201
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102371  0.008188589712253 -0.013790999932786 -0.066013267343743 -0.002979179364400  0.115067560152139 -0.029904774000612  0.075658337330171  0.005135342269600
-    1  (  1) -0.415137332088601  0.400791789518638  0.060626653167993 -0.009777722957293  0.182694524485328  0.107591424113232 -0.071470092116899  0.210805299972914 -0.029640655301113
-    2  (  2)  0.731004204598520 -0.977674938020327  0.030910735141464  0.126476447646343  0.160297857646314 -0.115254107794063  0.017919423470237  0.019160269758155  0.056677210806000
-    3  (  3) -0.052710934455990  0.190825342618795 -0.121683764296164  0.058318753384800 -0.051331848225844  0.122833340921047  0.176985596744929 -0.321410474763129  0.015752780623213
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449213 -0.003857954296837  0.001116934481339 -0.006268480889136  0.011819863965877  0.022338641059405
-    1  (  1)  0.026581167918671 -0.003242138995827  0.002209759168118 -0.126256065331473  0.064001666171839  0.019583311633873
-    2  (  2)  0.060541607763312 -0.048685401885036 -0.005324531906369 -0.077364982992387 -0.023160042352107 -0.131997334895641
-    3  (  3)  0.086532549077855 -0.501054912835389 -0.033953281830232 -0.045954160893793  0.007588765668991  0.026055365513597
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407922 -0.003874637131508  0.017573675069981 -0.250000468336213  0.193535227171919 -0.023949830014063 -0.006344215172670 -0.002637721142585  0.025018403626543
-    1  (  5) -0.061066900138168  0.119597101102997  0.077747477731561 -0.181802110874954 -0.105212352540637 -0.191650240311696 -0.067261595147758  0.101033231559049  0.034053487252848
-    2  (  6) -0.129779125650155  0.272168473286835  0.218088904973350 -0.105590817864479  0.170044089806049 -0.413895401404366 -0.204721805057804  0.193774792721739  0.022574107317581
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304092 -0.022619515940244  0.001370551331509 -0.019480287608797 -0.016611790333304
-    1  (  5) -0.015006262168536  0.018557640744952 -0.000086080146175 -0.193359672647774  0.037991057379311
-    2  (  6)  0.020942063740395 -0.276121820896827 -0.020375408054503  0.090755244706104  0.038585932807349
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234755470283494 -0.089757897373020 -0.029226311105252
-    1  (  1)  0.628249611487235  0.562405195056318  1.006567293279179
-    2  (  2) -1.014513658696574  0.324469533164471  0.758540603298664
-    3  (  3)  0.070695571972197 -1.217301397368710  0.544825504539347
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235350713719763  0.628273412467382 -1.016171307500330  0.070820853933159
-    1  (  5) -0.089319079346847  0.558364917857372  0.332433157387859 -1.220987955904316
-    2  (  6) -0.028486683819977  1.000293875862972  0.767362449165329  0.543367325750415
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.804113115082476  0.859865209405978  0.271144212420722  0.233800284186400 -0.124039945960302 -0.010266323749701 -0.092708567501353  0.016778206024767 -0.004458179405382
-    1  (  1)  0.400343044462577 -0.255491137898964  1.725894952211806  0.228060869773276 -0.016813664829395  0.078025484956049 -0.010667432793276  0.508783176705980  0.007215780908188
-    2  (  2) -0.011354346714470 -0.088649218741431 -0.217285460959696 -0.271127696601060 -0.847424926486828 -0.636922641013174  0.167096970483907  0.613137270589982  0.118274978265568
-    3  (  3)  0.794199691903238 -0.188240166832123  0.221783053519905 -0.127263314849504  0.529647578782938 -1.234322959040903  0.503694754515607 -0.716759154325272  0.003713884622693
-    4  (  4) -0.401724672662203  0.338296304392140  0.027696569600284 -1.521982152310056  0.118592993377401  0.737822504259554  0.133024505198137  0.089529285352600  0.037479870573311
-    5  (  5) -0.062644206103431  0.401210407583383 -0.021849381974102 -0.715241456861441 -1.272083761860537  0.501726128250219 -0.443637757248850 -0.893021281361452  0.592660402987318
-    6  (  6) -0.010995449282209  0.203452242512905 -0.137034668384831 -0.113107359606073 -0.481513340581640  0.549194810269266  1.454087044363765 -0.104931286723953 -0.037492008681457
-    7  (  7)  0.128269755499557  0.321618430212614  0.165227456397847  0.036785042290031  0.490368577399565  0.556638814927009 -0.027991830909201  0.572834606710096  0.836617597163443
-    8  (  8)  0.028289154881459 -0.066964202719289 -0.261747148048837 -0.132206243094573 -0.099640531633427  0.125261053712928 -0.191170844521896  0.152462184420595 -0.345612464691053
-    9  (  9) -0.116917200683994  0.677293814759277  0.057457633837352  0.132537898195641 -0.004175807366595 -0.154875636337893 -0.038546773688736 -0.121822888362931 -0.349244520254478
-   10  ( 10) -0.180886604759012 -0.111792204438004  0.370617548329878 -0.010060948397306  0.175897261426789 -0.187416342815067 -0.018902126694380  0.507517994343604 -0.113620600518286
-   11  ( 11) -0.014433403132825  0.015210570936209  0.010143344331716 -0.005691229002309 -0.031059326071816 -0.023288546292970  0.128101332902295 -0.039392944850365 -0.110920114561223
-   12  ( 12) -0.125268954735601 -0.096735894811095  0.052480306210840  0.258243594453840  0.005805250173734  0.145107299027993  0.116452856795828 -0.074374807730486  0.022119923916482
-   13  ( 13) -0.016491827683000 -0.002316794514604 -0.087971851878040 -0.101325911412249 -0.036377238947136  0.195278206944885 -0.010131352705033  0.009611107176441 -0.056274461553023
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020619978804336  0.055393926260187  0.016493468301721 -0.100372381621025  0.100626242248385  0.085758294302206
-    1  (  1) -0.158166323997471 -0.302157830906837 -0.003244540958725  0.141116982835112 -0.086717578223953 -0.004480871143073
-    2  (  2)  0.117237563107159 -0.174570847573259 -0.011204345589108 -0.263173432731341  0.005218532196564 -0.028842080195291
-    3  (  3)  0.116941646649189 -0.002586479599499 -0.011231548488132 -0.058984655279808 -0.019822661982984  0.041048882280058
-    4  (  4)  0.050776820640492 -0.220908341720040  0.039982596283606 -0.028513186801397  0.038501560477761 -0.072498198103566
-    5  (  5) -0.020348029264266  0.163764941111612 -0.082946711645337  0.111452654944128  0.037984566239181 -0.107199595568986
-    6  (  6)  0.021256126103379  0.388694787591390  0.114910007821006  0.018804713347374  0.008937619959600 -0.015873506672536
-    7  (  7)  0.297925323013482  0.033191669222652  0.094278199439545 -0.060174035263233  0.021406855727383  0.043089336483829
-    8  (  8)  1.538149876661748  0.255388094594388 -0.163312643003206 -0.034677585072596 -0.142125228818852 -0.045738087971663
-    9  (  9)  0.091443541252263 -0.031128123891510 -0.061982026707845 -0.058678185009713  0.760839955512426  0.950617857123983
-   10  ( 10) -0.067301877513073  0.211057800702045 -0.020603819563676  1.234407038988020 -0.163795705022985  0.167535211420867
-   11  ( 11)  0.163445976328785 -0.060082779666638  1.332811809287810  0.048638214648072 -0.084741484840249  0.093756111599780
-   12  ( 12)  0.205948682024844 -1.200679744036826 -0.135474810029670  0.365861100667224 -0.094093662797851  0.008686523394777
-   13  ( 13) -0.181605938452019 -0.042014918886121  0.112406427108198  0.222953862798531  0.995139187403178 -0.917632565321793
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802008727902676  0.406135528069464 -0.010476316014009  0.784475556802925 -0.394386683091379 -0.066798881058913 -0.011980564813184  0.124376056524327  0.033526134230615
-    1  ( 15)  0.862028914432798 -0.259382739909270 -0.086667305572556 -0.180064784220824  0.329908607377610  0.399964089565218  0.202187771096648  0.330121816685668 -0.071953120874649
-    2  ( 16)  0.271307809960556  1.724790149840180 -0.218446172710940  0.221581282093097  0.027552874986014 -0.019301351758279 -0.136156749402974  0.163711145289557 -0.262315292158515
-    3  ( 17)  0.233832160360352  0.228075923415961 -0.271855585595643 -0.127498943532479 -1.519236751765249 -0.714946933274063 -0.112783303905572  0.035742190545400 -0.131799331720385
-    4  ( 18) -0.125884857507763 -0.016503178327094 -0.848590316809874  0.528676059271103  0.118589942995782 -1.271521009941038 -0.481050683706501  0.489094666232462 -0.100427993377482
-    5  ( 19) -0.011410411929745  0.078504916539371 -0.635756927956321 -1.233330464680106  0.737249034134023  0.499445190730480  0.548364048058884  0.558640131287018  0.124411035854046
-    6  ( 20) -0.091600083261379 -0.011874324392688  0.166095509172862  0.503931355593045  0.132971166339029 -0.442847331045808  1.455101200236588 -0.028340512672182 -0.190421039545484
-    7  ( 21)  0.014506888035513  0.509793857361997  0.613540224928976 -0.716635769138246  0.088503909894013 -0.892421715175110 -0.105643577538776  0.572215069358599  0.150576387127195
-    8  ( 22) -0.004177720337585  0.006709815498361  0.117678875953393  0.003186946250580  0.038303116431615  0.593619431704741 -0.036920385902422  0.835672825510649 -0.345283877638179
-    9  ( 23) -0.021586239236066 -0.156869719857391  0.117889758366706  0.115161423657162  0.052238225817572 -0.022709102193988  0.020562459070751  0.298677779552442  1.538509512042474
-   10  ( 24)  0.054682068155322 -0.300070995804169 -0.172660016100411 -0.004680568559172 -0.221321821680690  0.163619483231716  0.386948477906845  0.033115261343835  0.254769962308442
-   11  ( 25)  0.016488293849114 -0.003235639473042 -0.011174682028037 -0.011243945686257  0.039809588242799 -0.082761513420842  0.114884412151977  0.094200391738445 -0.163393716854439
-   12  ( 26) -0.099231335638990  0.141112668735458 -0.262446613088940 -0.059563147663723 -0.028574452319685  0.111394864273785  0.018513759386789 -0.059760408126138 -0.034040397389902
-   13  ( 27)  0.100244162906012 -0.086825753516494  0.005142496829835 -0.019052879526336  0.037887085038889  0.037954868269104  0.008919579926839  0.021672382001860 -0.142649674386495
-   14  ( 28)  0.086046561377276 -0.004744302368676 -0.028249738219529  0.042030603060909 -0.073561648753534 -0.107720217983957 -0.016217142075148  0.044341471770554 -0.046187444393712
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124233708134524 -0.184518326175241 -0.014667753095383 -0.126540650902724 -0.015843433752182
-    1  ( 15)  0.686899770278225 -0.109692117003678  0.015377495137089 -0.096723489130419 -0.002397757787942
-    2  ( 16)  0.057205529179578  0.372042133273666  0.010210131259620  0.052160697899357 -0.088271643130929
-    3  ( 17)  0.131871345108673 -0.011180948360743 -0.005727193367058  0.259941586635743 -0.101614450210782
-    4  ( 18) -0.005079597151441  0.176830214271515 -0.031032942109520  0.004628941737829 -0.036366477592845
-    5  ( 19) -0.153488339566637 -0.188246645479869 -0.023332293508375  0.145173541284822  0.195552538719584
-    6  ( 20) -0.038666420291799 -0.018333798481476  0.128217423491274  0.116258211557263 -0.010271886085243
-    7  ( 21) -0.121961409061181  0.508144909444715 -0.039497933150391 -0.074911313979370  0.009738174256592
-    8  ( 22) -0.349752281191330 -0.113379050365496 -0.110884161439947  0.022227055299984 -0.056428042287631
-    9  ( 23)  0.091274387643073 -0.068482004342729  0.163392525285683  0.205701365643175 -0.181416453396984
-   10  ( 24) -0.031494844080999  0.210984913522458 -0.060264440706329 -1.201297108840472 -0.041823116964630
-   11  ( 25) -0.061998986866118 -0.020468588707436  1.332808723106094 -0.135556576828281  0.112406197562940
-   12  ( 26) -0.058487448549072  1.234274465594829  0.048631105388928  0.365854082846019  0.222962926250735
-   13  ( 27)  0.761200546740672 -0.163618812251219 -0.084738989433889 -0.094122389252772  0.995165590894077
-   14  ( 28)  0.951772998269747  0.167560207344577  0.093759874796889  0.008708619204375 -0.917569948681374
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062431637468593  0.002416441043502 -0.004633709181853 -0.077570764564644 -0.013832459901153  0.123710471759642 -0.027165779035152  0.071044010954106  0.019658423662045
-    1  (  1) -0.407170389584207  0.333069478291504  0.076649076907715  0.002175328366486  0.197922707135412  0.117656968282773 -0.067757706616657  0.182812175438104 -0.031734247883933
-    2  (  2)  0.673185035517364 -0.888138019247633  0.034358376579768  0.125358507387098  0.172994941404750 -0.106755581181878  0.013852200121285  0.009496870454365  0.036809619943040
-    3  (  3) -0.040742790622464  0.181389056204803 -0.117008669682237  0.012401302848610 -0.022196391591020  0.102862126461667  0.166049221641567 -0.310434511631989  0.017146561969842
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.010530607294137 -0.003710118206635  0.001098184033274 -0.004177259623775  0.010641720243898  0.020819711535909
-    1  (  1)  0.026376312845794 -0.003084063695378  0.001935075690030 -0.112197866496257  0.055637648529143  0.022260912302157
-    2  (  2)  0.054059905057588 -0.043789787513272 -0.004472231165835 -0.071437136436271 -0.024456749693059 -0.126350825107537
-    3  (  3)  0.083331116085336 -0.461426302980743 -0.028171699513186 -0.043194879139585  0.008942983333376  0.024389199674006
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.021216263100624  0.005003175055611  0.013535160841110 -0.263704651382069  0.210918804180354  0.005688291976377  0.005207710700420 -0.000895282201931  0.031550648985105
-    1  (  5) -0.080441383224434  0.123194069685476  0.057717422634421 -0.198323986141409 -0.141861353254402 -0.184709849630280 -0.056481718890564  0.088971412091769  0.030305733467363
-    2  (  6) -0.146541148918456  0.264369470289011  0.161465568338032 -0.083507608614794  0.171726934895348 -0.400382872983885 -0.201596935132391  0.184414767198936  0.015497227351117
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.010467742288235 -0.019463191825823  0.001308339278104 -0.016880359740534 -0.016885157913524
-    1  (  5) -0.009224792466209  0.019323723500934 -0.001197784436253 -0.171358632107000  0.032143333569082
-    2  (  6)  0.022721945593511 -0.245666385556987 -0.017093671892173  0.084713974597813  0.032963157176325
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521806 -0.064555152855150  0.195953381503074 -0.041248493404101 -0.011229686922118 -0.030149441468389 -0.052245051042507 -0.006640144591450 -0.060816046803629
-    1  (  1)  0.618380750339701 -0.527850820452489 -0.215416501468042 -0.157035437820978 -0.069798458053206  0.063297476854315 -0.224803808806328 -0.036770088857857 -0.093292414355450
-    2  (  2)  0.089963765220201  0.016694193855691 -0.049894217028077 -0.224500363636593  0.100545586935602 -0.339808932362407 -0.300486601785008  0.103978674940020  0.003854593986179
-    3  (  3) -0.017912540893906  0.240051544179780  0.016875920141062 -0.019658112757037  0.000950481978191  0.139486307895354 -0.307526295494235 -0.245045411721377  0.038982174459016
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151715 -0.053483299255778  0.001461399819935 -0.009996127160186  0.040844890766482
-    1  (  1)  0.010356156252337  0.045196494943178  0.123149462829325 -0.009608799091532 -0.092775098416542
-    2  (  2)  0.068261626755321 -0.266621644473694  0.090983468547793 -0.007824999539039 -0.015479677414574
-    3  (  3)  0.102991688131891  0.095940846129218  0.235195882789532  0.030438278876707  0.100331913639094
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065252  0.055002400477820 -0.190701615134350 -0.008587073556999 -0.137456634337686 -0.102685174742854 -0.038575707278163  0.049077773985903  0.038775520871493
-    1  (  5)  0.266426121061197  0.201904502527540 -0.404472747743452  0.112355452346377  0.244543383067891  0.203488255110601  0.093346083766343  0.046662175778558  0.162564534078692
-    2  (  6)  0.310200495971193  0.275860886663895 -0.334362481171644  0.111323203428054  0.107269573508054 -0.015396505983498 -0.485347827861586 -0.115211810541092 -0.189399381355332
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661083 -0.010182782856370  0.015536223735827  0.027148068637771  0.019304531582391 -0.012170541889264
-    1  (  5) -0.076359104752405  0.072719944885937 -0.105706045053704 -0.076791075572625 -0.095250630872875  0.044053081318692
-    2  (  6) -0.023401555368550 -0.060789750773997  0.233844071164904 -0.060200608258467 -0.022972229731698  0.078966373846355
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134464733238505 -0.662210405494710 -0.268087036060520 -0.078995101665645
-    1  (  1) -0.664136191142175 -0.208512216408344  0.147227682691111  0.068768195668233
-    2  (  2) -0.267178832853329  0.148347614169083  0.187155712816505  0.001725942570582
-    3  (  3) -0.077975712094607  0.066243031692251  0.004079617492315  0.013944312169831
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274618126592083 -0.278113702179192 -0.671633022270393
-    1  (  5) -0.277949145712574 -0.011863615919937 -0.010374435234627
-    2  (  6) -0.670048686168263 -0.009476206950281  0.097890068097075
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959494414290863 -0.408191876587327 -0.490587797784240  0.038620088951639 -0.077925870525908 -0.487449819239226 -0.107605742375965 -0.396082210854085 -0.237542456199032
-    1  (  1) -0.404346098969015 -1.325089706115945  0.174671472615795  0.248857938939654 -0.197997176299344 -0.317531715369510 -0.251443125494019 -0.030205216051526  0.632709778669922
-    2  (  2) -0.488203594414096  0.174177358170181  0.686637133275358  0.342440322128134 -0.009976595906060  0.483509687591480  0.287263685741040  0.302820486761619 -0.272146504988732
-    3  (  3)  0.037519851932744  0.250891430235972  0.345028453615760 -0.288802596502157  0.242048997262005 -0.302155533583566 -0.510767048111895  0.184742116191421 -0.216988138473829
-    4  (  4) -0.076335128439655 -0.199690457337249 -0.011287590259897  0.242287343472375 -0.131826185478723  0.385784652335424 -0.241579744319049 -0.375155233716569  0.062534851979750
-    5  (  5) -0.485786339572480 -0.319069045647666  0.484028655874751 -0.298894130368339  0.382592029688619 -0.557110750088232  0.333239304019222  0.111824333667385  0.019820080095697
-    6  (  6) -0.105004388042450 -0.251919494300284  0.289657780268665 -0.510934745583747 -0.243423593715404  0.333487274729421 -0.859815579894716 -0.040189411214490  0.015976724219770
-    7  (  7) -0.396742866204475 -0.028527583501468  0.303542401120437  0.181332247012458 -0.373287106593945  0.109028339876173 -0.042483577229020 -0.424450995877430 -0.165337209178976
-    8  (  8) -0.232477111217568  0.628541780993326 -0.273469783503661 -0.217890852518759  0.061988654737634  0.020919866007563  0.015643111904890 -0.165546891359501 -1.139952791754352
-    9  (  9)  0.005546163403777  0.056122031350978  0.162961042742066 -0.082482781173148  0.072908205250711 -0.108799436968507 -0.023533780380778  0.044777427042681 -0.147235448199837
-   10  ( 10) -0.006901975709222  0.054429650490004 -0.040577693872421  0.341755839709625 -0.179734725561089  0.323402736691826  0.128204737160702 -0.274641710567075 -0.052505646555500
-   11  ( 11)  0.095370531310643 -0.102133079874740  0.068438122875491 -0.163729824989551 -0.155636229704599  0.243225496644137 -0.456632637964522 -0.005300419866762 -0.049825612054664
-   12  ( 12) -0.031656876480324  0.049261490140928 -0.071615793822912  0.132066208561300 -0.108599421258577  0.096544859699582  0.079601642520223 -0.086582876221009 -0.054558080822574
-   13  ( 13) -0.055177843918689  0.125972146875366 -0.045925897173261 -0.019932953437905 -0.072414580136130 -0.032514397877207 -0.014074648780379 -0.073540469649077  0.566252900794774
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006844108037305 -0.007417708485432  0.096179215271909 -0.031845351907952 -0.055819107034905
-    1  (  1)  0.055009072408372  0.054764569974465 -0.101360748266647  0.049483066032708  0.126311659941349
-    2  (  2)  0.163126461717715 -0.041474056730542  0.069773970511485 -0.071604513134729 -0.045921679797623
-    3  (  3) -0.081145867550878  0.339512714763498 -0.164814632361136  0.131963409806733 -0.019701057447459
-    4  (  4)  0.071392957638917 -0.177541925322340 -0.155855587434776 -0.108549913772844 -0.072788709838574
-    5  (  5) -0.105620913909823  0.324570384536922  0.243426148668966  0.096676164465062 -0.032493241135613
-    6  (  6) -0.022622971576123  0.128555788054646 -0.457558865820389  0.079424640656347 -0.014304063550758
-    7  (  7)  0.043872369029000 -0.277428590499607 -0.005167508600307 -0.086808599804727 -0.073543295023523
-    8  (  8) -0.147656701585296 -0.051770671721883 -0.049464276722939 -0.054622357068261  0.565518286432945
-    9  (  9)  0.072058098581738  0.045414939179581  0.010276622684317  0.009607329011719  0.026546654266797
-   10  ( 10)  0.047972578248001 -0.139091273135487 -0.006969817312947 -0.101924439794117 -0.021963395913837
-   11  ( 11)  0.010225949518788 -0.006903254834441 -0.093461448932079 -0.006458623521931  0.037408632154768
-   12  ( 12)  0.009659072763445 -0.101989750292791 -0.006543886552569  0.055499957258899  0.004536647288292
-   13  ( 13)  0.026525022859872 -0.022073627181822  0.037503294944025  0.004573821056446 -0.064450805660415
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.531729549886336 -0.787699013260711 -0.218007437963115  0.182768764967355  0.602768885926282 -0.199812958117875  0.029032839745446 -0.008774056557020 -0.142478600997377
-    1  ( 15) -0.793340915328507 -0.320131124132642 -0.162653978535479  0.058649157291271  0.020639907683380 -0.223525268439364  0.107699068558597 -0.353783645623565 -0.095871343640249
-    2  ( 16) -0.212191388052973 -0.164888118017383 -1.296946785661586  0.042300146112855  0.273826728839961 -0.438781481182550 -0.122091204716331  0.097191959044978 -0.140871391153818
-    3  ( 17)  0.179719553134575  0.058669914491576  0.044506714025033  0.293003077614387  0.349110568675538  0.303215667162520  0.076915097449359  0.005807473712119  0.013837821467220
-    4  ( 18)  0.599360800493505  0.022132908209847  0.274035423937645  0.351223850237559  0.210864723100271  0.044675310303964 -0.438675626813631 -0.490920343842280 -0.399212333009756
-    5  ( 19) -0.200407898503427 -0.221431932840866 -0.440102897905119  0.305762109213035  0.044881546181680 -0.117472965844256 -0.191665223291193 -0.319783714572763 -0.359452162382458
-    6  ( 20)  0.032165821117665  0.105941691907444 -0.123879210125596  0.078979233990767 -0.440650088275849 -0.189889145121464 -1.110705925194973  0.246906737793532  0.255259757334054
-    7  ( 21) -0.008321241705322 -0.354528191467819  0.096628486245017  0.006334262611286 -0.491255100347697 -0.318969662674755  0.247541587785853 -1.005004062277624  0.329386657154203
-    8  ( 22) -0.142962699223523 -0.097023037413530 -0.141097052846409  0.015166149439238 -0.401326717044742 -0.359426368362030  0.255258622579642  0.329097335449191  0.052132117322068
-    9  ( 23) -0.219955098740499 -0.249965476004892  0.576414624728276  0.098982863369343 -0.020508824733562  0.097549190747026 -0.059941456738195  0.014715712854362  0.155030958604457
-   10  ( 24) -0.078889746445527  0.108239301318897  0.027162587747058  0.046514963820383  0.091370815063919  0.113422647703527 -0.170202961400925  0.302110584863863 -0.032804637243869
-   11  ( 25)  0.043306270957026  0.032344455295712 -0.179576712827780  0.107307667430552 -0.187560546689518 -0.097222488608923 -0.510712264729798 -0.080025590477581  0.081254866792341
-   12  ( 26) -0.068084805818493  0.217394768160213  0.162482224135843  0.182198793902355 -0.078588038008432 -0.138375144701558  0.045964808967518 -0.318369645237641 -0.094340949188741
-   13  ( 27)  0.012776338365628 -0.163304628586267  0.065170181095061  0.076353862355042 -0.116471236774195 -0.057100568669669  0.002733328139538  0.275543901650377 -0.101218272889569
-   14  ( 28)  0.072542900570939  0.116082117753815 -0.039461901860544 -0.060056679393734 -0.063442716501357 -0.039954821491213 -0.007431183194753  0.061660754619166  0.127196734189517
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223424944652205 -0.079375640508214  0.044559638332807 -0.069603179695816  0.011608492724546  0.073681298891784
-    1  ( 15) -0.252190810534113  0.107773105664066  0.031929727381877  0.217773765514473 -0.162942254516887  0.115583488493233
-    2  ( 16)  0.579669499848566  0.028398284174976 -0.180764151357445  0.163082238678478  0.065318137383573 -0.039861277950853
-    3  ( 17)  0.098419070380167  0.045497640187089  0.108888066901941  0.182679251676306  0.077063420292993 -0.060270475148176
-    4  ( 18) -0.021657152218187  0.091391477818870 -0.188694941835267 -0.078654463992964 -0.116917635244834 -0.063687461311406
-    5  ( 19)  0.097200061293753  0.112946819841992 -0.096557046310024 -0.138722208764681 -0.057492822647808 -0.039657945432959
-    6  ( 20) -0.058061983715333 -0.170140847494680 -0.511516651549457  0.046153385708912  0.002608094185220 -0.007424017797983
-    7  ( 21)  0.014898598107653  0.302204656416846 -0.080604696411276 -0.318409184220321  0.275439068186140  0.061680442175976
-    8  ( 22)  0.155158381420886 -0.033182129585344  0.080993013335585 -0.094077880752310 -0.101045740908416  0.127069446713644
-    9  ( 23) -1.153500606432321 -0.223848574870770  0.084940142762237 -0.000172697505786  0.401118128913110 -0.346039941954426
-   10  ( 24) -0.224004522828896 -0.014993374950362 -0.013190820033297  0.067266852084061 -0.009898419000692 -0.084301934906628
-   11  ( 25)  0.084246516406395 -0.012971453666469 -0.099638608783541  0.005049425073667 -0.012239639402266  0.023058100761840
-   12  ( 26)  0.000190360752578  0.067412521796060  0.005072007098540  0.014663156532777 -0.012615786454228 -0.021995005158495
-   13  ( 27)  0.401506800485792 -0.009668467136178 -0.012313296328665 -0.012645382168427 -0.008180220628749  0.091135079144539
-   14  ( 28) -0.346436667192449 -0.084407881559674  0.023159285170774 -0.022057721310478  0.091092458906105  0.040126683454989
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057778460125472 -0.058621598376460  0.204961973610432 -0.030014886957090 -0.012702201238060 -0.012361806840327 -0.042464722570110  0.000589178332859 -0.053783176425630
-    1  (  1)  0.588150716074127 -0.466021636272277 -0.203183245475034 -0.148450737716235 -0.057365952908249  0.049828198627842 -0.211650340717439 -0.033709163320866 -0.066014023276544
-    2  (  2)  0.097096715428359  0.013316869335678 -0.075592001791479 -0.184144455632625  0.076454331448205 -0.322693901417435 -0.283033300411692  0.095787940086183  0.009135557725688
-    3  (  3) -0.012585457310347  0.213693355283453  0.008392879074061 -0.006477176275196  0.025095812734807  0.122050564721420 -0.287478867297995 -0.227752050770291  0.025535574433445
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004343658462411 -0.045416781087738  0.000353809954908 -0.008814420994646  0.038608153091639
-    1  (  1)  0.012371345270909  0.037357699916557  0.110010051271464 -0.008428651261313 -0.087698412018729
-    2  (  2)  0.059734573261686 -0.241104936943562  0.080654968743400 -0.004302203609175 -0.010690545484548
-    3  (  3)  0.093269555935925  0.087251850932647  0.210582632378021  0.029543407964617  0.092601662289161
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.096268685878254  0.067598109905927 -0.171831816211853 -0.019892225326838 -0.151432830345480 -0.102828613678833 -0.031328453208212  0.054857782228207  0.045391983457322
-    1  (  5)  0.259548823811751  0.185158249821503 -0.361847535039694  0.121706180799256  0.214912924418858  0.198674927692151  0.082249065771632  0.046754216202716  0.144894234012036
-    2  (  6)  0.316675644828396  0.241534850892174 -0.298024592816770  0.095120602156107  0.117908244615366 -0.011781114685607 -0.451417780640775 -0.113394265201573 -0.193663841427175
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.075217766018101 -0.009009066779016  0.013059078733353  0.023267742031501  0.019382631456242 -0.010439549922317
-    1  (  5) -0.055615787731079  0.073750137089777 -0.094740835467118 -0.066906556461928 -0.087569521638075  0.039832146294917
-    2  (  6) -0.007989421944937 -0.055545532554459  0.206332460425464 -0.056516118698086 -0.025725290779723  0.073743491663517
-
-	DPD File2: P*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.034398581574139  0.022991789103343 -0.034442469541574 -0.330456382558595  0.233180601662081 -0.129080132683952  0.099470500295552  0.033215263141241  0.017533788887759
-    1  (  1)  0.125193963201420  0.094056863638828 -0.250103765613866  0.112936578244967  0.149788194818876  0.227437707997397  0.485204338670596 -0.001668370995162  0.115356975205661
-    2  (  2) -0.012233240715705 -0.002368950907699 -0.032425209658723  0.111084203408140  0.039672156088148  0.068595430902717 -0.075952847158656  0.294199045975953  0.119345992966551
-    3  (  3) -0.102558388937001 -0.078769752966251 -0.070643800093594 -0.002465923506388  0.048634367995697  0.013847332731639 -0.279588501721531 -0.161409573415975  0.750269595437933
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.124162189892697  0.147322676383198 -0.023215723712951 -0.018481088431889  0.062726537287574 -0.032176124900128
-    1  (  1) -0.077900000614672 -0.192270763412161 -0.391012068764259 -0.097598573976617 -0.208812184695007  0.131278202406216
-    2  (  2) -0.138682144513485  0.743794268000919 -0.082765968014440 -0.105416894706173 -0.124502895186539  0.026640226681012
-    3  (  3)  0.046377167184700 -0.100266413297349  0.419637942135347 -0.187251279348108 -0.523906963118894 -0.155125602890936
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.041912647030473 -0.112025419050593 -0.015709063071357  0.296474982770456  0.369528478363753 -0.133936885862951  0.093834818402243  0.023683854572816 -0.145081231878617
-    1  (  5)  0.197308914804751  0.009979277982960 -0.032584585136142 -0.110675051536769  0.043528206747949 -0.380347857156503  0.467872633414304 -0.360690381381106  0.081727457648454
-    2  (  6) -0.017175555719515 -0.257070166950214 -0.064576654101859 -0.063636492651100 -0.124214525851134 -0.043707573882425  0.279300768930124  0.436090246737450 -0.143049583009588
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000746191936210 -0.015117415730589 -0.105376277097060  0.086551013225984  0.048055402355572
-    1  (  5)  0.421110018244562  0.132676872543725 -0.513327593087781 -0.036293567607712  0.089362635661765
-    2  (  6) -0.356450473386590 -0.161425142060580 -0.191834100484274 -0.123847982073522 -0.439997591973663
-
-	DPD File2: P*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.029996182749086 -0.414832297711576  0.157003165507011
-    1  (  1)  0.055478735634457 -0.002196588374944 -0.023132699054813
-    2  (  2) -0.030157480407918  0.003965129810969 -0.011365271034479
-    3  (  3) -0.379654970672918  0.026306776079243  0.008208478993038
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.031312576109208 -0.054324731747600  0.030004942403624  0.379837271496892
-    1  (  5)  0.410777629523562 -0.000546200526033 -0.004395778687124 -0.022468424749377
-    2  (  6) -0.155134874665963  0.021960972132954  0.010503724381488 -0.005891989839471
-
-	DPD File2: P*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.041599393589885 -0.048291903336677 -0.117743150821259 -0.017705215406280  0.102750295559090 -0.051687934108131  0.132725758102637 -0.024528471901836  0.009589411271459
-    1  (  1)  0.072748330347250  0.064838255172247 -0.046249888316539 -0.094886169756313  0.054353256296636  0.001900039815832  0.496484885699642  0.156782601344965 -0.027727244644896
-    2  (  2) -0.003177839573369  0.021969851213782 -0.169948604805852  0.034169379981814  0.096419218256700  0.054353168415603  0.268581512702098  0.051387229616377  0.132183241821031
-    3  (  3)  0.006137248486677 -0.083042433269493 -0.145748994350269  0.009514642471795  0.083396174376552 -0.050339592310292  0.147508653266551 -0.025994438523140 -0.274243623684456
-    4  (  4) -0.041743411936218 -0.025314466729841 -0.109116009514395  0.054695145126701  0.041005429820194 -0.040692158860824  0.089212628083091  0.089778026874393 -0.379559976718284
-    5  (  5)  0.144052404015687 -0.020202343348371  0.250448180839798 -0.333938875810814 -0.025165926872358 -0.198674007872287 -0.028751096000422  0.150673278776424 -0.071892589434733
-    6  (  6) -0.035008068923664 -0.061157292133481 -0.423122850397629  0.168586232676417  0.215300951076719  0.176816011547681 -0.082786884188413 -0.107997254201703  0.322302818265947
-    7  (  7)  0.040302039339094  0.134662805884699 -0.074305590729076 -0.347285947244785  0.297150726695267 -0.120577275637125 -0.158244548193724 -0.221247160594885  0.027161970952188
-    8  (  8)  0.102303986757075  0.083520013523575 -0.381308184856285  0.143001282615579 -0.075527648534131 -0.132398234942646 -0.075131991247111  0.046753082020740  0.011707789197025
-    9  (  9) -0.017637489191487 -0.048428952825929 -0.034610320117865  0.459992261564512 -0.414982694469193  0.130318968246814  0.031074590688744 -0.007719514803475 -0.025148594805028
-   10  ( 10) -0.073180570141060  0.217870134214265 -0.063234912206834  0.261216160873510 -0.027363003829309 -0.069320876175761  0.042163326174403  0.184139514400861 -0.015591773535866
-   11  ( 11)  0.219122634582937  0.188385339460405 -0.640855359878310 -0.491678336416958  0.065767561519751 -0.413066703397514  0.291084239981445  0.093425757726901  0.193265915162178
-   12  ( 12)  0.256885363420365 -0.713325451456200 -0.225955555841318 -0.439590507884674 -0.345303095230338  0.616947103758895 -0.172377723246676  0.152457697169388  0.041630471494425
-   13  ( 13)  0.012167367476476  0.157114215675033 -0.156454629287810  0.271295067840173 -0.465831347294122 -0.087124608448573  0.001414398542050  0.117289965933426  0.301481262964454
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.150893623694895 -0.070181619718899 -0.231121270771796 -0.047212329811452 -0.038360068214684  0.065024101530573
-    1  (  1)  0.459608701558993  0.017988718780734  0.620163221664037  0.047501992394079 -0.054935480129094 -0.084306620301789
-    2  (  2) -0.170353437709830  0.137438184253801 -0.448066510819233 -0.273677026815508 -0.394525740926135  0.158445088257267
-    3  (  3)  0.027380670374415 -0.505626164435732 -0.414944314617527  0.268646310616022  0.386727191221954  0.113140672337300
-    4  (  4)  0.013445627632877  0.536383433584967 -0.308426011289951  0.080146650927920  0.587918144857996  0.127182537475191
-    5  (  5) -0.035132080582143  0.167243745339779  0.093457222254525  0.023174375055702 -0.241438836836271  0.025034069681694
-    6  (  6)  0.086275759818652  0.157794617049890 -0.091627759449496  0.100678024828998 -0.039930496632404 -0.039747117277017
-    7  (  7)  0.064055657553950 -0.320525847624377 -0.102126662685902 -0.025362375541365  0.011829791315064  0.091201427043929
-    8  (  8) -0.004186527107181  0.116906210612177  0.371187985035768  0.069143142950027  0.337550034775452 -0.350111866606547
-    9  (  9)  0.075561519107680 -0.174471452153015  0.018361558412792 -0.007353276651567 -0.041439267169245 -0.006958189017632
-   10  ( 10)  0.027806429179180 -0.167045135107807  0.001907984997949 -0.011283070546443  0.060669265876427  0.055774837261520
-   11  ( 11) -0.242522311612009 -0.043113021308048  0.036594154697736 -0.051685667595428  0.018454723698115  0.000828881346793
-   12  ( 12)  0.005035323729735 -0.080726831317060  0.052335499542956 -0.044973984976305 -0.061396486662391 -0.099208229191671
-   13  ( 13) -0.438941651704024 -0.153468022162067  0.023659734102045 -0.002885107851831  0.071809885174399  0.077694612962715
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.044666447845943 -0.075416998324096  0.002009211971351 -0.008745765947599  0.041041980388066 -0.148478826412725  0.043148497905126 -0.040061402921621 -0.101604386418633
-    1  ( 15)  0.049162162504633 -0.064892835130685 -0.021916980092655  0.084534607702244  0.027746026910093  0.020171890051146  0.060412253106789 -0.135461490072396 -0.083108283525263
-    2  ( 16)  0.115794665664267  0.047097729608731  0.169526813418150  0.148848835873427  0.110367886513380 -0.250308022536814  0.421430914373290  0.072716285234647  0.379882079141591
-    3  ( 17)  0.016234704461670  0.093143898198671 -0.032604929784834 -0.008570214748756 -0.053618454434530  0.336390621280297 -0.171051246725478  0.351382500390790 -0.144302708365158
-    4  ( 18) -0.099685614405052 -0.053576457156830 -0.096408379043871 -0.083491653355765 -0.040031855455092  0.023231985357187 -0.214146456651999 -0.299411639286517  0.077061465722781
-    5  ( 19)  0.053256491006665 -0.003075384449121 -0.053515222726753  0.048399268191864  0.040795198256978  0.198132545540493 -0.175051498642490  0.121535923725232  0.133335441765840
-    6  ( 20) -0.128712692365555 -0.496870742485916 -0.268871209763746 -0.149658569303091 -0.086711112842081  0.028977130072006  0.083484855541891  0.156340017572166  0.079418276499146
-    7  ( 21)  0.026401094602506 -0.157512598855912 -0.050672592676314  0.027957891435237 -0.092269588876111 -0.151809482826698  0.107865561412261  0.222862187720663 -0.046783186727291
-    8  ( 22) -0.009612639390837  0.030421923009696 -0.129146467815306  0.272344846639473  0.379884587515890  0.072760001001148 -0.325598038741842 -0.027479294568787 -0.012294936872080
-    9  ( 23)  0.149880437140593 -0.460631247362792  0.169664291741312 -0.027589402289004 -0.011349753598096  0.033685842546708 -0.083139401924745 -0.064655346261025  0.002952710962413
-   10  ( 24)  0.073162117570193 -0.020016390706408 -0.135536511029942  0.511692353689708 -0.542889881863847 -0.170172745263858 -0.158312356422075  0.326976851708720 -0.119792799568885
-   11  ( 25)  0.227319331530806 -0.618159967248025  0.448267162037961  0.415380348389647  0.307673615218558 -0.093264262201907  0.090383721735685  0.101137463170207 -0.374119595658697
-   12  ( 26)  0.046325835806633 -0.048013260965168  0.272519638024099 -0.267929097643861 -0.079599126690116 -0.023217992764788 -0.099878544648145  0.024929139459656 -0.069393891025270
-   13  ( 27)  0.037489883688669  0.053493928653226  0.391870980933739 -0.384400627963214 -0.588279019279798  0.241045539088516  0.041562667530972 -0.011794273471007 -0.337810411804872
-   14  ( 28) -0.063867435849832  0.083549153123607 -0.158471290677241 -0.113540200875422 -0.127048928726566 -0.025106714900888  0.040372191298617 -0.090932947916166  0.351148385967210
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.018436133716857  0.072929640795625 -0.226474353889952 -0.258554501885766 -0.015629581468102
-    1  ( 15)  0.048844627710976 -0.217699525631316 -0.187612863297424  0.714214561739857 -0.155652904029163
-    2  ( 16)  0.036504178760377  0.064141704639546  0.642298500392749  0.226999184132633  0.158883513257702
-    3  ( 17) -0.464003802662343 -0.262951360765947  0.494608205306355  0.439690590633845 -0.272979507733357
-    4  ( 18)  0.417911613304926  0.028340434910992 -0.067656000741894  0.345749519725828  0.467548326168384
-    5  ( 19) -0.131287835524258  0.068639225223597  0.411512073768996 -0.617585289861537  0.085587328981715
-    6  ( 20) -0.031740361337335 -0.042325765757491 -0.290709707718165  0.172790703648515 -0.000532545780898
-    7  ( 21)  0.011558038421621 -0.183385354532032 -0.093657523746171 -0.152317012205746 -0.116530260167129
-    8  ( 22)  0.024591234247673  0.015437963416840 -0.192723206306395 -0.041545920874624 -0.300722952291357
-    9  ( 23) -0.076860307291410 -0.028222730174457  0.239744246838648 -0.005401314981702  0.437602472364683
-   10  ( 24)  0.182325175721446  0.168262818970868  0.041985084407523  0.080814437382504  0.153682650364464
-   11  ( 25) -0.018251396178258 -0.001487318511567 -0.036744565685453 -0.052466578072734 -0.023330767494251
-   12  ( 26)  0.006994832022894  0.011312050265967  0.051710399870511  0.045052170184275  0.002799991775595
-   13  ( 27)  0.042051003701905 -0.060322036458563 -0.018224376602008  0.061574434209411 -0.071889000854515
-   14  ( 28)  0.006898519418229 -0.055936666673248 -0.000904652270607  0.099150038783025 -0.077924550244227
-
-	DPD File2: P*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.024746315003693 -0.016019947683600  0.033657454181441  0.314697310181057 -0.226266938924475  0.124444118187600 -0.100976019942115 -0.040776992946741 -0.016684212809041
-    1  (  1) -0.134389185453098 -0.111083358436336  0.277285327152191 -0.119300944830562 -0.165892793225342 -0.243843028361365 -0.522257860139305  0.003856507813829 -0.130032133651498
-    2  (  2)  0.005712363782982  0.008727960227379  0.039141212770465 -0.103639199943747 -0.051337772042530 -0.071715964883614  0.083650082880478 -0.323814625304121 -0.126954317090625
-    3  (  3)  0.081293710540179  0.115829551524333  0.096804246842583 -0.012689929096652 -0.055158220665324 -0.020215225885504  0.309792669510693  0.175501033742058 -0.786497084573792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.131346722870458 -0.163299814747146  0.027069647322617  0.020320497257903 -0.063430953058875  0.031962758863077
-    1  (  1)  0.087630835970581  0.216123500984143  0.418559649023597  0.101182356933807  0.219334050753127 -0.138730916232525
-    2  (  2)  0.150883742374018 -0.808729391001562  0.082068044594556  0.109718430012718  0.126065481544348 -0.025072338478445
-    3  (  3) -0.037377902285561  0.112570729969231 -0.441791115721159  0.197182836023279  0.548068009411335  0.161473931329561
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.035230659308422  0.106839323325161  0.014678428381540 -0.286556627519623 -0.361604275339255  0.140599935526212 -0.104171301624044 -0.023270847691008  0.152469667501182
-    1  (  5) -0.205844940105254 -0.013703890486825  0.030101864871895  0.113405292167378 -0.067278306831822  0.396432225285843 -0.507639566286884  0.374194080683992 -0.087133202725049
-    2  (  6)  0.008020887713167  0.297537793700841  0.070946233356648  0.062333784651526  0.130550836206602  0.053406231056288 -0.297352200120301 -0.465262963875225  0.160837314824145
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.001388437190181  0.015460041565487  0.116558611446075 -0.083788280005113 -0.046694291841919
-    1  (  5) -0.445165309099416 -0.139286068687201  0.540190784438892  0.030841865046205 -0.087779833305208
-    2  (  6)  0.377644271326903  0.173431493737049  0.206412471480948  0.122708702224090  0.459634387384366
-
-	DPD File2: P*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.059484933862835  0.014840374750558 -0.035360338576360 -0.173310409629633 -0.059725101605321  0.257184966477164 -0.063490095178001  0.155623028848452 -0.002426177597214
-    1  (  1) -0.228582316542215  0.259588493824183  0.059979506895381  0.002310310036236  0.214166554941788  0.116943892441225 -0.108842892801007  0.344598351692938 -0.046446999584419
-    2  (  2)  0.320448650163398 -0.500204746721717  0.049266542548722  0.152597804353277  0.167277822949482 -0.193147703880440  0.032524845682255  0.036762728768834  0.080681033267355
-    3  (  3) -0.009703572292968  0.082952949000966 -0.090825897592600  0.068137067278425 -0.068002795336981  0.155982720923085  0.189371220312700 -0.353775834732784  0.023853285599523
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.026559166873629 -0.005391969117388  0.002011264512932 -0.046870885231393 -0.012715635371485 -0.026571877043427
-    1  (  1)  0.038988897688016 -0.019721374639789  0.014060753119275 -0.430701935913609  0.259024740507495  0.161810701507464
-    2  (  2)  0.100083737029750 -0.093431068521730 -0.015885697887836 -0.259560607774115 -0.146766142473160 -0.593605654650708
-    3  (  3)  0.130235873557485 -0.844890867177988 -0.085670264124908 -0.093010825973034  0.012325537516171  0.119484996772910
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.011411967833044 -0.019523193555091  0.029394421691951 -0.441924368380274  0.383516159929503 -0.004430337133144  0.015018368377510 -0.081006354989878  0.100709067945280
-    1  (  5) -0.015106432068076  0.115430718880751  0.094613417260511 -0.153153896682510 -0.130891773654437 -0.255513104617105 -0.100481979342603  0.182641502384039  0.046231419137374
-    2  (  6) -0.045469725116844  0.216512507684084  0.240553163844151 -0.059703803473819  0.128799103778847 -0.466867168048645 -0.230376363698085  0.268754231533815  0.029632489718661
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.031283386269007 -0.083595055179233  0.003915100351561 -0.081115225653286 -0.074158142938438
-    1  (  5) -0.011556443169135  0.036659881745781 -0.006532048558871 -0.596174583603508  0.114916319653540
-    2  (  6)  0.066233849453724 -0.593708066141070 -0.047160183567134  0.205443006234017  0.123500019606919
-
-	DPD File2: P*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.278545233415530 -0.059599409615732 -0.026034432106375
-    1  (  1) -0.187007295905470  0.038238309701257  0.175982197292767
-    2  (  2)  0.431926204916829 -0.006084496586666  0.049694339002754
-    3  (  3) -0.039723645794201  0.196249784920444 -0.036043663433459
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.275546881197932  0.180389519378317 -0.425074243400924  0.037767422186350
-    1  (  5)  0.058081529209830 -0.037390441931729  0.000516662884118 -0.195055591570635
-    2  (  6)  0.026038612826744 -0.173019988726883 -0.056080139617911  0.032715759186560
-
-	DPD File2: P*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.062756867817297  0.201112023907446  0.056048025131715 -0.046055783450926 -0.033806686060762  0.171722205176695 -0.081098506544458  0.087289620763258 -0.042152324091961
-    1  (  1) -0.113018477232488  0.112319744349513  0.016834583533921  0.057284464999085  0.226208700821363  0.112272688334417 -0.062097026682019  0.556436717149114  0.098351092785228
-    2  (  2) -0.050464428261919  0.043116595966000  0.019513144045664  0.037294003656203  0.049535289314410 -0.026512882856009 -0.020955734915841  0.396348457994657  0.049143039709126
-    3  (  3) -0.026907740943173  0.173985640449646  0.354309597307579  0.088737881833013 -0.026690278443481 -0.192249138616519  0.023099922234093  0.151104956103080  0.187993798800110
-    4  (  4) -0.028814397262738 -0.124011423960611 -0.200563657745864 -0.022231046170139  0.001789869716556  0.223408416821475 -0.102318476102237  0.153384891973446 -0.236674672698061
-    5  (  5)  0.088145317682978 -0.132491290238854  0.182899281954052 -0.186746219907929 -0.187197714495176 -0.005898923884498 -0.002120811015656  0.021990162397056 -0.123551537605536
-    6  (  6)  0.024460586881498 -0.068797047909759  0.142150384104535 -0.131743429120178 -0.105639058982537 -0.045294852609385  0.029270704887015 -0.020804211601159 -0.117878860256254
-    7  (  7)  0.033776769859701 -0.354245094845972 -0.243166450499757  0.029612149638602  0.008896656564269  0.116804879825504  0.018695560701790 -0.326627365972202  0.206018976643332
-    8  (  8) -0.143077917661487  0.151560533054490  0.301409236473389  0.100740265108897  0.039290343645488 -0.041763953575394  0.058170430215780 -0.076845206100452 -0.024633152032860
-    9  (  9)  0.347018728951025 -1.079771981804557 -0.078138529282464 -0.501451378510505 -0.195061660317550  0.758451032278065 -0.096995118436252  0.075303195155611  0.028459788963157
-   10  ( 10)  0.223810118885824  0.056979536028989 -0.716810245770532  0.128868097994349 -0.539754687175803 -0.113296255679437  0.098974782607496 -0.009049828893309  0.202384864538250
-   11  ( 11)  0.022769270154477 -0.034674358156828 -0.014405983056596 -0.017571848532967 -0.048691998407531  0.015583395228223 -0.114409081561630  0.021951676689174  0.044426938305339
-   12  ( 12)  0.135981286187464  0.120998241259176 -0.262301521327982 -0.750392323278277  0.334209910038890 -0.448078191688466 -0.024767148532186 -0.115571945209708  0.066264929381116
-   13  ( 13) -0.080577472282162  0.105823730084873  0.089794541855267  0.254940117418226  0.138440117204762 -0.236499087990863  0.038859436706735 -0.192105181610312 -0.090975801731982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.032425074737930  0.078425462405257  0.011344832045570 -0.197456331002049  0.134718406025863  0.096409404413494
-    1  (  1) -0.173273250041635 -0.433566222378215 -0.007405001112899  0.457114065135928 -0.172943454488407  0.008895375735183
-    2  (  2)  0.109774013784441 -0.217911727490325 -0.003528460413992 -0.763520159635318  0.225537275802117 -0.118975501733302
-    3  (  3) -0.036378102698420  0.454361087703980  0.077915823523940  0.013309796680696  0.234332299564134  0.507177620624500
-    4  (  4) -0.092551473116606  0.475045168698850  0.084968775693714  0.026919469339922 -0.202750989391175 -0.617924078766471
-    5  (  5) -0.097554141145429 -0.018018586167576 -0.079671555600775 -0.092305854243185 -0.173736284561078 -0.411194160500052
-    6  (  6) -0.003414072729569 -0.093327360188558  0.085627914021145 -0.078229939466915 -0.111156480724274 -0.178796621382799
-    7  (  7)  0.114277067577274  0.105960426671338  0.044841696220246  0.134585263057439  0.180631730229559  0.229243957069555
-    8  (  8)  0.037886837147022 -0.102808395063350 -0.069798483920400  0.254580996722497 -0.401920559110064 -0.147751839658310
-    9  (  9) -0.010988821514225  0.007410444750660 -0.002972535589617 -0.025318418426566  0.448643260566270  0.804372772080077
-   10  ( 10) -0.261244020497494 -0.038064665016323  0.048636140959014  0.326624772892826  0.029954423230419  0.215793554756145
-   11  ( 11) -0.048015789596366 -0.069114116273897  0.007572832400964 -0.004238339483900 -0.020816591473394  0.043178136132549
-   12  ( 12) -0.214695948487578  0.274288590232604 -0.016230298683875  0.029548384872336  0.038140072907363  0.033057792945377
-   13  ( 13)  0.275326653840915  0.061284883995154 -0.041285946542463 -0.084706584831174 -0.090480508761559 -0.181791085214834
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.063850422313355  0.115683680262588  0.054827490001665  0.028354117168169  0.025100127178731 -0.096410771095777 -0.028664016097217 -0.026051889825173  0.141339706448534
-    1  ( 15) -0.201263187433031 -0.111831464020197 -0.045175609028392 -0.180549663650845  0.130383086147566  0.135646922045465  0.070781303898657  0.348002287778712 -0.148260195426479
-    2  ( 16) -0.055113649368610 -0.018738606654586 -0.020705966421020 -0.355086450538750  0.201294850701097 -0.180112010383658 -0.140523266780582  0.241544163680772 -0.300925921088622
-    3  ( 17)  0.045920336133779 -0.057784764027644 -0.035886357056501 -0.088932856294833  0.024235675752436  0.187147654830588  0.131361762793480 -0.029658114101546 -0.101263553912617
-    4  ( 18)  0.035958486319751 -0.227134777791688 -0.048687972069102  0.024933262428833 -0.002173989672721  0.187305076269607  0.105829902417925 -0.008056867875506 -0.037853803971042
-    5  ( 19) -0.171149922579415 -0.110039862501994  0.026813452459140  0.190061024816887 -0.222174491954054  0.004093825553016  0.044188302806112 -0.116881315421755  0.043225291916047
-    6  ( 20)  0.080019590838700  0.062262232462848  0.021096034332220 -0.023057305471526  0.101639862804641  0.003152213311187 -0.029422735136868 -0.019240780036951 -0.059315335454636
-    7  ( 21) -0.083510548402123 -0.557993066791473 -0.397235243356208 -0.151190399349717 -0.153637137534004 -0.021828958802507  0.022025876078118  0.327175118374607  0.079618949429238
-    8  ( 22)  0.042227049954364 -0.098944758472646 -0.049249083184483 -0.187848524484403  0.236611254443533  0.124376089369001  0.118097176171872 -0.206089300936335  0.024158581021498
-    9  ( 23) -0.032033977750932  0.174724865726956 -0.107565757409839  0.033957075679687  0.093408693176877  0.094735950835808  0.001596176802057 -0.112245900387886 -0.037372397271166
-   10  ( 24) -0.077636129797919  0.430853371998705  0.215233761055940 -0.452386714098273 -0.474453371679467  0.016809820271846  0.095741323886920 -0.105100659091080  0.104107445539310
-   11  ( 25) -0.011149970874610  0.007035579685386  0.003127573400518 -0.077702883164627 -0.084954198370187  0.079818042644370 -0.085248456841504 -0.044951104587653  0.070017705668783
-   12  ( 26)  0.193344086617498 -0.456776432013422  0.761441366858404 -0.011910497712878 -0.026326742647963  0.092364226349286  0.078937949371178 -0.136041391718326 -0.256815257193465
-   13  ( 27) -0.133610614090005  0.173243160128294 -0.225605563113523 -0.236498022568823  0.204477528431671  0.174386164144365  0.111604362943586 -0.182311312483583  0.403964555885563
-   14  ( 28) -0.098101278195306 -0.007008756260166  0.117389775367317 -0.511914224685440  0.622957281459333  0.412506446069418  0.179820830724467 -0.234600868408507  0.150158824761841
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.343234558725567 -0.228637063726269 -0.023307266959502 -0.140382240172792  0.083235444793760
-    1  ( 15)  1.074711095873744 -0.056336734854343  0.034809000083236 -0.121348785991751 -0.106814989655091
-    2  ( 16)  0.078219304152202  0.719658957943986  0.014720519366158  0.261816502529916 -0.090881991750144
-    3  ( 17)  0.502805356071942 -0.131166561688672  0.017463933389579  0.755157521149267 -0.255568620797102
-    4  ( 18)  0.195634688856887  0.541360385537898  0.048854453075291 -0.337587696841954 -0.138455603989787
-    5  ( 19) -0.760143596830987  0.110879995008927 -0.015821843299894  0.447903356003643  0.237096867164475
-    6  ( 20)  0.097106884263887 -0.097545405975693  0.114437354251730  0.024000531999102 -0.039042927829059
-    7  ( 21) -0.075531866838301  0.009858499302833 -0.021730854579213  0.114681897686178  0.191988442177111
-    8  ( 22) -0.027711318590147 -0.201621760195186 -0.044350251642364 -0.065874285776240  0.090522977876112
-    9  ( 23)  0.011879012685435  0.258606547469066  0.047776074363499  0.213401932184194 -0.274704590606944
-   10  ( 24) -0.006858605937754  0.038088449389244  0.069395356141264 -0.275242327171399 -0.061260041265231
-   11  ( 25)  0.002890089589219 -0.048355005791387 -0.007521454792553  0.016094295989108  0.041236148462184
-   12  ( 26)  0.024624287461246 -0.326411349050862  0.004226520020176 -0.029493735437593  0.084692672982552
-   13  ( 27) -0.450726956342698 -0.030201266401628  0.020823649440091 -0.038233714612970  0.090500946858406
-   14  ( 28) -0.809945076459086 -0.216752990291181 -0.043269372622044 -0.033145255679139  0.181828971805248
-
-	DPD File2: P*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.063013364696514 -0.044010513010140  0.033832526224211  0.162024471696236  0.051333545713143 -0.246461238669107  0.063609486603270 -0.159478583547076  0.006207989114076
-    1  (  1)  0.226546037179395 -0.291390639777102 -0.048328229754705  0.000396116910678 -0.216137862922779 -0.115706811352044  0.113227048986677 -0.363481206263983  0.049424206162689
-    2  (  2) -0.353995982753623  0.570067383955282 -0.052742449525010 -0.144888216829452 -0.158139021131471  0.195548321941560 -0.035681653601236 -0.044365181477906 -0.094047723024953
-    3  (  3)  0.014909685853208 -0.093363165202933  0.099368126188753 -0.092807318931361  0.081502054050149 -0.166990973951771 -0.201832262285607  0.375763253843030 -0.022961121211245
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.027461792188467  0.004811887789740 -0.001758716793345  0.052146222606019  0.015489645876144  0.034542443930348
-    1  (  1) -0.038878540290940  0.018432422578327 -0.015238310520594  0.445890608944474 -0.276103308767449 -0.178613718171164
-    2  (  2) -0.112212317864169  0.097070429592677  0.017583930410099  0.264050273165228  0.167988430449652  0.635838792277428
-    3  (  3) -0.134391135826268  0.880500790171335  0.088985519620608  0.095884376650580 -0.014499630081693 -0.127955545332533
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.037904901187616  0.025077601146789 -0.027398631479947  0.443691662113588 -0.381793026485785  0.022010734273084 -0.009578999727395  0.091037438378063 -0.103637073384889
-    1  (  5)  0.010563786544947 -0.113947073526168 -0.106465996568323  0.155511131041724  0.116554544974583  0.262895686214063  0.105092877292920 -0.193457955253204 -0.048498356991785
-    2  (  6)  0.044887612702522 -0.228580277279931 -0.273604650547313  0.078952413042729 -0.139355988549377  0.486362168413732  0.239519122057504 -0.286842566968737 -0.031193390212920
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.028779621541873  0.090907914561767 -0.003460105941843  0.087167181054995  0.071921470779774
-    1  (  5)  0.003930295039018 -0.035914981429889  0.006741878538669  0.611390099224952 -0.116946571666512
-    2  (  6) -0.076298500757009  0.614894877751711  0.048926788565139 -0.209608637563865 -0.127192306297029
-
-	DPD File2: P*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.068337016677695 -0.096446452026756  0.360475449331991 -0.092239288371853 -0.026203678917511 -0.022509846886799 -0.073478827117419 -0.022464061625998 -0.227372488621395
-    1  (  1)  0.348245092774866 -0.473201941683207 -0.285296343579762 -0.183481268326088 -0.077575420562874  0.072099125969722 -0.272473569856386 -0.064219415204321 -0.197165880719729
-    2  (  2)  0.067585908335283  0.050372922133506 -0.060758167744452 -0.207525430642987  0.124589544508062 -0.366296688963713 -0.319501792505756  0.144609263799336  0.034557292153017
-    3  (  3)  0.003490778097580  0.176771187112973  0.057522831103622  0.000116418648382  0.000778288019112  0.154495740627781 -0.307263828587522 -0.311985415435969  0.072067405458553
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009055593070151 -0.169294476018032  0.004376707873729 -0.043035427357302  0.152530590698355
-    1  (  1)  0.043732146257221  0.133230210157229  0.321492959581682 -0.026647195860165 -0.380687102934580
-    2  (  2)  0.166530147628729 -0.613643715672385  0.216790209047481 -0.084469048804484 -0.070950252851931
-    3  (  3)  0.193623455804687  0.188085387663198  0.577128561869679  0.079182256640786  0.329374829305157
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.094184605186671  0.056664612816556 -0.249611394657184  0.001240336497952 -0.251113263182976 -0.167204841127316 -0.053738355395826  0.110451910693142  0.110225244293220
-    1  (  5)  0.138889396111012  0.115961679782817 -0.323179744158626  0.121252123207265  0.292076432419815  0.241576686510115  0.062989099171507  0.028273376478118  0.195878521271564
-    2  (  6)  0.158880157678560  0.136139940912615 -0.265648578874291  0.093877387268260  0.142453752235908  0.054140913517762 -0.560779480954688 -0.138233927899815 -0.254132036688695
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.293992892729715 -0.040800750956591  0.057675088119180  0.076602392465323  0.065335333102758 -0.026360508286139
-    1  (  5) -0.140101157166617  0.119683195321807 -0.266691635597033 -0.245738117504136 -0.344104644828940  0.220704301441665
-    2  (  6) -0.056921768258958 -0.103403744090827  0.598429877431589 -0.146214200734754 -0.059974751023664  0.323525482450488
-
-	DPD File2: P*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.001194434516926 -0.365406825873877 -0.191112170654786 -0.072953190005452
-    1  (  1)  0.363385965896555 -0.001278838882578  0.019794428206453  0.015546405496121
-    2  (  2)  0.188455836576036 -0.023464280272920 -0.001313653362102  0.003971811529941
-    3  (  3)  0.071937190909342 -0.014204649752708 -0.004012943205250 -0.001742183215196
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.002207002387747 -0.099036313248809 -0.350070270006789
-    1  (  5)  0.099717351351760 -0.002187155419577 -0.000406257568929
-    2  (  6)  0.350175744645045 -0.003726626970778 -0.004104233297166
-
-	DPD File2: P*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.002966254715231 -0.240855988266728  0.015168347488530 -0.064366755524788 -0.058337095528916 -0.095917557609408 -0.080552351010748 -0.173850272969471 -0.326738509325595
-    1  (  1)  0.236928751733350  0.000606734226053  0.349434191365712  0.093200906311076 -0.041406943350823  0.069404274429693 -0.288704930708582  0.111892041376425  0.888816026581642
-    2  (  2) -0.015227164699160 -0.348726210567974 -0.001624946372493 -0.082520881475572 -0.073422056547723 -0.232856655438329 -0.287989353510736 -0.229619697744185 -0.234594833443005
-    3  (  3)  0.060136079807310 -0.090244643623410  0.083460850918858 -0.000190675057493 -0.021666820127845  0.049054167667433  0.003318783332088  0.014942478625699 -0.184116482215884
-    4  (  4)  0.058810580653892  0.039254180139711  0.072185299720667  0.023983542956374 -0.001162617768289 -0.085082802307878 -0.048921193420164  0.153382943802422  0.107278309526120
-    5  (  5)  0.094673430029074 -0.068328286783388  0.231594556891859 -0.051852594552707  0.087895099396058  0.001022706922957 -0.009481397805757 -0.039804866070152  0.148588908121843
-    6  (  6)  0.077478276137780  0.287498549855759  0.285112820054957 -0.001996885796048  0.050199534762013  0.010169007281739  0.001566818575017 -0.173488828459951  0.045840640430952
-    7  (  7)  0.174574943301410 -0.112673533261648  0.229919171659831 -0.014304085765577 -0.153548872211132  0.035649109336757  0.172043564633104  0.001747195829410 -0.038631522766057
-    8  (  8)  0.326784468679605 -0.892435693037357  0.233569726528789  0.184065381075518 -0.108484932678938 -0.147374626265501 -0.046903987933936  0.038178109185914 -0.001735751957207
-    9  (  9)  0.006821679719377 -0.058926743509393 -0.208367267805622  0.285685508477399 -0.014180918165163  0.077838258063458 -0.021878341498618 -0.053464078274748  0.072201437911745
-   10  ( 10) -0.009056199429691 -0.188962532231488  0.202934615692329 -0.587329922811144  0.635977084568857 -0.025679043651857  0.020098430100480 -0.176535847273173  0.134249054850628
-   11  ( 11) -0.122433619087449  0.184482339508693 -0.564618465141536  0.437678405523193  0.566648296764866 -0.293188916460713  0.283810265313721  0.077678717328954  0.171076053515931
-   12  ( 12)  0.036292153208947 -0.108484898349320  0.145104583947026 -0.147429251741648  0.198788533301527 -0.103598496618116 -0.121175312167554  0.030985473315147  0.001761958158343
-   13  ( 13)  0.133923970852792 -0.204871678949702  0.411285239061003  0.299554669797709  0.284169606525854  0.162383457794127 -0.004545044711178  0.249571768159739 -1.096350485902953
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.006556329110841  0.006088586386751  0.124678079831954 -0.037126112155215 -0.136830700261450
-    1  (  1)  0.060788036015694  0.191479282295534 -0.182968697985886  0.108878994177096  0.206615313543699
-    2  (  2)  0.210374331017044 -0.203724330933666  0.567874430260769 -0.145071803402332 -0.411903076822992
-    3  (  3) -0.286917147696723  0.581979187814224 -0.440566780256406  0.146724205480600 -0.298411655566699
-    4  (  4)  0.014298727005834 -0.630110791185791 -0.567066919718617 -0.198113213886521 -0.285451610676776
-    5  (  5) -0.081474334265114  0.027014198849763  0.293476840962639  0.103773751793710 -0.162461435377736
-    6  (  6)  0.019534299275936 -0.018969452720832 -0.285789804049686  0.121256569831033  0.003481312727309
-    7  (  7)  0.056370622889280  0.170673347832600 -0.077097071581232 -0.031742893248721 -0.249704021902801
-    8  (  8) -0.071994852203822 -0.132015517717158 -0.170148143024151 -0.001951350044678  1.093751141653295
-    9  (  9)  0.000953866523975  0.167467737198046  0.013767962244439  0.007434218290124 -0.054780735052675
-   10  ( 10) -0.173318734659126 -0.000810695586467 -0.044701276287093 -0.097338149388905 -0.081237613430460
-   11  ( 11) -0.013895240641951  0.044282356293427 -0.000179785703801 -0.004575065369641  0.075680209341763
-   12  ( 12) -0.008279323048061  0.097099690667968  0.004296013685779 -0.000048011111236  0.035877871824266
-   13  ( 13)  0.055107661683376  0.081651595745875 -0.075682651530469 -0.035936424072868  0.000029147707292
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.002983283073552 -0.069963597569041 -0.177874917667998  0.062698638146301  0.106213761198913 -0.103906931767555 -0.039245016352398  0.108223517603678  0.012203119212599
-    1  ( 15)  0.072298870307035 -0.000296799608796 -0.117346282403810  0.011865025714908 -0.081057312629942 -0.082184434890961  0.047411637016207 -0.318551609279607 -0.030383483166489
-    2  ( 16)  0.171245613988674  0.116654951277647  0.001073144643332 -0.130649581927528 -0.144907410540790 -0.208150327953063 -0.198240370201554  0.179277720823411  0.001547973613629
-    3  ( 17) -0.060703226947660 -0.012583282832888  0.130776798167377 -0.000627586286590 -0.018993088317931  0.044159196655903 -0.007932945197872 -0.099780861993881 -0.079859961463087
-    4  ( 18) -0.100987762729975  0.079245986001353  0.141690159528846  0.016637213332155  0.000279400820895  0.188760521966200  0.218195531933535 -0.080299124518616  0.270793478609675
-    5  ( 19)  0.108074704635216  0.081590264498889  0.205498810382318 -0.045801307693771 -0.187063236245240  0.000710419758875  0.073671862989187  0.043877487134678 -0.003892010725365
-    6  ( 20)  0.034177446867522 -0.046254597520027  0.201430745227679  0.005427131993230 -0.216675775592057 -0.075812938142253  0.001274951349149  0.134520130532184 -0.103162147021421
-    7  ( 21) -0.109552512569813  0.319375904304575 -0.177972755772711  0.099543500716481  0.081539270937629 -0.043994632054622 -0.133148819770476  0.000136132680380 -0.101451568181800
-    8  ( 22) -0.012932579381132  0.031214135384490  0.000281145990656  0.077687686709702 -0.270019497869643  0.002445122305778  0.104445784052100  0.102366601596632  0.000293374111723
-    9  ( 23)  0.258661075798788  0.226451306397380 -0.883677423513705 -0.031877470630129  0.145903964590500 -0.329887844134728  0.092796308819851  0.020328633409678  0.044508005290364
-   10  ( 24)  0.092756800530096 -0.166962776711625 -0.090732033242854  0.033047276838485 -0.181047632927145  0.062682569832297  0.131253772479093 -0.125666164674422 -0.010098556627625
-   11  ( 25) -0.085247662084319 -0.052988724588725  0.426265235226709 -0.453475536447167  0.668253171471624  0.144399850217273  0.422325162892048 -0.144483844450738 -0.151429271642033
-   12  ( 26)  0.279045843991891 -0.538081255792683 -0.338024638087139 -0.681172358850588 -0.181070323444015  0.460341461990372 -0.046122199431924  0.472432043418077  0.099681899420099
-   13  ( 27) -0.031769949568578  0.364837871962491 -0.009792757368435 -0.264546010179783  0.131321500070479 -0.369805258593067  0.160328386436444 -0.216930526986653  0.408555062086236
-   14  ( 28) -0.069122236052376 -0.228562041286249  0.181966055883684  0.129261778712552  0.172738024644993  0.293166654576352 -0.081465083951240 -0.165047538527886 -0.415612188545544
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.259003180995999 -0.092034359732091  0.088092444988971 -0.283228839847223  0.027238337345788  0.074809429137092
-    1  ( 15) -0.226401057047801  0.167244181564770  0.051680013843725  0.539247725941338 -0.363958831235579  0.227197833049861
-    2  ( 16)  0.880204617361986  0.090080695403138 -0.428803021300672  0.339354335014476  0.011073919861198 -0.184183385405081
-    3  ( 17)  0.032548488106633 -0.034116564240178  0.457440817331429  0.682846299872809  0.267172551643223 -0.129975094303440
-    4  ( 18) -0.146446220661130  0.182273160793426 -0.671045144484618  0.180560000424842 -0.132242486336168 -0.172542944677419
-    5  ( 19)  0.329935957691708 -0.062440148449723 -0.142514523618445 -0.461407225484117  0.369136535324331 -0.291356141625179
-    6  ( 20) -0.095137293654559 -0.130985936102436 -0.423469417337729  0.046319908681962 -0.160102833893605  0.080585118835760
-    7  ( 21) -0.020207238092615  0.126147064104969  0.143168454940269 -0.472622130455173  0.216404140117317  0.164767679261412
-    8  ( 22) -0.044837771622786  0.010451598353546  0.151184144406440 -0.098993252397369 -0.407878413312189  0.414658535507476
-    9  ( 23) -0.001737606134934 -0.018616595639929 -0.107543267833085  0.163017051753013  0.647726175645918 -0.636571415515610
-   10  ( 24)  0.017899922228044  0.000213602824426 -0.053374660165807  0.073998998716505  0.058121913122542 -0.162859588181722
-   11  ( 25)  0.109492695348190  0.053011202690733 -0.000327739740203  0.000312768703591 -0.053080921470257  0.055086051279352
-   12  ( 26) -0.164160765816315 -0.074526437813364 -0.000205041264621  0.000008221388086  0.003647906535196 -0.023090840612045
-   13  ( 27) -0.648519944554920 -0.058749585422481  0.052822010998177 -0.003709251683372 -0.000103802664845  0.203134785839326
-   14  ( 28)  0.638592033397192  0.163371069122125 -0.055018466584646  0.022957117292923 -0.203277611770653  0.000205390113949
-
-	DPD File2: P*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.050918463672837  0.088577095911626 -0.347792606459412  0.095753675403874  0.021868934225380  0.033922841975857  0.081457049638017  0.022670295387980  0.235434049572332
-    1  (  1) -0.382949048662791  0.528689769706688  0.299634584086346  0.202752933016224  0.082733390999563 -0.092422540316925  0.290813237500084  0.058004392324892  0.224615068405588
-    2  (  2) -0.072432527585316 -0.056118386776062  0.040222186558432  0.242175264454298 -0.146547807338018  0.390266206867364  0.347025142548880 -0.162810044865207 -0.041509720616448
-    3  (  3)  0.002509556424329 -0.208248007860462 -0.062422901369848  0.007679044749759  0.008571630545112 -0.174062990005658  0.334967725932269  0.336081407145288 -0.081599082536296
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.010892131457533  0.184129002689570 -0.006516359878994  0.045872381230752 -0.153258318093946
-    1  (  1) -0.044796011029196 -0.153644284644512 -0.339325263566756  0.025646141032274  0.405174708389161
-    2  (  2) -0.178039316366764  0.664464704148233 -0.224969390534104  0.089440380756525  0.066874687913745
-    3  (  3) -0.205823412452233 -0.203327440636405 -0.607212535172871 -0.084515912728930 -0.343929939556071
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.078798727127085 -0.050234519025036  0.245209481862661 -0.005696954168209  0.236120915868886  0.165120845160626  0.059294811018549 -0.108390851582836 -0.111673906302634
-    1  (  5) -0.155915068579220 -0.141324548768777  0.367116438384255 -0.121574775208674 -0.314513424545348 -0.257608736751094 -0.074849697192160 -0.032932966046337 -0.220860722558199
-    2  (  6) -0.156801606542398 -0.183207885627035  0.298465110849382 -0.100930243056436 -0.131083210552854 -0.050444928584622  0.606210604165772  0.146614859921357  0.248216540567658
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.311128511448673  0.042835689156568 -0.063170810110215 -0.070842689432729 -0.064570105984912  0.023339590654715
-    1  (  5)  0.156644000440875 -0.124669553061406  0.274932589468273  0.248710717987319  0.361639916876500 -0.231627984560414
-    2  (  6)  0.060874079553630  0.108175278252638 -0.629356829293933  0.147027352951220  0.067479673265597 -0.339908703023576
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.016118777276718 -0.076689387067913  0.125264792267221 -0.007931013310217  0.098301937535593  0.089040062536424  0.042653189503994 -0.143650549015436 -0.062698356849212
-    1  (  1)  0.038523460792179 -0.325926212074865  0.217436403108293 -0.076210929079432 -0.124956744969497 -0.049869905306322  0.256022567536767 -0.049219148025195  0.025163660677602
-    2  (  2)  0.015460259327547 -0.182364499530156  0.081021447104321 -0.065186772706330 -0.193628085224677 -0.090709199284776  0.144227288852923 -0.007154481293498  0.060483347873675
-    3  (  3)  0.069494321441893  0.016013992178317 -0.169506236224066  0.050547669997832  0.177140340538940  0.181255025833280  0.201077665225234  0.109139777586644  0.215083611892043
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.159361864611547  0.056476108299595 -0.034334354535918  0.068420323850582 -0.100698715800708  0.049820592017770
-    1  (  1)  0.121041364374114  0.003994619377141 -0.190684428167188 -0.052070114913576  0.189028662705244 -0.205096915582729
-    2  (  2) -0.013836799939810  0.073875918803127 -0.147901928532532  0.343158528114237 -0.053056478393270 -0.086736758175874
-    3  (  3) -0.065392768372805  0.072388535495378 -0.365788807268921 -0.156911353062510 -0.184439406968008  0.043117455907294
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.095080611028908  0.132974666952804 -0.233475927910161  0.109077700761846  0.033619328181737  0.003336619392380  0.079318686273404  0.006541773193158  0.188514066103897
-    1  (  5) -0.133180554197727  0.220459497770331  0.122961007604824  0.144493780528946 -0.034530325126907  0.144382538755413 -0.001565508478524 -0.179104189145753  0.084352671049968
-    2  (  6) -0.305369897772513  0.245966510909099  0.171589985467973  0.288954965589218 -0.048536799653855  0.105233271021501  0.400024803684154  0.035818012706252  0.066124321501178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.011358647742863 -0.047842821118303 -0.011877525445924  0.012099889406653 -0.055702357687979
-    1  (  5)  0.060987538430201  0.100437160073965  0.174976176295347  0.033059202656665  0.296249624542352
-    2  (  6) -0.156959926194247  0.053853503787388 -0.406665675932452  0.026462885456154  0.143060389345537
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.020933994600407  0.036837370041379  0.105536213576206
-    1  (  1) -0.298453027380229  0.115575201783048  0.255528599615226
-    2  (  2) -0.258793135913466 -0.115959940555419 -0.442826057795207
-    3  (  3) -0.060024736570871  0.030098554189580  0.068752806226701
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019369167440737  0.299662599013855  0.261538199445486  0.060711849430240
-    1  (  5) -0.036904684367184 -0.115259605353545  0.117033018013317 -0.032657591929025
-    2  (  6) -0.104769015611942 -0.252811001882398  0.444270078409878 -0.069751899589244
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.140264901989733 -0.063903836208699  0.058837720478352 -0.099834492513907  0.059321359064120  0.159667027697165 -0.002087278187155  0.046204224826822 -0.008601023391654
-    1  (  1) -0.090548490120094 -0.202601353512521  0.092021876157039  0.096539072052076 -0.170154281529190 -0.083912296322856  0.509059273187919 -0.818772979644944  0.070828284365831
-    2  (  2)  0.023785290834440 -0.356113587695746  0.273990976839633 -0.279080899835077 -0.352444630227807  0.196438091918127  0.305379232907246 -0.066497365309673  0.201285694555553
-    3  (  3)  0.097000901586890  0.245927544981609 -0.317839114090104  0.024062116307509 -0.214330573426622 -0.049574376579038 -0.029033713280387 -0.054130019251520 -0.003096872422290
-    4  (  4) -0.057665969694975 -0.180120952217609  0.233587576455003  0.044983378670389  0.207784279042752  0.114395252588051  0.123426849025620 -0.227078923197640 -0.055512731053919
-    5  (  5) -0.215771286107017  0.314990234779514 -0.316883540178273  0.120867850220651  0.280144439745990  0.294187393366344 -0.216440287801491 -0.200727103538268 -0.064432166939549
-    6  (  6) -0.088234371667199  0.148935506374453 -0.366935246390926  0.011963781822206  0.214228897418480  0.110020140834853 -0.192637863546336 -0.231329350431262  0.059800681126411
-    7  (  7) -0.046850408794017 -0.280155317167354  0.370918303757493 -0.110906122388338  0.088736250126073 -0.146624611249212 -0.021132431838050  0.399622620248781  0.041122390922446
-    8  (  8) -0.213219122375795 -0.108141657808912  0.632333203738691  0.072815736912248  0.035034243651177  0.162896842787152 -0.072787072592851  0.219123938652928 -0.041084573561980
-    9  (  9)  0.053156461400872 -0.091068663315953 -0.087565530354209  0.029252405162185 -0.135958664144556  0.072618412616147  0.001674517036243  0.447580570679361  0.046048420321104
-   10  ( 10) -0.217389369502915  0.434955320268289  0.409591028918221  0.322091930890678  0.032769693001793 -0.320487371417185  0.022524010208261 -0.286088771348247 -0.028739508255570
-   11  ( 11)  0.043655408036923  0.078795431314355 -0.262179238045958  0.331516326719145 -0.435766491266973 -0.063689969335775 -0.247099037158842  0.001834914627208  0.140224560742036
-   12  ( 12) -0.056091676196041  0.010888223476601  0.132073582410605  0.097444459311610  0.064913316133021 -0.000177701715007  0.216786241209526 -0.136744724942230  0.129238968566818
-   13  ( 13) -0.037502956248588 -0.225853404732459  0.091597810906130  0.251988574100633  0.015208060782166  0.284415044485862 -0.108318027167763  0.003844624714701 -0.367465648248442
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222316043515167  0.015706219813463 -0.082385006687323 -0.001598515176526  0.060473243217389 -0.093727480766949
-    1  (  1) -0.559608456549858  0.123427525882107  0.153467678522300 -0.170334032667733 -0.080737466652229  0.083738891751815
-    2  (  2)  0.169476216588372  0.033571289044868 -0.409164888922183  0.223598543173703  0.075034173166592 -0.314714537560898
-    3  (  3)  0.116710909315587  0.019725573527899  0.283423547853851 -0.175125619030571  0.285157403250330  0.036616525847272
-    4  (  4) -0.005652624292139  0.042302085019157  0.326173261129769  0.429217689689009  0.082297928451406 -0.119033467524284
-    5  (  5)  0.013435701805302  0.050340607661262 -0.120543829176020 -0.018862712789976  0.153571720838539  0.076183620287342
-    6  (  6)  0.081289708009931  0.326406046335036  0.215268699384039  0.111421444458008  0.019027619773839  0.098888316320561
-    7  (  7) -0.155159820795191 -0.099172439421062  0.073800976886369 -0.027692155232150  0.092694133839465 -0.234604646553242
-    8  (  8)  0.037085102415804 -0.221081896212579 -0.033634728216750  0.500286732444351 -0.749342092540156  0.380702305205404
-    9  (  9)  0.121604531068674 -0.307665948271799 -0.063134933207080 -0.759313712683920  0.291120411772340 -0.157024245706381
-   10  ( 10) -0.436899181077485 -0.180584483336558  0.427706818265059 -0.039319556166540  0.042977724169090  0.570262735340486
-   11  ( 11) -0.012744975594807 -0.355849153273437 -0.014473345977422 -0.331011762918571  0.082407538751978  0.048301595441151
-   12  ( 12) -0.275248111407278  0.041018113706033 -0.197136817157671 -0.114052207324907 -0.270934107062802  0.185007344485103
-   13  ( 13)  0.588095271872907 -0.141945816656544 -0.099720177389796  0.418487800295615 -0.225864709971247 -0.209383142865026
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.136055292355694  0.095447390079347 -0.020092912976434 -0.093125301806220  0.056850399225407  0.218468169087224  0.091857234706707  0.045161486852285  0.214714486134322
-    1  ( 15)  0.061207776400221  0.202708633629203  0.353114471023019 -0.245649376419509  0.180866138364055 -0.315320438007609 -0.149515492263402  0.279091224397235  0.106858935875576
-    2  ( 16) -0.054684214245548 -0.094025065222631 -0.275943577798576  0.316343751367853 -0.233336305598421  0.315879985031554  0.365377908227226 -0.369960150477034 -0.630562926717983
-    3  ( 17)  0.098691998170038 -0.096665834479755  0.277640044986255 -0.024005765248171 -0.044522040617363 -0.121507599385942 -0.010509659584452  0.111862233831111 -0.073060388343777
-    4  ( 18) -0.060773979545103  0.171895263117879  0.351151470699543  0.213576840796561 -0.206989754617355 -0.279451579746568 -0.215385933896327 -0.091082110140094 -0.034953691198189
-    5  ( 19) -0.161690364133666  0.086139117701405 -0.195608563911700  0.050196750893511 -0.114409300434365 -0.293302924591731 -0.108870291716062  0.145705855705796 -0.162864209989072
-    6  ( 20)  0.004933077734451 -0.509112916459710 -0.304189657786548  0.027011307788327 -0.123564513171828  0.216326146660916  0.190918994832488  0.021599458243800  0.073921971953618
-    7  ( 21) -0.046939300208702  0.818898745115203  0.067231269443300  0.053385434393296  0.227366778650237  0.200959323300597  0.230355491785385 -0.400408400878960 -0.219890208910705
-    8  ( 22)  0.008875208231352 -0.070617448884289 -0.201028236092674  0.001986037102761  0.055524570746341  0.064229773357339 -0.060955407810688 -0.040899342701131  0.040928237624119
-    9  ( 23) -0.222811666664924  0.561652381203117 -0.169673185845513 -0.114995614482548  0.005558626156144 -0.012604855943771 -0.079125943676940  0.154935461007958 -0.034774271928086
-   10  ( 24) -0.015658264689240 -0.122684274627557 -0.033049817652525 -0.019053422527856 -0.043070830779647 -0.050152205966201 -0.326697513368332  0.099443390036437  0.221198097566913
-   11  ( 25)  0.081038041563998 -0.154593341750109  0.407140318932015 -0.281943720612524 -0.325675147388091  0.120351655341300 -0.214124337140198 -0.074325284613070  0.033051994607934
-   12  ( 26)  0.003149016432995  0.169066126704247 -0.222974141740589  0.178167341127522 -0.432229982121926  0.017874255780557 -0.111773550217198  0.031100511775823 -0.501206663109641
-   13  ( 27) -0.059358328554787  0.079903052840459 -0.074950199177092 -0.286331686497645 -0.080924619758582 -0.153353900448008 -0.018409365441285 -0.093462744168481  0.750750124348623
-   14  ( 28)  0.091958135023799 -0.083203421400522  0.314158605792346 -0.035767063530523  0.118730598661038 -0.076122730197959 -0.098773188363533  0.234233392684110 -0.381969165301674
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054160915945435  0.219019011349662 -0.045758113327127  0.056667077142789  0.042241899582406
-    1  ( 15)  0.090944710506667 -0.435278295065967 -0.077842273581986 -0.010976755804933  0.224792334219630
-    2  ( 16)  0.088739489380716 -0.410297160213696  0.264172456920591 -0.132125091344127 -0.093086518366917
-    3  ( 17) -0.030526782846372 -0.322820843845168 -0.334117022964461 -0.097597092001327 -0.253965732413029
-    4  ( 18)  0.135352462834385 -0.032599183228470  0.437639446212980 -0.064872058901817 -0.014497262646809
-    5  ( 19) -0.073899654730418  0.320885730724582  0.062344415655815  0.000276840662838 -0.283336476795494
-    6  ( 20) -0.001158784637986 -0.022837257389258  0.248024269025134 -0.216907823965295  0.108098145849832
-    7  ( 21) -0.447481917087615  0.286161905602593 -0.000998969948768  0.136653733410725 -0.003506425728696
-    8  ( 22) -0.045854947627217  0.028382633755544 -0.139989494186326 -0.129405417600200  0.366820033409189
-    9  ( 23) -0.122256207458047  0.437180402944018  0.011581755997574  0.275567866951771 -0.586898649032607
-   10  ( 24)  0.308323852677716  0.180850894824874  0.356131896237587 -0.040945642422097  0.142574344254175
-   11  ( 25)  0.063098776158311 -0.427549053292048  0.014802143274602  0.197270506582776  0.099635293972029
-   12  ( 26)  0.762581095039526  0.039734172920420  0.331033022441233  0.114161465508821 -0.418490755826768
-   13  ( 27) -0.291938944356791 -0.043222558646299 -0.082214356128397  0.270960148007918  0.225910263769329
-   14  ( 28)  0.156871086239258 -0.569997035340427 -0.048467653901961 -0.184994394399640  0.209531521675463
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.009005560415623  0.070810523176756 -0.120067832596336  0.009073132789111 -0.090464498751398 -0.086174111119373 -0.045794981404386  0.145874969594553  0.061668751575060
-    1  (  1) -0.049157751161972  0.341837336007350 -0.225991322214187  0.079794887273929  0.129000775913247  0.051890082528236 -0.264098306233448  0.041882987798599 -0.014437873768970
-    2  (  2) -0.004178475304277  0.176534362212289 -0.088484784587537  0.060893560844690  0.188770646517555  0.098157508320735 -0.154422738208034  0.028159762307555 -0.056745595914693
-    3  (  3) -0.078632631263388 -0.018162490565873  0.185802179760100 -0.047918543127627 -0.190222116766269 -0.186537019008413 -0.211456806958065 -0.116264562677772 -0.222361952728926
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.163744366705642 -0.058513889685970  0.036529339633759 -0.074890516703334  0.101980211526259 -0.048987870817685
-    1  (  1) -0.129678391589482 -0.003465728257172  0.197451754644998  0.065935565415855 -0.202740138649215  0.212710296862526
-    2  (  2)  0.022460564343481 -0.084272909470110  0.151124340943610 -0.372643880141893  0.063147940573229  0.083681000851943
-    3  (  3)  0.069418152871991 -0.077040623108211  0.377203303892570  0.165559399244409  0.189357768189075 -0.044737808867411
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.085668830826553 -0.137820799821437  0.214610467959115 -0.105542261331556 -0.036859097160689 -0.000473863191174 -0.079606876493944 -0.008613359831916 -0.198755661758929
-    1  (  5)  0.139412038667802 -0.235636886292819 -0.125284829879155 -0.147970518740886  0.038362154224415 -0.146537444592957  0.006121389458957  0.189794595760352 -0.090516747843845
-    2  (  6)  0.309048143972662 -0.258748687397471 -0.168238503241560 -0.304764034594855  0.050456064213728 -0.094565768675384 -0.416604423570803 -0.027331415693024 -0.066446598559605
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.012674523904092  0.052192101234842  0.013753920669735 -0.012760663896321  0.052741920591875
-    1  (  5) -0.065601509403616 -0.098250162685792 -0.177768481553462 -0.033008693934466 -0.305584708162464
-    2  (  6)  0.160962535198798 -0.052046626684920  0.419200543530858 -0.024457493928166 -0.150587999794565
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002292052292102  0.001327689025616  0.000248352651822  0.007958119616396  0.006332326100070  0.018602233716079  0.068879285117607  0.007819744108382 -0.006538352080530
-    1  (  1)  0.002764164951481 -0.002219747844780  0.018293151832047 -0.029668233290932  0.039848292773056  0.022489745012599  0.162281988584092  0.020804504235237 -0.019083175045333
-    2  (  2) -0.011217835122943 -0.011598249376099  0.016968466001430 -0.008250037510452 -0.006232273271200 -0.008766677291359 -0.010338243291249 -0.010725726663582 -0.004470553150491
-    3  (  3) -0.050562851864420 -0.047527304873166  0.078707468856856 -0.000484758494300 -0.025585059000145 -0.011993586441410 -0.049963781283816  0.008029454242806 -0.026864587292980
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006805334012410 -0.003000362320124 -0.002228041038775 -0.000013471324712 -0.003129940535122  0.001748281527537
-    1  (  1)  0.013913717596781  0.013715090430948  0.022806809849796  0.002206415430011  0.006824605289547 -0.005086150284379
-    2  (  2)  0.011033408042675 -0.021897939524418  0.000684908130867  0.006441462755861  0.002207402072499  0.000019160522387
-    3  (  3)  0.030996252825103  0.007986449014412 -0.024562077320802  0.006200249162118  0.010690383251547  0.011486173135262
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.008068643711801  0.010525757489217  0.001816581937116  0.014852647204911  0.016446444650489 -0.051123908211829  0.105303074579255  0.010186396385181  0.002604742010165
-    1  (  5)  0.024807027264736 -0.041872241876176 -0.005357408083722  0.028564486604491  0.031353252400090 -0.040716482303683  0.082357809569043  0.022204595749263 -0.028676826310240
-    2  (  6) -0.057433465116018  0.072910653400307  0.007950207598680  0.045866077252406  0.051478467074873 -0.066399959025177  0.120267838044182 -0.002980749702429  0.024762093508970
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000934050050601 -0.000604010149742  0.003646663045597 -0.000033137801782 -0.002019175758165
-    1  (  5) -0.015497094356084 -0.002871076746167  0.025548488367169  0.001995117147543  0.006447008967148
-    2  (  6)  0.009288606849912  0.006735078994323  0.016930923349151  0.006239987724853  0.010309885333920
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.002224796248932 -0.043809288397671  0.042786645812819
-    1  (  1) -0.035961652529642 -0.375558249507302  0.229138680808403
-    2  (  2) -0.031482392637320 -0.208906969570401  0.045224347296993
-    3  (  3) -0.099946950247304 -0.215409785029959 -0.414532197880427
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.002181806445193  0.035979573047748  0.031640926892772  0.100238553322267
-    1  (  5)  0.043671265862198  0.375015508928970  0.208917842140989  0.216574490738357
-    2  (  6) -0.042527296867706 -0.228253198541367 -0.044456455969980  0.415218734433248
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.071571831474078 -0.044653489385004 -0.010701302384523  0.107261739958220 -0.107631207507425 -0.021982609216167 -0.087555139416076  0.002428271330292 -0.013116395341904
-    1  (  1) -0.000994163831951  0.002283385696650 -0.009683189881161 -0.069987093364780  0.211165412824198  0.144806549288885  0.839471629333555  0.082797629633041 -0.083995255816967
-    2  (  2) -0.048029450774166 -0.034159151942760 -0.005345969743360  0.362094457083817 -0.166955343421057  0.200138180389873  0.200325175150560  0.048097856321723 -0.015226624624379
-    3  (  3)  0.099901242333767  0.066741882163175 -0.192006761021459 -0.037162207196483 -0.149491220617225 -0.091957380518256  0.124661875998717  0.114474410410791  0.084751404274494
-    4  (  4)  0.098292057994736  0.060260709677483 -0.234095836344223 -0.042527139722308 -0.172693635464839 -0.110397071373777  0.184879337331547  0.074537123570678  0.084735776692218
-    5  (  5) -0.074314676568813 -0.053240577551294  0.354242764435309 -0.039009834260888 -0.144962419013369 -0.061650919712934  0.045188344047315  0.085035282721835 -0.173092563485620
-    6  (  6)  0.068641550367940  0.078242424055450 -0.700330832585738  0.207548816757483  0.389421892794459  0.222244858530413 -0.109406330044345 -0.045457397940435  0.343867539807074
-    7  (  7) -0.021723320720408 -0.016351205203477 -0.098413699787284 -0.004057278627183 -0.006939091834822 -0.079051971654245 -0.378143817290545 -0.122761983444906  0.057845298080862
-    8  (  8) -0.009573032166807 -0.006109372122326  0.063933429430759 -0.085659891507852  0.069748375065056 -0.032412606198403 -0.211702458249096 -0.046995111806493  0.044380498011908
-    9  (  9)  0.004993361863042  0.003634014150995  0.021315829704567 -0.021713795540608  0.030056681969923  0.023359631271160  0.128991093821748  0.016400014214086  0.007638043352379
-   10  ( 10) -0.003364468158750 -0.005158901374854 -0.010157814233360 -0.013146135283302  0.036788603301885  0.001796925979308  0.031087735489024  0.158319551738172  0.001398916399981
-   11  ( 11)  0.005212014578835  0.005572219785769 -0.129300362837610  0.009016877484923 -0.009416239426417 -0.064438058134476 -0.026488687258818  0.021963612194052 -0.285489003307896
-   12  ( 12) -0.022889675001499  0.014028568601137  0.005258310077958  0.012614598275054 -0.011181538654869 -0.041924328606938  0.003053461905652 -0.141650155501185  0.005090787707419
-   13  ( 13) -0.006246133552104 -0.010356570946206 -0.013049157750693  0.012424981952369  0.009162366348552  0.014458376447183  0.062634797746517  0.024809108873564 -0.013232375979096
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.002828230885257  0.008462795614422 -0.005154038879345 -0.009706144885120  0.000351690712200  0.003016908410820
-    1  (  1)  0.016542909801999  0.036808232009347  0.132827410709679 -0.012545312927284 -0.013603497625073  0.014243226256360
-    2  (  2)  0.056531888264120 -0.026681841564725 -0.044472892095947  0.008316762319548  0.009818160226073 -0.003132505638468
-    3  (  3) -0.065664012413416  0.084000307061427 -0.024123678461562  0.011516052481209 -0.005295212539445 -0.009770444853693
-    4  (  4) -0.036042306167921 -0.066196882580862  0.035814283991972 -0.000422354014022 -0.007346814292348 -0.010225200735508
-    5  (  5) -0.148907428019918  0.109320100216994  0.041270431698859  0.008286052492360 -0.000171545458785 -0.012799874602531
-    6  (  6)  0.267740896585406  0.203497348994038 -0.004880757246489  0.039144439238724 -0.017848850593881  0.043282221917125
-    7  (  7)  0.072391125356366 -0.141340064883921  0.132216664302808 -0.021712276497551  0.014580212743968 -0.003413596406031
-    8  (  8) -0.065338926975319 -0.070417584641912 -0.663636576046729 -0.043614890913103 -0.008447529962627  0.017635456067555
-    9  (  9) -0.053338372051575 -0.015608392811417 -0.295869564541774 -0.007118975871935 -0.021727777212887  0.010944181246414
-   10  ( 10) -0.043778421907204  0.395589362339910 -0.177341233202875 -0.145584179195590  0.046786531122207 -0.019085441444643
-   11  ( 11)  0.612579899217910  0.015866362451346 -0.053555820669517  0.384133045755119  0.648991284315080 -0.223359237845109
-   12  ( 12) -0.089924264835296  0.149474889068188 -0.147998013353456  0.410950037016053 -0.122612685939115  0.053519931502491
-   13  ( 13)  0.016968386753172  0.001120736716630 -0.667558162177866 -0.016648983669703  0.049072172914944 -0.011592992748873
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.071349801352714  0.001077758689270  0.047849010758340 -0.099049708991052 -0.097373218549672  0.073249702217701 -0.066497399663850  0.021905924000244  0.009611371244576
-    1  ( 15)  0.044780949738342 -0.002559008927920  0.033951661393695 -0.066729312295418 -0.060308115101382  0.053229541901542 -0.078046690958419  0.016360376267858  0.006154062585816
-    2  ( 16)  0.011020054803350  0.009639577990263  0.005659342412151  0.191466387657664  0.233770018397497 -0.353943104953966  0.699652203951216  0.098429630868852 -0.064028996133412
-    3  ( 17) -0.107854789786884  0.070585793426189 -0.362141920362822  0.037292065848003  0.042427554280107  0.038929544624269 -0.207453249613655  0.003913287572505  0.085781111935072
-    4  ( 18)  0.108209449998533 -0.211629628691212  0.166874900133377  0.149325288082881  0.172890816462238  0.144890994778070 -0.389082003854782  0.007000687821947 -0.069612637937327
-    5  ( 19)  0.022019034844539 -0.144617634612061 -0.200192966932170  0.092059326306527  0.110737371319849  0.061364605633219 -0.221637061620898  0.079021140430878  0.032667339771975
-    6  ( 20)  0.089130158761328 -0.839805360702557 -0.200387491136614 -0.125541335494723 -0.184496760040866 -0.044995250241913  0.109402692051618  0.378035804168236  0.212908503907272
-    7  ( 21) -0.002178057091038 -0.082925436926418 -0.048118216149291 -0.114730021254943 -0.074453346277443 -0.084891108935477  0.045281773316412  0.122667104662941  0.047081579488126
-    8  ( 22)  0.013014867453703  0.083878416356711  0.015105645463008 -0.084649544925900 -0.084843093804859  0.173122296622810 -0.343876299664282 -0.057834963947660 -0.044464266623987
-    9  ( 23) -0.002901775226444 -0.016234828173143 -0.056359654971922  0.065872157385180  0.036362021680561  0.148332139389917 -0.266718078511413 -0.072258279284242  0.065401012908070
-   10  ( 24) -0.008445720197207 -0.036804429594076  0.026642166859473 -0.084168947416289  0.066510758074250 -0.109381013548519 -0.203196264302626  0.141165925569744  0.070499221179183
-   11  ( 25)  0.005377792056996 -0.132971363586081  0.044450134013502  0.024046237867946 -0.035750577264436 -0.041236558408702  0.004898258174401 -0.132214673314328  0.663804812343684
-   12  ( 26)  0.009728994170679  0.012565610031584 -0.008265487183249 -0.011507462056027  0.000390885497570 -0.008310505974517 -0.039141081466560  0.021755546401072  0.043610775840953
-   13  ( 27) -0.000301420723236  0.013603051175605 -0.009758944837903  0.005201669668065  0.007344582365288  0.000240423767531  0.017707548228084 -0.014600989921618  0.008461166379513
-   14  ( 28) -0.003079753925572 -0.014179269497255  0.003153288832508  0.009783782056838  0.010222304053931  0.012792812982900 -0.043303231879501  0.003407229733488 -0.017679792666437
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.005093584579739  0.003397430557442 -0.004751145314814  0.022993999775599  0.006406607432760
-    1  ( 15) -0.003664268681973  0.005140681437481 -0.005623137023323 -0.014031183819186  0.010293722738862
-    2  ( 16) -0.021380720709285  0.010101149193740  0.129156907046771 -0.005327658954335  0.012995314092573
-    3  ( 17)  0.021888212102997  0.013219387248758 -0.009147784998772 -0.012607741489433 -0.012451560776453
-    4  ( 18) -0.030283770762187 -0.036869387279963  0.009496744772073  0.011181780485751 -0.009182409552409
-    5  ( 19) -0.023453672116028 -0.001799424920857  0.064551617042565  0.041960641260948 -0.014420118956798
-    6  ( 20) -0.129458546494562 -0.031271046054797  0.026491102279077 -0.003035012140173 -0.062712336606288
-    7  ( 21) -0.016591446747124 -0.158366047016835 -0.021959782838748  0.141640631249081 -0.024819174074486
-    8  ( 22) -0.007575701587651 -0.001384112156408  0.285443557719759 -0.005092627774536  0.013202606990520
-    9  ( 23)  0.053335089301784  0.043785415746465 -0.612428033952438  0.089945127333786 -0.016908784258587
-   10  ( 24)  0.015338693676902 -0.395633576722134 -0.015809806174577 -0.149475505805735 -0.001108572795377
-   11  ( 25)  0.295832367201880  0.177313650229228  0.053561286295937  0.148004020967965  0.667548449264998
-   12  ( 26)  0.007157154416068  0.145586590426015 -0.384132810582926 -0.410951719442920  0.016651787670969
-   13  ( 27)  0.021701996830369 -0.046797876195772 -0.648997652718994  0.122606232077394 -0.049068049852585
-   14  ( 28) -0.010942221777254  0.019093183683669  0.223365949415077 -0.053520759465635  0.011602247780486
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002779955261603 -0.001692895942304  0.000296900585249 -0.009027308047393 -0.005517424530413 -0.019392785745098 -0.071615718156204 -0.008379623734860  0.006552142468186
-    1  (  1) -0.002104549417694  0.002248748312389 -0.016268779471159  0.026298614529309 -0.037020427509987 -0.022919155336998 -0.164160248243371 -0.021028638082436  0.018807600972837
-    2  (  2)  0.012197014321068  0.010749741004113 -0.015969423342584  0.008379419120707  0.005700661608131  0.009182078264489  0.007072493012824  0.010651845449983  0.003884546255787
-    3  (  3)  0.055916626202381  0.044952545452401 -0.075693796863105  0.001117242062940  0.024281174456380  0.014619597544444  0.053283290640729 -0.007703747637900  0.022436578410207
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006982563138735  0.003194903879745  0.002336222897235 -0.000159319304138  0.003153288870770 -0.001705858583767
-    1  (  1) -0.013922175981332 -0.014264739151757 -0.027533427644978 -0.002422850658312 -0.006842699761048  0.005360945695369
-    2  (  2) -0.010224586423112  0.021331787446369 -0.001728789794737 -0.007349416930945 -0.001927444504520 -0.000065986060579
-    3  (  3) -0.028649073776619 -0.008193923965952  0.026834068422643 -0.006433642271152 -0.011064478009773 -0.011417291735948
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.007713676236592 -0.011322134542428 -0.003907084678219 -0.013398999832293 -0.015469012646278  0.052157960120007 -0.107410796770658 -0.010366341516333 -0.002761603992801
-    1  (  5) -0.025927350683997  0.036918918076002  0.006183726668218 -0.026765793037023 -0.030906551194513  0.042649472793187 -0.084196537695915 -0.021256853976094  0.026253718608666
-    2  (  6)  0.059547667994813 -0.071575508753465 -0.010792071396250 -0.045987434407762 -0.051692908853277  0.069048919754819 -0.125623895288423  0.001752094627183 -0.022191347480180
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000950352585130  0.000964031243708 -0.004357151868409 -0.000282508389387  0.001887057940293
-    1  (  5)  0.015009418487876  0.001705110486742 -0.029429172036478 -0.001075595895759 -0.006702102006371
-    2  (  6) -0.007980731926488 -0.006589892733093 -0.020940438262106 -0.005674678855389 -0.010940914550877
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.022503440295579 -0.058098623160149 -0.000062770556748  0.132305009159629  0.206845253888047 -0.090151367716489  0.021622993201571  0.039361663017831 -0.081041759541844
-    1  (  1)  0.058446002592381 -0.108172168387665 -0.020491566069368 -0.029038345945867  0.075256281089894 -0.197244333760875  0.268904698800623  0.104165934684913 -0.067340388337437
-    2  (  2)  0.015395531940668 -0.065975044888453 -0.020693241252053 -0.145278172828441 -0.156811977467575 -0.026190455409877  0.072791620600644  0.106379132149940 -0.008110007387647
-    3  (  3) -0.209889648220478 -0.051262205346318  0.016792464687917  0.095510023534389 -0.095336437810925  0.289116526954890 -0.245753636284337  0.379261907424074 -0.084194488967514
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009235922100177  0.024147628250432 -0.039515998201657 -0.082736569420113  0.047511948424277
-    1  (  1) -0.028213287461096 -0.067760885411213 -0.238885785807082  0.125969164479716 -0.177609465312033
-    2  (  2) -0.077606300081110  0.045313543916728 -0.093141189396729 -0.365274041996181 -0.093447143795063
-    3  (  3) -0.414915648100444 -0.159852566418804  0.273568285227133  0.034618677637948 -0.200919751819526
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.016102681987247  0.069778483698171 -0.053388820632185 -0.227201022134194  0.199230027457400 -0.049687576281265  0.168877445270916  0.014461225328824  0.006078045812775
-    1  (  5) -0.058029574787099  0.323045692563543 -0.030451397472044  0.087822399116233  0.049669665032459  0.052839306746938  0.277652121541255  0.149775076383338 -0.305937155270736
-    2  (  6)  0.084055275470361 -0.046073375199290 -0.190725804864306  0.087557818530500  0.137785527514624  0.205465571554547  0.198777590920688  0.118276962990440  0.298899363373310
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.065173985616706 -0.083163093490792 -0.059838819851121 -0.009394325001926  0.030439464329859 -0.004211858017358
-    1  (  5) -0.056299326992358  0.068872084539624 -0.330916524068169  0.053769676104327  0.184435947376520  0.103868547783993
-    2  (  6) -0.066328790174072  0.124449756312364 -0.113043685745447 -0.144452726550998 -0.299204372306587  0.043729255680790
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.000261962805528 -0.008184590036915 -0.017078206714546  0.120797444663216
-    1  (  1)  0.008556708940913 -0.000310357479341 -0.070665159347735  0.263733240360107
-    2  (  2)  0.016665957640930  0.070092969568198 -0.000658296979419 -0.516406140442807
-    3  (  3) -0.119815260993819 -0.260397085059199  0.515923296927153 -0.000854850636510
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.000399146441393 -0.382166830385042  0.144086395309985
-    1  (  5)  0.378879203373120  0.000650240992922 -0.057572968692994
-    2  (  6) -0.142267704977138  0.057783925625685 -0.001456329094587
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000900630817553 -0.057480932301248 -0.021776185729735  0.109986124582381  0.040974945330860 -0.038859091716901  0.013722976007051 -0.027662163358443 -0.095856958174051
-    1  (  1)  0.055475653729802 -0.000055946423413  0.161049994133622 -0.114708024204125  0.226365261647020 -0.429957047290467  0.365226817146534  0.339873184728948  0.220417191818894
-    2  (  2)  0.021015776391238 -0.161427052909899 -0.000077274959500 -0.056803578516095 -0.009014493962493 -0.218381032705550  0.249538253456372  0.218329398300741 -0.109423644471862
-    3  (  3) -0.109912942235432  0.115891216387191  0.056027564915092 -0.000745943372337 -0.462877633738750 -0.122572187022588 -0.103916786291663 -0.116372032296575 -0.000178644283993
-    4  (  4) -0.040100257401862 -0.225977964738017  0.007764610803091  0.462832592343483  0.000863713188323 -0.292983388565641  0.009504255770576  0.051881331882871  0.039789084738637
-    5  (  5)  0.036362528925743  0.431143684565124  0.219013710239096  0.122734678900441  0.292859375843399  0.000211534680093 -0.380048338834318 -0.122563604837507 -0.042304270254871
-    6  (  6) -0.010482485700737 -0.366095597661562 -0.249485788064450  0.103549341685710 -0.008516226169361  0.379084427040252  0.000639775867465 -0.110614613813780  0.062004820067370
-    7  (  7)  0.028768402882082 -0.339119958859154 -0.216813059372775  0.114011828936202 -0.053232451800242  0.122211769727445  0.109878960190336  0.000261733603901  0.084697348659745
-    8  (  8)  0.095810944695334 -0.221328249276204  0.109105398407007  0.000872051363339 -0.038539628128307  0.040520833999881 -0.059740000698578 -0.084693665490196 -0.000412317879658
-    9  (  9) -0.014697085572369  0.105287145446058  0.107273285124578 -0.218858370800804 -0.309735125099696  0.105267325854039  0.129620026346504 -0.117982202893285 -0.042502371715711
-   10  ( 10)  0.029182274069823 -0.107750482915279  0.099755873232373 -0.053540519729348 -0.138357776561317 -0.190065661316311  0.089951321859060  0.050398080030964  0.205938711533222
-   11  ( 11)  0.155188100419269 -0.443693923193159  0.328775787594980  0.218791170588477  0.215183707581260 -0.086687685172586  0.081438682030100  0.042661060649411 -0.076989743302322
-   12  ( 12) -0.047041819133236 -0.056356277723761  0.091876156457291 -0.290703693299362  0.241933426060878  0.247197194304100 -0.042704222313214 -0.092541926182743  0.274193192866205
-   13  ( 13)  0.050345457187286 -0.050309029533978  0.290248962160664 -0.162027268205565 -0.213802087129928  0.103771321970540  0.033795235497894  0.045614675872296 -0.299788281594493
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015094426489382 -0.029115659613984 -0.157755053899573  0.046090500922971 -0.051508699260239
-    1  (  1) -0.106870813652789  0.107133528015314  0.444981848759519  0.057242056092259  0.049852574162928
-    2  (  2) -0.109000377776210 -0.100245307552928 -0.328735836791196 -0.092813183683061 -0.291725571255713
-    3  (  3)  0.218950464663657  0.054805102085238 -0.218886888542902  0.287519470239761  0.163372131318506
-    4  (  4)  0.309058290561676  0.137567383239759 -0.215197532854513 -0.238351393836438  0.213552990219087
-    5  (  5) -0.105624117972044  0.189859620690792  0.086820347884678 -0.246317074454998 -0.103852569604008
-    6  (  6) -0.128090000856966 -0.089849284790653 -0.081980995688413  0.043663325009335 -0.033155703031441
-    7  (  7)  0.117989240855155 -0.049695249544262 -0.043676012478621  0.088835836027429 -0.045632574214248
-    8  (  8)  0.043185512310113 -0.206252030230831  0.075219160600274 -0.272504390674237  0.299099410447326
-    9  (  9)  0.000057792160807 -0.416496446259873 -0.033591110007561  1.079044045817668 -0.144878189091330
-   10  ( 10)  0.417381448990192  0.000164005362256  0.288881720270970  0.322059475407983  0.291538277058570
-   11  ( 11)  0.033261524584639 -0.288678211108026 -0.000120543612153 -0.357470920187357  0.110246704427599
-   12  ( 12) -1.082405304483691 -0.322498276514608  0.357322196019213 -0.000062083058686  0.002512916703858
-   13  ( 13)  0.144912114579253 -0.291369916474370 -0.110105006775579 -0.002446483993989 -0.000063534084907
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000175081543235 -0.016120371429445 -0.025072002498307  0.062542190001810  0.021350885611608 -0.118270325314450  0.004836963443519  0.089308321494217 -0.035265121599228
-    1  ( 15)  0.019016581108200  0.000074621970578 -0.073692709803711  0.220090875517914 -0.117001241546639  0.069843654088588  0.194734592940078 -0.297334325625656  0.000079679030782
-    2  ( 16)  0.022601123418381  0.074079137647858  0.000898075728427  0.015352523942492  0.086856492084776  0.105020764975991  0.399309885639210  0.436863382131761 -0.175020106394679
-    3  ( 17) -0.059722097345652 -0.223919505098606 -0.017236939707940 -0.001153330835786 -0.251337783789116  0.316047497618471 -0.195069502405311 -0.070796117852672  0.376854141068940
-    4  ( 18) -0.020136753535465  0.119176676580060 -0.086690091555956  0.251646590139118  0.000253931741203 -0.043128862347025 -0.031767565075530 -0.166618171717967 -0.162853353427601
-    5  ( 19)  0.121150060676480 -0.070465337136678 -0.107141402917501 -0.315382260507230  0.043144844880487  0.000915299484024 -0.084836748925369 -0.176704257940149  0.191804096130299
-    6  ( 20) -0.000227153495201 -0.194659284089699 -0.399818522753260  0.193896536829102  0.032525351177556  0.085523354347259 -0.000313079507664 -0.483156326770458  0.288322768300912
-    7  ( 21) -0.086746307137042  0.297294170806809 -0.437363838809426  0.070300496686555  0.166591994782662  0.177217714676487  0.482838971708778  0.000010492293158 -0.098273184847402
-    8  ( 22)  0.034845258926466 -0.000856544015064  0.174085542944908 -0.374309528502842  0.160749665940872 -0.191624326414407 -0.289454904423216  0.097021267550271  0.000014930403133
-    9  ( 23)  0.146129839058632 -0.053485685235498 -0.324250294825684 -0.062889229683982 -0.055229748354918 -0.064112736518466 -0.152978751390774 -0.139451617186818  0.103725991413656
-   10  ( 24) -0.228960109301500  0.607985902209189  0.190616272123952  0.232984732345903  0.097313246050666 -0.308149392800276  0.021807135674585 -0.163587870408675 -0.316482089556363
-   11  ( 25)  0.113565876404484  0.174438492287332 -0.418980586076642 -0.308342622144823  0.075432621027986 -0.339103289288024  0.159452756259661  0.028406298387555  0.098839597099930
-   12  ( 26)  0.037444327267505  0.021664072112537 -0.117362801200434  0.051936890369197 -0.180410685976209 -0.010675625355649 -0.081438166282149  0.155940478341532 -0.070485054402575
-   13  ( 27) -0.017297506490468  0.067203074043419 -0.031147633780082  0.363738862057262 -0.387270613641776 -0.012184715254227 -0.015942188037276 -0.055059690817367  0.199296990199261
-   14  ( 28) -0.034092252177278 -0.073609066570293  0.020468002829466  0.085810470847391 -0.016765555515284  0.112839616184051  0.014153257364854 -0.178002322135800 -0.110338785365484
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147095539872383  0.230933799773564 -0.118289772746167 -0.038253772767447  0.016292190599368  0.035682534667396
-    1  ( 15)  0.054490936726031 -0.608135664745124 -0.173899591973767 -0.021325225109119 -0.066354839577592  0.073331369735506
-    2  ( 16)  0.323391847959358 -0.191801489512728  0.419969130886923  0.118001273092276  0.032684795751626 -0.020933916119487
-    3  ( 17)  0.062697350486204 -0.233350536310715  0.310310140488118 -0.052850324165985 -0.365716314917495 -0.086296396691572
-    4  ( 18)  0.056488793458219 -0.097314229222686 -0.076761540605080  0.181114864878134  0.388829148158841  0.017043041264758
-    5  ( 19)  0.064628320787155  0.308910350912390  0.338058227371875  0.010220898623446  0.011328162399087 -0.112362127982896
-    6  ( 20)  0.155379178216769 -0.021354195203646 -0.159398635050546  0.081833336858156  0.016534888228459 -0.014163359612821
-    7  ( 21)  0.140544774640624  0.163930417297846 -0.028664595573870 -0.155618444233808  0.055735865052552  0.178161215640947
-    8  ( 22) -0.103335943311615  0.315447824318108 -0.098508893733037  0.070643837593468 -0.199190551733382  0.110186805922078
-    9  ( 23) -0.000685205966667  0.100205727138143  0.098177984906045 -0.175404901290359  0.218086466804531 -0.228138153241008
-   10  ( 24) -0.099957378010069  0.000114683002834 -0.318552989781446  0.225328174596363  0.500054658950197  0.463890214112047
-   11  ( 25) -0.099837194917025  0.317752725239556  0.000013072206941 -0.325584528982697  0.211934933711027  0.064802310197898
-   12  ( 26)  0.174911687089768 -0.225249469039723  0.325644361756696 -0.000020583584119  0.212000345487721 -0.097990759740804
-   13  ( 27) -0.218595256276638 -0.499626470482149 -0.211748903875054 -0.211985776866883  0.000065067673371  0.140785106097381
-   14  ( 28)  0.228612967389234 -0.463548085364345 -0.064895093957785  0.097943745399791 -0.140883877569212  0.000043885507604
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019700182677109  0.054538984090237 -0.000657293183073 -0.126059310809830 -0.202210998435536  0.093434338948922 -0.024491292826910 -0.039730679308164  0.082949626694243
-    1  (  1) -0.060570767175444  0.116914550591559  0.021887147512717  0.031244847376016 -0.072525220228198  0.201021150446193 -0.281719713830578 -0.109054645892929  0.074327440399931
-    2  (  2) -0.019917912309235  0.073498936617270  0.021015841735422  0.144973687437576  0.148661911932313  0.032805680200546 -0.073267109264708 -0.114043301611785  0.006398273119572
-    3  (  3)  0.203013924377868  0.061956730055068 -0.012687970996334 -0.097374198936088  0.112619147770757 -0.293844050008894  0.262428514093194 -0.382217125669632  0.093448479811708
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009866900732451 -0.025414444169080  0.042903095265214  0.089054808289041 -0.047172870515859
-    1  (  1)  0.029479300283787  0.071852668133049  0.250209813738974 -0.142668644531385  0.184582935130079
-    2  (  2)  0.082839864480014 -0.055172054044896  0.094169081580928  0.401277867082131  0.092346870950097
-    3  (  3)  0.429785932962393  0.170247315400438 -0.282336698266602 -0.039589385431130  0.207542683133729
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.009866584979615 -0.069659389537491  0.056437231681763  0.210909857783049 -0.193232853181170  0.044263163299008 -0.177086741570328 -0.011251791029684 -0.005974944716268
-    1  (  5)  0.063966745715490 -0.332083812922557  0.023959233352896 -0.077592998716556 -0.049685567261474 -0.057922845574600 -0.292828526996057 -0.156611147799580  0.308189152931944
-    2  (  6) -0.093646243694873  0.043886805978712  0.210333087134862 -0.092497904992983 -0.147507586034141 -0.211245402574096 -0.209822842363991 -0.120370292677788 -0.308437245541850
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.068407482810993  0.091070726633550  0.065843093849228  0.010412482581381 -0.030047987986095  0.002926817734499
-    1  (  5)  0.052950259935732 -0.069489349844531  0.341748563636028 -0.056521413026742 -0.185361514981393 -0.106113084848249
-    2  (  6)  0.072195900884652 -0.125482826256955  0.118114475628592  0.149158088490872  0.308475854808773 -0.046262836261975
-
 	Computing Mu_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.375799332377
-	   1         5.296859595086    3.096e-01
-	   2         6.160547161060    1.889e-01
-	   3         6.261605992749    5.683e-02
-	   4         6.288911116024    2.841e-02
-	   5         6.293219867196    9.327e-03
-	   6         6.295001984787    4.895e-03
-	   7         6.294804800934    2.214e-03
-	   8         6.294697863019    1.065e-03
-	   9         6.294565693243    5.236e-04
-	  10         6.294593758840    2.339e-04
-	  11         6.294619975942    5.184e-05
-	  12         6.294638606832    1.755e-05
-	  13         6.294647194102    7.981e-06
-	  14         6.294652317588    3.968e-06
-	  15         6.294654523159    1.440e-06
-	  16         6.294655328244    5.885e-07
-	  17         6.294655419782    1.479e-07
+	   0         4.375799322300
+	   1         5.296859580919    3.096e-01
+	   2         6.160547142252    1.889e-01
+	   3         6.261605972756    5.683e-02
+	   4         6.288911096112    2.841e-02
+	   5         6.293219847131    9.327e-03
+	   6         6.295001964725    4.895e-03
+	   7         6.294804780862    2.214e-03
+	   8         6.294697842944    1.065e-03
+	   9         6.294565673175    5.236e-04
+	  10         6.294593738769    2.339e-04
+	  11         6.294619955871    5.184e-05
+	  12         6.294638586760    1.755e-05
+	  13         6.294647174029    7.981e-06
+	  14         6.294652297516    3.968e-06
+	  15         6.294654503086    1.440e-06
+	  16         6.294655308171    5.885e-07
+	  17         6.294655399709    1.479e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.886e-08
 
 	Computing P*_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.589500953497
-	   1         9.557968161930    2.364e-01
-	   2        10.091844466465    1.253e-01
-	   3        10.164909223819    5.563e-02
-	   4        10.178022237017    2.728e-02
-	   5        10.182250508071    9.925e-03
-	   6        10.184337333986    5.307e-03
-	   7        10.184106055328    2.293e-03
-	   8        10.184170560394    1.063e-03
-	   9        10.184098292041    4.046e-04
-	  10        10.184163049080    1.811e-04
-	  11        10.184182035621    4.660e-05
-	  12        10.184190623346    1.282e-05
-	  13        10.184195560797    5.641e-06
-	  14        10.184197702905    2.666e-06
-	  15        10.184198803415    1.041e-06
-	  16        10.184199302762    5.581e-07
-	  17        10.184199403072    2.539e-07
-	  18        10.184199416637    1.021e-07
+	   0         8.589500972542
+	   1         9.557968181971    2.364e-01
+	   2        10.091844488146    1.253e-01
+	   3        10.164909245325    5.563e-02
+	   4        10.178022258607    2.728e-02
+	   5        10.182250529592    9.925e-03
+	   6        10.184337355486    5.307e-03
+	   7        10.184106076799    2.293e-03
+	   8        10.184170581868    1.063e-03
+	   9        10.184098313515    4.046e-04
+	  10        10.184163070552    1.811e-04
+	  11        10.184182057092    4.660e-05
+	  12        10.184190644817    1.282e-05
+	  13        10.184195582269    5.641e-06
+	  14        10.184197724376    2.666e-06
+	  15        10.184198824886    1.041e-06
+	  16        10.184199324233    5.581e-07
+	  17        10.184199424543    2.539e-07
+	  18        10.184199438108    1.021e-07
 	-----------------------------------------
 	Converged P*_X-Perturbed Wfn to 3.155e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.439398874095
-	   1         5.371293204264    2.594e-01
-	   2         6.076617273373    1.387e-01
-	   3         6.119138911669    3.100e-02
-	   4         6.127598203786    1.467e-02
-	   5         6.129699936149    3.204e-03
-	   6         6.130036210635    1.681e-03
-	   7         6.130049865879    4.765e-04
-	   8         6.130060297181    1.704e-04
-	   9         6.130049043145    6.134e-05
-	  10         6.130053995384    1.861e-05
-	  11         6.130057803553    4.494e-06
-	  12         6.130060157243    1.399e-06
-	  13         6.130061264132    5.305e-07
-	  14         6.130061602091    2.079e-07
+	   0         4.439398845487
+	   1         5.371293170025    2.594e-01
+	   2         6.076617232969    1.387e-01
+	   3         6.119138869419    3.100e-02
+	   4         6.127598161318    1.467e-02
+	   5         6.129699893574    3.204e-03
+	   6         6.130036168029    1.681e-03
+	   7         6.130049823274    4.765e-04
+	   8         6.130060254574    1.704e-04
+	   9         6.130049000540    6.134e-05
+	  10         6.130053952778    1.861e-05
+	  11         6.130057760947    4.494e-06
+	  12         6.130060114637    1.399e-06
+	  13         6.130061221526    5.305e-07
+	  14         6.130061559485    2.079e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 7.568e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.046333557452
-	   1        12.442227680470    5.227e-01
-	   2        14.864939955441    3.202e-01
-	   3        15.429117008258    9.656e-02
-	   4        15.470238268066    3.649e-02
-	   5        15.489124886185    1.247e-02
-	   6        15.489391069277    6.942e-03
-	   7        15.487859478399    3.096e-03
-	   8        15.489514226158    1.635e-03
-	   9        15.489187856558    6.258e-04
-	  10        15.489248974295    2.963e-04
-	  11        15.489272487987    1.114e-04
-	  12        15.489341020155    3.327e-05
-	  13        15.489369668837    8.608e-06
-	  14        15.489381485873    3.758e-06
-	  15        15.489386092445    1.725e-06
-	  16        15.489386987137    6.803e-07
-	  17        15.489386387659    2.201e-07
-	  18        15.489386272899    1.091e-07
+	   0        10.046333454849
+	   1        12.442227557130    5.227e-01
+	   2        14.864939808708    3.202e-01
+	   3        15.429116835827    9.656e-02
+	   4        15.470238094959    3.649e-02
+	   5        15.489124712215    1.247e-02
+	   6        15.489390895336    6.942e-03
+	   7        15.487859304466    3.096e-03
+	   8        15.489514052123    1.635e-03
+	   9        15.489187682538    6.258e-04
+	  10        15.489248800273    2.963e-04
+	  11        15.489272313966    1.114e-04
+	  12        15.489340846132    3.327e-05
+	  13        15.489369494813    8.608e-06
+	  14        15.489381311848    3.758e-06
+	  15        15.489385918420    1.725e-06
+	  16        15.489386813112    6.803e-07
+	  17        15.489386213634    2.201e-07
+	  18        15.489386098874    1.091e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 3.554e-08
 
 	Computing P*_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.947949060932
-	   1        10.193706292002    2.933e-01
-	   2        10.965088445772    1.583e-01
-	   3        11.181975973860    5.366e-02
-	   4        11.185232766411    1.838e-02
-	   5        11.189258408047    5.169e-03
-	   6        11.189231465443    2.483e-03
-	   7        11.189164788942    7.426e-04
-	   8        11.189268584811    3.892e-04
-	   9        11.189159250493    2.060e-04
-	  10        11.189211226418    1.032e-04
-	  11        11.189209984884    4.998e-05
-	  12        11.189227709195    1.982e-05
-	  13        11.189228555926    6.927e-06
-	  14        11.189229981561    1.937e-06
-	  15        11.189229929413    7.262e-07
-	  16        11.189230078441    2.714e-07
+	   0         8.947949074028
+	   1        10.193706312528    2.933e-01
+	   2        10.965088472727    1.583e-01
+	   3        11.181975996133    5.366e-02
+	   4        11.185232788727    1.838e-02
+	   5        11.189258430298    5.169e-03
+	   6        11.189231487698    2.483e-03
+	   7        11.189164811187    7.426e-04
+	   8        11.189268607058    3.892e-04
+	   9        11.189159272741    2.060e-04
+	  10        11.189211248665    1.032e-04
+	  11        11.189210007131    4.998e-05
+	  12        11.189227731442    1.982e-05
+	  13        11.189228578173    6.927e-06
+	  14        11.189230003808    1.937e-06
+	  15        11.189229951660    7.262e-07
+	  16        11.189230100688    2.714e-07
 	-----------------------------------------
 	Converged P*_Y-Perturbed Wfn to 9.987e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.252621959256
-	   1         0.324103642800    7.375e-02
-	   2         0.381905556661    4.092e-02
-	   3         0.384055317728    8.396e-03
-	   4         0.384878293300    3.789e-03
-	   5         0.384947270287    4.893e-04
-	   6         0.384933279475    2.098e-04
-	   7         0.384935359547    7.052e-05
-	   8         0.384934890925    3.136e-05
-	   9         0.384934809142    6.904e-06
-	  10         0.384934961278    2.363e-06
-	  11         0.384935042979    5.761e-07
-	  12         0.384935082789    2.231e-07
+	   0         0.252621955661
+	   1         0.324103637822    7.375e-02
+	   2         0.381905549941    4.092e-02
+	   3         0.384055310874    8.396e-03
+	   4         0.384878286410    3.789e-03
+	   5         0.384947263393    4.893e-04
+	   6         0.384933272582    2.098e-04
+	   7         0.384935352653    7.052e-05
+	   8         0.384934884031    3.136e-05
+	   9         0.384934802248    6.904e-06
+	  10         0.384934954384    2.363e-06
+	  11         0.384935036085    5.761e-07
+	  12         0.384935075896    2.231e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 3.189e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.821161588437
-	   1         8.349288795591    4.037e-01
-	   2         9.783177391714    2.271e-01
-	   3         9.931957521415    5.931e-02
-	   4         9.951293369120    2.642e-02
-	   5         9.956872385170    7.970e-03
-	   6         9.958275001707    4.187e-03
-	   7         9.958051262575    1.433e-03
-	   8         9.958083725945    6.311e-04
-	   9         9.958056525014    1.750e-04
-	  10         9.958081775558    6.638e-05
-	  11         9.958084675327    3.195e-05
-	  12         9.958089432948    1.455e-05
-	  13         9.958091732727    7.828e-06
-	  14         9.958094312640    3.705e-06
-	  15         9.958095869157    1.468e-06
-	  16         9.958096412692    6.359e-07
-	  17         9.958096483400    2.878e-07
-	  18         9.958096428897    1.575e-07
+	   0         6.821161539097
+	   1         8.349288731365    4.037e-01
+	   2         9.783177309502    2.271e-01
+	   3         9.931957436080    5.931e-02
+	   4         9.951293283494    2.642e-02
+	   5         9.956872299430    7.970e-03
+	   6         9.958274915925    4.187e-03
+	   7         9.958051176803    1.433e-03
+	   8         9.958083640170    6.311e-04
+	   9         9.958056439241    1.750e-04
+	  10         9.958081689784    6.638e-05
+	  11         9.958084589553    3.195e-05
+	  12         9.958089347174    1.455e-05
+	  13         9.958091646953    7.828e-06
+	  14         9.958094226866    3.705e-06
+	  15         9.958095783383    1.468e-06
+	  16         9.958096326918    6.359e-07
+	  17         9.958096397627    2.878e-07
+	  18         9.958096343123    1.575e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 6.046e-08
 
 	Computing P*_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.277352874220
-	   1        10.359326282769    2.750e-01
-	   2        11.061869480272    1.360e-01
-	   3        11.155455852667    4.543e-02
-	   4        11.157204486141    1.960e-02
-	   5        11.160034122563    6.110e-03
-	   6        11.161208954770    3.311e-03
-	   7        11.161124209194    1.258e-03
-	   8        11.161128851721    5.757e-04
-	   9        11.161081399919    2.140e-04
-	  10        11.161120906446    8.816e-05
-	  11        11.161130830537    4.784e-05
-	  12        11.161138852738    1.910e-05
-	  13        11.161140560995    9.208e-06
-	  14        11.161140989490    3.405e-06
-	  15        11.161142030750    1.243e-06
-	  16        11.161142551387    5.446e-07
-	  17        11.161142739733    2.514e-07
-	  18        11.161142772902    1.075e-07
+	   0         9.277352892635
+	   1        10.359326303002    2.750e-01
+	   2        11.061869501046    1.360e-01
+	   3        11.155455872421    4.543e-02
+	   4        11.157204505893    1.960e-02
+	   5        11.160034142294    6.110e-03
+	   6        11.161208974483    3.311e-03
+	   7        11.161124228904    1.258e-03
+	   8        11.161128871432    5.757e-04
+	   9        11.161081419630    2.140e-04
+	  10        11.161120926157    8.816e-05
+	  11        11.161130850249    4.784e-05
+	  12        11.161138872450    1.910e-05
+	  13        11.161140580707    9.208e-06
+	  14        11.161141009202    3.405e-06
+	  15        11.161142050462    1.243e-06
+	  16        11.161142571099    5.446e-07
+	  17        11.161142759445    2.514e-07
+	  18        11.161142792614    1.075e-07
 	-----------------------------------------
 	Converged P*_Z-Perturbed Wfn to 2.636e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.974039174967
-	   1         4.741444632544    2.312e-01
-	   2         5.312770350415    1.345e-01
-	   3         5.367746351153    3.797e-02
-	   4         5.383237423570    1.742e-02
-	   5         5.384022465788    3.055e-03
-	   6         5.384259935227    1.514e-03
-	   7         5.384211934459    3.426e-04
-	   8         5.384189956466    1.023e-04
-	   9         5.384179383688    2.823e-05
-	  10         5.384178994033    9.138e-06
-	  11         5.384180034462    3.103e-06
-	  12         5.384180685105    1.140e-06
-	  13         5.384181018266    4.324e-07
-	  14         5.384181202611    1.822e-07
+	   0         3.974039147813
+	   1         4.741444600123    2.312e-01
+	   2         5.312770312389    1.345e-01
+	   3         5.367746311024    3.797e-02
+	   4         5.383237383031    1.742e-02
+	   5         5.384022425187    3.055e-03
+	   6         5.384259894609    1.514e-03
+	   7         5.384211893840    3.426e-04
+	   8         5.384189915847    1.023e-04
+	   9         5.384179343069    2.823e-05
+	  10         5.384178953415    9.138e-06
+	  11         5.384179993843    3.103e-06
+	  12         5.384180644486    1.140e-06
+	  13         5.384180977648    4.324e-07
+	  14         5.384181161993    1.822e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 5.700e-08
 
@@ -6579,9 +1148,9 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.158728295592413    -0.066346095137326     0.000000000000000
-    1     -0.272773167947186    -0.014108130749903     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.127667934489866
+    0      0.158728294539562    -0.066346094594683     0.000000000000000
+    1     -0.272773167749082    -0.014108130360601     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.127667932423499
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
 	[alpha]_(0.077) =  -83.11386 deg/[dm (g/cm^3)]
@@ -6593,12 +1162,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.374037562174131    -0.355326609532233     0.000000000000000
-    1     -0.077531897792830    -0.006930950517266     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.382608809751905
+    0      0.374037560357567    -0.355326606655554     0.000000000000000
+    1     -0.077531897840927    -0.006930950258492     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.382608807749547
 
    Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.077) =  982.51574 deg/[dm (g/cm^3)]
+	[alpha]_(0.077) =  982.51558 deg/[dm (g/cm^3)]
 
         CC2 Optical Rotation Tensor (Modified Velocity Gauge):
   -------------------------------------------------------------------------
@@ -6607,4480 +1176,430 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.012678493961059    -0.011363545775485     0.000000000000000
-    1     -0.021830696175979    -0.000817002501635     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.008747573061817
+    0      0.012678493985372    -0.011363545769079     0.000000000000000
+    1     -0.021830696459201    -0.000817002475747     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.008747573002850
 
    Specific rotation using modified velocity-gauge Rosenfeld tensor.
-	[alpha]_(0.077) = -197.35742 deg/[dm (g/cm^3)]
+	[alpha]_(0.077) = -197.35740 deg/[dm (g/cm^3)]
 
    Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.
      Delta_x =   0.00   Delta_y =   0.00   Delta_z = -19.67
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933719  0.015024519180328 -0.027415915569927 -0.162886507397778  0.113254822182172 -0.064023650931690  0.055316304980596  0.030988679956786  0.002674429417477
-    1  (  1)  0.215473680254303  0.146951879885484 -0.277734064030081  0.062883278347954  0.148483123915935  0.181595053380814  0.367001371843722  0.003086313328534  0.095386404339393
-    2  (  2) -0.028492499167414  0.000076506520592 -0.059221747197113  0.071711487991955  0.074053260083134  0.055563200913425 -0.046720222778269  0.241063526706415  0.098194384215310
-    3  (  3) -0.132536698935225 -0.177581639220036 -0.107360746511047 -0.032262815899199  0.006088751294667  0.053657437577797 -0.241466578728664 -0.131962062699398  0.577380042604837
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927832  0.060461893794974 -0.005615477646775 -0.003888920206542  0.016113135271293 -0.008672229740057
-    1  (  1) -0.037058680758818 -0.084686071934143 -0.145302623884171 -0.027760832624295 -0.054555858489399  0.022009727182523
-    2  (  2) -0.087315818129461  0.399047483163753 -0.041723099752478 -0.020041920189952 -0.040600995633868  0.007777357868478
-    3  (  3)  0.035307803556741 -0.050920479686544  0.165550414172814 -0.068091463340302 -0.144062340529055 -0.042051983076328
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356551 -0.081063517853362  0.006129432768986  0.163964563111019  0.188951419459760 -0.080047732466264  0.074988303081860  0.007836242506545 -0.044696302205990
-    1  (  5)  0.348085979138498  0.014814724303187 -0.054134117524106 -0.070406995762195  0.073423358836442 -0.343984245233778  0.389896180591041 -0.295068043464420  0.051928952937995
-    2  (  6)  0.021691230674299 -0.340003625622924 -0.038072452179293 -0.014533847126865 -0.084733391360494 -0.004556444515594  0.201335045135129  0.349717311230211 -0.082620936463628
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932767 -0.007485730843830 -0.029474818409048  0.032209758674475  0.014108652541198
-    1  (  5)  0.209382720135360  0.066996563725018 -0.203801631001162 -0.021994746468443  0.025790645299269
-    2  (  6) -0.188199132187482 -0.086167806666975 -0.070501884768036 -0.051440727873375 -0.127552190835519
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135226960454329 -0.626072128797856  0.189283545408859
-    1  (  1) -0.198601340506734 -0.037544167210706 -0.132449472453120
-    2  (  2)  0.054869769604055  0.126822216303605 -0.064658685102821
-    3  (  3)  0.615161980452155 -0.126204375217765 -0.081927924761018
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135552779706607 -0.198154082714879  0.054851984676127  0.616510373253303
-    1  (  5) -0.625008803021780 -0.037782453643458  0.128063646533814 -0.126279998076331
-    2  (  6)  0.187629167441129 -0.129442737930206 -0.067422044676100 -0.079936634548172
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904639712499451 -0.487488103200076 -0.229076194035639  0.577203417890310 -0.193643876562866 -0.103447604010490 -0.002742470403339 -0.002451788094673 -0.093813724218951
-    1  (  1) -0.150591231752366 -0.132839961398672 -0.684911223766594  0.231736797158550 -0.050522572299863 -0.177494490840206  0.234003342486174  0.124606643062300 -0.128494931356720
-    2  (  2)  0.012679732612875 -0.025746334218933  0.172509146876756 -0.235881170188724 -0.123364008457064 -0.206129657450651 -0.121800673855344 -0.114140784221077 -0.027356216567683
-    3  (  3) -0.420686741899109  0.000223888623798 -0.019382136800427 -0.199660686586779 -0.007228242971357  0.053875733566216 -0.291408914352131  0.275298575094287  0.504737487457482
-    4  (  4) -0.444479349932693 -0.097546029689334 -0.201324076119099 -0.112193453655926 -0.168730295177634  0.009510393466796 -0.073326647656899 -0.314743664834695  0.576679302947873
-    5  (  5) -0.139143305540458  0.035439861017558 -0.250210390538763 -0.395563451554525  0.287109450839577 -0.179399443391397  0.197453518892115  0.283328589948476 -0.108409713739241
-    6  (  6) -0.129858112319494 -0.067528694061774  0.181320447910016  0.198216451549469  0.101434222271579  0.004260476702610 -0.540044484893358  0.047093544204538 -0.240211227858318
-    7  (  7) -0.134029026372210 -0.177806690148742  0.066071255125305 -0.420048245168344  0.282274848902259 -0.347456793165350 -0.074406017626731 -0.307127129684507  0.001639432917235
-    8  (  8) -0.063335732549803 -0.086906710930682  0.269779701592786  0.018783692891885  0.093247017991791  0.136863024113204  0.153892981652107 -0.031577691616058  0.057553836246905
-    9  (  9)  0.014012585179935  0.032071651340396  0.006363849845329 -0.122564599853837  0.077119470960815 -0.029965581352467  0.027046636903364  0.089397837094507 -0.000802529924293
-   10  ( 10)  0.055348506435332 -0.144624122276400  0.060432277066905 -0.048567020795871 -0.074912986944558 -0.098523802539065  0.029250640804258 -0.193836130554797  0.085063532916863
-   11  ( 11) -0.167019155111356 -0.139650558475056  0.283534980836447  0.091894060309841 -0.065838077605531 -0.024336945622807 -0.227843897422644  0.001167201554402 -0.053408806911177
-   12  ( 12) -0.031974022074094  0.367173995466684  0.116713714097489  0.049340092544995  0.015070529788415 -0.072500414701037  0.058353998450091 -0.115184864373284 -0.153182495837622
-   13  ( 13)  0.015928358602524 -0.071164774172970  0.101660897809921 -0.105977026406682  0.126658664034758 -0.065056017101762 -0.035738606034781 -0.004435603298656 -0.059994356828778
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128825974989509 -0.011693877694956 -0.146729379814636 -0.059424684705193 -0.018525365113581  0.062705489025799
-    1  (  1)  0.288526396149447  0.103129875764739  0.289919344105948  0.006241427794524  0.000597805518378 -0.002126961584359
-    2  (  2) -0.124928230102748 -0.010221797026422 -0.056571189754990 -0.103418885736763 -0.082343433199812  0.048808132756786
-    3  (  3)  0.041255915551182 -0.068310001947041 -0.078413018324291  0.150330242984032  0.179548999452936  0.040220285290074
-    4  (  4)  0.222674700983985  0.064061711596271 -0.051112895424348 -0.009318828777699  0.269456744732776  0.059360036713982
-    5  (  5) -0.030199751599662 -0.174896036167204  0.092691422408890  0.028256224393045 -0.095222992765338 -0.000984235427179
-    6  (  6)  0.000100463193790 -0.095109995484221 -0.236670455787565  0.077272409830334 -0.062627657605178 -0.003574021992867
-    7  (  7) -0.071380631315585  0.113168055430629 -0.125965816328841 -0.059330696538415  0.017157541349944  0.045135077260112
-    8  (  8) -0.578000624333793 -0.096150086854243  0.034301394867322  0.008135450733159  0.200641611845460 -0.180371714719462
-    9  (  9) -0.075918662396497  0.004599198141429  0.008112602200918  0.005143287525083  0.000284986477862 -0.012193359543266
-   10  ( 10) -0.010150745998766  0.093962320907848  0.012547284938522 -0.048325478252251  0.058041984098958  0.029299969972017
-   11  ( 11) -0.079273276366059 -0.056402585822246 -0.083755323132189 -0.007973236673640  0.003424691269612 -0.009405123180745
-   12  ( 12) -0.063303823644203  0.041869083940428 -0.019024216633724 -0.031772697856612 -0.042532243078164 -0.051259918656063
-   13  ( 13)  0.241542081048425  0.060829474159106 -0.029241791046113 -0.004754249561521 -0.057213036452335  0.050348392969429
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902374530738022 -0.153219479021377  0.011852929174237 -0.420772110136454 -0.445657281852233 -0.142990081433834 -0.124215890045092 -0.133483278617486 -0.065282671277575
-    1  ( 15) -0.489111175456921 -0.131490362750624 -0.025259277994888  0.001430871050471 -0.096952824968496  0.035534183248533 -0.068855717941569 -0.178542279529003 -0.088180183979087
-    2  ( 16) -0.227418381124785 -0.683144902334149  0.173877572588752 -0.020414541641232 -0.199817592754852 -0.249739904936588  0.179565732929473  0.064581867916785  0.271668362709088
-    3  ( 17)  0.574685513420631  0.230755641765144 -0.236330653993451 -0.198455558262947 -0.112539659295239 -0.393276362435767  0.196125851624956 -0.416930913980481  0.017841111258302
-    4  ( 18) -0.193861200268992 -0.049521286941690 -0.123799353815169 -0.006786264808002 -0.167396168176774  0.285560945535521  0.102872968175184  0.279329859462782  0.092685860122555
-    5  ( 19) -0.103950692672536 -0.178731366743218 -0.207305979104179  0.054759646458521  0.008750479265458 -0.180116361743218  0.005850873308053 -0.346544100781250  0.135656056953800
-    6  ( 20) -0.005630218802764  0.235616494969928 -0.121418775897667 -0.289705308748940 -0.074615700944863  0.197147960229531 -0.541298908627625 -0.074766151907221  0.151080244573413
-    7  ( 21) -0.003422639573229  0.126273883662637 -0.114690954063485  0.273155566178120 -0.312791095371318  0.283606567582012  0.047453631637779 -0.310404476862355 -0.030935364545071
-    8  ( 22) -0.094384208857050 -0.130119390042033 -0.029535782736702  0.507266905754751  0.577412507794685 -0.108469543731725 -0.239044626830660  0.001740919827196  0.057806922411999
-    9  ( 23) -0.126661063777409  0.286542775287408 -0.124995270818088  0.042040769766258  0.222601161131206 -0.031774064783095  0.002289661982445 -0.069973062056331 -0.578237160301556
-   10  ( 24) -0.012316706158688  0.104097860742328 -0.011505288408996 -0.071480242591920  0.067861431955970 -0.174641527191865 -0.093323115387981  0.108845273419844 -0.094609691027850
-   11  ( 25) -0.145222688889763  0.289337733151126 -0.056602400212228 -0.078531799009324 -0.050892925184258  0.092549568885425 -0.236281405460416 -0.125802430136002  0.035465582481700
-   12  ( 26) -0.059239279504459  0.006390267291517 -0.103087074498887  0.150070392220881 -0.009342684456032  0.028289380811624  0.077066678658251 -0.059246681674569  0.008175814399583
-   13  ( 27) -0.018271401982902  0.001173845770900 -0.081596168939475  0.178729785139683  0.269264211536985 -0.095094170813457 -0.063160456524518  0.017032758007907  0.200794357953944
-   14  ( 28)  0.062542890221320 -0.002043353345753  0.048801696637924  0.040072732580057  0.059190323152548 -0.000990742681887 -0.003556361910882  0.045152229102533 -0.180550803638744
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015123588660554  0.055493926114086 -0.169975137829357 -0.032809701818419  0.015002120333835
-    1  ( 15)  0.032575974689068 -0.144334404568220 -0.139389411890772  0.367448169822372 -0.070672349646380
-    2  ( 16)  0.006576811925777  0.060477069258309  0.284097691628268  0.117086244456111  0.102358639196809
-    3  ( 17) -0.124972828077174 -0.049265564522405  0.093111727254450  0.049489377800986 -0.106573762761508
-    4  ( 18)  0.078337257989412 -0.074315417379022 -0.066598566061427  0.015174881916742  0.127229135544739
-    5  ( 19) -0.030091617468876 -0.098524033243520 -0.024929078981092 -0.072709941383626 -0.065547640079006
-    6  ( 20)  0.028642219542832  0.029887343616837 -0.227866902460195  0.058376706970884 -0.035321371844135
-    7  ( 21)  0.087782136491553 -0.193844146817677  0.000960256633726 -0.115246048391410 -0.004217096818020
-    8  ( 22) -0.000480626398768  0.085216781964239 -0.052876715620283 -0.152779703755060 -0.059953833408394
-    9  ( 23) -0.075367737260776 -0.010279381835842 -0.080270644652149 -0.063438855793640  0.241130315879110
-   10  ( 24)  0.001339830230092  0.093599534020443 -0.056909491966955  0.041771584176774  0.060831797189675
-   11  ( 25)  0.008376396051511  0.012488344592190 -0.083677242445135 -0.018943587777834 -0.029225017366591
-   12  ( 26)  0.005096769732662 -0.048366952557418 -0.008003858722242 -0.031797935609827 -0.004752495908706
-   13  ( 27)  0.000291047131527  0.058011237654453  0.003385274769851 -0.042619295059266 -0.057154993286885
-   14  ( 28) -0.012282741908214  0.029296735642711 -0.009480582784426 -0.051319211356101  0.050295534824424
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027700885793090  0.024831013973620 -0.023766237412625 -0.167016603039327  0.109441555361099 -0.067202506902943  0.052695088582618  0.024064411648558  0.006188438734744
-    1  (  1)  0.211348759010705  0.133908962277450 -0.251856181342018  0.050198620343957  0.139035741221492  0.172926066548658  0.339110899470513  0.007367826854054  0.086633467632879
-    2  (  2) -0.033041625132306  0.014036582200115 -0.054189619432057  0.084538537056286  0.066377206996811  0.053646226488719 -0.037306526458897  0.220368264081415  0.092674869094203
-    3  (  3) -0.148568319902254 -0.152791211204353 -0.088570806082631 -0.044321874775550  0.009397298861476  0.049588338511193 -0.223116042687511 -0.123854255485030  0.553492211947825
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031010458886505  0.050729211215458 -0.003248182162608 -0.003208641714203  0.015229535075598 -0.008450459157620
-    1  (  1) -0.026218145702581 -0.073512341998455 -0.129399675880907 -0.023964582987074 -0.050019383975377  0.020539415914057
-    2  (  2) -0.075590807542000  0.365585379125664 -0.036729157945636 -0.016058134590280 -0.036438378068464  0.005536360852376
-    3  (  3)  0.037937313174203 -0.045234909961237  0.147760703126575 -0.060764535561285 -0.127333495556462 -0.038975339991211
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.051048798017959 -0.074362715758791  0.011189550347852  0.166183248293228  0.192475433446903 -0.070879824995202  0.064177194660685  0.010742342939179 -0.040136733536896
-    1  (  5)  0.352033813656898  0.019031583986232 -0.054018125678766 -0.066876079961775  0.060148226317511 -0.330348230405564  0.365124970723465 -0.284795973003407  0.051302526538107
-    2  (  6)  0.016809582021521 -0.311268516971315 -0.037661154101055 -0.006688597064538 -0.076727139945066  0.002675593746451  0.192087236696226  0.332474625249023 -0.065875996007769
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002709655241188 -0.005736834567419 -0.024459935540253  0.027202469191560  0.013148077561853
-    1  (  5)  0.191661619772415  0.061070263266085 -0.180667286312627 -0.019964047997524  0.020757203718351
-    2  (  6) -0.172312444590060 -0.078944608822718 -0.060240884585305 -0.044786922712268 -0.117310123601201
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102371  0.008188589712253 -0.013790999932786 -0.066013267343743 -0.002979179364400  0.115067560152139 -0.029904774000612  0.075658337330171  0.005135342269600
-    1  (  1) -0.415137332088601  0.400791789518638  0.060626653167993 -0.009777722957293  0.182694524485328  0.107591424113232 -0.071470092116899  0.210805299972914 -0.029640655301113
-    2  (  2)  0.731004204598520 -0.977674938020327  0.030910735141464  0.126476447646343  0.160297857646314 -0.115254107794063  0.017919423470237  0.019160269758155  0.056677210806000
-    3  (  3) -0.052710934455990  0.190825342618795 -0.121683764296164  0.058318753384800 -0.051331848225844  0.122833340921047  0.176985596744929 -0.321410474763129  0.015752780623213
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449213 -0.003857954296837  0.001116934481339 -0.006268480889136  0.011819863965877  0.022338641059405
-    1  (  1)  0.026581167918671 -0.003242138995827  0.002209759168118 -0.126256065331473  0.064001666171839  0.019583311633873
-    2  (  2)  0.060541607763312 -0.048685401885036 -0.005324531906369 -0.077364982992387 -0.023160042352107 -0.131997334895641
-    3  (  3)  0.086532549077855 -0.501054912835389 -0.033953281830232 -0.045954160893793  0.007588765668991  0.026055365513597
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407922 -0.003874637131508  0.017573675069981 -0.250000468336213  0.193535227171919 -0.023949830014063 -0.006344215172670 -0.002637721142585  0.025018403626543
-    1  (  5) -0.061066900138168  0.119597101102997  0.077747477731561 -0.181802110874954 -0.105212352540637 -0.191650240311696 -0.067261595147758  0.101033231559049  0.034053487252848
-    2  (  6) -0.129779125650155  0.272168473286835  0.218088904973350 -0.105590817864479  0.170044089806049 -0.413895401404366 -0.204721805057804  0.193774792721739  0.022574107317581
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304092 -0.022619515940244  0.001370551331509 -0.019480287608797 -0.016611790333304
-    1  (  5) -0.015006262168536  0.018557640744952 -0.000086080146175 -0.193359672647774  0.037991057379311
-    2  (  6)  0.020942063740395 -0.276121820896827 -0.020375408054503  0.090755244706104  0.038585932807349
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234755470283494 -0.089757897373020 -0.029226311105252
-    1  (  1)  0.628249611487235  0.562405195056318  1.006567293279179
-    2  (  2) -1.014513658696574  0.324469533164471  0.758540603298664
-    3  (  3)  0.070695571972197 -1.217301397368710  0.544825504539347
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235350713719763  0.628273412467382 -1.016171307500330  0.070820853933159
-    1  (  5) -0.089319079346847  0.558364917857372  0.332433157387859 -1.220987955904316
-    2  (  6) -0.028486683819977  1.000293875862972  0.767362449165329  0.543367325750415
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.804113115082476  0.859865209405978  0.271144212420722  0.233800284186400 -0.124039945960302 -0.010266323749701 -0.092708567501353  0.016778206024767 -0.004458179405382
-    1  (  1)  0.400343044462577 -0.255491137898964  1.725894952211806  0.228060869773276 -0.016813664829395  0.078025484956049 -0.010667432793276  0.508783176705980  0.007215780908188
-    2  (  2) -0.011354346714470 -0.088649218741431 -0.217285460959696 -0.271127696601060 -0.847424926486828 -0.636922641013174  0.167096970483907  0.613137270589982  0.118274978265568
-    3  (  3)  0.794199691903238 -0.188240166832123  0.221783053519905 -0.127263314849504  0.529647578782938 -1.234322959040903  0.503694754515607 -0.716759154325272  0.003713884622693
-    4  (  4) -0.401724672662203  0.338296304392140  0.027696569600284 -1.521982152310056  0.118592993377401  0.737822504259554  0.133024505198137  0.089529285352600  0.037479870573311
-    5  (  5) -0.062644206103431  0.401210407583383 -0.021849381974102 -0.715241456861441 -1.272083761860537  0.501726128250219 -0.443637757248850 -0.893021281361452  0.592660402987318
-    6  (  6) -0.010995449282209  0.203452242512905 -0.137034668384831 -0.113107359606073 -0.481513340581640  0.549194810269266  1.454087044363765 -0.104931286723953 -0.037492008681457
-    7  (  7)  0.128269755499557  0.321618430212614  0.165227456397847  0.036785042290031  0.490368577399565  0.556638814927009 -0.027991830909201  0.572834606710096  0.836617597163443
-    8  (  8)  0.028289154881459 -0.066964202719289 -0.261747148048837 -0.132206243094573 -0.099640531633427  0.125261053712928 -0.191170844521896  0.152462184420595 -0.345612464691053
-    9  (  9) -0.116917200683994  0.677293814759277  0.057457633837352  0.132537898195641 -0.004175807366595 -0.154875636337893 -0.038546773688736 -0.121822888362931 -0.349244520254478
-   10  ( 10) -0.180886604759012 -0.111792204438004  0.370617548329878 -0.010060948397306  0.175897261426789 -0.187416342815067 -0.018902126694380  0.507517994343604 -0.113620600518286
-   11  ( 11) -0.014433403132825  0.015210570936209  0.010143344331716 -0.005691229002309 -0.031059326071816 -0.023288546292970  0.128101332902295 -0.039392944850365 -0.110920114561223
-   12  ( 12) -0.125268954735601 -0.096735894811095  0.052480306210840  0.258243594453840  0.005805250173734  0.145107299027993  0.116452856795828 -0.074374807730486  0.022119923916482
-   13  ( 13) -0.016491827683000 -0.002316794514604 -0.087971851878040 -0.101325911412249 -0.036377238947136  0.195278206944885 -0.010131352705033  0.009611107176441 -0.056274461553023
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020619978804336  0.055393926260187  0.016493468301721 -0.100372381621025  0.100626242248385  0.085758294302206
-    1  (  1) -0.158166323997471 -0.302157830906837 -0.003244540958725  0.141116982835112 -0.086717578223953 -0.004480871143073
-    2  (  2)  0.117237563107159 -0.174570847573259 -0.011204345589108 -0.263173432731341  0.005218532196564 -0.028842080195291
-    3  (  3)  0.116941646649189 -0.002586479599499 -0.011231548488132 -0.058984655279808 -0.019822661982984  0.041048882280058
-    4  (  4)  0.050776820640492 -0.220908341720040  0.039982596283606 -0.028513186801397  0.038501560477761 -0.072498198103566
-    5  (  5) -0.020348029264266  0.163764941111612 -0.082946711645337  0.111452654944128  0.037984566239181 -0.107199595568986
-    6  (  6)  0.021256126103379  0.388694787591390  0.114910007821006  0.018804713347374  0.008937619959600 -0.015873506672536
-    7  (  7)  0.297925323013482  0.033191669222652  0.094278199439545 -0.060174035263233  0.021406855727383  0.043089336483829
-    8  (  8)  1.538149876661748  0.255388094594388 -0.163312643003206 -0.034677585072596 -0.142125228818852 -0.045738087971663
-    9  (  9)  0.091443541252263 -0.031128123891510 -0.061982026707845 -0.058678185009713  0.760839955512426  0.950617857123983
-   10  ( 10) -0.067301877513073  0.211057800702045 -0.020603819563676  1.234407038988020 -0.163795705022985  0.167535211420867
-   11  ( 11)  0.163445976328785 -0.060082779666638  1.332811809287810  0.048638214648072 -0.084741484840249  0.093756111599780
-   12  ( 12)  0.205948682024844 -1.200679744036826 -0.135474810029670  0.365861100667224 -0.094093662797851  0.008686523394777
-   13  ( 13) -0.181605938452019 -0.042014918886121  0.112406427108198  0.222953862798531  0.995139187403178 -0.917632565321793
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802008727902676  0.406135528069464 -0.010476316014009  0.784475556802925 -0.394386683091379 -0.066798881058913 -0.011980564813184  0.124376056524327  0.033526134230615
-    1  ( 15)  0.862028914432798 -0.259382739909270 -0.086667305572556 -0.180064784220824  0.329908607377610  0.399964089565218  0.202187771096648  0.330121816685668 -0.071953120874649
-    2  ( 16)  0.271307809960556  1.724790149840180 -0.218446172710940  0.221581282093097  0.027552874986014 -0.019301351758279 -0.136156749402974  0.163711145289557 -0.262315292158515
-    3  ( 17)  0.233832160360352  0.228075923415961 -0.271855585595643 -0.127498943532479 -1.519236751765249 -0.714946933274063 -0.112783303905572  0.035742190545400 -0.131799331720385
-    4  ( 18) -0.125884857507763 -0.016503178327094 -0.848590316809874  0.528676059271103  0.118589942995782 -1.271521009941038 -0.481050683706501  0.489094666232462 -0.100427993377482
-    5  ( 19) -0.011410411929745  0.078504916539371 -0.635756927956321 -1.233330464680106  0.737249034134023  0.499445190730480  0.548364048058884  0.558640131287018  0.124411035854046
-    6  ( 20) -0.091600083261379 -0.011874324392688  0.166095509172862  0.503931355593045  0.132971166339029 -0.442847331045808  1.455101200236588 -0.028340512672182 -0.190421039545484
-    7  ( 21)  0.014506888035513  0.509793857361997  0.613540224928976 -0.716635769138246  0.088503909894013 -0.892421715175110 -0.105643577538776  0.572215069358599  0.150576387127195
-    8  ( 22) -0.004177720337585  0.006709815498361  0.117678875953393  0.003186946250580  0.038303116431615  0.593619431704741 -0.036920385902422  0.835672825510649 -0.345283877638179
-    9  ( 23) -0.021586239236066 -0.156869719857391  0.117889758366706  0.115161423657162  0.052238225817572 -0.022709102193988  0.020562459070751  0.298677779552442  1.538509512042474
-   10  ( 24)  0.054682068155322 -0.300070995804169 -0.172660016100411 -0.004680568559172 -0.221321821680690  0.163619483231716  0.386948477906845  0.033115261343835  0.254769962308442
-   11  ( 25)  0.016488293849114 -0.003235639473042 -0.011174682028037 -0.011243945686257  0.039809588242799 -0.082761513420842  0.114884412151977  0.094200391738445 -0.163393716854439
-   12  ( 26) -0.099231335638990  0.141112668735458 -0.262446613088940 -0.059563147663723 -0.028574452319685  0.111394864273785  0.018513759386789 -0.059760408126138 -0.034040397389902
-   13  ( 27)  0.100244162906012 -0.086825753516494  0.005142496829835 -0.019052879526336  0.037887085038889  0.037954868269104  0.008919579926839  0.021672382001860 -0.142649674386495
-   14  ( 28)  0.086046561377276 -0.004744302368676 -0.028249738219529  0.042030603060909 -0.073561648753534 -0.107720217983957 -0.016217142075148  0.044341471770554 -0.046187444393712
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124233708134524 -0.184518326175241 -0.014667753095383 -0.126540650902724 -0.015843433752182
-    1  ( 15)  0.686899770278225 -0.109692117003678  0.015377495137089 -0.096723489130419 -0.002397757787942
-    2  ( 16)  0.057205529179578  0.372042133273666  0.010210131259620  0.052160697899357 -0.088271643130929
-    3  ( 17)  0.131871345108673 -0.011180948360743 -0.005727193367058  0.259941586635743 -0.101614450210782
-    4  ( 18) -0.005079597151441  0.176830214271515 -0.031032942109520  0.004628941737829 -0.036366477592845
-    5  ( 19) -0.153488339566637 -0.188246645479869 -0.023332293508375  0.145173541284822  0.195552538719584
-    6  ( 20) -0.038666420291799 -0.018333798481476  0.128217423491274  0.116258211557263 -0.010271886085243
-    7  ( 21) -0.121961409061181  0.508144909444715 -0.039497933150391 -0.074911313979370  0.009738174256592
-    8  ( 22) -0.349752281191330 -0.113379050365496 -0.110884161439947  0.022227055299984 -0.056428042287631
-    9  ( 23)  0.091274387643073 -0.068482004342729  0.163392525285683  0.205701365643175 -0.181416453396984
-   10  ( 24) -0.031494844080999  0.210984913522458 -0.060264440706329 -1.201297108840472 -0.041823116964630
-   11  ( 25) -0.061998986866118 -0.020468588707436  1.332808723106094 -0.135556576828281  0.112406197562940
-   12  ( 26) -0.058487448549072  1.234274465594829  0.048631105388928  0.365854082846019  0.222962926250735
-   13  ( 27)  0.761200546740672 -0.163618812251219 -0.084738989433889 -0.094122389252772  0.995165590894077
-   14  ( 28)  0.951772998269747  0.167560207344577  0.093759874796889  0.008708619204375 -0.917569948681374
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062431637468593  0.002416441043502 -0.004633709181853 -0.077570764564644 -0.013832459901153  0.123710471759642 -0.027165779035152  0.071044010954106  0.019658423662045
-    1  (  1) -0.407170389584207  0.333069478291504  0.076649076907715  0.002175328366486  0.197922707135412  0.117656968282773 -0.067757706616657  0.182812175438104 -0.031734247883933
-    2  (  2)  0.673185035517364 -0.888138019247633  0.034358376579768  0.125358507387098  0.172994941404750 -0.106755581181878  0.013852200121285  0.009496870454365  0.036809619943040
-    3  (  3) -0.040742790622464  0.181389056204803 -0.117008669682237  0.012401302848610 -0.022196391591020  0.102862126461667  0.166049221641567 -0.310434511631989  0.017146561969842
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.010530607294137 -0.003710118206635  0.001098184033274 -0.004177259623775  0.010641720243898  0.020819711535909
-    1  (  1)  0.026376312845794 -0.003084063695378  0.001935075690030 -0.112197866496257  0.055637648529143  0.022260912302157
-    2  (  2)  0.054059905057588 -0.043789787513272 -0.004472231165835 -0.071437136436271 -0.024456749693059 -0.126350825107537
-    3  (  3)  0.083331116085336 -0.461426302980743 -0.028171699513186 -0.043194879139585  0.008942983333376  0.024389199674006
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.021216263100624  0.005003175055611  0.013535160841110 -0.263704651382069  0.210918804180354  0.005688291976377  0.005207710700420 -0.000895282201931  0.031550648985105
-    1  (  5) -0.080441383224434  0.123194069685476  0.057717422634421 -0.198323986141409 -0.141861353254402 -0.184709849630280 -0.056481718890564  0.088971412091769  0.030305733467363
-    2  (  6) -0.146541148918456  0.264369470289011  0.161465568338032 -0.083507608614794  0.171726934895348 -0.400382872983885 -0.201596935132391  0.184414767198936  0.015497227351117
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.010467742288235 -0.019463191825823  0.001308339278104 -0.016880359740534 -0.016885157913524
-    1  (  5) -0.009224792466209  0.019323723500934 -0.001197784436253 -0.171358632107000  0.032143333569082
-    2  (  6)  0.022721945593511 -0.245666385556987 -0.017093671892173  0.084713974597813  0.032963157176325
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521806 -0.064555152855150  0.195953381503074 -0.041248493404101 -0.011229686922118 -0.030149441468389 -0.052245051042507 -0.006640144591450 -0.060816046803629
-    1  (  1)  0.618380750339701 -0.527850820452489 -0.215416501468042 -0.157035437820978 -0.069798458053206  0.063297476854315 -0.224803808806328 -0.036770088857857 -0.093292414355450
-    2  (  2)  0.089963765220201  0.016694193855691 -0.049894217028077 -0.224500363636593  0.100545586935602 -0.339808932362407 -0.300486601785008  0.103978674940020  0.003854593986179
-    3  (  3) -0.017912540893906  0.240051544179780  0.016875920141062 -0.019658112757037  0.000950481978191  0.139486307895354 -0.307526295494235 -0.245045411721377  0.038982174459016
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151715 -0.053483299255778  0.001461399819935 -0.009996127160186  0.040844890766482
-    1  (  1)  0.010356156252337  0.045196494943178  0.123149462829325 -0.009608799091532 -0.092775098416542
-    2  (  2)  0.068261626755321 -0.266621644473694  0.090983468547793 -0.007824999539039 -0.015479677414574
-    3  (  3)  0.102991688131891  0.095940846129218  0.235195882789532  0.030438278876707  0.100331913639094
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065252  0.055002400477820 -0.190701615134350 -0.008587073556999 -0.137456634337686 -0.102685174742854 -0.038575707278163  0.049077773985903  0.038775520871493
-    1  (  5)  0.266426121061197  0.201904502527540 -0.404472747743452  0.112355452346377  0.244543383067891  0.203488255110601  0.093346083766343  0.046662175778558  0.162564534078692
-    2  (  6)  0.310200495971193  0.275860886663895 -0.334362481171644  0.111323203428054  0.107269573508054 -0.015396505983498 -0.485347827861586 -0.115211810541092 -0.189399381355332
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661083 -0.010182782856370  0.015536223735827  0.027148068637771  0.019304531582391 -0.012170541889264
-    1  (  5) -0.076359104752405  0.072719944885937 -0.105706045053704 -0.076791075572625 -0.095250630872875  0.044053081318692
-    2  (  6) -0.023401555368550 -0.060789750773997  0.233844071164904 -0.060200608258467 -0.022972229731698  0.078966373846355
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134464733238505 -0.662210405494710 -0.268087036060520 -0.078995101665645
-    1  (  1) -0.664136191142175 -0.208512216408344  0.147227682691111  0.068768195668233
-    2  (  2) -0.267178832853329  0.148347614169083  0.187155712816505  0.001725942570582
-    3  (  3) -0.077975712094607  0.066243031692251  0.004079617492315  0.013944312169831
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274618126592083 -0.278113702179192 -0.671633022270393
-    1  (  5) -0.277949145712574 -0.011863615919937 -0.010374435234627
-    2  (  6) -0.670048686168263 -0.009476206950281  0.097890068097075
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959494414290863 -0.408191876587327 -0.490587797784240  0.038620088951639 -0.077925870525908 -0.487449819239226 -0.107605742375965 -0.396082210854085 -0.237542456199032
-    1  (  1) -0.404346098969015 -1.325089706115945  0.174671472615795  0.248857938939654 -0.197997176299344 -0.317531715369510 -0.251443125494019 -0.030205216051526  0.632709778669922
-    2  (  2) -0.488203594414096  0.174177358170181  0.686637133275358  0.342440322128134 -0.009976595906060  0.483509687591480  0.287263685741040  0.302820486761619 -0.272146504988732
-    3  (  3)  0.037519851932744  0.250891430235972  0.345028453615760 -0.288802596502157  0.242048997262005 -0.302155533583566 -0.510767048111895  0.184742116191421 -0.216988138473829
-    4  (  4) -0.076335128439655 -0.199690457337249 -0.011287590259897  0.242287343472375 -0.131826185478723  0.385784652335424 -0.241579744319049 -0.375155233716569  0.062534851979750
-    5  (  5) -0.485786339572480 -0.319069045647666  0.484028655874751 -0.298894130368339  0.382592029688619 -0.557110750088232  0.333239304019222  0.111824333667385  0.019820080095697
-    6  (  6) -0.105004388042450 -0.251919494300284  0.289657780268665 -0.510934745583747 -0.243423593715404  0.333487274729421 -0.859815579894716 -0.040189411214490  0.015976724219770
-    7  (  7) -0.396742866204475 -0.028527583501468  0.303542401120437  0.181332247012458 -0.373287106593945  0.109028339876173 -0.042483577229020 -0.424450995877430 -0.165337209178976
-    8  (  8) -0.232477111217568  0.628541780993326 -0.273469783503661 -0.217890852518759  0.061988654737634  0.020919866007563  0.015643111904890 -0.165546891359501 -1.139952791754352
-    9  (  9)  0.005546163403777  0.056122031350978  0.162961042742066 -0.082482781173148  0.072908205250711 -0.108799436968507 -0.023533780380778  0.044777427042681 -0.147235448199837
-   10  ( 10) -0.006901975709222  0.054429650490004 -0.040577693872421  0.341755839709625 -0.179734725561089  0.323402736691826  0.128204737160702 -0.274641710567075 -0.052505646555500
-   11  ( 11)  0.095370531310643 -0.102133079874740  0.068438122875491 -0.163729824989551 -0.155636229704599  0.243225496644137 -0.456632637964522 -0.005300419866762 -0.049825612054664
-   12  ( 12) -0.031656876480324  0.049261490140928 -0.071615793822912  0.132066208561300 -0.108599421258577  0.096544859699582  0.079601642520223 -0.086582876221009 -0.054558080822574
-   13  ( 13) -0.055177843918689  0.125972146875366 -0.045925897173261 -0.019932953437905 -0.072414580136130 -0.032514397877207 -0.014074648780379 -0.073540469649077  0.566252900794774
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006844108037305 -0.007417708485432  0.096179215271909 -0.031845351907952 -0.055819107034905
-    1  (  1)  0.055009072408372  0.054764569974465 -0.101360748266647  0.049483066032708  0.126311659941349
-    2  (  2)  0.163126461717715 -0.041474056730542  0.069773970511485 -0.071604513134729 -0.045921679797623
-    3  (  3) -0.081145867550878  0.339512714763498 -0.164814632361136  0.131963409806733 -0.019701057447459
-    4  (  4)  0.071392957638917 -0.177541925322340 -0.155855587434776 -0.108549913772844 -0.072788709838574
-    5  (  5) -0.105620913909823  0.324570384536922  0.243426148668966  0.096676164465062 -0.032493241135613
-    6  (  6) -0.022622971576123  0.128555788054646 -0.457558865820389  0.079424640656347 -0.014304063550758
-    7  (  7)  0.043872369029000 -0.277428590499607 -0.005167508600307 -0.086808599804727 -0.073543295023523
-    8  (  8) -0.147656701585296 -0.051770671721883 -0.049464276722939 -0.054622357068261  0.565518286432945
-    9  (  9)  0.072058098581738  0.045414939179581  0.010276622684317  0.009607329011719  0.026546654266797
-   10  ( 10)  0.047972578248001 -0.139091273135487 -0.006969817312947 -0.101924439794117 -0.021963395913837
-   11  ( 11)  0.010225949518788 -0.006903254834441 -0.093461448932079 -0.006458623521931  0.037408632154768
-   12  ( 12)  0.009659072763445 -0.101989750292791 -0.006543886552569  0.055499957258899  0.004536647288292
-   13  ( 13)  0.026525022859872 -0.022073627181822  0.037503294944025  0.004573821056446 -0.064450805660415
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.531729549886336 -0.787699013260711 -0.218007437963115  0.182768764967355  0.602768885926282 -0.199812958117875  0.029032839745446 -0.008774056557020 -0.142478600997377
-    1  ( 15) -0.793340915328507 -0.320131124132642 -0.162653978535479  0.058649157291271  0.020639907683380 -0.223525268439364  0.107699068558597 -0.353783645623565 -0.095871343640249
-    2  ( 16) -0.212191388052973 -0.164888118017383 -1.296946785661586  0.042300146112855  0.273826728839961 -0.438781481182550 -0.122091204716331  0.097191959044978 -0.140871391153818
-    3  ( 17)  0.179719553134575  0.058669914491576  0.044506714025033  0.293003077614387  0.349110568675538  0.303215667162520  0.076915097449359  0.005807473712119  0.013837821467220
-    4  ( 18)  0.599360800493505  0.022132908209847  0.274035423937645  0.351223850237559  0.210864723100271  0.044675310303964 -0.438675626813631 -0.490920343842280 -0.399212333009756
-    5  ( 19) -0.200407898503427 -0.221431932840866 -0.440102897905119  0.305762109213035  0.044881546181680 -0.117472965844256 -0.191665223291193 -0.319783714572763 -0.359452162382458
-    6  ( 20)  0.032165821117665  0.105941691907444 -0.123879210125596  0.078979233990767 -0.440650088275849 -0.189889145121464 -1.110705925194973  0.246906737793532  0.255259757334054
-    7  ( 21) -0.008321241705322 -0.354528191467819  0.096628486245017  0.006334262611286 -0.491255100347697 -0.318969662674755  0.247541587785853 -1.005004062277624  0.329386657154203
-    8  ( 22) -0.142962699223523 -0.097023037413530 -0.141097052846409  0.015166149439238 -0.401326717044742 -0.359426368362030  0.255258622579642  0.329097335449191  0.052132117322068
-    9  ( 23) -0.219955098740499 -0.249965476004892  0.576414624728276  0.098982863369343 -0.020508824733562  0.097549190747026 -0.059941456738195  0.014715712854362  0.155030958604457
-   10  ( 24) -0.078889746445527  0.108239301318897  0.027162587747058  0.046514963820383  0.091370815063919  0.113422647703527 -0.170202961400925  0.302110584863863 -0.032804637243869
-   11  ( 25)  0.043306270957026  0.032344455295712 -0.179576712827780  0.107307667430552 -0.187560546689518 -0.097222488608923 -0.510712264729798 -0.080025590477581  0.081254866792341
-   12  ( 26) -0.068084805818493  0.217394768160213  0.162482224135843  0.182198793902355 -0.078588038008432 -0.138375144701558  0.045964808967518 -0.318369645237641 -0.094340949188741
-   13  ( 27)  0.012776338365628 -0.163304628586267  0.065170181095061  0.076353862355042 -0.116471236774195 -0.057100568669669  0.002733328139538  0.275543901650377 -0.101218272889569
-   14  ( 28)  0.072542900570939  0.116082117753815 -0.039461901860544 -0.060056679393734 -0.063442716501357 -0.039954821491213 -0.007431183194753  0.061660754619166  0.127196734189517
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223424944652205 -0.079375640508214  0.044559638332807 -0.069603179695816  0.011608492724546  0.073681298891784
-    1  ( 15) -0.252190810534113  0.107773105664066  0.031929727381877  0.217773765514473 -0.162942254516887  0.115583488493233
-    2  ( 16)  0.579669499848566  0.028398284174976 -0.180764151357445  0.163082238678478  0.065318137383573 -0.039861277950853
-    3  ( 17)  0.098419070380167  0.045497640187089  0.108888066901941  0.182679251676306  0.077063420292993 -0.060270475148176
-    4  ( 18) -0.021657152218187  0.091391477818870 -0.188694941835267 -0.078654463992964 -0.116917635244834 -0.063687461311406
-    5  ( 19)  0.097200061293753  0.112946819841992 -0.096557046310024 -0.138722208764681 -0.057492822647808 -0.039657945432959
-    6  ( 20) -0.058061983715333 -0.170140847494680 -0.511516651549457  0.046153385708912  0.002608094185220 -0.007424017797983
-    7  ( 21)  0.014898598107653  0.302204656416846 -0.080604696411276 -0.318409184220321  0.275439068186140  0.061680442175976
-    8  ( 22)  0.155158381420886 -0.033182129585344  0.080993013335585 -0.094077880752310 -0.101045740908416  0.127069446713644
-    9  ( 23) -1.153500606432321 -0.223848574870770  0.084940142762237 -0.000172697505786  0.401118128913110 -0.346039941954426
-   10  ( 24) -0.224004522828896 -0.014993374950362 -0.013190820033297  0.067266852084061 -0.009898419000692 -0.084301934906628
-   11  ( 25)  0.084246516406395 -0.012971453666469 -0.099638608783541  0.005049425073667 -0.012239639402266  0.023058100761840
-   12  ( 26)  0.000190360752578  0.067412521796060  0.005072007098540  0.014663156532777 -0.012615786454228 -0.021995005158495
-   13  ( 27)  0.401506800485792 -0.009668467136178 -0.012313296328665 -0.012645382168427 -0.008180220628749  0.091135079144539
-   14  ( 28) -0.346436667192449 -0.084407881559674  0.023159285170774 -0.022057721310478  0.091092458906105  0.040126683454989
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057778460125472 -0.058621598376460  0.204961973610432 -0.030014886957090 -0.012702201238060 -0.012361806840327 -0.042464722570110  0.000589178332859 -0.053783176425630
-    1  (  1)  0.588150716074127 -0.466021636272277 -0.203183245475034 -0.148450737716235 -0.057365952908249  0.049828198627842 -0.211650340717439 -0.033709163320866 -0.066014023276544
-    2  (  2)  0.097096715428359  0.013316869335678 -0.075592001791479 -0.184144455632625  0.076454331448205 -0.322693901417435 -0.283033300411692  0.095787940086183  0.009135557725688
-    3  (  3) -0.012585457310347  0.213693355283453  0.008392879074061 -0.006477176275196  0.025095812734807  0.122050564721420 -0.287478867297995 -0.227752050770291  0.025535574433445
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004343658462411 -0.045416781087738  0.000353809954908 -0.008814420994646  0.038608153091639
-    1  (  1)  0.012371345270909  0.037357699916557  0.110010051271464 -0.008428651261313 -0.087698412018729
-    2  (  2)  0.059734573261686 -0.241104936943562  0.080654968743400 -0.004302203609175 -0.010690545484548
-    3  (  3)  0.093269555935925  0.087251850932647  0.210582632378021  0.029543407964617  0.092601662289161
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.096268685878254  0.067598109905927 -0.171831816211853 -0.019892225326838 -0.151432830345480 -0.102828613678833 -0.031328453208212  0.054857782228207  0.045391983457322
-    1  (  5)  0.259548823811751  0.185158249821503 -0.361847535039694  0.121706180799256  0.214912924418858  0.198674927692151  0.082249065771632  0.046754216202716  0.144894234012036
-    2  (  6)  0.316675644828396  0.241534850892174 -0.298024592816770  0.095120602156107  0.117908244615366 -0.011781114685607 -0.451417780640775 -0.113394265201573 -0.193663841427175
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.075217766018101 -0.009009066779016  0.013059078733353  0.023267742031501  0.019382631456242 -0.010439549922317
-    1  (  5) -0.055615787731079  0.073750137089777 -0.094740835467118 -0.066906556461928 -0.087569521638075  0.039832146294917
-    2  (  6) -0.007989421944937 -0.055545532554459  0.206332460425464 -0.056516118698086 -0.025725290779723  0.073743491663517
-
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.034398581574139 -0.022991789103343  0.034442469541574  0.330456382558595 -0.233180601662081  0.129080132683952 -0.099470500295552 -0.033215263141241 -0.017533788887759
-    1  (  1) -0.125193963201420 -0.094056863638828  0.250103765613866 -0.112936578244967 -0.149788194818876 -0.227437707997397 -0.485204338670596  0.001668370995162 -0.115356975205661
-    2  (  2)  0.012233240715705  0.002368950907699  0.032425209658723 -0.111084203408140 -0.039672156088148 -0.068595430902717  0.075952847158656 -0.294199045975953 -0.119345992966551
-    3  (  3)  0.102558388937001  0.078769752966251  0.070643800093594  0.002465923506388 -0.048634367995697 -0.013847332731639  0.279588501721531  0.161409573415975 -0.750269595437933
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.124162189892697 -0.147322676383198  0.023215723712951  0.018481088431889 -0.062726537287574  0.032176124900128
-    1  (  1)  0.077900000614672  0.192270763412161  0.391012068764259  0.097598573976617  0.208812184695007 -0.131278202406216
-    2  (  2)  0.138682144513485 -0.743794268000919  0.082765968014440  0.105416894706173  0.124502895186539 -0.026640226681012
-    3  (  3) -0.046377167184700  0.100266413297349 -0.419637942135347  0.187251279348108  0.523906963118894  0.155125602890936
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.041912647030473  0.112025419050593  0.015709063071357 -0.296474982770456 -0.369528478363753  0.133936885862951 -0.093834818402243 -0.023683854572816  0.145081231878617
-    1  (  5) -0.197308914804751 -0.009979277982960  0.032584585136142  0.110675051536769 -0.043528206747949  0.380347857156503 -0.467872633414304  0.360690381381106 -0.081727457648454
-    2  (  6)  0.017175555719515  0.257070166950214  0.064576654101859  0.063636492651100  0.124214525851134  0.043707573882425 -0.279300768930124 -0.436090246737450  0.143049583009588
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000746191936210  0.015117415730589  0.105376277097060 -0.086551013225984 -0.048055402355572
-    1  (  5) -0.421110018244562 -0.132676872543725  0.513327593087781  0.036293567607712 -0.089362635661765
-    2  (  6)  0.356450473386590  0.161425142060580  0.191834100484274  0.123847982073522  0.439997591973663
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.029996182749086  0.414832297711576 -0.157003165507011
-    1  (  1) -0.055478735634457  0.002196588374944  0.023132699054813
-    2  (  2)  0.030157480407918 -0.003965129810969  0.011365271034479
-    3  (  3)  0.379654970672918 -0.026306776079243 -0.008208478993038
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.031312576109208  0.054324731747600 -0.030004942403624 -0.379837271496892
-    1  (  5) -0.410777629523562  0.000546200526033  0.004395778687124  0.022468424749377
-    2  (  6)  0.155134874665963 -0.021960972132954 -0.010503724381488  0.005891989839471
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.041599393589885  0.048291903336677  0.117743150821259  0.017705215406280 -0.102750295559090  0.051687934108131 -0.132725758102637  0.024528471901836 -0.009589411271459
-    1  (  1) -0.072748330347250 -0.064838255172247  0.046249888316539  0.094886169756313 -0.054353256296636 -0.001900039815832 -0.496484885699642 -0.156782601344965  0.027727244644896
-    2  (  2)  0.003177839573369 -0.021969851213782  0.169948604805852 -0.034169379981814 -0.096419218256700 -0.054353168415603 -0.268581512702098 -0.051387229616377 -0.132183241821031
-    3  (  3) -0.006137248486677  0.083042433269493  0.145748994350269 -0.009514642471795 -0.083396174376552  0.050339592310292 -0.147508653266551  0.025994438523140  0.274243623684456
-    4  (  4)  0.041743411936218  0.025314466729841  0.109116009514395 -0.054695145126701 -0.041005429820194  0.040692158860824 -0.089212628083091 -0.089778026874393  0.379559976718284
-    5  (  5) -0.144052404015687  0.020202343348371 -0.250448180839798  0.333938875810814  0.025165926872358  0.198674007872287  0.028751096000422 -0.150673278776424  0.071892589434733
-    6  (  6)  0.035008068923664  0.061157292133481  0.423122850397629 -0.168586232676417 -0.215300951076719 -0.176816011547681  0.082786884188413  0.107997254201703 -0.322302818265947
-    7  (  7) -0.040302039339094 -0.134662805884699  0.074305590729076  0.347285947244785 -0.297150726695267  0.120577275637125  0.158244548193724  0.221247160594885 -0.027161970952188
-    8  (  8) -0.102303986757075 -0.083520013523575  0.381308184856285 -0.143001282615579  0.075527648534131  0.132398234942646  0.075131991247111 -0.046753082020740 -0.011707789197025
-    9  (  9)  0.017637489191487  0.048428952825929  0.034610320117865 -0.459992261564512  0.414982694469193 -0.130318968246814 -0.031074590688744  0.007719514803475  0.025148594805028
-   10  ( 10)  0.073180570141060 -0.217870134214265  0.063234912206834 -0.261216160873510  0.027363003829309  0.069320876175761 -0.042163326174403 -0.184139514400861  0.015591773535866
-   11  ( 11) -0.219122634582937 -0.188385339460405  0.640855359878310  0.491678336416958 -0.065767561519751  0.413066703397514 -0.291084239981445 -0.093425757726901 -0.193265915162178
-   12  ( 12) -0.256885363420365  0.713325451456200  0.225955555841318  0.439590507884674  0.345303095230338 -0.616947103758895  0.172377723246676 -0.152457697169388 -0.041630471494425
-   13  ( 13) -0.012167367476476 -0.157114215675033  0.156454629287810 -0.271295067840173  0.465831347294122  0.087124608448573 -0.001414398542050 -0.117289965933426 -0.301481262964454
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.150893623694895  0.070181619718899  0.231121270771796  0.047212329811452  0.038360068214684 -0.065024101530573
-    1  (  1) -0.459608701558993 -0.017988718780734 -0.620163221664037 -0.047501992394079  0.054935480129094  0.084306620301789
-    2  (  2)  0.170353437709830 -0.137438184253801  0.448066510819233  0.273677026815508  0.394525740926135 -0.158445088257267
-    3  (  3) -0.027380670374415  0.505626164435732  0.414944314617527 -0.268646310616022 -0.386727191221954 -0.113140672337300
-    4  (  4) -0.013445627632877 -0.536383433584967  0.308426011289951 -0.080146650927920 -0.587918144857996 -0.127182537475191
-    5  (  5)  0.035132080582143 -0.167243745339779 -0.093457222254525 -0.023174375055702  0.241438836836271 -0.025034069681694
-    6  (  6) -0.086275759818652 -0.157794617049890  0.091627759449496 -0.100678024828998  0.039930496632404  0.039747117277017
-    7  (  7) -0.064055657553950  0.320525847624377  0.102126662685902  0.025362375541365 -0.011829791315064 -0.091201427043929
-    8  (  8)  0.004186527107181 -0.116906210612177 -0.371187985035768 -0.069143142950027 -0.337550034775452  0.350111866606547
-    9  (  9) -0.075561519107680  0.174471452153015 -0.018361558412792  0.007353276651567  0.041439267169245  0.006958189017632
-   10  ( 10) -0.027806429179180  0.167045135107807 -0.001907984997949  0.011283070546443 -0.060669265876427 -0.055774837261520
-   11  ( 11)  0.242522311612009  0.043113021308048 -0.036594154697736  0.051685667595428 -0.018454723698115 -0.000828881346793
-   12  ( 12) -0.005035323729735  0.080726831317060 -0.052335499542956  0.044973984976305  0.061396486662391  0.099208229191671
-   13  ( 13)  0.438941651704024  0.153468022162067 -0.023659734102045  0.002885107851831 -0.071809885174399 -0.077694612962715
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.044666447845943  0.075416998324096 -0.002009211971351  0.008745765947599 -0.041041980388066  0.148478826412725 -0.043148497905126  0.040061402921621  0.101604386418633
-    1  ( 15) -0.049162162504633  0.064892835130685  0.021916980092655 -0.084534607702244 -0.027746026910093 -0.020171890051146 -0.060412253106789  0.135461490072396  0.083108283525263
-    2  ( 16) -0.115794665664267 -0.047097729608731 -0.169526813418150 -0.148848835873427 -0.110367886513380  0.250308022536814 -0.421430914373290 -0.072716285234647 -0.379882079141591
-    3  ( 17) -0.016234704461670 -0.093143898198671  0.032604929784834  0.008570214748756  0.053618454434530 -0.336390621280297  0.171051246725478 -0.351382500390790  0.144302708365158
-    4  ( 18)  0.099685614405052  0.053576457156830  0.096408379043871  0.083491653355765  0.040031855455092 -0.023231985357187  0.214146456651999  0.299411639286517 -0.077061465722781
-    5  ( 19) -0.053256491006665  0.003075384449121  0.053515222726753 -0.048399268191864 -0.040795198256978 -0.198132545540493  0.175051498642490 -0.121535923725232 -0.133335441765840
-    6  ( 20)  0.128712692365555  0.496870742485916  0.268871209763746  0.149658569303091  0.086711112842081 -0.028977130072006 -0.083484855541891 -0.156340017572166 -0.079418276499146
-    7  ( 21) -0.026401094602506  0.157512598855912  0.050672592676314 -0.027957891435237  0.092269588876111  0.151809482826698 -0.107865561412261 -0.222862187720663  0.046783186727291
-    8  ( 22)  0.009612639390837 -0.030421923009696  0.129146467815306 -0.272344846639473 -0.379884587515890 -0.072760001001148  0.325598038741842  0.027479294568787  0.012294936872080
-    9  ( 23) -0.149880437140593  0.460631247362792 -0.169664291741312  0.027589402289004  0.011349753598096 -0.033685842546708  0.083139401924745  0.064655346261025 -0.002952710962413
-   10  ( 24) -0.073162117570193  0.020016390706408  0.135536511029942 -0.511692353689708  0.542889881863847  0.170172745263858  0.158312356422075 -0.326976851708720  0.119792799568885
-   11  ( 25) -0.227319331530806  0.618159967248025 -0.448267162037961 -0.415380348389647 -0.307673615218558  0.093264262201907 -0.090383721735685 -0.101137463170207  0.374119595658697
-   12  ( 26) -0.046325835806633  0.048013260965168 -0.272519638024099  0.267929097643861  0.079599126690116  0.023217992764788  0.099878544648145 -0.024929139459656  0.069393891025270
-   13  ( 27) -0.037489883688669 -0.053493928653226 -0.391870980933739  0.384400627963214  0.588279019279798 -0.241045539088516 -0.041562667530972  0.011794273471007  0.337810411804872
-   14  ( 28)  0.063867435849832 -0.083549153123607  0.158471290677241  0.113540200875422  0.127048928726566  0.025106714900888 -0.040372191298617  0.090932947916166 -0.351148385967210
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.018436133716857 -0.072929640795625  0.226474353889952  0.258554501885766  0.015629581468102
-    1  ( 15) -0.048844627710976  0.217699525631316  0.187612863297424 -0.714214561739857  0.155652904029163
-    2  ( 16) -0.036504178760377 -0.064141704639546 -0.642298500392749 -0.226999184132633 -0.158883513257702
-    3  ( 17)  0.464003802662343  0.262951360765947 -0.494608205306355 -0.439690590633845  0.272979507733357
-    4  ( 18) -0.417911613304926 -0.028340434910992  0.067656000741894 -0.345749519725828 -0.467548326168384
-    5  ( 19)  0.131287835524258 -0.068639225223597 -0.411512073768996  0.617585289861537 -0.085587328981715
-    6  ( 20)  0.031740361337335  0.042325765757491  0.290709707718165 -0.172790703648515  0.000532545780898
-    7  ( 21) -0.011558038421621  0.183385354532032  0.093657523746171  0.152317012205746  0.116530260167129
-    8  ( 22) -0.024591234247673 -0.015437963416840  0.192723206306395  0.041545920874624  0.300722952291357
-    9  ( 23)  0.076860307291410  0.028222730174457 -0.239744246838648  0.005401314981702 -0.437602472364683
-   10  ( 24) -0.182325175721446 -0.168262818970868 -0.041985084407523 -0.080814437382504 -0.153682650364464
-   11  ( 25)  0.018251396178258  0.001487318511567  0.036744565685453  0.052466578072734  0.023330767494251
-   12  ( 26) -0.006994832022894 -0.011312050265967 -0.051710399870511 -0.045052170184275 -0.002799991775595
-   13  ( 27) -0.042051003701905  0.060322036458563  0.018224376602008 -0.061574434209411  0.071889000854515
-   14  ( 28) -0.006898519418229  0.055936666673248  0.000904652270607 -0.099150038783025  0.077924550244227
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.024746315003693  0.016019947683600 -0.033657454181441 -0.314697310181057  0.226266938924475 -0.124444118187600  0.100976019942115  0.040776992946741  0.016684212809041
-    1  (  1)  0.134389185453098  0.111083358436336 -0.277285327152191  0.119300944830562  0.165892793225342  0.243843028361365  0.522257860139305 -0.003856507813829  0.130032133651498
-    2  (  2) -0.005712363782982 -0.008727960227379 -0.039141212770465  0.103639199943747  0.051337772042530  0.071715964883614 -0.083650082880478  0.323814625304121  0.126954317090625
-    3  (  3) -0.081293710540179 -0.115829551524333 -0.096804246842583  0.012689929096652  0.055158220665324  0.020215225885504 -0.309792669510693 -0.175501033742058  0.786497084573792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.131346722870458  0.163299814747146 -0.027069647322617 -0.020320497257903  0.063430953058875 -0.031962758863077
-    1  (  1) -0.087630835970581 -0.216123500984143 -0.418559649023597 -0.101182356933807 -0.219334050753127  0.138730916232525
-    2  (  2) -0.150883742374018  0.808729391001562 -0.082068044594556 -0.109718430012718 -0.126065481544348  0.025072338478445
-    3  (  3)  0.037377902285561 -0.112570729969231  0.441791115721159 -0.197182836023279 -0.548068009411335 -0.161473931329561
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.035230659308422 -0.106839323325161 -0.014678428381540  0.286556627519623  0.361604275339255 -0.140599935526212  0.104171301624044  0.023270847691008 -0.152469667501182
-    1  (  5)  0.205844940105254  0.013703890486825 -0.030101864871895 -0.113405292167378  0.067278306831822 -0.396432225285843  0.507639566286884 -0.374194080683992  0.087133202725049
-    2  (  6) -0.008020887713167 -0.297537793700841 -0.070946233356648 -0.062333784651526 -0.130550836206602 -0.053406231056288  0.297352200120301  0.465262963875225 -0.160837314824145
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001388437190181 -0.015460041565487 -0.116558611446075  0.083788280005113  0.046694291841919
-    1  (  5)  0.445165309099416  0.139286068687201 -0.540190784438892 -0.030841865046205  0.087779833305208
-    2  (  6) -0.377644271326903 -0.173431493737049 -0.206412471480948 -0.122708702224090 -0.459634387384366
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.059484933862835 -0.014840374750558  0.035360338576360  0.173310409629633  0.059725101605321 -0.257184966477164  0.063490095178001 -0.155623028848452  0.002426177597214
-    1  (  1)  0.228582316542215 -0.259588493824183 -0.059979506895381 -0.002310310036236 -0.214166554941788 -0.116943892441225  0.108842892801007 -0.344598351692938  0.046446999584419
-    2  (  2) -0.320448650163398  0.500204746721717 -0.049266542548722 -0.152597804353277 -0.167277822949482  0.193147703880440 -0.032524845682255 -0.036762728768834 -0.080681033267355
-    3  (  3)  0.009703572292968 -0.082952949000966  0.090825897592600 -0.068137067278425  0.068002795336981 -0.155982720923085 -0.189371220312700  0.353775834732784 -0.023853285599523
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.026559166873629  0.005391969117388 -0.002011264512932  0.046870885231393  0.012715635371485  0.026571877043427
-    1  (  1) -0.038988897688016  0.019721374639789 -0.014060753119275  0.430701935913609 -0.259024740507495 -0.161810701507464
-    2  (  2) -0.100083737029750  0.093431068521730  0.015885697887836  0.259560607774115  0.146766142473160  0.593605654650708
-    3  (  3) -0.130235873557485  0.844890867177988  0.085670264124908  0.093010825973034 -0.012325537516171 -0.119484996772910
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.011411967833044  0.019523193555091 -0.029394421691951  0.441924368380274 -0.383516159929503  0.004430337133144 -0.015018368377510  0.081006354989878 -0.100709067945280
-    1  (  5)  0.015106432068076 -0.115430718880751 -0.094613417260511  0.153153896682510  0.130891773654437  0.255513104617105  0.100481979342603 -0.182641502384039 -0.046231419137374
-    2  (  6)  0.045469725116844 -0.216512507684084 -0.240553163844151  0.059703803473819 -0.128799103778847  0.466867168048645  0.230376363698085 -0.268754231533815 -0.029632489718661
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.031283386269007  0.083595055179233 -0.003915100351561  0.081115225653286  0.074158142938438
-    1  (  5)  0.011556443169135 -0.036659881745781  0.006532048558871  0.596174583603508 -0.114916319653540
-    2  (  6) -0.066233849453724  0.593708066141070  0.047160183567134 -0.205443006234017 -0.123500019606919
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.278545233415530  0.059599409615732  0.026034432106375
-    1  (  1)  0.187007295905470 -0.038238309701257 -0.175982197292767
-    2  (  2) -0.431926204916829  0.006084496586666 -0.049694339002754
-    3  (  3)  0.039723645794201 -0.196249784920444  0.036043663433459
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.275546881197932 -0.180389519378317  0.425074243400924 -0.037767422186350
-    1  (  5) -0.058081529209830  0.037390441931729 -0.000516662884118  0.195055591570635
-    2  (  6) -0.026038612826744  0.173019988726883  0.056080139617911 -0.032715759186560
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062756867817297 -0.201112023907446 -0.056048025131715  0.046055783450926  0.033806686060762 -0.171722205176695  0.081098506544458 -0.087289620763258  0.042152324091961
-    1  (  1)  0.113018477232488 -0.112319744349513 -0.016834583533921 -0.057284464999085 -0.226208700821363 -0.112272688334417  0.062097026682019 -0.556436717149114 -0.098351092785228
-    2  (  2)  0.050464428261919 -0.043116595966000 -0.019513144045664 -0.037294003656203 -0.049535289314410  0.026512882856009  0.020955734915841 -0.396348457994657 -0.049143039709126
-    3  (  3)  0.026907740943173 -0.173985640449646 -0.354309597307579 -0.088737881833013  0.026690278443481  0.192249138616519 -0.023099922234093 -0.151104956103080 -0.187993798800110
-    4  (  4)  0.028814397262738  0.124011423960611  0.200563657745864  0.022231046170139 -0.001789869716556 -0.223408416821475  0.102318476102237 -0.153384891973446  0.236674672698061
-    5  (  5) -0.088145317682978  0.132491290238854 -0.182899281954052  0.186746219907929  0.187197714495176  0.005898923884498  0.002120811015656 -0.021990162397056  0.123551537605536
-    6  (  6) -0.024460586881498  0.068797047909759 -0.142150384104535  0.131743429120178  0.105639058982537  0.045294852609385 -0.029270704887015  0.020804211601159  0.117878860256254
-    7  (  7) -0.033776769859701  0.354245094845972  0.243166450499757 -0.029612149638602 -0.008896656564269 -0.116804879825504 -0.018695560701790  0.326627365972202 -0.206018976643332
-    8  (  8)  0.143077917661487 -0.151560533054490 -0.301409236473389 -0.100740265108897 -0.039290343645488  0.041763953575394 -0.058170430215780  0.076845206100452  0.024633152032860
-    9  (  9) -0.347018728951025  1.079771981804557  0.078138529282464  0.501451378510505  0.195061660317550 -0.758451032278065  0.096995118436252 -0.075303195155611 -0.028459788963157
-   10  ( 10) -0.223810118885824 -0.056979536028989  0.716810245770532 -0.128868097994349  0.539754687175803  0.113296255679437 -0.098974782607496  0.009049828893309 -0.202384864538250
-   11  ( 11) -0.022769270154477  0.034674358156828  0.014405983056596  0.017571848532967  0.048691998407531 -0.015583395228223  0.114409081561630 -0.021951676689174 -0.044426938305339
-   12  ( 12) -0.135981286187464 -0.120998241259176  0.262301521327982  0.750392323278277 -0.334209910038890  0.448078191688466  0.024767148532186  0.115571945209708 -0.066264929381116
-   13  ( 13)  0.080577472282162 -0.105823730084873 -0.089794541855267 -0.254940117418226 -0.138440117204762  0.236499087990863 -0.038859436706735  0.192105181610312  0.090975801731982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.032425074737930 -0.078425462405257 -0.011344832045570  0.197456331002049 -0.134718406025863 -0.096409404413494
-    1  (  1)  0.173273250041635  0.433566222378215  0.007405001112899 -0.457114065135928  0.172943454488407 -0.008895375735183
-    2  (  2) -0.109774013784441  0.217911727490325  0.003528460413992  0.763520159635318 -0.225537275802117  0.118975501733302
-    3  (  3)  0.036378102698420 -0.454361087703980 -0.077915823523940 -0.013309796680696 -0.234332299564134 -0.507177620624500
-    4  (  4)  0.092551473116606 -0.475045168698850 -0.084968775693714 -0.026919469339922  0.202750989391175  0.617924078766471
-    5  (  5)  0.097554141145429  0.018018586167576  0.079671555600775  0.092305854243185  0.173736284561078  0.411194160500052
-    6  (  6)  0.003414072729569  0.093327360188558 -0.085627914021145  0.078229939466915  0.111156480724274  0.178796621382799
-    7  (  7) -0.114277067577274 -0.105960426671338 -0.044841696220246 -0.134585263057439 -0.180631730229559 -0.229243957069555
-    8  (  8) -0.037886837147022  0.102808395063350  0.069798483920400 -0.254580996722497  0.401920559110064  0.147751839658310
-    9  (  9)  0.010988821514225 -0.007410444750660  0.002972535589617  0.025318418426566 -0.448643260566270 -0.804372772080077
-   10  ( 10)  0.261244020497494  0.038064665016323 -0.048636140959014 -0.326624772892826 -0.029954423230419 -0.215793554756145
-   11  ( 11)  0.048015789596366  0.069114116273897 -0.007572832400964  0.004238339483900  0.020816591473394 -0.043178136132549
-   12  ( 12)  0.214695948487578 -0.274288590232604  0.016230298683875 -0.029548384872336 -0.038140072907363 -0.033057792945377
-   13  ( 13) -0.275326653840915 -0.061284883995154  0.041285946542463  0.084706584831174  0.090480508761559  0.181791085214834
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.063850422313355 -0.115683680262588 -0.054827490001665 -0.028354117168169 -0.025100127178731  0.096410771095777  0.028664016097217  0.026051889825173 -0.141339706448534
-    1  ( 15)  0.201263187433031  0.111831464020197  0.045175609028392  0.180549663650845 -0.130383086147566 -0.135646922045465 -0.070781303898657 -0.348002287778712  0.148260195426479
-    2  ( 16)  0.055113649368610  0.018738606654586  0.020705966421020  0.355086450538750 -0.201294850701097  0.180112010383658  0.140523266780582 -0.241544163680772  0.300925921088622
-    3  ( 17) -0.045920336133779  0.057784764027644  0.035886357056501  0.088932856294833 -0.024235675752436 -0.187147654830588 -0.131361762793480  0.029658114101546  0.101263553912617
-    4  ( 18) -0.035958486319751  0.227134777791688  0.048687972069102 -0.024933262428833  0.002173989672721 -0.187305076269607 -0.105829902417925  0.008056867875506  0.037853803971042
-    5  ( 19)  0.171149922579415  0.110039862501994 -0.026813452459140 -0.190061024816887  0.222174491954054 -0.004093825553016 -0.044188302806112  0.116881315421755 -0.043225291916047
-    6  ( 20) -0.080019590838700 -0.062262232462848 -0.021096034332220  0.023057305471526 -0.101639862804641 -0.003152213311187  0.029422735136868  0.019240780036951  0.059315335454636
-    7  ( 21)  0.083510548402123  0.557993066791473  0.397235243356208  0.151190399349717  0.153637137534004  0.021828958802507 -0.022025876078118 -0.327175118374607 -0.079618949429238
-    8  ( 22) -0.042227049954364  0.098944758472646  0.049249083184483  0.187848524484403 -0.236611254443533 -0.124376089369001 -0.118097176171872  0.206089300936335 -0.024158581021498
-    9  ( 23)  0.032033977750932 -0.174724865726956  0.107565757409839 -0.033957075679687 -0.093408693176877 -0.094735950835808 -0.001596176802057  0.112245900387886  0.037372397271166
-   10  ( 24)  0.077636129797919 -0.430853371998705 -0.215233761055940  0.452386714098273  0.474453371679467 -0.016809820271846 -0.095741323886920  0.105100659091080 -0.104107445539310
-   11  ( 25)  0.011149970874610 -0.007035579685386 -0.003127573400518  0.077702883164627  0.084954198370187 -0.079818042644370  0.085248456841504  0.044951104587653 -0.070017705668783
-   12  ( 26) -0.193344086617498  0.456776432013422 -0.761441366858404  0.011910497712878  0.026326742647963 -0.092364226349286 -0.078937949371178  0.136041391718326  0.256815257193465
-   13  ( 27)  0.133610614090005 -0.173243160128294  0.225605563113523  0.236498022568823 -0.204477528431671 -0.174386164144365 -0.111604362943586  0.182311312483583 -0.403964555885563
-   14  ( 28)  0.098101278195306  0.007008756260166 -0.117389775367317  0.511914224685440 -0.622957281459333 -0.412506446069418 -0.179820830724467  0.234600868408507 -0.150158824761841
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.343234558725567  0.228637063726269  0.023307266959502  0.140382240172792 -0.083235444793760
-    1  ( 15) -1.074711095873744  0.056336734854343 -0.034809000083236  0.121348785991751  0.106814989655091
-    2  ( 16) -0.078219304152202 -0.719658957943986 -0.014720519366158 -0.261816502529916  0.090881991750144
-    3  ( 17) -0.502805356071942  0.131166561688672 -0.017463933389579 -0.755157521149267  0.255568620797102
-    4  ( 18) -0.195634688856887 -0.541360385537898 -0.048854453075291  0.337587696841954  0.138455603989787
-    5  ( 19)  0.760143596830987 -0.110879995008927  0.015821843299894 -0.447903356003643 -0.237096867164475
-    6  ( 20) -0.097106884263887  0.097545405975693 -0.114437354251730 -0.024000531999102  0.039042927829059
-    7  ( 21)  0.075531866838301 -0.009858499302833  0.021730854579213 -0.114681897686178 -0.191988442177111
-    8  ( 22)  0.027711318590147  0.201621760195186  0.044350251642364  0.065874285776240 -0.090522977876112
-    9  ( 23) -0.011879012685435 -0.258606547469066 -0.047776074363499 -0.213401932184194  0.274704590606944
-   10  ( 24)  0.006858605937754 -0.038088449389244 -0.069395356141264  0.275242327171399  0.061260041265231
-   11  ( 25) -0.002890089589219  0.048355005791387  0.007521454792553 -0.016094295989108 -0.041236148462184
-   12  ( 26) -0.024624287461246  0.326411349050862 -0.004226520020176  0.029493735437593 -0.084692672982552
-   13  ( 27)  0.450726956342698  0.030201266401628 -0.020823649440091  0.038233714612970 -0.090500946858406
-   14  ( 28)  0.809945076459086  0.216752990291181  0.043269372622044  0.033145255679139 -0.181828971805248
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.063013364696514  0.044010513010140 -0.033832526224211 -0.162024471696236 -0.051333545713143  0.246461238669107 -0.063609486603270  0.159478583547076 -0.006207989114076
-    1  (  1) -0.226546037179395  0.291390639777102  0.048328229754705 -0.000396116910678  0.216137862922779  0.115706811352044 -0.113227048986677  0.363481206263983 -0.049424206162689
-    2  (  2)  0.353995982753623 -0.570067383955282  0.052742449525010  0.144888216829452  0.158139021131471 -0.195548321941560  0.035681653601236  0.044365181477906  0.094047723024953
-    3  (  3) -0.014909685853208  0.093363165202933 -0.099368126188753  0.092807318931361 -0.081502054050149  0.166990973951771  0.201832262285607 -0.375763253843030  0.022961121211245
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.027461792188467 -0.004811887789740  0.001758716793345 -0.052146222606019 -0.015489645876144 -0.034542443930348
-    1  (  1)  0.038878540290940 -0.018432422578327  0.015238310520594 -0.445890608944474  0.276103308767449  0.178613718171164
-    2  (  2)  0.112212317864169 -0.097070429592677 -0.017583930410099 -0.264050273165228 -0.167988430449652 -0.635838792277428
-    3  (  3)  0.134391135826268 -0.880500790171335 -0.088985519620608 -0.095884376650580  0.014499630081693  0.127955545332533
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.037904901187616 -0.025077601146789  0.027398631479947 -0.443691662113588  0.381793026485785 -0.022010734273084  0.009578999727395 -0.091037438378063  0.103637073384889
-    1  (  5) -0.010563786544947  0.113947073526168  0.106465996568323 -0.155511131041724 -0.116554544974583 -0.262895686214063 -0.105092877292920  0.193457955253204  0.048498356991785
-    2  (  6) -0.044887612702522  0.228580277279931  0.273604650547313 -0.078952413042729  0.139355988549377 -0.486362168413732 -0.239519122057504  0.286842566968737  0.031193390212920
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.028779621541873 -0.090907914561767  0.003460105941843 -0.087167181054995 -0.071921470779774
-    1  (  5) -0.003930295039018  0.035914981429889 -0.006741878538669 -0.611390099224952  0.116946571666512
-    2  (  6)  0.076298500757009 -0.614894877751711 -0.048926788565139  0.209608637563865  0.127192306297029
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.068337016677695  0.096446452026756 -0.360475449331991  0.092239288371853  0.026203678917511  0.022509846886799  0.073478827117419  0.022464061625998  0.227372488621395
-    1  (  1) -0.348245092774866  0.473201941683207  0.285296343579762  0.183481268326088  0.077575420562874 -0.072099125969722  0.272473569856386  0.064219415204321  0.197165880719729
-    2  (  2) -0.067585908335283 -0.050372922133506  0.060758167744452  0.207525430642987 -0.124589544508062  0.366296688963713  0.319501792505756 -0.144609263799336 -0.034557292153017
-    3  (  3) -0.003490778097580 -0.176771187112973 -0.057522831103622 -0.000116418648382 -0.000778288019112 -0.154495740627781  0.307263828587522  0.311985415435969 -0.072067405458553
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009055593070151  0.169294476018032 -0.004376707873729  0.043035427357302 -0.152530590698355
-    1  (  1) -0.043732146257221 -0.133230210157229 -0.321492959581682  0.026647195860165  0.380687102934580
-    2  (  2) -0.166530147628729  0.613643715672385 -0.216790209047481  0.084469048804484  0.070950252851931
-    3  (  3) -0.193623455804687 -0.188085387663198 -0.577128561869679 -0.079182256640786 -0.329374829305157
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.094184605186671 -0.056664612816556  0.249611394657184 -0.001240336497952  0.251113263182976  0.167204841127316  0.053738355395826 -0.110451910693142 -0.110225244293220
-    1  (  5) -0.138889396111012 -0.115961679782817  0.323179744158626 -0.121252123207265 -0.292076432419815 -0.241576686510115 -0.062989099171507 -0.028273376478118 -0.195878521271564
-    2  (  6) -0.158880157678560 -0.136139940912615  0.265648578874291 -0.093877387268260 -0.142453752235908 -0.054140913517762  0.560779480954688  0.138233927899815  0.254132036688695
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.293992892729715  0.040800750956591 -0.057675088119180 -0.076602392465323 -0.065335333102758  0.026360508286139
-    1  (  5)  0.140101157166617 -0.119683195321807  0.266691635597033  0.245738117504136  0.344104644828940 -0.220704301441665
-    2  (  6)  0.056921768258958  0.103403744090827 -0.598429877431589  0.146214200734754  0.059974751023664 -0.323525482450488
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.001194434516926  0.365406825873877  0.191112170654786  0.072953190005452
-    1  (  1) -0.363385965896555  0.001278838882578 -0.019794428206453 -0.015546405496121
-    2  (  2) -0.188455836576036  0.023464280272920  0.001313653362102 -0.003971811529941
-    3  (  3) -0.071937190909342  0.014204649752708  0.004012943205250  0.001742183215196
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.002207002387747  0.099036313248809  0.350070270006789
-    1  (  5) -0.099717351351760  0.002187155419577  0.000406257568929
-    2  (  6) -0.350175744645045  0.003726626970778  0.004104233297166
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002966254715231  0.240855988266728 -0.015168347488530  0.064366755524788  0.058337095528916  0.095917557609408  0.080552351010748  0.173850272969471  0.326738509325595
-    1  (  1) -0.236928751733350 -0.000606734226053 -0.349434191365712 -0.093200906311076  0.041406943350823 -0.069404274429693  0.288704930708582 -0.111892041376425 -0.888816026581642
-    2  (  2)  0.015227164699160  0.348726210567974  0.001624946372493  0.082520881475572  0.073422056547723  0.232856655438329  0.287989353510736  0.229619697744185  0.234594833443005
-    3  (  3) -0.060136079807310  0.090244643623410 -0.083460850918858  0.000190675057493  0.021666820127845 -0.049054167667433 -0.003318783332088 -0.014942478625699  0.184116482215884
-    4  (  4) -0.058810580653892 -0.039254180139711 -0.072185299720667 -0.023983542956374  0.001162617768289  0.085082802307878  0.048921193420164 -0.153382943802422 -0.107278309526120
-    5  (  5) -0.094673430029074  0.068328286783388 -0.231594556891859  0.051852594552707 -0.087895099396058 -0.001022706922957  0.009481397805757  0.039804866070152 -0.148588908121843
-    6  (  6) -0.077478276137780 -0.287498549855759 -0.285112820054957  0.001996885796048 -0.050199534762013 -0.010169007281739 -0.001566818575017  0.173488828459951 -0.045840640430952
-    7  (  7) -0.174574943301410  0.112673533261648 -0.229919171659831  0.014304085765577  0.153548872211132 -0.035649109336757 -0.172043564633104 -0.001747195829410  0.038631522766057
-    8  (  8) -0.326784468679605  0.892435693037357 -0.233569726528789 -0.184065381075518  0.108484932678938  0.147374626265501  0.046903987933936 -0.038178109185914  0.001735751957207
-    9  (  9) -0.006821679719377  0.058926743509393  0.208367267805622 -0.285685508477399  0.014180918165163 -0.077838258063458  0.021878341498618  0.053464078274748 -0.072201437911745
-   10  ( 10)  0.009056199429691  0.188962532231488 -0.202934615692329  0.587329922811144 -0.635977084568857  0.025679043651857 -0.020098430100480  0.176535847273173 -0.134249054850628
-   11  ( 11)  0.122433619087449 -0.184482339508693  0.564618465141536 -0.437678405523193 -0.566648296764866  0.293188916460713 -0.283810265313721 -0.077678717328954 -0.171076053515931
-   12  ( 12) -0.036292153208947  0.108484898349320 -0.145104583947026  0.147429251741648 -0.198788533301527  0.103598496618116  0.121175312167554 -0.030985473315147 -0.001761958158343
-   13  ( 13) -0.133923970852792  0.204871678949702 -0.411285239061003 -0.299554669797709 -0.284169606525854 -0.162383457794127  0.004545044711178 -0.249571768159739  1.096350485902953
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006556329110841 -0.006088586386751 -0.124678079831954  0.037126112155215  0.136830700261450
-    1  (  1) -0.060788036015694 -0.191479282295534  0.182968697985886 -0.108878994177096 -0.206615313543699
-    2  (  2) -0.210374331017044  0.203724330933666 -0.567874430260769  0.145071803402332  0.411903076822992
-    3  (  3)  0.286917147696723 -0.581979187814224  0.440566780256406 -0.146724205480600  0.298411655566699
-    4  (  4) -0.014298727005834  0.630110791185791  0.567066919718617  0.198113213886521  0.285451610676776
-    5  (  5)  0.081474334265114 -0.027014198849763 -0.293476840962639 -0.103773751793710  0.162461435377736
-    6  (  6) -0.019534299275936  0.018969452720832  0.285789804049686 -0.121256569831033 -0.003481312727309
-    7  (  7) -0.056370622889280 -0.170673347832600  0.077097071581232  0.031742893248721  0.249704021902801
-    8  (  8)  0.071994852203822  0.132015517717158  0.170148143024151  0.001951350044678 -1.093751141653295
-    9  (  9) -0.000953866523975 -0.167467737198046 -0.013767962244439 -0.007434218290124  0.054780735052675
-   10  ( 10)  0.173318734659126  0.000810695586467  0.044701276287093  0.097338149388905  0.081237613430460
-   11  ( 11)  0.013895240641951 -0.044282356293427  0.000179785703801  0.004575065369641 -0.075680209341763
-   12  ( 12)  0.008279323048061 -0.097099690667968 -0.004296013685779  0.000048011111236 -0.035877871824266
-   13  ( 13) -0.055107661683376 -0.081651595745875  0.075682651530469  0.035936424072868 -0.000029147707292
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.002983283073552  0.069963597569041  0.177874917667998 -0.062698638146301 -0.106213761198913  0.103906931767555  0.039245016352398 -0.108223517603678 -0.012203119212599
-    1  ( 15) -0.072298870307035  0.000296799608796  0.117346282403810 -0.011865025714908  0.081057312629942  0.082184434890961 -0.047411637016207  0.318551609279607  0.030383483166489
-    2  ( 16) -0.171245613988674 -0.116654951277647 -0.001073144643332  0.130649581927528  0.144907410540790  0.208150327953063  0.198240370201554 -0.179277720823411 -0.001547973613629
-    3  ( 17)  0.060703226947660  0.012583282832888 -0.130776798167377  0.000627586286590  0.018993088317931 -0.044159196655903  0.007932945197872  0.099780861993881  0.079859961463087
-    4  ( 18)  0.100987762729975 -0.079245986001353 -0.141690159528846 -0.016637213332155 -0.000279400820895 -0.188760521966200 -0.218195531933535  0.080299124518616 -0.270793478609675
-    5  ( 19) -0.108074704635216 -0.081590264498889 -0.205498810382318  0.045801307693771  0.187063236245240 -0.000710419758875 -0.073671862989187 -0.043877487134678  0.003892010725365
-    6  ( 20) -0.034177446867522  0.046254597520027 -0.201430745227679 -0.005427131993230  0.216675775592057  0.075812938142253 -0.001274951349149 -0.134520130532184  0.103162147021421
-    7  ( 21)  0.109552512569813 -0.319375904304575  0.177972755772711 -0.099543500716481 -0.081539270937629  0.043994632054622  0.133148819770476 -0.000136132680380  0.101451568181800
-    8  ( 22)  0.012932579381132 -0.031214135384490 -0.000281145990656 -0.077687686709702  0.270019497869643 -0.002445122305778 -0.104445784052100 -0.102366601596632 -0.000293374111723
-    9  ( 23) -0.258661075798788 -0.226451306397380  0.883677423513705  0.031877470630129 -0.145903964590500  0.329887844134728 -0.092796308819851 -0.020328633409678 -0.044508005290364
-   10  ( 24) -0.092756800530096  0.166962776711625  0.090732033242854 -0.033047276838485  0.181047632927145 -0.062682569832297 -0.131253772479093  0.125666164674422  0.010098556627625
-   11  ( 25)  0.085247662084319  0.052988724588725 -0.426265235226709  0.453475536447167 -0.668253171471624 -0.144399850217273 -0.422325162892048  0.144483844450738  0.151429271642033
-   12  ( 26) -0.279045843991891  0.538081255792683  0.338024638087139  0.681172358850588  0.181070323444015 -0.460341461990372  0.046122199431924 -0.472432043418077 -0.099681899420099
-   13  ( 27)  0.031769949568578 -0.364837871962491  0.009792757368435  0.264546010179783 -0.131321500070479  0.369805258593067 -0.160328386436444  0.216930526986653 -0.408555062086236
-   14  ( 28)  0.069122236052376  0.228562041286249 -0.181966055883684 -0.129261778712552 -0.172738024644993 -0.293166654576352  0.081465083951240  0.165047538527886  0.415612188545544
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.259003180995999  0.092034359732091 -0.088092444988971  0.283228839847223 -0.027238337345788 -0.074809429137092
-    1  ( 15)  0.226401057047801 -0.167244181564770 -0.051680013843725 -0.539247725941338  0.363958831235579 -0.227197833049861
-    2  ( 16) -0.880204617361986 -0.090080695403138  0.428803021300672 -0.339354335014476 -0.011073919861198  0.184183385405081
-    3  ( 17) -0.032548488106633  0.034116564240178 -0.457440817331429 -0.682846299872809 -0.267172551643223  0.129975094303440
-    4  ( 18)  0.146446220661130 -0.182273160793426  0.671045144484618 -0.180560000424842  0.132242486336168  0.172542944677419
-    5  ( 19) -0.329935957691708  0.062440148449723  0.142514523618445  0.461407225484117 -0.369136535324331  0.291356141625179
-    6  ( 20)  0.095137293654559  0.130985936102436  0.423469417337729 -0.046319908681962  0.160102833893605 -0.080585118835760
-    7  ( 21)  0.020207238092615 -0.126147064104969 -0.143168454940269  0.472622130455173 -0.216404140117317 -0.164767679261412
-    8  ( 22)  0.044837771622786 -0.010451598353546 -0.151184144406440  0.098993252397369  0.407878413312189 -0.414658535507476
-    9  ( 23)  0.001737606134934  0.018616595639929  0.107543267833085 -0.163017051753013 -0.647726175645918  0.636571415515610
-   10  ( 24) -0.017899922228044 -0.000213602824426  0.053374660165807 -0.073998998716505 -0.058121913122542  0.162859588181722
-   11  ( 25) -0.109492695348190 -0.053011202690733  0.000327739740203 -0.000312768703591  0.053080921470257 -0.055086051279352
-   12  ( 26)  0.164160765816315  0.074526437813364  0.000205041264621 -0.000008221388086 -0.003647906535196  0.023090840612045
-   13  ( 27)  0.648519944554920  0.058749585422481 -0.052822010998177  0.003709251683372  0.000103802664845 -0.203134785839326
-   14  ( 28) -0.638592033397192 -0.163371069122125  0.055018466584646 -0.022957117292923  0.203277611770653 -0.000205390113949
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.050918463672837 -0.088577095911626  0.347792606459412 -0.095753675403874 -0.021868934225380 -0.033922841975857 -0.081457049638017 -0.022670295387980 -0.235434049572332
-    1  (  1)  0.382949048662791 -0.528689769706688 -0.299634584086346 -0.202752933016224 -0.082733390999563  0.092422540316925 -0.290813237500084 -0.058004392324892 -0.224615068405588
-    2  (  2)  0.072432527585316  0.056118386776062 -0.040222186558432 -0.242175264454298  0.146547807338018 -0.390266206867364 -0.347025142548880  0.162810044865207  0.041509720616448
-    3  (  3) -0.002509556424329  0.208248007860462  0.062422901369848 -0.007679044749759 -0.008571630545112  0.174062990005658 -0.334967725932269 -0.336081407145288  0.081599082536296
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.010892131457533 -0.184129002689570  0.006516359878994 -0.045872381230752  0.153258318093946
-    1  (  1)  0.044796011029196  0.153644284644512  0.339325263566756 -0.025646141032274 -0.405174708389161
-    2  (  2)  0.178039316366764 -0.664464704148233  0.224969390534104 -0.089440380756525 -0.066874687913745
-    3  (  3)  0.205823412452233  0.203327440636405  0.607212535172871  0.084515912728930  0.343929939556071
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.078798727127085  0.050234519025036 -0.245209481862661  0.005696954168209 -0.236120915868886 -0.165120845160626 -0.059294811018549  0.108390851582836  0.111673906302634
-    1  (  5)  0.155915068579220  0.141324548768777 -0.367116438384255  0.121574775208674  0.314513424545348  0.257608736751094  0.074849697192160  0.032932966046337  0.220860722558199
-    2  (  6)  0.156801606542398  0.183207885627035 -0.298465110849382  0.100930243056436  0.131083210552854  0.050444928584622 -0.606210604165772 -0.146614859921357 -0.248216540567658
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.311128511448673 -0.042835689156568  0.063170810110215  0.070842689432729  0.064570105984912 -0.023339590654715
-    1  (  5) -0.156644000440875  0.124669553061406 -0.274932589468273 -0.248710717987319 -0.361639916876500  0.231627984560414
-    2  (  6) -0.060874079553630 -0.108175278252638  0.629356829293933 -0.147027352951220 -0.067479673265597  0.339908703023576
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016118777276718  0.076689387067913 -0.125264792267221  0.007931013310217 -0.098301937535593 -0.089040062536424 -0.042653189503994  0.143650549015436  0.062698356849212
-    1  (  1) -0.038523460792179  0.325926212074865 -0.217436403108293  0.076210929079432  0.124956744969497  0.049869905306322 -0.256022567536767  0.049219148025195 -0.025163660677602
-    2  (  2) -0.015460259327547  0.182364499530156 -0.081021447104321  0.065186772706330  0.193628085224677  0.090709199284776 -0.144227288852923  0.007154481293498 -0.060483347873675
-    3  (  3) -0.069494321441893 -0.016013992178317  0.169506236224066 -0.050547669997832 -0.177140340538940 -0.181255025833280 -0.201077665225234 -0.109139777586644 -0.215083611892043
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159361864611547 -0.056476108299595  0.034334354535918 -0.068420323850582  0.100698715800708 -0.049820592017770
-    1  (  1) -0.121041364374114 -0.003994619377141  0.190684428167188  0.052070114913576 -0.189028662705244  0.205096915582729
-    2  (  2)  0.013836799939810 -0.073875918803127  0.147901928532532 -0.343158528114237  0.053056478393270  0.086736758175874
-    3  (  3)  0.065392768372805 -0.072388535495378  0.365788807268921  0.156911353062510  0.184439406968008 -0.043117455907294
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095080611028908 -0.132974666952804  0.233475927910161 -0.109077700761846 -0.033619328181737 -0.003336619392380 -0.079318686273404 -0.006541773193158 -0.188514066103897
-    1  (  5)  0.133180554197727 -0.220459497770331 -0.122961007604824 -0.144493780528946  0.034530325126907 -0.144382538755413  0.001565508478524  0.179104189145753 -0.084352671049968
-    2  (  6)  0.305369897772513 -0.245966510909099 -0.171589985467973 -0.288954965589218  0.048536799653855 -0.105233271021501 -0.400024803684154 -0.035818012706252 -0.066124321501178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011358647742863  0.047842821118303  0.011877525445924 -0.012099889406653  0.055702357687979
-    1  (  5) -0.060987538430201 -0.100437160073965 -0.174976176295347 -0.033059202656665 -0.296249624542352
-    2  (  6)  0.156959926194247 -0.053853503787388  0.406665675932452 -0.026462885456154 -0.143060389345537
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.020933994600407 -0.036837370041379 -0.105536213576206
-    1  (  1)  0.298453027380229 -0.115575201783048 -0.255528599615226
-    2  (  2)  0.258793135913466  0.115959940555419  0.442826057795207
-    3  (  3)  0.060024736570871 -0.030098554189580 -0.068752806226701
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019369167440737 -0.299662599013855 -0.261538199445486 -0.060711849430240
-    1  (  5)  0.036904684367184  0.115259605353545 -0.117033018013317  0.032657591929025
-    2  (  6)  0.104769015611942  0.252811001882398 -0.444270078409878  0.069751899589244
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.140264901989733  0.063903836208699 -0.058837720478352  0.099834492513907 -0.059321359064120 -0.159667027697165  0.002087278187155 -0.046204224826822  0.008601023391654
-    1  (  1)  0.090548490120094  0.202601353512521 -0.092021876157039 -0.096539072052076  0.170154281529190  0.083912296322856 -0.509059273187919  0.818772979644944 -0.070828284365831
-    2  (  2) -0.023785290834440  0.356113587695746 -0.273990976839633  0.279080899835077  0.352444630227807 -0.196438091918127 -0.305379232907246  0.066497365309673 -0.201285694555553
-    3  (  3) -0.097000901586890 -0.245927544981609  0.317839114090104 -0.024062116307509  0.214330573426622  0.049574376579038  0.029033713280387  0.054130019251520  0.003096872422290
-    4  (  4)  0.057665969694975  0.180120952217609 -0.233587576455003 -0.044983378670389 -0.207784279042752 -0.114395252588051 -0.123426849025620  0.227078923197640  0.055512731053919
-    5  (  5)  0.215771286107017 -0.314990234779514  0.316883540178273 -0.120867850220651 -0.280144439745990 -0.294187393366344  0.216440287801491  0.200727103538268  0.064432166939549
-    6  (  6)  0.088234371667199 -0.148935506374453  0.366935246390926 -0.011963781822206 -0.214228897418480 -0.110020140834853  0.192637863546336  0.231329350431262 -0.059800681126411
-    7  (  7)  0.046850408794017  0.280155317167354 -0.370918303757493  0.110906122388338 -0.088736250126073  0.146624611249212  0.021132431838050 -0.399622620248781 -0.041122390922446
-    8  (  8)  0.213219122375795  0.108141657808912 -0.632333203738691 -0.072815736912248 -0.035034243651177 -0.162896842787152  0.072787072592851 -0.219123938652928  0.041084573561980
-    9  (  9) -0.053156461400872  0.091068663315953  0.087565530354209 -0.029252405162185  0.135958664144556 -0.072618412616147 -0.001674517036243 -0.447580570679361 -0.046048420321104
-   10  ( 10)  0.217389369502915 -0.434955320268289 -0.409591028918221 -0.322091930890678 -0.032769693001793  0.320487371417185 -0.022524010208261  0.286088771348247  0.028739508255570
-   11  ( 11) -0.043655408036923 -0.078795431314355  0.262179238045958 -0.331516326719145  0.435766491266973  0.063689969335775  0.247099037158842 -0.001834914627208 -0.140224560742036
-   12  ( 12)  0.056091676196041 -0.010888223476601 -0.132073582410605 -0.097444459311610 -0.064913316133021  0.000177701715007 -0.216786241209526  0.136744724942230 -0.129238968566818
-   13  ( 13)  0.037502956248588  0.225853404732459 -0.091597810906130 -0.251988574100633 -0.015208060782166 -0.284415044485862  0.108318027167763 -0.003844624714701  0.367465648248442
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222316043515167 -0.015706219813463  0.082385006687323  0.001598515176526 -0.060473243217389  0.093727480766949
-    1  (  1)  0.559608456549858 -0.123427525882107 -0.153467678522300  0.170334032667733  0.080737466652229 -0.083738891751815
-    2  (  2) -0.169476216588372 -0.033571289044868  0.409164888922183 -0.223598543173703 -0.075034173166592  0.314714537560898
-    3  (  3) -0.116710909315587 -0.019725573527899 -0.283423547853851  0.175125619030571 -0.285157403250330 -0.036616525847272
-    4  (  4)  0.005652624292139 -0.042302085019157 -0.326173261129769 -0.429217689689009 -0.082297928451406  0.119033467524284
-    5  (  5) -0.013435701805302 -0.050340607661262  0.120543829176020  0.018862712789976 -0.153571720838539 -0.076183620287342
-    6  (  6) -0.081289708009931 -0.326406046335036 -0.215268699384039 -0.111421444458008 -0.019027619773839 -0.098888316320561
-    7  (  7)  0.155159820795191  0.099172439421062 -0.073800976886369  0.027692155232150 -0.092694133839465  0.234604646553242
-    8  (  8) -0.037085102415804  0.221081896212579  0.033634728216750 -0.500286732444351  0.749342092540156 -0.380702305205404
-    9  (  9) -0.121604531068674  0.307665948271799  0.063134933207080  0.759313712683920 -0.291120411772340  0.157024245706381
-   10  ( 10)  0.436899181077485  0.180584483336558 -0.427706818265059  0.039319556166540 -0.042977724169090 -0.570262735340486
-   11  ( 11)  0.012744975594807  0.355849153273437  0.014473345977422  0.331011762918571 -0.082407538751978 -0.048301595441151
-   12  ( 12)  0.275248111407278 -0.041018113706033  0.197136817157671  0.114052207324907  0.270934107062802 -0.185007344485103
-   13  ( 13) -0.588095271872907  0.141945816656544  0.099720177389796 -0.418487800295615  0.225864709971247  0.209383142865026
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.136055292355694 -0.095447390079347  0.020092912976434  0.093125301806220 -0.056850399225407 -0.218468169087224 -0.091857234706707 -0.045161486852285 -0.214714486134322
-    1  ( 15) -0.061207776400221 -0.202708633629203 -0.353114471023019  0.245649376419509 -0.180866138364055  0.315320438007609  0.149515492263402 -0.279091224397235 -0.106858935875576
-    2  ( 16)  0.054684214245548  0.094025065222631  0.275943577798576 -0.316343751367853  0.233336305598421 -0.315879985031554 -0.365377908227226  0.369960150477034  0.630562926717983
-    3  ( 17) -0.098691998170038  0.096665834479755 -0.277640044986255  0.024005765248171  0.044522040617363  0.121507599385942  0.010509659584452 -0.111862233831111  0.073060388343777
-    4  ( 18)  0.060773979545103 -0.171895263117879 -0.351151470699543 -0.213576840796561  0.206989754617355  0.279451579746568  0.215385933896327  0.091082110140094  0.034953691198189
-    5  ( 19)  0.161690364133666 -0.086139117701405  0.195608563911700 -0.050196750893511  0.114409300434365  0.293302924591731  0.108870291716062 -0.145705855705796  0.162864209989072
-    6  ( 20) -0.004933077734451  0.509112916459710  0.304189657786548 -0.027011307788327  0.123564513171828 -0.216326146660916 -0.190918994832488 -0.021599458243800 -0.073921971953618
-    7  ( 21)  0.046939300208702 -0.818898745115203 -0.067231269443300 -0.053385434393296 -0.227366778650237 -0.200959323300597 -0.230355491785385  0.400408400878960  0.219890208910705
-    8  ( 22) -0.008875208231352  0.070617448884289  0.201028236092674 -0.001986037102761 -0.055524570746341 -0.064229773357339  0.060955407810688  0.040899342701131 -0.040928237624119
-    9  ( 23)  0.222811666664924 -0.561652381203117  0.169673185845513  0.114995614482548 -0.005558626156144  0.012604855943771  0.079125943676940 -0.154935461007958  0.034774271928086
-   10  ( 24)  0.015658264689240  0.122684274627557  0.033049817652525  0.019053422527856  0.043070830779647  0.050152205966201  0.326697513368332 -0.099443390036437 -0.221198097566913
-   11  ( 25) -0.081038041563998  0.154593341750109 -0.407140318932015  0.281943720612524  0.325675147388091 -0.120351655341300  0.214124337140198  0.074325284613070 -0.033051994607934
-   12  ( 26) -0.003149016432995 -0.169066126704247  0.222974141740589 -0.178167341127522  0.432229982121926 -0.017874255780557  0.111773550217198 -0.031100511775823  0.501206663109641
-   13  ( 27)  0.059358328554787 -0.079903052840459  0.074950199177092  0.286331686497645  0.080924619758582  0.153353900448008  0.018409365441285  0.093462744168481 -0.750750124348623
-   14  ( 28) -0.091958135023799  0.083203421400522 -0.314158605792346  0.035767063530523 -0.118730598661038  0.076122730197959  0.098773188363533 -0.234233392684110  0.381969165301674
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054160915945435 -0.219019011349662  0.045758113327127 -0.056667077142789 -0.042241899582406
-    1  ( 15) -0.090944710506667  0.435278295065967  0.077842273581986  0.010976755804933 -0.224792334219630
-    2  ( 16) -0.088739489380716  0.410297160213696 -0.264172456920591  0.132125091344127  0.093086518366917
-    3  ( 17)  0.030526782846372  0.322820843845168  0.334117022964461  0.097597092001327  0.253965732413029
-    4  ( 18) -0.135352462834385  0.032599183228470 -0.437639446212980  0.064872058901817  0.014497262646809
-    5  ( 19)  0.073899654730418 -0.320885730724582 -0.062344415655815 -0.000276840662838  0.283336476795494
-    6  ( 20)  0.001158784637986  0.022837257389258 -0.248024269025134  0.216907823965295 -0.108098145849832
-    7  ( 21)  0.447481917087615 -0.286161905602593  0.000998969948768 -0.136653733410725  0.003506425728696
-    8  ( 22)  0.045854947627217 -0.028382633755544  0.139989494186326  0.129405417600200 -0.366820033409189
-    9  ( 23)  0.122256207458047 -0.437180402944018 -0.011581755997574 -0.275567866951771  0.586898649032607
-   10  ( 24) -0.308323852677716 -0.180850894824874 -0.356131896237587  0.040945642422097 -0.142574344254175
-   11  ( 25) -0.063098776158311  0.427549053292048 -0.014802143274602 -0.197270506582776 -0.099635293972029
-   12  ( 26) -0.762581095039526 -0.039734172920420 -0.331033022441233 -0.114161465508821  0.418490755826768
-   13  ( 27)  0.291938944356791  0.043222558646299  0.082214356128397 -0.270960148007918 -0.225910263769329
-   14  ( 28) -0.156871086239258  0.569997035340427  0.048467653901961  0.184994394399640 -0.209531521675463
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.009005560415623 -0.070810523176756  0.120067832596336 -0.009073132789111  0.090464498751398  0.086174111119373  0.045794981404386 -0.145874969594553 -0.061668751575060
-    1  (  1)  0.049157751161972 -0.341837336007350  0.225991322214187 -0.079794887273929 -0.129000775913247 -0.051890082528236  0.264098306233448 -0.041882987798599  0.014437873768970
-    2  (  2)  0.004178475304277 -0.176534362212289  0.088484784587537 -0.060893560844690 -0.188770646517555 -0.098157508320735  0.154422738208034 -0.028159762307555  0.056745595914693
-    3  (  3)  0.078632631263388  0.018162490565873 -0.185802179760100  0.047918543127627  0.190222116766269  0.186537019008413  0.211456806958065  0.116264562677772  0.222361952728926
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163744366705642  0.058513889685970 -0.036529339633759  0.074890516703334 -0.101980211526259  0.048987870817685
-    1  (  1)  0.129678391589482  0.003465728257172 -0.197451754644998 -0.065935565415855  0.202740138649215 -0.212710296862526
-    2  (  2) -0.022460564343481  0.084272909470110 -0.151124340943610  0.372643880141893 -0.063147940573229 -0.083681000851943
-    3  (  3) -0.069418152871991  0.077040623108211 -0.377203303892570 -0.165559399244409 -0.189357768189075  0.044737808867411
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.085668830826553  0.137820799821437 -0.214610467959115  0.105542261331556  0.036859097160689  0.000473863191174  0.079606876493944  0.008613359831916  0.198755661758929
-    1  (  5) -0.139412038667802  0.235636886292819  0.125284829879155  0.147970518740886 -0.038362154224415  0.146537444592957 -0.006121389458957 -0.189794595760352  0.090516747843845
-    2  (  6) -0.309048143972662  0.258748687397471  0.168238503241560  0.304764034594855 -0.050456064213728  0.094565768675384  0.416604423570803  0.027331415693024  0.066446598559605
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.012674523904092 -0.052192101234842 -0.013753920669735  0.012760663896321 -0.052741920591875
-    1  (  5)  0.065601509403616  0.098250162685792  0.177768481553462  0.033008693934466  0.305584708162464
-    2  (  6) -0.160962535198798  0.052046626684920 -0.419200543530858  0.024457493928166  0.150587999794565
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002292052292102 -0.001327689025616 -0.000248352651822 -0.007958119616396 -0.006332326100070 -0.018602233716079 -0.068879285117607 -0.007819744108382  0.006538352080530
-    1  (  1) -0.002764164951481  0.002219747844780 -0.018293151832047  0.029668233290932 -0.039848292773056 -0.022489745012599 -0.162281988584092 -0.020804504235237  0.019083175045333
-    2  (  2)  0.011217835122943  0.011598249376099 -0.016968466001430  0.008250037510452  0.006232273271200  0.008766677291359  0.010338243291249  0.010725726663582  0.004470553150491
-    3  (  3)  0.050562851864420  0.047527304873166 -0.078707468856856  0.000484758494300  0.025585059000145  0.011993586441410  0.049963781283816 -0.008029454242806  0.026864587292980
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006805334012410  0.003000362320124  0.002228041038775  0.000013471324712  0.003129940535122 -0.001748281527537
-    1  (  1) -0.013913717596781 -0.013715090430948 -0.022806809849796 -0.002206415430011 -0.006824605289547  0.005086150284379
-    2  (  2) -0.011033408042675  0.021897939524418 -0.000684908130867 -0.006441462755861 -0.002207402072499 -0.000019160522387
-    3  (  3) -0.030996252825103 -0.007986449014412  0.024562077320802 -0.006200249162118 -0.010690383251547 -0.011486173135262
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.008068643711801 -0.010525757489217 -0.001816581937116 -0.014852647204911 -0.016446444650489  0.051123908211829 -0.105303074579255 -0.010186396385181 -0.002604742010165
-    1  (  5) -0.024807027264736  0.041872241876176  0.005357408083722 -0.028564486604491 -0.031353252400090  0.040716482303683 -0.082357809569043 -0.022204595749263  0.028676826310240
-    2  (  6)  0.057433465116018 -0.072910653400307 -0.007950207598680 -0.045866077252406 -0.051478467074873  0.066399959025177 -0.120267838044182  0.002980749702429 -0.024762093508970
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000934050050601  0.000604010149742 -0.003646663045597  0.000033137801782  0.002019175758165
-    1  (  5)  0.015497094356084  0.002871076746167 -0.025548488367169 -0.001995117147543 -0.006447008967148
-    2  (  6) -0.009288606849912 -0.006735078994323 -0.016930923349151 -0.006239987724853 -0.010309885333920
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.002224796248932  0.043809288397671 -0.042786645812819
-    1  (  1)  0.035961652529642  0.375558249507302 -0.229138680808403
-    2  (  2)  0.031482392637320  0.208906969570401 -0.045224347296993
-    3  (  3)  0.099946950247304  0.215409785029959  0.414532197880427
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.002181806445193 -0.035979573047748 -0.031640926892772 -0.100238553322267
-    1  (  5) -0.043671265862198 -0.375015508928970 -0.208917842140989 -0.216574490738357
-    2  (  6)  0.042527296867706  0.228253198541367  0.044456455969980 -0.415218734433248
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.071571831474078  0.044653489385004  0.010701302384523 -0.107261739958220  0.107631207507425  0.021982609216167  0.087555139416076 -0.002428271330292  0.013116395341904
-    1  (  1)  0.000994163831951 -0.002283385696650  0.009683189881161  0.069987093364780 -0.211165412824198 -0.144806549288885 -0.839471629333555 -0.082797629633041  0.083995255816967
-    2  (  2)  0.048029450774166  0.034159151942760  0.005345969743360 -0.362094457083817  0.166955343421057 -0.200138180389873 -0.200325175150560 -0.048097856321723  0.015226624624379
-    3  (  3) -0.099901242333767 -0.066741882163175  0.192006761021459  0.037162207196483  0.149491220617225  0.091957380518256 -0.124661875998717 -0.114474410410791 -0.084751404274494
-    4  (  4) -0.098292057994736 -0.060260709677483  0.234095836344223  0.042527139722308  0.172693635464839  0.110397071373777 -0.184879337331547 -0.074537123570678 -0.084735776692218
-    5  (  5)  0.074314676568813  0.053240577551294 -0.354242764435309  0.039009834260888  0.144962419013369  0.061650919712934 -0.045188344047315 -0.085035282721835  0.173092563485620
-    6  (  6) -0.068641550367940 -0.078242424055450  0.700330832585738 -0.207548816757483 -0.389421892794459 -0.222244858530413  0.109406330044345  0.045457397940435 -0.343867539807074
-    7  (  7)  0.021723320720408  0.016351205203477  0.098413699787284  0.004057278627183  0.006939091834822  0.079051971654245  0.378143817290545  0.122761983444906 -0.057845298080862
-    8  (  8)  0.009573032166807  0.006109372122326 -0.063933429430759  0.085659891507852 -0.069748375065056  0.032412606198403  0.211702458249096  0.046995111806493 -0.044380498011908
-    9  (  9) -0.004993361863042 -0.003634014150995 -0.021315829704567  0.021713795540608 -0.030056681969923 -0.023359631271160 -0.128991093821748 -0.016400014214086 -0.007638043352379
-   10  ( 10)  0.003364468158750  0.005158901374854  0.010157814233360  0.013146135283302 -0.036788603301885 -0.001796925979308 -0.031087735489024 -0.158319551738172 -0.001398916399981
-   11  ( 11) -0.005212014578835 -0.005572219785769  0.129300362837610 -0.009016877484923  0.009416239426417  0.064438058134476  0.026488687258818 -0.021963612194052  0.285489003307896
-   12  ( 12)  0.022889675001499 -0.014028568601137 -0.005258310077958 -0.012614598275054  0.011181538654869  0.041924328606938 -0.003053461905652  0.141650155501185 -0.005090787707419
-   13  ( 13)  0.006246133552104  0.010356570946206  0.013049157750693 -0.012424981952369 -0.009162366348552 -0.014458376447183 -0.062634797746517 -0.024809108873564  0.013232375979096
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.002828230885257 -0.008462795614422  0.005154038879345  0.009706144885120 -0.000351690712200 -0.003016908410820
-    1  (  1) -0.016542909801999 -0.036808232009347 -0.132827410709679  0.012545312927284  0.013603497625073 -0.014243226256360
-    2  (  2) -0.056531888264120  0.026681841564725  0.044472892095947 -0.008316762319548 -0.009818160226073  0.003132505638468
-    3  (  3)  0.065664012413416 -0.084000307061427  0.024123678461562 -0.011516052481209  0.005295212539445  0.009770444853693
-    4  (  4)  0.036042306167921  0.066196882580862 -0.035814283991972  0.000422354014022  0.007346814292348  0.010225200735508
-    5  (  5)  0.148907428019918 -0.109320100216994 -0.041270431698859 -0.008286052492360  0.000171545458785  0.012799874602531
-    6  (  6) -0.267740896585406 -0.203497348994038  0.004880757246489 -0.039144439238724  0.017848850593881 -0.043282221917125
-    7  (  7) -0.072391125356366  0.141340064883921 -0.132216664302808  0.021712276497551 -0.014580212743968  0.003413596406031
-    8  (  8)  0.065338926975319  0.070417584641912  0.663636576046729  0.043614890913103  0.008447529962627 -0.017635456067555
-    9  (  9)  0.053338372051575  0.015608392811417  0.295869564541774  0.007118975871935  0.021727777212887 -0.010944181246414
-   10  ( 10)  0.043778421907204 -0.395589362339910  0.177341233202875  0.145584179195590 -0.046786531122207  0.019085441444643
-   11  ( 11) -0.612579899217910 -0.015866362451346  0.053555820669517 -0.384133045755119 -0.648991284315080  0.223359237845109
-   12  ( 12)  0.089924264835296 -0.149474889068188  0.147998013353456 -0.410950037016053  0.122612685939115 -0.053519931502491
-   13  ( 13) -0.016968386753172 -0.001120736716630  0.667558162177866  0.016648983669703 -0.049072172914944  0.011592992748873
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.071349801352714 -0.001077758689270 -0.047849010758340  0.099049708991052  0.097373218549672 -0.073249702217701  0.066497399663850 -0.021905924000244 -0.009611371244576
-    1  ( 15) -0.044780949738342  0.002559008927920 -0.033951661393695  0.066729312295418  0.060308115101382 -0.053229541901542  0.078046690958419 -0.016360376267858 -0.006154062585816
-    2  ( 16) -0.011020054803350 -0.009639577990263 -0.005659342412151 -0.191466387657664 -0.233770018397497  0.353943104953966 -0.699652203951216 -0.098429630868852  0.064028996133412
-    3  ( 17)  0.107854789786884 -0.070585793426189  0.362141920362822 -0.037292065848003 -0.042427554280107 -0.038929544624269  0.207453249613655 -0.003913287572505 -0.085781111935072
-    4  ( 18) -0.108209449998533  0.211629628691212 -0.166874900133377 -0.149325288082881 -0.172890816462238 -0.144890994778070  0.389082003854782 -0.007000687821947  0.069612637937327
-    5  ( 19) -0.022019034844539  0.144617634612061  0.200192966932170 -0.092059326306527 -0.110737371319849 -0.061364605633219  0.221637061620898 -0.079021140430878 -0.032667339771975
-    6  ( 20) -0.089130158761328  0.839805360702557  0.200387491136614  0.125541335494723  0.184496760040866  0.044995250241913 -0.109402692051618 -0.378035804168236 -0.212908503907272
-    7  ( 21)  0.002178057091038  0.082925436926418  0.048118216149291  0.114730021254943  0.074453346277443  0.084891108935477 -0.045281773316412 -0.122667104662941 -0.047081579488126
-    8  ( 22) -0.013014867453703 -0.083878416356711 -0.015105645463008  0.084649544925900  0.084843093804859 -0.173122296622810  0.343876299664282  0.057834963947660  0.044464266623987
-    9  ( 23)  0.002901775226444  0.016234828173143  0.056359654971922 -0.065872157385180 -0.036362021680561 -0.148332139389917  0.266718078511413  0.072258279284242 -0.065401012908070
-   10  ( 24)  0.008445720197207  0.036804429594076 -0.026642166859473  0.084168947416289 -0.066510758074250  0.109381013548519  0.203196264302626 -0.141165925569744 -0.070499221179183
-   11  ( 25) -0.005377792056996  0.132971363586081 -0.044450134013502 -0.024046237867946  0.035750577264436  0.041236558408702 -0.004898258174401  0.132214673314328 -0.663804812343684
-   12  ( 26) -0.009728994170679 -0.012565610031584  0.008265487183249  0.011507462056027 -0.000390885497570  0.008310505974517  0.039141081466560 -0.021755546401072 -0.043610775840953
-   13  ( 27)  0.000301420723236 -0.013603051175605  0.009758944837903 -0.005201669668065 -0.007344582365288 -0.000240423767531 -0.017707548228084  0.014600989921618 -0.008461166379513
-   14  ( 28)  0.003079753925572  0.014179269497255 -0.003153288832508 -0.009783782056838 -0.010222304053931 -0.012792812982900  0.043303231879501 -0.003407229733488  0.017679792666437
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.005093584579739 -0.003397430557442  0.004751145314814 -0.022993999775599 -0.006406607432760
-    1  ( 15)  0.003664268681973 -0.005140681437481  0.005623137023323  0.014031183819186 -0.010293722738862
-    2  ( 16)  0.021380720709285 -0.010101149193740 -0.129156907046771  0.005327658954335 -0.012995314092573
-    3  ( 17) -0.021888212102997 -0.013219387248758  0.009147784998772  0.012607741489433  0.012451560776453
-    4  ( 18)  0.030283770762187  0.036869387279963 -0.009496744772073 -0.011181780485751  0.009182409552409
-    5  ( 19)  0.023453672116028  0.001799424920857 -0.064551617042565 -0.041960641260948  0.014420118956798
-    6  ( 20)  0.129458546494562  0.031271046054797 -0.026491102279077  0.003035012140173  0.062712336606288
-    7  ( 21)  0.016591446747124  0.158366047016835  0.021959782838748 -0.141640631249081  0.024819174074486
-    8  ( 22)  0.007575701587651  0.001384112156408 -0.285443557719759  0.005092627774536 -0.013202606990520
-    9  ( 23) -0.053335089301784 -0.043785415746465  0.612428033952438 -0.089945127333786  0.016908784258587
-   10  ( 24) -0.015338693676902  0.395633576722134  0.015809806174577  0.149475505805735  0.001108572795377
-   11  ( 25) -0.295832367201880 -0.177313650229228 -0.053561286295937 -0.148004020967965 -0.667548449264998
-   12  ( 26) -0.007157154416068 -0.145586590426015  0.384132810582926  0.410951719442920 -0.016651787670969
-   13  ( 27) -0.021701996830369  0.046797876195772  0.648997652718994 -0.122606232077394  0.049068049852585
-   14  ( 28)  0.010942221777254 -0.019093183683669 -0.223365949415077  0.053520759465635 -0.011602247780486
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002779955261603  0.001692895942304 -0.000296900585249  0.009027308047393  0.005517424530413  0.019392785745098  0.071615718156204  0.008379623734860 -0.006552142468186
-    1  (  1)  0.002104549417694 -0.002248748312389  0.016268779471159 -0.026298614529309  0.037020427509987  0.022919155336998  0.164160248243371  0.021028638082436 -0.018807600972837
-    2  (  2) -0.012197014321068 -0.010749741004113  0.015969423342584 -0.008379419120707 -0.005700661608131 -0.009182078264489 -0.007072493012824 -0.010651845449983 -0.003884546255787
-    3  (  3) -0.055916626202381 -0.044952545452401  0.075693796863105 -0.001117242062940 -0.024281174456380 -0.014619597544444 -0.053283290640729  0.007703747637900 -0.022436578410207
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006982563138735 -0.003194903879745 -0.002336222897235  0.000159319304138 -0.003153288870770  0.001705858583767
-    1  (  1)  0.013922175981332  0.014264739151757  0.027533427644978  0.002422850658312  0.006842699761048 -0.005360945695369
-    2  (  2)  0.010224586423112 -0.021331787446369  0.001728789794737  0.007349416930945  0.001927444504520  0.000065986060579
-    3  (  3)  0.028649073776619  0.008193923965952 -0.026834068422643  0.006433642271152  0.011064478009773  0.011417291735948
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.007713676236592  0.011322134542428  0.003907084678219  0.013398999832293  0.015469012646278 -0.052157960120007  0.107410796770658  0.010366341516333  0.002761603992801
-    1  (  5)  0.025927350683997 -0.036918918076002 -0.006183726668218  0.026765793037023  0.030906551194513 -0.042649472793187  0.084196537695915  0.021256853976094 -0.026253718608666
-    2  (  6) -0.059547667994813  0.071575508753465  0.010792071396250  0.045987434407762  0.051692908853277 -0.069048919754819  0.125623895288423 -0.001752094627183  0.022191347480180
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000950352585130 -0.000964031243708  0.004357151868409  0.000282508389387 -0.001887057940293
-    1  (  5) -0.015009418487876 -0.001705110486742  0.029429172036478  0.001075595895759  0.006702102006371
-    2  (  6)  0.007980731926488  0.006589892733093  0.020940438262106  0.005674678855389  0.010940914550877
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440295579  0.058098623160149  0.000062770556748 -0.132305009159629 -0.206845253888047  0.090151367716489 -0.021622993201571 -0.039361663017831  0.081041759541844
-    1  (  1) -0.058446002592381  0.108172168387665  0.020491566069368  0.029038345945867 -0.075256281089894  0.197244333760875 -0.268904698800623 -0.104165934684913  0.067340388337437
-    2  (  2) -0.015395531940668  0.065975044888453  0.020693241252053  0.145278172828441  0.156811977467575  0.026190455409877 -0.072791620600644 -0.106379132149940  0.008110007387647
-    3  (  3)  0.209889648220478  0.051262205346318 -0.016792464687917 -0.095510023534389  0.095336437810925 -0.289116526954890  0.245753636284337 -0.379261907424074  0.084194488967514
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922100177 -0.024147628250432  0.039515998201657  0.082736569420113 -0.047511948424277
-    1  (  1)  0.028213287461096  0.067760885411213  0.238885785807082 -0.125969164479716  0.177609465312033
-    2  (  2)  0.077606300081110 -0.045313543916728  0.093141189396729  0.365274041996181  0.093447143795063
-    3  (  3)  0.414915648100444  0.159852566418804 -0.273568285227133 -0.034618677637948  0.200919751819526
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102681987247 -0.069778483698171  0.053388820632185  0.227201022134194 -0.199230027457400  0.049687576281265 -0.168877445270916 -0.014461225328824 -0.006078045812775
-    1  (  5)  0.058029574787099 -0.323045692563543  0.030451397472044 -0.087822399116233 -0.049669665032459 -0.052839306746938 -0.277652121541255 -0.149775076383338  0.305937155270736
-    2  (  6) -0.084055275470361  0.046073375199290  0.190725804864306 -0.087557818530500 -0.137785527514624 -0.205465571554547 -0.198777590920688 -0.118276962990440 -0.298899363373310
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985616706  0.083163093490792  0.059838819851121  0.009394325001926 -0.030439464329859  0.004211858017358
-    1  (  5)  0.056299326992358 -0.068872084539624  0.330916524068169 -0.053769676104327 -0.184435947376520 -0.103868547783993
-    2  (  6)  0.066328790174072 -0.124449756312364  0.113043685745447  0.144452726550998  0.299204372306587 -0.043729255680790
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000261962805528  0.008184590036915  0.017078206714546 -0.120797444663216
-    1  (  1) -0.008556708940913  0.000310357479341  0.070665159347735 -0.263733240360107
-    2  (  2) -0.016665957640930 -0.070092969568198  0.000658296979419  0.516406140442807
-    3  (  3)  0.119815260993819  0.260397085059199 -0.515923296927153  0.000854850636510
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000399146441393  0.382166830385042 -0.144086395309985
-    1  (  5) -0.378879203373120 -0.000650240992922  0.057572968692994
-    2  (  6)  0.142267704977138 -0.057783925625685  0.001456329094587
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000900630817553  0.057480932301248  0.021776185729735 -0.109986124582381 -0.040974945330860  0.038859091716901 -0.013722976007051  0.027662163358443  0.095856958174051
-    1  (  1) -0.055475653729802  0.000055946423413 -0.161049994133622  0.114708024204125 -0.226365261647020  0.429957047290467 -0.365226817146534 -0.339873184728948 -0.220417191818894
-    2  (  2) -0.021015776391238  0.161427052909899  0.000077274959500  0.056803578516095  0.009014493962493  0.218381032705550 -0.249538253456372 -0.218329398300741  0.109423644471862
-    3  (  3)  0.109912942235432 -0.115891216387191 -0.056027564915092  0.000745943372337  0.462877633738750  0.122572187022588  0.103916786291663  0.116372032296575  0.000178644283993
-    4  (  4)  0.040100257401862  0.225977964738017 -0.007764610803091 -0.462832592343483 -0.000863713188323  0.292983388565641 -0.009504255770576 -0.051881331882871 -0.039789084738637
-    5  (  5) -0.036362528925743 -0.431143684565124 -0.219013710239096 -0.122734678900441 -0.292859375843399 -0.000211534680093  0.380048338834318  0.122563604837507  0.042304270254871
-    6  (  6)  0.010482485700737  0.366095597661562  0.249485788064450 -0.103549341685710  0.008516226169361 -0.379084427040252 -0.000639775867465  0.110614613813780 -0.062004820067370
-    7  (  7) -0.028768402882082  0.339119958859154  0.216813059372775 -0.114011828936202  0.053232451800242 -0.122211769727445 -0.109878960190336 -0.000261733603901 -0.084697348659745
-    8  (  8) -0.095810944695334  0.221328249276204 -0.109105398407007 -0.000872051363339  0.038539628128307 -0.040520833999881  0.059740000698578  0.084693665490196  0.000412317879658
-    9  (  9)  0.014697085572369 -0.105287145446058 -0.107273285124578  0.218858370800804  0.309735125099696 -0.105267325854039 -0.129620026346504  0.117982202893285  0.042502371715711
-   10  ( 10) -0.029182274069823  0.107750482915279 -0.099755873232373  0.053540519729348  0.138357776561317  0.190065661316311 -0.089951321859060 -0.050398080030964 -0.205938711533222
-   11  ( 11) -0.155188100419269  0.443693923193159 -0.328775787594980 -0.218791170588477 -0.215183707581260  0.086687685172586 -0.081438682030100 -0.042661060649411  0.076989743302322
-   12  ( 12)  0.047041819133236  0.056356277723761 -0.091876156457291  0.290703693299362 -0.241933426060878 -0.247197194304100  0.042704222313214  0.092541926182743 -0.274193192866205
-   13  ( 13) -0.050345457187286  0.050309029533978 -0.290248962160664  0.162027268205565  0.213802087129928 -0.103771321970540 -0.033795235497894 -0.045614675872296  0.299788281594493
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015094426489382  0.029115659613984  0.157755053899573 -0.046090500922971  0.051508699260239
-    1  (  1)  0.106870813652789 -0.107133528015314 -0.444981848759519 -0.057242056092259 -0.049852574162928
-    2  (  2)  0.109000377776210  0.100245307552928  0.328735836791196  0.092813183683061  0.291725571255713
-    3  (  3) -0.218950464663657 -0.054805102085238  0.218886888542902 -0.287519470239761 -0.163372131318506
-    4  (  4) -0.309058290561676 -0.137567383239759  0.215197532854513  0.238351393836438 -0.213552990219087
-    5  (  5)  0.105624117972044 -0.189859620690792 -0.086820347884678  0.246317074454998  0.103852569604008
-    6  (  6)  0.128090000856966  0.089849284790653  0.081980995688413 -0.043663325009335  0.033155703031441
-    7  (  7) -0.117989240855155  0.049695249544262  0.043676012478621 -0.088835836027429  0.045632574214248
-    8  (  8) -0.043185512310113  0.206252030230831 -0.075219160600274  0.272504390674237 -0.299099410447326
-    9  (  9) -0.000057792160807  0.416496446259873  0.033591110007561 -1.079044045817668  0.144878189091330
-   10  ( 10) -0.417381448990192 -0.000164005362256 -0.288881720270970 -0.322059475407983 -0.291538277058570
-   11  ( 11) -0.033261524584639  0.288678211108026  0.000120543612153  0.357470920187357 -0.110246704427599
-   12  ( 12)  1.082405304483691  0.322498276514608 -0.357322196019213  0.000062083058686 -0.002512916703858
-   13  ( 13) -0.144912114579253  0.291369916474370  0.110105006775579  0.002446483993989  0.000063534084907
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000175081543235  0.016120371429445  0.025072002498307 -0.062542190001810 -0.021350885611608  0.118270325314450 -0.004836963443519 -0.089308321494217  0.035265121599228
-    1  ( 15) -0.019016581108200 -0.000074621970578  0.073692709803711 -0.220090875517914  0.117001241546639 -0.069843654088588 -0.194734592940078  0.297334325625656 -0.000079679030782
-    2  ( 16) -0.022601123418381 -0.074079137647858 -0.000898075728427 -0.015352523942492 -0.086856492084776 -0.105020764975991 -0.399309885639210 -0.436863382131761  0.175020106394679
-    3  ( 17)  0.059722097345652  0.223919505098606  0.017236939707940  0.001153330835786  0.251337783789116 -0.316047497618471  0.195069502405311  0.070796117852672 -0.376854141068940
-    4  ( 18)  0.020136753535465 -0.119176676580060  0.086690091555956 -0.251646590139118 -0.000253931741203  0.043128862347025  0.031767565075530  0.166618171717967  0.162853353427601
-    5  ( 19) -0.121150060676480  0.070465337136678  0.107141402917501  0.315382260507230 -0.043144844880487 -0.000915299484024  0.084836748925369  0.176704257940149 -0.191804096130299
-    6  ( 20)  0.000227153495201  0.194659284089699  0.399818522753260 -0.193896536829102 -0.032525351177556 -0.085523354347259  0.000313079507664  0.483156326770458 -0.288322768300912
-    7  ( 21)  0.086746307137042 -0.297294170806809  0.437363838809426 -0.070300496686555 -0.166591994782662 -0.177217714676487 -0.482838971708778 -0.000010492293158  0.098273184847402
-    8  ( 22) -0.034845258926466  0.000856544015064 -0.174085542944908  0.374309528502842 -0.160749665940872  0.191624326414407  0.289454904423216 -0.097021267550271 -0.000014930403133
-    9  ( 23) -0.146129839058632  0.053485685235498  0.324250294825684  0.062889229683982  0.055229748354918  0.064112736518466  0.152978751390774  0.139451617186818 -0.103725991413656
-   10  ( 24)  0.228960109301500 -0.607985902209189 -0.190616272123952 -0.232984732345903 -0.097313246050666  0.308149392800276 -0.021807135674585  0.163587870408675  0.316482089556363
-   11  ( 25) -0.113565876404484 -0.174438492287332  0.418980586076642  0.308342622144823 -0.075432621027986  0.339103289288024 -0.159452756259661 -0.028406298387555 -0.098839597099930
-   12  ( 26) -0.037444327267505 -0.021664072112537  0.117362801200434 -0.051936890369197  0.180410685976209  0.010675625355649  0.081438166282149 -0.155940478341532  0.070485054402575
-   13  ( 27)  0.017297506490468 -0.067203074043419  0.031147633780082 -0.363738862057262  0.387270613641776  0.012184715254227  0.015942188037276  0.055059690817367 -0.199296990199261
-   14  ( 28)  0.034092252177278  0.073609066570293 -0.020468002829466 -0.085810470847391  0.016765555515284 -0.112839616184051 -0.014153257364854  0.178002322135800  0.110338785365484
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147095539872383 -0.230933799773564  0.118289772746167  0.038253772767447 -0.016292190599368 -0.035682534667396
-    1  ( 15) -0.054490936726031  0.608135664745124  0.173899591973767  0.021325225109119  0.066354839577592 -0.073331369735506
-    2  ( 16) -0.323391847959358  0.191801489512728 -0.419969130886923 -0.118001273092276 -0.032684795751626  0.020933916119487
-    3  ( 17) -0.062697350486204  0.233350536310715 -0.310310140488118  0.052850324165985  0.365716314917495  0.086296396691572
-    4  ( 18) -0.056488793458219  0.097314229222686  0.076761540605080 -0.181114864878134 -0.388829148158841 -0.017043041264758
-    5  ( 19) -0.064628320787155 -0.308910350912390 -0.338058227371875 -0.010220898623446 -0.011328162399087  0.112362127982896
-    6  ( 20) -0.155379178216769  0.021354195203646  0.159398635050546 -0.081833336858156 -0.016534888228459  0.014163359612821
-    7  ( 21) -0.140544774640624 -0.163930417297846  0.028664595573870  0.155618444233808 -0.055735865052552 -0.178161215640947
-    8  ( 22)  0.103335943311615 -0.315447824318108  0.098508893733037 -0.070643837593468  0.199190551733382 -0.110186805922078
-    9  ( 23)  0.000685205966667 -0.100205727138143 -0.098177984906045  0.175404901290359 -0.218086466804531  0.228138153241008
-   10  ( 24)  0.099957378010069 -0.000114683002834  0.318552989781446 -0.225328174596363 -0.500054658950197 -0.463890214112047
-   11  ( 25)  0.099837194917025 -0.317752725239556 -0.000013072206941  0.325584528982697 -0.211934933711027 -0.064802310197898
-   12  ( 26) -0.174911687089768  0.225249469039723 -0.325644361756696  0.000020583584119 -0.212000345487721  0.097990759740804
-   13  ( 27)  0.218595256276638  0.499626470482149  0.211748903875054  0.211985776866883 -0.000065067673371 -0.140785106097381
-   14  ( 28) -0.228612967389234  0.463548085364345  0.064895093957785 -0.097943745399791  0.140883877569212 -0.000043885507604
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019700182677109 -0.054538984090237  0.000657293183073  0.126059310809830  0.202210998435536 -0.093434338948922  0.024491292826910  0.039730679308164 -0.082949626694243
-    1  (  1)  0.060570767175444 -0.116914550591559 -0.021887147512717 -0.031244847376016  0.072525220228198 -0.201021150446193  0.281719713830578  0.109054645892929 -0.074327440399931
-    2  (  2)  0.019917912309235 -0.073498936617270 -0.021015841735422 -0.144973687437576 -0.148661911932313 -0.032805680200546  0.073267109264708  0.114043301611785 -0.006398273119572
-    3  (  3) -0.203013924377868 -0.061956730055068  0.012687970996334  0.097374198936088 -0.112619147770757  0.293844050008894 -0.262428514093194  0.382217125669632 -0.093448479811708
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009866900732451  0.025414444169080 -0.042903095265214 -0.089054808289041  0.047172870515859
-    1  (  1) -0.029479300283787 -0.071852668133049 -0.250209813738974  0.142668644531385 -0.184582935130079
-    2  (  2) -0.082839864480014  0.055172054044896 -0.094169081580928 -0.401277867082131 -0.092346870950097
-    3  (  3) -0.429785932962393 -0.170247315400438  0.282336698266602  0.039589385431130 -0.207542683133729
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.009866584979615  0.069659389537491 -0.056437231681763 -0.210909857783049  0.193232853181170 -0.044263163299008  0.177086741570328  0.011251791029684  0.005974944716268
-    1  (  5) -0.063966745715490  0.332083812922557 -0.023959233352896  0.077592998716556  0.049685567261474  0.057922845574600  0.292828526996057  0.156611147799580 -0.308189152931944
-    2  (  6)  0.093646243694873 -0.043886805978712 -0.210333087134862  0.092497904992983  0.147507586034141  0.211245402574096  0.209822842363991  0.120370292677788  0.308437245541850
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068407482810993 -0.091070726633550 -0.065843093849228 -0.010412482581381  0.030047987986095 -0.002926817734499
-    1  (  5) -0.052950259935732  0.069489349844531 -0.341748563636028  0.056521413026742  0.185361514981393  0.106113084848249
-    2  (  6) -0.072195900884652  0.125482826256955 -0.118114475628592 -0.149158088490872 -0.308475854808773  0.046262836261975
-
 	Computing Mu_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.841616280598
-	   1         4.511795705571    2.109e-01
-	   2         4.959050111723    1.004e-01
-	   3         4.980051362351    2.096e-02
-	   4         4.981320179484    7.724e-03
-	   5         4.981712301022    1.504e-03
-	   6         4.981835231534    5.699e-04
-	   7         4.981819356707    1.580e-04
-	   8         4.981812139647    5.884e-05
-	   9         4.981808242510    1.860e-05
-	  10         4.981808168486    8.098e-06
-	  11         4.981808837701    2.000e-06
-	  12         4.981809266352    4.488e-07
-	  13         4.981809436467    1.498e-07
+	   0         3.841616266483
+	   1         4.511795686270    2.109e-01
+	   2         4.959050086804    1.004e-01
+	   3         4.980051336735    2.096e-02
+	   4         4.981320153822    7.724e-03
+	   5         4.981712275335    1.504e-03
+	   6         4.981835205844    5.699e-04
+	   7         4.981819331017    1.580e-04
+	   8         4.981812113957    5.884e-05
+	   9         4.981808216821    1.860e-05
+	  10         4.981808142797    8.098e-06
+	  11         4.981808812011    2.000e-06
+	  12         4.981809240662    4.488e-07
+	  13         4.981809410777    1.498e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.562e-08
 
 	Computing P_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.877068913296
-	   1         8.662249365086    1.748e-01
-	   2         9.001158426101    6.919e-02
-	   3         9.020866658724    2.159e-02
-	   4         9.019165082285    8.099e-03
-	   5         9.019684680662    1.868e-03
-	   6         9.019837425236    7.664e-04
-	   7         9.019814329834    2.406e-04
-	   8         9.019812469188    8.004e-05
-	   9         9.019806906183    2.165e-05
-	  10         9.019809934296    7.104e-06
-	  11         9.019810954950    1.915e-06
-	  12         9.019811348299    4.420e-07
-	  13         9.019811504952    1.427e-07
+	   0         7.877068921725
+	   1         8.662249372157    1.748e-01
+	   2         9.001158432211    6.919e-02
+	   3         9.020866664433    2.159e-02
+	   4         9.019165087978    8.099e-03
+	   5         9.019684686339    1.868e-03
+	   6         9.019837430908    7.664e-04
+	   7         9.019814335506    2.406e-04
+	   8         9.019812474860    8.004e-05
+	   9         9.019806911855    2.165e-05
+	  10         9.019809939967    7.104e-06
+	  11         9.019810960622    1.915e-06
+	  12         9.019811353970    4.420e-07
+	  13         9.019811510623    1.427e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 5.346e-08
 
 	Computing L_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.095996289782
-	   1         6.401596951212    3.937e-01
-	   2         7.797672748548    2.746e-01
-	   3         8.105509880086    9.848e-02
-	   4         8.202475872992    6.039e-02
-	   5         8.232003385578    2.167e-02
-	   6         8.240339701422    1.437e-02
-	   7         8.242815228230    6.444e-03
-	   8         8.243750371709    3.872e-03
-	   9         8.243811218558    1.729e-03
-	  10         8.244025976019    6.964e-04
-	  11         8.244145019707    2.164e-04
-	  12         8.244270446726    1.004e-04
-	  13         8.244319437498    4.431e-05
-	  14         8.244354784931    2.740e-05
-	  15         8.244377042272    1.336e-05
-	  16         8.244393992810    5.930e-06
-	  17         8.244396855967    1.275e-06
-	  18         8.244398212127    4.908e-07
-	  19         8.244398122576    2.569e-07
-	  20         8.244398166129    1.002e-07
+	   0         5.095996266154
+	   1         6.401596925248    3.937e-01
+	   2         7.797672723860    2.746e-01
+	   3         8.105509853867    9.848e-02
+	   4         8.202475847793    6.039e-02
+	   5         8.232003359838    2.167e-02
+	   6         8.240339675148    1.437e-02
+	   7         8.242815201852    6.444e-03
+	   8         8.243750345219    3.872e-03
+	   9         8.243811192088    1.729e-03
+	  10         8.244025949533    6.964e-04
+	  11         8.244144993224    2.164e-04
+	  12         8.244270420239    1.004e-04
+	  13         8.244319411009    4.431e-05
+	  14         8.244354758443    2.740e-05
+	  15         8.244377015783    1.336e-05
+	  16         8.244393966320    5.930e-06
+	  17         8.244396829477    1.275e-06
+	  18         8.244398185637    4.908e-07
+	  19         8.244398096086    2.569e-07
+	  20         8.244398139640    1.002e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 4.203e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.329380164115
-	   1         9.982622912399    3.629e-01
-	   2        11.316565097793    1.815e-01
-	   3        11.483610038950    4.249e-02
-	   4        11.487719401060    1.145e-02
-	   5        11.490868056764    2.611e-03
-	   6        11.490678794860    1.109e-03
-	   7        11.490551310701    3.019e-04
-	   8        11.490621874917    1.299e-04
-	   9        11.490607272896    3.636e-05
-	  10        11.490610763466    9.668e-06
-	  11        11.490612036643    2.944e-06
-	  12        11.490613344936    9.958e-07
-	  13        11.490613800255    2.559e-07
+	   0         8.329380069571
+	   1         9.982622799105    3.629e-01
+	   2        11.316564962112    1.815e-01
+	   3        11.483609893762    4.249e-02
+	   4        11.487719255728    1.145e-02
+	   5        11.490867911252    2.611e-03
+	   6        11.490678649360    1.109e-03
+	   7        11.490551165206    3.019e-04
+	   8        11.490621729416    1.299e-04
+	   9        11.490607127396    3.636e-05
+	  10        11.490610617966    9.668e-06
+	  11        11.490611891143    2.944e-06
+	  12        11.490613199435    9.958e-07
+	  13        11.490613654755    2.559e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.332e-08
 
 	Computing P_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.948822607154
-	   1         8.923898678075    2.173e-01
-	   2         9.423321029137    9.256e-02
-	   3         9.501915011809    2.425e-02
-	   4         9.500069660457    6.478e-03
-	   5         9.500816936863    1.236e-03
-	   6         9.500783022645    4.472e-04
-	   7         9.500782652651    1.055e-04
-	   8         9.500788526869    3.065e-05
-	   9         9.500784026870    1.190e-05
-	  10         9.500785812654    5.224e-06
-	  11         9.500786179551    1.477e-06
-	  12         9.500786663389    4.385e-07
-	  13         9.500786771148    1.624e-07
+	   0         7.948822608724
+	   1         8.923898682477    2.173e-01
+	   2         9.423321034491    9.256e-02
+	   3         9.501915014715    2.425e-02
+	   4         9.500069663396    6.478e-03
+	   5         9.500816939782    1.236e-03
+	   6         9.500783025565    4.472e-04
+	   7         9.500782655570    1.055e-04
+	   8         9.500788529788    3.065e-05
+	   9         9.500784029789    1.190e-05
+	  10         9.500785815573    5.224e-06
+	  11         9.500786182470    1.477e-06
+	  12         9.500786666308    4.385e-07
+	  13         9.500786774067    1.624e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 4.807e-08
 
 	Computing L_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.291582245314
-	   1         0.391360792165    1.143e-01
-	   2         0.514608664360    8.375e-02
-	   3         0.540629484353    3.014e-02
-	   4         0.551092090644    1.684e-02
-	   5         0.552549053313    4.703e-03
-	   6         0.552460440102    3.209e-03
-	   7         0.552807688285    1.921e-03
-	   8         0.552828305284    6.241e-04
-	   9         0.552824586002    1.739e-04
-	  10         0.552831493610    1.022e-04
-	  11         0.552830688522    3.442e-05
-	  12         0.552831290252    1.883e-05
-	  13         0.552831270170    6.104e-06
-	  14         0.552832487454    3.439e-06
-	  15         0.552833334194    1.199e-06
-	  16         0.552833945135    5.391e-07
-	  17         0.552834170620    1.869e-07
+	   0         0.291582241455
+	   1         0.391360786593    1.143e-01
+	   2         0.514608655744    8.375e-02
+	   3         0.540629474944    3.014e-02
+	   4         0.551092081033    1.684e-02
+	   5         0.552549043629    4.703e-03
+	   6         0.552460430401    3.209e-03
+	   7         0.552807678538    1.921e-03
+	   8         0.552828295532    6.241e-04
+	   9         0.552824576250    1.739e-04
+	  10         0.552831483857    1.022e-04
+	  11         0.552830678770    3.442e-05
+	  12         0.552831280500    1.883e-05
+	  13         0.552831260418    6.104e-06
+	  14         0.552832477702    3.439e-06
+	  15         0.552833324442    1.199e-06
+	  16         0.552833935383    5.391e-07
+	  17         0.552834160868    1.869e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 6.600e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.819681087960
-	   1         6.899835155239    2.798e-01
-	   2         7.664038983693    1.259e-01
-	   3         7.705339789575    2.470e-02
-	   4         7.705610751208    7.996e-03
-	   5         7.706340128198    1.678e-03
-	   6         7.706507735661    6.930e-04
-	   7         7.706472063356    1.633e-04
-	   8         7.706469048057    6.155e-05
-	   9         7.706466402851    1.459e-05
-	  10         7.706467448390    4.167e-06
-	  11         7.706467926070    1.273e-06
-	  12         7.706468214800    3.747e-07
-	  13         7.706468324110    1.051e-07
+	   0         5.819681038435
+	   1         6.899835092030    2.798e-01
+	   2         7.664038906396    1.259e-01
+	   3         7.705339710771    2.470e-02
+	   4         7.705610672325    7.996e-03
+	   5         7.706340049284    1.678e-03
+	   6         7.706507656739    6.930e-04
+	   7         7.706471984436    1.633e-04
+	   8         7.706468969137    6.155e-05
+	   9         7.706466323931    1.459e-05
+	  10         7.706467369470    4.167e-06
+	  11         7.706467847150    1.273e-06
+	  12         7.706468135880    3.747e-07
+	  13         7.706468245191    1.051e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 3.397e-08
 
 	Computing P_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.353071493661
-	   1         9.195708547533    2.030e-01
-	   2         9.633596615265    7.841e-02
-	   3         9.666200906151    1.961e-02
-	   4         9.663555037950    6.432e-03
-	   5         9.664006052907    1.429e-03
-	   6         9.664166436023    5.686e-04
-	   7         9.664155449815    1.632e-04
-	   8         9.664155901370    4.922e-05
-	   9         9.664152086893    1.418e-05
-	  10         9.664153957181    3.323e-06
-	  11         9.664154587680    1.043e-06
-	  12         9.664154893055    3.091e-07
-	  13         9.664155004500    1.178e-07
+	   0         8.353071500501
+	   1         9.195708553595    2.030e-01
+	   2         9.633596619541    7.841e-02
+	   3         9.666200909688    1.961e-02
+	   4         9.663555041496    6.432e-03
+	   5         9.664006056442    1.429e-03
+	   6         9.664166439552    5.686e-04
+	   7         9.664155453344    1.632e-04
+	   8         9.664155904900    4.922e-05
+	   9         9.664152090423    1.418e-05
+	  10         9.664153960710    3.323e-06
+	  11         9.664154591209    1.043e-06
+	  12         9.664154896585    3.091e-07
+	  13         9.664155008030    1.178e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 3.510e-08
 
 	Computing L_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.474769876147
-	   1         5.526295847669    3.606e-01
-	   2         6.609530180555    2.826e-01
-	   3         7.125831101786    1.487e-01
-	   4         7.367086459667    9.337e-02
-	   5         7.417232111235    3.155e-02
-	   6         7.433498205025    1.839e-02
-	   7         7.435046902193    5.844e-03
-	   8         7.434207112168    2.565e-03
-	   9         7.433995521881    1.114e-03
-	  10         7.433956521439    5.405e-04
-	  11         7.433940521986    2.026e-04
-	  12         7.434010604710    7.193e-05
-	  13         7.434031997663    2.958e-05
-	  14         7.434067355257    1.772e-05
-	  15         7.434091951598    6.997e-06
-	  16         7.434104173139    2.786e-06
-	  17         7.434107868770    7.688e-07
-	  18         7.434108079734    2.424e-07
-	  19         7.434108081302    1.112e-07
+	   0         4.474769853145
+	   1         5.526295822132    3.606e-01
+	   2         6.609530153650    2.826e-01
+	   3         7.125831079300    1.487e-01
+	   4         7.367086443196    9.337e-02
+	   5         7.417232095929    3.155e-02
+	   6         7.433498190198    1.839e-02
+	   7         7.435046887357    5.844e-03
+	   8         7.434207097286    2.565e-03
+	   9         7.433995507019    1.114e-03
+	  10         7.433956506573    5.405e-04
+	  11         7.433940507125    2.026e-04
+	  12         7.434010589849    7.193e-05
+	  13         7.434031982802    2.958e-05
+	  14         7.434067340395    1.772e-05
+	  15         7.434091936735    6.997e-06
+	  16         7.434104158276    2.786e-06
+	  17         7.434107853907    7.688e-07
+	  18         7.434108064871    2.424e-07
+	  19         7.434108066439    1.112e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 6.199e-08
 
 	Computing 1/2 <<Mu;L>>_(0.128) tensor.
 	Computing 1/2 <<P;L>>_(0.128) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.028431507933719  0.015024519180328 -0.027415915569927 -0.162886507397778  0.113254822182172 -0.064023650931690  0.055316304980596  0.030988679956786  0.002674429417477
-    1  (  1)  0.215473680254303  0.146951879885484 -0.277734064030081  0.062883278347954  0.148483123915935  0.181595053380814  0.367001371843722  0.003086313328534  0.095386404339393
-    2  (  2) -0.028492499167414  0.000076506520592 -0.059221747197113  0.071711487991955  0.074053260083134  0.055563200913425 -0.046720222778269  0.241063526706415  0.098194384215310
-    3  (  3) -0.132536698935225 -0.177581639220036 -0.107360746511047 -0.032262815899199  0.006088751294667  0.053657437577797 -0.241466578728664 -0.131962062699398  0.577380042604837
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.037029546927832  0.060461893794974 -0.005615477646775 -0.003888920206542  0.016113135271293 -0.008672229740057
-    1  (  1) -0.037058680758818 -0.084686071934143 -0.145302623884171 -0.027760832624295 -0.054555858489399  0.022009727182523
-    2  (  2) -0.087315818129461  0.399047483163753 -0.041723099752478 -0.020041920189952 -0.040600995633868  0.007777357868478
-    3  (  3)  0.035307803556741 -0.050920479686544  0.165550414172814 -0.068091463340302 -0.144062340529055 -0.042051983076328
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052065980356551 -0.081063517853362  0.006129432768986  0.163964563111019  0.188951419459760 -0.080047732466264  0.074988303081860  0.007836242506545 -0.044696302205990
-    1  (  5)  0.348085979138498  0.014814724303187 -0.054134117524106 -0.070406995762195  0.073423358836442 -0.343984245233778  0.389896180591041 -0.295068043464420  0.051928952937995
-    2  (  6)  0.021691230674299 -0.340003625622924 -0.038072452179293 -0.014533847126865 -0.084733391360494 -0.004556444515594  0.201335045135129  0.349717311230211 -0.082620936463628
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001362372932767 -0.007485730843830 -0.029474818409048  0.032209758674475  0.014108652541198
-    1  (  5)  0.209382720135360  0.066996563725018 -0.203801631001162 -0.021994746468443  0.025790645299269
-    2  (  6) -0.188199132187482 -0.086167806666975 -0.070501884768036 -0.051440727873375 -0.127552190835519
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.135226960454329 -0.626072128797856  0.189283545408859
-    1  (  1) -0.198601340506734 -0.037544167210706 -0.132449472453120
-    2  (  2)  0.054869769604055  0.126822216303605 -0.064658685102821
-    3  (  3)  0.615161980452155 -0.126204375217765 -0.081927924761018
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.135552779706607 -0.198154082714879  0.054851984676127  0.616510373253303
-    1  (  5) -0.625008803021780 -0.037782453643458  0.128063646533814 -0.126279998076331
-    2  (  6)  0.187629167441129 -0.129442737930206 -0.067422044676100 -0.079936634548172
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.904639712499451 -0.487488103200076 -0.229076194035639  0.577203417890310 -0.193643876562866 -0.103447604010490 -0.002742470403339 -0.002451788094673 -0.093813724218951
-    1  (  1) -0.150591231752366 -0.132839961398672 -0.684911223766594  0.231736797158550 -0.050522572299863 -0.177494490840206  0.234003342486174  0.124606643062300 -0.128494931356720
-    2  (  2)  0.012679732612875 -0.025746334218933  0.172509146876756 -0.235881170188724 -0.123364008457064 -0.206129657450651 -0.121800673855344 -0.114140784221077 -0.027356216567683
-    3  (  3) -0.420686741899109  0.000223888623798 -0.019382136800427 -0.199660686586779 -0.007228242971357  0.053875733566216 -0.291408914352131  0.275298575094287  0.504737487457482
-    4  (  4) -0.444479349932693 -0.097546029689334 -0.201324076119099 -0.112193453655926 -0.168730295177634  0.009510393466796 -0.073326647656899 -0.314743664834695  0.576679302947873
-    5  (  5) -0.139143305540458  0.035439861017558 -0.250210390538763 -0.395563451554525  0.287109450839577 -0.179399443391397  0.197453518892115  0.283328589948476 -0.108409713739241
-    6  (  6) -0.129858112319494 -0.067528694061774  0.181320447910016  0.198216451549469  0.101434222271579  0.004260476702610 -0.540044484893358  0.047093544204538 -0.240211227858318
-    7  (  7) -0.134029026372210 -0.177806690148742  0.066071255125305 -0.420048245168344  0.282274848902259 -0.347456793165350 -0.074406017626731 -0.307127129684507  0.001639432917235
-    8  (  8) -0.063335732549803 -0.086906710930682  0.269779701592786  0.018783692891885  0.093247017991791  0.136863024113204  0.153892981652107 -0.031577691616058  0.057553836246905
-    9  (  9)  0.014012585179935  0.032071651340396  0.006363849845329 -0.122564599853837  0.077119470960815 -0.029965581352467  0.027046636903364  0.089397837094507 -0.000802529924293
-   10  ( 10)  0.055348506435332 -0.144624122276400  0.060432277066905 -0.048567020795871 -0.074912986944558 -0.098523802539065  0.029250640804258 -0.193836130554797  0.085063532916863
-   11  ( 11) -0.167019155111356 -0.139650558475056  0.283534980836447  0.091894060309841 -0.065838077605531 -0.024336945622807 -0.227843897422644  0.001167201554402 -0.053408806911177
-   12  ( 12) -0.031974022074094  0.367173995466684  0.116713714097489  0.049340092544995  0.015070529788415 -0.072500414701037  0.058353998450091 -0.115184864373284 -0.153182495837622
-   13  ( 13)  0.015928358602524 -0.071164774172970  0.101660897809921 -0.105977026406682  0.126658664034758 -0.065056017101762 -0.035738606034781 -0.004435603298656 -0.059994356828778
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.128825974989509 -0.011693877694956 -0.146729379814636 -0.059424684705193 -0.018525365113581  0.062705489025799
-    1  (  1)  0.288526396149447  0.103129875764739  0.289919344105948  0.006241427794524  0.000597805518378 -0.002126961584359
-    2  (  2) -0.124928230102748 -0.010221797026422 -0.056571189754990 -0.103418885736763 -0.082343433199812  0.048808132756786
-    3  (  3)  0.041255915551182 -0.068310001947041 -0.078413018324291  0.150330242984032  0.179548999452936  0.040220285290074
-    4  (  4)  0.222674700983985  0.064061711596271 -0.051112895424348 -0.009318828777699  0.269456744732776  0.059360036713982
-    5  (  5) -0.030199751599662 -0.174896036167204  0.092691422408890  0.028256224393045 -0.095222992765338 -0.000984235427179
-    6  (  6)  0.000100463193790 -0.095109995484221 -0.236670455787565  0.077272409830334 -0.062627657605178 -0.003574021992867
-    7  (  7) -0.071380631315585  0.113168055430629 -0.125965816328841 -0.059330696538415  0.017157541349944  0.045135077260112
-    8  (  8) -0.578000624333793 -0.096150086854243  0.034301394867322  0.008135450733159  0.200641611845460 -0.180371714719462
-    9  (  9) -0.075918662396497  0.004599198141429  0.008112602200918  0.005143287525083  0.000284986477862 -0.012193359543266
-   10  ( 10) -0.010150745998766  0.093962320907848  0.012547284938522 -0.048325478252251  0.058041984098958  0.029299969972017
-   11  ( 11) -0.079273276366059 -0.056402585822246 -0.083755323132189 -0.007973236673640  0.003424691269612 -0.009405123180745
-   12  ( 12) -0.063303823644203  0.041869083940428 -0.019024216633724 -0.031772697856612 -0.042532243078164 -0.051259918656063
-   13  ( 13)  0.241542081048425  0.060829474159106 -0.029241791046113 -0.004754249561521 -0.057213036452335  0.050348392969429
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.902374530738022 -0.153219479021377  0.011852929174237 -0.420772110136454 -0.445657281852233 -0.142990081433834 -0.124215890045092 -0.133483278617486 -0.065282671277575
-    1  ( 15) -0.489111175456921 -0.131490362750624 -0.025259277994888  0.001430871050471 -0.096952824968496  0.035534183248533 -0.068855717941569 -0.178542279529003 -0.088180183979087
-    2  ( 16) -0.227418381124785 -0.683144902334149  0.173877572588752 -0.020414541641232 -0.199817592754852 -0.249739904936588  0.179565732929473  0.064581867916785  0.271668362709088
-    3  ( 17)  0.574685513420631  0.230755641765144 -0.236330653993451 -0.198455558262947 -0.112539659295239 -0.393276362435767  0.196125851624956 -0.416930913980481  0.017841111258302
-    4  ( 18) -0.193861200268992 -0.049521286941690 -0.123799353815169 -0.006786264808002 -0.167396168176774  0.285560945535521  0.102872968175184  0.279329859462782  0.092685860122555
-    5  ( 19) -0.103950692672536 -0.178731366743218 -0.207305979104179  0.054759646458521  0.008750479265458 -0.180116361743218  0.005850873308053 -0.346544100781250  0.135656056953800
-    6  ( 20) -0.005630218802764  0.235616494969928 -0.121418775897667 -0.289705308748940 -0.074615700944863  0.197147960229531 -0.541298908627625 -0.074766151907221  0.151080244573413
-    7  ( 21) -0.003422639573229  0.126273883662637 -0.114690954063485  0.273155566178120 -0.312791095371318  0.283606567582012  0.047453631637779 -0.310404476862355 -0.030935364545071
-    8  ( 22) -0.094384208857050 -0.130119390042033 -0.029535782736702  0.507266905754751  0.577412507794685 -0.108469543731725 -0.239044626830660  0.001740919827196  0.057806922411999
-    9  ( 23) -0.126661063777409  0.286542775287408 -0.124995270818088  0.042040769766258  0.222601161131206 -0.031774064783095  0.002289661982445 -0.069973062056331 -0.578237160301556
-   10  ( 24) -0.012316706158688  0.104097860742328 -0.011505288408996 -0.071480242591920  0.067861431955970 -0.174641527191865 -0.093323115387981  0.108845273419844 -0.094609691027850
-   11  ( 25) -0.145222688889763  0.289337733151126 -0.056602400212228 -0.078531799009324 -0.050892925184258  0.092549568885425 -0.236281405460416 -0.125802430136002  0.035465582481700
-   12  ( 26) -0.059239279504459  0.006390267291517 -0.103087074498887  0.150070392220881 -0.009342684456032  0.028289380811624  0.077066678658251 -0.059246681674569  0.008175814399583
-   13  ( 27) -0.018271401982902  0.001173845770900 -0.081596168939475  0.178729785139683  0.269264211536985 -0.095094170813457 -0.063160456524518  0.017032758007907  0.200794357953944
-   14  ( 28)  0.062542890221320 -0.002043353345753  0.048801696637924  0.040072732580057  0.059190323152548 -0.000990742681887 -0.003556361910882  0.045152229102533 -0.180550803638744
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.015123588660554  0.055493926114086 -0.169975137829357 -0.032809701818419  0.015002120333835
-    1  ( 15)  0.032575974689068 -0.144334404568220 -0.139389411890772  0.367448169822372 -0.070672349646380
-    2  ( 16)  0.006576811925777  0.060477069258309  0.284097691628268  0.117086244456111  0.102358639196809
-    3  ( 17) -0.124972828077174 -0.049265564522405  0.093111727254450  0.049489377800986 -0.106573762761508
-    4  ( 18)  0.078337257989412 -0.074315417379022 -0.066598566061427  0.015174881916742  0.127229135544739
-    5  ( 19) -0.030091617468876 -0.098524033243520 -0.024929078981092 -0.072709941383626 -0.065547640079006
-    6  ( 20)  0.028642219542832  0.029887343616837 -0.227866902460195  0.058376706970884 -0.035321371844135
-    7  ( 21)  0.087782136491553 -0.193844146817677  0.000960256633726 -0.115246048391410 -0.004217096818020
-    8  ( 22) -0.000480626398768  0.085216781964239 -0.052876715620283 -0.152779703755060 -0.059953833408394
-    9  ( 23) -0.075367737260776 -0.010279381835842 -0.080270644652149 -0.063438855793640  0.241130315879110
-   10  ( 24)  0.001339830230092  0.093599534020443 -0.056909491966955  0.041771584176774  0.060831797189675
-   11  ( 25)  0.008376396051511  0.012488344592190 -0.083677242445135 -0.018943587777834 -0.029225017366591
-   12  ( 26)  0.005096769732662 -0.048366952557418 -0.008003858722242 -0.031797935609827 -0.004752495908706
-   13  ( 27)  0.000291047131527  0.058011237654453  0.003385274769851 -0.042619295059266 -0.057154993286885
-   14  ( 28) -0.012282741908214  0.029296735642711 -0.009480582784426 -0.051319211356101  0.050295534824424
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027700885793090  0.024831013973620 -0.023766237412625 -0.167016603039327  0.109441555361099 -0.067202506902943  0.052695088582618  0.024064411648558  0.006188438734744
-    1  (  1)  0.211348759010705  0.133908962277450 -0.251856181342018  0.050198620343957  0.139035741221492  0.172926066548658  0.339110899470513  0.007367826854054  0.086633467632879
-    2  (  2) -0.033041625132306  0.014036582200115 -0.054189619432057  0.084538537056286  0.066377206996811  0.053646226488719 -0.037306526458897  0.220368264081415  0.092674869094203
-    3  (  3) -0.148568319902254 -0.152791211204353 -0.088570806082631 -0.044321874775550  0.009397298861476  0.049588338511193 -0.223116042687511 -0.123854255485030  0.553492211947825
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031010458886505  0.050729211215458 -0.003248182162608 -0.003208641714203  0.015229535075598 -0.008450459157620
-    1  (  1) -0.026218145702581 -0.073512341998455 -0.129399675880907 -0.023964582987074 -0.050019383975377  0.020539415914057
-    2  (  2) -0.075590807542000  0.365585379125664 -0.036729157945636 -0.016058134590280 -0.036438378068464  0.005536360852376
-    3  (  3)  0.037937313174203 -0.045234909961237  0.147760703126575 -0.060764535561285 -0.127333495556462 -0.038975339991211
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.051048798017959 -0.074362715758791  0.011189550347852  0.166183248293228  0.192475433446903 -0.070879824995202  0.064177194660685  0.010742342939179 -0.040136733536896
-    1  (  5)  0.352033813656898  0.019031583986232 -0.054018125678766 -0.066876079961775  0.060148226317511 -0.330348230405564  0.365124970723465 -0.284795973003407  0.051302526538107
-    2  (  6)  0.016809582021521 -0.311268516971315 -0.037661154101055 -0.006688597064538 -0.076727139945066  0.002675593746451  0.192087236696226  0.332474625249023 -0.065875996007769
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002709655241188 -0.005736834567419 -0.024459935540253  0.027202469191560  0.013148077561853
-    1  (  5)  0.191661619772415  0.061070263266085 -0.180667286312627 -0.019964047997524  0.020757203718351
-    2  (  6) -0.172312444590060 -0.078944608822718 -0.060240884585305 -0.044786922712268 -0.117310123601201
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.032597617102371  0.008188589712253 -0.013790999932786 -0.066013267343743 -0.002979179364400  0.115067560152139 -0.029904774000612  0.075658337330171  0.005135342269600
-    1  (  1) -0.415137332088601  0.400791789518638  0.060626653167993 -0.009777722957293  0.182694524485328  0.107591424113232 -0.071470092116899  0.210805299972914 -0.029640655301113
-    2  (  2)  0.731004204598520 -0.977674938020327  0.030910735141464  0.126476447646343  0.160297857646314 -0.115254107794063  0.017919423470237  0.019160269758155  0.056677210806000
-    3  (  3) -0.052710934455990  0.190825342618795 -0.121683764296164  0.058318753384800 -0.051331848225844  0.122833340921047  0.176985596744929 -0.321410474763129  0.015752780623213
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003269623449213 -0.003857954296837  0.001116934481339 -0.006268480889136  0.011819863965877  0.022338641059405
-    1  (  1)  0.026581167918671 -0.003242138995827  0.002209759168118 -0.126256065331473  0.064001666171839  0.019583311633873
-    2  (  2)  0.060541607763312 -0.048685401885036 -0.005324531906369 -0.077364982992387 -0.023160042352107 -0.131997334895641
-    3  (  3)  0.086532549077855 -0.501054912835389 -0.033953281830232 -0.045954160893793  0.007588765668991  0.026055365513597
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.018916678407922 -0.003874637131508  0.017573675069981 -0.250000468336213  0.193535227171919 -0.023949830014063 -0.006344215172670 -0.002637721142585  0.025018403626543
-    1  (  5) -0.061066900138168  0.119597101102997  0.077747477731561 -0.181802110874954 -0.105212352540637 -0.191650240311696 -0.067261595147758  0.101033231559049  0.034053487252848
-    2  (  6) -0.129779125650155  0.272168473286835  0.218088904973350 -0.105590817864479  0.170044089806049 -0.413895401404366 -0.204721805057804  0.193774792721739  0.022574107317581
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021566104304092 -0.022619515940244  0.001370551331509 -0.019480287608797 -0.016611790333304
-    1  (  5) -0.015006262168536  0.018557640744952 -0.000086080146175 -0.193359672647774  0.037991057379311
-    2  (  6)  0.020942063740395 -0.276121820896827 -0.020375408054503  0.090755244706104  0.038585932807349
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.234755470283494 -0.089757897373020 -0.029226311105252
-    1  (  1)  0.628249611487235  0.562405195056318  1.006567293279179
-    2  (  2) -1.014513658696574  0.324469533164471  0.758540603298664
-    3  (  3)  0.070695571972197 -1.217301397368710  0.544825504539347
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.235350713719763  0.628273412467382 -1.016171307500330  0.070820853933159
-    1  (  5) -0.089319079346847  0.558364917857372  0.332433157387859 -1.220987955904316
-    2  (  6) -0.028486683819977  1.000293875862972  0.767362449165329  0.543367325750415
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.804113115082476  0.859865209405978  0.271144212420722  0.233800284186400 -0.124039945960302 -0.010266323749701 -0.092708567501353  0.016778206024767 -0.004458179405382
-    1  (  1)  0.400343044462577 -0.255491137898964  1.725894952211806  0.228060869773276 -0.016813664829395  0.078025484956049 -0.010667432793276  0.508783176705980  0.007215780908188
-    2  (  2) -0.011354346714470 -0.088649218741431 -0.217285460959696 -0.271127696601060 -0.847424926486828 -0.636922641013174  0.167096970483907  0.613137270589982  0.118274978265568
-    3  (  3)  0.794199691903238 -0.188240166832123  0.221783053519905 -0.127263314849504  0.529647578782938 -1.234322959040903  0.503694754515607 -0.716759154325272  0.003713884622693
-    4  (  4) -0.401724672662203  0.338296304392140  0.027696569600284 -1.521982152310056  0.118592993377401  0.737822504259554  0.133024505198137  0.089529285352600  0.037479870573311
-    5  (  5) -0.062644206103431  0.401210407583383 -0.021849381974102 -0.715241456861441 -1.272083761860537  0.501726128250219 -0.443637757248850 -0.893021281361452  0.592660402987318
-    6  (  6) -0.010995449282209  0.203452242512905 -0.137034668384831 -0.113107359606073 -0.481513340581640  0.549194810269266  1.454087044363765 -0.104931286723953 -0.037492008681457
-    7  (  7)  0.128269755499557  0.321618430212614  0.165227456397847  0.036785042290031  0.490368577399565  0.556638814927009 -0.027991830909201  0.572834606710096  0.836617597163443
-    8  (  8)  0.028289154881459 -0.066964202719289 -0.261747148048837 -0.132206243094573 -0.099640531633427  0.125261053712928 -0.191170844521896  0.152462184420595 -0.345612464691053
-    9  (  9) -0.116917200683994  0.677293814759277  0.057457633837352  0.132537898195641 -0.004175807366595 -0.154875636337893 -0.038546773688736 -0.121822888362931 -0.349244520254478
-   10  ( 10) -0.180886604759012 -0.111792204438004  0.370617548329878 -0.010060948397306  0.175897261426789 -0.187416342815067 -0.018902126694380  0.507517994343604 -0.113620600518286
-   11  ( 11) -0.014433403132825  0.015210570936209  0.010143344331716 -0.005691229002309 -0.031059326071816 -0.023288546292970  0.128101332902295 -0.039392944850365 -0.110920114561223
-   12  ( 12) -0.125268954735601 -0.096735894811095  0.052480306210840  0.258243594453840  0.005805250173734  0.145107299027993  0.116452856795828 -0.074374807730486  0.022119923916482
-   13  ( 13) -0.016491827683000 -0.002316794514604 -0.087971851878040 -0.101325911412249 -0.036377238947136  0.195278206944885 -0.010131352705033  0.009611107176441 -0.056274461553023
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.020619978804336  0.055393926260187  0.016493468301721 -0.100372381621025  0.100626242248385  0.085758294302206
-    1  (  1) -0.158166323997471 -0.302157830906837 -0.003244540958725  0.141116982835112 -0.086717578223953 -0.004480871143073
-    2  (  2)  0.117237563107159 -0.174570847573259 -0.011204345589108 -0.263173432731341  0.005218532196564 -0.028842080195291
-    3  (  3)  0.116941646649189 -0.002586479599499 -0.011231548488132 -0.058984655279808 -0.019822661982984  0.041048882280058
-    4  (  4)  0.050776820640492 -0.220908341720040  0.039982596283606 -0.028513186801397  0.038501560477761 -0.072498198103566
-    5  (  5) -0.020348029264266  0.163764941111612 -0.082946711645337  0.111452654944128  0.037984566239181 -0.107199595568986
-    6  (  6)  0.021256126103379  0.388694787591390  0.114910007821006  0.018804713347374  0.008937619959600 -0.015873506672536
-    7  (  7)  0.297925323013482  0.033191669222652  0.094278199439545 -0.060174035263233  0.021406855727383  0.043089336483829
-    8  (  8)  1.538149876661748  0.255388094594388 -0.163312643003206 -0.034677585072596 -0.142125228818852 -0.045738087971663
-    9  (  9)  0.091443541252263 -0.031128123891510 -0.061982026707845 -0.058678185009713  0.760839955512426  0.950617857123983
-   10  ( 10) -0.067301877513073  0.211057800702045 -0.020603819563676  1.234407038988020 -0.163795705022985  0.167535211420867
-   11  ( 11)  0.163445976328785 -0.060082779666638  1.332811809287810  0.048638214648072 -0.084741484840249  0.093756111599780
-   12  ( 12)  0.205948682024844 -1.200679744036826 -0.135474810029670  0.365861100667224 -0.094093662797851  0.008686523394777
-   13  ( 13) -0.181605938452019 -0.042014918886121  0.112406427108198  0.222953862798531  0.995139187403178 -0.917632565321793
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.802008727902676  0.406135528069464 -0.010476316014009  0.784475556802925 -0.394386683091379 -0.066798881058913 -0.011980564813184  0.124376056524327  0.033526134230615
-    1  ( 15)  0.862028914432798 -0.259382739909270 -0.086667305572556 -0.180064784220824  0.329908607377610  0.399964089565218  0.202187771096648  0.330121816685668 -0.071953120874649
-    2  ( 16)  0.271307809960556  1.724790149840180 -0.218446172710940  0.221581282093097  0.027552874986014 -0.019301351758279 -0.136156749402974  0.163711145289557 -0.262315292158515
-    3  ( 17)  0.233832160360352  0.228075923415961 -0.271855585595643 -0.127498943532479 -1.519236751765249 -0.714946933274063 -0.112783303905572  0.035742190545400 -0.131799331720385
-    4  ( 18) -0.125884857507763 -0.016503178327094 -0.848590316809874  0.528676059271103  0.118589942995782 -1.271521009941038 -0.481050683706501  0.489094666232462 -0.100427993377482
-    5  ( 19) -0.011410411929745  0.078504916539371 -0.635756927956321 -1.233330464680106  0.737249034134023  0.499445190730480  0.548364048058884  0.558640131287018  0.124411035854046
-    6  ( 20) -0.091600083261379 -0.011874324392688  0.166095509172862  0.503931355593045  0.132971166339029 -0.442847331045808  1.455101200236588 -0.028340512672182 -0.190421039545484
-    7  ( 21)  0.014506888035513  0.509793857361997  0.613540224928976 -0.716635769138246  0.088503909894013 -0.892421715175110 -0.105643577538776  0.572215069358599  0.150576387127195
-    8  ( 22) -0.004177720337585  0.006709815498361  0.117678875953393  0.003186946250580  0.038303116431615  0.593619431704741 -0.036920385902422  0.835672825510649 -0.345283877638179
-    9  ( 23) -0.021586239236066 -0.156869719857391  0.117889758366706  0.115161423657162  0.052238225817572 -0.022709102193988  0.020562459070751  0.298677779552442  1.538509512042474
-   10  ( 24)  0.054682068155322 -0.300070995804169 -0.172660016100411 -0.004680568559172 -0.221321821680690  0.163619483231716  0.386948477906845  0.033115261343835  0.254769962308442
-   11  ( 25)  0.016488293849114 -0.003235639473042 -0.011174682028037 -0.011243945686257  0.039809588242799 -0.082761513420842  0.114884412151977  0.094200391738445 -0.163393716854439
-   12  ( 26) -0.099231335638990  0.141112668735458 -0.262446613088940 -0.059563147663723 -0.028574452319685  0.111394864273785  0.018513759386789 -0.059760408126138 -0.034040397389902
-   13  ( 27)  0.100244162906012 -0.086825753516494  0.005142496829835 -0.019052879526336  0.037887085038889  0.037954868269104  0.008919579926839  0.021672382001860 -0.142649674386495
-   14  ( 28)  0.086046561377276 -0.004744302368676 -0.028249738219529  0.042030603060909 -0.073561648753534 -0.107720217983957 -0.016217142075148  0.044341471770554 -0.046187444393712
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124233708134524 -0.184518326175241 -0.014667753095383 -0.126540650902724 -0.015843433752182
-    1  ( 15)  0.686899770278225 -0.109692117003678  0.015377495137089 -0.096723489130419 -0.002397757787942
-    2  ( 16)  0.057205529179578  0.372042133273666  0.010210131259620  0.052160697899357 -0.088271643130929
-    3  ( 17)  0.131871345108673 -0.011180948360743 -0.005727193367058  0.259941586635743 -0.101614450210782
-    4  ( 18) -0.005079597151441  0.176830214271515 -0.031032942109520  0.004628941737829 -0.036366477592845
-    5  ( 19) -0.153488339566637 -0.188246645479869 -0.023332293508375  0.145173541284822  0.195552538719584
-    6  ( 20) -0.038666420291799 -0.018333798481476  0.128217423491274  0.116258211557263 -0.010271886085243
-    7  ( 21) -0.121961409061181  0.508144909444715 -0.039497933150391 -0.074911313979370  0.009738174256592
-    8  ( 22) -0.349752281191330 -0.113379050365496 -0.110884161439947  0.022227055299984 -0.056428042287631
-    9  ( 23)  0.091274387643073 -0.068482004342729  0.163392525285683  0.205701365643175 -0.181416453396984
-   10  ( 24) -0.031494844080999  0.210984913522458 -0.060264440706329 -1.201297108840472 -0.041823116964630
-   11  ( 25) -0.061998986866118 -0.020468588707436  1.332808723106094 -0.135556576828281  0.112406197562940
-   12  ( 26) -0.058487448549072  1.234274465594829  0.048631105388928  0.365854082846019  0.222962926250735
-   13  ( 27)  0.761200546740672 -0.163618812251219 -0.084738989433889 -0.094122389252772  0.995165590894077
-   14  ( 28)  0.951772998269747  0.167560207344577  0.093759874796889  0.008708619204375 -0.917569948681374
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062431637468593  0.002416441043502 -0.004633709181853 -0.077570764564644 -0.013832459901153  0.123710471759642 -0.027165779035152  0.071044010954106  0.019658423662045
-    1  (  1) -0.407170389584207  0.333069478291504  0.076649076907715  0.002175328366486  0.197922707135412  0.117656968282773 -0.067757706616657  0.182812175438104 -0.031734247883933
-    2  (  2)  0.673185035517364 -0.888138019247633  0.034358376579768  0.125358507387098  0.172994941404750 -0.106755581181878  0.013852200121285  0.009496870454365  0.036809619943040
-    3  (  3) -0.040742790622464  0.181389056204803 -0.117008669682237  0.012401302848610 -0.022196391591020  0.102862126461667  0.166049221641567 -0.310434511631989  0.017146561969842
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.010530607294137 -0.003710118206635  0.001098184033274 -0.004177259623775  0.010641720243898  0.020819711535909
-    1  (  1)  0.026376312845794 -0.003084063695378  0.001935075690030 -0.112197866496257  0.055637648529143  0.022260912302157
-    2  (  2)  0.054059905057588 -0.043789787513272 -0.004472231165835 -0.071437136436271 -0.024456749693059 -0.126350825107537
-    3  (  3)  0.083331116085336 -0.461426302980743 -0.028171699513186 -0.043194879139585  0.008942983333376  0.024389199674006
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.021216263100624  0.005003175055611  0.013535160841110 -0.263704651382069  0.210918804180354  0.005688291976377  0.005207710700420 -0.000895282201931  0.031550648985105
-    1  (  5) -0.080441383224434  0.123194069685476  0.057717422634421 -0.198323986141409 -0.141861353254402 -0.184709849630280 -0.056481718890564  0.088971412091769  0.030305733467363
-    2  (  6) -0.146541148918456  0.264369470289011  0.161465568338032 -0.083507608614794  0.171726934895348 -0.400382872983885 -0.201596935132391  0.184414767198936  0.015497227351117
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.010467742288235 -0.019463191825823  0.001308339278104 -0.016880359740534 -0.016885157913524
-    1  (  5) -0.009224792466209  0.019323723500934 -0.001197784436253 -0.171358632107000  0.032143333569082
-    2  (  6)  0.022721945593511 -0.245666385556987 -0.017093671892173  0.084713974597813  0.032963157176325
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130521806 -0.064555152855150  0.195953381503074 -0.041248493404101 -0.011229686922118 -0.030149441468389 -0.052245051042507 -0.006640144591450 -0.060816046803629
-    1  (  1)  0.618380750339701 -0.527850820452489 -0.215416501468042 -0.157035437820978 -0.069798458053206  0.063297476854315 -0.224803808806328 -0.036770088857857 -0.093292414355450
-    2  (  2)  0.089963765220201  0.016694193855691 -0.049894217028077 -0.224500363636593  0.100545586935602 -0.339808932362407 -0.300486601785008  0.103978674940020  0.003854593986179
-    3  (  3) -0.017912540893906  0.240051544179780  0.016875920141062 -0.019658112757037  0.000950481978191  0.139486307895354 -0.307526295494235 -0.245045411721377  0.038982174459016
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228151715 -0.053483299255778  0.001461399819935 -0.009996127160186  0.040844890766482
-    1  (  1)  0.010356156252337  0.045196494943178  0.123149462829325 -0.009608799091532 -0.092775098416542
-    2  (  2)  0.068261626755321 -0.266621644473694  0.090983468547793 -0.007824999539039 -0.015479677414574
-    3  (  3)  0.102991688131891  0.095940846129218  0.235195882789532  0.030438278876707  0.100331913639094
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713065252  0.055002400477820 -0.190701615134350 -0.008587073556999 -0.137456634337686 -0.102685174742854 -0.038575707278163  0.049077773985903  0.038775520871493
-    1  (  5)  0.266426121061197  0.201904502527540 -0.404472747743452  0.112355452346377  0.244543383067891  0.203488255110601  0.093346083766343  0.046662175778558  0.162564534078692
-    2  (  6)  0.310200495971193  0.275860886663895 -0.334362481171644  0.111323203428054  0.107269573508054 -0.015396505983498 -0.485347827861586 -0.115211810541092 -0.189399381355332
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448661083 -0.010182782856370  0.015536223735827  0.027148068637771  0.019304531582391 -0.012170541889264
-    1  (  5) -0.076359104752405  0.072719944885937 -0.105706045053704 -0.076791075572625 -0.095250630872875  0.044053081318692
-    2  (  6) -0.023401555368550 -0.060789750773997  0.233844071164904 -0.060200608258467 -0.022972229731698  0.078966373846355
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134464733238505 -0.662210405494710 -0.268087036060520 -0.078995101665645
-    1  (  1) -0.664136191142175 -0.208512216408344  0.147227682691111  0.068768195668233
-    2  (  2) -0.267178832853329  0.148347614169083  0.187155712816505  0.001725942570582
-    3  (  3) -0.077975712094607  0.066243031692251  0.004079617492315  0.013944312169831
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274618126592083 -0.278113702179192 -0.671633022270393
-    1  (  5) -0.277949145712574 -0.011863615919937 -0.010374435234627
-    2  (  6) -0.670048686168263 -0.009476206950281  0.097890068097075
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959494414290863 -0.408191876587327 -0.490587797784240  0.038620088951639 -0.077925870525908 -0.487449819239226 -0.107605742375965 -0.396082210854085 -0.237542456199032
-    1  (  1) -0.404346098969015 -1.325089706115945  0.174671472615795  0.248857938939654 -0.197997176299344 -0.317531715369510 -0.251443125494019 -0.030205216051526  0.632709778669922
-    2  (  2) -0.488203594414096  0.174177358170181  0.686637133275358  0.342440322128134 -0.009976595906060  0.483509687591480  0.287263685741040  0.302820486761619 -0.272146504988732
-    3  (  3)  0.037519851932744  0.250891430235972  0.345028453615760 -0.288802596502157  0.242048997262005 -0.302155533583566 -0.510767048111895  0.184742116191421 -0.216988138473829
-    4  (  4) -0.076335128439655 -0.199690457337249 -0.011287590259897  0.242287343472375 -0.131826185478723  0.385784652335424 -0.241579744319049 -0.375155233716569  0.062534851979750
-    5  (  5) -0.485786339572480 -0.319069045647666  0.484028655874751 -0.298894130368339  0.382592029688619 -0.557110750088232  0.333239304019222  0.111824333667385  0.019820080095697
-    6  (  6) -0.105004388042450 -0.251919494300284  0.289657780268665 -0.510934745583747 -0.243423593715404  0.333487274729421 -0.859815579894716 -0.040189411214490  0.015976724219770
-    7  (  7) -0.396742866204475 -0.028527583501468  0.303542401120437  0.181332247012458 -0.373287106593945  0.109028339876173 -0.042483577229020 -0.424450995877430 -0.165337209178976
-    8  (  8) -0.232477111217568  0.628541780993326 -0.273469783503661 -0.217890852518759  0.061988654737634  0.020919866007563  0.015643111904890 -0.165546891359501 -1.139952791754352
-    9  (  9)  0.005546163403777  0.056122031350978  0.162961042742066 -0.082482781173148  0.072908205250711 -0.108799436968507 -0.023533780380778  0.044777427042681 -0.147235448199837
-   10  ( 10) -0.006901975709222  0.054429650490004 -0.040577693872421  0.341755839709625 -0.179734725561089  0.323402736691826  0.128204737160702 -0.274641710567075 -0.052505646555500
-   11  ( 11)  0.095370531310643 -0.102133079874740  0.068438122875491 -0.163729824989551 -0.155636229704599  0.243225496644137 -0.456632637964522 -0.005300419866762 -0.049825612054664
-   12  ( 12) -0.031656876480324  0.049261490140928 -0.071615793822912  0.132066208561300 -0.108599421258577  0.096544859699582  0.079601642520223 -0.086582876221009 -0.054558080822574
-   13  ( 13) -0.055177843918689  0.125972146875366 -0.045925897173261 -0.019932953437905 -0.072414580136130 -0.032514397877207 -0.014074648780379 -0.073540469649077  0.566252900794774
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006844108037305 -0.007417708485432  0.096179215271909 -0.031845351907952 -0.055819107034905
-    1  (  1)  0.055009072408372  0.054764569974465 -0.101360748266647  0.049483066032708  0.126311659941349
-    2  (  2)  0.163126461717715 -0.041474056730542  0.069773970511485 -0.071604513134729 -0.045921679797623
-    3  (  3) -0.081145867550878  0.339512714763498 -0.164814632361136  0.131963409806733 -0.019701057447459
-    4  (  4)  0.071392957638917 -0.177541925322340 -0.155855587434776 -0.108549913772844 -0.072788709838574
-    5  (  5) -0.105620913909823  0.324570384536922  0.243426148668966  0.096676164465062 -0.032493241135613
-    6  (  6) -0.022622971576123  0.128555788054646 -0.457558865820389  0.079424640656347 -0.014304063550758
-    7  (  7)  0.043872369029000 -0.277428590499607 -0.005167508600307 -0.086808599804727 -0.073543295023523
-    8  (  8) -0.147656701585296 -0.051770671721883 -0.049464276722939 -0.054622357068261  0.565518286432945
-    9  (  9)  0.072058098581738  0.045414939179581  0.010276622684317  0.009607329011719  0.026546654266797
-   10  ( 10)  0.047972578248001 -0.139091273135487 -0.006969817312947 -0.101924439794117 -0.021963395913837
-   11  ( 11)  0.010225949518788 -0.006903254834441 -0.093461448932079 -0.006458623521931  0.037408632154768
-   12  ( 12)  0.009659072763445 -0.101989750292791 -0.006543886552569  0.055499957258899  0.004536647288292
-   13  ( 13)  0.026525022859872 -0.022073627181822  0.037503294944025  0.004573821056446 -0.064450805660415
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.531729549886336 -0.787699013260711 -0.218007437963115  0.182768764967355  0.602768885926282 -0.199812958117875  0.029032839745446 -0.008774056557020 -0.142478600997377
-    1  ( 15) -0.793340915328507 -0.320131124132642 -0.162653978535479  0.058649157291271  0.020639907683380 -0.223525268439364  0.107699068558597 -0.353783645623565 -0.095871343640249
-    2  ( 16) -0.212191388052973 -0.164888118017383 -1.296946785661586  0.042300146112855  0.273826728839961 -0.438781481182550 -0.122091204716331  0.097191959044978 -0.140871391153818
-    3  ( 17)  0.179719553134575  0.058669914491576  0.044506714025033  0.293003077614387  0.349110568675538  0.303215667162520  0.076915097449359  0.005807473712119  0.013837821467220
-    4  ( 18)  0.599360800493505  0.022132908209847  0.274035423937645  0.351223850237559  0.210864723100271  0.044675310303964 -0.438675626813631 -0.490920343842280 -0.399212333009756
-    5  ( 19) -0.200407898503427 -0.221431932840866 -0.440102897905119  0.305762109213035  0.044881546181680 -0.117472965844256 -0.191665223291193 -0.319783714572763 -0.359452162382458
-    6  ( 20)  0.032165821117665  0.105941691907444 -0.123879210125596  0.078979233990767 -0.440650088275849 -0.189889145121464 -1.110705925194973  0.246906737793532  0.255259757334054
-    7  ( 21) -0.008321241705322 -0.354528191467819  0.096628486245017  0.006334262611286 -0.491255100347697 -0.318969662674755  0.247541587785853 -1.005004062277624  0.329386657154203
-    8  ( 22) -0.142962699223523 -0.097023037413530 -0.141097052846409  0.015166149439238 -0.401326717044742 -0.359426368362030  0.255258622579642  0.329097335449191  0.052132117322068
-    9  ( 23) -0.219955098740499 -0.249965476004892  0.576414624728276  0.098982863369343 -0.020508824733562  0.097549190747026 -0.059941456738195  0.014715712854362  0.155030958604457
-   10  ( 24) -0.078889746445527  0.108239301318897  0.027162587747058  0.046514963820383  0.091370815063919  0.113422647703527 -0.170202961400925  0.302110584863863 -0.032804637243869
-   11  ( 25)  0.043306270957026  0.032344455295712 -0.179576712827780  0.107307667430552 -0.187560546689518 -0.097222488608923 -0.510712264729798 -0.080025590477581  0.081254866792341
-   12  ( 26) -0.068084805818493  0.217394768160213  0.162482224135843  0.182198793902355 -0.078588038008432 -0.138375144701558  0.045964808967518 -0.318369645237641 -0.094340949188741
-   13  ( 27)  0.012776338365628 -0.163304628586267  0.065170181095061  0.076353862355042 -0.116471236774195 -0.057100568669669  0.002733328139538  0.275543901650377 -0.101218272889569
-   14  ( 28)  0.072542900570939  0.116082117753815 -0.039461901860544 -0.060056679393734 -0.063442716501357 -0.039954821491213 -0.007431183194753  0.061660754619166  0.127196734189517
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223424944652205 -0.079375640508214  0.044559638332807 -0.069603179695816  0.011608492724546  0.073681298891784
-    1  ( 15) -0.252190810534113  0.107773105664066  0.031929727381877  0.217773765514473 -0.162942254516887  0.115583488493233
-    2  ( 16)  0.579669499848566  0.028398284174976 -0.180764151357445  0.163082238678478  0.065318137383573 -0.039861277950853
-    3  ( 17)  0.098419070380167  0.045497640187089  0.108888066901941  0.182679251676306  0.077063420292993 -0.060270475148176
-    4  ( 18) -0.021657152218187  0.091391477818870 -0.188694941835267 -0.078654463992964 -0.116917635244834 -0.063687461311406
-    5  ( 19)  0.097200061293753  0.112946819841992 -0.096557046310024 -0.138722208764681 -0.057492822647808 -0.039657945432959
-    6  ( 20) -0.058061983715333 -0.170140847494680 -0.511516651549457  0.046153385708912  0.002608094185220 -0.007424017797983
-    7  ( 21)  0.014898598107653  0.302204656416846 -0.080604696411276 -0.318409184220321  0.275439068186140  0.061680442175976
-    8  ( 22)  0.155158381420886 -0.033182129585344  0.080993013335585 -0.094077880752310 -0.101045740908416  0.127069446713644
-    9  ( 23) -1.153500606432321 -0.223848574870770  0.084940142762237 -0.000172697505786  0.401118128913110 -0.346039941954426
-   10  ( 24) -0.224004522828896 -0.014993374950362 -0.013190820033297  0.067266852084061 -0.009898419000692 -0.084301934906628
-   11  ( 25)  0.084246516406395 -0.012971453666469 -0.099638608783541  0.005049425073667 -0.012239639402266  0.023058100761840
-   12  ( 26)  0.000190360752578  0.067412521796060  0.005072007098540  0.014663156532777 -0.012615786454228 -0.021995005158495
-   13  ( 27)  0.401506800485792 -0.009668467136178 -0.012313296328665 -0.012645382168427 -0.008180220628749  0.091135079144539
-   14  ( 28) -0.346436667192449 -0.084407881559674  0.023159285170774 -0.022057721310478  0.091092458906105  0.040126683454989
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057778460125472 -0.058621598376460  0.204961973610432 -0.030014886957090 -0.012702201238060 -0.012361806840327 -0.042464722570110  0.000589178332859 -0.053783176425630
-    1  (  1)  0.588150716074127 -0.466021636272277 -0.203183245475034 -0.148450737716235 -0.057365952908249  0.049828198627842 -0.211650340717439 -0.033709163320866 -0.066014023276544
-    2  (  2)  0.097096715428359  0.013316869335678 -0.075592001791479 -0.184144455632625  0.076454331448205 -0.322693901417435 -0.283033300411692  0.095787940086183  0.009135557725688
-    3  (  3) -0.012585457310347  0.213693355283453  0.008392879074061 -0.006477176275196  0.025095812734807  0.122050564721420 -0.287478867297995 -0.227752050770291  0.025535574433445
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004343658462411 -0.045416781087738  0.000353809954908 -0.008814420994646  0.038608153091639
-    1  (  1)  0.012371345270909  0.037357699916557  0.110010051271464 -0.008428651261313 -0.087698412018729
-    2  (  2)  0.059734573261686 -0.241104936943562  0.080654968743400 -0.004302203609175 -0.010690545484548
-    3  (  3)  0.093269555935925  0.087251850932647  0.210582632378021  0.029543407964617  0.092601662289161
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.096268685878254  0.067598109905927 -0.171831816211853 -0.019892225326838 -0.151432830345480 -0.102828613678833 -0.031328453208212  0.054857782228207  0.045391983457322
-    1  (  5)  0.259548823811751  0.185158249821503 -0.361847535039694  0.121706180799256  0.214912924418858  0.198674927692151  0.082249065771632  0.046754216202716  0.144894234012036
-    2  (  6)  0.316675644828396  0.241534850892174 -0.298024592816770  0.095120602156107  0.117908244615366 -0.011781114685607 -0.451417780640775 -0.113394265201573 -0.193663841427175
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.075217766018101 -0.009009066779016  0.013059078733353  0.023267742031501  0.019382631456242 -0.010439549922317
-    1  (  5) -0.055615787731079  0.073750137089777 -0.094740835467118 -0.066906556461928 -0.087569521638075  0.039832146294917
-    2  (  6) -0.007989421944937 -0.055545532554459  0.206332460425464 -0.056516118698086 -0.025725290779723  0.073743491663517
-
-	DPD File2: P*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.034398581574139  0.022991789103343 -0.034442469541574 -0.330456382558595  0.233180601662081 -0.129080132683952  0.099470500295552  0.033215263141241  0.017533788887759
-    1  (  1)  0.125193963201420  0.094056863638828 -0.250103765613866  0.112936578244967  0.149788194818876  0.227437707997397  0.485204338670596 -0.001668370995162  0.115356975205661
-    2  (  2) -0.012233240715705 -0.002368950907699 -0.032425209658723  0.111084203408140  0.039672156088148  0.068595430902717 -0.075952847158656  0.294199045975953  0.119345992966551
-    3  (  3) -0.102558388937001 -0.078769752966251 -0.070643800093594 -0.002465923506388  0.048634367995697  0.013847332731639 -0.279588501721531 -0.161409573415975  0.750269595437933
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.124162189892697  0.147322676383198 -0.023215723712951 -0.018481088431889  0.062726537287574 -0.032176124900128
-    1  (  1) -0.077900000614672 -0.192270763412161 -0.391012068764259 -0.097598573976617 -0.208812184695007  0.131278202406216
-    2  (  2) -0.138682144513485  0.743794268000919 -0.082765968014440 -0.105416894706173 -0.124502895186539  0.026640226681012
-    3  (  3)  0.046377167184700 -0.100266413297349  0.419637942135347 -0.187251279348108 -0.523906963118894 -0.155125602890936
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.041912647030473 -0.112025419050593 -0.015709063071357  0.296474982770456  0.369528478363753 -0.133936885862951  0.093834818402243  0.023683854572816 -0.145081231878617
-    1  (  5)  0.197308914804751  0.009979277982960 -0.032584585136142 -0.110675051536769  0.043528206747949 -0.380347857156503  0.467872633414304 -0.360690381381106  0.081727457648454
-    2  (  6) -0.017175555719515 -0.257070166950214 -0.064576654101859 -0.063636492651100 -0.124214525851134 -0.043707573882425  0.279300768930124  0.436090246737450 -0.143049583009588
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000746191936210 -0.015117415730589 -0.105376277097060  0.086551013225984  0.048055402355572
-    1  (  5)  0.421110018244562  0.132676872543725 -0.513327593087781 -0.036293567607712  0.089362635661765
-    2  (  6) -0.356450473386590 -0.161425142060580 -0.191834100484274 -0.123847982073522 -0.439997591973663
-
-	DPD File2: P*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.029996182749086 -0.414832297711576  0.157003165507011
-    1  (  1)  0.055478735634457 -0.002196588374944 -0.023132699054813
-    2  (  2) -0.030157480407918  0.003965129810969 -0.011365271034479
-    3  (  3) -0.379654970672918  0.026306776079243  0.008208478993038
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.031312576109208 -0.054324731747600  0.030004942403624  0.379837271496892
-    1  (  5)  0.410777629523562 -0.000546200526033 -0.004395778687124 -0.022468424749377
-    2  (  6) -0.155134874665963  0.021960972132954  0.010503724381488 -0.005891989839471
-
-	DPD File2: P*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.041599393589885 -0.048291903336677 -0.117743150821259 -0.017705215406280  0.102750295559090 -0.051687934108131  0.132725758102637 -0.024528471901836  0.009589411271459
-    1  (  1)  0.072748330347250  0.064838255172247 -0.046249888316539 -0.094886169756313  0.054353256296636  0.001900039815832  0.496484885699642  0.156782601344965 -0.027727244644896
-    2  (  2) -0.003177839573369  0.021969851213782 -0.169948604805852  0.034169379981814  0.096419218256700  0.054353168415603  0.268581512702098  0.051387229616377  0.132183241821031
-    3  (  3)  0.006137248486677 -0.083042433269493 -0.145748994350269  0.009514642471795  0.083396174376552 -0.050339592310292  0.147508653266551 -0.025994438523140 -0.274243623684456
-    4  (  4) -0.041743411936218 -0.025314466729841 -0.109116009514395  0.054695145126701  0.041005429820194 -0.040692158860824  0.089212628083091  0.089778026874393 -0.379559976718284
-    5  (  5)  0.144052404015687 -0.020202343348371  0.250448180839798 -0.333938875810814 -0.025165926872358 -0.198674007872287 -0.028751096000422  0.150673278776424 -0.071892589434733
-    6  (  6) -0.035008068923664 -0.061157292133481 -0.423122850397629  0.168586232676417  0.215300951076719  0.176816011547681 -0.082786884188413 -0.107997254201703  0.322302818265947
-    7  (  7)  0.040302039339094  0.134662805884699 -0.074305590729076 -0.347285947244785  0.297150726695267 -0.120577275637125 -0.158244548193724 -0.221247160594885  0.027161970952188
-    8  (  8)  0.102303986757075  0.083520013523575 -0.381308184856285  0.143001282615579 -0.075527648534131 -0.132398234942646 -0.075131991247111  0.046753082020740  0.011707789197025
-    9  (  9) -0.017637489191487 -0.048428952825929 -0.034610320117865  0.459992261564512 -0.414982694469193  0.130318968246814  0.031074590688744 -0.007719514803475 -0.025148594805028
-   10  ( 10) -0.073180570141060  0.217870134214265 -0.063234912206834  0.261216160873510 -0.027363003829309 -0.069320876175761  0.042163326174403  0.184139514400861 -0.015591773535866
-   11  ( 11)  0.219122634582937  0.188385339460405 -0.640855359878310 -0.491678336416958  0.065767561519751 -0.413066703397514  0.291084239981445  0.093425757726901  0.193265915162178
-   12  ( 12)  0.256885363420365 -0.713325451456200 -0.225955555841318 -0.439590507884674 -0.345303095230338  0.616947103758895 -0.172377723246676  0.152457697169388  0.041630471494425
-   13  ( 13)  0.012167367476476  0.157114215675033 -0.156454629287810  0.271295067840173 -0.465831347294122 -0.087124608448573  0.001414398542050  0.117289965933426  0.301481262964454
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.150893623694895 -0.070181619718899 -0.231121270771796 -0.047212329811452 -0.038360068214684  0.065024101530573
-    1  (  1)  0.459608701558993  0.017988718780734  0.620163221664037  0.047501992394079 -0.054935480129094 -0.084306620301789
-    2  (  2) -0.170353437709830  0.137438184253801 -0.448066510819233 -0.273677026815508 -0.394525740926135  0.158445088257267
-    3  (  3)  0.027380670374415 -0.505626164435732 -0.414944314617527  0.268646310616022  0.386727191221954  0.113140672337300
-    4  (  4)  0.013445627632877  0.536383433584967 -0.308426011289951  0.080146650927920  0.587918144857996  0.127182537475191
-    5  (  5) -0.035132080582143  0.167243745339779  0.093457222254525  0.023174375055702 -0.241438836836271  0.025034069681694
-    6  (  6)  0.086275759818652  0.157794617049890 -0.091627759449496  0.100678024828998 -0.039930496632404 -0.039747117277017
-    7  (  7)  0.064055657553950 -0.320525847624377 -0.102126662685902 -0.025362375541365  0.011829791315064  0.091201427043929
-    8  (  8) -0.004186527107181  0.116906210612177  0.371187985035768  0.069143142950027  0.337550034775452 -0.350111866606547
-    9  (  9)  0.075561519107680 -0.174471452153015  0.018361558412792 -0.007353276651567 -0.041439267169245 -0.006958189017632
-   10  ( 10)  0.027806429179180 -0.167045135107807  0.001907984997949 -0.011283070546443  0.060669265876427  0.055774837261520
-   11  ( 11) -0.242522311612009 -0.043113021308048  0.036594154697736 -0.051685667595428  0.018454723698115  0.000828881346793
-   12  ( 12)  0.005035323729735 -0.080726831317060  0.052335499542956 -0.044973984976305 -0.061396486662391 -0.099208229191671
-   13  ( 13) -0.438941651704024 -0.153468022162067  0.023659734102045 -0.002885107851831  0.071809885174399  0.077694612962715
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.044666447845943 -0.075416998324096  0.002009211971351 -0.008745765947599  0.041041980388066 -0.148478826412725  0.043148497905126 -0.040061402921621 -0.101604386418633
-    1  ( 15)  0.049162162504633 -0.064892835130685 -0.021916980092655  0.084534607702244  0.027746026910093  0.020171890051146  0.060412253106789 -0.135461490072396 -0.083108283525263
-    2  ( 16)  0.115794665664267  0.047097729608731  0.169526813418150  0.148848835873427  0.110367886513380 -0.250308022536814  0.421430914373290  0.072716285234647  0.379882079141591
-    3  ( 17)  0.016234704461670  0.093143898198671 -0.032604929784834 -0.008570214748756 -0.053618454434530  0.336390621280297 -0.171051246725478  0.351382500390790 -0.144302708365158
-    4  ( 18) -0.099685614405052 -0.053576457156830 -0.096408379043871 -0.083491653355765 -0.040031855455092  0.023231985357187 -0.214146456651999 -0.299411639286517  0.077061465722781
-    5  ( 19)  0.053256491006665 -0.003075384449121 -0.053515222726753  0.048399268191864  0.040795198256978  0.198132545540493 -0.175051498642490  0.121535923725232  0.133335441765840
-    6  ( 20) -0.128712692365555 -0.496870742485916 -0.268871209763746 -0.149658569303091 -0.086711112842081  0.028977130072006  0.083484855541891  0.156340017572166  0.079418276499146
-    7  ( 21)  0.026401094602506 -0.157512598855912 -0.050672592676314  0.027957891435237 -0.092269588876111 -0.151809482826698  0.107865561412261  0.222862187720663 -0.046783186727291
-    8  ( 22) -0.009612639390837  0.030421923009696 -0.129146467815306  0.272344846639473  0.379884587515890  0.072760001001148 -0.325598038741842 -0.027479294568787 -0.012294936872080
-    9  ( 23)  0.149880437140593 -0.460631247362792  0.169664291741312 -0.027589402289004 -0.011349753598096  0.033685842546708 -0.083139401924745 -0.064655346261025  0.002952710962413
-   10  ( 24)  0.073162117570193 -0.020016390706408 -0.135536511029942  0.511692353689708 -0.542889881863847 -0.170172745263858 -0.158312356422075  0.326976851708720 -0.119792799568885
-   11  ( 25)  0.227319331530806 -0.618159967248025  0.448267162037961  0.415380348389647  0.307673615218558 -0.093264262201907  0.090383721735685  0.101137463170207 -0.374119595658697
-   12  ( 26)  0.046325835806633 -0.048013260965168  0.272519638024099 -0.267929097643861 -0.079599126690116 -0.023217992764788 -0.099878544648145  0.024929139459656 -0.069393891025270
-   13  ( 27)  0.037489883688669  0.053493928653226  0.391870980933739 -0.384400627963214 -0.588279019279798  0.241045539088516  0.041562667530972 -0.011794273471007 -0.337810411804872
-   14  ( 28) -0.063867435849832  0.083549153123607 -0.158471290677241 -0.113540200875422 -0.127048928726566 -0.025106714900888  0.040372191298617 -0.090932947916166  0.351148385967210
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.018436133716857  0.072929640795625 -0.226474353889952 -0.258554501885766 -0.015629581468102
-    1  ( 15)  0.048844627710976 -0.217699525631316 -0.187612863297424  0.714214561739857 -0.155652904029163
-    2  ( 16)  0.036504178760377  0.064141704639546  0.642298500392749  0.226999184132633  0.158883513257702
-    3  ( 17) -0.464003802662343 -0.262951360765947  0.494608205306355  0.439690590633845 -0.272979507733357
-    4  ( 18)  0.417911613304926  0.028340434910992 -0.067656000741894  0.345749519725828  0.467548326168384
-    5  ( 19) -0.131287835524258  0.068639225223597  0.411512073768996 -0.617585289861537  0.085587328981715
-    6  ( 20) -0.031740361337335 -0.042325765757491 -0.290709707718165  0.172790703648515 -0.000532545780898
-    7  ( 21)  0.011558038421621 -0.183385354532032 -0.093657523746171 -0.152317012205746 -0.116530260167129
-    8  ( 22)  0.024591234247673  0.015437963416840 -0.192723206306395 -0.041545920874624 -0.300722952291357
-    9  ( 23) -0.076860307291410 -0.028222730174457  0.239744246838648 -0.005401314981702  0.437602472364683
-   10  ( 24)  0.182325175721446  0.168262818970868  0.041985084407523  0.080814437382504  0.153682650364464
-   11  ( 25) -0.018251396178258 -0.001487318511567 -0.036744565685453 -0.052466578072734 -0.023330767494251
-   12  ( 26)  0.006994832022894  0.011312050265967  0.051710399870511  0.045052170184275  0.002799991775595
-   13  ( 27)  0.042051003701905 -0.060322036458563 -0.018224376602008  0.061574434209411 -0.071889000854515
-   14  ( 28)  0.006898519418229 -0.055936666673248 -0.000904652270607  0.099150038783025 -0.077924550244227
-
-	DPD File2: P*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.024746315003693 -0.016019947683600  0.033657454181441  0.314697310181057 -0.226266938924475  0.124444118187600 -0.100976019942115 -0.040776992946741 -0.016684212809041
-    1  (  1) -0.134389185453098 -0.111083358436336  0.277285327152191 -0.119300944830562 -0.165892793225342 -0.243843028361365 -0.522257860139305  0.003856507813829 -0.130032133651498
-    2  (  2)  0.005712363782982  0.008727960227379  0.039141212770465 -0.103639199943747 -0.051337772042530 -0.071715964883614  0.083650082880478 -0.323814625304121 -0.126954317090625
-    3  (  3)  0.081293710540179  0.115829551524333  0.096804246842583 -0.012689929096652 -0.055158220665324 -0.020215225885504  0.309792669510693  0.175501033742058 -0.786497084573792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.131346722870458 -0.163299814747146  0.027069647322617  0.020320497257903 -0.063430953058875  0.031962758863077
-    1  (  1)  0.087630835970581  0.216123500984143  0.418559649023597  0.101182356933807  0.219334050753127 -0.138730916232525
-    2  (  2)  0.150883742374018 -0.808729391001562  0.082068044594556  0.109718430012718  0.126065481544348 -0.025072338478445
-    3  (  3) -0.037377902285561  0.112570729969231 -0.441791115721159  0.197182836023279  0.548068009411335  0.161473931329561
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.035230659308422  0.106839323325161  0.014678428381540 -0.286556627519623 -0.361604275339255  0.140599935526212 -0.104171301624044 -0.023270847691008  0.152469667501182
-    1  (  5) -0.205844940105254 -0.013703890486825  0.030101864871895  0.113405292167378 -0.067278306831822  0.396432225285843 -0.507639566286884  0.374194080683992 -0.087133202725049
-    2  (  6)  0.008020887713167  0.297537793700841  0.070946233356648  0.062333784651526  0.130550836206602  0.053406231056288 -0.297352200120301 -0.465262963875225  0.160837314824145
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.001388437190181  0.015460041565487  0.116558611446075 -0.083788280005113 -0.046694291841919
-    1  (  5) -0.445165309099416 -0.139286068687201  0.540190784438892  0.030841865046205 -0.087779833305208
-    2  (  6)  0.377644271326903  0.173431493737049  0.206412471480948  0.122708702224090  0.459634387384366
-
-	DPD File2: P*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.059484933862835  0.014840374750558 -0.035360338576360 -0.173310409629633 -0.059725101605321  0.257184966477164 -0.063490095178001  0.155623028848452 -0.002426177597214
-    1  (  1) -0.228582316542215  0.259588493824183  0.059979506895381  0.002310310036236  0.214166554941788  0.116943892441225 -0.108842892801007  0.344598351692938 -0.046446999584419
-    2  (  2)  0.320448650163398 -0.500204746721717  0.049266542548722  0.152597804353277  0.167277822949482 -0.193147703880440  0.032524845682255  0.036762728768834  0.080681033267355
-    3  (  3) -0.009703572292968  0.082952949000966 -0.090825897592600  0.068137067278425 -0.068002795336981  0.155982720923085  0.189371220312700 -0.353775834732784  0.023853285599523
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.026559166873629 -0.005391969117388  0.002011264512932 -0.046870885231393 -0.012715635371485 -0.026571877043427
-    1  (  1)  0.038988897688016 -0.019721374639789  0.014060753119275 -0.430701935913609  0.259024740507495  0.161810701507464
-    2  (  2)  0.100083737029750 -0.093431068521730 -0.015885697887836 -0.259560607774115 -0.146766142473160 -0.593605654650708
-    3  (  3)  0.130235873557485 -0.844890867177988 -0.085670264124908 -0.093010825973034  0.012325537516171  0.119484996772910
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.011411967833044 -0.019523193555091  0.029394421691951 -0.441924368380274  0.383516159929503 -0.004430337133144  0.015018368377510 -0.081006354989878  0.100709067945280
-    1  (  5) -0.015106432068076  0.115430718880751  0.094613417260511 -0.153153896682510 -0.130891773654437 -0.255513104617105 -0.100481979342603  0.182641502384039  0.046231419137374
-    2  (  6) -0.045469725116844  0.216512507684084  0.240553163844151 -0.059703803473819  0.128799103778847 -0.466867168048645 -0.230376363698085  0.268754231533815  0.029632489718661
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.031283386269007 -0.083595055179233  0.003915100351561 -0.081115225653286 -0.074158142938438
-    1  (  5) -0.011556443169135  0.036659881745781 -0.006532048558871 -0.596174583603508  0.114916319653540
-    2  (  6)  0.066233849453724 -0.593708066141070 -0.047160183567134  0.205443006234017  0.123500019606919
-
-	DPD File2: P*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.278545233415530 -0.059599409615732 -0.026034432106375
-    1  (  1) -0.187007295905470  0.038238309701257  0.175982197292767
-    2  (  2)  0.431926204916829 -0.006084496586666  0.049694339002754
-    3  (  3) -0.039723645794201  0.196249784920444 -0.036043663433459
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.275546881197932  0.180389519378317 -0.425074243400924  0.037767422186350
-    1  (  5)  0.058081529209830 -0.037390441931729  0.000516662884118 -0.195055591570635
-    2  (  6)  0.026038612826744 -0.173019988726883 -0.056080139617911  0.032715759186560
-
-	DPD File2: P*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.062756867817297  0.201112023907446  0.056048025131715 -0.046055783450926 -0.033806686060762  0.171722205176695 -0.081098506544458  0.087289620763258 -0.042152324091961
-    1  (  1) -0.113018477232488  0.112319744349513  0.016834583533921  0.057284464999085  0.226208700821363  0.112272688334417 -0.062097026682019  0.556436717149114  0.098351092785228
-    2  (  2) -0.050464428261919  0.043116595966000  0.019513144045664  0.037294003656203  0.049535289314410 -0.026512882856009 -0.020955734915841  0.396348457994657  0.049143039709126
-    3  (  3) -0.026907740943173  0.173985640449646  0.354309597307579  0.088737881833013 -0.026690278443481 -0.192249138616519  0.023099922234093  0.151104956103080  0.187993798800110
-    4  (  4) -0.028814397262738 -0.124011423960611 -0.200563657745864 -0.022231046170139  0.001789869716556  0.223408416821475 -0.102318476102237  0.153384891973446 -0.236674672698061
-    5  (  5)  0.088145317682978 -0.132491290238854  0.182899281954052 -0.186746219907929 -0.187197714495176 -0.005898923884498 -0.002120811015656  0.021990162397056 -0.123551537605536
-    6  (  6)  0.024460586881498 -0.068797047909759  0.142150384104535 -0.131743429120178 -0.105639058982537 -0.045294852609385  0.029270704887015 -0.020804211601159 -0.117878860256254
-    7  (  7)  0.033776769859701 -0.354245094845972 -0.243166450499757  0.029612149638602  0.008896656564269  0.116804879825504  0.018695560701790 -0.326627365972202  0.206018976643332
-    8  (  8) -0.143077917661487  0.151560533054490  0.301409236473389  0.100740265108897  0.039290343645488 -0.041763953575394  0.058170430215780 -0.076845206100452 -0.024633152032860
-    9  (  9)  0.347018728951025 -1.079771981804557 -0.078138529282464 -0.501451378510505 -0.195061660317550  0.758451032278065 -0.096995118436252  0.075303195155611  0.028459788963157
-   10  ( 10)  0.223810118885824  0.056979536028989 -0.716810245770532  0.128868097994349 -0.539754687175803 -0.113296255679437  0.098974782607496 -0.009049828893309  0.202384864538250
-   11  ( 11)  0.022769270154477 -0.034674358156828 -0.014405983056596 -0.017571848532967 -0.048691998407531  0.015583395228223 -0.114409081561630  0.021951676689174  0.044426938305339
-   12  ( 12)  0.135981286187464  0.120998241259176 -0.262301521327982 -0.750392323278277  0.334209910038890 -0.448078191688466 -0.024767148532186 -0.115571945209708  0.066264929381116
-   13  ( 13) -0.080577472282162  0.105823730084873  0.089794541855267  0.254940117418226  0.138440117204762 -0.236499087990863  0.038859436706735 -0.192105181610312 -0.090975801731982
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.032425074737930  0.078425462405257  0.011344832045570 -0.197456331002049  0.134718406025863  0.096409404413494
-    1  (  1) -0.173273250041635 -0.433566222378215 -0.007405001112899  0.457114065135928 -0.172943454488407  0.008895375735183
-    2  (  2)  0.109774013784441 -0.217911727490325 -0.003528460413992 -0.763520159635318  0.225537275802117 -0.118975501733302
-    3  (  3) -0.036378102698420  0.454361087703980  0.077915823523940  0.013309796680696  0.234332299564134  0.507177620624500
-    4  (  4) -0.092551473116606  0.475045168698850  0.084968775693714  0.026919469339922 -0.202750989391175 -0.617924078766471
-    5  (  5) -0.097554141145429 -0.018018586167576 -0.079671555600775 -0.092305854243185 -0.173736284561078 -0.411194160500052
-    6  (  6) -0.003414072729569 -0.093327360188558  0.085627914021145 -0.078229939466915 -0.111156480724274 -0.178796621382799
-    7  (  7)  0.114277067577274  0.105960426671338  0.044841696220246  0.134585263057439  0.180631730229559  0.229243957069555
-    8  (  8)  0.037886837147022 -0.102808395063350 -0.069798483920400  0.254580996722497 -0.401920559110064 -0.147751839658310
-    9  (  9) -0.010988821514225  0.007410444750660 -0.002972535589617 -0.025318418426566  0.448643260566270  0.804372772080077
-   10  ( 10) -0.261244020497494 -0.038064665016323  0.048636140959014  0.326624772892826  0.029954423230419  0.215793554756145
-   11  ( 11) -0.048015789596366 -0.069114116273897  0.007572832400964 -0.004238339483900 -0.020816591473394  0.043178136132549
-   12  ( 12) -0.214695948487578  0.274288590232604 -0.016230298683875  0.029548384872336  0.038140072907363  0.033057792945377
-   13  ( 13)  0.275326653840915  0.061284883995154 -0.041285946542463 -0.084706584831174 -0.090480508761559 -0.181791085214834
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.063850422313355  0.115683680262588  0.054827490001665  0.028354117168169  0.025100127178731 -0.096410771095777 -0.028664016097217 -0.026051889825173  0.141339706448534
-    1  ( 15) -0.201263187433031 -0.111831464020197 -0.045175609028392 -0.180549663650845  0.130383086147566  0.135646922045465  0.070781303898657  0.348002287778712 -0.148260195426479
-    2  ( 16) -0.055113649368610 -0.018738606654586 -0.020705966421020 -0.355086450538750  0.201294850701097 -0.180112010383658 -0.140523266780582  0.241544163680772 -0.300925921088622
-    3  ( 17)  0.045920336133779 -0.057784764027644 -0.035886357056501 -0.088932856294833  0.024235675752436  0.187147654830588  0.131361762793480 -0.029658114101546 -0.101263553912617
-    4  ( 18)  0.035958486319751 -0.227134777791688 -0.048687972069102  0.024933262428833 -0.002173989672721  0.187305076269607  0.105829902417925 -0.008056867875506 -0.037853803971042
-    5  ( 19) -0.171149922579415 -0.110039862501994  0.026813452459140  0.190061024816887 -0.222174491954054  0.004093825553016  0.044188302806112 -0.116881315421755  0.043225291916047
-    6  ( 20)  0.080019590838700  0.062262232462848  0.021096034332220 -0.023057305471526  0.101639862804641  0.003152213311187 -0.029422735136868 -0.019240780036951 -0.059315335454636
-    7  ( 21) -0.083510548402123 -0.557993066791473 -0.397235243356208 -0.151190399349717 -0.153637137534004 -0.021828958802507  0.022025876078118  0.327175118374607  0.079618949429238
-    8  ( 22)  0.042227049954364 -0.098944758472646 -0.049249083184483 -0.187848524484403  0.236611254443533  0.124376089369001  0.118097176171872 -0.206089300936335  0.024158581021498
-    9  ( 23) -0.032033977750932  0.174724865726956 -0.107565757409839  0.033957075679687  0.093408693176877  0.094735950835808  0.001596176802057 -0.112245900387886 -0.037372397271166
-   10  ( 24) -0.077636129797919  0.430853371998705  0.215233761055940 -0.452386714098273 -0.474453371679467  0.016809820271846  0.095741323886920 -0.105100659091080  0.104107445539310
-   11  ( 25) -0.011149970874610  0.007035579685386  0.003127573400518 -0.077702883164627 -0.084954198370187  0.079818042644370 -0.085248456841504 -0.044951104587653  0.070017705668783
-   12  ( 26)  0.193344086617498 -0.456776432013422  0.761441366858404 -0.011910497712878 -0.026326742647963  0.092364226349286  0.078937949371178 -0.136041391718326 -0.256815257193465
-   13  ( 27) -0.133610614090005  0.173243160128294 -0.225605563113523 -0.236498022568823  0.204477528431671  0.174386164144365  0.111604362943586 -0.182311312483583  0.403964555885563
-   14  ( 28) -0.098101278195306 -0.007008756260166  0.117389775367317 -0.511914224685440  0.622957281459333  0.412506446069418  0.179820830724467 -0.234600868408507  0.150158824761841
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.343234558725567 -0.228637063726269 -0.023307266959502 -0.140382240172792  0.083235444793760
-    1  ( 15)  1.074711095873744 -0.056336734854343  0.034809000083236 -0.121348785991751 -0.106814989655091
-    2  ( 16)  0.078219304152202  0.719658957943986  0.014720519366158  0.261816502529916 -0.090881991750144
-    3  ( 17)  0.502805356071942 -0.131166561688672  0.017463933389579  0.755157521149267 -0.255568620797102
-    4  ( 18)  0.195634688856887  0.541360385537898  0.048854453075291 -0.337587696841954 -0.138455603989787
-    5  ( 19) -0.760143596830987  0.110879995008927 -0.015821843299894  0.447903356003643  0.237096867164475
-    6  ( 20)  0.097106884263887 -0.097545405975693  0.114437354251730  0.024000531999102 -0.039042927829059
-    7  ( 21) -0.075531866838301  0.009858499302833 -0.021730854579213  0.114681897686178  0.191988442177111
-    8  ( 22) -0.027711318590147 -0.201621760195186 -0.044350251642364 -0.065874285776240  0.090522977876112
-    9  ( 23)  0.011879012685435  0.258606547469066  0.047776074363499  0.213401932184194 -0.274704590606944
-   10  ( 24) -0.006858605937754  0.038088449389244  0.069395356141264 -0.275242327171399 -0.061260041265231
-   11  ( 25)  0.002890089589219 -0.048355005791387 -0.007521454792553  0.016094295989108  0.041236148462184
-   12  ( 26)  0.024624287461246 -0.326411349050862  0.004226520020176 -0.029493735437593  0.084692672982552
-   13  ( 27) -0.450726956342698 -0.030201266401628  0.020823649440091 -0.038233714612970  0.090500946858406
-   14  ( 28) -0.809945076459086 -0.216752990291181 -0.043269372622044 -0.033145255679139  0.181828971805248
-
-	DPD File2: P*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.063013364696514 -0.044010513010140  0.033832526224211  0.162024471696236  0.051333545713143 -0.246461238669107  0.063609486603270 -0.159478583547076  0.006207989114076
-    1  (  1)  0.226546037179395 -0.291390639777102 -0.048328229754705  0.000396116910678 -0.216137862922779 -0.115706811352044  0.113227048986677 -0.363481206263983  0.049424206162689
-    2  (  2) -0.353995982753623  0.570067383955282 -0.052742449525010 -0.144888216829452 -0.158139021131471  0.195548321941560 -0.035681653601236 -0.044365181477906 -0.094047723024953
-    3  (  3)  0.014909685853208 -0.093363165202933  0.099368126188753 -0.092807318931361  0.081502054050149 -0.166990973951771 -0.201832262285607  0.375763253843030 -0.022961121211245
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.027461792188467  0.004811887789740 -0.001758716793345  0.052146222606019  0.015489645876144  0.034542443930348
-    1  (  1) -0.038878540290940  0.018432422578327 -0.015238310520594  0.445890608944474 -0.276103308767449 -0.178613718171164
-    2  (  2) -0.112212317864169  0.097070429592677  0.017583930410099  0.264050273165228  0.167988430449652  0.635838792277428
-    3  (  3) -0.134391135826268  0.880500790171335  0.088985519620608  0.095884376650580 -0.014499630081693 -0.127955545332533
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.037904901187616  0.025077601146789 -0.027398631479947  0.443691662113588 -0.381793026485785  0.022010734273084 -0.009578999727395  0.091037438378063 -0.103637073384889
-    1  (  5)  0.010563786544947 -0.113947073526168 -0.106465996568323  0.155511131041724  0.116554544974583  0.262895686214063  0.105092877292920 -0.193457955253204 -0.048498356991785
-    2  (  6)  0.044887612702522 -0.228580277279931 -0.273604650547313  0.078952413042729 -0.139355988549377  0.486362168413732  0.239519122057504 -0.286842566968737 -0.031193390212920
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.028779621541873  0.090907914561767 -0.003460105941843  0.087167181054995  0.071921470779774
-    1  (  5)  0.003930295039018 -0.035914981429889  0.006741878538669  0.611390099224952 -0.116946571666512
-    2  (  6) -0.076298500757009  0.614894877751711  0.048926788565139 -0.209608637563865 -0.127192306297029
-
-	DPD File2: P*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.068337016677695 -0.096446452026756  0.360475449331991 -0.092239288371853 -0.026203678917511 -0.022509846886799 -0.073478827117419 -0.022464061625998 -0.227372488621395
-    1  (  1)  0.348245092774866 -0.473201941683207 -0.285296343579762 -0.183481268326088 -0.077575420562874  0.072099125969722 -0.272473569856386 -0.064219415204321 -0.197165880719729
-    2  (  2)  0.067585908335283  0.050372922133506 -0.060758167744452 -0.207525430642987  0.124589544508062 -0.366296688963713 -0.319501792505756  0.144609263799336  0.034557292153017
-    3  (  3)  0.003490778097580  0.176771187112973  0.057522831103622  0.000116418648382  0.000778288019112  0.154495740627781 -0.307263828587522 -0.311985415435969  0.072067405458553
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009055593070151 -0.169294476018032  0.004376707873729 -0.043035427357302  0.152530590698355
-    1  (  1)  0.043732146257221  0.133230210157229  0.321492959581682 -0.026647195860165 -0.380687102934580
-    2  (  2)  0.166530147628729 -0.613643715672385  0.216790209047481 -0.084469048804484 -0.070950252851931
-    3  (  3)  0.193623455804687  0.188085387663198  0.577128561869679  0.079182256640786  0.329374829305157
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.094184605186671  0.056664612816556 -0.249611394657184  0.001240336497952 -0.251113263182976 -0.167204841127316 -0.053738355395826  0.110451910693142  0.110225244293220
-    1  (  5)  0.138889396111012  0.115961679782817 -0.323179744158626  0.121252123207265  0.292076432419815  0.241576686510115  0.062989099171507  0.028273376478118  0.195878521271564
-    2  (  6)  0.158880157678560  0.136139940912615 -0.265648578874291  0.093877387268260  0.142453752235908  0.054140913517762 -0.560779480954688 -0.138233927899815 -0.254132036688695
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.293992892729715 -0.040800750956591  0.057675088119180  0.076602392465323  0.065335333102758 -0.026360508286139
-    1  (  5) -0.140101157166617  0.119683195321807 -0.266691635597033 -0.245738117504136 -0.344104644828940  0.220704301441665
-    2  (  6) -0.056921768258958 -0.103403744090827  0.598429877431589 -0.146214200734754 -0.059974751023664  0.323525482450488
-
-	DPD File2: P*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.001194434516926 -0.365406825873877 -0.191112170654786 -0.072953190005452
-    1  (  1)  0.363385965896555 -0.001278838882578  0.019794428206453  0.015546405496121
-    2  (  2)  0.188455836576036 -0.023464280272920 -0.001313653362102  0.003971811529941
-    3  (  3)  0.071937190909342 -0.014204649752708 -0.004012943205250 -0.001742183215196
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.002207002387747 -0.099036313248809 -0.350070270006789
-    1  (  5)  0.099717351351760 -0.002187155419577 -0.000406257568929
-    2  (  6)  0.350175744645045 -0.003726626970778 -0.004104233297166
-
-	DPD File2: P*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.002966254715231 -0.240855988266728  0.015168347488530 -0.064366755524788 -0.058337095528916 -0.095917557609408 -0.080552351010748 -0.173850272969471 -0.326738509325595
-    1  (  1)  0.236928751733350  0.000606734226053  0.349434191365712  0.093200906311076 -0.041406943350823  0.069404274429693 -0.288704930708582  0.111892041376425  0.888816026581642
-    2  (  2) -0.015227164699160 -0.348726210567974 -0.001624946372493 -0.082520881475572 -0.073422056547723 -0.232856655438329 -0.287989353510736 -0.229619697744185 -0.234594833443005
-    3  (  3)  0.060136079807310 -0.090244643623410  0.083460850918858 -0.000190675057493 -0.021666820127845  0.049054167667433  0.003318783332088  0.014942478625699 -0.184116482215884
-    4  (  4)  0.058810580653892  0.039254180139711  0.072185299720667  0.023983542956374 -0.001162617768289 -0.085082802307878 -0.048921193420164  0.153382943802422  0.107278309526120
-    5  (  5)  0.094673430029074 -0.068328286783388  0.231594556891859 -0.051852594552707  0.087895099396058  0.001022706922957 -0.009481397805757 -0.039804866070152  0.148588908121843
-    6  (  6)  0.077478276137780  0.287498549855759  0.285112820054957 -0.001996885796048  0.050199534762013  0.010169007281739  0.001566818575017 -0.173488828459951  0.045840640430952
-    7  (  7)  0.174574943301410 -0.112673533261648  0.229919171659831 -0.014304085765577 -0.153548872211132  0.035649109336757  0.172043564633104  0.001747195829410 -0.038631522766057
-    8  (  8)  0.326784468679605 -0.892435693037357  0.233569726528789  0.184065381075518 -0.108484932678938 -0.147374626265501 -0.046903987933936  0.038178109185914 -0.001735751957207
-    9  (  9)  0.006821679719377 -0.058926743509393 -0.208367267805622  0.285685508477399 -0.014180918165163  0.077838258063458 -0.021878341498618 -0.053464078274748  0.072201437911745
-   10  ( 10) -0.009056199429691 -0.188962532231488  0.202934615692329 -0.587329922811144  0.635977084568857 -0.025679043651857  0.020098430100480 -0.176535847273173  0.134249054850628
-   11  ( 11) -0.122433619087449  0.184482339508693 -0.564618465141536  0.437678405523193  0.566648296764866 -0.293188916460713  0.283810265313721  0.077678717328954  0.171076053515931
-   12  ( 12)  0.036292153208947 -0.108484898349320  0.145104583947026 -0.147429251741648  0.198788533301527 -0.103598496618116 -0.121175312167554  0.030985473315147  0.001761958158343
-   13  ( 13)  0.133923970852792 -0.204871678949702  0.411285239061003  0.299554669797709  0.284169606525854  0.162383457794127 -0.004545044711178  0.249571768159739 -1.096350485902953
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.006556329110841  0.006088586386751  0.124678079831954 -0.037126112155215 -0.136830700261450
-    1  (  1)  0.060788036015694  0.191479282295534 -0.182968697985886  0.108878994177096  0.206615313543699
-    2  (  2)  0.210374331017044 -0.203724330933666  0.567874430260769 -0.145071803402332 -0.411903076822992
-    3  (  3) -0.286917147696723  0.581979187814224 -0.440566780256406  0.146724205480600 -0.298411655566699
-    4  (  4)  0.014298727005834 -0.630110791185791 -0.567066919718617 -0.198113213886521 -0.285451610676776
-    5  (  5) -0.081474334265114  0.027014198849763  0.293476840962639  0.103773751793710 -0.162461435377736
-    6  (  6)  0.019534299275936 -0.018969452720832 -0.285789804049686  0.121256569831033  0.003481312727309
-    7  (  7)  0.056370622889280  0.170673347832600 -0.077097071581232 -0.031742893248721 -0.249704021902801
-    8  (  8) -0.071994852203822 -0.132015517717158 -0.170148143024151 -0.001951350044678  1.093751141653295
-    9  (  9)  0.000953866523975  0.167467737198046  0.013767962244439  0.007434218290124 -0.054780735052675
-   10  ( 10) -0.173318734659126 -0.000810695586467 -0.044701276287093 -0.097338149388905 -0.081237613430460
-   11  ( 11) -0.013895240641951  0.044282356293427 -0.000179785703801 -0.004575065369641  0.075680209341763
-   12  ( 12) -0.008279323048061  0.097099690667968  0.004296013685779 -0.000048011111236  0.035877871824266
-   13  ( 13)  0.055107661683376  0.081651595745875 -0.075682651530469 -0.035936424072868  0.000029147707292
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.002983283073552 -0.069963597569041 -0.177874917667998  0.062698638146301  0.106213761198913 -0.103906931767555 -0.039245016352398  0.108223517603678  0.012203119212599
-    1  ( 15)  0.072298870307035 -0.000296799608796 -0.117346282403810  0.011865025714908 -0.081057312629942 -0.082184434890961  0.047411637016207 -0.318551609279607 -0.030383483166489
-    2  ( 16)  0.171245613988674  0.116654951277647  0.001073144643332 -0.130649581927528 -0.144907410540790 -0.208150327953063 -0.198240370201554  0.179277720823411  0.001547973613629
-    3  ( 17) -0.060703226947660 -0.012583282832888  0.130776798167377 -0.000627586286590 -0.018993088317931  0.044159196655903 -0.007932945197872 -0.099780861993881 -0.079859961463087
-    4  ( 18) -0.100987762729975  0.079245986001353  0.141690159528846  0.016637213332155  0.000279400820895  0.188760521966200  0.218195531933535 -0.080299124518616  0.270793478609675
-    5  ( 19)  0.108074704635216  0.081590264498889  0.205498810382318 -0.045801307693771 -0.187063236245240  0.000710419758875  0.073671862989187  0.043877487134678 -0.003892010725365
-    6  ( 20)  0.034177446867522 -0.046254597520027  0.201430745227679  0.005427131993230 -0.216675775592057 -0.075812938142253  0.001274951349149  0.134520130532184 -0.103162147021421
-    7  ( 21) -0.109552512569813  0.319375904304575 -0.177972755772711  0.099543500716481  0.081539270937629 -0.043994632054622 -0.133148819770476  0.000136132680380 -0.101451568181800
-    8  ( 22) -0.012932579381132  0.031214135384490  0.000281145990656  0.077687686709702 -0.270019497869643  0.002445122305778  0.104445784052100  0.102366601596632  0.000293374111723
-    9  ( 23)  0.258661075798788  0.226451306397380 -0.883677423513705 -0.031877470630129  0.145903964590500 -0.329887844134728  0.092796308819851  0.020328633409678  0.044508005290364
-   10  ( 24)  0.092756800530096 -0.166962776711625 -0.090732033242854  0.033047276838485 -0.181047632927145  0.062682569832297  0.131253772479093 -0.125666164674422 -0.010098556627625
-   11  ( 25) -0.085247662084319 -0.052988724588725  0.426265235226709 -0.453475536447167  0.668253171471624  0.144399850217273  0.422325162892048 -0.144483844450738 -0.151429271642033
-   12  ( 26)  0.279045843991891 -0.538081255792683 -0.338024638087139 -0.681172358850588 -0.181070323444015  0.460341461990372 -0.046122199431924  0.472432043418077  0.099681899420099
-   13  ( 27) -0.031769949568578  0.364837871962491 -0.009792757368435 -0.264546010179783  0.131321500070479 -0.369805258593067  0.160328386436444 -0.216930526986653  0.408555062086236
-   14  ( 28) -0.069122236052376 -0.228562041286249  0.181966055883684  0.129261778712552  0.172738024644993  0.293166654576352 -0.081465083951240 -0.165047538527886 -0.415612188545544
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.259003180995999 -0.092034359732091  0.088092444988971 -0.283228839847223  0.027238337345788  0.074809429137092
-    1  ( 15) -0.226401057047801  0.167244181564770  0.051680013843725  0.539247725941338 -0.363958831235579  0.227197833049861
-    2  ( 16)  0.880204617361986  0.090080695403138 -0.428803021300672  0.339354335014476  0.011073919861198 -0.184183385405081
-    3  ( 17)  0.032548488106633 -0.034116564240178  0.457440817331429  0.682846299872809  0.267172551643223 -0.129975094303440
-    4  ( 18) -0.146446220661130  0.182273160793426 -0.671045144484618  0.180560000424842 -0.132242486336168 -0.172542944677419
-    5  ( 19)  0.329935957691708 -0.062440148449723 -0.142514523618445 -0.461407225484117  0.369136535324331 -0.291356141625179
-    6  ( 20) -0.095137293654559 -0.130985936102436 -0.423469417337729  0.046319908681962 -0.160102833893605  0.080585118835760
-    7  ( 21) -0.020207238092615  0.126147064104969  0.143168454940269 -0.472622130455173  0.216404140117317  0.164767679261412
-    8  ( 22) -0.044837771622786  0.010451598353546  0.151184144406440 -0.098993252397369 -0.407878413312189  0.414658535507476
-    9  ( 23) -0.001737606134934 -0.018616595639929 -0.107543267833085  0.163017051753013  0.647726175645918 -0.636571415515610
-   10  ( 24)  0.017899922228044  0.000213602824426 -0.053374660165807  0.073998998716505  0.058121913122542 -0.162859588181722
-   11  ( 25)  0.109492695348190  0.053011202690733 -0.000327739740203  0.000312768703591 -0.053080921470257  0.055086051279352
-   12  ( 26) -0.164160765816315 -0.074526437813364 -0.000205041264621  0.000008221388086  0.003647906535196 -0.023090840612045
-   13  ( 27) -0.648519944554920 -0.058749585422481  0.052822010998177 -0.003709251683372 -0.000103802664845  0.203134785839326
-   14  ( 28)  0.638592033397192  0.163371069122125 -0.055018466584646  0.022957117292923 -0.203277611770653  0.000205390113949
-
-	DPD File2: P*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.050918463672837  0.088577095911626 -0.347792606459412  0.095753675403874  0.021868934225380  0.033922841975857  0.081457049638017  0.022670295387980  0.235434049572332
-    1  (  1) -0.382949048662791  0.528689769706688  0.299634584086346  0.202752933016224  0.082733390999563 -0.092422540316925  0.290813237500084  0.058004392324892  0.224615068405588
-    2  (  2) -0.072432527585316 -0.056118386776062  0.040222186558432  0.242175264454298 -0.146547807338018  0.390266206867364  0.347025142548880 -0.162810044865207 -0.041509720616448
-    3  (  3)  0.002509556424329 -0.208248007860462 -0.062422901369848  0.007679044749759  0.008571630545112 -0.174062990005658  0.334967725932269  0.336081407145288 -0.081599082536296
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.010892131457533  0.184129002689570 -0.006516359878994  0.045872381230752 -0.153258318093946
-    1  (  1) -0.044796011029196 -0.153644284644512 -0.339325263566756  0.025646141032274  0.405174708389161
-    2  (  2) -0.178039316366764  0.664464704148233 -0.224969390534104  0.089440380756525  0.066874687913745
-    3  (  3) -0.205823412452233 -0.203327440636405 -0.607212535172871 -0.084515912728930 -0.343929939556071
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.078798727127085 -0.050234519025036  0.245209481862661 -0.005696954168209  0.236120915868886  0.165120845160626  0.059294811018549 -0.108390851582836 -0.111673906302634
-    1  (  5) -0.155915068579220 -0.141324548768777  0.367116438384255 -0.121574775208674 -0.314513424545348 -0.257608736751094 -0.074849697192160 -0.032932966046337 -0.220860722558199
-    2  (  6) -0.156801606542398 -0.183207885627035  0.298465110849382 -0.100930243056436 -0.131083210552854 -0.050444928584622  0.606210604165772  0.146614859921357  0.248216540567658
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.311128511448673  0.042835689156568 -0.063170810110215 -0.070842689432729 -0.064570105984912  0.023339590654715
-    1  (  5)  0.156644000440875 -0.124669553061406  0.274932589468273  0.248710717987319  0.361639916876500 -0.231627984560414
-    2  (  6)  0.060874079553630  0.108175278252638 -0.629356829293933  0.147027352951220  0.067479673265597 -0.339908703023576
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.016118777276718 -0.076689387067913  0.125264792267221 -0.007931013310217  0.098301937535593  0.089040062536424  0.042653189503994 -0.143650549015436 -0.062698356849212
-    1  (  1)  0.038523460792179 -0.325926212074865  0.217436403108293 -0.076210929079432 -0.124956744969497 -0.049869905306322  0.256022567536767 -0.049219148025195  0.025163660677602
-    2  (  2)  0.015460259327547 -0.182364499530156  0.081021447104321 -0.065186772706330 -0.193628085224677 -0.090709199284776  0.144227288852923 -0.007154481293498  0.060483347873675
-    3  (  3)  0.069494321441893  0.016013992178317 -0.169506236224066  0.050547669997832  0.177140340538940  0.181255025833280  0.201077665225234  0.109139777586644  0.215083611892043
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.159361864611547  0.056476108299595 -0.034334354535918  0.068420323850582 -0.100698715800708  0.049820592017770
-    1  (  1)  0.121041364374114  0.003994619377141 -0.190684428167188 -0.052070114913576  0.189028662705244 -0.205096915582729
-    2  (  2) -0.013836799939810  0.073875918803127 -0.147901928532532  0.343158528114237 -0.053056478393270 -0.086736758175874
-    3  (  3) -0.065392768372805  0.072388535495378 -0.365788807268921 -0.156911353062510 -0.184439406968008  0.043117455907294
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.095080611028908  0.132974666952804 -0.233475927910161  0.109077700761846  0.033619328181737  0.003336619392380  0.079318686273404  0.006541773193158  0.188514066103897
-    1  (  5) -0.133180554197727  0.220459497770331  0.122961007604824  0.144493780528946 -0.034530325126907  0.144382538755413 -0.001565508478524 -0.179104189145753  0.084352671049968
-    2  (  6) -0.305369897772513  0.245966510909099  0.171589985467973  0.288954965589218 -0.048536799653855  0.105233271021501  0.400024803684154  0.035818012706252  0.066124321501178
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.011358647742863 -0.047842821118303 -0.011877525445924  0.012099889406653 -0.055702357687979
-    1  (  5)  0.060987538430201  0.100437160073965  0.174976176295347  0.033059202656665  0.296249624542352
-    2  (  6) -0.156959926194247  0.053853503787388 -0.406665675932452  0.026462885456154  0.143060389345537
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.020933994600407  0.036837370041379  0.105536213576206
-    1  (  1) -0.298453027380229  0.115575201783048  0.255528599615226
-    2  (  2) -0.258793135913466 -0.115959940555419 -0.442826057795207
-    3  (  3) -0.060024736570871  0.030098554189580  0.068752806226701
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019369167440737  0.299662599013855  0.261538199445486  0.060711849430240
-    1  (  5) -0.036904684367184 -0.115259605353545  0.117033018013317 -0.032657591929025
-    2  (  6) -0.104769015611942 -0.252811001882398  0.444270078409878 -0.069751899589244
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.140264901989733 -0.063903836208699  0.058837720478352 -0.099834492513907  0.059321359064120  0.159667027697165 -0.002087278187155  0.046204224826822 -0.008601023391654
-    1  (  1) -0.090548490120094 -0.202601353512521  0.092021876157039  0.096539072052076 -0.170154281529190 -0.083912296322856  0.509059273187919 -0.818772979644944  0.070828284365831
-    2  (  2)  0.023785290834440 -0.356113587695746  0.273990976839633 -0.279080899835077 -0.352444630227807  0.196438091918127  0.305379232907246 -0.066497365309673  0.201285694555553
-    3  (  3)  0.097000901586890  0.245927544981609 -0.317839114090104  0.024062116307509 -0.214330573426622 -0.049574376579038 -0.029033713280387 -0.054130019251520 -0.003096872422290
-    4  (  4) -0.057665969694975 -0.180120952217609  0.233587576455003  0.044983378670389  0.207784279042752  0.114395252588051  0.123426849025620 -0.227078923197640 -0.055512731053919
-    5  (  5) -0.215771286107017  0.314990234779514 -0.316883540178273  0.120867850220651  0.280144439745990  0.294187393366344 -0.216440287801491 -0.200727103538268 -0.064432166939549
-    6  (  6) -0.088234371667199  0.148935506374453 -0.366935246390926  0.011963781822206  0.214228897418480  0.110020140834853 -0.192637863546336 -0.231329350431262  0.059800681126411
-    7  (  7) -0.046850408794017 -0.280155317167354  0.370918303757493 -0.110906122388338  0.088736250126073 -0.146624611249212 -0.021132431838050  0.399622620248781  0.041122390922446
-    8  (  8) -0.213219122375795 -0.108141657808912  0.632333203738691  0.072815736912248  0.035034243651177  0.162896842787152 -0.072787072592851  0.219123938652928 -0.041084573561980
-    9  (  9)  0.053156461400872 -0.091068663315953 -0.087565530354209  0.029252405162185 -0.135958664144556  0.072618412616147  0.001674517036243  0.447580570679361  0.046048420321104
-   10  ( 10) -0.217389369502915  0.434955320268289  0.409591028918221  0.322091930890678  0.032769693001793 -0.320487371417185  0.022524010208261 -0.286088771348247 -0.028739508255570
-   11  ( 11)  0.043655408036923  0.078795431314355 -0.262179238045958  0.331516326719145 -0.435766491266973 -0.063689969335775 -0.247099037158842  0.001834914627208  0.140224560742036
-   12  ( 12) -0.056091676196041  0.010888223476601  0.132073582410605  0.097444459311610  0.064913316133021 -0.000177701715007  0.216786241209526 -0.136744724942230  0.129238968566818
-   13  ( 13) -0.037502956248588 -0.225853404732459  0.091597810906130  0.251988574100633  0.015208060782166  0.284415044485862 -0.108318027167763  0.003844624714701 -0.367465648248442
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222316043515167  0.015706219813463 -0.082385006687323 -0.001598515176526  0.060473243217389 -0.093727480766949
-    1  (  1) -0.559608456549858  0.123427525882107  0.153467678522300 -0.170334032667733 -0.080737466652229  0.083738891751815
-    2  (  2)  0.169476216588372  0.033571289044868 -0.409164888922183  0.223598543173703  0.075034173166592 -0.314714537560898
-    3  (  3)  0.116710909315587  0.019725573527899  0.283423547853851 -0.175125619030571  0.285157403250330  0.036616525847272
-    4  (  4) -0.005652624292139  0.042302085019157  0.326173261129769  0.429217689689009  0.082297928451406 -0.119033467524284
-    5  (  5)  0.013435701805302  0.050340607661262 -0.120543829176020 -0.018862712789976  0.153571720838539  0.076183620287342
-    6  (  6)  0.081289708009931  0.326406046335036  0.215268699384039  0.111421444458008  0.019027619773839  0.098888316320561
-    7  (  7) -0.155159820795191 -0.099172439421062  0.073800976886369 -0.027692155232150  0.092694133839465 -0.234604646553242
-    8  (  8)  0.037085102415804 -0.221081896212579 -0.033634728216750  0.500286732444351 -0.749342092540156  0.380702305205404
-    9  (  9)  0.121604531068674 -0.307665948271799 -0.063134933207080 -0.759313712683920  0.291120411772340 -0.157024245706381
-   10  ( 10) -0.436899181077485 -0.180584483336558  0.427706818265059 -0.039319556166540  0.042977724169090  0.570262735340486
-   11  ( 11) -0.012744975594807 -0.355849153273437 -0.014473345977422 -0.331011762918571  0.082407538751978  0.048301595441151
-   12  ( 12) -0.275248111407278  0.041018113706033 -0.197136817157671 -0.114052207324907 -0.270934107062802  0.185007344485103
-   13  ( 13)  0.588095271872907 -0.141945816656544 -0.099720177389796  0.418487800295615 -0.225864709971247 -0.209383142865026
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.136055292355694  0.095447390079347 -0.020092912976434 -0.093125301806220  0.056850399225407  0.218468169087224  0.091857234706707  0.045161486852285  0.214714486134322
-    1  ( 15)  0.061207776400221  0.202708633629203  0.353114471023019 -0.245649376419509  0.180866138364055 -0.315320438007609 -0.149515492263402  0.279091224397235  0.106858935875576
-    2  ( 16) -0.054684214245548 -0.094025065222631 -0.275943577798576  0.316343751367853 -0.233336305598421  0.315879985031554  0.365377908227226 -0.369960150477034 -0.630562926717983
-    3  ( 17)  0.098691998170038 -0.096665834479755  0.277640044986255 -0.024005765248171 -0.044522040617363 -0.121507599385942 -0.010509659584452  0.111862233831111 -0.073060388343777
-    4  ( 18) -0.060773979545103  0.171895263117879  0.351151470699543  0.213576840796561 -0.206989754617355 -0.279451579746568 -0.215385933896327 -0.091082110140094 -0.034953691198189
-    5  ( 19) -0.161690364133666  0.086139117701405 -0.195608563911700  0.050196750893511 -0.114409300434365 -0.293302924591731 -0.108870291716062  0.145705855705796 -0.162864209989072
-    6  ( 20)  0.004933077734451 -0.509112916459710 -0.304189657786548  0.027011307788327 -0.123564513171828  0.216326146660916  0.190918994832488  0.021599458243800  0.073921971953618
-    7  ( 21) -0.046939300208702  0.818898745115203  0.067231269443300  0.053385434393296  0.227366778650237  0.200959323300597  0.230355491785385 -0.400408400878960 -0.219890208910705
-    8  ( 22)  0.008875208231352 -0.070617448884289 -0.201028236092674  0.001986037102761  0.055524570746341  0.064229773357339 -0.060955407810688 -0.040899342701131  0.040928237624119
-    9  ( 23) -0.222811666664924  0.561652381203117 -0.169673185845513 -0.114995614482548  0.005558626156144 -0.012604855943771 -0.079125943676940  0.154935461007958 -0.034774271928086
-   10  ( 24) -0.015658264689240 -0.122684274627557 -0.033049817652525 -0.019053422527856 -0.043070830779647 -0.050152205966201 -0.326697513368332  0.099443390036437  0.221198097566913
-   11  ( 25)  0.081038041563998 -0.154593341750109  0.407140318932015 -0.281943720612524 -0.325675147388091  0.120351655341300 -0.214124337140198 -0.074325284613070  0.033051994607934
-   12  ( 26)  0.003149016432995  0.169066126704247 -0.222974141740589  0.178167341127522 -0.432229982121926  0.017874255780557 -0.111773550217198  0.031100511775823 -0.501206663109641
-   13  ( 27) -0.059358328554787  0.079903052840459 -0.074950199177092 -0.286331686497645 -0.080924619758582 -0.153353900448008 -0.018409365441285 -0.093462744168481  0.750750124348623
-   14  ( 28)  0.091958135023799 -0.083203421400522  0.314158605792346 -0.035767063530523  0.118730598661038 -0.076122730197959 -0.098773188363533  0.234233392684110 -0.381969165301674
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054160915945435  0.219019011349662 -0.045758113327127  0.056667077142789  0.042241899582406
-    1  ( 15)  0.090944710506667 -0.435278295065967 -0.077842273581986 -0.010976755804933  0.224792334219630
-    2  ( 16)  0.088739489380716 -0.410297160213696  0.264172456920591 -0.132125091344127 -0.093086518366917
-    3  ( 17) -0.030526782846372 -0.322820843845168 -0.334117022964461 -0.097597092001327 -0.253965732413029
-    4  ( 18)  0.135352462834385 -0.032599183228470  0.437639446212980 -0.064872058901817 -0.014497262646809
-    5  ( 19) -0.073899654730418  0.320885730724582  0.062344415655815  0.000276840662838 -0.283336476795494
-    6  ( 20) -0.001158784637986 -0.022837257389258  0.248024269025134 -0.216907823965295  0.108098145849832
-    7  ( 21) -0.447481917087615  0.286161905602593 -0.000998969948768  0.136653733410725 -0.003506425728696
-    8  ( 22) -0.045854947627217  0.028382633755544 -0.139989494186326 -0.129405417600200  0.366820033409189
-    9  ( 23) -0.122256207458047  0.437180402944018  0.011581755997574  0.275567866951771 -0.586898649032607
-   10  ( 24)  0.308323852677716  0.180850894824874  0.356131896237587 -0.040945642422097  0.142574344254175
-   11  ( 25)  0.063098776158311 -0.427549053292048  0.014802143274602  0.197270506582776  0.099635293972029
-   12  ( 26)  0.762581095039526  0.039734172920420  0.331033022441233  0.114161465508821 -0.418490755826768
-   13  ( 27) -0.291938944356791 -0.043222558646299 -0.082214356128397  0.270960148007918  0.225910263769329
-   14  ( 28)  0.156871086239258 -0.569997035340427 -0.048467653901961 -0.184994394399640  0.209531521675463
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.009005560415623  0.070810523176756 -0.120067832596336  0.009073132789111 -0.090464498751398 -0.086174111119373 -0.045794981404386  0.145874969594553  0.061668751575060
-    1  (  1) -0.049157751161972  0.341837336007350 -0.225991322214187  0.079794887273929  0.129000775913247  0.051890082528236 -0.264098306233448  0.041882987798599 -0.014437873768970
-    2  (  2) -0.004178475304277  0.176534362212289 -0.088484784587537  0.060893560844690  0.188770646517555  0.098157508320735 -0.154422738208034  0.028159762307555 -0.056745595914693
-    3  (  3) -0.078632631263388 -0.018162490565873  0.185802179760100 -0.047918543127627 -0.190222116766269 -0.186537019008413 -0.211456806958065 -0.116264562677772 -0.222361952728926
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.163744366705642 -0.058513889685970  0.036529339633759 -0.074890516703334  0.101980211526259 -0.048987870817685
-    1  (  1) -0.129678391589482 -0.003465728257172  0.197451754644998  0.065935565415855 -0.202740138649215  0.212710296862526
-    2  (  2)  0.022460564343481 -0.084272909470110  0.151124340943610 -0.372643880141893  0.063147940573229  0.083681000851943
-    3  (  3)  0.069418152871991 -0.077040623108211  0.377203303892570  0.165559399244409  0.189357768189075 -0.044737808867411
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.085668830826553 -0.137820799821437  0.214610467959115 -0.105542261331556 -0.036859097160689 -0.000473863191174 -0.079606876493944 -0.008613359831916 -0.198755661758929
-    1  (  5)  0.139412038667802 -0.235636886292819 -0.125284829879155 -0.147970518740886  0.038362154224415 -0.146537444592957  0.006121389458957  0.189794595760352 -0.090516747843845
-    2  (  6)  0.309048143972662 -0.258748687397471 -0.168238503241560 -0.304764034594855  0.050456064213728 -0.094565768675384 -0.416604423570803 -0.027331415693024 -0.066446598559605
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.012674523904092  0.052192101234842  0.013753920669735 -0.012760663896321  0.052741920591875
-    1  (  5) -0.065601509403616 -0.098250162685792 -0.177768481553462 -0.033008693934466 -0.305584708162464
-    2  (  6)  0.160962535198798 -0.052046626684920  0.419200543530858 -0.024457493928166 -0.150587999794565
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002292052292102  0.001327689025616  0.000248352651822  0.007958119616396  0.006332326100070  0.018602233716079  0.068879285117607  0.007819744108382 -0.006538352080530
-    1  (  1)  0.002764164951481 -0.002219747844780  0.018293151832047 -0.029668233290932  0.039848292773056  0.022489745012599  0.162281988584092  0.020804504235237 -0.019083175045333
-    2  (  2) -0.011217835122943 -0.011598249376099  0.016968466001430 -0.008250037510452 -0.006232273271200 -0.008766677291359 -0.010338243291249 -0.010725726663582 -0.004470553150491
-    3  (  3) -0.050562851864420 -0.047527304873166  0.078707468856856 -0.000484758494300 -0.025585059000145 -0.011993586441410 -0.049963781283816  0.008029454242806 -0.026864587292980
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006805334012410 -0.003000362320124 -0.002228041038775 -0.000013471324712 -0.003129940535122  0.001748281527537
-    1  (  1)  0.013913717596781  0.013715090430948  0.022806809849796  0.002206415430011  0.006824605289547 -0.005086150284379
-    2  (  2)  0.011033408042675 -0.021897939524418  0.000684908130867  0.006441462755861  0.002207402072499  0.000019160522387
-    3  (  3)  0.030996252825103  0.007986449014412 -0.024562077320802  0.006200249162118  0.010690383251547  0.011486173135262
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.008068643711801  0.010525757489217  0.001816581937116  0.014852647204911  0.016446444650489 -0.051123908211829  0.105303074579255  0.010186396385181  0.002604742010165
-    1  (  5)  0.024807027264736 -0.041872241876176 -0.005357408083722  0.028564486604491  0.031353252400090 -0.040716482303683  0.082357809569043  0.022204595749263 -0.028676826310240
-    2  (  6) -0.057433465116018  0.072910653400307  0.007950207598680  0.045866077252406  0.051478467074873 -0.066399959025177  0.120267838044182 -0.002980749702429  0.024762093508970
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.000934050050601 -0.000604010149742  0.003646663045597 -0.000033137801782 -0.002019175758165
-    1  (  5) -0.015497094356084 -0.002871076746167  0.025548488367169  0.001995117147543  0.006447008967148
-    2  (  6)  0.009288606849912  0.006735078994323  0.016930923349151  0.006239987724853  0.010309885333920
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.002224796248932 -0.043809288397671  0.042786645812819
-    1  (  1) -0.035961652529642 -0.375558249507302  0.229138680808403
-    2  (  2) -0.031482392637320 -0.208906969570401  0.045224347296993
-    3  (  3) -0.099946950247304 -0.215409785029959 -0.414532197880427
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.002181806445193  0.035979573047748  0.031640926892772  0.100238553322267
-    1  (  5)  0.043671265862198  0.375015508928970  0.208917842140989  0.216574490738357
-    2  (  6) -0.042527296867706 -0.228253198541367 -0.044456455969980  0.415218734433248
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.071571831474078 -0.044653489385004 -0.010701302384523  0.107261739958220 -0.107631207507425 -0.021982609216167 -0.087555139416076  0.002428271330292 -0.013116395341904
-    1  (  1) -0.000994163831951  0.002283385696650 -0.009683189881161 -0.069987093364780  0.211165412824198  0.144806549288885  0.839471629333555  0.082797629633041 -0.083995255816967
-    2  (  2) -0.048029450774166 -0.034159151942760 -0.005345969743360  0.362094457083817 -0.166955343421057  0.200138180389873  0.200325175150560  0.048097856321723 -0.015226624624379
-    3  (  3)  0.099901242333767  0.066741882163175 -0.192006761021459 -0.037162207196483 -0.149491220617225 -0.091957380518256  0.124661875998717  0.114474410410791  0.084751404274494
-    4  (  4)  0.098292057994736  0.060260709677483 -0.234095836344223 -0.042527139722308 -0.172693635464839 -0.110397071373777  0.184879337331547  0.074537123570678  0.084735776692218
-    5  (  5) -0.074314676568813 -0.053240577551294  0.354242764435309 -0.039009834260888 -0.144962419013369 -0.061650919712934  0.045188344047315  0.085035282721835 -0.173092563485620
-    6  (  6)  0.068641550367940  0.078242424055450 -0.700330832585738  0.207548816757483  0.389421892794459  0.222244858530413 -0.109406330044345 -0.045457397940435  0.343867539807074
-    7  (  7) -0.021723320720408 -0.016351205203477 -0.098413699787284 -0.004057278627183 -0.006939091834822 -0.079051971654245 -0.378143817290545 -0.122761983444906  0.057845298080862
-    8  (  8) -0.009573032166807 -0.006109372122326  0.063933429430759 -0.085659891507852  0.069748375065056 -0.032412606198403 -0.211702458249096 -0.046995111806493  0.044380498011908
-    9  (  9)  0.004993361863042  0.003634014150995  0.021315829704567 -0.021713795540608  0.030056681969923  0.023359631271160  0.128991093821748  0.016400014214086  0.007638043352379
-   10  ( 10) -0.003364468158750 -0.005158901374854 -0.010157814233360 -0.013146135283302  0.036788603301885  0.001796925979308  0.031087735489024  0.158319551738172  0.001398916399981
-   11  ( 11)  0.005212014578835  0.005572219785769 -0.129300362837610  0.009016877484923 -0.009416239426417 -0.064438058134476 -0.026488687258818  0.021963612194052 -0.285489003307896
-   12  ( 12) -0.022889675001499  0.014028568601137  0.005258310077958  0.012614598275054 -0.011181538654869 -0.041924328606938  0.003053461905652 -0.141650155501185  0.005090787707419
-   13  ( 13) -0.006246133552104 -0.010356570946206 -0.013049157750693  0.012424981952369  0.009162366348552  0.014458376447183  0.062634797746517  0.024809108873564 -0.013232375979096
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.002828230885257  0.008462795614422 -0.005154038879345 -0.009706144885120  0.000351690712200  0.003016908410820
-    1  (  1)  0.016542909801999  0.036808232009347  0.132827410709679 -0.012545312927284 -0.013603497625073  0.014243226256360
-    2  (  2)  0.056531888264120 -0.026681841564725 -0.044472892095947  0.008316762319548  0.009818160226073 -0.003132505638468
-    3  (  3) -0.065664012413416  0.084000307061427 -0.024123678461562  0.011516052481209 -0.005295212539445 -0.009770444853693
-    4  (  4) -0.036042306167921 -0.066196882580862  0.035814283991972 -0.000422354014022 -0.007346814292348 -0.010225200735508
-    5  (  5) -0.148907428019918  0.109320100216994  0.041270431698859  0.008286052492360 -0.000171545458785 -0.012799874602531
-    6  (  6)  0.267740896585406  0.203497348994038 -0.004880757246489  0.039144439238724 -0.017848850593881  0.043282221917125
-    7  (  7)  0.072391125356366 -0.141340064883921  0.132216664302808 -0.021712276497551  0.014580212743968 -0.003413596406031
-    8  (  8) -0.065338926975319 -0.070417584641912 -0.663636576046729 -0.043614890913103 -0.008447529962627  0.017635456067555
-    9  (  9) -0.053338372051575 -0.015608392811417 -0.295869564541774 -0.007118975871935 -0.021727777212887  0.010944181246414
-   10  ( 10) -0.043778421907204  0.395589362339910 -0.177341233202875 -0.145584179195590  0.046786531122207 -0.019085441444643
-   11  ( 11)  0.612579899217910  0.015866362451346 -0.053555820669517  0.384133045755119  0.648991284315080 -0.223359237845109
-   12  ( 12) -0.089924264835296  0.149474889068188 -0.147998013353456  0.410950037016053 -0.122612685939115  0.053519931502491
-   13  ( 13)  0.016968386753172  0.001120736716630 -0.667558162177866 -0.016648983669703  0.049072172914944 -0.011592992748873
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.071349801352714  0.001077758689270  0.047849010758340 -0.099049708991052 -0.097373218549672  0.073249702217701 -0.066497399663850  0.021905924000244  0.009611371244576
-    1  ( 15)  0.044780949738342 -0.002559008927920  0.033951661393695 -0.066729312295418 -0.060308115101382  0.053229541901542 -0.078046690958419  0.016360376267858  0.006154062585816
-    2  ( 16)  0.011020054803350  0.009639577990263  0.005659342412151  0.191466387657664  0.233770018397497 -0.353943104953966  0.699652203951216  0.098429630868852 -0.064028996133412
-    3  ( 17) -0.107854789786884  0.070585793426189 -0.362141920362822  0.037292065848003  0.042427554280107  0.038929544624269 -0.207453249613655  0.003913287572505  0.085781111935072
-    4  ( 18)  0.108209449998533 -0.211629628691212  0.166874900133377  0.149325288082881  0.172890816462238  0.144890994778070 -0.389082003854782  0.007000687821947 -0.069612637937327
-    5  ( 19)  0.022019034844539 -0.144617634612061 -0.200192966932170  0.092059326306527  0.110737371319849  0.061364605633219 -0.221637061620898  0.079021140430878  0.032667339771975
-    6  ( 20)  0.089130158761328 -0.839805360702557 -0.200387491136614 -0.125541335494723 -0.184496760040866 -0.044995250241913  0.109402692051618  0.378035804168236  0.212908503907272
-    7  ( 21) -0.002178057091038 -0.082925436926418 -0.048118216149291 -0.114730021254943 -0.074453346277443 -0.084891108935477  0.045281773316412  0.122667104662941  0.047081579488126
-    8  ( 22)  0.013014867453703  0.083878416356711  0.015105645463008 -0.084649544925900 -0.084843093804859  0.173122296622810 -0.343876299664282 -0.057834963947660 -0.044464266623987
-    9  ( 23) -0.002901775226444 -0.016234828173143 -0.056359654971922  0.065872157385180  0.036362021680561  0.148332139389917 -0.266718078511413 -0.072258279284242  0.065401012908070
-   10  ( 24) -0.008445720197207 -0.036804429594076  0.026642166859473 -0.084168947416289  0.066510758074250 -0.109381013548519 -0.203196264302626  0.141165925569744  0.070499221179183
-   11  ( 25)  0.005377792056996 -0.132971363586081  0.044450134013502  0.024046237867946 -0.035750577264436 -0.041236558408702  0.004898258174401 -0.132214673314328  0.663804812343684
-   12  ( 26)  0.009728994170679  0.012565610031584 -0.008265487183249 -0.011507462056027  0.000390885497570 -0.008310505974517 -0.039141081466560  0.021755546401072  0.043610775840953
-   13  ( 27) -0.000301420723236  0.013603051175605 -0.009758944837903  0.005201669668065  0.007344582365288  0.000240423767531  0.017707548228084 -0.014600989921618  0.008461166379513
-   14  ( 28) -0.003079753925572 -0.014179269497255  0.003153288832508  0.009783782056838  0.010222304053931  0.012792812982900 -0.043303231879501  0.003407229733488 -0.017679792666437
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.005093584579739  0.003397430557442 -0.004751145314814  0.022993999775599  0.006406607432760
-    1  ( 15) -0.003664268681973  0.005140681437481 -0.005623137023323 -0.014031183819186  0.010293722738862
-    2  ( 16) -0.021380720709285  0.010101149193740  0.129156907046771 -0.005327658954335  0.012995314092573
-    3  ( 17)  0.021888212102997  0.013219387248758 -0.009147784998772 -0.012607741489433 -0.012451560776453
-    4  ( 18) -0.030283770762187 -0.036869387279963  0.009496744772073  0.011181780485751 -0.009182409552409
-    5  ( 19) -0.023453672116028 -0.001799424920857  0.064551617042565  0.041960641260948 -0.014420118956798
-    6  ( 20) -0.129458546494562 -0.031271046054797  0.026491102279077 -0.003035012140173 -0.062712336606288
-    7  ( 21) -0.016591446747124 -0.158366047016835 -0.021959782838748  0.141640631249081 -0.024819174074486
-    8  ( 22) -0.007575701587651 -0.001384112156408  0.285443557719759 -0.005092627774536  0.013202606990520
-    9  ( 23)  0.053335089301784  0.043785415746465 -0.612428033952438  0.089945127333786 -0.016908784258587
-   10  ( 24)  0.015338693676902 -0.395633576722134 -0.015809806174577 -0.149475505805735 -0.001108572795377
-   11  ( 25)  0.295832367201880  0.177313650229228  0.053561286295937  0.148004020967965  0.667548449264998
-   12  ( 26)  0.007157154416068  0.145586590426015 -0.384132810582926 -0.410951719442920  0.016651787670969
-   13  ( 27)  0.021701996830369 -0.046797876195772 -0.648997652718994  0.122606232077394 -0.049068049852585
-   14  ( 28) -0.010942221777254  0.019093183683669  0.223365949415077 -0.053520759465635  0.011602247780486
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002779955261603 -0.001692895942304  0.000296900585249 -0.009027308047393 -0.005517424530413 -0.019392785745098 -0.071615718156204 -0.008379623734860  0.006552142468186
-    1  (  1) -0.002104549417694  0.002248748312389 -0.016268779471159  0.026298614529309 -0.037020427509987 -0.022919155336998 -0.164160248243371 -0.021028638082436  0.018807600972837
-    2  (  2)  0.012197014321068  0.010749741004113 -0.015969423342584  0.008379419120707  0.005700661608131  0.009182078264489  0.007072493012824  0.010651845449983  0.003884546255787
-    3  (  3)  0.055916626202381  0.044952545452401 -0.075693796863105  0.001117242062940  0.024281174456380  0.014619597544444  0.053283290640729 -0.007703747637900  0.022436578410207
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006982563138735  0.003194903879745  0.002336222897235 -0.000159319304138  0.003153288870770 -0.001705858583767
-    1  (  1) -0.013922175981332 -0.014264739151757 -0.027533427644978 -0.002422850658312 -0.006842699761048  0.005360945695369
-    2  (  2) -0.010224586423112  0.021331787446369 -0.001728789794737 -0.007349416930945 -0.001927444504520 -0.000065986060579
-    3  (  3) -0.028649073776619 -0.008193923965952  0.026834068422643 -0.006433642271152 -0.011064478009773 -0.011417291735948
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.007713676236592 -0.011322134542428 -0.003907084678219 -0.013398999832293 -0.015469012646278  0.052157960120007 -0.107410796770658 -0.010366341516333 -0.002761603992801
-    1  (  5) -0.025927350683997  0.036918918076002  0.006183726668218 -0.026765793037023 -0.030906551194513  0.042649472793187 -0.084196537695915 -0.021256853976094  0.026253718608666
-    2  (  6)  0.059547667994813 -0.071575508753465 -0.010792071396250 -0.045987434407762 -0.051692908853277  0.069048919754819 -0.125623895288423  0.001752094627183 -0.022191347480180
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.000950352585130  0.000964031243708 -0.004357151868409 -0.000282508389387  0.001887057940293
-    1  (  5)  0.015009418487876  0.001705110486742 -0.029429172036478 -0.001075595895759 -0.006702102006371
-    2  (  6) -0.007980731926488 -0.006589892733093 -0.020940438262106 -0.005674678855389 -0.010940914550877
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.022503440295579 -0.058098623160149 -0.000062770556748  0.132305009159629  0.206845253888047 -0.090151367716489  0.021622993201571  0.039361663017831 -0.081041759541844
-    1  (  1)  0.058446002592381 -0.108172168387665 -0.020491566069368 -0.029038345945867  0.075256281089894 -0.197244333760875  0.268904698800623  0.104165934684913 -0.067340388337437
-    2  (  2)  0.015395531940668 -0.065975044888453 -0.020693241252053 -0.145278172828441 -0.156811977467575 -0.026190455409877  0.072791620600644  0.106379132149940 -0.008110007387647
-    3  (  3) -0.209889648220478 -0.051262205346318  0.016792464687917  0.095510023534389 -0.095336437810925  0.289116526954890 -0.245753636284337  0.379261907424074 -0.084194488967514
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009235922100177  0.024147628250432 -0.039515998201657 -0.082736569420113  0.047511948424277
-    1  (  1) -0.028213287461096 -0.067760885411213 -0.238885785807082  0.125969164479716 -0.177609465312033
-    2  (  2) -0.077606300081110  0.045313543916728 -0.093141189396729 -0.365274041996181 -0.093447143795063
-    3  (  3) -0.414915648100444 -0.159852566418804  0.273568285227133  0.034618677637948 -0.200919751819526
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.016102681987247  0.069778483698171 -0.053388820632185 -0.227201022134194  0.199230027457400 -0.049687576281265  0.168877445270916  0.014461225328824  0.006078045812775
-    1  (  5) -0.058029574787099  0.323045692563543 -0.030451397472044  0.087822399116233  0.049669665032459  0.052839306746938  0.277652121541255  0.149775076383338 -0.305937155270736
-    2  (  6)  0.084055275470361 -0.046073375199290 -0.190725804864306  0.087557818530500  0.137785527514624  0.205465571554547  0.198777590920688  0.118276962990440  0.298899363373310
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.065173985616706 -0.083163093490792 -0.059838819851121 -0.009394325001926  0.030439464329859 -0.004211858017358
-    1  (  5) -0.056299326992358  0.068872084539624 -0.330916524068169  0.053769676104327  0.184435947376520  0.103868547783993
-    2  (  6) -0.066328790174072  0.124449756312364 -0.113043685745447 -0.144452726550998 -0.299204372306587  0.043729255680790
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.000261962805528 -0.008184590036915 -0.017078206714546  0.120797444663216
-    1  (  1)  0.008556708940913 -0.000310357479341 -0.070665159347735  0.263733240360107
-    2  (  2)  0.016665957640930  0.070092969568198 -0.000658296979419 -0.516406140442807
-    3  (  3) -0.119815260993819 -0.260397085059199  0.515923296927153 -0.000854850636510
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.000399146441393 -0.382166830385042  0.144086395309985
-    1  (  5)  0.378879203373120  0.000650240992922 -0.057572968692994
-    2  (  6) -0.142267704977138  0.057783925625685 -0.001456329094587
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000900630817553 -0.057480932301248 -0.021776185729735  0.109986124582381  0.040974945330860 -0.038859091716901  0.013722976007051 -0.027662163358443 -0.095856958174051
-    1  (  1)  0.055475653729802 -0.000055946423413  0.161049994133622 -0.114708024204125  0.226365261647020 -0.429957047290467  0.365226817146534  0.339873184728948  0.220417191818894
-    2  (  2)  0.021015776391238 -0.161427052909899 -0.000077274959500 -0.056803578516095 -0.009014493962493 -0.218381032705550  0.249538253456372  0.218329398300741 -0.109423644471862
-    3  (  3) -0.109912942235432  0.115891216387191  0.056027564915092 -0.000745943372337 -0.462877633738750 -0.122572187022588 -0.103916786291663 -0.116372032296575 -0.000178644283993
-    4  (  4) -0.040100257401862 -0.225977964738017  0.007764610803091  0.462832592343483  0.000863713188323 -0.292983388565641  0.009504255770576  0.051881331882871  0.039789084738637
-    5  (  5)  0.036362528925743  0.431143684565124  0.219013710239096  0.122734678900441  0.292859375843399  0.000211534680093 -0.380048338834318 -0.122563604837507 -0.042304270254871
-    6  (  6) -0.010482485700737 -0.366095597661562 -0.249485788064450  0.103549341685710 -0.008516226169361  0.379084427040252  0.000639775867465 -0.110614613813780  0.062004820067370
-    7  (  7)  0.028768402882082 -0.339119958859154 -0.216813059372775  0.114011828936202 -0.053232451800242  0.122211769727445  0.109878960190336  0.000261733603901  0.084697348659745
-    8  (  8)  0.095810944695334 -0.221328249276204  0.109105398407007  0.000872051363339 -0.038539628128307  0.040520833999881 -0.059740000698578 -0.084693665490196 -0.000412317879658
-    9  (  9) -0.014697085572369  0.105287145446058  0.107273285124578 -0.218858370800804 -0.309735125099696  0.105267325854039  0.129620026346504 -0.117982202893285 -0.042502371715711
-   10  ( 10)  0.029182274069823 -0.107750482915279  0.099755873232373 -0.053540519729348 -0.138357776561317 -0.190065661316311  0.089951321859060  0.050398080030964  0.205938711533222
-   11  ( 11)  0.155188100419269 -0.443693923193159  0.328775787594980  0.218791170588477  0.215183707581260 -0.086687685172586  0.081438682030100  0.042661060649411 -0.076989743302322
-   12  ( 12) -0.047041819133236 -0.056356277723761  0.091876156457291 -0.290703693299362  0.241933426060878  0.247197194304100 -0.042704222313214 -0.092541926182743  0.274193192866205
-   13  ( 13)  0.050345457187286 -0.050309029533978  0.290248962160664 -0.162027268205565 -0.213802087129928  0.103771321970540  0.033795235497894  0.045614675872296 -0.299788281594493
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015094426489382 -0.029115659613984 -0.157755053899573  0.046090500922971 -0.051508699260239
-    1  (  1) -0.106870813652789  0.107133528015314  0.444981848759519  0.057242056092259  0.049852574162928
-    2  (  2) -0.109000377776210 -0.100245307552928 -0.328735836791196 -0.092813183683061 -0.291725571255713
-    3  (  3)  0.218950464663657  0.054805102085238 -0.218886888542902  0.287519470239761  0.163372131318506
-    4  (  4)  0.309058290561676  0.137567383239759 -0.215197532854513 -0.238351393836438  0.213552990219087
-    5  (  5) -0.105624117972044  0.189859620690792  0.086820347884678 -0.246317074454998 -0.103852569604008
-    6  (  6) -0.128090000856966 -0.089849284790653 -0.081980995688413  0.043663325009335 -0.033155703031441
-    7  (  7)  0.117989240855155 -0.049695249544262 -0.043676012478621  0.088835836027429 -0.045632574214248
-    8  (  8)  0.043185512310113 -0.206252030230831  0.075219160600274 -0.272504390674237  0.299099410447326
-    9  (  9)  0.000057792160807 -0.416496446259873 -0.033591110007561  1.079044045817668 -0.144878189091330
-   10  ( 10)  0.417381448990192  0.000164005362256  0.288881720270970  0.322059475407983  0.291538277058570
-   11  ( 11)  0.033261524584639 -0.288678211108026 -0.000120543612153 -0.357470920187357  0.110246704427599
-   12  ( 12) -1.082405304483691 -0.322498276514608  0.357322196019213 -0.000062083058686  0.002512916703858
-   13  ( 13)  0.144912114579253 -0.291369916474370 -0.110105006775579 -0.002446483993989 -0.000063534084907
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000175081543235 -0.016120371429445 -0.025072002498307  0.062542190001810  0.021350885611608 -0.118270325314450  0.004836963443519  0.089308321494217 -0.035265121599228
-    1  ( 15)  0.019016581108200  0.000074621970578 -0.073692709803711  0.220090875517914 -0.117001241546639  0.069843654088588  0.194734592940078 -0.297334325625656  0.000079679030782
-    2  ( 16)  0.022601123418381  0.074079137647858  0.000898075728427  0.015352523942492  0.086856492084776  0.105020764975991  0.399309885639210  0.436863382131761 -0.175020106394679
-    3  ( 17) -0.059722097345652 -0.223919505098606 -0.017236939707940 -0.001153330835786 -0.251337783789116  0.316047497618471 -0.195069502405311 -0.070796117852672  0.376854141068940
-    4  ( 18) -0.020136753535465  0.119176676580060 -0.086690091555956  0.251646590139118  0.000253931741203 -0.043128862347025 -0.031767565075530 -0.166618171717967 -0.162853353427601
-    5  ( 19)  0.121150060676480 -0.070465337136678 -0.107141402917501 -0.315382260507230  0.043144844880487  0.000915299484024 -0.084836748925369 -0.176704257940149  0.191804096130299
-    6  ( 20) -0.000227153495201 -0.194659284089699 -0.399818522753260  0.193896536829102  0.032525351177556  0.085523354347259 -0.000313079507664 -0.483156326770458  0.288322768300912
-    7  ( 21) -0.086746307137042  0.297294170806809 -0.437363838809426  0.070300496686555  0.166591994782662  0.177217714676487  0.482838971708778  0.000010492293158 -0.098273184847402
-    8  ( 22)  0.034845258926466 -0.000856544015064  0.174085542944908 -0.374309528502842  0.160749665940872 -0.191624326414407 -0.289454904423216  0.097021267550271  0.000014930403133
-    9  ( 23)  0.146129839058632 -0.053485685235498 -0.324250294825684 -0.062889229683982 -0.055229748354918 -0.064112736518466 -0.152978751390774 -0.139451617186818  0.103725991413656
-   10  ( 24) -0.228960109301500  0.607985902209189  0.190616272123952  0.232984732345903  0.097313246050666 -0.308149392800276  0.021807135674585 -0.163587870408675 -0.316482089556363
-   11  ( 25)  0.113565876404484  0.174438492287332 -0.418980586076642 -0.308342622144823  0.075432621027986 -0.339103289288024  0.159452756259661  0.028406298387555  0.098839597099930
-   12  ( 26)  0.037444327267505  0.021664072112537 -0.117362801200434  0.051936890369197 -0.180410685976209 -0.010675625355649 -0.081438166282149  0.155940478341532 -0.070485054402575
-   13  ( 27) -0.017297506490468  0.067203074043419 -0.031147633780082  0.363738862057262 -0.387270613641776 -0.012184715254227 -0.015942188037276 -0.055059690817367  0.199296990199261
-   14  ( 28) -0.034092252177278 -0.073609066570293  0.020468002829466  0.085810470847391 -0.016765555515284  0.112839616184051  0.014153257364854 -0.178002322135800 -0.110338785365484
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147095539872383  0.230933799773564 -0.118289772746167 -0.038253772767447  0.016292190599368  0.035682534667396
-    1  ( 15)  0.054490936726031 -0.608135664745124 -0.173899591973767 -0.021325225109119 -0.066354839577592  0.073331369735506
-    2  ( 16)  0.323391847959358 -0.191801489512728  0.419969130886923  0.118001273092276  0.032684795751626 -0.020933916119487
-    3  ( 17)  0.062697350486204 -0.233350536310715  0.310310140488118 -0.052850324165985 -0.365716314917495 -0.086296396691572
-    4  ( 18)  0.056488793458219 -0.097314229222686 -0.076761540605080  0.181114864878134  0.388829148158841  0.017043041264758
-    5  ( 19)  0.064628320787155  0.308910350912390  0.338058227371875  0.010220898623446  0.011328162399087 -0.112362127982896
-    6  ( 20)  0.155379178216769 -0.021354195203646 -0.159398635050546  0.081833336858156  0.016534888228459 -0.014163359612821
-    7  ( 21)  0.140544774640624  0.163930417297846 -0.028664595573870 -0.155618444233808  0.055735865052552  0.178161215640947
-    8  ( 22) -0.103335943311615  0.315447824318108 -0.098508893733037  0.070643837593468 -0.199190551733382  0.110186805922078
-    9  ( 23) -0.000685205966667  0.100205727138143  0.098177984906045 -0.175404901290359  0.218086466804531 -0.228138153241008
-   10  ( 24) -0.099957378010069  0.000114683002834 -0.318552989781446  0.225328174596363  0.500054658950197  0.463890214112047
-   11  ( 25) -0.099837194917025  0.317752725239556  0.000013072206941 -0.325584528982697  0.211934933711027  0.064802310197898
-   12  ( 26)  0.174911687089768 -0.225249469039723  0.325644361756696 -0.000020583584119  0.212000345487721 -0.097990759740804
-   13  ( 27) -0.218595256276638 -0.499626470482149 -0.211748903875054 -0.211985776866883  0.000065067673371  0.140785106097381
-   14  ( 28)  0.228612967389234 -0.463548085364345 -0.064895093957785  0.097943745399791 -0.140883877569212  0.000043885507604
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019700182677109  0.054538984090237 -0.000657293183073 -0.126059310809830 -0.202210998435536  0.093434338948922 -0.024491292826910 -0.039730679308164  0.082949626694243
-    1  (  1) -0.060570767175444  0.116914550591559  0.021887147512717  0.031244847376016 -0.072525220228198  0.201021150446193 -0.281719713830578 -0.109054645892929  0.074327440399931
-    2  (  2) -0.019917912309235  0.073498936617270  0.021015841735422  0.144973687437576  0.148661911932313  0.032805680200546 -0.073267109264708 -0.114043301611785  0.006398273119572
-    3  (  3)  0.203013924377868  0.061956730055068 -0.012687970996334 -0.097374198936088  0.112619147770757 -0.293844050008894  0.262428514093194 -0.382217125669632  0.093448479811708
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009866900732451 -0.025414444169080  0.042903095265214  0.089054808289041 -0.047172870515859
-    1  (  1)  0.029479300283787  0.071852668133049  0.250209813738974 -0.142668644531385  0.184582935130079
-    2  (  2)  0.082839864480014 -0.055172054044896  0.094169081580928  0.401277867082131  0.092346870950097
-    3  (  3)  0.429785932962393  0.170247315400438 -0.282336698266602 -0.039589385431130  0.207542683133729
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.009866584979615 -0.069659389537491  0.056437231681763  0.210909857783049 -0.193232853181170  0.044263163299008 -0.177086741570328 -0.011251791029684 -0.005974944716268
-    1  (  5)  0.063966745715490 -0.332083812922557  0.023959233352896 -0.077592998716556 -0.049685567261474 -0.057922845574600 -0.292828526996057 -0.156611147799580  0.308189152931944
-    2  (  6) -0.093646243694873  0.043886805978712  0.210333087134862 -0.092497904992983 -0.147507586034141 -0.211245402574096 -0.209822842363991 -0.120370292677788 -0.308437245541850
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.068407482810993  0.091070726633550  0.065843093849228  0.010412482581381 -0.030047987986095  0.002926817734499
-    1  (  5)  0.052950259935732 -0.069489349844531  0.341748563636028 -0.056521413026742 -0.185361514981393 -0.106113084848249
-    2  (  6)  0.072195900884652 -0.125482826256955  0.118114475628592  0.149158088490872  0.308475854808773 -0.046262836261975
-
 	Computing Mu_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.540697431193
-	   1         5.552916117478    3.480e-01
-	   2         6.604958020371    2.284e-01
-	   3         6.775215300811    7.934e-02
-	   4         6.834035245668    4.394e-02
-	   5         6.845160672783    1.738e-02
-	   6         6.850503279364    1.025e-02
-	   7         6.850632769023    5.347e-03
-	   8         6.850566640390    2.859e-03
-	   9         6.850241817246    1.566e-03
-	  10         6.850405195016    6.971e-04
-	  11         6.850478753078    1.698e-04
-	  12         6.850543404312    7.065e-05
-	  13         6.850571882241    3.674e-05
-	  14         6.850594686286    1.964e-05
-	  15         6.850605491784    7.311e-06
-	  16         6.850609755845    2.877e-06
-	  17         6.850610013933    7.266e-07
-	  18         6.850609678966    3.402e-07
-	  19         6.850609542810    1.219e-07
+	   0         4.540697422749
+	   1         5.552916105745    3.480e-01
+	   2         6.604958005788    2.284e-01
+	   3         6.775215285821    7.934e-02
+	   4         6.834035231501    4.394e-02
+	   5         6.845160658466    1.738e-02
+	   6         6.850503265133    1.025e-02
+	   7         6.850632754759    5.347e-03
+	   8         6.850566626109    2.859e-03
+	   9         6.850241802983    1.566e-03
+	  10         6.850405180741    6.971e-04
+	  11         6.850478738804    1.698e-04
+	  12         6.850543390036    7.065e-05
+	  13         6.850571867964    3.674e-05
+	  14         6.850594672009    1.964e-05
+	  15         6.850605477506    7.311e-06
+	  16         6.850609741567    2.877e-06
+	  17         6.850609999654    7.266e-07
+	  18         6.850609664687    3.402e-07
+	  19         6.850609528531    1.219e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.325e-08
 
 	Computing P*_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.792316925792
-	   1         9.820637514567    2.598e-01
-	   2        10.431156591209    1.503e-01
-	   3        10.543304342659    7.502e-02
-	   4        10.577122754481    4.078e-02
-	   5        10.586800644294    1.756e-02
-	   6        10.592735755015    1.038e-02
-	   7        10.592669873170    5.140e-03
-	   8        10.593116620007    2.679e-03
-	   9        10.593004677210    1.168e-03
-	  10        10.593228313196    5.509e-04
-	  11        10.593286571021    1.426e-04
-	  12        10.593309878924    4.629e-05
-	  13        10.593326400264    2.390e-05
-	  14        10.593334201958    1.228e-05
-	  15        10.593338537922    5.060e-06
-	  16        10.593340408570    2.637e-06
-	  17        10.593340554247    1.139e-06
-	  18        10.593340628164    5.782e-07
-	  19        10.593340733388    2.217e-07
-	  20        10.593340821478    1.062e-07
+	   0         8.792316948214
+	   1         9.820637538969    2.598e-01
+	   2        10.431156618762    1.503e-01
+	   3        10.543304370821    7.502e-02
+	   4        10.577122783308    4.078e-02
+	   5        10.586800673097    1.756e-02
+	   6        10.592735783861    1.038e-02
+	   7        10.592669901909    5.140e-03
+	   8        10.593116648752    2.679e-03
+	   9        10.593004705951    1.168e-03
+	  10        10.593228341932    5.509e-04
+	  11        10.593286599757    1.426e-04
+	  12        10.593309907659    4.629e-05
+	  13        10.593326428998    2.390e-05
+	  14        10.593334230692    1.228e-05
+	  15        10.593338566656    5.060e-06
+	  16        10.593340437304    2.637e-06
+	  17        10.593340582981    1.139e-06
+	  18        10.593340656898    5.782e-07
+	  19        10.593340762122    2.217e-07
+	  20        10.593340850212    1.062e-07
 	-----------------------------------------
 	Converged P*_X-Perturbed Wfn to 5.027e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.308774510044
-	   1         5.177251147516    2.385e-01
-	   2         5.788144734198    1.206e-01
-	   3         5.817401245271    2.506e-02
-	   4         5.822428669112    1.120e-02
-	   5         5.823746001128    2.243e-03
-	   6         5.823954312245    1.112e-03
-	   7         5.823956740112    3.004e-04
-	   8         5.823962111139    9.653e-05
-	   9         5.823955533594    3.317e-05
-	  10         5.823958206449    9.554e-06
-	  11         5.823960101372    2.275e-06
-	  12         5.823961215410    6.655e-07
-	  13         5.823961727557    2.438e-07
+	   0         4.308774480793
+	   1         5.177251112373    2.385e-01
+	   2         5.788144692758    1.206e-01
+	   3         5.817401202381    2.506e-02
+	   4         5.822428626061    1.120e-02
+	   5         5.823745958006    2.243e-03
+	   6         5.823954269104    1.112e-03
+	   7         5.823956696972    3.004e-04
+	   8         5.823962067999    9.653e-05
+	   9         5.823955490454    3.317e-05
+	  10         5.823958163309    9.554e-06
+	  11         5.823960058231    2.275e-06
+	  12         5.823961172270    6.655e-07
+	  13         5.823961684417    2.438e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 8.940e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.602235857656
-	   1        13.271677057014    5.821e-01
-	   2        16.135822785318    3.780e-01
-	   3        16.959451373770    1.255e-01
-	   4        17.038031086023    5.281e-02
-	   5        17.073133975370    2.081e-02
-	   6        17.076161098532    1.277e-02
-	   7        17.073021378674    6.659e-03
-	   8        17.077922418366    3.883e-03
-	   9        17.076962153451    1.776e-03
-	  10        17.077205376846    9.815e-04
-	  11        17.077267411913    3.595e-04
-	  12        17.077514625867    1.084e-04
-	  13        17.077629152399    3.194e-05
-	  14        17.077680905589    1.733e-05
-	  15        17.077702717659    9.195e-06
-	  16        17.077704067073    4.270e-06
-	  17        17.077698484866    1.559e-06
-	  18        17.077697685414    6.697e-07
-	  19        17.077697400523    2.714e-07
+	   0        10.602235753425
+	   1        13.271676932128    5.821e-01
+	   2        16.135822640251    3.780e-01
+	   3        16.959451195178    1.255e-01
+	   4        17.038030906681    5.281e-02
+	   5        17.073133794699    2.081e-02
+	   6        17.076160917884    1.277e-02
+	   7        17.073021197998    6.659e-03
+	   8        17.077922237410    3.883e-03
+	   9        17.076961972524    1.776e-03
+	  10        17.077205195910    9.815e-04
+	  11        17.077267230982    3.595e-04
+	  12        17.077514444931    1.084e-04
+	  13        17.077628971462    3.194e-05
+	  14        17.077680724650    1.733e-05
+	  15        17.077702536719    9.195e-06
+	  16        17.077703886132    4.270e-06
+	  17        17.077698303925    1.559e-06
+	  18        17.077697504474    6.697e-07
+	  19        17.077697219582    2.714e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 9.713e-08
 
 	Computing P*_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.251457726110
-	   1        10.589647093578    3.208e-01
-	   2        11.460703461573    1.854e-01
-	   3        11.756069852001    6.855e-02
-	   4        11.765813776050    2.537e-02
-	   5        11.772798626300    8.227e-03
-	   6        11.773011783180    4.281e-03
-	   7        11.772860554008    1.485e-03
-	   8        11.773139526655    8.964e-04
-	   9        11.772853818032    5.154e-04
-	  10        11.773003931345    2.965e-04
-	  11        11.772980868550    1.692e-04
-	  12        11.773040256211    6.561e-05
-	  13        11.773041808156    2.246e-05
-	  14        11.773048251773    7.645e-06
-	  15        11.773049474181    3.360e-06
-	  16        11.773050583583    1.576e-06
-	  17        11.773050694909    7.130e-07
-	  18        11.773050459064    3.152e-07
-	  19        11.773050279192    1.475e-07
+	   0         9.251457743171
+	   1        10.589647119894    3.208e-01
+	   2        11.460703497067    1.854e-01
+	   3        11.756069882207    6.855e-02
+	   4        11.765813806381    2.537e-02
+	   5        11.772798656556    8.227e-03
+	   6        11.773011813449    4.281e-03
+	   7        11.772860584256    1.485e-03
+	   8        11.773139556909    8.964e-04
+	   9        11.772853848286    5.154e-04
+	  10        11.773003961596    2.965e-04
+	  11        11.772980898802    1.692e-04
+	  12        11.773040286463    6.561e-05
+	  13        11.773041838408    2.246e-05
+	  14        11.773048282025    7.645e-06
+	  15        11.773049504433    3.360e-06
+	  16        11.773050613835    1.576e-06
+	  17        11.773050725162    7.130e-07
+	  18        11.773050489316    3.152e-07
+	  19        11.773050309445    1.475e-07
 	-----------------------------------------
 	Converged P*_Y-Perturbed Wfn to 6.612e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.244930554509
-	   1         0.311636624039    6.760e-02
-	   2         0.361199110032    3.539e-02
-	   3         0.362499590815    6.680e-03
-	   4         0.362993605803    2.873e-03
-	   5         0.363033480938    3.354e-04
-	   6         0.363025221809    1.308e-04
-	   7         0.363026115518    3.393e-05
-	   8         0.363025851986    1.573e-05
-	   9         0.363025808831    3.876e-06
-	  10         0.363025880342    1.247e-06
-	  11         0.363025925513    2.950e-07
-	  12         0.363025946102    1.072e-07
+	   0         0.244930550976
+	   1         0.311636619191    6.760e-02
+	   2         0.361199103660    3.539e-02
+	   3         0.362499584351    6.680e-03
+	   4         0.362993599316    2.873e-03
+	   5         0.363033474449    3.354e-04
+	   6         0.363025215320    1.308e-04
+	   7         0.363026109029    3.393e-05
+	   8         0.363025845497    1.573e-05
+	   9         0.363025802342    3.876e-06
+	  10         0.363025873854    1.247e-06
+	  11         0.363025919025    2.950e-07
+	  12         0.363025939613    1.072e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 1.612e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.136885453445
-	   1         8.827959964632    4.504e-01
-	   2        10.556417242071    2.704e-01
-	   3        10.782604403022    7.855e-02
-	   4        10.823407882015    3.852e-02
-	   5        10.834692997361    1.311e-02
-	   6        10.837906126725    7.418e-03
-	   7        10.837673587110    2.897e-03
-	   8        10.837862221434    1.321e-03
-	   9        10.837807614417    4.095e-04
-	  10        10.837877551051    1.842e-04
-	  11        10.837874871306    1.127e-04
-	  12        10.837880350125    6.643e-05
-	  13        10.837882578520    3.884e-05
-	  14        10.837896108461    1.776e-05
-	  15        10.837905201770    6.583e-06
-	  16        10.837910723726    3.571e-06
-	  17        10.837912086926    1.677e-06
-	  18        10.837912427624    9.968e-07
-	  19        10.837912585503    4.166e-07
-	  20        10.837912731788    1.603e-07
+	   0         7.136885404839
+	   1         8.827959901316    4.504e-01
+	   2        10.556417160848    2.704e-01
+	   3        10.782604318565    7.855e-02
+	   4        10.823407797411    3.852e-02
+	   5        10.834692912643    1.311e-02
+	   6        10.837906041941    7.418e-03
+	   7        10.837673502344    2.897e-03
+	   8        10.837862136659    1.321e-03
+	   9        10.837807529645    4.095e-04
+	  10        10.837877466278    1.842e-04
+	  11        10.837874786533    1.127e-04
+	  12        10.837880265350    6.643e-05
+	  13        10.837882493744    3.884e-05
+	  14        10.837896023688    1.776e-05
+	  15        10.837905116999    6.583e-06
+	  16        10.837910638957    3.571e-06
+	  17        10.837912002158    1.677e-06
+	  18        10.837912342856    9.968e-07
+	  19        10.837912500735    4.166e-07
+	  20        10.837912647019    1.603e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 7.150e-08
 
 	Computing P*_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.549537144870
-	   1        10.712689725897    3.014e-01
-	   2        11.520133226657    1.604e-01
-	   3        11.651520207706    5.896e-02
-	   4        11.660315652789    2.770e-02
-	   5        11.665606003908    9.842e-03
-	   6        11.668007355174    5.866e-03
-	   7        11.667965714600    2.584e-03
-	   8        11.668033293549    1.362e-03
-	   9        11.667930506092    5.861e-04
-	  10        11.668049592418    3.075e-04
-	  11        11.668073366522    1.780e-04
-	  12        11.668095101153    6.875e-05
-	  13        11.668098461865    3.421e-05
-	  14        11.668101480332    1.424e-05
-	  15        11.668107291995    5.139e-06
-	  16        11.668110114391    2.399e-06
-	  17        11.668111124175    1.194e-06
-	  18        11.668111340458    5.671e-07
-	  19        11.668111245307    1.432e-07
+	   0         9.549537167137
+	   1        10.712689751102    3.014e-01
+	   2        11.520133253868    1.604e-01
+	   3        11.651520234154    5.896e-02
+	   4        11.660315679376    2.770e-02
+	   5        11.665606030506    9.842e-03
+	   6        11.668007381760    5.866e-03
+	   7        11.667965741182    2.584e-03
+	   8        11.668033320136    1.362e-03
+	   9        11.667930532677    5.861e-04
+	  10        11.668049619006    3.075e-04
+	  11        11.668073393112    1.780e-04
+	  12        11.668095127744    6.875e-05
+	  13        11.668098488456    3.421e-05
+	  14        11.668101506923    1.424e-05
+	  15        11.668107318587    5.139e-06
+	  16        11.668110140982    2.399e-06
+	  17        11.668111150766    1.194e-06
+	  18        11.668111367049    5.671e-07
+	  19        11.668111271899    1.432e-07
 	-----------------------------------------
 	Converged P*_Z-Perturbed Wfn to 6.024e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.872510404753
-	   1         4.591669370067    2.120e-01
-	   2         5.085547488762    1.160e-01
-	   3         5.121987048699    2.992e-02
-	   4         5.131210468924    1.294e-02
-	   5         5.131618039119    2.045e-03
-	   6         5.131761970312    9.597e-04
-	   7         5.131734102928    2.100e-04
-	   8         5.131723837644    5.883e-05
-	   9         5.131718337669    1.520e-05
-	  10         5.131718484323    4.160e-06
-	  11         5.131719052295    1.198e-06
-	  12         5.131719331290    4.377e-07
-	  13         5.131719470515    1.751e-07
+	   0         3.872510377042
+	   1         4.591669336887    2.120e-01
+	   2         5.085547449875    1.160e-01
+	   3         5.121987008165    2.992e-02
+	   4         5.131210428081    1.294e-02
+	   5         5.131617998237    2.045e-03
+	   6         5.131761929419    9.597e-04
+	   7         5.131734062034    2.100e-04
+	   8         5.131723796750    5.883e-05
+	   9         5.131718296775    1.520e-05
+	  10         5.131718443429    4.160e-06
+	  11         5.131719011401    1.198e-06
+	  12         5.131719290397    4.377e-07
+	  13         5.131719429622    1.751e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 6.824e-08
 
@@ -11095,9 +1614,9 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.279315258737972    -0.123252237132550     0.000000000000000
-    1     -0.488104243387056    -0.028164898887981     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.221999670108362
+    0      0.279315257111821    -0.123252236365221     0.000000000000000
+    1     -0.488104244070402    -0.028164898177226     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.221999666119615
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
 	[alpha]_(0.128) = -237.12775 deg/[dm (g/cm^3)]
@@ -11109,12 +1628,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.399325681803787    -0.379486458787803     0.000000000000000
-    1     -0.120585417251772    -0.008851315788493     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.397645877164831
+    0      0.399325680016755    -0.379486455964309     0.000000000000000
+    1     -0.120585417981737    -0.008851315481093     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.397645874903929
 
    Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) =  454.52410 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) =  454.52398 deg/[dm (g/cm^3)]
 
         CC2 Optical Rotation Tensor (Modified Velocity Gauge):
   -------------------------------------------------------------------------
@@ -11123,12 +1642,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.037966613590714    -0.035523395031054     0.000000000000000
-    1     -0.064884215634922    -0.002737367772863     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.023784640474743
+    0      0.037966613644560    -0.035523395077833     0.000000000000000
+    1     -0.064884216600011    -0.002737367698347     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.023784640157232
 
    Specific rotation using modified velocity-gauge Rosenfeld tensor.
-	[alpha]_(0.128) = -725.34907 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -725.34899 deg/[dm (g/cm^3)]
 
    Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.
      Delta_x =   0.00   Delta_y =   0.00   Delta_z = -73.01
@@ -11141,7 +1660,7 @@ Total time:
    -----   ------ ------------------  ----------------------------------
                                           x           y           z      
    0.077   589.00       -83.11386       0.00000     0.00000   -19.66940
-   0.128   355.00      -237.12775       0.00000     0.00000   -73.00565
+   0.128   355.00      -237.12775       0.00000     0.00000   -73.00564
 
    ------------------------------------------------------
             CC2 Velocity-Gauge Optical Rotation
@@ -11150,17 +1669,10 @@ Total time:
 
     E_h      nm   Velocity-Gauge  Modified Velocity-Gauge
    -----   ------ --------------  -----------------------
-   0.077   589.00    982.51574          -197.35742
-   0.128   355.00    454.52410          -725.34907
+   0.077   589.00    982.51558          -197.35740
+   0.128   355.00    454.52398          -725.34899
 
-*** tstop() called on psinet at Mon May 15 15:34:51 2017
-Module time:
-	user time   =       3.96 seconds =       0.07 minutes
-	system time =       4.29 seconds =       0.07 minutes
-	total time  =          9 seconds =       0.15 minutes
-Total time:
-	user time   =       4.99 seconds =       0.08 minutes
-	system time =       4.76 seconds =       0.08 minutes
-	total time  =         11 seconds =       0.18 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:24PM
+    Psi4 wall time for execution: 0:00:22.22
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc42/output.ref
+++ b/tests/cc42/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:25PM
 
-    Process ID:  12876
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65782
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -53,25 +66,26 @@ set {
   omega [589, 355, nm]
 }
 
-property('cc2',properties=['rotation'])
+properties('cc2',properties=['rotation'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:51 2022
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-3  entry C          line    60 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 4    entry O          line    80 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 5-10 entry H          line    18 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 1-3  entry C          line    61 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 4    entry O          line    81 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 5-10 entry H          line    19 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -85,22 +99,22 @@ property('cc2',properties=['rotation'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.201751522566     0.002392992405     0.490202120079    12.000000000000
-           C         -0.989856477434     0.654130992405    -0.056843879921    12.000000000000
-           C          1.556762522566     0.135998992405    -0.144054879921    12.000000000000
-           O         -0.778596477434    -0.750055007595    -0.235025879921    15.994914619560
-           H          0.203343522566    -0.211065007595     1.556541120079     1.007825032070
-           H         -1.813559477434     0.920113992405     0.597738120079     1.007825032070
-           H         -0.900188477434     1.252402992405    -0.958365879921     1.007825032070
-           H          2.126424522566    -0.787996007595    -0.032265879921     1.007825032070
-           H          2.124083522566     0.939980992405     0.329511120079     1.007825032070
-           H          1.464513522566     0.354044992405    -1.207812879921     1.007825032070
+         C            0.201751522558     0.002392992399     0.490202120078    12.000000000000
+         C           -0.989856477442     0.654130992399    -0.056843879922    12.000000000000
+         C            1.556762522558     0.135998992399    -0.144054879922    12.000000000000
+         O           -0.778596477442    -0.750055007601    -0.235025879922    15.994914619570
+         H            0.203343522558    -0.211065007601     1.556541120078     1.007825032230
+         H           -1.813559477442     0.920113992399     0.597738120078     1.007825032230
+         H           -0.900188477442     1.252402992399    -0.958365879922     1.007825032230
+         H            2.126424522558    -0.787996007601    -0.032265879922     1.007825032230
+         H            2.124083522558     0.939980992399     0.329511120078     1.007825032230
+         H            1.464513522558     0.354044992399    -1.207812879922     1.007825032230
 
   Running in c1 symmetry.
 
   Rotational constants: A =      0.60799  B =      0.22239  C =      0.19815 [cm^-1]
-  Rotational constants: A =  18226.99774  B =   6666.95622  C =   5940.33276 [MHz]
-  Nuclear repulsion =  124.788534121264803
+  Rotational constants: A =  18226.99788  B =   6666.95627  C =   5940.33280 [MHz]
+  Nuclear repulsion =  124.788534611762472
 
   Charge       = 0
   Multiplicity = 1
@@ -117,27 +131,17 @@ property('cc2',properties=['rotation'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 18
-    Number of basis function: 26
+    Number of basis functions: 26
     Number of Cartesian functions: 26
     Spherical Harmonics?: true
     Max angular momentum: 1
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         26      26       0       0       0       0
-   -------------------------------------------------------
-    Total      26      26      16      16      16       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -156,45 +160,59 @@ property('cc2',properties=['rotation'])
   Using 123552 doubles for integral storage.
   We computed 14355 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.0902507179E-01.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.0902506889E-01.
+  Reciprocal condition number of the overlap matrix is 8.4122044079E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         26      26 
+   -------------------------
+    Total      26      26
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -189.41976534870165   -1.89420e+02   1.12671e-01 
-   @RHF iter   1:  -189.30558765724510    1.14178e-01   1.85610e-02 
-   @RHF iter   2:  -189.48177566679436   -1.76188e-01   8.26145e-03 DIIS
-   @RHF iter   3:  -189.51053786197357   -2.87622e-02   1.68511e-03 DIIS
-   @RHF iter   4:  -189.51325091536503   -2.71305e-03   3.54210e-04 DIIS
-   @RHF iter   5:  -189.51339254673462   -1.41631e-04   1.35641e-04 DIIS
-   @RHF iter   6:  -189.51341598866529   -2.34419e-05   3.17752e-05 DIIS
-   @RHF iter   7:  -189.51341716329620   -1.17463e-06   7.70830e-06 DIIS
-   @RHF iter   8:  -189.51341723494519   -7.16490e-08   1.60970e-06 DIIS
-   @RHF iter   9:  -189.51341723731156   -2.36636e-09   4.74878e-07 DIIS
-   @RHF iter  10:  -189.51341723756769   -2.56136e-10   9.86183e-08 DIIS
-   @RHF iter  11:  -189.51341723757949   -1.17950e-11   2.15603e-08 DIIS
-   @RHF iter  12:  -189.51341723758003   -5.40012e-13   4.05424e-09 DIIS
-   @RHF iter  13:  -189.51341723758009   -5.68434e-14   7.10239e-10 DIIS
-   @RHF iter  14:  -189.51341723758000    8.52651e-14   2.10640e-10 DIIS
-   @RHF iter  15:  -189.51341723758000    0.00000e+00   6.72374e-11 DIIS
+   @RHF iter SAD:  -186.43072166022984   -1.86431e+02   0.00000e+00 
+   @RHF iter   1:  -189.43266126778377   -3.00194e+00   1.28222e-02 ADIIS/DIIS
+   @RHF iter   2:  -189.50256237003040   -6.99011e-02   5.10734e-03 ADIIS/DIIS
+   @RHF iter   3:  -189.51308752257808   -1.05252e-02   6.61403e-04 ADIIS/DIIS
+   @RHF iter   4:  -189.51341362083542   -3.26098e-04   6.54297e-05 DIIS
+   @RHF iter   5:  -189.51341710353631   -3.48270e-06   1.19638e-05 DIIS
+   @RHF iter   6:  -189.51341723375194   -1.30216e-07   1.91468e-06 DIIS
+   @RHF iter   7:  -189.51341723649381   -2.74187e-09   7.28366e-07 DIIS
+   @RHF iter   8:  -189.51341723702984   -5.36033e-10   2.37098e-07 DIIS
+   @RHF iter   9:  -189.51341723710047   -7.06279e-11   4.41139e-08 DIIS
+   @RHF iter  10:  -189.51341723710254   -2.07478e-12   7.00241e-09 DIIS
+   @RHF iter  11:  -189.51341723710254    0.00000e+00   1.79171e-09 DIIS
+   @RHF iter  12:  -189.51341723710249    5.68434e-14   4.46110e-10 DIIS
+   @RHF iter  13:  -189.51341723710263   -1.42109e-13   1.14589e-10 DIIS
+   @RHF iter  14:  -189.51341723710254    8.52651e-14   1.75049e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -216,48 +234,43 @@ property('cc2',properties=['rotation'])
               A 
     DOCC [    16 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -189.51341723758000
+  @RHF Final Energy:  -189.51341723710254
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =            124.7885341212648029
-    One-Electron Energy =                -505.7302694787643986
-    Two-Electron Energy =                 191.4283181199196235
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -189.5134172375800006
+    Nuclear Repulsion Energy =            124.7885346117624721
+    One-Electron Energy =                -505.7302704013803805
+    Two-Electron Energy =                 191.4283185525153499
+    Total Energy =                       -189.5134172371025443
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     3.0005      Y:     2.3096      Z:     0.2664
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:    -2.7337      Y:    -1.8166      Z:    -0.0674
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.2668      Y:     0.4930      Z:     0.1990     Total:     0.5948
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.6781      Y:     1.2530      Z:     0.5057     Total:     1.5118
 
 
-*** tstop() called on psinet at Mon May 15 15:34:42 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:52 2022
 Module time:
-	user time   =       0.67 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.67 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -272,19 +285,19 @@ Total time:
       Number of basis functions:        26
 
       Number of irreps:                  1
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  26 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 61560 non-zero two-electron integrals.
+      Computed 60690 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:53 2022
 
 
 	Wfn Parameters:
@@ -306,7 +319,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -342,7 +355,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -209.07983613514321
+	Frozen core energy     =   -209.07983635006943
 
 	Size of irrep 0 of <ab|cd> integrals:      0.010 (MW) /      0.080 (MB)
 	Total:                                     0.010 (MW) /      0.080 (MB)
@@ -353,34 +366,30 @@ Total time:
 	Size of irrep 0 of tijab amplitudes:       0.014 (MW) /      0.115 (MB)
 	Total:                                     0.014 (MW) /      0.115 (MB)
 
-	Nuclear Rep. energy          =    124.78853412126480
-	SCF energy                   =   -189.51341723758000
-	One-electron energy          =   -194.60728307304521
-	Two-electron energy          =     89.38516784934311
-	Reference energy             =   -189.51341723758051
+	Nuclear Rep. energy          =    124.78853461176247
+	SCF energy                   =   -189.51341723710254
+	One-electron energy          =   -194.60728356878917
+	Two-electron energy          =     89.38516806999395
+	Reference energy             =   -189.51341723710217
 
-*** tstop() called on psinet at Mon May 15 15:34:42 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:53 2022
 Module time:
-	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.83 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
-
+	user time   =       1.53 seconds =       0.03 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =  124.788534121264803
-    SCF energy          (wfn)     = -189.513417237580001
-    Reference energy    (file100) = -189.513417237580512
+    Nuclear Rep. energy (wfn)     =  124.788534611762472
+    SCF energy          (wfn)     = -189.513417237102544
+    Reference energy    (file100) = -189.513417237102175
 
     Input parameters:
     -----------------
@@ -408,74 +417,61 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.1984983538101992
+MP2 correlation energy -0.1984983521050260
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.198498353810199    0.000e+00    0.000000    0.000000    0.000000    0.124632
-     1        -0.198386689299877    2.456e-02    0.005013    0.019208    0.019208    0.124632
-     2        -0.199744020160671    7.393e-03    0.005756    0.022873    0.022873    0.125832
-     3        -0.200084920619632    3.729e-03    0.006768    0.027963    0.027963    0.126111
-     4        -0.200115319676321    6.852e-04    0.006878    0.028762    0.028762    0.126089
-     5        -0.200118669301748    1.694e-04    0.006896    0.028947    0.028947    0.126086
-     6        -0.200118439802851    3.259e-05    0.006898    0.028967    0.028967    0.126084
-     7        -0.200118408188058    1.039e-05    0.006898    0.028968    0.028968    0.126083
-     8        -0.200118429865298    3.934e-06    0.006898    0.028968    0.028968    0.126083
-     9        -0.200118429204316    1.144e-06    0.006898    0.028968    0.028968    0.126083
-    10        -0.200118431545464    4.391e-07    0.006898    0.028968    0.028968    0.126083
-    11        -0.200118431235805    9.823e-08    0.006898    0.028968    0.028968    0.126083
+     0        -0.198498352105026    0.000e+00    0.000000    0.000000    0.000000    0.124632
+     1        -0.198386687596309    2.456e-02    0.005013    0.019208    0.019208    0.124632
+     2        -0.199744018436219    7.393e-03    0.005756    0.022873    0.022873    0.125832
+     3        -0.200084918887300    3.729e-03    0.006768    0.027963    0.027963    0.126111
+     4        -0.200115317942039    6.852e-04    0.006878    0.028762    0.028762    0.126089
+     5        -0.200118667567232    1.694e-04    0.006896    0.028947    0.028947    0.126085
+     6        -0.200118438068357    3.259e-05    0.006898    0.028967    0.028967    0.126084
+     7        -0.200118406453567    1.039e-05    0.006898    0.028968    0.028968    0.126083
+     8        -0.200118428130805    3.934e-06    0.006898    0.028968    0.028968    0.126083
+     9        -0.200118427469824    1.144e-06    0.006898    0.028968    0.028968    0.126083
+    10        -0.200118429810973    4.391e-07    0.006898    0.028968    0.028968    0.126083
+    11        -0.200118429501313    9.823e-08    0.006898    0.028968    0.028968    0.126083
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-             11   2         0.0197255943
-             11   3        -0.0114902911
-             11   5         0.0092063278
-             11   1        -0.0075665081
-              9   0         0.0074808409
-              4   2        -0.0071415173
-              2   1         0.0060498066
-             10   2        -0.0059927841
+             11   2         0.0197255945
+             11   3        -0.0114902909
+             11   5         0.0092063267
+             11   1        -0.0075665073
+              9   0         0.0074808408
+              4   2        -0.0071415172
+              2   1         0.0060498064
+             10   2        -0.0059927839
              10   1        -0.0055990860
-             11   4        -0.0047844227
+             11   4        -0.0047844241
 
     Largest TIjAb Amplitudes:
-     10  10   0   0        -0.0499696178
-      9   9   0   0        -0.0472348458
-      6   6   6   6        -0.0323415531
-      9  10   0   1         0.0282266083
-     10   9   1   0         0.0282266083
-     10  10   1   1        -0.0276616351
-      0   0   1   1        -0.0190922677
-      9  10   1   0         0.0182861875
-     10   9   0   1         0.0182861875
-      8   8   8   8        -0.0174521682
+     10  10   0   0        -0.0499696175
+      9   9   0   0        -0.0472348452
+      6   6   6   6        -0.0323415524
+      9  10   0   1         0.0282266079
+     10   9   1   0         0.0282266079
+     10  10   1   1        -0.0276616345
+      0   0   1   1        -0.0190922674
+      9  10   1   0         0.0182861872
+     10   9   0   1         0.0182861872
+      8   8   8   8        -0.0174521683
 
-    SCF energy       (wfn)                    = -189.513417237580001
-    Reference energy (file100)                = -189.513417237580512
+    SCF energy       (wfn)                    = -189.513417237102544
+    Reference energy (file100)                = -189.513417237102175
 
-    Opposite-spin MP2 correlation energy      =   -0.172369086880245
-    Same-spin MP2 correlation energy          =   -0.026129266929954
-    MP2 correlation energy                    =   -0.198498353810199
-      * MP2 total energy                      = -189.711915591390721
-    CC2 correlation energy                    =   -0.200118431235805
-      * CC2 total energy                      = -189.713535668816320
-
-
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
-Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.97 seconds =       0.02 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
+    Opposite-spin MP2 correlation energy      =   -0.172369085425346
+    Same-spin MP2 correlation energy          =   -0.026129266679680
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.198498352105026
+      * MP2 total energy                      = -189.711915589207194
+    CC2 correlation energy                    =   -0.200118429501313
+      * CC2 total energy                      = -189.713535666603491
 
 
 			**************************
@@ -485,31 +481,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.98 seconds =       0.02 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =  124.788534121264803
+	Nuclear Rep. energy (wfn)     =  124.788534611762472
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -189.513417237580001
-	Reference energy    (CC_INFO) = -189.513417237580512
-	CC2 energy          (CC_INFO) =   -0.200118431235805
-	Total CC2 energy    (CC_INFO) = -189.713535668816320
+	SCF energy          (wfn)     = -189.513417237102544
+	Reference energy    (CC_INFO) = -189.513417237102175
+	CC2 energy          (CC_INFO) =   -0.200118429501313
+	Total CC2 energy    (CC_INFO) = -189.713535666603491
 
 	Input parameters:
 	-----------------
@@ -522,7 +504,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -535,59 +517,45 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.200255252097002    0.000e+00
-	   1        -0.200237820765584    1.045e-02
-	   2        -0.199973107551451    1.485e-03
-	   3        -0.199954623633709    4.864e-04
-	   4        -0.199946897293502    1.053e-04
-	   5        -0.199946308537976    2.929e-05
-	   6        -0.199946157936786    6.703e-06
-	   7        -0.199946138584980    1.596e-06
-	   8        -0.199946137030889    5.076e-07
-	   9        -0.199946135249655    1.768e-07
-	  10        -0.199946134664678    6.638e-08
+	   0        -0.200255250360407    0.000e+00
+	   1        -0.200237819029770    1.045e-02
+	   2        -0.199973105822700    1.485e-03
+	   3        -0.199954621905730    4.864e-04
+	   4        -0.199946895565814    1.053e-04
+	   5        -0.199946306810320    2.929e-05
+	   6        -0.199946156209135    6.703e-06
+	   7        -0.199946136857328    1.596e-06
+	   8        -0.199946135303239    5.076e-07
+	   9        -0.199946133522006    1.768e-07
+	  10        -0.199946132937027    6.638e-08
 
 	Largest LIA Amplitudes:
-	         11   2         0.0187278535
-	         11   3        -0.0108160630
-	         11   5         0.0086709062
-	          4   2        -0.0067631543
-	         11   1        -0.0064539502
-	          2   1         0.0057797146
-	         10   2        -0.0046309835
-	         11   4        -0.0044345897
-	          1   1         0.0039297406
-	          0   1        -0.0038896347
+	         11   2         0.0187278537
+	         11   3        -0.0108160627
+	         11   5         0.0086709051
+	          4   2        -0.0067631542
+	         11   1        -0.0064539495
+	          2   1         0.0057797144
+	         10   2        -0.0046309834
+	         11   4        -0.0044345910
+	          1   1         0.0039297405
+	          0   1        -0.0038896346
 
 	Largest LIjAb Amplitudes:
-	 10  10   0   0        -0.0498652177
-	  9   9   0   0        -0.0470033203
-	  6   6   6   6        -0.0323371349
-	  9  10   0   1         0.0281551854
-	 10   9   1   0         0.0281551854
-	 10  10   1   1        -0.0276581001
-	  0   0   1   1        -0.0190238470
-	  9  10   1   0         0.0181945355
-	 10   9   0   1         0.0181945355
+	 10  10   0   0        -0.0498652174
+	  9   9   0   0        -0.0470033197
+	  6   6   6   6        -0.0323371342
+	  9  10   0   1         0.0281551850
+	 10   9   1   0         0.0281551850
+	 10  10   1   1        -0.0276580994
+	  0   0   1   1        -0.0190238467
+	  9  10   1   0         0.0181945352
+	 10   9   0   1         0.0181945352
 	  8   8   8   8        -0.0174424905
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.91534388508
-
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
-Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.01 seconds =       0.02 minutes
-	system time =       0.28 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
-
+	Overlap <L|e^T> =        0.91534388636
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -621,2401 +589,241 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008614927932901 -0.046442352400056  0.027924113420848 -0.003342105613042 -0.019198187280149 -0.043605993010684  0.000124507843934 -0.017903232775755 -0.064037761769677
-    1  (  1) -0.004023859954382  0.002812567241188 -0.015355365220565  0.063211982369858  0.033868800032563 -0.011581015700219 -0.004465574115878 -0.047030919129079 -0.048793907716228
-    2  (  2)  0.028525640721225  0.068120190051797 -0.016739332483522 -0.005073216914996  0.071940864110972 -0.066733646998345 -0.019605473406179 -0.001610556181541  0.004701378003057
-    3  (  3) -0.054155290592472 -0.054244334984755 -0.021962628004576 -0.018282485083091 -0.037028274309951  0.016786978556275  0.022024618578561  0.004302299401540 -0.167953274084101
-    4  (  4) -0.063182596929128 -0.128748808697011  0.121465113794596  0.160938411624414 -0.233917278334855  0.054052147786148  0.025334190025568  0.127021105025468 -0.261448831371970
-    5  (  5)  0.148864678539144  0.254187426901849 -0.169654893765005  0.284620623487219  0.104152411510991  0.359543809296571  0.133744009364038  0.041861549395911  0.169452799563311
-    6  (  6) -0.084956716693293  0.126613830958100 -0.017431389376921 -0.048281125785785  0.083267553859489 -0.206713853889007  0.428812335356187  0.005011018790693  0.061186511244325
-    7  (  7)  0.173630436499038  0.181276581467465 -0.440332497406727 -0.059456065314793  0.303618967332177  0.080016792150091 -0.104444652264320  0.251866044362601  0.089940979754426
-    8  (  8)  0.057697740265636  0.070180597319316 -0.383387445877903  0.514874723728167  0.465292274425094 -0.060917787458673  0.016262524997932  0.068972295825028 -0.265391565564862
-    9  (  9) -0.279247635392508  0.560707539445326  0.044547355247966  0.161505455840491 -0.002588377300620  0.219223272852673  0.096307931275233  0.176467158787115 -0.104344971075325
-   10  ( 10) -0.977075550189082  0.176418272338824  0.228294317792423 -0.099370607761785  0.027777959043915 -0.149348953174007  0.027413414685573 -0.102632226214496  0.005531527026329
-   11  ( 11) -0.211429004068205  0.082644794913083 -0.055680052865830  0.289018099852967 -0.067789578528906  0.064107786895450  0.141855082713117  0.071186757345684 -0.332576681432119
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071990946341156
-    1  (  1)  0.010142476746200
-    2  (  2) -0.112423878596356
-    3  (  3) -0.059253840833002
-    4  (  4) -0.014639189231197
-    5  (  5)  0.248038168374966
-    6  (  6) -0.055159646937661
-    7  (  7)  0.115432903674626
-    8  (  8) -0.135363224547124
-    9  (  9)  0.174678345310946
-   10  ( 10) -0.086140984938274
-   11  ( 11)  0.161723358519153
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.197572413114517 -0.541318632877371  0.139927415914873 -0.359578444130330 -0.398937843975486 -0.026586872167534 -0.139627977382516 -0.005896246491228 -0.003746644388905
-    1  (  1) -0.541058731973333 -2.034801242188507  0.920540457917585  1.016218584629480  0.729164689940962  0.054412526301737  0.235971924521468  0.315223615831553  0.096208087340554
-    2  (  2)  0.139828960639396  0.920734025049694  1.243601677781983 -0.974300649425054 -0.758553357750500  0.024609548649431  0.513266755137957 -0.116926330823923  0.094501440802452
-    3  (  3) -0.358970389612551  1.015833032444632 -0.974440229907822 -0.266348920037382 -0.133799224826450 -1.276907891719884  0.042984364188955 -0.410608972745146 -0.602345206758872
-    4  (  4) -0.398323035382104  0.727797072638099 -0.759857932028957 -0.133858878725855  0.575448485405805  0.056475665846990 -0.484493838094732 -1.583666059960473 -0.976878960945650
-    5  (  5) -0.027166282529876  0.055084907439528  0.024891154244808 -1.275543890392068  0.058746221115305  0.155399297624787 -0.236023461595880  0.812878944882876 -1.048535633945681
-    6  (  6) -0.139452284652001  0.236223353106611  0.513262677276795  0.042879631015553 -0.482819583744289 -0.235933155306163 -2.554180022039243  0.492117808091915  0.545404391969618
-    7  (  7) -0.005841417486080  0.316274368087248 -0.116163386132942 -0.410094172620351 -1.579571504351393  0.813774264702327  0.492423579055058 -1.700719634572147  0.685529426222534
-    8  (  8) -0.003628131523111  0.096035529406495  0.094131958822655 -0.602680558554738 -0.970206233042967 -1.045482011639248  0.544249830480973  0.683514460656999 -0.254958894521937
-    9  (  9)  0.326098978034070 -0.130935443755898 -0.379595166178810 -0.575990923913880 -0.393471965772156 -0.365686482354661 -1.227740649572571 -0.905826585766955  0.039987575439783
-   10  ( 10)  0.008103557010829 -0.039575543043785 -0.358664813530415  0.339232504235094  0.207222390004838  0.025784782686722 -0.874465143496950  0.752110557173402  0.140644707838520
-   11  ( 11)  0.161744201604777 -0.084371238126416 -0.371150000615002 -0.062082553987999 -0.264710244109502 -0.257261524594595 -0.444570825837596  0.002821912169167 -0.878431482758543
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.327854256723191  0.009019714201806  0.162710661594080
-    1  (  1) -0.133091859401188 -0.040697608916971 -0.085480013261477
-    2  (  2) -0.381849466582258 -0.359835698966555 -0.372555502654032
-    3  (  3) -0.579249329460985  0.337242930789026 -0.062083381101115
-    4  (  4) -0.396591932227294  0.208613968377681 -0.263534161447186
-    5  (  5) -0.365098796840620  0.027806203875135 -0.265146511184336
-    6  (  6) -1.230804866141472 -0.879767261427487 -0.448789926588722
-    7  (  7) -0.904635210810701  0.753869376128870 -0.007723762422951
-    8  (  8)  0.040323953888643  0.145561462630237 -0.894627985530935
-    9  (  9)  0.423095730032689 -0.296000598729972 -0.177730944535255
-   10  ( 10) -0.299463152132731  0.634536265412446 -0.073348108781663
-   11  ( 11) -0.175836972560684 -0.076105887981834  1.184769463941312
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.567008918440454  0.722443194224100  0.422402078329773  0.057554368538511 -0.068012024097596 -0.451975147608540  0.709419418128490 -0.110422168786063  0.095704108927647
-    1  (  1)  0.720885472964738  0.332527211352729  0.737390933664557  0.281750515995843  0.280761290393686 -0.598548871078422 -1.146750917560074 -0.177301134607867  0.234694928374046
-    2  (  2)  0.422183102929830  0.736485274543817  0.007829109729841 -0.365399185160488 -0.965501991519851  1.065090224342325 -0.394390877157068  0.239359282041345 -1.218182428400336
-    3  (  3)  0.059687201587689  0.280769829516347 -0.363255319277090 -0.833720445234328 -1.345952507284314 -0.189309823206009 -0.179890587463359  1.060334267261244  0.772514544005070
-    4  (  4) -0.069257393950461  0.281296543593726 -0.966923508415862 -1.344162403478837  1.514830798821686  0.013670590813123  0.227285042195308 -0.333966365834383  0.386248727994588
-    5  (  5) -0.449135841837750 -0.599397616398023  1.066820631137579 -0.189649110609729  0.013795397601274 -0.565008204089947  0.487292179201877  0.306200785308481  0.347063761059997
-    6  (  6)  0.708465668575064 -1.146562417015747 -0.391890894794961 -0.180811610825629  0.226633708337573  0.487729597603209 -2.767088081148377 -0.044613761228256 -0.000972346438746
-    7  (  7) -0.108981479701481 -0.177538422258191  0.240499334967173  1.059842333943978 -0.334391646412731  0.306249622802239 -0.044471110656761 -3.232660954268523  0.514839123397967
-    8  (  8)  0.094277588726801  0.235043460722862 -1.221823739304416  0.774952681271118  0.386077819008107  0.344858044218004 -0.000341133693178  0.514916107143190  0.507086715271392
-    9  (  9) -0.063381219775898  0.233965663654109 -0.093343357924906 -0.360354041999586 -1.006820146552738  1.344825106449130  0.268434803850821  0.315156353069794 -0.332938610236887
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.063808920787530
-    1  (  1)  0.235710820172182
-    2  (  2) -0.096202914418848
-    3  (  3) -0.360121798161892
-    4  (  4) -1.006476097602190
-    5  (  5)  1.343619008167611
-    6  (  6)  0.268106090274240
-    7  (  7)  0.315242334513133
-    8  (  8) -0.332481313383264
-    9  (  9) -0.175400025059932
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010284048494255 -0.022581971135931  0.025184528241746  0.002553505114185 -0.007866760216735 -0.035704112150886 -0.002766394497905 -0.015588851752449 -0.054894237910669
-    1  (  1)  0.001129370063260 -0.004341567056713 -0.012471737690510  0.068518821494219  0.037428649672491 -0.002857552975536 -0.002731409738209 -0.051935588474977 -0.049204102006071
-    2  (  2)  0.045340581598934  0.060774626672080 -0.014665202394902 -0.013163382447340  0.085552378847967 -0.055885373659009 -0.012884187954087 -0.000025912808653  0.007546289398551
-    3  (  3) -0.053518724373857 -0.051858316930917 -0.015829576226974  0.002308038466593 -0.033376912491914  0.026566608759227  0.020736863226261  0.017163432001033 -0.156611857939886
-    4  (  4) -0.057073647917578 -0.121620677730040  0.116559461318180  0.152459611673760 -0.224360677266659  0.063635487600126  0.025109630293686  0.123561544969923 -0.260705677431782
-    5  (  5)  0.132736043071323  0.228873275971275 -0.157588806451895  0.278203525609905  0.112411249713211  0.339424025956772  0.132778586915835  0.041442079822076  0.144607854949093
-    6  (  6) -0.099037108772820  0.133050971019321 -0.016390463092699 -0.047994853534082  0.082590754367535 -0.196599146843337  0.423704532236322  0.002588517799838  0.062442412924455
-    7  (  7)  0.164573996270568  0.174187584517111 -0.442718231735592 -0.055107629768529  0.292277213599590  0.090352016025029 -0.100915507153634  0.242008735185081  0.079009239652453
-    8  (  8)  0.059450407301305  0.065508844735816 -0.375580889101448  0.518979554864539  0.457917802055341 -0.070408637451188  0.013466768623613  0.072872586601375 -0.257559025462184
-    9  (  9) -0.246894722162695  0.551859769243373  0.044670824987361  0.162240888664295 -0.012774136938901  0.203595879781061  0.102036778576897  0.168067562706153 -0.111682944808914
-   10  ( 10) -0.913654455951997  0.155328532380750  0.215519674293101 -0.100970035089767  0.021969337557273 -0.148862369984030  0.046525143909590 -0.100083990349210  0.020780587060978
-   11  ( 11) -0.198781019683999  0.090074442467030 -0.050453210014304  0.292395282220077 -0.068054938936099  0.077531780115388  0.149511822875939  0.072921096134366 -0.357789764657410
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.062212803584986
-    1  (  1)  0.008222801612735
-    2  (  2) -0.107232253166961
-    3  (  3) -0.058083892735771
-    4  (  4) -0.001519088368734
-    5  (  5)  0.232883930798086
-    6  (  6) -0.056471183426688
-    7  (  7)  0.097796104480775
-    8  (  8) -0.126488666884472
-    9  (  9)  0.156849504238605
-   10  ( 10) -0.081446420280763
-   11  ( 11)  0.176341903152824
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007749096020893 -0.085883219860789 -0.036741821640513 -0.003365465554254 -0.013826624434967  0.045778129863205  0.040669337017936  0.010509742963645  0.029540605017242
-    1  (  1) -0.033323633544771  0.071013231293301  0.009381535649954  0.001865195819276 -0.004385218315905 -0.001145589403992 -0.107240463714063 -0.004928891794835 -0.020784313339082
-    2  (  2)  0.052107391808055  0.092519548352413  0.009858355445846  0.037319719751115 -0.023857034470632 -0.010135084101246  0.037769988668842 -0.015917832336735  0.090581268987334
-    3  (  3) -0.109820166860700  0.034268818868662  0.003318299125654 -0.047343590144125  0.049224764312370 -0.055554817528594  0.048303583350885 -0.021295778567536 -0.056731125392159
-    4  (  4) -0.007052162455570 -0.070092516335627 -0.001616209300804  0.100452686687340 -0.017125496300488  0.011804649620296  0.317168773449601 -0.015679790140276  0.134810835290821
-    5  (  5) -0.101789034987347  0.450242114045570  0.095257897029759  0.154575128248214 -0.107484330343030 -0.276349446627330 -0.224432437333530  0.138878619319231 -0.069374899620443
-    6  (  6)  0.129481070378189  0.190214182802185 -0.111482363704469 -0.289845791886638 -0.214082604248960  0.130539668518305  0.176627871859896  0.507792819613372 -0.145016045312478
-    7  (  7) -0.031015915682170  0.467808966358201  0.323231774623313  0.163051942437066 -0.027878152128557 -0.222130149400228  0.355582804042090 -0.345169178258104 -0.117503613032291
-    8  (  8) -0.081114418656010 -0.129458136695794  0.321266021811150 -0.116738859709862  0.112997348404402  0.150149613835924  0.100022037588641 -0.009859219508172 -0.185497355865147
-    9  (  9) -0.840897499603665 -0.103193956572518 -0.262141263376961 -0.179652800220136  0.091540284698060  0.263027818637292  0.232988427097700  0.132664590100508  0.080643129784317
-   10  ( 10)  0.396138270139100  0.527358178663247  0.115585436142149 -0.350404487392900  0.098592337861551  0.056041756240516 -0.132708614971811  0.130232826037073  0.024142145251939
-   11  ( 11)  0.048038049575401  0.184019168140566 -0.243899393243605  0.184449948512382  0.067903231499648 -0.173184976481832  0.074519873620110  0.122524072160336  0.175482839393722
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.029757291821339
-    1  (  1) -0.000721108481725
-    2  (  2)  0.081115665687732
-    3  (  3)  0.028764622397233
-    4  (  4) -0.020368316409772
-    5  (  5) -0.173632225317480
-    6  (  6) -0.281328230047800
-    7  (  7) -0.030401209370270
-    8  (  8)  0.093738850403327
-    9  (  9)  0.138017132925940
-   10  ( 10)  0.057334975405403
-   11  ( 11) -0.087072361680799
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.718905282963311 -0.301300066815098 -0.767801784865940  0.078512808825352 -0.203134864329395  0.241932163232250  0.058076631858574  0.196398858308336 -0.039008858124194
-    1  (  1) -0.301256490728193 -0.157440548180653 -0.036029555945222  0.243436823804201 -0.005929795652985  0.115486356935965  0.826228436942721 -0.465135369554618  0.058491264513800
-    2  (  2) -0.767289827428610 -0.036275730111077 -0.756926663794728  0.450133498634738  0.207784604973971 -0.828712724024022 -0.324647417359493 -0.353270502638369  0.092835605795882
-    3  (  3)  0.078579571414042  0.243310568002833  0.450095063336851 -0.208139431363607 -0.062202704649669  0.279001105370900 -0.076077558481815  0.262112030046533 -0.378810215172718
-    4  (  4) -0.202510304245595 -0.006692039856945  0.206011713498273 -0.062773519685661 -0.370731419489490 -0.256994084769574 -0.019543706164301  0.220490721787851  0.607096866069924
-    5  (  5)  0.239969372403163  0.117504635997786 -0.825053657412313  0.279484173569987 -0.255386254541418 -0.397595357673452 -0.135369610755389  0.236221247146237  0.269522215039686
-    6  (  6)  0.058390572588279  0.825859124407247 -0.324193078352693 -0.076854690390370 -0.019228317672495 -0.137735601227498 -0.351485727273275 -0.487761380462257 -0.103056409920122
-    7  (  7)  0.194458563409000 -0.463590717501173 -0.349817673328107  0.262678828099312  0.220495817360137  0.236701749060628 -0.486100377719484  0.043036203375607 -0.169360995578035
-    8  (  8) -0.038844766636175  0.058006360789407  0.092452034322386 -0.377838465048525  0.603441383275525  0.267460191997309 -0.103192305796676 -0.168696834715057 -0.618488124049516
-    9  (  9) -0.174642021637819  0.179686913958803  0.584519432729807 -0.531375857305351 -0.237827440080434  0.122408493834100 -0.350613084838644 -0.156778679126698 -0.027661506214973
-   10  ( 10)  0.043298420781037 -0.218837511618004 -0.611680553974653 -0.687832529301005 -0.249683832986975  0.553064660821027 -0.144105807777605  0.115245275900936 -0.084193131593124
-   11  ( 11)  0.061064657985430 -0.108300572115386 -0.188797311905296 -0.022208683609426 -0.827900622936499 -0.341922472618851  0.022718392329079  0.232401592689427  0.164619669402136
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.175684511601603  0.045513516298602  0.061672515006080
-    1  (  1)  0.179323083833167 -0.221567937419786 -0.109140577543022
-    2  (  2)  0.587827397093136 -0.616289532030193 -0.190305864672640
-    3  (  3) -0.534590179358002 -0.689583787093839 -0.022209033963942
-    4  (  4) -0.239000891867221 -0.249187499059157 -0.832603923332527
-    5  (  5)  0.122010791877518  0.553620901013401 -0.348332351708050
-    6  (  6) -0.352732495297565 -0.145056644635348  0.023781601660354
-    7  (  7) -0.157242165562723  0.112854519200918  0.232190589319976
-    8  (  8) -0.027709907045481 -0.086030263039170  0.172274707819854
-    9  (  9)  0.207109600584589  0.096837430686223 -0.023218950236813
-   10  ( 10)  0.100164655230671  0.138181178066476 -0.148224446144570
-   11  ( 11) -0.022320179734203 -0.148849259998097  0.901205762410303
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.179939828491769 -0.273263983919761 -0.077241939802207 -0.131310571537764 -0.452108955794121 -0.373710053222736  0.012756857043078  0.188686131296855 -0.281717657996437
-    1  (  1) -0.271865636595074  0.080204205184229  0.237736668579935  0.053954037181141  0.088144371186311  0.094298665169508 -0.396703489007358 -0.164374392009126 -0.012743809563993
-    2  (  2) -0.076549157175288  0.237611423410488 -0.235916884249811  0.330279805489172  0.156363656188217 -0.135525945480897  0.113532621668593 -0.192996543934043  0.505097349395040
-    3  (  3) -0.133008481204441  0.051978470711429  0.330705317892875 -0.689079279022158  0.681025162416434  0.230126506813665  0.220012049909173 -0.221793013382862 -0.415574431905058
-    4  (  4) -0.450299145657576  0.087908600365275  0.156309970041408  0.681002122520780 -1.360248251424318  0.202273753159192 -0.167570810051337  0.246051223487190  0.206738411458247
-    5  (  5) -0.373567193155845  0.094555329734040 -0.136731584498100  0.229377893488984  0.202581599883435 -0.322498154757568 -0.226671631570763  0.408374954790996  0.307423751717641
-    6  (  6)  0.013230492577454 -0.395220303624150  0.113830041131736  0.218897296842682 -0.167381205612527 -0.226319762003687 -0.422981172464967 -0.882122931150610  0.208582936748456
-    7  (  7)  0.187587553988559 -0.164973338711578 -0.192266029819867 -0.222193739599766  0.245811643454060  0.408813624326959 -0.882511768104148 -0.161881530949274 -0.197931622292553
-    8  (  8) -0.280045996340605 -0.013187886145669  0.507423753200987 -0.417462155137855  0.206022606034107  0.308302993473083  0.207495521066743 -0.198012373935716 -0.598880759668382
-    9  (  9) -0.299128216307527  0.222289305708678 -0.374826664894612 -0.022250761597490  0.198104512558476 -0.291885255576850  0.011569749529353 -0.150670269953426  0.186378706038956
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301492091129213
-    1  (  1)  0.222023461274417
-    2  (  2) -0.373275862159688
-    3  (  3) -0.022769731837422
-    4  (  4)  0.197531018509810
-    5  (  5) -0.291038388606400
-    6  (  6)  0.011766677818707
-    7  (  7) -0.150956367275849
-    8  (  8)  0.186282415361357
-    9  (  9) -0.408641391244209
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006541040222368 -0.029135588169222 -0.017330822595744  0.002628911660037 -0.012344009141809  0.034496132624923  0.021629830242309  0.010441885402291  0.025478364815458
-    1  (  1) -0.038275138470075  0.054424566886903  0.005683589031010  0.001642391288003 -0.005493648653247  0.001124544236485 -0.102028934451313 -0.004961744404475 -0.019198498257850
-    2  (  2)  0.053024456913342  0.083754722151204  0.014366999014575  0.045684709272444 -0.045425854355333 -0.015659092798954  0.035306515857362 -0.013688960188417  0.082596341754868
-    3  (  3) -0.125696090540634  0.031717757592640 -0.000802365038104 -0.050871771309593  0.061705711345850 -0.045742890419344  0.045450419445688 -0.021064845035616 -0.054716959844684
-    4  (  4) -0.016613018731749 -0.059371668786672 -0.003754167403423  0.095982620955076 -0.007240466240122  0.008043456529988  0.296808016923276 -0.015369394286441  0.136610478911713
-    5  (  5) -0.093091489377706  0.398657588863068  0.074430182364354  0.149030211928108 -0.108745535372234 -0.256250392240536 -0.205814737045222  0.134201000957220 -0.055103512993348
-    6  (  6)  0.103501697780443  0.185147067962843 -0.104829304475355 -0.273669393328239 -0.199802423052909  0.136710211986565  0.166053639619828  0.483268157942075 -0.135434527757446
-    7  (  7) -0.041456689404135  0.416662529525886  0.296499443846860  0.151835770270295 -0.027648961071683 -0.196853254585748  0.346148931870815 -0.324194030503122 -0.108656389838073
-    8  (  8) -0.069099920157317 -0.122455303618133  0.312946042218845 -0.115185983609626  0.104240832235501  0.145175805702234  0.095088539986730 -0.010672631592564 -0.187147060865154
-    9  (  9) -0.712671855893174 -0.096350152389786 -0.234711067777686 -0.171596024164591  0.065322769896798  0.213466874289907  0.226529390715592  0.118201066093080  0.055528795004367
-   10  ( 10)  0.365512212430565  0.443597144956858  0.088760713787529 -0.336294489487780  0.089380999156301  0.050585935158758 -0.112358935032342  0.122526344346197  0.011836823928278
-   11  ( 11)  0.046393846223224  0.165011629057398 -0.228781961279396  0.178941949643574  0.063752947031584 -0.164789871590981  0.073726138142668  0.117333811839271  0.181371275992210
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.026880621041360
-    1  (  1) -0.000642066544117
-    2  (  2)  0.075046583216661
-    3  (  3)  0.030887223304929
-    4  (  4) -0.027083357083367
-    5  (  5) -0.161323349919549
-    6  (  6) -0.260652499025702
-    7  (  7) -0.019658118713907
-    8  (  8)  0.093794795124770
-    9  (  9)  0.110456626093643
-   10  ( 10)  0.048798146100140
-   11  ( 11) -0.097571556382824
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001432746297450 -0.032810674091764 -0.033331937480253  0.023032547083763 -0.002808019310921 -0.039246266926320  0.018692018505171  0.008842597191367 -0.029091078569617
-    1  (  1) -0.008821922403183 -0.001742272088788  0.082771016704519 -0.022297486221974  0.039163604166239 -0.010818853488427 -0.047294425339584  0.013135326021221  0.049034393857867
-    2  (  2)  0.024274942916815  0.027096978669207  0.097516386902391 -0.041392368694666 -0.004119390757880  0.075691552303805 -0.023677742397495 -0.003953261558318 -0.122163189427397
-    3  (  3) -0.047038460283817 -0.039422636027069  0.017791086341758  0.115660160117630 -0.067224158887899  0.095036576800958  0.032022129167533  0.022732157345389  0.120912741709036
-    4  (  4) -0.041035802352368  0.001934742020068 -0.201409668003493 -0.406246991276172  0.228435905047063 -0.366034413601436  0.036563318346743 -0.036692328708082 -0.082010843429842
-    5  (  5)  0.098338733570095  0.243746073973362  0.282884501181602 -0.425804208023662  0.108408993563040  0.505586602390370  0.102717653176241 -0.183779423720787  0.023433267817945
-    6  (  6)  0.135336854760563 -0.062874421564495  0.076338309095403 -0.023002937162434 -0.130902824611473 -0.185164583438217  0.398907643233867  0.217551510448046 -0.032105677017803
-    7  (  7) -0.035062191357078 -0.113858796831119  0.431604299875852 -0.029482805357536 -0.029652466640804 -0.242847719350325 -0.077765311277989  0.367073496056810  0.139022006906444
-    8  (  8) -0.068272847454715  0.294672021175633 -0.568959581650588 -0.125921031197012 -0.707592810771387  0.017806583156209 -0.015845746565047 -0.212947645825718  0.125196335187716
-    9  (  9) -0.288858276698774  0.093713692739213  0.209035012311688  0.075382622510660  0.083405488851542  0.016184965058288  0.000548295704545  0.266294088315547  0.380874642506837
-   10  ( 10) -0.378738518488000  0.204837316203508 -0.069415360994347  0.062065163074324  0.029622876137723 -0.058750752587050 -0.120574645247794  0.008130897374692  0.009265965929469
-   11  ( 11) -0.080018520143771  0.225808316863723 -0.312311376663230 -0.316597637367698  0.125757542829493 -0.146130016020174  0.016179298260010 -0.136308703902615 -0.120756904157899
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.036093305578397
-    1  (  1) -0.001707679185378
-    2  (  2)  0.005295607540268
-    3  (  3) -0.304573937377439
-    4  (  4) -0.014287077020118
-    5  (  5) -0.068885443054321
-    6  (  6)  0.111979958895137
-    7  (  7)  0.321243115116497
-    8  (  8)  0.158205355334404
-    9  (  9) -0.080091690471286
-   10  ( 10) -0.065074315967804
-   11  ( 11)  0.075517488980888
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.151581395944457 -0.159877768539019 -0.191397517423370 -0.495232284867177  0.365561840480614  0.240680277087037 -0.079714342464060 -0.017889526464511  0.054577038131019
-    1  (  1) -0.159795957250344 -0.047735218799445 -0.125025973520529 -0.592230248738643  0.329204795623399 -0.563899565056737  0.474518384859258  0.371816427010336 -0.204007450193307
-    2  (  2) -0.191333337555164 -0.125299228178318  0.032743525999057 -0.248173196102997  0.424015573762028  0.373304795371779 -0.124367805075759 -0.383343230710404 -0.176623528718579
-    3  (  3) -0.494849488362154 -0.592714843248357 -0.248959287226432 -0.423717062956694  0.236470791317215 -0.415768039926139 -0.007927078894393 -0.295339114007336  1.138817517977087
-    4  (  4)  0.365842786381904  0.329912791129377  0.425309312530905  0.236284335454773 -0.297797609245548  0.287162197148014 -0.015195390583447  0.149575460395682 -0.352881082019632
-    5  (  5)  0.239666720470004 -0.562521840762128  0.375748994888085 -0.414021321385147  0.283842862620087  0.299376587010529 -0.122721640145877 -0.329969308300871  0.156494792176823
-    6  (  6) -0.079132044596257  0.473605179791134 -0.125255855635513 -0.008774504854422 -0.015965010341322 -0.123144104694353 -0.040262615853229  0.053291869268360 -0.230047243580867
-    7  (  7) -0.018210362041773  0.371975596266125 -0.382949144540519 -0.295062546320220  0.147969605902060 -0.330844143538271  0.053247875304319  0.437054225002062 -0.295575334707162
-    8  (  8)  0.054384972764257 -0.203042333758326 -0.176317356102570  1.137981680675850 -0.349930528471567  0.158219435758802 -0.229361079354617 -0.295174183029699 -0.201170965133917
-    9  (  9)  0.162593186917498 -0.096068090323904 -0.131721885594255 -0.537260876669133  0.048165192812382 -0.386108653062500  0.083321052788424  0.067822247358744  0.259623842469249
-   10  ( 10)  0.093086276325347 -0.110390627511003 -0.528311347000350  0.014888006239538 -0.100997055269664  0.192126958830561  0.038787614394956  0.063975054988451  0.077127488930246
-   11  ( 11) -0.248608674285678  0.166558436146830  0.438779225583925  0.334557445644043 -0.324782623645273  0.179928478753780  0.012126762707773  0.006418605871888 -0.316369462085207
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.163245257155421  0.094276717552644 -0.249582936616881
-    1  (  1) -0.097089753942058 -0.112180528774260  0.167323530234027
-    2  (  2) -0.131901378869784 -0.530116652654623  0.440616284282449
-    3  (  3) -0.539218683643804  0.014310072965047  0.335266942696954
-    4  (  4)  0.048635984706568 -0.103433325040069 -0.331331261588337
-    5  (  5) -0.385516013729792  0.187104305011894  0.193398800890046
-    6  (  6)  0.082991815026247  0.037352860323020  0.011014682786961
-    7  (  7)  0.067841455828072  0.062642922337485  0.014204699225385
-    8  (  8)  0.258473930207162  0.077886035701004 -0.325054438919389
-    9  (  9)  0.001773142889432 -0.053105768300802  0.034600115019000
-   10  ( 10) -0.053689547832438 -0.018246255837546 -0.196162567936867
-   11  ( 11)  0.031756575503292 -0.193298510202671  0.164652237069869
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.236069150423928  0.221583137218639  0.087467481976269 -0.023767225350154 -0.157884977853517 -0.128673956390029 -0.176595879969474  0.001131012317203 -0.181143452404233
-    1  (  1)  0.220430431059073  0.112052435313968  0.015869249151473  0.264485428778921 -0.165982030219470  0.159260926468858 -0.018854654828287 -0.249502649443057  0.052130725228418
-    2  (  2)  0.087694752982164  0.015013031218300 -0.683310722703039 -0.454889777527338  0.270539149606414 -0.876133156261866  0.064372104092668  0.069959767509230 -0.359585122327188
-    3  (  3) -0.022349867884997  0.265917774305981 -0.459885376820098  0.156118351029157 -0.442698949429053 -0.633164352365545 -0.123599096035318 -0.000681276488754  0.329408685832541
-    4  (  4) -0.157925484616889 -0.166044552973515  0.271218387113143 -0.443885849212600 -0.013362398764761 -0.176284165832649 -0.004716950323026  0.078109759941717 -0.609000288591445
-    5  (  5) -0.127616278770967  0.158011849801079 -0.876037618276795 -0.629854882079848 -0.177186230678137  0.012211398531521  0.059425698366986 -0.774979266274861 -0.486618182967767
-    6  (  6) -0.178241606252947 -0.017090192450387  0.064522373941146 -0.124240074207901 -0.004293285267873  0.059087683211698 -0.104000927528902 -0.330829052901522 -0.038045687603335
-    7  (  7)  0.002208432976113 -0.248689840257510  0.068573896371648  0.000014323070255  0.078530114044465 -0.775881123063332 -0.330687300606162  0.375687386105441  0.140607455827148
-    8  (  8) -0.178615853440425  0.052090468900394 -0.360562489485138  0.330978975217506 -0.607342070790934 -0.487347100955227 -0.037705399031252  0.140808054960246 -0.394251292282697
-    9  (  9) -0.046812023124734 -0.356025366669854  0.690811815119252  0.312933605279832  0.666333150435849  0.222468929331266  0.069111321865738  0.559435147572457  0.132671563084754
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045842278134109
-    1  (  1) -0.355929482932053
-    2  (  2)  0.690401613030498
-    3  (  3)  0.314450068453419
-    4  (  4)  0.667992312261241
-    5  (  5)  0.221641972273241
-    6  (  6)  0.069286377187356
-    7  (  7)  0.560338391968248
-    8  (  8)  0.132249466359632
-    9  (  9) -0.305201514350595
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003531322887475 -0.011853964282953 -0.013997173425702  0.018382792154192  0.000899996441170 -0.027829789222902  0.010946278656521  0.009416135608630 -0.023987807904262
-    1  (  1) -0.006388621957170 -0.005171201061298  0.075116414644925 -0.012351518893597  0.041297277094542 -0.006441657661851 -0.042094675941536  0.014500044658877  0.045272474380981
-    2  (  2)  0.036883171135873  0.025743377437805  0.085964964522995 -0.036572128405842  0.000741779132517  0.071901849285639 -0.017612259522947 -0.002857549793791 -0.114428225581804
-    3  (  3) -0.050379148878904 -0.038280516537017  0.018275237269774  0.118578575241743 -0.057964689431887  0.100743381549064  0.031817975653707  0.026538904209037  0.119963525599056
-    4  (  4) -0.040259568572502  0.011229705198348 -0.188809172609568 -0.380757486353216  0.215445879830049 -0.344569392827444  0.033187603168238 -0.033507608911701 -0.079582925346094
-    5  (  5)  0.087141198545524  0.216785041786672  0.270610048744647 -0.398997177058604  0.102170025016676  0.478625848854116  0.098949415070036 -0.170373600936987  0.015652914812384
-    6  (  6)  0.115394650619668 -0.055172374414511  0.068645251662214 -0.021005537436634 -0.120222938768552 -0.172201054646963  0.377862520931175  0.205771786365183 -0.028486300590321
-    7  (  7) -0.040171141537119 -0.121048023653740  0.403132598347777 -0.027760474590503 -0.026374510769541 -0.228317794220799 -0.070878790612320  0.346601006753617  0.129893637962627
-    8  (  8) -0.063034884678852  0.280866798080653 -0.540496031356204 -0.119391576371009 -0.673073389093966  0.010663808807394 -0.016147690801371 -0.200745867995305  0.117394935881043
-    9  (  9) -0.239823863619059  0.087614347419962  0.205995256328994  0.074059708937832  0.068748575207548 -0.000454096504958  0.003028317523563  0.249475422318809  0.352711368821821
-   10  ( 10) -0.336588165834448  0.173514331887659 -0.070029614207528  0.058791676167547  0.024501304819872 -0.052124336325614 -0.104213155529188  0.008639636736157  0.013496509549194
-   11  ( 11) -0.070036515714458  0.195530601320237 -0.305644951639726 -0.322831866596268  0.121530762471617 -0.141977993846978  0.021998928318675 -0.134440837975978 -0.127122644721006
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.030353030422789
-    1  (  1) -0.003358262791905
-    2  (  2)  0.006176160600104
-    3  (  3) -0.295046081788652
-    4  (  4) -0.003816440522472
-    5  (  5) -0.074325961201587
-    6  (  6)  0.109014636987132
-    7  (  7)  0.303731536940852
-    8  (  8)  0.152250258689580
-    9  (  9) -0.089511140585649
-   10  ( 10) -0.060789805292351
-   11  ( 11)  0.082293619260989
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057770723551805  0.007686176362995 -0.037676874102239  0.021875314889184 -0.005506967440553 -0.033731453254856  0.019605915987929  0.000153810358456  0.020480209762043
-    1  (  1) -0.007936092328855  0.008454757012618  0.010966637507272 -0.001712970012603 -0.003491085971866  0.000515536715359  0.020166951580993 -0.003537118918414 -0.007401819292438
-    2  (  2) -0.004823273660701 -0.024918096949402 -0.013456316532648  0.018061040723257  0.007928867774181 -0.029348077247204 -0.008305651855965  0.003787093111853  0.048173394734837
-    3  (  3) -0.011675775125104  0.107663431050362  0.048399528007616 -0.036525102270435  0.040730641356466 -0.022154401905676 -0.022459222262206 -0.014732815012435 -0.056193647103106
-    4  (  4)  0.087218313447135 -0.162702625594382 -0.040016358931151  0.090893257640902 -0.161526551014906  0.070532962320029  0.041494660476799  0.036307465283525  0.053954994619678
-    5  (  5) -0.299080380154522 -0.047071149143854 -0.050599107356677  0.086076035660096 -0.105747613370625  0.016291716828988  0.035370479977499  0.024570880182810  0.019740472062472
-    6  (  6)  0.064660820062842  0.041897488689090 -0.115036198620178  0.009494466980017  0.021741244197439  0.082050622741463 -0.041036304002792 -0.093842813724870 -0.099009311380003
-    7  (  7) -0.041406109005398 -0.013292096025031  0.015299070066933 -0.090658889471223  0.096664535474361  0.020138730803122 -0.181635797654581 -0.008096043748855 -0.043219320460348
-    8  (  8)  0.213166983290885  0.019961961605909  0.071163032757987 -0.089566388255459  0.187567657300030 -0.059322694628756  0.181371262434162 -0.031805535782928 -0.037438192749058
-    9  (  9) -0.029081682004423  0.052377114086944 -0.016598919354525  0.054121123864817 -0.005943121322964  0.052845962329270 -0.099913404453613 -0.011257505074012  0.046946017590445
-   10  ( 10) -0.029775807936917 -0.011144658296549  0.123616713069900 -0.069048925266029  0.072425392135727  0.175724644218768  0.020473761865880 -0.027329304597195  0.030635509122054
-   11  ( 11)  0.065686621670288  0.046175058814983  0.054739230530016  0.067089838730126 -0.085213076503212  0.033327993779702  0.039100303871838  0.006432393458887  0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007846989553355
-    1  (  1) -0.003599492488651
-    2  (  2) -0.050462951485827
-    3  (  3)  0.025590884562196
-    4  (  4)  0.058023095683205
-    5  (  5)  0.032774222915836
-    6  (  6) -0.063967275967677
-    7  (  7) -0.008682341559207
-    8  (  8) -0.054096899442108
-    9  (  9) -0.060114344610370
-   10  ( 10) -0.027778486812577
-   11  ( 11)  0.026791075407401
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000027040423887 -0.011060683872803 -0.004793456647899 -0.073481718860181  0.071504628495016  0.043329380984548 -0.025554578097106 -0.020981780177699  0.009741644195740
-    1  (  1)  0.011009750762997  0.000007607240151 -0.023558132508086  0.077101510719000 -0.072464798814331 -0.012890143420536  0.005683277430906  0.006920173400283 -0.002574145843753
-    2  (  2)  0.004842956248702  0.023538681455719 -0.000165226839542  0.207870652255993 -0.210753100259611 -0.104860036207310  0.066732822825146  0.046426833468215  0.005606364639263
-    3  (  3)  0.072846425542822 -0.076633967419021 -0.207131819599136  0.000363002499158  0.003747206858118  0.078444561827851  0.135702906183535 -0.013002670417717 -0.066080178603036
-    4  (  4) -0.070600283658190  0.071629978927021  0.209426851727876 -0.004131403945752 -0.000622007773293 -0.030404083775686 -0.072573499649568  0.005804369418180 -0.017256603820917
-    5  (  5) -0.042938103533211  0.012767138266668  0.104089521411634 -0.078509088982138  0.031589837534126  0.000702189622727  0.234416668036359  0.006073164073880  0.085676616502380
-    6  (  6)  0.025301081140471 -0.005670371975564 -0.066621493148361 -0.135369815380962  0.072186642283625 -0.233429156027521 -0.000193153533248  0.257186865053465 -0.080618496507255
-    7  (  7)  0.020822354558258 -0.006724508724119 -0.045993762455479  0.012965367547761 -0.005443358605263 -0.006173477804865 -0.257050229473736 -0.000107746294773  0.140355654948263
-    8  (  8) -0.009433315806276  0.002386871891496 -0.004905034102302  0.065444732417879  0.016877777772437 -0.086229493149666  0.079936884810997 -0.140925849197376  0.000032973152365
-    9  (  9) -0.050122316171813  0.043792237275169  0.089139695085719  0.017498120874682  0.031599257819379  0.003933044438540  0.023956851013655 -0.023591093022906 -0.231355322027963
-   10  ( 10) -0.021733936110572  0.028861084661254  0.012680330783905  0.120427356784394 -0.061995107162282 -0.110107780731446 -0.044522956915282 -0.044154909833586 -0.092344585382497
-   11  ( 11)  0.054009861310889 -0.049060128861341 -0.116101359422429 -0.043743279836749 -0.090347856826429  0.186254068915307 -0.010091097621831  0.182439821622372 -0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.050351452990167  0.022080091821478 -0.055614920128739
-    1  (  1) -0.043523152379598 -0.028913570586242  0.049281187081852
-    2  (  2) -0.088800989050704 -0.012387284429283  0.115844546053497
-    3  (  3) -0.017174780224652 -0.120766108673226  0.043936127494914
-    4  (  4) -0.030870076304731  0.062251132422338  0.090680792727787
-    5  (  5) -0.006295822004517  0.109602420736026 -0.187179028172583
-    6  (  6) -0.023342165877015  0.045357751936196  0.008109043414047
-    7  (  7)  0.023116687534610  0.043892116907456 -0.180954962224114
-    8  (  8)  0.233341712412303  0.091442003006516  0.004136900096905
-    9  (  9) -0.000301754743843 -0.311200434843549  0.071746006250031
-   10  ( 10)  0.310579381122594 -0.001146128096000 -0.337175845358798
-   11  ( 11) -0.071759110731455  0.341710402101474  0.000514995746851
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000373475564698 -0.036374284715410  0.020675408038120  0.041938611278043 -0.014954064130636  0.008670693741941  0.001941666498966 -0.002175213653671  0.081223953533966
-    1  (  1)  0.035409311090430  0.000583412494499 -0.021912114995751 -0.019686191919175 -0.001337756516393  0.101410043872272  0.013539530463413  0.021085032009130  0.104140442794578
-    2  (  2) -0.022476650279619  0.020869170321065 -0.000623148668542 -0.026925059222749  0.022600045203783  0.054500059821995  0.019747085432266  0.002197258536137  0.059803959084815
-    3  (  3) -0.040527884961938  0.020785023904239  0.026269813130118  0.000471315833621 -0.011435927824319 -0.005094359128676 -0.021078069661848  0.001900689912103 -0.049285996887456
-    4  (  4)  0.014876995236008  0.001935832477363 -0.021280417512247  0.011112950356736 -0.000010954074914  0.001375736589678  0.021071346294591 -0.002540388393255  0.057176443725449
-    5  (  5) -0.009413911140341 -0.101590521816804 -0.054440250203052  0.004479146413684 -0.000983185589705 -0.000044886603863 -0.008942266041566  0.007734744988056  0.012623227871857
-    6  (  6) -0.001228199632690 -0.013460754514196 -0.019370737847276  0.021147815413154 -0.021180440912387  0.009078596190780  0.000060187992369 -0.021757615671251 -0.021546696625458
-    7  (  7)  0.002386621109668 -0.020697715049428 -0.002142304032572 -0.001889845237358  0.002502377714011 -0.007891184567460  0.021671667697211 -0.000014467640044 -0.019485620614445
-    8  (  8) -0.082726042327291 -0.104120679625015 -0.059410287861643  0.049170685661379 -0.057558349352742 -0.011952514103015  0.021313492463386  0.019559674827960  0.000280085719614
-    9  (  9)  0.081272328726009 -0.110754135563007 -0.028218762900775 -0.005318083145326  0.020981856638396  0.014567561104212  0.097856532501808  0.003185861516469  0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.080531031337273
-    1  (  1)  0.111220099551316
-    2  (  2)  0.028332370195928
-    3  (  3)  0.005372945270244
-    4  (  4) -0.020768901638641
-    5  (  5) -0.014982546342664
-    6  (  6) -0.097582479807565
-    7  (  7) -0.003277826561639
-    8  (  8) -0.003260780284830
-    9  (  9) -0.000186812021876
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055078142867828 -0.005804719299681  0.036780646353647 -0.020745008939831  0.005631321838333  0.032388434299089 -0.019554696167851 -0.000026315290494 -0.020764618651157
-    1  (  1)  0.007062764870854 -0.009531925050962 -0.009339128991500  0.000585332198702  0.003536715157378  0.000717716084393 -0.020997702694190  0.003197609406412  0.007543205569196
-    2  (  2)  0.003273721829615  0.024127785783056  0.019803917766004 -0.021792459075320 -0.009225997435944  0.033280936086821  0.008357612389432 -0.004534634518823 -0.049752671423908
-    3  (  3)  0.009467819748219 -0.109846311430058 -0.049077069582499  0.038067479834844 -0.041344367688361  0.023164856965512  0.023494777837550  0.015492414054440  0.057415728354703
-    4  (  4) -0.087998530211411  0.166680738017738  0.040492236619192 -0.094854089537164  0.166732509395464 -0.071703004448668 -0.042087550249065 -0.037122017300705 -0.054342710801435
-    5  (  5)  0.299229806278301  0.048658757713325  0.047129705842446 -0.086908947365866  0.109728878663932 -0.016789363568018 -0.035383410684614 -0.025335321764417 -0.020816334753998
-    6  (  6) -0.066809370303780 -0.045194542515417  0.116536125053039 -0.010429907504714 -0.024187359392906 -0.082665971873618  0.044425337546003  0.096427706292236  0.099634759729367
-    7  (  7)  0.040692585686945  0.010414403444448 -0.019197392244389  0.094603783326762 -0.099044517012418 -0.021567521501408  0.184530946067710  0.010140666068000  0.044429992698867
-    8  (  8) -0.213871489773344 -0.016533777636027 -0.072796199007045  0.091991735348903 -0.195396773842710  0.059284334625803 -0.184339397290396  0.031894612373968  0.038856272349111
-    9  (  9)  0.030682243044227 -0.041775517875249  0.024602057980135 -0.057287290343526  0.006772740334119 -0.055735826221076  0.097648839100779  0.011580457295414 -0.048271645082472
-   10  ( 10)  0.033182564179255  0.014791814568441 -0.134627953730393  0.074303509883212 -0.072048570540947 -0.178297714606306 -0.018972497943516  0.029382172234938 -0.026191954922422
-   11  ( 11) -0.065304385216644 -0.054065687922946 -0.058978656197155 -0.069527138693935  0.087278294466894 -0.031923025189413 -0.037244505404452 -0.006712268565440 -0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007990021156235
-    1  (  1)  0.003543862611170
-    2  (  2)  0.051263654644270
-    3  (  3) -0.026303130686066
-    4  (  4) -0.059400171065937
-    5  (  5) -0.033889468632128
-    6  (  6)  0.063573026890197
-    7  (  7)  0.010425863419296
-    8  (  8)  0.056178737365981
-    9  (  9)  0.060112542127891
-   10  ( 10)  0.033303474011037
-   11  ( 11) -0.026602109435667
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.023607177491195  0.019696611969885  0.037221212000385 -0.015590319696057  0.002020189842990  0.021016653547429 -0.007873916136755  0.003448340610807  0.079821954504390
-    1  (  1) -0.007327805297828 -0.018867534486269  0.042212469078496 -0.001447360534353  0.028939866752754 -0.077938653083341 -0.061948383376365  0.004945505795557  0.075894556663474
-    2  (  2) -0.009007071740861 -0.016177005802987 -0.068312932673240  0.041184857036759  0.003023256838844 -0.009849571097863  0.004290386808972  0.004340519661127  0.085840789796801
-    3  (  3)  0.026077185963910  0.012520558385893  0.023360353465929 -0.029787599349062  0.027312833784239  0.081100062029021  0.033406666012159 -0.054430078300136 -0.042036783131155
-    4  (  4)  0.044521029970710  0.101548028530885  0.092152577419686 -0.036969661342643 -0.235975964790827 -0.022489800485005 -0.018037809327809  0.163273258200919  0.255997686637622
-    5  (  5) -0.075082806179399  0.059495559215694 -0.178951166772656  0.134634824114366 -0.237022622504406  0.054772185517501  0.024504277147484 -0.150049663229407  0.003365655895118
-    6  (  6) -0.075564373604390  0.030719217759732  0.086498148733354 -0.160325933966896  0.064234285643905 -0.161900908445555  0.266146706738358  0.238096934941697  0.054011663901563
-    7  (  7) -0.117049393955643 -0.184359827232724  0.154835473828309 -0.196676571259727  0.209716028817009 -0.429620861048445 -0.096138950091600  0.371356959007903  0.058084061024513
-    8  (  8) -0.116322044765828  0.134673176933366 -0.115490121530453 -0.372419146214479  0.134366059259054  0.090977060566167 -0.047847126119104 -0.349531731511066  0.026343643532612
-    9  (  9)  0.016166361653787 -0.064655468388956  0.096603309196917 -0.102141195994536 -0.004689543577322 -0.174053614560893  0.096535422651742  0.179574162178272 -0.093140031286430
-   10  ( 10)  0.038118657992317 -0.011712936317703 -0.109233641260348  0.041948680427994  0.067033240911419  0.043789144467457  0.119198984082488  0.019961916251994  0.046236232124822
-   11  ( 11)  0.202537936665755  0.041865413038804 -0.001109842658197 -0.036047997932446 -0.209039172907281 -0.039634162843452  0.042796449278664 -0.037154632643052  0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001464671751436
-    1  (  1)  0.092168971837118
-    2  (  2) -0.096834154775615
-    3  (  3) -0.085232004143247
-    4  (  4)  0.224276823308218
-    5  (  5) -0.037070717977035
-    6  (  6) -0.017788678150516
-    7  (  7)  0.125655013910958
-    8  (  8) -0.036753750028807
-    9  (  9)  0.104788947042948
-   10  ( 10) -0.055723652563089
-   11  ( 11)  0.029086171780033
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000103943053471  0.020502980666838  0.044487026908476  0.112522389921676 -0.115190927698806 -0.086304427533430  0.028732798000328  0.005755262072674 -0.052707374815472
-    1  (  1) -0.020396732597728  0.000175507711089 -0.066631576709106 -0.188566511167110  0.188604507023904 -0.081802717690830  0.123212599282903  0.146580404278728 -0.063843813395139
-    2  (  2) -0.044224363892114  0.066688325942716 -0.000328779542201  0.131627364199491 -0.085838688001563  0.039792906367986 -0.071990397116460 -0.041811204620793  0.129151440044184
-    3  (  3) -0.112356491847955  0.188595812422395 -0.131743983691740  0.000034238258909  0.146405835083834  0.293116155503685 -0.174354593749844 -0.234740190959724  0.068400431241803
-    4  (  4)  0.114478156906703 -0.187880772610577  0.086711640119064 -0.146345707242046 -0.000351413466984  0.200401380550659 -0.118118144680811 -0.106599388398520  0.027535193682288
-    5  (  5)  0.086013769068620  0.081687368012874 -0.039811317138268 -0.293720012918757 -0.199751621453618  0.000779002249077 -0.029574633012291 -0.100809576430270  0.310087999943630
-    6  (  6) -0.028593362634754 -0.122990647052479  0.071886866993686  0.174357265134888  0.118164594946332  0.029455932226559  0.000323502179386  0.067588972736558  0.054838186724730
-    7  (  7) -0.005405231783831 -0.146637005514722  0.041701223809144  0.234444344892692  0.106310138998589  0.100760684833959 -0.067340032280388  0.000050446895501  0.206356025427645
-    8  (  8)  0.052734404217526  0.064663294136106 -0.127867798766573 -0.067686878519552 -0.027452578317565 -0.311518253800823 -0.053511305641188 -0.206912543882787 -0.000090733997612
-    9  (  9)  0.040822323151076 -0.050351126620632  0.033443030139718  0.028678071562223 -0.070729562284205  0.035204318394559 -0.035088801145452 -0.003858253384271  0.209126878103916
-   10  ( 10)  0.043554697985060 -0.034029200702705 -0.113396889510888  0.025104351967769  0.057922093461755  0.050331966245759 -0.113578028555237  0.006845000513571 -0.183899295084893
-   11  ( 11) -0.104445737487499  0.085327185159750  0.138831980783855  0.068059267872915  0.045287984054307 -0.106421559557756  0.126370094892912 -0.085884676801538 -0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.040472375428214 -0.043732687824618  0.105326662293090
-    1  (  1)  0.050113148730272  0.033553830886801 -0.085228632878169
-    2  (  2) -0.033648303602896  0.113430364410931 -0.140304701766262
-    3  (  3) -0.028908821271170 -0.025577280295259 -0.067243263311150
-    4  (  4)  0.070488811800233 -0.058243639304596 -0.043815524401846
-    5  (  5) -0.035954881502730 -0.048633621823234  0.102557737449989
-    6  (  6)  0.034599692943826  0.112216626584703 -0.126288398892548
-    7  (  7)  0.003737404887253 -0.007316223089443  0.087031799969318
-    8  (  8) -0.210522602449556  0.181960897898471  0.040780655119777
-    9  (  9)  0.000486792078199 -0.154877597629272  0.324381992896252
-   10  ( 10)  0.154731729402294  0.001003846432056  0.227757018056261
-   11  ( 11) -0.321308213629134 -0.230320716710505  0.000521529871008
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000267990887146 -0.017094909685382  0.026886221509252 -0.009154729792392 -0.028447394308811  0.043026223139973 -0.007934241734193  0.017529929372393 -0.048064409198736
-    1  (  1)  0.019165257539447 -0.000577613190074 -0.023971643573307  0.023362002438445 -0.020466955482562  0.074368923093670  0.021220838937975  0.006899315294507  0.004345205689582
-    2  (  2) -0.030573367311208  0.023520686332899 -0.000895230171902 -0.026482533037414  0.055578356600337  0.061212128793543  0.006033035982650 -0.029878597421323  0.067713186454891
-    3  (  3)  0.011556055604803 -0.022912214561881  0.028040995483179 -0.000806143570890 -0.016669730389240 -0.057830279830177 -0.001162806518994  0.022110531165998 -0.132937508894661
-    4  (  4)  0.029247962187325  0.019722933579604 -0.053631431975867  0.015590855142050 -0.000406564753787 -0.013151443352440  0.005583751708839 -0.048344741694769  0.058950645196782
-    5  (  5) -0.044502924478349 -0.074343902828738 -0.059891074519534  0.057011647107618  0.013642181191740  0.000660380157385  0.021619837229525  0.066247874288904 -0.026658775788480
-    6  (  6)  0.008416217090956 -0.021046309429680 -0.006522358687724  0.001270652730649 -0.005678899154477 -0.021925039235368  0.000233190982568  0.044213316193167 -0.019149792461568
-    7  (  7) -0.017220078580887 -0.007669026797702  0.030414088472195 -0.022279636607030  0.047947045698118 -0.066391322818188 -0.044159499520014 -0.000036612147908 -0.012788358083278
-    8  (  8)  0.049286641691243 -0.005157181302332 -0.067669102261374  0.134137839836174 -0.059598226202850  0.026736423898111  0.019691121432993  0.012900597372237 -0.000145671342113
-    9  (  9) -0.013771428368881  0.001534324314609 -0.097208563857550 -0.041538777135659  0.016922202614382  0.071792645864290  0.010700525463409 -0.088926800959210  0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.013388445223016
-    1  (  1) -0.001743269961120
-    2  (  2)  0.097384653394849
-    3  (  3)  0.041118719872747
-    4  (  4) -0.017104740675403
-    5  (  5) -0.071235600573670
-    6  (  6) -0.010744046806778
-    7  (  7)  0.088045104682667
-    8  (  8) -0.027915642785476
-    9  (  9) -0.000257740691093
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.024087436020668 -0.024234923487922 -0.034655069016827  0.013002508462274 -0.003506876735183 -0.019138226509165  0.008729154622077 -0.004126516633947 -0.080810387962203
-    1  (  1)  0.007340388106341  0.022740162593799 -0.047399213843079  0.000077807499313 -0.029710781800549  0.077091731467965  0.063337905707382 -0.003225301246506 -0.076935684639064
-    2  (  2)  0.008533292606078  0.014866249844284  0.069414473601385 -0.039067032188858 -0.004447555351962  0.009557153079335 -0.003933218079563 -0.004684619630234 -0.087696717260759
-    3  (  3) -0.022970088927143 -0.014796917693540 -0.027844101865804  0.035221698386289 -0.026363064761687 -0.090054977556852 -0.034727496736464  0.055362273105074  0.041999796595917
-    4  (  4) -0.041840045940810 -0.108064430049583 -0.094169303786903  0.038045467810124  0.242703284807102  0.022096059239039  0.018423933000872 -0.169152570163926 -0.255707171958253
-    5  (  5)  0.076575292532566 -0.064169513057282  0.187842221364997 -0.139017281082776  0.239663562780447 -0.056101309100792 -0.026864961939161  0.152773054853442 -0.000863550220823
-    6  (  6)  0.082619291232389 -0.034129866388443 -0.092672858212650  0.166047996934064 -0.066033557533197  0.164979644828487 -0.279604374284854 -0.245415146187524 -0.057275952528883
-    7  (  7)  0.119525510255884  0.192558180615050 -0.157479601093184  0.199612815310399 -0.216488749413977  0.438370355171240  0.097840156788249 -0.385286937285113 -0.058774287435548
-    8  (  8)  0.115070416909243 -0.142091116044252  0.125572997790340  0.378869543679260 -0.139572537143277 -0.093921809248974  0.047279124915748  0.359195083957732 -0.024443650320069
-    9  (  9) -0.023211259159309  0.064251202673602 -0.092489429719048  0.099069758679955  0.005272254913816  0.184087259640687 -0.103465084079069 -0.187259798043465  0.097400286560574
-   10  ( 10) -0.039092748606065  0.013006586457309  0.115772480099790 -0.044153430983449 -0.068039357936569 -0.040474168285568 -0.124671276809929 -0.020291967592974 -0.043718085717437
-   11  ( 11) -0.205517300660670 -0.035576186745690  0.000856944671273  0.036648470964825  0.217305799958921  0.037828885346138 -0.045859373489911  0.037554955798535 -0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001311477468569
-    1  (  1) -0.093224324445080
-    2  (  2)  0.099200064811294
-    3  (  3)  0.086458921973920
-    4  (  4) -0.229446975291319
-    5  (  5)  0.035136747289852
-    6  (  6)  0.019108151626501
-    7  (  7) -0.127376470092273
-    8  (  8)  0.036832911731868
-    9  (  9) -0.106598068979743
-   10  ( 10)  0.058544237541584
-   11  ( 11) -0.029477471817291
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.089840465204225 -0.055253525883540 -0.050839656601929  0.011592120168853  0.028453073767485  0.033272498563027  0.013123122183092  0.010376152774617  0.046773274930095
-    1  (  1)  0.019180458750845 -0.004406050242553  0.021028155566967  0.011538680320289 -0.014109247012132 -0.033202867729220  0.146724711919951 -0.006291497986158  0.032816512639240
-    2  (  2)  0.008004935891454  0.083588166091295 -0.024500417662889 -0.004976479402859 -0.015361678869856  0.027030028650554 -0.075999531355577  0.040388417899799  0.092155828534757
-    3  (  3) -0.072751395760345 -0.101339872261880 -0.027554632505315 -0.017104143799594  0.009883810143648  0.054325029446985 -0.038424568195001 -0.007564948769101 -0.050859249479548
-    4  (  4) -0.116869612062058 -0.168448689602172 -0.076045170807919  0.039076911238534 -0.141061895780680  0.082089594379007 -0.096305838370831  0.090937592520626  0.089867596085833
-    5  (  5)  0.362411548066203  0.116301468610581  0.067304641586918  0.178833394354847 -0.120526935264372 -0.077690766748935  0.087853646530869 -0.131583743921650  0.005449987066682
-    6  (  6)  0.023022243577310 -0.091878291587840  0.168295716396468  0.360782087280141  0.197772285105134 -0.118427120672179 -0.100301554555422 -0.545992767837121  0.002274268616602
-    7  (  7)  0.332469089310140  0.094037896803367  0.021326282942452 -0.202588446745432 -0.003095262967230 -0.074773576198707 -0.261809753005545  0.312310926113466 -0.101271338039676
-    8  (  8)  0.102262443511968  0.018323432973791 -0.030286707735275 -0.141132962784100  0.140087132441384  0.016144892573022  0.105178803101546 -0.077042517784067 -0.061204405030880
-    9  (  9) -0.062921845500970 -0.223934495766079 -0.055471945329417 -0.006791304491310  0.142947280894142  0.007991932919943 -0.047858230706461 -0.145718178913241  0.072195393114585
-   10  ( 10)  0.062281498028430  0.059385022217194  0.196384149116451  0.042900612771916 -0.059951865879116 -0.109494756681462 -0.025377610533051 -0.255425379720525  0.006903138405362
-   11  ( 11)  0.109893814765672  0.036299338598219  0.008950289795172  0.103979082032925 -0.089663281746559 -0.076642658317109 -0.017386558594104 -0.075203103677764  0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015115955084904
-    1  (  1)  0.030649150844450
-    2  (  2) -0.004117081641871
-    3  (  3) -0.011275331966881
-    4  (  4)  0.082379096749867
-    5  (  5)  0.010925397739678
-    6  (  6)  0.209001724905895
-    7  (  7) -0.094421017044117
-    8  (  8) -0.009881568354141
-    9  (  9)  0.113416879853688
-   10  ( 10)  0.045856944277529
-   11  ( 11) -0.007202279712064
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000220708940429 -0.002285125103983 -0.191707004311250  0.079176547202062  0.015343724284655  0.090762856917070  0.035966370439669  0.080228715251931 -0.022632088832219
-    1  (  1)  0.002270884902228 -0.000127565392507  0.181504505051190 -0.084301622984598  0.019134286473150 -0.136527597935967 -0.291828838790707  0.086935165867290  0.003153353795357
-    2  (  2)  0.190790178739451 -0.181286631653937  0.000456958950263 -0.098736144982791 -0.201937120878681 -0.060858985812145  0.102547416191644 -0.128157455079926  0.052263022287278
-    3  (  3) -0.078674978461285  0.083802623610643  0.098399673810258  0.000007811365746  0.051373438075815  0.073262818066183  0.213681674768555 -0.159362252554929 -0.021801220424175
-    4  (  4) -0.014664072597960 -0.019624839214450  0.200908806156840 -0.051706138267892 -0.000345872163641  0.060049554881332  0.188299165959522 -0.122222075869351 -0.002767654097179
-    5  (  5) -0.090883158144736  0.136634126073923  0.061672946710902 -0.074085610649007 -0.059059222367226  0.000127348357414  0.089421360456473 -0.068061409120582  0.127845689145142
-    6  (  6) -0.036070137194869  0.291478881075219 -0.101913218910275 -0.213840026067922 -0.188217301311726 -0.090313292624869 -0.000227988253159 -0.211121150654972 -0.048790729392591
-    7  (  7) -0.080292928774450 -0.086502244153537  0.129683189759572  0.159077086898913  0.122727489493275  0.066634459735053  0.210168861536432 -0.000749252129634  0.114771568876213
-    8  (  8)  0.022833189301314 -0.003149552694449 -0.051809982276026  0.021432628906503  0.002600755913054 -0.127892598520278  0.048118709288206 -0.114794510187460 -0.000092800261922
-    9  (  9)  0.153861672366712 -0.063959309581427 -0.276686698038017 -0.018129236980868 -0.051934404023196 -0.023341508326279 -0.078386885605064 -0.038564733458116 -0.117925763161383
-   10  ( 10) -0.030779230036139  0.047764824598951  0.139550834348758 -0.058848096986720 -0.072156858928456 -0.071321440087986  0.120905085647966 -0.006516751215124 -0.144681807612295
-   11  ( 11)  0.005585664265456 -0.000647324323586 -0.016353426872082 -0.045937924242292 -0.003353711579607  0.138994412824604  0.062414171800322  0.018128246119697 -0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.154066232086317  0.030728257975556 -0.006318091498164
-    1  (  1)  0.063643818147584 -0.047463638962418  0.000566548572565
-    2  (  2)  0.275258773270295 -0.138888616959566  0.015969350630016
-    3  (  3)  0.017345671201066  0.059189082677904  0.046475381464176
-    4  (  4)  0.050392875387071  0.072424486885238  0.004459708301674
-    5  (  5)  0.026836133802329  0.070805989588457 -0.140760690762251
-    6  (  6)  0.078585377266712 -0.120742726291724 -0.064292229739042
-    7  (  7)  0.041858894695365  0.005665298794286 -0.017186389956069
-    8  (  8)  0.118429783701800  0.144155118064025  0.113213711259466
-    9  (  9) -0.000756388118591  0.455654623157072  0.231432578787543
-   10  ( 10) -0.453567841489266 -0.001497567906129 -0.172275686133391
-   11  ( 11) -0.230120702539645  0.175050207490782 -0.001480251815160
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000516219946816  0.034778633659956  0.032999546928151 -0.009629039776278  0.052966719633617 -0.030450001531878 -0.014875222246015 -0.072128990177077  0.048218822417803
-    1  (  1) -0.030877691560804  0.001883541097772  0.071434334115879 -0.019325009721534 -0.017452039030100 -0.158145751795333 -0.010537309557875 -0.021583100108147 -0.169934651056250
-    2  (  2) -0.033565318682613 -0.071200997372983  0.000581071534985 -0.036850040138101  0.007310816547227 -0.008797901115406 -0.029229533057666 -0.016744128499400 -0.070455787497455
-    3  (  3)  0.011004884819686  0.019179310791618  0.034909263032370  0.000523661128158 -0.007125267622899 -0.017666281606150 -0.025274953349027  0.006048522524524 -0.042959205727090
-    4  (  4) -0.052383681601535  0.016788640224883 -0.007028507044452  0.007472760866637 -0.000164741631073 -0.026820745242549  0.000005495327564 -0.022752424410877  0.031410113616428
-    5  (  5)  0.028924597602342  0.155705177520586  0.009708873936879  0.016613543931604  0.026890889200954  0.000863820528475 -0.026461589325309  0.030900211040800  0.024762473040831
-    6  (  6)  0.014335467827216  0.010396285650159  0.029624823660296  0.025462090585912  0.000149096444494  0.026996065218364 -0.000042625626758 -0.107465667965402  0.101121105248233
-    7  (  7)  0.071280711647029  0.021473260264964  0.016888851213230 -0.005990055447048  0.022650874097521 -0.030884846999677  0.107059671381934  0.000085380718295  0.001222830424055
-    8  (  8) -0.049124632890092  0.169889327710618  0.068826403708743  0.044339001017875 -0.031493314676472 -0.025080049766767 -0.100845039831255 -0.001167614688641  0.000278385825403
-    9  (  9)  0.004591463397670  0.224641690035662  0.054391854978822 -0.000520714575472  0.041379699430161 -0.035041097267503 -0.048865193892848 -0.034233303767760  0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.004372643490859
-    1  (  1) -0.225448428944350
-    2  (  2) -0.053543340635201
-    3  (  3)  0.000029286176363
-    4  (  4) -0.041473098636741
-    5  (  5)  0.035500700267141
-    6  (  6)  0.049415179037896
-    7  (  7)  0.033722251526408
-    8  (  8) -0.002108270875613
-    9  (  9) -0.000059855095180
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.083178189184036  0.063320502543375  0.053448860291133 -0.010119942476578 -0.027962494700737 -0.033408156898410 -0.016646686372055 -0.009688142905594 -0.047753876913682
-    1  (  1) -0.015436953954369  0.001484194684011 -0.023035398887205 -0.013457869405466  0.013993527195521  0.033943979767543 -0.150850131221437  0.006054179455746 -0.032861777904130
-    2  (  2) -0.007416632072171 -0.085535883632607  0.031035920631781  0.004414026005139  0.010136741110915 -0.029006493089287  0.078308410406643 -0.042862583013635 -0.094615352193845
-    3  (  3)  0.060864804294684  0.107990348400789  0.029334441164075  0.017074561166948 -0.006770814971091 -0.056161219994893  0.038880977880177  0.007186858274067  0.050898617184209
-    4  (  4)  0.109193273208522  0.178421304573120  0.074992061457995 -0.038015102633012  0.147910228795514 -0.087181398607820  0.098582275644141 -0.093570766915846 -0.088687564658624
-    5  (  5) -0.362309556227904 -0.121304099182945 -0.074968023841376 -0.180660703600124  0.122438585672172  0.079096894998506 -0.085876030826778  0.136109864287558 -0.002214631278523
-    6  (  6) -0.026835628168075  0.104282391359254 -0.172843582770517 -0.372105341696267 -0.200623348657875  0.124556824110224  0.101871864602057  0.564196462169744 -0.000688785089474
-    7  (  7) -0.344945182303497 -0.095060217852336 -0.019692892185405  0.208607222836184  0.002627647973779  0.075715664253568  0.273373001503080 -0.322679649636761  0.103750880742886
-    8  (  8) -0.103243578213400 -0.018995126733818  0.033613347666093  0.143946559071139 -0.146180680800982 -0.017308359580339 -0.107684620440504  0.078982837453949  0.062496256435255
-    9  (  9)  0.085648241806344  0.209611729409149  0.056224829650480  0.004822853433113 -0.155473341074989 -0.012971266670028  0.058097898147224  0.150335378963730 -0.078057323449305
-   10  ( 10) -0.070132629148842 -0.074702785463534 -0.209329818275843 -0.042566217114534  0.058034325280006  0.102370728009941  0.025801004099357  0.264561180085366 -0.017482708757363
-   11  ( 11) -0.113963029107499 -0.045073298009464 -0.000413587765283 -0.112463923253522  0.089423608765749  0.081287727377731  0.019439635907878  0.076622183257520 -0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015270950350973
-    1  (  1) -0.030946721870550
-    2  (  2)  0.003707642076146
-    3  (  3)  0.011960041321321
-    4  (  4) -0.086083869661608
-    5  (  5) -0.009867768215709
-    6  (  6) -0.209680707316341
-    7  (  7)  0.097843271017668
-    8  (  8)  0.010325909660635
-    9  (  9) -0.121632163838855
-   10  ( 10) -0.058275044600178
-   11  ( 11)  0.003021331907582
-
 	Computing Mu_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.663852495952
-	   1        17.349316646619    5.172e-01
-	   2        19.385113345909    1.883e-01
-	   3        19.407847597477    2.113e-02
-	   4        19.414241734665    7.755e-03
-	   5        19.415176455114    1.032e-03
-	   6        19.415012990662    3.160e-04
-	   7        19.415033958417    5.837e-05
-	   8        19.415041993874    1.888e-05
-	   9        19.415040949666    5.204e-06
-	  10        19.415040546963    1.666e-06
-	  11        19.415040734904    4.928e-07
-	  12        19.415040994304    1.203e-07
+	   0        13.663852328482
+	   1        17.349316422742    5.172e-01
+	   2        19.385113079902    1.883e-01
+	   3        19.407847329965    2.113e-02
+	   4        19.414241466868    7.755e-03
+	   5        19.415176187248    1.032e-03
+	   6        19.415012722798    3.160e-04
+	   7        19.415033690551    5.837e-05
+	   8        19.415041726007    1.888e-05
+	   9        19.415040681799    5.204e-06
+	  10        19.415040279096    1.666e-06
+	  11        19.415040467037    4.928e-07
+	  12        19.415040726437    1.203e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 3.402e-08
 
 	Computing L_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.300703482645
-	   1         3.121289906292    2.885e-01
-	   2         3.752310252093    1.328e-01
-	   3         3.767783325289    2.436e-02
-	   4         3.776714913955    1.243e-02
-	   5         3.777836484382    3.983e-03
-	   6         3.777768504411    1.141e-03
-	   7         3.777808011524    3.482e-04
-	   8         3.777806751835    1.218e-04
-	   9         3.777799472842    4.621e-05
-	  10         3.777798809266    1.539e-05
-	  11         3.777800013552    3.124e-06
-	  12         3.777800855667    1.120e-06
-	  13         3.777801091414    2.688e-07
-	  14         3.777801254163    1.261e-07
+	   0         2.300703468868
+	   1         3.121289885462    2.885e-01
+	   2         3.752310222470    1.328e-01
+	   3         3.767783294992    2.436e-02
+	   4         3.776714883264    1.243e-02
+	   5         3.777836453622    3.983e-03
+	   6         3.777768473650    1.141e-03
+	   7         3.777807980762    3.482e-04
+	   8         3.777806721072    1.218e-04
+	   9         3.777799442080    4.621e-05
+	  10         3.777798778504    1.539e-05
+	  11         3.777799982789    3.124e-06
+	  12         3.777800824905    1.120e-06
+	  13         3.777801060651    2.688e-07
+	  14         3.777801223401    1.261e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.107e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.329948285773
-	   1        13.411421217298    3.567e-01
-	   2        14.315309207607    1.102e-01
-	   3        14.357443663129    1.983e-02
-	   4        14.362381922354    6.059e-03
-	   5        14.363016926461    9.670e-04
-	   6        14.362953466067    2.647e-04
-	   7        14.362975622137    5.528e-05
-	   8        14.362980629521    1.635e-05
-	   9        14.362980593940    4.161e-06
-	  10        14.362980698305    1.472e-06
-	  11        14.362980838668    3.685e-07
-	  12        14.362980972689    1.227e-07
+	   0        11.329948161504
+	   1        13.411421068744    3.567e-01
+	   2        14.315309044441    1.102e-01
+	   3        14.357443498125    1.983e-02
+	   4        14.362381757162    6.059e-03
+	   5        14.363016761229    9.670e-04
+	   6        14.362953300836    2.647e-04
+	   7        14.362975456904    5.528e-05
+	   8        14.362980464287    1.635e-05
+	   9        14.362980428706    4.161e-06
+	  10        14.362980533071    1.472e-06
+	  11        14.362980673434    3.685e-07
+	  12        14.362980807455    1.227e-07
 	-----------------------------------------
-	Converged Mu_Y-Perturbed Wfn to 2.971e-08
+	Converged Mu_Y-Perturbed Wfn to 2.970e-08
 
 	Computing L_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.496880118727
-	   1         8.584125224274    4.215e-01
-	   2         9.867718731120    1.834e-01
-	   3         9.932572455386    5.520e-02
-	   4         9.966701252967    2.429e-02
-	   5         9.968657722528    5.269e-03
-	   6         9.968350196991    1.238e-03
-	   7         9.968424289999    3.637e-04
-	   8         9.968417466383    8.674e-05
-	   9         9.968417381026    3.012e-05
-	  10         9.968415729223    1.207e-05
-	  11         9.968416777999    2.944e-06
-	  12         9.968417365925    1.184e-06
-	  13         9.968417596207    3.589e-07
-	  14         9.968417751615    1.515e-07
+	   0         6.496880090884
+	   1         8.584125184372    4.215e-01
+	   2         9.867718679631    1.834e-01
+	   3         9.932572402175    5.520e-02
+	   4         9.966701198597    2.429e-02
+	   5         9.968657668021    5.269e-03
+	   6         9.968350142488    1.238e-03
+	   7         9.968424235493    3.637e-04
+	   8         9.968417411876    8.674e-05
+	   9         9.968417326520    3.012e-05
+	  10         9.968415674717    1.207e-05
+	  11         9.968416723492    2.944e-06
+	  12         9.968417311419    1.184e-06
+	  13         9.968417541701    3.589e-07
+	  14         9.968417697109    1.515e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 5.471e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.357414759766
-	   1        13.937822077621    3.768e-01
-	   2        14.977230543975    1.121e-01
-	   3        14.992312975776    1.472e-02
-	   4        14.996460695181    6.152e-03
-	   5        14.996903745094    6.700e-04
-	   6        14.996856800909    2.049e-04
-	   7        14.996864223215    4.712e-05
-	   8        14.996864928986    1.506e-05
-	   9        14.996864499750    3.809e-06
-	  10        14.996864384462    1.116e-06
-	  11        14.996864502208    2.116e-07
+	   0        11.357414639791
+	   1        13.937821924355    3.768e-01
+	   2        14.977230372953    1.121e-01
+	   3        14.992312804032    1.472e-02
+	   4        14.996460523268    6.152e-03
+	   5        14.996903573155    6.700e-04
+	   6        14.996856628970    2.049e-04
+	   7        14.996864051275    4.712e-05
+	   8        14.996864757046    1.506e-05
+	   9        14.996864327810    3.809e-06
+	  10        14.996864212522    1.116e-06
+	  11        14.996864330269    2.116e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 5.589e-08
 
 	Computing L_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.631525392543
-	   1         8.727961461472    4.299e-01
-	   2        10.061240342645    1.812e-01
-	   3        10.106609313520    3.611e-02
-	   4        10.122396493451    1.704e-02
-	   5        10.124736815494    5.870e-03
-	   6        10.124280001559    1.978e-03
-	   7        10.124433854178    4.386e-04
-	   8        10.124449799174    1.303e-04
-	   9        10.124443685199    4.187e-05
-	  10        10.124444176979    1.792e-05
-	  11        10.124445213477    4.900e-06
-	  12        10.124446595285    1.647e-06
-	  13        10.124446932567    5.315e-07
-	  14        10.124447071579    1.789e-07
+	   0         6.631525365571
+	   1         8.727961423050    4.299e-01
+	   2        10.061240292053    1.812e-01
+	   3        10.106609261672    3.611e-02
+	   4        10.122396441092    1.704e-02
+	   5        10.124736763008    5.870e-03
+	   6        10.124279949075    1.978e-03
+	   7        10.124433801688    4.386e-04
+	   8        10.124449746683    1.303e-04
+	   9        10.124443632709    4.187e-05
+	  10        10.124444124490    1.792e-05
+	  11        10.124445160987    4.900e-06
+	  12        10.124446542795    1.647e-06
+	  13        10.124446880076    5.315e-07
+	  14        10.124447019088    1.789e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 6.879e-08
 
 	Computing 1/2 <<Mu;L>>_(0.077) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008614927932901 -0.046442352400056  0.027924113420848 -0.003342105613042 -0.019198187280149 -0.043605993010684  0.000124507843934 -0.017903232775755 -0.064037761769677
-    1  (  1) -0.004023859954382  0.002812567241188 -0.015355365220565  0.063211982369858  0.033868800032563 -0.011581015700219 -0.004465574115878 -0.047030919129079 -0.048793907716228
-    2  (  2)  0.028525640721225  0.068120190051797 -0.016739332483522 -0.005073216914996  0.071940864110972 -0.066733646998345 -0.019605473406179 -0.001610556181541  0.004701378003057
-    3  (  3) -0.054155290592472 -0.054244334984755 -0.021962628004576 -0.018282485083091 -0.037028274309951  0.016786978556275  0.022024618578561  0.004302299401540 -0.167953274084101
-    4  (  4) -0.063182596929128 -0.128748808697011  0.121465113794596  0.160938411624414 -0.233917278334855  0.054052147786148  0.025334190025568  0.127021105025468 -0.261448831371970
-    5  (  5)  0.148864678539144  0.254187426901849 -0.169654893765005  0.284620623487219  0.104152411510991  0.359543809296571  0.133744009364038  0.041861549395911  0.169452799563311
-    6  (  6) -0.084956716693293  0.126613830958100 -0.017431389376921 -0.048281125785785  0.083267553859489 -0.206713853889007  0.428812335356187  0.005011018790693  0.061186511244325
-    7  (  7)  0.173630436499038  0.181276581467465 -0.440332497406727 -0.059456065314793  0.303618967332177  0.080016792150091 -0.104444652264320  0.251866044362601  0.089940979754426
-    8  (  8)  0.057697740265636  0.070180597319316 -0.383387445877903  0.514874723728167  0.465292274425094 -0.060917787458673  0.016262524997932  0.068972295825028 -0.265391565564862
-    9  (  9) -0.279247635392508  0.560707539445326  0.044547355247966  0.161505455840491 -0.002588377300620  0.219223272852673  0.096307931275233  0.176467158787115 -0.104344971075325
-   10  ( 10) -0.977075550189082  0.176418272338824  0.228294317792423 -0.099370607761785  0.027777959043915 -0.149348953174007  0.027413414685573 -0.102632226214496  0.005531527026329
-   11  ( 11) -0.211429004068205  0.082644794913083 -0.055680052865830  0.289018099852967 -0.067789578528906  0.064107786895450  0.141855082713117  0.071186757345684 -0.332576681432119
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071990946341156
-    1  (  1)  0.010142476746200
-    2  (  2) -0.112423878596356
-    3  (  3) -0.059253840833002
-    4  (  4) -0.014639189231197
-    5  (  5)  0.248038168374966
-    6  (  6) -0.055159646937661
-    7  (  7)  0.115432903674626
-    8  (  8) -0.135363224547124
-    9  (  9)  0.174678345310946
-   10  ( 10) -0.086140984938274
-   11  ( 11)  0.161723358519153
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.197572413114517 -0.541318632877371  0.139927415914873 -0.359578444130330 -0.398937843975486 -0.026586872167534 -0.139627977382516 -0.005896246491228 -0.003746644388905
-    1  (  1) -0.541058731973333 -2.034801242188507  0.920540457917585  1.016218584629480  0.729164689940962  0.054412526301737  0.235971924521468  0.315223615831553  0.096208087340554
-    2  (  2)  0.139828960639396  0.920734025049694  1.243601677781983 -0.974300649425054 -0.758553357750500  0.024609548649431  0.513266755137957 -0.116926330823923  0.094501440802452
-    3  (  3) -0.358970389612551  1.015833032444632 -0.974440229907822 -0.266348920037382 -0.133799224826450 -1.276907891719884  0.042984364188955 -0.410608972745146 -0.602345206758872
-    4  (  4) -0.398323035382104  0.727797072638099 -0.759857932028957 -0.133858878725855  0.575448485405805  0.056475665846990 -0.484493838094732 -1.583666059960473 -0.976878960945650
-    5  (  5) -0.027166282529876  0.055084907439528  0.024891154244808 -1.275543890392068  0.058746221115305  0.155399297624787 -0.236023461595880  0.812878944882876 -1.048535633945681
-    6  (  6) -0.139452284652001  0.236223353106611  0.513262677276795  0.042879631015553 -0.482819583744289 -0.235933155306163 -2.554180022039243  0.492117808091915  0.545404391969618
-    7  (  7) -0.005841417486080  0.316274368087248 -0.116163386132942 -0.410094172620351 -1.579571504351393  0.813774264702327  0.492423579055058 -1.700719634572147  0.685529426222534
-    8  (  8) -0.003628131523111  0.096035529406495  0.094131958822655 -0.602680558554738 -0.970206233042967 -1.045482011639248  0.544249830480973  0.683514460656999 -0.254958894521937
-    9  (  9)  0.326098978034070 -0.130935443755898 -0.379595166178810 -0.575990923913880 -0.393471965772156 -0.365686482354661 -1.227740649572571 -0.905826585766955  0.039987575439783
-   10  ( 10)  0.008103557010829 -0.039575543043785 -0.358664813530415  0.339232504235094  0.207222390004838  0.025784782686722 -0.874465143496950  0.752110557173402  0.140644707838520
-   11  ( 11)  0.161744201604777 -0.084371238126416 -0.371150000615002 -0.062082553987999 -0.264710244109502 -0.257261524594595 -0.444570825837596  0.002821912169167 -0.878431482758543
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.327854256723191  0.009019714201806  0.162710661594080
-    1  (  1) -0.133091859401188 -0.040697608916971 -0.085480013261477
-    2  (  2) -0.381849466582258 -0.359835698966555 -0.372555502654032
-    3  (  3) -0.579249329460985  0.337242930789026 -0.062083381101115
-    4  (  4) -0.396591932227294  0.208613968377681 -0.263534161447186
-    5  (  5) -0.365098796840620  0.027806203875135 -0.265146511184336
-    6  (  6) -1.230804866141472 -0.879767261427487 -0.448789926588722
-    7  (  7) -0.904635210810701  0.753869376128870 -0.007723762422951
-    8  (  8)  0.040323953888643  0.145561462630237 -0.894627985530935
-    9  (  9)  0.423095730032689 -0.296000598729972 -0.177730944535255
-   10  ( 10) -0.299463152132731  0.634536265412446 -0.073348108781663
-   11  ( 11) -0.175836972560684 -0.076105887981834  1.184769463941312
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.567008918440454  0.722443194224100  0.422402078329773  0.057554368538511 -0.068012024097596 -0.451975147608540  0.709419418128490 -0.110422168786063  0.095704108927647
-    1  (  1)  0.720885472964738  0.332527211352729  0.737390933664557  0.281750515995843  0.280761290393686 -0.598548871078422 -1.146750917560074 -0.177301134607867  0.234694928374046
-    2  (  2)  0.422183102929830  0.736485274543817  0.007829109729841 -0.365399185160488 -0.965501991519851  1.065090224342325 -0.394390877157068  0.239359282041345 -1.218182428400336
-    3  (  3)  0.059687201587689  0.280769829516347 -0.363255319277090 -0.833720445234328 -1.345952507284314 -0.189309823206009 -0.179890587463359  1.060334267261244  0.772514544005070
-    4  (  4) -0.069257393950461  0.281296543593726 -0.966923508415862 -1.344162403478837  1.514830798821686  0.013670590813123  0.227285042195308 -0.333966365834383  0.386248727994588
-    5  (  5) -0.449135841837750 -0.599397616398023  1.066820631137579 -0.189649110609729  0.013795397601274 -0.565008204089947  0.487292179201877  0.306200785308481  0.347063761059997
-    6  (  6)  0.708465668575064 -1.146562417015747 -0.391890894794961 -0.180811610825629  0.226633708337573  0.487729597603209 -2.767088081148377 -0.044613761228256 -0.000972346438746
-    7  (  7) -0.108981479701481 -0.177538422258191  0.240499334967173  1.059842333943978 -0.334391646412731  0.306249622802239 -0.044471110656761 -3.232660954268523  0.514839123397967
-    8  (  8)  0.094277588726801  0.235043460722862 -1.221823739304416  0.774952681271118  0.386077819008107  0.344858044218004 -0.000341133693178  0.514916107143190  0.507086715271392
-    9  (  9) -0.063381219775898  0.233965663654109 -0.093343357924906 -0.360354041999586 -1.006820146552738  1.344825106449130  0.268434803850821  0.315156353069794 -0.332938610236887
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.063808920787530
-    1  (  1)  0.235710820172182
-    2  (  2) -0.096202914418848
-    3  (  3) -0.360121798161892
-    4  (  4) -1.006476097602190
-    5  (  5)  1.343619008167611
-    6  (  6)  0.268106090274240
-    7  (  7)  0.315242334513133
-    8  (  8) -0.332481313383264
-    9  (  9) -0.175400025059932
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010284048494255 -0.022581971135931  0.025184528241746  0.002553505114185 -0.007866760216735 -0.035704112150886 -0.002766394497905 -0.015588851752449 -0.054894237910669
-    1  (  1)  0.001129370063260 -0.004341567056713 -0.012471737690510  0.068518821494219  0.037428649672491 -0.002857552975536 -0.002731409738209 -0.051935588474977 -0.049204102006071
-    2  (  2)  0.045340581598934  0.060774626672080 -0.014665202394902 -0.013163382447340  0.085552378847967 -0.055885373659009 -0.012884187954087 -0.000025912808653  0.007546289398551
-    3  (  3) -0.053518724373857 -0.051858316930917 -0.015829576226974  0.002308038466593 -0.033376912491914  0.026566608759227  0.020736863226261  0.017163432001033 -0.156611857939886
-    4  (  4) -0.057073647917578 -0.121620677730040  0.116559461318180  0.152459611673760 -0.224360677266659  0.063635487600126  0.025109630293686  0.123561544969923 -0.260705677431782
-    5  (  5)  0.132736043071323  0.228873275971275 -0.157588806451895  0.278203525609905  0.112411249713211  0.339424025956772  0.132778586915835  0.041442079822076  0.144607854949093
-    6  (  6) -0.099037108772820  0.133050971019321 -0.016390463092699 -0.047994853534082  0.082590754367535 -0.196599146843337  0.423704532236322  0.002588517799838  0.062442412924455
-    7  (  7)  0.164573996270568  0.174187584517111 -0.442718231735592 -0.055107629768529  0.292277213599590  0.090352016025029 -0.100915507153634  0.242008735185081  0.079009239652453
-    8  (  8)  0.059450407301305  0.065508844735816 -0.375580889101448  0.518979554864539  0.457917802055341 -0.070408637451188  0.013466768623613  0.072872586601375 -0.257559025462184
-    9  (  9) -0.246894722162695  0.551859769243373  0.044670824987361  0.162240888664295 -0.012774136938901  0.203595879781061  0.102036778576897  0.168067562706153 -0.111682944808914
-   10  ( 10) -0.913654455951997  0.155328532380750  0.215519674293101 -0.100970035089767  0.021969337557273 -0.148862369984030  0.046525143909590 -0.100083990349210  0.020780587060978
-   11  ( 11) -0.198781019683999  0.090074442467030 -0.050453210014304  0.292395282220077 -0.068054938936099  0.077531780115388  0.149511822875939  0.072921096134366 -0.357789764657410
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.062212803584986
-    1  (  1)  0.008222801612735
-    2  (  2) -0.107232253166961
-    3  (  3) -0.058083892735771
-    4  (  4) -0.001519088368734
-    5  (  5)  0.232883930798086
-    6  (  6) -0.056471183426688
-    7  (  7)  0.097796104480775
-    8  (  8) -0.126488666884472
-    9  (  9)  0.156849504238605
-   10  ( 10) -0.081446420280763
-   11  ( 11)  0.176341903152824
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007749096020893 -0.085883219860789 -0.036741821640513 -0.003365465554254 -0.013826624434967  0.045778129863205  0.040669337017936  0.010509742963645  0.029540605017242
-    1  (  1) -0.033323633544771  0.071013231293301  0.009381535649954  0.001865195819276 -0.004385218315905 -0.001145589403992 -0.107240463714063 -0.004928891794835 -0.020784313339082
-    2  (  2)  0.052107391808055  0.092519548352413  0.009858355445846  0.037319719751115 -0.023857034470632 -0.010135084101246  0.037769988668842 -0.015917832336735  0.090581268987334
-    3  (  3) -0.109820166860700  0.034268818868662  0.003318299125654 -0.047343590144125  0.049224764312370 -0.055554817528594  0.048303583350885 -0.021295778567536 -0.056731125392159
-    4  (  4) -0.007052162455570 -0.070092516335627 -0.001616209300804  0.100452686687340 -0.017125496300488  0.011804649620296  0.317168773449601 -0.015679790140276  0.134810835290821
-    5  (  5) -0.101789034987347  0.450242114045570  0.095257897029759  0.154575128248214 -0.107484330343030 -0.276349446627330 -0.224432437333530  0.138878619319231 -0.069374899620443
-    6  (  6)  0.129481070378189  0.190214182802185 -0.111482363704469 -0.289845791886638 -0.214082604248960  0.130539668518305  0.176627871859896  0.507792819613372 -0.145016045312478
-    7  (  7) -0.031015915682170  0.467808966358201  0.323231774623313  0.163051942437066 -0.027878152128557 -0.222130149400228  0.355582804042090 -0.345169178258104 -0.117503613032291
-    8  (  8) -0.081114418656010 -0.129458136695794  0.321266021811150 -0.116738859709862  0.112997348404402  0.150149613835924  0.100022037588641 -0.009859219508172 -0.185497355865147
-    9  (  9) -0.840897499603665 -0.103193956572518 -0.262141263376961 -0.179652800220136  0.091540284698060  0.263027818637292  0.232988427097700  0.132664590100508  0.080643129784317
-   10  ( 10)  0.396138270139100  0.527358178663247  0.115585436142149 -0.350404487392900  0.098592337861551  0.056041756240516 -0.132708614971811  0.130232826037073  0.024142145251939
-   11  ( 11)  0.048038049575401  0.184019168140566 -0.243899393243605  0.184449948512382  0.067903231499648 -0.173184976481832  0.074519873620110  0.122524072160336  0.175482839393722
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.029757291821339
-    1  (  1) -0.000721108481725
-    2  (  2)  0.081115665687732
-    3  (  3)  0.028764622397233
-    4  (  4) -0.020368316409772
-    5  (  5) -0.173632225317480
-    6  (  6) -0.281328230047800
-    7  (  7) -0.030401209370270
-    8  (  8)  0.093738850403327
-    9  (  9)  0.138017132925940
-   10  ( 10)  0.057334975405403
-   11  ( 11) -0.087072361680799
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.718905282963311 -0.301300066815098 -0.767801784865940  0.078512808825352 -0.203134864329395  0.241932163232250  0.058076631858574  0.196398858308336 -0.039008858124194
-    1  (  1) -0.301256490728193 -0.157440548180653 -0.036029555945222  0.243436823804201 -0.005929795652985  0.115486356935965  0.826228436942721 -0.465135369554618  0.058491264513800
-    2  (  2) -0.767289827428610 -0.036275730111077 -0.756926663794728  0.450133498634738  0.207784604973971 -0.828712724024022 -0.324647417359493 -0.353270502638369  0.092835605795882
-    3  (  3)  0.078579571414042  0.243310568002833  0.450095063336851 -0.208139431363607 -0.062202704649669  0.279001105370900 -0.076077558481815  0.262112030046533 -0.378810215172718
-    4  (  4) -0.202510304245595 -0.006692039856945  0.206011713498273 -0.062773519685661 -0.370731419489490 -0.256994084769574 -0.019543706164301  0.220490721787851  0.607096866069924
-    5  (  5)  0.239969372403163  0.117504635997786 -0.825053657412313  0.279484173569987 -0.255386254541418 -0.397595357673452 -0.135369610755389  0.236221247146237  0.269522215039686
-    6  (  6)  0.058390572588279  0.825859124407247 -0.324193078352693 -0.076854690390370 -0.019228317672495 -0.137735601227498 -0.351485727273275 -0.487761380462257 -0.103056409920122
-    7  (  7)  0.194458563409000 -0.463590717501173 -0.349817673328107  0.262678828099312  0.220495817360137  0.236701749060628 -0.486100377719484  0.043036203375607 -0.169360995578035
-    8  (  8) -0.038844766636175  0.058006360789407  0.092452034322386 -0.377838465048525  0.603441383275525  0.267460191997309 -0.103192305796676 -0.168696834715057 -0.618488124049516
-    9  (  9) -0.174642021637819  0.179686913958803  0.584519432729807 -0.531375857305351 -0.237827440080434  0.122408493834100 -0.350613084838644 -0.156778679126698 -0.027661506214973
-   10  ( 10)  0.043298420781037 -0.218837511618004 -0.611680553974653 -0.687832529301005 -0.249683832986975  0.553064660821027 -0.144105807777605  0.115245275900936 -0.084193131593124
-   11  ( 11)  0.061064657985430 -0.108300572115386 -0.188797311905296 -0.022208683609426 -0.827900622936499 -0.341922472618851  0.022718392329079  0.232401592689427  0.164619669402136
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.175684511601603  0.045513516298602  0.061672515006080
-    1  (  1)  0.179323083833167 -0.221567937419786 -0.109140577543022
-    2  (  2)  0.587827397093136 -0.616289532030193 -0.190305864672640
-    3  (  3) -0.534590179358002 -0.689583787093839 -0.022209033963942
-    4  (  4) -0.239000891867221 -0.249187499059157 -0.832603923332527
-    5  (  5)  0.122010791877518  0.553620901013401 -0.348332351708050
-    6  (  6) -0.352732495297565 -0.145056644635348  0.023781601660354
-    7  (  7) -0.157242165562723  0.112854519200918  0.232190589319976
-    8  (  8) -0.027709907045481 -0.086030263039170  0.172274707819854
-    9  (  9)  0.207109600584589  0.096837430686223 -0.023218950236813
-   10  ( 10)  0.100164655230671  0.138181178066476 -0.148224446144570
-   11  ( 11) -0.022320179734203 -0.148849259998097  0.901205762410303
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.179939828491769 -0.273263983919761 -0.077241939802207 -0.131310571537764 -0.452108955794121 -0.373710053222736  0.012756857043078  0.188686131296855 -0.281717657996437
-    1  (  1) -0.271865636595074  0.080204205184229  0.237736668579935  0.053954037181141  0.088144371186311  0.094298665169508 -0.396703489007358 -0.164374392009126 -0.012743809563993
-    2  (  2) -0.076549157175288  0.237611423410488 -0.235916884249811  0.330279805489172  0.156363656188217 -0.135525945480897  0.113532621668593 -0.192996543934043  0.505097349395040
-    3  (  3) -0.133008481204441  0.051978470711429  0.330705317892875 -0.689079279022158  0.681025162416434  0.230126506813665  0.220012049909173 -0.221793013382862 -0.415574431905058
-    4  (  4) -0.450299145657576  0.087908600365275  0.156309970041408  0.681002122520780 -1.360248251424318  0.202273753159192 -0.167570810051337  0.246051223487190  0.206738411458247
-    5  (  5) -0.373567193155845  0.094555329734040 -0.136731584498100  0.229377893488984  0.202581599883435 -0.322498154757568 -0.226671631570763  0.408374954790996  0.307423751717641
-    6  (  6)  0.013230492577454 -0.395220303624150  0.113830041131736  0.218897296842682 -0.167381205612527 -0.226319762003687 -0.422981172464967 -0.882122931150610  0.208582936748456
-    7  (  7)  0.187587553988559 -0.164973338711578 -0.192266029819867 -0.222193739599766  0.245811643454060  0.408813624326959 -0.882511768104148 -0.161881530949274 -0.197931622292553
-    8  (  8) -0.280045996340605 -0.013187886145669  0.507423753200987 -0.417462155137855  0.206022606034107  0.308302993473083  0.207495521066743 -0.198012373935716 -0.598880759668382
-    9  (  9) -0.299128216307527  0.222289305708678 -0.374826664894612 -0.022250761597490  0.198104512558476 -0.291885255576850  0.011569749529353 -0.150670269953426  0.186378706038956
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301492091129213
-    1  (  1)  0.222023461274417
-    2  (  2) -0.373275862159688
-    3  (  3) -0.022769731837422
-    4  (  4)  0.197531018509810
-    5  (  5) -0.291038388606400
-    6  (  6)  0.011766677818707
-    7  (  7) -0.150956367275849
-    8  (  8)  0.186282415361357
-    9  (  9) -0.408641391244209
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006541040222368 -0.029135588169222 -0.017330822595744  0.002628911660037 -0.012344009141809  0.034496132624923  0.021629830242309  0.010441885402291  0.025478364815458
-    1  (  1) -0.038275138470075  0.054424566886903  0.005683589031010  0.001642391288003 -0.005493648653247  0.001124544236485 -0.102028934451313 -0.004961744404475 -0.019198498257850
-    2  (  2)  0.053024456913342  0.083754722151204  0.014366999014575  0.045684709272444 -0.045425854355333 -0.015659092798954  0.035306515857362 -0.013688960188417  0.082596341754868
-    3  (  3) -0.125696090540634  0.031717757592640 -0.000802365038104 -0.050871771309593  0.061705711345850 -0.045742890419344  0.045450419445688 -0.021064845035616 -0.054716959844684
-    4  (  4) -0.016613018731749 -0.059371668786672 -0.003754167403423  0.095982620955076 -0.007240466240122  0.008043456529988  0.296808016923276 -0.015369394286441  0.136610478911713
-    5  (  5) -0.093091489377706  0.398657588863068  0.074430182364354  0.149030211928108 -0.108745535372234 -0.256250392240536 -0.205814737045222  0.134201000957220 -0.055103512993348
-    6  (  6)  0.103501697780443  0.185147067962843 -0.104829304475355 -0.273669393328239 -0.199802423052909  0.136710211986565  0.166053639619828  0.483268157942075 -0.135434527757446
-    7  (  7) -0.041456689404135  0.416662529525886  0.296499443846860  0.151835770270295 -0.027648961071683 -0.196853254585748  0.346148931870815 -0.324194030503122 -0.108656389838073
-    8  (  8) -0.069099920157317 -0.122455303618133  0.312946042218845 -0.115185983609626  0.104240832235501  0.145175805702234  0.095088539986730 -0.010672631592564 -0.187147060865154
-    9  (  9) -0.712671855893174 -0.096350152389786 -0.234711067777686 -0.171596024164591  0.065322769896798  0.213466874289907  0.226529390715592  0.118201066093080  0.055528795004367
-   10  ( 10)  0.365512212430565  0.443597144956858  0.088760713787529 -0.336294489487780  0.089380999156301  0.050585935158758 -0.112358935032342  0.122526344346197  0.011836823928278
-   11  ( 11)  0.046393846223224  0.165011629057398 -0.228781961279396  0.178941949643574  0.063752947031584 -0.164789871590981  0.073726138142668  0.117333811839271  0.181371275992210
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.026880621041360
-    1  (  1) -0.000642066544117
-    2  (  2)  0.075046583216661
-    3  (  3)  0.030887223304929
-    4  (  4) -0.027083357083367
-    5  (  5) -0.161323349919549
-    6  (  6) -0.260652499025702
-    7  (  7) -0.019658118713907
-    8  (  8)  0.093794795124770
-    9  (  9)  0.110456626093643
-   10  ( 10)  0.048798146100140
-   11  ( 11) -0.097571556382824
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001432746297450 -0.032810674091764 -0.033331937480253  0.023032547083763 -0.002808019310921 -0.039246266926320  0.018692018505171  0.008842597191367 -0.029091078569617
-    1  (  1) -0.008821922403183 -0.001742272088788  0.082771016704519 -0.022297486221974  0.039163604166239 -0.010818853488427 -0.047294425339584  0.013135326021221  0.049034393857867
-    2  (  2)  0.024274942916815  0.027096978669207  0.097516386902391 -0.041392368694666 -0.004119390757880  0.075691552303805 -0.023677742397495 -0.003953261558318 -0.122163189427397
-    3  (  3) -0.047038460283817 -0.039422636027069  0.017791086341758  0.115660160117630 -0.067224158887899  0.095036576800958  0.032022129167533  0.022732157345389  0.120912741709036
-    4  (  4) -0.041035802352368  0.001934742020068 -0.201409668003493 -0.406246991276172  0.228435905047063 -0.366034413601436  0.036563318346743 -0.036692328708082 -0.082010843429842
-    5  (  5)  0.098338733570095  0.243746073973362  0.282884501181602 -0.425804208023662  0.108408993563040  0.505586602390370  0.102717653176241 -0.183779423720787  0.023433267817945
-    6  (  6)  0.135336854760563 -0.062874421564495  0.076338309095403 -0.023002937162434 -0.130902824611473 -0.185164583438217  0.398907643233867  0.217551510448046 -0.032105677017803
-    7  (  7) -0.035062191357078 -0.113858796831119  0.431604299875852 -0.029482805357536 -0.029652466640804 -0.242847719350325 -0.077765311277989  0.367073496056810  0.139022006906444
-    8  (  8) -0.068272847454715  0.294672021175633 -0.568959581650588 -0.125921031197012 -0.707592810771387  0.017806583156209 -0.015845746565047 -0.212947645825718  0.125196335187716
-    9  (  9) -0.288858276698774  0.093713692739213  0.209035012311688  0.075382622510660  0.083405488851542  0.016184965058288  0.000548295704545  0.266294088315547  0.380874642506837
-   10  ( 10) -0.378738518488000  0.204837316203508 -0.069415360994347  0.062065163074324  0.029622876137723 -0.058750752587050 -0.120574645247794  0.008130897374692  0.009265965929469
-   11  ( 11) -0.080018520143771  0.225808316863723 -0.312311376663230 -0.316597637367698  0.125757542829493 -0.146130016020174  0.016179298260010 -0.136308703902615 -0.120756904157899
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.036093305578397
-    1  (  1) -0.001707679185378
-    2  (  2)  0.005295607540268
-    3  (  3) -0.304573937377439
-    4  (  4) -0.014287077020118
-    5  (  5) -0.068885443054321
-    6  (  6)  0.111979958895137
-    7  (  7)  0.321243115116497
-    8  (  8)  0.158205355334404
-    9  (  9) -0.080091690471286
-   10  ( 10) -0.065074315967804
-   11  ( 11)  0.075517488980888
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.151581395944457 -0.159877768539019 -0.191397517423370 -0.495232284867177  0.365561840480614  0.240680277087037 -0.079714342464060 -0.017889526464511  0.054577038131019
-    1  (  1) -0.159795957250344 -0.047735218799445 -0.125025973520529 -0.592230248738643  0.329204795623399 -0.563899565056737  0.474518384859258  0.371816427010336 -0.204007450193307
-    2  (  2) -0.191333337555164 -0.125299228178318  0.032743525999057 -0.248173196102997  0.424015573762028  0.373304795371779 -0.124367805075759 -0.383343230710404 -0.176623528718579
-    3  (  3) -0.494849488362154 -0.592714843248357 -0.248959287226432 -0.423717062956694  0.236470791317215 -0.415768039926139 -0.007927078894393 -0.295339114007336  1.138817517977087
-    4  (  4)  0.365842786381904  0.329912791129377  0.425309312530905  0.236284335454773 -0.297797609245548  0.287162197148014 -0.015195390583447  0.149575460395682 -0.352881082019632
-    5  (  5)  0.239666720470004 -0.562521840762128  0.375748994888085 -0.414021321385147  0.283842862620087  0.299376587010529 -0.122721640145877 -0.329969308300871  0.156494792176823
-    6  (  6) -0.079132044596257  0.473605179791134 -0.125255855635513 -0.008774504854422 -0.015965010341322 -0.123144104694353 -0.040262615853229  0.053291869268360 -0.230047243580867
-    7  (  7) -0.018210362041773  0.371975596266125 -0.382949144540519 -0.295062546320220  0.147969605902060 -0.330844143538271  0.053247875304319  0.437054225002062 -0.295575334707162
-    8  (  8)  0.054384972764257 -0.203042333758326 -0.176317356102570  1.137981680675850 -0.349930528471567  0.158219435758802 -0.229361079354617 -0.295174183029699 -0.201170965133917
-    9  (  9)  0.162593186917498 -0.096068090323904 -0.131721885594255 -0.537260876669133  0.048165192812382 -0.386108653062500  0.083321052788424  0.067822247358744  0.259623842469249
-   10  ( 10)  0.093086276325347 -0.110390627511003 -0.528311347000350  0.014888006239538 -0.100997055269664  0.192126958830561  0.038787614394956  0.063975054988451  0.077127488930246
-   11  ( 11) -0.248608674285678  0.166558436146830  0.438779225583925  0.334557445644043 -0.324782623645273  0.179928478753780  0.012126762707773  0.006418605871888 -0.316369462085207
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.163245257155421  0.094276717552644 -0.249582936616881
-    1  (  1) -0.097089753942058 -0.112180528774260  0.167323530234027
-    2  (  2) -0.131901378869784 -0.530116652654623  0.440616284282449
-    3  (  3) -0.539218683643804  0.014310072965047  0.335266942696954
-    4  (  4)  0.048635984706568 -0.103433325040069 -0.331331261588337
-    5  (  5) -0.385516013729792  0.187104305011894  0.193398800890046
-    6  (  6)  0.082991815026247  0.037352860323020  0.011014682786961
-    7  (  7)  0.067841455828072  0.062642922337485  0.014204699225385
-    8  (  8)  0.258473930207162  0.077886035701004 -0.325054438919389
-    9  (  9)  0.001773142889432 -0.053105768300802  0.034600115019000
-   10  ( 10) -0.053689547832438 -0.018246255837546 -0.196162567936867
-   11  ( 11)  0.031756575503292 -0.193298510202671  0.164652237069869
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.236069150423928  0.221583137218639  0.087467481976269 -0.023767225350154 -0.157884977853517 -0.128673956390029 -0.176595879969474  0.001131012317203 -0.181143452404233
-    1  (  1)  0.220430431059073  0.112052435313968  0.015869249151473  0.264485428778921 -0.165982030219470  0.159260926468858 -0.018854654828287 -0.249502649443057  0.052130725228418
-    2  (  2)  0.087694752982164  0.015013031218300 -0.683310722703039 -0.454889777527338  0.270539149606414 -0.876133156261866  0.064372104092668  0.069959767509230 -0.359585122327188
-    3  (  3) -0.022349867884997  0.265917774305981 -0.459885376820098  0.156118351029157 -0.442698949429053 -0.633164352365545 -0.123599096035318 -0.000681276488754  0.329408685832541
-    4  (  4) -0.157925484616889 -0.166044552973515  0.271218387113143 -0.443885849212600 -0.013362398764761 -0.176284165832649 -0.004716950323026  0.078109759941717 -0.609000288591445
-    5  (  5) -0.127616278770967  0.158011849801079 -0.876037618276795 -0.629854882079848 -0.177186230678137  0.012211398531521  0.059425698366986 -0.774979266274861 -0.486618182967767
-    6  (  6) -0.178241606252947 -0.017090192450387  0.064522373941146 -0.124240074207901 -0.004293285267873  0.059087683211698 -0.104000927528902 -0.330829052901522 -0.038045687603335
-    7  (  7)  0.002208432976113 -0.248689840257510  0.068573896371648  0.000014323070255  0.078530114044465 -0.775881123063332 -0.330687300606162  0.375687386105441  0.140607455827148
-    8  (  8) -0.178615853440425  0.052090468900394 -0.360562489485138  0.330978975217506 -0.607342070790934 -0.487347100955227 -0.037705399031252  0.140808054960246 -0.394251292282697
-    9  (  9) -0.046812023124734 -0.356025366669854  0.690811815119252  0.312933605279832  0.666333150435849  0.222468929331266  0.069111321865738  0.559435147572457  0.132671563084754
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045842278134109
-    1  (  1) -0.355929482932053
-    2  (  2)  0.690401613030498
-    3  (  3)  0.314450068453419
-    4  (  4)  0.667992312261241
-    5  (  5)  0.221641972273241
-    6  (  6)  0.069286377187356
-    7  (  7)  0.560338391968248
-    8  (  8)  0.132249466359632
-    9  (  9) -0.305201514350595
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003531322887475 -0.011853964282953 -0.013997173425702  0.018382792154192  0.000899996441170 -0.027829789222902  0.010946278656521  0.009416135608630 -0.023987807904262
-    1  (  1) -0.006388621957170 -0.005171201061298  0.075116414644925 -0.012351518893597  0.041297277094542 -0.006441657661851 -0.042094675941536  0.014500044658877  0.045272474380981
-    2  (  2)  0.036883171135873  0.025743377437805  0.085964964522995 -0.036572128405842  0.000741779132517  0.071901849285639 -0.017612259522947 -0.002857549793791 -0.114428225581804
-    3  (  3) -0.050379148878904 -0.038280516537017  0.018275237269774  0.118578575241743 -0.057964689431887  0.100743381549064  0.031817975653707  0.026538904209037  0.119963525599056
-    4  (  4) -0.040259568572502  0.011229705198348 -0.188809172609568 -0.380757486353216  0.215445879830049 -0.344569392827444  0.033187603168238 -0.033507608911701 -0.079582925346094
-    5  (  5)  0.087141198545524  0.216785041786672  0.270610048744647 -0.398997177058604  0.102170025016676  0.478625848854116  0.098949415070036 -0.170373600936987  0.015652914812384
-    6  (  6)  0.115394650619668 -0.055172374414511  0.068645251662214 -0.021005537436634 -0.120222938768552 -0.172201054646963  0.377862520931175  0.205771786365183 -0.028486300590321
-    7  (  7) -0.040171141537119 -0.121048023653740  0.403132598347777 -0.027760474590503 -0.026374510769541 -0.228317794220799 -0.070878790612320  0.346601006753617  0.129893637962627
-    8  (  8) -0.063034884678852  0.280866798080653 -0.540496031356204 -0.119391576371009 -0.673073389093966  0.010663808807394 -0.016147690801371 -0.200745867995305  0.117394935881043
-    9  (  9) -0.239823863619059  0.087614347419962  0.205995256328994  0.074059708937832  0.068748575207548 -0.000454096504958  0.003028317523563  0.249475422318809  0.352711368821821
-   10  ( 10) -0.336588165834448  0.173514331887659 -0.070029614207528  0.058791676167547  0.024501304819872 -0.052124336325614 -0.104213155529188  0.008639636736157  0.013496509549194
-   11  ( 11) -0.070036515714458  0.195530601320237 -0.305644951639726 -0.322831866596268  0.121530762471617 -0.141977993846978  0.021998928318675 -0.134440837975978 -0.127122644721006
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.030353030422789
-    1  (  1) -0.003358262791905
-    2  (  2)  0.006176160600104
-    3  (  3) -0.295046081788652
-    4  (  4) -0.003816440522472
-    5  (  5) -0.074325961201587
-    6  (  6)  0.109014636987132
-    7  (  7)  0.303731536940852
-    8  (  8)  0.152250258689580
-    9  (  9) -0.089511140585649
-   10  ( 10) -0.060789805292351
-   11  ( 11)  0.082293619260989
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.057770723551805 -0.007686176362995  0.037676874102239 -0.021875314889184  0.005506967440553  0.033731453254856 -0.019605915987929 -0.000153810358456 -0.020480209762043
-    1  (  1)  0.007936092328855 -0.008454757012618 -0.010966637507272  0.001712970012603  0.003491085971866 -0.000515536715359 -0.020166951580993  0.003537118918414  0.007401819292438
-    2  (  2)  0.004823273660701  0.024918096949402  0.013456316532648 -0.018061040723257 -0.007928867774181  0.029348077247204  0.008305651855965 -0.003787093111853 -0.048173394734837
-    3  (  3)  0.011675775125104 -0.107663431050362 -0.048399528007616  0.036525102270435 -0.040730641356466  0.022154401905676  0.022459222262206  0.014732815012435  0.056193647103106
-    4  (  4) -0.087218313447135  0.162702625594382  0.040016358931151 -0.090893257640902  0.161526551014906 -0.070532962320029 -0.041494660476799 -0.036307465283525 -0.053954994619678
-    5  (  5)  0.299080380154522  0.047071149143854  0.050599107356677 -0.086076035660096  0.105747613370625 -0.016291716828988 -0.035370479977499 -0.024570880182810 -0.019740472062472
-    6  (  6) -0.064660820062842 -0.041897488689090  0.115036198620178 -0.009494466980017 -0.021741244197439 -0.082050622741463  0.041036304002792  0.093842813724870  0.099009311380003
-    7  (  7)  0.041406109005398  0.013292096025031 -0.015299070066933  0.090658889471223 -0.096664535474361 -0.020138730803122  0.181635797654581  0.008096043748855  0.043219320460348
-    8  (  8) -0.213166983290885 -0.019961961605909 -0.071163032757987  0.089566388255459 -0.187567657300030  0.059322694628756 -0.181371262434162  0.031805535782928  0.037438192749058
-    9  (  9)  0.029081682004423 -0.052377114086944  0.016598919354525 -0.054121123864817  0.005943121322964 -0.052845962329270  0.099913404453613  0.011257505074012 -0.046946017590445
-   10  ( 10)  0.029775807936917  0.011144658296549 -0.123616713069900  0.069048925266029 -0.072425392135727 -0.175724644218768 -0.020473761865880  0.027329304597195 -0.030635509122054
-   11  ( 11) -0.065686621670288 -0.046175058814983 -0.054739230530016 -0.067089838730126  0.085213076503212 -0.033327993779702 -0.039100303871838 -0.006432393458887 -0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007846989553355
-    1  (  1)  0.003599492488651
-    2  (  2)  0.050462951485827
-    3  (  3) -0.025590884562196
-    4  (  4) -0.058023095683205
-    5  (  5) -0.032774222915836
-    6  (  6)  0.063967275967677
-    7  (  7)  0.008682341559207
-    8  (  8)  0.054096899442108
-    9  (  9)  0.060114344610370
-   10  ( 10)  0.027778486812577
-   11  ( 11) -0.026791075407401
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000027040423887  0.011060683872803  0.004793456647899  0.073481718860181 -0.071504628495016 -0.043329380984548  0.025554578097106  0.020981780177699 -0.009741644195740
-    1  (  1) -0.011009750762997 -0.000007607240151  0.023558132508086 -0.077101510719000  0.072464798814331  0.012890143420536 -0.005683277430906 -0.006920173400283  0.002574145843753
-    2  (  2) -0.004842956248702 -0.023538681455719  0.000165226839542 -0.207870652255993  0.210753100259611  0.104860036207310 -0.066732822825146 -0.046426833468215 -0.005606364639263
-    3  (  3) -0.072846425542822  0.076633967419021  0.207131819599136 -0.000363002499158 -0.003747206858118 -0.078444561827851 -0.135702906183535  0.013002670417717  0.066080178603036
-    4  (  4)  0.070600283658190 -0.071629978927021 -0.209426851727876  0.004131403945752  0.000622007773293  0.030404083775686  0.072573499649568 -0.005804369418180  0.017256603820917
-    5  (  5)  0.042938103533211 -0.012767138266668 -0.104089521411634  0.078509088982138 -0.031589837534126 -0.000702189622727 -0.234416668036359 -0.006073164073880 -0.085676616502380
-    6  (  6) -0.025301081140471  0.005670371975564  0.066621493148361  0.135369815380962 -0.072186642283625  0.233429156027521  0.000193153533248 -0.257186865053465  0.080618496507255
-    7  (  7) -0.020822354558258  0.006724508724119  0.045993762455479 -0.012965367547761  0.005443358605263  0.006173477804865  0.257050229473736  0.000107746294773 -0.140355654948263
-    8  (  8)  0.009433315806276 -0.002386871891496  0.004905034102302 -0.065444732417879 -0.016877777772437  0.086229493149666 -0.079936884810997  0.140925849197376 -0.000032973152365
-    9  (  9)  0.050122316171813 -0.043792237275169 -0.089139695085719 -0.017498120874682 -0.031599257819379 -0.003933044438540 -0.023956851013655  0.023591093022906  0.231355322027963
-   10  ( 10)  0.021733936110572 -0.028861084661254 -0.012680330783905 -0.120427356784394  0.061995107162282  0.110107780731446  0.044522956915282  0.044154909833586  0.092344585382497
-   11  ( 11) -0.054009861310889  0.049060128861341  0.116101359422429  0.043743279836749  0.090347856826429 -0.186254068915307  0.010091097621831 -0.182439821622372  0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.050351452990167 -0.022080091821478  0.055614920128739
-    1  (  1)  0.043523152379598  0.028913570586242 -0.049281187081852
-    2  (  2)  0.088800989050704  0.012387284429283 -0.115844546053497
-    3  (  3)  0.017174780224652  0.120766108673226 -0.043936127494914
-    4  (  4)  0.030870076304731 -0.062251132422338 -0.090680792727787
-    5  (  5)  0.006295822004517 -0.109602420736026  0.187179028172583
-    6  (  6)  0.023342165877015 -0.045357751936196 -0.008109043414047
-    7  (  7) -0.023116687534610 -0.043892116907456  0.180954962224114
-    8  (  8) -0.233341712412303 -0.091442003006516 -0.004136900096905
-    9  (  9)  0.000301754743843  0.311200434843549 -0.071746006250031
-   10  ( 10) -0.310579381122594  0.001146128096000  0.337175845358798
-   11  ( 11)  0.071759110731455 -0.341710402101474 -0.000514995746851
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000373475564698  0.036374284715410 -0.020675408038120 -0.041938611278043  0.014954064130636 -0.008670693741941 -0.001941666498966  0.002175213653671 -0.081223953533966
-    1  (  1) -0.035409311090430 -0.000583412494499  0.021912114995751  0.019686191919175  0.001337756516393 -0.101410043872272 -0.013539530463413 -0.021085032009130 -0.104140442794578
-    2  (  2)  0.022476650279619 -0.020869170321065  0.000623148668542  0.026925059222749 -0.022600045203783 -0.054500059821995 -0.019747085432266 -0.002197258536137 -0.059803959084815
-    3  (  3)  0.040527884961938 -0.020785023904239 -0.026269813130118 -0.000471315833621  0.011435927824319  0.005094359128676  0.021078069661848 -0.001900689912103  0.049285996887456
-    4  (  4) -0.014876995236008 -0.001935832477363  0.021280417512247 -0.011112950356736  0.000010954074914 -0.001375736589678 -0.021071346294591  0.002540388393255 -0.057176443725449
-    5  (  5)  0.009413911140341  0.101590521816804  0.054440250203052 -0.004479146413684  0.000983185589705  0.000044886603863  0.008942266041566 -0.007734744988056 -0.012623227871857
-    6  (  6)  0.001228199632690  0.013460754514196  0.019370737847276 -0.021147815413154  0.021180440912387 -0.009078596190780 -0.000060187992369  0.021757615671251  0.021546696625458
-    7  (  7) -0.002386621109668  0.020697715049428  0.002142304032572  0.001889845237358 -0.002502377714011  0.007891184567460 -0.021671667697211  0.000014467640044  0.019485620614445
-    8  (  8)  0.082726042327291  0.104120679625015  0.059410287861643 -0.049170685661379  0.057558349352742  0.011952514103015 -0.021313492463386 -0.019559674827960 -0.000280085719614
-    9  (  9) -0.081272328726009  0.110754135563007  0.028218762900775  0.005318083145326 -0.020981856638396 -0.014567561104212 -0.097856532501808 -0.003185861516469 -0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.080531031337273
-    1  (  1) -0.111220099551316
-    2  (  2) -0.028332370195928
-    3  (  3) -0.005372945270244
-    4  (  4)  0.020768901638641
-    5  (  5)  0.014982546342664
-    6  (  6)  0.097582479807565
-    7  (  7)  0.003277826561639
-    8  (  8)  0.003260780284830
-    9  (  9)  0.000186812021876
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055078142867828  0.005804719299681 -0.036780646353647  0.020745008939831 -0.005631321838333 -0.032388434299089  0.019554696167851  0.000026315290494  0.020764618651157
-    1  (  1) -0.007062764870854  0.009531925050962  0.009339128991500 -0.000585332198702 -0.003536715157378 -0.000717716084393  0.020997702694190 -0.003197609406412 -0.007543205569196
-    2  (  2) -0.003273721829615 -0.024127785783056 -0.019803917766004  0.021792459075320  0.009225997435944 -0.033280936086821 -0.008357612389432  0.004534634518823  0.049752671423908
-    3  (  3) -0.009467819748219  0.109846311430058  0.049077069582499 -0.038067479834844  0.041344367688361 -0.023164856965512 -0.023494777837550 -0.015492414054440 -0.057415728354703
-    4  (  4)  0.087998530211411 -0.166680738017738 -0.040492236619192  0.094854089537164 -0.166732509395464  0.071703004448668  0.042087550249065  0.037122017300705  0.054342710801435
-    5  (  5) -0.299229806278301 -0.048658757713325 -0.047129705842446  0.086908947365866 -0.109728878663932  0.016789363568018  0.035383410684614  0.025335321764417  0.020816334753998
-    6  (  6)  0.066809370303780  0.045194542515417 -0.116536125053039  0.010429907504714  0.024187359392906  0.082665971873618 -0.044425337546003 -0.096427706292236 -0.099634759729367
-    7  (  7) -0.040692585686945 -0.010414403444448  0.019197392244389 -0.094603783326762  0.099044517012418  0.021567521501408 -0.184530946067710 -0.010140666068000 -0.044429992698867
-    8  (  8)  0.213871489773344  0.016533777636027  0.072796199007045 -0.091991735348903  0.195396773842710 -0.059284334625803  0.184339397290396 -0.031894612373968 -0.038856272349111
-    9  (  9) -0.030682243044227  0.041775517875249 -0.024602057980135  0.057287290343526 -0.006772740334119  0.055735826221076 -0.097648839100779 -0.011580457295414  0.048271645082472
-   10  ( 10) -0.033182564179255 -0.014791814568441  0.134627953730393 -0.074303509883212  0.072048570540947  0.178297714606306  0.018972497943516 -0.029382172234938  0.026191954922422
-   11  ( 11)  0.065304385216644  0.054065687922946  0.058978656197155  0.069527138693935 -0.087278294466894  0.031923025189413  0.037244505404452  0.006712268565440  0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007990021156235
-    1  (  1) -0.003543862611170
-    2  (  2) -0.051263654644270
-    3  (  3)  0.026303130686066
-    4  (  4)  0.059400171065937
-    5  (  5)  0.033889468632128
-    6  (  6) -0.063573026890197
-    7  (  7) -0.010425863419296
-    8  (  8) -0.056178737365981
-    9  (  9) -0.060112542127891
-   10  ( 10) -0.033303474011037
-   11  ( 11)  0.026602109435667
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.023607177491195 -0.019696611969885 -0.037221212000385  0.015590319696057 -0.002020189842990 -0.021016653547429  0.007873916136755 -0.003448340610807 -0.079821954504390
-    1  (  1)  0.007327805297828  0.018867534486269 -0.042212469078496  0.001447360534353 -0.028939866752754  0.077938653083341  0.061948383376365 -0.004945505795557 -0.075894556663474
-    2  (  2)  0.009007071740861  0.016177005802987  0.068312932673240 -0.041184857036759 -0.003023256838844  0.009849571097863 -0.004290386808972 -0.004340519661127 -0.085840789796801
-    3  (  3) -0.026077185963910 -0.012520558385893 -0.023360353465929  0.029787599349062 -0.027312833784239 -0.081100062029021 -0.033406666012159  0.054430078300136  0.042036783131155
-    4  (  4) -0.044521029970710 -0.101548028530885 -0.092152577419686  0.036969661342643  0.235975964790827  0.022489800485005  0.018037809327809 -0.163273258200919 -0.255997686637622
-    5  (  5)  0.075082806179399 -0.059495559215694  0.178951166772656 -0.134634824114366  0.237022622504406 -0.054772185517501 -0.024504277147484  0.150049663229407 -0.003365655895118
-    6  (  6)  0.075564373604390 -0.030719217759732 -0.086498148733354  0.160325933966896 -0.064234285643905  0.161900908445555 -0.266146706738358 -0.238096934941697 -0.054011663901563
-    7  (  7)  0.117049393955643  0.184359827232724 -0.154835473828309  0.196676571259727 -0.209716028817009  0.429620861048445  0.096138950091600 -0.371356959007903 -0.058084061024513
-    8  (  8)  0.116322044765828 -0.134673176933366  0.115490121530453  0.372419146214479 -0.134366059259054 -0.090977060566167  0.047847126119104  0.349531731511066 -0.026343643532612
-    9  (  9) -0.016166361653787  0.064655468388956 -0.096603309196917  0.102141195994536  0.004689543577322  0.174053614560893 -0.096535422651742 -0.179574162178272  0.093140031286430
-   10  ( 10) -0.038118657992317  0.011712936317703  0.109233641260348 -0.041948680427994 -0.067033240911419 -0.043789144467457 -0.119198984082488 -0.019961916251994 -0.046236232124822
-   11  ( 11) -0.202537936665755 -0.041865413038804  0.001109842658197  0.036047997932446  0.209039172907281  0.039634162843452 -0.042796449278664  0.037154632643052 -0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001464671751436
-    1  (  1) -0.092168971837118
-    2  (  2)  0.096834154775615
-    3  (  3)  0.085232004143247
-    4  (  4) -0.224276823308218
-    5  (  5)  0.037070717977035
-    6  (  6)  0.017788678150516
-    7  (  7) -0.125655013910958
-    8  (  8)  0.036753750028807
-    9  (  9) -0.104788947042948
-   10  ( 10)  0.055723652563089
-   11  ( 11) -0.029086171780033
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000103943053471 -0.020502980666838 -0.044487026908476 -0.112522389921676  0.115190927698806  0.086304427533430 -0.028732798000328 -0.005755262072674  0.052707374815472
-    1  (  1)  0.020396732597728 -0.000175507711089  0.066631576709106  0.188566511167110 -0.188604507023904  0.081802717690830 -0.123212599282903 -0.146580404278728  0.063843813395139
-    2  (  2)  0.044224363892114 -0.066688325942716  0.000328779542201 -0.131627364199491  0.085838688001563 -0.039792906367986  0.071990397116460  0.041811204620793 -0.129151440044184
-    3  (  3)  0.112356491847955 -0.188595812422395  0.131743983691740 -0.000034238258909 -0.146405835083834 -0.293116155503685  0.174354593749844  0.234740190959724 -0.068400431241803
-    4  (  4) -0.114478156906703  0.187880772610577 -0.086711640119064  0.146345707242046  0.000351413466984 -0.200401380550659  0.118118144680811  0.106599388398520 -0.027535193682288
-    5  (  5) -0.086013769068620 -0.081687368012874  0.039811317138268  0.293720012918757  0.199751621453618 -0.000779002249077  0.029574633012291  0.100809576430270 -0.310087999943630
-    6  (  6)  0.028593362634754  0.122990647052479 -0.071886866993686 -0.174357265134888 -0.118164594946332 -0.029455932226559 -0.000323502179386 -0.067588972736558 -0.054838186724730
-    7  (  7)  0.005405231783831  0.146637005514722 -0.041701223809144 -0.234444344892692 -0.106310138998589 -0.100760684833959  0.067340032280388 -0.000050446895501 -0.206356025427645
-    8  (  8) -0.052734404217526 -0.064663294136106  0.127867798766573  0.067686878519552  0.027452578317565  0.311518253800823  0.053511305641188  0.206912543882787  0.000090733997612
-    9  (  9) -0.040822323151076  0.050351126620632 -0.033443030139718 -0.028678071562223  0.070729562284205 -0.035204318394559  0.035088801145452  0.003858253384271 -0.209126878103916
-   10  ( 10) -0.043554697985060  0.034029200702705  0.113396889510888 -0.025104351967769 -0.057922093461755 -0.050331966245759  0.113578028555237 -0.006845000513571  0.183899295084893
-   11  ( 11)  0.104445737487499 -0.085327185159750 -0.138831980783855 -0.068059267872915 -0.045287984054307  0.106421559557756 -0.126370094892912  0.085884676801538  0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.040472375428214  0.043732687824618 -0.105326662293090
-    1  (  1) -0.050113148730272 -0.033553830886801  0.085228632878169
-    2  (  2)  0.033648303602896 -0.113430364410931  0.140304701766262
-    3  (  3)  0.028908821271170  0.025577280295259  0.067243263311150
-    4  (  4) -0.070488811800233  0.058243639304596  0.043815524401846
-    5  (  5)  0.035954881502730  0.048633621823234 -0.102557737449989
-    6  (  6) -0.034599692943826 -0.112216626584703  0.126288398892548
-    7  (  7) -0.003737404887253  0.007316223089443 -0.087031799969318
-    8  (  8)  0.210522602449556 -0.181960897898471 -0.040780655119777
-    9  (  9) -0.000486792078199  0.154877597629272 -0.324381992896252
-   10  ( 10) -0.154731729402294 -0.001003846432056 -0.227757018056261
-   11  ( 11)  0.321308213629134  0.230320716710505 -0.000521529871008
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000267990887146  0.017094909685382 -0.026886221509252  0.009154729792392  0.028447394308811 -0.043026223139973  0.007934241734193 -0.017529929372393  0.048064409198736
-    1  (  1) -0.019165257539447  0.000577613190074  0.023971643573307 -0.023362002438445  0.020466955482562 -0.074368923093670 -0.021220838937975 -0.006899315294507 -0.004345205689582
-    2  (  2)  0.030573367311208 -0.023520686332899  0.000895230171902  0.026482533037414 -0.055578356600337 -0.061212128793543 -0.006033035982650  0.029878597421323 -0.067713186454891
-    3  (  3) -0.011556055604803  0.022912214561881 -0.028040995483179  0.000806143570890  0.016669730389240  0.057830279830177  0.001162806518994 -0.022110531165998  0.132937508894661
-    4  (  4) -0.029247962187325 -0.019722933579604  0.053631431975867 -0.015590855142050  0.000406564753787  0.013151443352440 -0.005583751708839  0.048344741694769 -0.058950645196782
-    5  (  5)  0.044502924478349  0.074343902828738  0.059891074519534 -0.057011647107618 -0.013642181191740 -0.000660380157385 -0.021619837229525 -0.066247874288904  0.026658775788480
-    6  (  6) -0.008416217090956  0.021046309429680  0.006522358687724 -0.001270652730649  0.005678899154477  0.021925039235368 -0.000233190982568 -0.044213316193167  0.019149792461568
-    7  (  7)  0.017220078580887  0.007669026797702 -0.030414088472195  0.022279636607030 -0.047947045698118  0.066391322818188  0.044159499520014  0.000036612147908  0.012788358083278
-    8  (  8) -0.049286641691243  0.005157181302332  0.067669102261374 -0.134137839836174  0.059598226202850 -0.026736423898111 -0.019691121432993 -0.012900597372237  0.000145671342113
-    9  (  9)  0.013771428368881 -0.001534324314609  0.097208563857550  0.041538777135659 -0.016922202614382 -0.071792645864290 -0.010700525463409  0.088926800959210 -0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.013388445223016
-    1  (  1)  0.001743269961120
-    2  (  2) -0.097384653394849
-    3  (  3) -0.041118719872747
-    4  (  4)  0.017104740675403
-    5  (  5)  0.071235600573670
-    6  (  6)  0.010744046806778
-    7  (  7) -0.088045104682667
-    8  (  8)  0.027915642785476
-    9  (  9)  0.000257740691093
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.024087436020668  0.024234923487922  0.034655069016827 -0.013002508462274  0.003506876735183  0.019138226509165 -0.008729154622077  0.004126516633947  0.080810387962203
-    1  (  1) -0.007340388106341 -0.022740162593799  0.047399213843079 -0.000077807499313  0.029710781800549 -0.077091731467965 -0.063337905707382  0.003225301246506  0.076935684639064
-    2  (  2) -0.008533292606078 -0.014866249844284 -0.069414473601385  0.039067032188858  0.004447555351962 -0.009557153079335  0.003933218079563  0.004684619630234  0.087696717260759
-    3  (  3)  0.022970088927143  0.014796917693540  0.027844101865804 -0.035221698386289  0.026363064761687  0.090054977556852  0.034727496736464 -0.055362273105074 -0.041999796595917
-    4  (  4)  0.041840045940810  0.108064430049583  0.094169303786903 -0.038045467810124 -0.242703284807102 -0.022096059239039 -0.018423933000872  0.169152570163926  0.255707171958253
-    5  (  5) -0.076575292532566  0.064169513057282 -0.187842221364997  0.139017281082776 -0.239663562780447  0.056101309100792  0.026864961939161 -0.152773054853442  0.000863550220823
-    6  (  6) -0.082619291232389  0.034129866388443  0.092672858212650 -0.166047996934064  0.066033557533197 -0.164979644828487  0.279604374284854  0.245415146187524  0.057275952528883
-    7  (  7) -0.119525510255884 -0.192558180615050  0.157479601093184 -0.199612815310399  0.216488749413977 -0.438370355171240 -0.097840156788249  0.385286937285113  0.058774287435548
-    8  (  8) -0.115070416909243  0.142091116044252 -0.125572997790340 -0.378869543679260  0.139572537143277  0.093921809248974 -0.047279124915748 -0.359195083957732  0.024443650320069
-    9  (  9)  0.023211259159309 -0.064251202673602  0.092489429719048 -0.099069758679955 -0.005272254913816 -0.184087259640687  0.103465084079069  0.187259798043465 -0.097400286560574
-   10  ( 10)  0.039092748606065 -0.013006586457309 -0.115772480099790  0.044153430983449  0.068039357936569  0.040474168285568  0.124671276809929  0.020291967592974  0.043718085717437
-   11  ( 11)  0.205517300660670  0.035576186745690 -0.000856944671273 -0.036648470964825 -0.217305799958921 -0.037828885346138  0.045859373489911 -0.037554955798535  0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001311477468569
-    1  (  1)  0.093224324445080
-    2  (  2) -0.099200064811294
-    3  (  3) -0.086458921973920
-    4  (  4)  0.229446975291319
-    5  (  5) -0.035136747289852
-    6  (  6) -0.019108151626501
-    7  (  7)  0.127376470092273
-    8  (  8) -0.036832911731868
-    9  (  9)  0.106598068979743
-   10  ( 10) -0.058544237541584
-   11  ( 11)  0.029477471817291
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.089840465204225  0.055253525883540  0.050839656601929 -0.011592120168853 -0.028453073767485 -0.033272498563027 -0.013123122183092 -0.010376152774617 -0.046773274930095
-    1  (  1) -0.019180458750845  0.004406050242553 -0.021028155566967 -0.011538680320289  0.014109247012132  0.033202867729220 -0.146724711919951  0.006291497986158 -0.032816512639240
-    2  (  2) -0.008004935891454 -0.083588166091295  0.024500417662889  0.004976479402859  0.015361678869856 -0.027030028650554  0.075999531355577 -0.040388417899799 -0.092155828534757
-    3  (  3)  0.072751395760345  0.101339872261880  0.027554632505315  0.017104143799594 -0.009883810143648 -0.054325029446985  0.038424568195001  0.007564948769101  0.050859249479548
-    4  (  4)  0.116869612062058  0.168448689602172  0.076045170807919 -0.039076911238534  0.141061895780680 -0.082089594379007  0.096305838370831 -0.090937592520626 -0.089867596085833
-    5  (  5) -0.362411548066203 -0.116301468610581 -0.067304641586918 -0.178833394354847  0.120526935264372  0.077690766748935 -0.087853646530869  0.131583743921650 -0.005449987066682
-    6  (  6) -0.023022243577310  0.091878291587840 -0.168295716396468 -0.360782087280141 -0.197772285105134  0.118427120672179  0.100301554555422  0.545992767837121 -0.002274268616602
-    7  (  7) -0.332469089310140 -0.094037896803367 -0.021326282942452  0.202588446745432  0.003095262967230  0.074773576198707  0.261809753005545 -0.312310926113466  0.101271338039676
-    8  (  8) -0.102262443511968 -0.018323432973791  0.030286707735275  0.141132962784100 -0.140087132441384 -0.016144892573022 -0.105178803101546  0.077042517784067  0.061204405030880
-    9  (  9)  0.062921845500970  0.223934495766079  0.055471945329417  0.006791304491310 -0.142947280894142 -0.007991932919943  0.047858230706461  0.145718178913241 -0.072195393114585
-   10  ( 10) -0.062281498028430 -0.059385022217194 -0.196384149116451 -0.042900612771916  0.059951865879116  0.109494756681462  0.025377610533051  0.255425379720525 -0.006903138405362
-   11  ( 11) -0.109893814765672 -0.036299338598219 -0.008950289795172 -0.103979082032925  0.089663281746559  0.076642658317109  0.017386558594104  0.075203103677764 -0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015115955084904
-    1  (  1) -0.030649150844450
-    2  (  2)  0.004117081641871
-    3  (  3)  0.011275331966881
-    4  (  4) -0.082379096749867
-    5  (  5) -0.010925397739678
-    6  (  6) -0.209001724905895
-    7  (  7)  0.094421017044117
-    8  (  8)  0.009881568354141
-    9  (  9) -0.113416879853688
-   10  ( 10) -0.045856944277529
-   11  ( 11)  0.007202279712064
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000220708940429  0.002285125103983  0.191707004311250 -0.079176547202062 -0.015343724284655 -0.090762856917070 -0.035966370439669 -0.080228715251931  0.022632088832219
-    1  (  1) -0.002270884902228  0.000127565392507 -0.181504505051190  0.084301622984598 -0.019134286473150  0.136527597935967  0.291828838790707 -0.086935165867290 -0.003153353795357
-    2  (  2) -0.190790178739451  0.181286631653937 -0.000456958950263  0.098736144982791  0.201937120878681  0.060858985812145 -0.102547416191644  0.128157455079926 -0.052263022287278
-    3  (  3)  0.078674978461285 -0.083802623610643 -0.098399673810258 -0.000007811365746 -0.051373438075815 -0.073262818066183 -0.213681674768555  0.159362252554929  0.021801220424175
-    4  (  4)  0.014664072597960  0.019624839214450 -0.200908806156840  0.051706138267892  0.000345872163641 -0.060049554881332 -0.188299165959522  0.122222075869351  0.002767654097179
-    5  (  5)  0.090883158144736 -0.136634126073923 -0.061672946710902  0.074085610649007  0.059059222367226 -0.000127348357414 -0.089421360456473  0.068061409120582 -0.127845689145142
-    6  (  6)  0.036070137194869 -0.291478881075219  0.101913218910275  0.213840026067922  0.188217301311726  0.090313292624869  0.000227988253159  0.211121150654972  0.048790729392591
-    7  (  7)  0.080292928774450  0.086502244153537 -0.129683189759572 -0.159077086898913 -0.122727489493275 -0.066634459735053 -0.210168861536432  0.000749252129634 -0.114771568876213
-    8  (  8) -0.022833189301314  0.003149552694449  0.051809982276026 -0.021432628906503 -0.002600755913054  0.127892598520278 -0.048118709288206  0.114794510187460  0.000092800261922
-    9  (  9) -0.153861672366712  0.063959309581427  0.276686698038017  0.018129236980868  0.051934404023196  0.023341508326279  0.078386885605064  0.038564733458116  0.117925763161383
-   10  ( 10)  0.030779230036139 -0.047764824598951 -0.139550834348758  0.058848096986720  0.072156858928456  0.071321440087986 -0.120905085647966  0.006516751215124  0.144681807612295
-   11  ( 11) -0.005585664265456  0.000647324323586  0.016353426872082  0.045937924242292  0.003353711579607 -0.138994412824604 -0.062414171800322 -0.018128246119697  0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.154066232086317 -0.030728257975556  0.006318091498164
-    1  (  1) -0.063643818147584  0.047463638962418 -0.000566548572565
-    2  (  2) -0.275258773270295  0.138888616959566 -0.015969350630016
-    3  (  3) -0.017345671201066 -0.059189082677904 -0.046475381464176
-    4  (  4) -0.050392875387071 -0.072424486885238 -0.004459708301674
-    5  (  5) -0.026836133802329 -0.070805989588457  0.140760690762251
-    6  (  6) -0.078585377266712  0.120742726291724  0.064292229739042
-    7  (  7) -0.041858894695365 -0.005665298794286  0.017186389956069
-    8  (  8) -0.118429783701800 -0.144155118064025 -0.113213711259466
-    9  (  9)  0.000756388118591 -0.455654623157072 -0.231432578787543
-   10  ( 10)  0.453567841489266  0.001497567906129  0.172275686133391
-   11  ( 11)  0.230120702539645 -0.175050207490782  0.001480251815160
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000516219946816 -0.034778633659956 -0.032999546928151  0.009629039776278 -0.052966719633617  0.030450001531878  0.014875222246015  0.072128990177077 -0.048218822417803
-    1  (  1)  0.030877691560804 -0.001883541097772 -0.071434334115879  0.019325009721534  0.017452039030100  0.158145751795333  0.010537309557875  0.021583100108147  0.169934651056250
-    2  (  2)  0.033565318682613  0.071200997372983 -0.000581071534985  0.036850040138101 -0.007310816547227  0.008797901115406  0.029229533057666  0.016744128499400  0.070455787497455
-    3  (  3) -0.011004884819686 -0.019179310791618 -0.034909263032370 -0.000523661128158  0.007125267622899  0.017666281606150  0.025274953349027 -0.006048522524524  0.042959205727090
-    4  (  4)  0.052383681601535 -0.016788640224883  0.007028507044452 -0.007472760866637  0.000164741631073  0.026820745242549 -0.000005495327564  0.022752424410877 -0.031410113616428
-    5  (  5) -0.028924597602342 -0.155705177520586 -0.009708873936879 -0.016613543931604 -0.026890889200954 -0.000863820528475  0.026461589325309 -0.030900211040800 -0.024762473040831
-    6  (  6) -0.014335467827216 -0.010396285650159 -0.029624823660296 -0.025462090585912 -0.000149096444494 -0.026996065218364  0.000042625626758  0.107465667965402 -0.101121105248233
-    7  (  7) -0.071280711647029 -0.021473260264964 -0.016888851213230  0.005990055447048 -0.022650874097521  0.030884846999677 -0.107059671381934 -0.000085380718295 -0.001222830424055
-    8  (  8)  0.049124632890092 -0.169889327710618 -0.068826403708743 -0.044339001017875  0.031493314676472  0.025080049766767  0.100845039831255  0.001167614688641 -0.000278385825403
-    9  (  9) -0.004591463397670 -0.224641690035662 -0.054391854978822  0.000520714575472 -0.041379699430161  0.035041097267503  0.048865193892848  0.034233303767760 -0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.004372643490859
-    1  (  1)  0.225448428944350
-    2  (  2)  0.053543340635201
-    3  (  3) -0.000029286176363
-    4  (  4)  0.041473098636741
-    5  (  5) -0.035500700267141
-    6  (  6) -0.049415179037896
-    7  (  7) -0.033722251526408
-    8  (  8)  0.002108270875613
-    9  (  9)  0.000059855095180
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.083178189184036 -0.063320502543375 -0.053448860291133  0.010119942476578  0.027962494700737  0.033408156898410  0.016646686372055  0.009688142905594  0.047753876913682
-    1  (  1)  0.015436953954369 -0.001484194684011  0.023035398887205  0.013457869405466 -0.013993527195521 -0.033943979767543  0.150850131221437 -0.006054179455746  0.032861777904130
-    2  (  2)  0.007416632072171  0.085535883632607 -0.031035920631781 -0.004414026005139 -0.010136741110915  0.029006493089287 -0.078308410406643  0.042862583013635  0.094615352193845
-    3  (  3) -0.060864804294684 -0.107990348400789 -0.029334441164075 -0.017074561166948  0.006770814971091  0.056161219994893 -0.038880977880177 -0.007186858274067 -0.050898617184209
-    4  (  4) -0.109193273208522 -0.178421304573120 -0.074992061457995  0.038015102633012 -0.147910228795514  0.087181398607820 -0.098582275644141  0.093570766915846  0.088687564658624
-    5  (  5)  0.362309556227904  0.121304099182945  0.074968023841376  0.180660703600124 -0.122438585672172 -0.079096894998506  0.085876030826778 -0.136109864287558  0.002214631278523
-    6  (  6)  0.026835628168075 -0.104282391359254  0.172843582770517  0.372105341696267  0.200623348657875 -0.124556824110224 -0.101871864602057 -0.564196462169744  0.000688785089474
-    7  (  7)  0.344945182303497  0.095060217852336  0.019692892185405 -0.208607222836184 -0.002627647973779 -0.075715664253568 -0.273373001503080  0.322679649636761 -0.103750880742886
-    8  (  8)  0.103243578213400  0.018995126733818 -0.033613347666093 -0.143946559071139  0.146180680800982  0.017308359580339  0.107684620440504 -0.078982837453949 -0.062496256435255
-    9  (  9) -0.085648241806344 -0.209611729409149 -0.056224829650480 -0.004822853433113  0.155473341074989  0.012971266670028 -0.058097898147224 -0.150335378963730  0.078057323449305
-   10  ( 10)  0.070132629148842  0.074702785463534  0.209329818275843  0.042566217114534 -0.058034325280006 -0.102370728009941 -0.025801004099357 -0.264561180085366  0.017482708757363
-   11  ( 11)  0.113963029107499  0.045073298009464  0.000413587765283  0.112463923253522 -0.089423608765749 -0.081287727377731 -0.019439635907878 -0.076622183257520  0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015270950350973
-    1  (  1)  0.030946721870550
-    2  (  2) -0.003707642076146
-    3  (  3) -0.011960041321321
-    4  (  4)  0.086083869661608
-    5  (  5)  0.009867768215709
-    6  (  6)  0.209680707316341
-    7  (  7) -0.097843271017668
-    8  (  8) -0.010325909660635
-    9  (  9)  0.121632163838855
-   10  ( 10)  0.058275044600178
-   11  ( 11) -0.003021331907582
-
 	Computing Mu_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        15.869051530939
-	   1        20.786899881722    6.883e-01
-	   2        24.160856182321    2.921e-01
-	   3        24.214077985635    4.032e-02
-	   4        24.234866574896    1.778e-02
-	   5        24.238122127501    2.752e-03
-	   6        24.237360543965    1.007e-03
-	   7        24.237431173771    2.677e-04
-	   8        24.237469322293    1.165e-04
-	   9        24.237453949005    4.587e-05
-	  10        24.237448088609    1.762e-05
-	  11        24.237451893497    4.708e-06
-	  12        24.237455859643    1.235e-06
-	  13        24.237457012494    4.415e-07
-	  14        24.237457127586    1.411e-07
+	   0        15.869051356245
+	   1        20.786899644170    6.883e-01
+	   2        24.160855889547    2.921e-01
+	   3        24.214077689704    4.032e-02
+	   4        24.234866278337    1.778e-02
+	   5        24.238121830738    2.752e-03
+	   6        24.237360247203    1.007e-03
+	   7        24.237430877005    2.677e-04
+	   8        24.237469025521    1.165e-04
+	   9        24.237453652235    4.587e-05
+	  10        24.237447791839    1.762e-05
+	  11        24.237451596727    4.708e-06
+	  12        24.237455562873    1.235e-06
+	  13        24.237456715724    4.415e-07
+	  14        24.237456830816    1.411e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.856e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.006909625581
-	   1         2.631364137145    2.199e-01
-	   2         3.015958456546    8.743e-02
-	   3         3.021590337169    1.159e-02
-	   4         3.023869152757    4.870e-03
-	   5         3.024010490790    1.155e-03
-	   6         3.023989980728    2.895e-04
-	   7         3.023995665293    6.351e-05
-	   8         3.023995017830    1.892e-05
-	   9         3.023994440811    5.303e-06
-	  10         3.023994289739    1.812e-06
-	  11         3.023994431149    2.747e-07
+	   0         2.006909611223
+	   1         2.631364115956    2.199e-01
+	   2         3.015958428527    8.743e-02
+	   3         3.021590308855    1.159e-02
+	   4         3.023869124319    4.870e-03
+	   5         3.024010462340    1.155e-03
+	   6         3.023989952279    2.895e-04
+	   7         3.023995636844    6.351e-05
+	   8         3.023994989381    1.892e-05
+	   9         3.023994412362    5.303e-06
+	  10         3.023994261289    1.812e-06
+	  11         3.023994402700    2.747e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 9.057e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.083964277537
-	   1        15.809006020552    4.632e-01
-	   2        17.211731140649    1.659e-01
-	   3        17.299274188752    3.528e-02
-	   4        17.311773652253    1.285e-02
-	   5        17.313826939489    2.395e-03
-	   6        17.313531500215    7.644e-04
-	   7        17.313604980304    1.895e-04
-	   8        17.313625719230    6.399e-05
-	   9        17.313624293811    2.184e-05
-	  10        17.313624723147    1.014e-05
-	  11        17.313625508640    3.150e-06
-	  12        17.313626820549    1.169e-06
-	  13        17.313626962982    3.666e-07
-	  14        17.313627007228    1.344e-07
+	   0        13.083964149864
+	   1        15.809005868071    4.632e-01
+	   2        17.211730971700    1.659e-01
+	   3        17.299274016488    3.528e-02
+	   4        17.311773479648    1.285e-02
+	   5        17.313826766776    2.395e-03
+	   6        17.313531327500    7.644e-04
+	   7        17.313604807584    1.895e-04
+	   8        17.313625546508    6.399e-05
+	   9        17.313624121089    2.184e-05
+	  10        17.313624550426    1.014e-05
+	  11        17.313625335918    3.150e-06
+	  12        17.313626647827    1.169e-06
+	  13        17.313626790260    3.666e-07
+	  14        17.313626834506    1.344e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 5.146e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.710020248878
-	   1         7.319667271611    3.232e-01
-	   2         8.126425682381    1.191e-01
-	   3         8.146199077783    2.497e-02
-	   4         8.153650604466    9.101e-03
-	   5         8.153807029244    1.562e-03
-	   6         8.153718651435    3.357e-04
-	   7         8.153729933933    7.971e-05
-	   8         8.153728597148    1.788e-05
-	   9         8.153728453440    4.361e-06
-	  10         8.153728282719    1.510e-06
-	  11         8.153728436457    2.733e-07
+	   0         5.710020217989
+	   1         7.319667227775    3.232e-01
+	   2         8.126425628080    1.191e-01
+	   3         8.146199022690    2.497e-02
+	   4         8.153650549044    9.101e-03
+	   5         8.153806973802    1.562e-03
+	   6         8.153718595996    3.357e-04
+	   7         8.153729878494    7.971e-05
+	   8         8.153728541710    1.788e-05
+	   9         8.153728398001    4.361e-06
+	  10         8.153728227281    1.510e-06
+	  11         8.153728381018    2.733e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 8.869e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        12.980210840681
-	   1        16.325277174360    4.870e-01
-	   2        17.934636706494    1.673e-01
-	   3        17.967479198896    2.699e-02
-	   4        17.979626846479    1.316e-02
-	   5        17.981154761762    1.725e-03
-	   6        17.980983099038    6.650e-04
-	   7        17.981013594168    2.098e-04
-	   8        17.981016594467    7.681e-05
-	   9        17.981012951514    2.221e-05
-	  10        17.981012225583    7.452e-06
-	  11        17.981013079625    1.569e-06
-	  12        17.981013666240    4.439e-07
-	  13        17.981013808580    1.269e-07
+	   0        12.980210718789
+	   1        16.325277017211    4.870e-01
+	   2        17.934636528240    1.673e-01
+	   3        17.967479019304    2.699e-02
+	   4        17.979626666531    1.316e-02
+	   5        17.981154581740    1.725e-03
+	   6        17.980982919014    6.650e-04
+	   7        17.981013414143    2.098e-04
+	   8        17.981016414442    7.681e-05
+	   9        17.981012771489    2.221e-05
+	  10        17.981012045558    7.452e-06
+	  11        17.981012899600    1.569e-06
+	  12        17.981013486215    4.439e-07
+	  13        17.981013628555    1.269e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.837e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.809373768687
-	   1         7.418526227871    3.298e-01
-	   2         8.252645021965    1.200e-01
-	   3         8.270512894258    1.792e-02
-	   4         8.274719776150    6.902e-03
-	   5         8.275068072751    1.689e-03
-	   6         8.274949992802    5.106e-04
-	   7         8.274972926554    8.864e-05
-	   8         8.274973997682    2.315e-05
-	   9         8.274973446583    5.399e-06
-	  10         8.274973427009    1.941e-06
-	  11         8.274973586213    4.355e-07
-	  12         8.274973697920    1.261e-07
+	   0         5.809373738666
+	   1         7.418526185466    3.298e-01
+	   2         8.252644968811    1.200e-01
+	   3         8.270512840460    1.792e-02
+	   4         8.274719722175    6.902e-03
+	   5         8.275068018750    1.689e-03
+	   6         8.274949938805    5.106e-04
+	   7         8.274972872556    8.864e-05
+	   8         8.274973943684    2.315e-05
+	   9         8.274973392585    5.399e-06
+	  10         8.274973373011    1.941e-06
+	  11         8.274973532215    4.355e-07
+	  12         8.274973643923    1.261e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 3.425e-08
 
@@ -3028,2414 +836,254 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.116653158375433    -0.136050295574527    -0.040317664550606
-    1      0.020178810379770     0.045708806656960    -0.130530471482358
-    2     -0.189602214127483     0.207372490736804    -0.145086273515407
+    0      0.116653158229350    -0.136050294376206    -0.040317663907168
+    1      0.020178810546506     0.045708806213428    -0.130530471978785
+    2     -0.189602214456136     0.207372491035560    -0.145086273406846
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.077) =  -49.62375 deg/[dm (g/cm^3)]
-
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008614927932901 -0.046442352400056  0.027924113420848 -0.003342105613042 -0.019198187280149 -0.043605993010684  0.000124507843934 -0.017903232775755 -0.064037761769677
-    1  (  1) -0.004023859954382  0.002812567241188 -0.015355365220565  0.063211982369858  0.033868800032563 -0.011581015700219 -0.004465574115878 -0.047030919129079 -0.048793907716228
-    2  (  2)  0.028525640721225  0.068120190051797 -0.016739332483522 -0.005073216914996  0.071940864110972 -0.066733646998345 -0.019605473406179 -0.001610556181541  0.004701378003057
-    3  (  3) -0.054155290592472 -0.054244334984755 -0.021962628004576 -0.018282485083091 -0.037028274309951  0.016786978556275  0.022024618578561  0.004302299401540 -0.167953274084101
-    4  (  4) -0.063182596929128 -0.128748808697011  0.121465113794596  0.160938411624414 -0.233917278334855  0.054052147786148  0.025334190025568  0.127021105025468 -0.261448831371970
-    5  (  5)  0.148864678539144  0.254187426901849 -0.169654893765005  0.284620623487219  0.104152411510991  0.359543809296571  0.133744009364038  0.041861549395911  0.169452799563311
-    6  (  6) -0.084956716693293  0.126613830958100 -0.017431389376921 -0.048281125785785  0.083267553859489 -0.206713853889007  0.428812335356187  0.005011018790693  0.061186511244325
-    7  (  7)  0.173630436499038  0.181276581467465 -0.440332497406727 -0.059456065314793  0.303618967332177  0.080016792150091 -0.104444652264320  0.251866044362601  0.089940979754426
-    8  (  8)  0.057697740265636  0.070180597319316 -0.383387445877903  0.514874723728167  0.465292274425094 -0.060917787458673  0.016262524997932  0.068972295825028 -0.265391565564862
-    9  (  9) -0.279247635392508  0.560707539445326  0.044547355247966  0.161505455840491 -0.002588377300620  0.219223272852673  0.096307931275233  0.176467158787115 -0.104344971075325
-   10  ( 10) -0.977075550189082  0.176418272338824  0.228294317792423 -0.099370607761785  0.027777959043915 -0.149348953174007  0.027413414685573 -0.102632226214496  0.005531527026329
-   11  ( 11) -0.211429004068205  0.082644794913083 -0.055680052865830  0.289018099852967 -0.067789578528906  0.064107786895450  0.141855082713117  0.071186757345684 -0.332576681432119
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071990946341156
-    1  (  1)  0.010142476746200
-    2  (  2) -0.112423878596356
-    3  (  3) -0.059253840833002
-    4  (  4) -0.014639189231197
-    5  (  5)  0.248038168374966
-    6  (  6) -0.055159646937661
-    7  (  7)  0.115432903674626
-    8  (  8) -0.135363224547124
-    9  (  9)  0.174678345310946
-   10  ( 10) -0.086140984938274
-   11  ( 11)  0.161723358519153
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.197572413114517 -0.541318632877371  0.139927415914873 -0.359578444130330 -0.398937843975486 -0.026586872167534 -0.139627977382516 -0.005896246491228 -0.003746644388905
-    1  (  1) -0.541058731973333 -2.034801242188507  0.920540457917585  1.016218584629480  0.729164689940962  0.054412526301737  0.235971924521468  0.315223615831553  0.096208087340554
-    2  (  2)  0.139828960639396  0.920734025049694  1.243601677781983 -0.974300649425054 -0.758553357750500  0.024609548649431  0.513266755137957 -0.116926330823923  0.094501440802452
-    3  (  3) -0.358970389612551  1.015833032444632 -0.974440229907822 -0.266348920037382 -0.133799224826450 -1.276907891719884  0.042984364188955 -0.410608972745146 -0.602345206758872
-    4  (  4) -0.398323035382104  0.727797072638099 -0.759857932028957 -0.133858878725855  0.575448485405805  0.056475665846990 -0.484493838094732 -1.583666059960473 -0.976878960945650
-    5  (  5) -0.027166282529876  0.055084907439528  0.024891154244808 -1.275543890392068  0.058746221115305  0.155399297624787 -0.236023461595880  0.812878944882876 -1.048535633945681
-    6  (  6) -0.139452284652001  0.236223353106611  0.513262677276795  0.042879631015553 -0.482819583744289 -0.235933155306163 -2.554180022039243  0.492117808091915  0.545404391969618
-    7  (  7) -0.005841417486080  0.316274368087248 -0.116163386132942 -0.410094172620351 -1.579571504351393  0.813774264702327  0.492423579055058 -1.700719634572147  0.685529426222534
-    8  (  8) -0.003628131523111  0.096035529406495  0.094131958822655 -0.602680558554738 -0.970206233042967 -1.045482011639248  0.544249830480973  0.683514460656999 -0.254958894521937
-    9  (  9)  0.326098978034070 -0.130935443755898 -0.379595166178810 -0.575990923913880 -0.393471965772156 -0.365686482354661 -1.227740649572571 -0.905826585766955  0.039987575439783
-   10  ( 10)  0.008103557010829 -0.039575543043785 -0.358664813530415  0.339232504235094  0.207222390004838  0.025784782686722 -0.874465143496950  0.752110557173402  0.140644707838520
-   11  ( 11)  0.161744201604777 -0.084371238126416 -0.371150000615002 -0.062082553987999 -0.264710244109502 -0.257261524594595 -0.444570825837596  0.002821912169167 -0.878431482758543
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.327854256723191  0.009019714201806  0.162710661594080
-    1  (  1) -0.133091859401188 -0.040697608916971 -0.085480013261477
-    2  (  2) -0.381849466582258 -0.359835698966555 -0.372555502654032
-    3  (  3) -0.579249329460985  0.337242930789026 -0.062083381101115
-    4  (  4) -0.396591932227294  0.208613968377681 -0.263534161447186
-    5  (  5) -0.365098796840620  0.027806203875135 -0.265146511184336
-    6  (  6) -1.230804866141472 -0.879767261427487 -0.448789926588722
-    7  (  7) -0.904635210810701  0.753869376128870 -0.007723762422951
-    8  (  8)  0.040323953888643  0.145561462630237 -0.894627985530935
-    9  (  9)  0.423095730032689 -0.296000598729972 -0.177730944535255
-   10  ( 10) -0.299463152132731  0.634536265412446 -0.073348108781663
-   11  ( 11) -0.175836972560684 -0.076105887981834  1.184769463941312
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.567008918440454  0.722443194224100  0.422402078329773  0.057554368538511 -0.068012024097596 -0.451975147608540  0.709419418128490 -0.110422168786063  0.095704108927647
-    1  (  1)  0.720885472964738  0.332527211352729  0.737390933664557  0.281750515995843  0.280761290393686 -0.598548871078422 -1.146750917560074 -0.177301134607867  0.234694928374046
-    2  (  2)  0.422183102929830  0.736485274543817  0.007829109729841 -0.365399185160488 -0.965501991519851  1.065090224342325 -0.394390877157068  0.239359282041345 -1.218182428400336
-    3  (  3)  0.059687201587689  0.280769829516347 -0.363255319277090 -0.833720445234328 -1.345952507284314 -0.189309823206009 -0.179890587463359  1.060334267261244  0.772514544005070
-    4  (  4) -0.069257393950461  0.281296543593726 -0.966923508415862 -1.344162403478837  1.514830798821686  0.013670590813123  0.227285042195308 -0.333966365834383  0.386248727994588
-    5  (  5) -0.449135841837750 -0.599397616398023  1.066820631137579 -0.189649110609729  0.013795397601274 -0.565008204089947  0.487292179201877  0.306200785308481  0.347063761059997
-    6  (  6)  0.708465668575064 -1.146562417015747 -0.391890894794961 -0.180811610825629  0.226633708337573  0.487729597603209 -2.767088081148377 -0.044613761228256 -0.000972346438746
-    7  (  7) -0.108981479701481 -0.177538422258191  0.240499334967173  1.059842333943978 -0.334391646412731  0.306249622802239 -0.044471110656761 -3.232660954268523  0.514839123397967
-    8  (  8)  0.094277588726801  0.235043460722862 -1.221823739304416  0.774952681271118  0.386077819008107  0.344858044218004 -0.000341133693178  0.514916107143190  0.507086715271392
-    9  (  9) -0.063381219775898  0.233965663654109 -0.093343357924906 -0.360354041999586 -1.006820146552738  1.344825106449130  0.268434803850821  0.315156353069794 -0.332938610236887
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.063808920787530
-    1  (  1)  0.235710820172182
-    2  (  2) -0.096202914418848
-    3  (  3) -0.360121798161892
-    4  (  4) -1.006476097602190
-    5  (  5)  1.343619008167611
-    6  (  6)  0.268106090274240
-    7  (  7)  0.315242334513133
-    8  (  8) -0.332481313383264
-    9  (  9) -0.175400025059932
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010284048494255 -0.022581971135931  0.025184528241746  0.002553505114185 -0.007866760216735 -0.035704112150886 -0.002766394497905 -0.015588851752449 -0.054894237910669
-    1  (  1)  0.001129370063260 -0.004341567056713 -0.012471737690510  0.068518821494219  0.037428649672491 -0.002857552975536 -0.002731409738209 -0.051935588474977 -0.049204102006071
-    2  (  2)  0.045340581598934  0.060774626672080 -0.014665202394902 -0.013163382447340  0.085552378847967 -0.055885373659009 -0.012884187954087 -0.000025912808653  0.007546289398551
-    3  (  3) -0.053518724373857 -0.051858316930917 -0.015829576226974  0.002308038466593 -0.033376912491914  0.026566608759227  0.020736863226261  0.017163432001033 -0.156611857939886
-    4  (  4) -0.057073647917578 -0.121620677730040  0.116559461318180  0.152459611673760 -0.224360677266659  0.063635487600126  0.025109630293686  0.123561544969923 -0.260705677431782
-    5  (  5)  0.132736043071323  0.228873275971275 -0.157588806451895  0.278203525609905  0.112411249713211  0.339424025956772  0.132778586915835  0.041442079822076  0.144607854949093
-    6  (  6) -0.099037108772820  0.133050971019321 -0.016390463092699 -0.047994853534082  0.082590754367535 -0.196599146843337  0.423704532236322  0.002588517799838  0.062442412924455
-    7  (  7)  0.164573996270568  0.174187584517111 -0.442718231735592 -0.055107629768529  0.292277213599590  0.090352016025029 -0.100915507153634  0.242008735185081  0.079009239652453
-    8  (  8)  0.059450407301305  0.065508844735816 -0.375580889101448  0.518979554864539  0.457917802055341 -0.070408637451188  0.013466768623613  0.072872586601375 -0.257559025462184
-    9  (  9) -0.246894722162695  0.551859769243373  0.044670824987361  0.162240888664295 -0.012774136938901  0.203595879781061  0.102036778576897  0.168067562706153 -0.111682944808914
-   10  ( 10) -0.913654455951997  0.155328532380750  0.215519674293101 -0.100970035089767  0.021969337557273 -0.148862369984030  0.046525143909590 -0.100083990349210  0.020780587060978
-   11  ( 11) -0.198781019683999  0.090074442467030 -0.050453210014304  0.292395282220077 -0.068054938936099  0.077531780115388  0.149511822875939  0.072921096134366 -0.357789764657410
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.062212803584986
-    1  (  1)  0.008222801612735
-    2  (  2) -0.107232253166961
-    3  (  3) -0.058083892735771
-    4  (  4) -0.001519088368734
-    5  (  5)  0.232883930798086
-    6  (  6) -0.056471183426688
-    7  (  7)  0.097796104480775
-    8  (  8) -0.126488666884472
-    9  (  9)  0.156849504238605
-   10  ( 10) -0.081446420280763
-   11  ( 11)  0.176341903152824
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007749096020893 -0.085883219860789 -0.036741821640513 -0.003365465554254 -0.013826624434967  0.045778129863205  0.040669337017936  0.010509742963645  0.029540605017242
-    1  (  1) -0.033323633544771  0.071013231293301  0.009381535649954  0.001865195819276 -0.004385218315905 -0.001145589403992 -0.107240463714063 -0.004928891794835 -0.020784313339082
-    2  (  2)  0.052107391808055  0.092519548352413  0.009858355445846  0.037319719751115 -0.023857034470632 -0.010135084101246  0.037769988668842 -0.015917832336735  0.090581268987334
-    3  (  3) -0.109820166860700  0.034268818868662  0.003318299125654 -0.047343590144125  0.049224764312370 -0.055554817528594  0.048303583350885 -0.021295778567536 -0.056731125392159
-    4  (  4) -0.007052162455570 -0.070092516335627 -0.001616209300804  0.100452686687340 -0.017125496300488  0.011804649620296  0.317168773449601 -0.015679790140276  0.134810835290821
-    5  (  5) -0.101789034987347  0.450242114045570  0.095257897029759  0.154575128248214 -0.107484330343030 -0.276349446627330 -0.224432437333530  0.138878619319231 -0.069374899620443
-    6  (  6)  0.129481070378189  0.190214182802185 -0.111482363704469 -0.289845791886638 -0.214082604248960  0.130539668518305  0.176627871859896  0.507792819613372 -0.145016045312478
-    7  (  7) -0.031015915682170  0.467808966358201  0.323231774623313  0.163051942437066 -0.027878152128557 -0.222130149400228  0.355582804042090 -0.345169178258104 -0.117503613032291
-    8  (  8) -0.081114418656010 -0.129458136695794  0.321266021811150 -0.116738859709862  0.112997348404402  0.150149613835924  0.100022037588641 -0.009859219508172 -0.185497355865147
-    9  (  9) -0.840897499603665 -0.103193956572518 -0.262141263376961 -0.179652800220136  0.091540284698060  0.263027818637292  0.232988427097700  0.132664590100508  0.080643129784317
-   10  ( 10)  0.396138270139100  0.527358178663247  0.115585436142149 -0.350404487392900  0.098592337861551  0.056041756240516 -0.132708614971811  0.130232826037073  0.024142145251939
-   11  ( 11)  0.048038049575401  0.184019168140566 -0.243899393243605  0.184449948512382  0.067903231499648 -0.173184976481832  0.074519873620110  0.122524072160336  0.175482839393722
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.029757291821339
-    1  (  1) -0.000721108481725
-    2  (  2)  0.081115665687732
-    3  (  3)  0.028764622397233
-    4  (  4) -0.020368316409772
-    5  (  5) -0.173632225317480
-    6  (  6) -0.281328230047800
-    7  (  7) -0.030401209370270
-    8  (  8)  0.093738850403327
-    9  (  9)  0.138017132925940
-   10  ( 10)  0.057334975405403
-   11  ( 11) -0.087072361680799
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.718905282963311 -0.301300066815098 -0.767801784865940  0.078512808825352 -0.203134864329395  0.241932163232250  0.058076631858574  0.196398858308336 -0.039008858124194
-    1  (  1) -0.301256490728193 -0.157440548180653 -0.036029555945222  0.243436823804201 -0.005929795652985  0.115486356935965  0.826228436942721 -0.465135369554618  0.058491264513800
-    2  (  2) -0.767289827428610 -0.036275730111077 -0.756926663794728  0.450133498634738  0.207784604973971 -0.828712724024022 -0.324647417359493 -0.353270502638369  0.092835605795882
-    3  (  3)  0.078579571414042  0.243310568002833  0.450095063336851 -0.208139431363607 -0.062202704649669  0.279001105370900 -0.076077558481815  0.262112030046533 -0.378810215172718
-    4  (  4) -0.202510304245595 -0.006692039856945  0.206011713498273 -0.062773519685661 -0.370731419489490 -0.256994084769574 -0.019543706164301  0.220490721787851  0.607096866069924
-    5  (  5)  0.239969372403163  0.117504635997786 -0.825053657412313  0.279484173569987 -0.255386254541418 -0.397595357673452 -0.135369610755389  0.236221247146237  0.269522215039686
-    6  (  6)  0.058390572588279  0.825859124407247 -0.324193078352693 -0.076854690390370 -0.019228317672495 -0.137735601227498 -0.351485727273275 -0.487761380462257 -0.103056409920122
-    7  (  7)  0.194458563409000 -0.463590717501173 -0.349817673328107  0.262678828099312  0.220495817360137  0.236701749060628 -0.486100377719484  0.043036203375607 -0.169360995578035
-    8  (  8) -0.038844766636175  0.058006360789407  0.092452034322386 -0.377838465048525  0.603441383275525  0.267460191997309 -0.103192305796676 -0.168696834715057 -0.618488124049516
-    9  (  9) -0.174642021637819  0.179686913958803  0.584519432729807 -0.531375857305351 -0.237827440080434  0.122408493834100 -0.350613084838644 -0.156778679126698 -0.027661506214973
-   10  ( 10)  0.043298420781037 -0.218837511618004 -0.611680553974653 -0.687832529301005 -0.249683832986975  0.553064660821027 -0.144105807777605  0.115245275900936 -0.084193131593124
-   11  ( 11)  0.061064657985430 -0.108300572115386 -0.188797311905296 -0.022208683609426 -0.827900622936499 -0.341922472618851  0.022718392329079  0.232401592689427  0.164619669402136
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.175684511601603  0.045513516298602  0.061672515006080
-    1  (  1)  0.179323083833167 -0.221567937419786 -0.109140577543022
-    2  (  2)  0.587827397093136 -0.616289532030193 -0.190305864672640
-    3  (  3) -0.534590179358002 -0.689583787093839 -0.022209033963942
-    4  (  4) -0.239000891867221 -0.249187499059157 -0.832603923332527
-    5  (  5)  0.122010791877518  0.553620901013401 -0.348332351708050
-    6  (  6) -0.352732495297565 -0.145056644635348  0.023781601660354
-    7  (  7) -0.157242165562723  0.112854519200918  0.232190589319976
-    8  (  8) -0.027709907045481 -0.086030263039170  0.172274707819854
-    9  (  9)  0.207109600584589  0.096837430686223 -0.023218950236813
-   10  ( 10)  0.100164655230671  0.138181178066476 -0.148224446144570
-   11  ( 11) -0.022320179734203 -0.148849259998097  0.901205762410303
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.179939828491769 -0.273263983919761 -0.077241939802207 -0.131310571537764 -0.452108955794121 -0.373710053222736  0.012756857043078  0.188686131296855 -0.281717657996437
-    1  (  1) -0.271865636595074  0.080204205184229  0.237736668579935  0.053954037181141  0.088144371186311  0.094298665169508 -0.396703489007358 -0.164374392009126 -0.012743809563993
-    2  (  2) -0.076549157175288  0.237611423410488 -0.235916884249811  0.330279805489172  0.156363656188217 -0.135525945480897  0.113532621668593 -0.192996543934043  0.505097349395040
-    3  (  3) -0.133008481204441  0.051978470711429  0.330705317892875 -0.689079279022158  0.681025162416434  0.230126506813665  0.220012049909173 -0.221793013382862 -0.415574431905058
-    4  (  4) -0.450299145657576  0.087908600365275  0.156309970041408  0.681002122520780 -1.360248251424318  0.202273753159192 -0.167570810051337  0.246051223487190  0.206738411458247
-    5  (  5) -0.373567193155845  0.094555329734040 -0.136731584498100  0.229377893488984  0.202581599883435 -0.322498154757568 -0.226671631570763  0.408374954790996  0.307423751717641
-    6  (  6)  0.013230492577454 -0.395220303624150  0.113830041131736  0.218897296842682 -0.167381205612527 -0.226319762003687 -0.422981172464967 -0.882122931150610  0.208582936748456
-    7  (  7)  0.187587553988559 -0.164973338711578 -0.192266029819867 -0.222193739599766  0.245811643454060  0.408813624326959 -0.882511768104148 -0.161881530949274 -0.197931622292553
-    8  (  8) -0.280045996340605 -0.013187886145669  0.507423753200987 -0.417462155137855  0.206022606034107  0.308302993473083  0.207495521066743 -0.198012373935716 -0.598880759668382
-    9  (  9) -0.299128216307527  0.222289305708678 -0.374826664894612 -0.022250761597490  0.198104512558476 -0.291885255576850  0.011569749529353 -0.150670269953426  0.186378706038956
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301492091129213
-    1  (  1)  0.222023461274417
-    2  (  2) -0.373275862159688
-    3  (  3) -0.022769731837422
-    4  (  4)  0.197531018509810
-    5  (  5) -0.291038388606400
-    6  (  6)  0.011766677818707
-    7  (  7) -0.150956367275849
-    8  (  8)  0.186282415361357
-    9  (  9) -0.408641391244209
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006541040222368 -0.029135588169222 -0.017330822595744  0.002628911660037 -0.012344009141809  0.034496132624923  0.021629830242309  0.010441885402291  0.025478364815458
-    1  (  1) -0.038275138470075  0.054424566886903  0.005683589031010  0.001642391288003 -0.005493648653247  0.001124544236485 -0.102028934451313 -0.004961744404475 -0.019198498257850
-    2  (  2)  0.053024456913342  0.083754722151204  0.014366999014575  0.045684709272444 -0.045425854355333 -0.015659092798954  0.035306515857362 -0.013688960188417  0.082596341754868
-    3  (  3) -0.125696090540634  0.031717757592640 -0.000802365038104 -0.050871771309593  0.061705711345850 -0.045742890419344  0.045450419445688 -0.021064845035616 -0.054716959844684
-    4  (  4) -0.016613018731749 -0.059371668786672 -0.003754167403423  0.095982620955076 -0.007240466240122  0.008043456529988  0.296808016923276 -0.015369394286441  0.136610478911713
-    5  (  5) -0.093091489377706  0.398657588863068  0.074430182364354  0.149030211928108 -0.108745535372234 -0.256250392240536 -0.205814737045222  0.134201000957220 -0.055103512993348
-    6  (  6)  0.103501697780443  0.185147067962843 -0.104829304475355 -0.273669393328239 -0.199802423052909  0.136710211986565  0.166053639619828  0.483268157942075 -0.135434527757446
-    7  (  7) -0.041456689404135  0.416662529525886  0.296499443846860  0.151835770270295 -0.027648961071683 -0.196853254585748  0.346148931870815 -0.324194030503122 -0.108656389838073
-    8  (  8) -0.069099920157317 -0.122455303618133  0.312946042218845 -0.115185983609626  0.104240832235501  0.145175805702234  0.095088539986730 -0.010672631592564 -0.187147060865154
-    9  (  9) -0.712671855893174 -0.096350152389786 -0.234711067777686 -0.171596024164591  0.065322769896798  0.213466874289907  0.226529390715592  0.118201066093080  0.055528795004367
-   10  ( 10)  0.365512212430565  0.443597144956858  0.088760713787529 -0.336294489487780  0.089380999156301  0.050585935158758 -0.112358935032342  0.122526344346197  0.011836823928278
-   11  ( 11)  0.046393846223224  0.165011629057398 -0.228781961279396  0.178941949643574  0.063752947031584 -0.164789871590981  0.073726138142668  0.117333811839271  0.181371275992210
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.026880621041360
-    1  (  1) -0.000642066544117
-    2  (  2)  0.075046583216661
-    3  (  3)  0.030887223304929
-    4  (  4) -0.027083357083367
-    5  (  5) -0.161323349919549
-    6  (  6) -0.260652499025702
-    7  (  7) -0.019658118713907
-    8  (  8)  0.093794795124770
-    9  (  9)  0.110456626093643
-   10  ( 10)  0.048798146100140
-   11  ( 11) -0.097571556382824
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001432746297450 -0.032810674091764 -0.033331937480253  0.023032547083763 -0.002808019310921 -0.039246266926320  0.018692018505171  0.008842597191367 -0.029091078569617
-    1  (  1) -0.008821922403183 -0.001742272088788  0.082771016704519 -0.022297486221974  0.039163604166239 -0.010818853488427 -0.047294425339584  0.013135326021221  0.049034393857867
-    2  (  2)  0.024274942916815  0.027096978669207  0.097516386902391 -0.041392368694666 -0.004119390757880  0.075691552303805 -0.023677742397495 -0.003953261558318 -0.122163189427397
-    3  (  3) -0.047038460283817 -0.039422636027069  0.017791086341758  0.115660160117630 -0.067224158887899  0.095036576800958  0.032022129167533  0.022732157345389  0.120912741709036
-    4  (  4) -0.041035802352368  0.001934742020068 -0.201409668003493 -0.406246991276172  0.228435905047063 -0.366034413601436  0.036563318346743 -0.036692328708082 -0.082010843429842
-    5  (  5)  0.098338733570095  0.243746073973362  0.282884501181602 -0.425804208023662  0.108408993563040  0.505586602390370  0.102717653176241 -0.183779423720787  0.023433267817945
-    6  (  6)  0.135336854760563 -0.062874421564495  0.076338309095403 -0.023002937162434 -0.130902824611473 -0.185164583438217  0.398907643233867  0.217551510448046 -0.032105677017803
-    7  (  7) -0.035062191357078 -0.113858796831119  0.431604299875852 -0.029482805357536 -0.029652466640804 -0.242847719350325 -0.077765311277989  0.367073496056810  0.139022006906444
-    8  (  8) -0.068272847454715  0.294672021175633 -0.568959581650588 -0.125921031197012 -0.707592810771387  0.017806583156209 -0.015845746565047 -0.212947645825718  0.125196335187716
-    9  (  9) -0.288858276698774  0.093713692739213  0.209035012311688  0.075382622510660  0.083405488851542  0.016184965058288  0.000548295704545  0.266294088315547  0.380874642506837
-   10  ( 10) -0.378738518488000  0.204837316203508 -0.069415360994347  0.062065163074324  0.029622876137723 -0.058750752587050 -0.120574645247794  0.008130897374692  0.009265965929469
-   11  ( 11) -0.080018520143771  0.225808316863723 -0.312311376663230 -0.316597637367698  0.125757542829493 -0.146130016020174  0.016179298260010 -0.136308703902615 -0.120756904157899
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.036093305578397
-    1  (  1) -0.001707679185378
-    2  (  2)  0.005295607540268
-    3  (  3) -0.304573937377439
-    4  (  4) -0.014287077020118
-    5  (  5) -0.068885443054321
-    6  (  6)  0.111979958895137
-    7  (  7)  0.321243115116497
-    8  (  8)  0.158205355334404
-    9  (  9) -0.080091690471286
-   10  ( 10) -0.065074315967804
-   11  ( 11)  0.075517488980888
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.151581395944457 -0.159877768539019 -0.191397517423370 -0.495232284867177  0.365561840480614  0.240680277087037 -0.079714342464060 -0.017889526464511  0.054577038131019
-    1  (  1) -0.159795957250344 -0.047735218799445 -0.125025973520529 -0.592230248738643  0.329204795623399 -0.563899565056737  0.474518384859258  0.371816427010336 -0.204007450193307
-    2  (  2) -0.191333337555164 -0.125299228178318  0.032743525999057 -0.248173196102997  0.424015573762028  0.373304795371779 -0.124367805075759 -0.383343230710404 -0.176623528718579
-    3  (  3) -0.494849488362154 -0.592714843248357 -0.248959287226432 -0.423717062956694  0.236470791317215 -0.415768039926139 -0.007927078894393 -0.295339114007336  1.138817517977087
-    4  (  4)  0.365842786381904  0.329912791129377  0.425309312530905  0.236284335454773 -0.297797609245548  0.287162197148014 -0.015195390583447  0.149575460395682 -0.352881082019632
-    5  (  5)  0.239666720470004 -0.562521840762128  0.375748994888085 -0.414021321385147  0.283842862620087  0.299376587010529 -0.122721640145877 -0.329969308300871  0.156494792176823
-    6  (  6) -0.079132044596257  0.473605179791134 -0.125255855635513 -0.008774504854422 -0.015965010341322 -0.123144104694353 -0.040262615853229  0.053291869268360 -0.230047243580867
-    7  (  7) -0.018210362041773  0.371975596266125 -0.382949144540519 -0.295062546320220  0.147969605902060 -0.330844143538271  0.053247875304319  0.437054225002062 -0.295575334707162
-    8  (  8)  0.054384972764257 -0.203042333758326 -0.176317356102570  1.137981680675850 -0.349930528471567  0.158219435758802 -0.229361079354617 -0.295174183029699 -0.201170965133917
-    9  (  9)  0.162593186917498 -0.096068090323904 -0.131721885594255 -0.537260876669133  0.048165192812382 -0.386108653062500  0.083321052788424  0.067822247358744  0.259623842469249
-   10  ( 10)  0.093086276325347 -0.110390627511003 -0.528311347000350  0.014888006239538 -0.100997055269664  0.192126958830561  0.038787614394956  0.063975054988451  0.077127488930246
-   11  ( 11) -0.248608674285678  0.166558436146830  0.438779225583925  0.334557445644043 -0.324782623645273  0.179928478753780  0.012126762707773  0.006418605871888 -0.316369462085207
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.163245257155421  0.094276717552644 -0.249582936616881
-    1  (  1) -0.097089753942058 -0.112180528774260  0.167323530234027
-    2  (  2) -0.131901378869784 -0.530116652654623  0.440616284282449
-    3  (  3) -0.539218683643804  0.014310072965047  0.335266942696954
-    4  (  4)  0.048635984706568 -0.103433325040069 -0.331331261588337
-    5  (  5) -0.385516013729792  0.187104305011894  0.193398800890046
-    6  (  6)  0.082991815026247  0.037352860323020  0.011014682786961
-    7  (  7)  0.067841455828072  0.062642922337485  0.014204699225385
-    8  (  8)  0.258473930207162  0.077886035701004 -0.325054438919389
-    9  (  9)  0.001773142889432 -0.053105768300802  0.034600115019000
-   10  ( 10) -0.053689547832438 -0.018246255837546 -0.196162567936867
-   11  ( 11)  0.031756575503292 -0.193298510202671  0.164652237069869
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.236069150423928  0.221583137218639  0.087467481976269 -0.023767225350154 -0.157884977853517 -0.128673956390029 -0.176595879969474  0.001131012317203 -0.181143452404233
-    1  (  1)  0.220430431059073  0.112052435313968  0.015869249151473  0.264485428778921 -0.165982030219470  0.159260926468858 -0.018854654828287 -0.249502649443057  0.052130725228418
-    2  (  2)  0.087694752982164  0.015013031218300 -0.683310722703039 -0.454889777527338  0.270539149606414 -0.876133156261866  0.064372104092668  0.069959767509230 -0.359585122327188
-    3  (  3) -0.022349867884997  0.265917774305981 -0.459885376820098  0.156118351029157 -0.442698949429053 -0.633164352365545 -0.123599096035318 -0.000681276488754  0.329408685832541
-    4  (  4) -0.157925484616889 -0.166044552973515  0.271218387113143 -0.443885849212600 -0.013362398764761 -0.176284165832649 -0.004716950323026  0.078109759941717 -0.609000288591445
-    5  (  5) -0.127616278770967  0.158011849801079 -0.876037618276795 -0.629854882079848 -0.177186230678137  0.012211398531521  0.059425698366986 -0.774979266274861 -0.486618182967767
-    6  (  6) -0.178241606252947 -0.017090192450387  0.064522373941146 -0.124240074207901 -0.004293285267873  0.059087683211698 -0.104000927528902 -0.330829052901522 -0.038045687603335
-    7  (  7)  0.002208432976113 -0.248689840257510  0.068573896371648  0.000014323070255  0.078530114044465 -0.775881123063332 -0.330687300606162  0.375687386105441  0.140607455827148
-    8  (  8) -0.178615853440425  0.052090468900394 -0.360562489485138  0.330978975217506 -0.607342070790934 -0.487347100955227 -0.037705399031252  0.140808054960246 -0.394251292282697
-    9  (  9) -0.046812023124734 -0.356025366669854  0.690811815119252  0.312933605279832  0.666333150435849  0.222468929331266  0.069111321865738  0.559435147572457  0.132671563084754
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045842278134109
-    1  (  1) -0.355929482932053
-    2  (  2)  0.690401613030498
-    3  (  3)  0.314450068453419
-    4  (  4)  0.667992312261241
-    5  (  5)  0.221641972273241
-    6  (  6)  0.069286377187356
-    7  (  7)  0.560338391968248
-    8  (  8)  0.132249466359632
-    9  (  9) -0.305201514350595
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003531322887475 -0.011853964282953 -0.013997173425702  0.018382792154192  0.000899996441170 -0.027829789222902  0.010946278656521  0.009416135608630 -0.023987807904262
-    1  (  1) -0.006388621957170 -0.005171201061298  0.075116414644925 -0.012351518893597  0.041297277094542 -0.006441657661851 -0.042094675941536  0.014500044658877  0.045272474380981
-    2  (  2)  0.036883171135873  0.025743377437805  0.085964964522995 -0.036572128405842  0.000741779132517  0.071901849285639 -0.017612259522947 -0.002857549793791 -0.114428225581804
-    3  (  3) -0.050379148878904 -0.038280516537017  0.018275237269774  0.118578575241743 -0.057964689431887  0.100743381549064  0.031817975653707  0.026538904209037  0.119963525599056
-    4  (  4) -0.040259568572502  0.011229705198348 -0.188809172609568 -0.380757486353216  0.215445879830049 -0.344569392827444  0.033187603168238 -0.033507608911701 -0.079582925346094
-    5  (  5)  0.087141198545524  0.216785041786672  0.270610048744647 -0.398997177058604  0.102170025016676  0.478625848854116  0.098949415070036 -0.170373600936987  0.015652914812384
-    6  (  6)  0.115394650619668 -0.055172374414511  0.068645251662214 -0.021005537436634 -0.120222938768552 -0.172201054646963  0.377862520931175  0.205771786365183 -0.028486300590321
-    7  (  7) -0.040171141537119 -0.121048023653740  0.403132598347777 -0.027760474590503 -0.026374510769541 -0.228317794220799 -0.070878790612320  0.346601006753617  0.129893637962627
-    8  (  8) -0.063034884678852  0.280866798080653 -0.540496031356204 -0.119391576371009 -0.673073389093966  0.010663808807394 -0.016147690801371 -0.200745867995305  0.117394935881043
-    9  (  9) -0.239823863619059  0.087614347419962  0.205995256328994  0.074059708937832  0.068748575207548 -0.000454096504958  0.003028317523563  0.249475422318809  0.352711368821821
-   10  ( 10) -0.336588165834448  0.173514331887659 -0.070029614207528  0.058791676167547  0.024501304819872 -0.052124336325614 -0.104213155529188  0.008639636736157  0.013496509549194
-   11  ( 11) -0.070036515714458  0.195530601320237 -0.305644951639726 -0.322831866596268  0.121530762471617 -0.141977993846978  0.021998928318675 -0.134440837975978 -0.127122644721006
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.030353030422789
-    1  (  1) -0.003358262791905
-    2  (  2)  0.006176160600104
-    3  (  3) -0.295046081788652
-    4  (  4) -0.003816440522472
-    5  (  5) -0.074325961201587
-    6  (  6)  0.109014636987132
-    7  (  7)  0.303731536940852
-    8  (  8)  0.152250258689580
-    9  (  9) -0.089511140585649
-   10  ( 10) -0.060789805292351
-   11  ( 11)  0.082293619260989
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057770723551805  0.007686176362995 -0.037676874102239  0.021875314889184 -0.005506967440553 -0.033731453254856  0.019605915987929  0.000153810358456  0.020480209762043
-    1  (  1) -0.007936092328855  0.008454757012618  0.010966637507272 -0.001712970012603 -0.003491085971866  0.000515536715359  0.020166951580993 -0.003537118918414 -0.007401819292438
-    2  (  2) -0.004823273660701 -0.024918096949402 -0.013456316532648  0.018061040723257  0.007928867774181 -0.029348077247204 -0.008305651855965  0.003787093111853  0.048173394734837
-    3  (  3) -0.011675775125104  0.107663431050362  0.048399528007616 -0.036525102270435  0.040730641356466 -0.022154401905676 -0.022459222262206 -0.014732815012435 -0.056193647103106
-    4  (  4)  0.087218313447135 -0.162702625594382 -0.040016358931151  0.090893257640902 -0.161526551014906  0.070532962320029  0.041494660476799  0.036307465283525  0.053954994619678
-    5  (  5) -0.299080380154522 -0.047071149143854 -0.050599107356677  0.086076035660096 -0.105747613370625  0.016291716828988  0.035370479977499  0.024570880182810  0.019740472062472
-    6  (  6)  0.064660820062842  0.041897488689090 -0.115036198620178  0.009494466980017  0.021741244197439  0.082050622741463 -0.041036304002792 -0.093842813724870 -0.099009311380003
-    7  (  7) -0.041406109005398 -0.013292096025031  0.015299070066933 -0.090658889471223  0.096664535474361  0.020138730803122 -0.181635797654581 -0.008096043748855 -0.043219320460348
-    8  (  8)  0.213166983290885  0.019961961605909  0.071163032757987 -0.089566388255459  0.187567657300030 -0.059322694628756  0.181371262434162 -0.031805535782928 -0.037438192749058
-    9  (  9) -0.029081682004423  0.052377114086944 -0.016598919354525  0.054121123864817 -0.005943121322964  0.052845962329270 -0.099913404453613 -0.011257505074012  0.046946017590445
-   10  ( 10) -0.029775807936917 -0.011144658296549  0.123616713069900 -0.069048925266029  0.072425392135727  0.175724644218768  0.020473761865880 -0.027329304597195  0.030635509122054
-   11  ( 11)  0.065686621670288  0.046175058814983  0.054739230530016  0.067089838730126 -0.085213076503212  0.033327993779702  0.039100303871838  0.006432393458887  0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007846989553355
-    1  (  1) -0.003599492488651
-    2  (  2) -0.050462951485827
-    3  (  3)  0.025590884562196
-    4  (  4)  0.058023095683205
-    5  (  5)  0.032774222915836
-    6  (  6) -0.063967275967677
-    7  (  7) -0.008682341559207
-    8  (  8) -0.054096899442108
-    9  (  9) -0.060114344610370
-   10  ( 10) -0.027778486812577
-   11  ( 11)  0.026791075407401
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000027040423887 -0.011060683872803 -0.004793456647899 -0.073481718860181  0.071504628495016  0.043329380984548 -0.025554578097106 -0.020981780177699  0.009741644195740
-    1  (  1)  0.011009750762997  0.000007607240151 -0.023558132508086  0.077101510719000 -0.072464798814331 -0.012890143420536  0.005683277430906  0.006920173400283 -0.002574145843753
-    2  (  2)  0.004842956248702  0.023538681455719 -0.000165226839542  0.207870652255993 -0.210753100259611 -0.104860036207310  0.066732822825146  0.046426833468215  0.005606364639263
-    3  (  3)  0.072846425542822 -0.076633967419021 -0.207131819599136  0.000363002499158  0.003747206858118  0.078444561827851  0.135702906183535 -0.013002670417717 -0.066080178603036
-    4  (  4) -0.070600283658190  0.071629978927021  0.209426851727876 -0.004131403945752 -0.000622007773293 -0.030404083775686 -0.072573499649568  0.005804369418180 -0.017256603820917
-    5  (  5) -0.042938103533211  0.012767138266668  0.104089521411634 -0.078509088982138  0.031589837534126  0.000702189622727  0.234416668036359  0.006073164073880  0.085676616502380
-    6  (  6)  0.025301081140471 -0.005670371975564 -0.066621493148361 -0.135369815380962  0.072186642283625 -0.233429156027521 -0.000193153533248  0.257186865053465 -0.080618496507255
-    7  (  7)  0.020822354558258 -0.006724508724119 -0.045993762455479  0.012965367547761 -0.005443358605263 -0.006173477804865 -0.257050229473736 -0.000107746294773  0.140355654948263
-    8  (  8) -0.009433315806276  0.002386871891496 -0.004905034102302  0.065444732417879  0.016877777772437 -0.086229493149666  0.079936884810997 -0.140925849197376  0.000032973152365
-    9  (  9) -0.050122316171813  0.043792237275169  0.089139695085719  0.017498120874682  0.031599257819379  0.003933044438540  0.023956851013655 -0.023591093022906 -0.231355322027963
-   10  ( 10) -0.021733936110572  0.028861084661254  0.012680330783905  0.120427356784394 -0.061995107162282 -0.110107780731446 -0.044522956915282 -0.044154909833586 -0.092344585382497
-   11  ( 11)  0.054009861310889 -0.049060128861341 -0.116101359422429 -0.043743279836749 -0.090347856826429  0.186254068915307 -0.010091097621831  0.182439821622372 -0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.050351452990167  0.022080091821478 -0.055614920128739
-    1  (  1) -0.043523152379598 -0.028913570586242  0.049281187081852
-    2  (  2) -0.088800989050704 -0.012387284429283  0.115844546053497
-    3  (  3) -0.017174780224652 -0.120766108673226  0.043936127494914
-    4  (  4) -0.030870076304731  0.062251132422338  0.090680792727787
-    5  (  5) -0.006295822004517  0.109602420736026 -0.187179028172583
-    6  (  6) -0.023342165877015  0.045357751936196  0.008109043414047
-    7  (  7)  0.023116687534610  0.043892116907456 -0.180954962224114
-    8  (  8)  0.233341712412303  0.091442003006516  0.004136900096905
-    9  (  9) -0.000301754743843 -0.311200434843549  0.071746006250031
-   10  ( 10)  0.310579381122594 -0.001146128096000 -0.337175845358798
-   11  ( 11) -0.071759110731455  0.341710402101474  0.000514995746851
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000373475564698 -0.036374284715410  0.020675408038120  0.041938611278043 -0.014954064130636  0.008670693741941  0.001941666498966 -0.002175213653671  0.081223953533966
-    1  (  1)  0.035409311090430  0.000583412494499 -0.021912114995751 -0.019686191919175 -0.001337756516393  0.101410043872272  0.013539530463413  0.021085032009130  0.104140442794578
-    2  (  2) -0.022476650279619  0.020869170321065 -0.000623148668542 -0.026925059222749  0.022600045203783  0.054500059821995  0.019747085432266  0.002197258536137  0.059803959084815
-    3  (  3) -0.040527884961938  0.020785023904239  0.026269813130118  0.000471315833621 -0.011435927824319 -0.005094359128676 -0.021078069661848  0.001900689912103 -0.049285996887456
-    4  (  4)  0.014876995236008  0.001935832477363 -0.021280417512247  0.011112950356736 -0.000010954074914  0.001375736589678  0.021071346294591 -0.002540388393255  0.057176443725449
-    5  (  5) -0.009413911140341 -0.101590521816804 -0.054440250203052  0.004479146413684 -0.000983185589705 -0.000044886603863 -0.008942266041566  0.007734744988056  0.012623227871857
-    6  (  6) -0.001228199632690 -0.013460754514196 -0.019370737847276  0.021147815413154 -0.021180440912387  0.009078596190780  0.000060187992369 -0.021757615671251 -0.021546696625458
-    7  (  7)  0.002386621109668 -0.020697715049428 -0.002142304032572 -0.001889845237358  0.002502377714011 -0.007891184567460  0.021671667697211 -0.000014467640044 -0.019485620614445
-    8  (  8) -0.082726042327291 -0.104120679625015 -0.059410287861643  0.049170685661379 -0.057558349352742 -0.011952514103015  0.021313492463386  0.019559674827960  0.000280085719614
-    9  (  9)  0.081272328726009 -0.110754135563007 -0.028218762900775 -0.005318083145326  0.020981856638396  0.014567561104212  0.097856532501808  0.003185861516469  0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.080531031337273
-    1  (  1)  0.111220099551316
-    2  (  2)  0.028332370195928
-    3  (  3)  0.005372945270244
-    4  (  4) -0.020768901638641
-    5  (  5) -0.014982546342664
-    6  (  6) -0.097582479807565
-    7  (  7) -0.003277826561639
-    8  (  8) -0.003260780284830
-    9  (  9) -0.000186812021876
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055078142867828 -0.005804719299681  0.036780646353647 -0.020745008939831  0.005631321838333  0.032388434299089 -0.019554696167851 -0.000026315290494 -0.020764618651157
-    1  (  1)  0.007062764870854 -0.009531925050962 -0.009339128991500  0.000585332198702  0.003536715157378  0.000717716084393 -0.020997702694190  0.003197609406412  0.007543205569196
-    2  (  2)  0.003273721829615  0.024127785783056  0.019803917766004 -0.021792459075320 -0.009225997435944  0.033280936086821  0.008357612389432 -0.004534634518823 -0.049752671423908
-    3  (  3)  0.009467819748219 -0.109846311430058 -0.049077069582499  0.038067479834844 -0.041344367688361  0.023164856965512  0.023494777837550  0.015492414054440  0.057415728354703
-    4  (  4) -0.087998530211411  0.166680738017738  0.040492236619192 -0.094854089537164  0.166732509395464 -0.071703004448668 -0.042087550249065 -0.037122017300705 -0.054342710801435
-    5  (  5)  0.299229806278301  0.048658757713325  0.047129705842446 -0.086908947365866  0.109728878663932 -0.016789363568018 -0.035383410684614 -0.025335321764417 -0.020816334753998
-    6  (  6) -0.066809370303780 -0.045194542515417  0.116536125053039 -0.010429907504714 -0.024187359392906 -0.082665971873618  0.044425337546003  0.096427706292236  0.099634759729367
-    7  (  7)  0.040692585686945  0.010414403444448 -0.019197392244389  0.094603783326762 -0.099044517012418 -0.021567521501408  0.184530946067710  0.010140666068000  0.044429992698867
-    8  (  8) -0.213871489773344 -0.016533777636027 -0.072796199007045  0.091991735348903 -0.195396773842710  0.059284334625803 -0.184339397290396  0.031894612373968  0.038856272349111
-    9  (  9)  0.030682243044227 -0.041775517875249  0.024602057980135 -0.057287290343526  0.006772740334119 -0.055735826221076  0.097648839100779  0.011580457295414 -0.048271645082472
-   10  ( 10)  0.033182564179255  0.014791814568441 -0.134627953730393  0.074303509883212 -0.072048570540947 -0.178297714606306 -0.018972497943516  0.029382172234938 -0.026191954922422
-   11  ( 11) -0.065304385216644 -0.054065687922946 -0.058978656197155 -0.069527138693935  0.087278294466894 -0.031923025189413 -0.037244505404452 -0.006712268565440 -0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007990021156235
-    1  (  1)  0.003543862611170
-    2  (  2)  0.051263654644270
-    3  (  3) -0.026303130686066
-    4  (  4) -0.059400171065937
-    5  (  5) -0.033889468632128
-    6  (  6)  0.063573026890197
-    7  (  7)  0.010425863419296
-    8  (  8)  0.056178737365981
-    9  (  9)  0.060112542127891
-   10  ( 10)  0.033303474011037
-   11  ( 11) -0.026602109435667
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.023607177491195  0.019696611969885  0.037221212000385 -0.015590319696057  0.002020189842990  0.021016653547429 -0.007873916136755  0.003448340610807  0.079821954504390
-    1  (  1) -0.007327805297828 -0.018867534486269  0.042212469078496 -0.001447360534353  0.028939866752754 -0.077938653083341 -0.061948383376365  0.004945505795557  0.075894556663474
-    2  (  2) -0.009007071740861 -0.016177005802987 -0.068312932673240  0.041184857036759  0.003023256838844 -0.009849571097863  0.004290386808972  0.004340519661127  0.085840789796801
-    3  (  3)  0.026077185963910  0.012520558385893  0.023360353465929 -0.029787599349062  0.027312833784239  0.081100062029021  0.033406666012159 -0.054430078300136 -0.042036783131155
-    4  (  4)  0.044521029970710  0.101548028530885  0.092152577419686 -0.036969661342643 -0.235975964790827 -0.022489800485005 -0.018037809327809  0.163273258200919  0.255997686637622
-    5  (  5) -0.075082806179399  0.059495559215694 -0.178951166772656  0.134634824114366 -0.237022622504406  0.054772185517501  0.024504277147484 -0.150049663229407  0.003365655895118
-    6  (  6) -0.075564373604390  0.030719217759732  0.086498148733354 -0.160325933966896  0.064234285643905 -0.161900908445555  0.266146706738358  0.238096934941697  0.054011663901563
-    7  (  7) -0.117049393955643 -0.184359827232724  0.154835473828309 -0.196676571259727  0.209716028817009 -0.429620861048445 -0.096138950091600  0.371356959007903  0.058084061024513
-    8  (  8) -0.116322044765828  0.134673176933366 -0.115490121530453 -0.372419146214479  0.134366059259054  0.090977060566167 -0.047847126119104 -0.349531731511066  0.026343643532612
-    9  (  9)  0.016166361653787 -0.064655468388956  0.096603309196917 -0.102141195994536 -0.004689543577322 -0.174053614560893  0.096535422651742  0.179574162178272 -0.093140031286430
-   10  ( 10)  0.038118657992317 -0.011712936317703 -0.109233641260348  0.041948680427994  0.067033240911419  0.043789144467457  0.119198984082488  0.019961916251994  0.046236232124822
-   11  ( 11)  0.202537936665755  0.041865413038804 -0.001109842658197 -0.036047997932446 -0.209039172907281 -0.039634162843452  0.042796449278664 -0.037154632643052  0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001464671751436
-    1  (  1)  0.092168971837118
-    2  (  2) -0.096834154775615
-    3  (  3) -0.085232004143247
-    4  (  4)  0.224276823308218
-    5  (  5) -0.037070717977035
-    6  (  6) -0.017788678150516
-    7  (  7)  0.125655013910958
-    8  (  8) -0.036753750028807
-    9  (  9)  0.104788947042948
-   10  ( 10) -0.055723652563089
-   11  ( 11)  0.029086171780033
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000103943053471  0.020502980666838  0.044487026908476  0.112522389921676 -0.115190927698806 -0.086304427533430  0.028732798000328  0.005755262072674 -0.052707374815472
-    1  (  1) -0.020396732597728  0.000175507711089 -0.066631576709106 -0.188566511167110  0.188604507023904 -0.081802717690830  0.123212599282903  0.146580404278728 -0.063843813395139
-    2  (  2) -0.044224363892114  0.066688325942716 -0.000328779542201  0.131627364199491 -0.085838688001563  0.039792906367986 -0.071990397116460 -0.041811204620793  0.129151440044184
-    3  (  3) -0.112356491847955  0.188595812422395 -0.131743983691740  0.000034238258909  0.146405835083834  0.293116155503685 -0.174354593749844 -0.234740190959724  0.068400431241803
-    4  (  4)  0.114478156906703 -0.187880772610577  0.086711640119064 -0.146345707242046 -0.000351413466984  0.200401380550659 -0.118118144680811 -0.106599388398520  0.027535193682288
-    5  (  5)  0.086013769068620  0.081687368012874 -0.039811317138268 -0.293720012918757 -0.199751621453618  0.000779002249077 -0.029574633012291 -0.100809576430270  0.310087999943630
-    6  (  6) -0.028593362634754 -0.122990647052479  0.071886866993686  0.174357265134888  0.118164594946332  0.029455932226559  0.000323502179386  0.067588972736558  0.054838186724730
-    7  (  7) -0.005405231783831 -0.146637005514722  0.041701223809144  0.234444344892692  0.106310138998589  0.100760684833959 -0.067340032280388  0.000050446895501  0.206356025427645
-    8  (  8)  0.052734404217526  0.064663294136106 -0.127867798766573 -0.067686878519552 -0.027452578317565 -0.311518253800823 -0.053511305641188 -0.206912543882787 -0.000090733997612
-    9  (  9)  0.040822323151076 -0.050351126620632  0.033443030139718  0.028678071562223 -0.070729562284205  0.035204318394559 -0.035088801145452 -0.003858253384271  0.209126878103916
-   10  ( 10)  0.043554697985060 -0.034029200702705 -0.113396889510888  0.025104351967769  0.057922093461755  0.050331966245759 -0.113578028555237  0.006845000513571 -0.183899295084893
-   11  ( 11) -0.104445737487499  0.085327185159750  0.138831980783855  0.068059267872915  0.045287984054307 -0.106421559557756  0.126370094892912 -0.085884676801538 -0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.040472375428214 -0.043732687824618  0.105326662293090
-    1  (  1)  0.050113148730272  0.033553830886801 -0.085228632878169
-    2  (  2) -0.033648303602896  0.113430364410931 -0.140304701766262
-    3  (  3) -0.028908821271170 -0.025577280295259 -0.067243263311150
-    4  (  4)  0.070488811800233 -0.058243639304596 -0.043815524401846
-    5  (  5) -0.035954881502730 -0.048633621823234  0.102557737449989
-    6  (  6)  0.034599692943826  0.112216626584703 -0.126288398892548
-    7  (  7)  0.003737404887253 -0.007316223089443  0.087031799969318
-    8  (  8) -0.210522602449556  0.181960897898471  0.040780655119777
-    9  (  9)  0.000486792078199 -0.154877597629272  0.324381992896252
-   10  ( 10)  0.154731729402294  0.001003846432056  0.227757018056261
-   11  ( 11) -0.321308213629134 -0.230320716710505  0.000521529871008
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000267990887146 -0.017094909685382  0.026886221509252 -0.009154729792392 -0.028447394308811  0.043026223139973 -0.007934241734193  0.017529929372393 -0.048064409198736
-    1  (  1)  0.019165257539447 -0.000577613190074 -0.023971643573307  0.023362002438445 -0.020466955482562  0.074368923093670  0.021220838937975  0.006899315294507  0.004345205689582
-    2  (  2) -0.030573367311208  0.023520686332899 -0.000895230171902 -0.026482533037414  0.055578356600337  0.061212128793543  0.006033035982650 -0.029878597421323  0.067713186454891
-    3  (  3)  0.011556055604803 -0.022912214561881  0.028040995483179 -0.000806143570890 -0.016669730389240 -0.057830279830177 -0.001162806518994  0.022110531165998 -0.132937508894661
-    4  (  4)  0.029247962187325  0.019722933579604 -0.053631431975867  0.015590855142050 -0.000406564753787 -0.013151443352440  0.005583751708839 -0.048344741694769  0.058950645196782
-    5  (  5) -0.044502924478349 -0.074343902828738 -0.059891074519534  0.057011647107618  0.013642181191740  0.000660380157385  0.021619837229525  0.066247874288904 -0.026658775788480
-    6  (  6)  0.008416217090956 -0.021046309429680 -0.006522358687724  0.001270652730649 -0.005678899154477 -0.021925039235368  0.000233190982568  0.044213316193167 -0.019149792461568
-    7  (  7) -0.017220078580887 -0.007669026797702  0.030414088472195 -0.022279636607030  0.047947045698118 -0.066391322818188 -0.044159499520014 -0.000036612147908 -0.012788358083278
-    8  (  8)  0.049286641691243 -0.005157181302332 -0.067669102261374  0.134137839836174 -0.059598226202850  0.026736423898111  0.019691121432993  0.012900597372237 -0.000145671342113
-    9  (  9) -0.013771428368881  0.001534324314609 -0.097208563857550 -0.041538777135659  0.016922202614382  0.071792645864290  0.010700525463409 -0.088926800959210  0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.013388445223016
-    1  (  1) -0.001743269961120
-    2  (  2)  0.097384653394849
-    3  (  3)  0.041118719872747
-    4  (  4) -0.017104740675403
-    5  (  5) -0.071235600573670
-    6  (  6) -0.010744046806778
-    7  (  7)  0.088045104682667
-    8  (  8) -0.027915642785476
-    9  (  9) -0.000257740691093
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.024087436020668 -0.024234923487922 -0.034655069016827  0.013002508462274 -0.003506876735183 -0.019138226509165  0.008729154622077 -0.004126516633947 -0.080810387962203
-    1  (  1)  0.007340388106341  0.022740162593799 -0.047399213843079  0.000077807499313 -0.029710781800549  0.077091731467965  0.063337905707382 -0.003225301246506 -0.076935684639064
-    2  (  2)  0.008533292606078  0.014866249844284  0.069414473601385 -0.039067032188858 -0.004447555351962  0.009557153079335 -0.003933218079563 -0.004684619630234 -0.087696717260759
-    3  (  3) -0.022970088927143 -0.014796917693540 -0.027844101865804  0.035221698386289 -0.026363064761687 -0.090054977556852 -0.034727496736464  0.055362273105074  0.041999796595917
-    4  (  4) -0.041840045940810 -0.108064430049583 -0.094169303786903  0.038045467810124  0.242703284807102  0.022096059239039  0.018423933000872 -0.169152570163926 -0.255707171958253
-    5  (  5)  0.076575292532566 -0.064169513057282  0.187842221364997 -0.139017281082776  0.239663562780447 -0.056101309100792 -0.026864961939161  0.152773054853442 -0.000863550220823
-    6  (  6)  0.082619291232389 -0.034129866388443 -0.092672858212650  0.166047996934064 -0.066033557533197  0.164979644828487 -0.279604374284854 -0.245415146187524 -0.057275952528883
-    7  (  7)  0.119525510255884  0.192558180615050 -0.157479601093184  0.199612815310399 -0.216488749413977  0.438370355171240  0.097840156788249 -0.385286937285113 -0.058774287435548
-    8  (  8)  0.115070416909243 -0.142091116044252  0.125572997790340  0.378869543679260 -0.139572537143277 -0.093921809248974  0.047279124915748  0.359195083957732 -0.024443650320069
-    9  (  9) -0.023211259159309  0.064251202673602 -0.092489429719048  0.099069758679955  0.005272254913816  0.184087259640687 -0.103465084079069 -0.187259798043465  0.097400286560574
-   10  ( 10) -0.039092748606065  0.013006586457309  0.115772480099790 -0.044153430983449 -0.068039357936569 -0.040474168285568 -0.124671276809929 -0.020291967592974 -0.043718085717437
-   11  ( 11) -0.205517300660670 -0.035576186745690  0.000856944671273  0.036648470964825  0.217305799958921  0.037828885346138 -0.045859373489911  0.037554955798535 -0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001311477468569
-    1  (  1) -0.093224324445080
-    2  (  2)  0.099200064811294
-    3  (  3)  0.086458921973920
-    4  (  4) -0.229446975291319
-    5  (  5)  0.035136747289852
-    6  (  6)  0.019108151626501
-    7  (  7) -0.127376470092273
-    8  (  8)  0.036832911731868
-    9  (  9) -0.106598068979743
-   10  ( 10)  0.058544237541584
-   11  ( 11) -0.029477471817291
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.089840465204225 -0.055253525883540 -0.050839656601929  0.011592120168853  0.028453073767485  0.033272498563027  0.013123122183092  0.010376152774617  0.046773274930095
-    1  (  1)  0.019180458750845 -0.004406050242553  0.021028155566967  0.011538680320289 -0.014109247012132 -0.033202867729220  0.146724711919951 -0.006291497986158  0.032816512639240
-    2  (  2)  0.008004935891454  0.083588166091295 -0.024500417662889 -0.004976479402859 -0.015361678869856  0.027030028650554 -0.075999531355577  0.040388417899799  0.092155828534757
-    3  (  3) -0.072751395760345 -0.101339872261880 -0.027554632505315 -0.017104143799594  0.009883810143648  0.054325029446985 -0.038424568195001 -0.007564948769101 -0.050859249479548
-    4  (  4) -0.116869612062058 -0.168448689602172 -0.076045170807919  0.039076911238534 -0.141061895780680  0.082089594379007 -0.096305838370831  0.090937592520626  0.089867596085833
-    5  (  5)  0.362411548066203  0.116301468610581  0.067304641586918  0.178833394354847 -0.120526935264372 -0.077690766748935  0.087853646530869 -0.131583743921650  0.005449987066682
-    6  (  6)  0.023022243577310 -0.091878291587840  0.168295716396468  0.360782087280141  0.197772285105134 -0.118427120672179 -0.100301554555422 -0.545992767837121  0.002274268616602
-    7  (  7)  0.332469089310140  0.094037896803367  0.021326282942452 -0.202588446745432 -0.003095262967230 -0.074773576198707 -0.261809753005545  0.312310926113466 -0.101271338039676
-    8  (  8)  0.102262443511968  0.018323432973791 -0.030286707735275 -0.141132962784100  0.140087132441384  0.016144892573022  0.105178803101546 -0.077042517784067 -0.061204405030880
-    9  (  9) -0.062921845500970 -0.223934495766079 -0.055471945329417 -0.006791304491310  0.142947280894142  0.007991932919943 -0.047858230706461 -0.145718178913241  0.072195393114585
-   10  ( 10)  0.062281498028430  0.059385022217194  0.196384149116451  0.042900612771916 -0.059951865879116 -0.109494756681462 -0.025377610533051 -0.255425379720525  0.006903138405362
-   11  ( 11)  0.109893814765672  0.036299338598219  0.008950289795172  0.103979082032925 -0.089663281746559 -0.076642658317109 -0.017386558594104 -0.075203103677764  0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015115955084904
-    1  (  1)  0.030649150844450
-    2  (  2) -0.004117081641871
-    3  (  3) -0.011275331966881
-    4  (  4)  0.082379096749867
-    5  (  5)  0.010925397739678
-    6  (  6)  0.209001724905895
-    7  (  7) -0.094421017044117
-    8  (  8) -0.009881568354141
-    9  (  9)  0.113416879853688
-   10  ( 10)  0.045856944277529
-   11  ( 11) -0.007202279712064
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000220708940429 -0.002285125103983 -0.191707004311250  0.079176547202062  0.015343724284655  0.090762856917070  0.035966370439669  0.080228715251931 -0.022632088832219
-    1  (  1)  0.002270884902228 -0.000127565392507  0.181504505051190 -0.084301622984598  0.019134286473150 -0.136527597935967 -0.291828838790707  0.086935165867290  0.003153353795357
-    2  (  2)  0.190790178739451 -0.181286631653937  0.000456958950263 -0.098736144982791 -0.201937120878681 -0.060858985812145  0.102547416191644 -0.128157455079926  0.052263022287278
-    3  (  3) -0.078674978461285  0.083802623610643  0.098399673810258  0.000007811365746  0.051373438075815  0.073262818066183  0.213681674768555 -0.159362252554929 -0.021801220424175
-    4  (  4) -0.014664072597960 -0.019624839214450  0.200908806156840 -0.051706138267892 -0.000345872163641  0.060049554881332  0.188299165959522 -0.122222075869351 -0.002767654097179
-    5  (  5) -0.090883158144736  0.136634126073923  0.061672946710902 -0.074085610649007 -0.059059222367226  0.000127348357414  0.089421360456473 -0.068061409120582  0.127845689145142
-    6  (  6) -0.036070137194869  0.291478881075219 -0.101913218910275 -0.213840026067922 -0.188217301311726 -0.090313292624869 -0.000227988253159 -0.211121150654972 -0.048790729392591
-    7  (  7) -0.080292928774450 -0.086502244153537  0.129683189759572  0.159077086898913  0.122727489493275  0.066634459735053  0.210168861536432 -0.000749252129634  0.114771568876213
-    8  (  8)  0.022833189301314 -0.003149552694449 -0.051809982276026  0.021432628906503  0.002600755913054 -0.127892598520278  0.048118709288206 -0.114794510187460 -0.000092800261922
-    9  (  9)  0.153861672366712 -0.063959309581427 -0.276686698038017 -0.018129236980868 -0.051934404023196 -0.023341508326279 -0.078386885605064 -0.038564733458116 -0.117925763161383
-   10  ( 10) -0.030779230036139  0.047764824598951  0.139550834348758 -0.058848096986720 -0.072156858928456 -0.071321440087986  0.120905085647966 -0.006516751215124 -0.144681807612295
-   11  ( 11)  0.005585664265456 -0.000647324323586 -0.016353426872082 -0.045937924242292 -0.003353711579607  0.138994412824604  0.062414171800322  0.018128246119697 -0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.154066232086317  0.030728257975556 -0.006318091498164
-    1  (  1)  0.063643818147584 -0.047463638962418  0.000566548572565
-    2  (  2)  0.275258773270295 -0.138888616959566  0.015969350630016
-    3  (  3)  0.017345671201066  0.059189082677904  0.046475381464176
-    4  (  4)  0.050392875387071  0.072424486885238  0.004459708301674
-    5  (  5)  0.026836133802329  0.070805989588457 -0.140760690762251
-    6  (  6)  0.078585377266712 -0.120742726291724 -0.064292229739042
-    7  (  7)  0.041858894695365  0.005665298794286 -0.017186389956069
-    8  (  8)  0.118429783701800  0.144155118064025  0.113213711259466
-    9  (  9) -0.000756388118591  0.455654623157072  0.231432578787543
-   10  ( 10) -0.453567841489266 -0.001497567906129 -0.172275686133391
-   11  ( 11) -0.230120702539645  0.175050207490782 -0.001480251815160
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000516219946816  0.034778633659956  0.032999546928151 -0.009629039776278  0.052966719633617 -0.030450001531878 -0.014875222246015 -0.072128990177077  0.048218822417803
-    1  (  1) -0.030877691560804  0.001883541097772  0.071434334115879 -0.019325009721534 -0.017452039030100 -0.158145751795333 -0.010537309557875 -0.021583100108147 -0.169934651056250
-    2  (  2) -0.033565318682613 -0.071200997372983  0.000581071534985 -0.036850040138101  0.007310816547227 -0.008797901115406 -0.029229533057666 -0.016744128499400 -0.070455787497455
-    3  (  3)  0.011004884819686  0.019179310791618  0.034909263032370  0.000523661128158 -0.007125267622899 -0.017666281606150 -0.025274953349027  0.006048522524524 -0.042959205727090
-    4  (  4) -0.052383681601535  0.016788640224883 -0.007028507044452  0.007472760866637 -0.000164741631073 -0.026820745242549  0.000005495327564 -0.022752424410877  0.031410113616428
-    5  (  5)  0.028924597602342  0.155705177520586  0.009708873936879  0.016613543931604  0.026890889200954  0.000863820528475 -0.026461589325309  0.030900211040800  0.024762473040831
-    6  (  6)  0.014335467827216  0.010396285650159  0.029624823660296  0.025462090585912  0.000149096444494  0.026996065218364 -0.000042625626758 -0.107465667965402  0.101121105248233
-    7  (  7)  0.071280711647029  0.021473260264964  0.016888851213230 -0.005990055447048  0.022650874097521 -0.030884846999677  0.107059671381934  0.000085380718295  0.001222830424055
-    8  (  8) -0.049124632890092  0.169889327710618  0.068826403708743  0.044339001017875 -0.031493314676472 -0.025080049766767 -0.100845039831255 -0.001167614688641  0.000278385825403
-    9  (  9)  0.004591463397670  0.224641690035662  0.054391854978822 -0.000520714575472  0.041379699430161 -0.035041097267503 -0.048865193892848 -0.034233303767760  0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.004372643490859
-    1  (  1) -0.225448428944350
-    2  (  2) -0.053543340635201
-    3  (  3)  0.000029286176363
-    4  (  4) -0.041473098636741
-    5  (  5)  0.035500700267141
-    6  (  6)  0.049415179037896
-    7  (  7)  0.033722251526408
-    8  (  8) -0.002108270875613
-    9  (  9) -0.000059855095180
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.083178189184036  0.063320502543375  0.053448860291133 -0.010119942476578 -0.027962494700737 -0.033408156898410 -0.016646686372055 -0.009688142905594 -0.047753876913682
-    1  (  1) -0.015436953954369  0.001484194684011 -0.023035398887205 -0.013457869405466  0.013993527195521  0.033943979767543 -0.150850131221437  0.006054179455746 -0.032861777904130
-    2  (  2) -0.007416632072171 -0.085535883632607  0.031035920631781  0.004414026005139  0.010136741110915 -0.029006493089287  0.078308410406643 -0.042862583013635 -0.094615352193845
-    3  (  3)  0.060864804294684  0.107990348400789  0.029334441164075  0.017074561166948 -0.006770814971091 -0.056161219994893  0.038880977880177  0.007186858274067  0.050898617184209
-    4  (  4)  0.109193273208522  0.178421304573120  0.074992061457995 -0.038015102633012  0.147910228795514 -0.087181398607820  0.098582275644141 -0.093570766915846 -0.088687564658624
-    5  (  5) -0.362309556227904 -0.121304099182945 -0.074968023841376 -0.180660703600124  0.122438585672172  0.079096894998506 -0.085876030826778  0.136109864287558 -0.002214631278523
-    6  (  6) -0.026835628168075  0.104282391359254 -0.172843582770517 -0.372105341696267 -0.200623348657875  0.124556824110224  0.101871864602057  0.564196462169744 -0.000688785089474
-    7  (  7) -0.344945182303497 -0.095060217852336 -0.019692892185405  0.208607222836184  0.002627647973779  0.075715664253568  0.273373001503080 -0.322679649636761  0.103750880742886
-    8  (  8) -0.103243578213400 -0.018995126733818  0.033613347666093  0.143946559071139 -0.146180680800982 -0.017308359580339 -0.107684620440504  0.078982837453949  0.062496256435255
-    9  (  9)  0.085648241806344  0.209611729409149  0.056224829650480  0.004822853433113 -0.155473341074989 -0.012971266670028  0.058097898147224  0.150335378963730 -0.078057323449305
-   10  ( 10) -0.070132629148842 -0.074702785463534 -0.209329818275843 -0.042566217114534  0.058034325280006  0.102370728009941  0.025801004099357  0.264561180085366 -0.017482708757363
-   11  ( 11) -0.113963029107499 -0.045073298009464 -0.000413587765283 -0.112463923253522  0.089423608765749  0.081287727377731  0.019439635907878  0.076622183257520 -0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015270950350973
-    1  (  1) -0.030946721870550
-    2  (  2)  0.003707642076146
-    3  (  3)  0.011960041321321
-    4  (  4) -0.086083869661608
-    5  (  5) -0.009867768215709
-    6  (  6) -0.209680707316341
-    7  (  7)  0.097843271017668
-    8  (  8)  0.010325909660635
-    9  (  9) -0.121632163838855
-   10  ( 10) -0.058275044600178
-   11  ( 11)  0.003021331907582
+	[alpha]_(0.077) =  -49.62374 deg/[dm (g/cm^3)]
 
 	Computing Mu_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.069164761529
-	   1        16.451915039014    4.754e-01
-	   2        18.210045318474    1.656e-01
-	   3        18.228206575195    1.761e-02
-	   4        18.232861753523    6.133e-03
-	   5        18.233517878040    7.884e-04
-	   6        18.233413053054    2.307e-04
-	   7        18.233428247409    3.953e-05
-	   8        18.233433472353    1.188e-05
-	   9        18.233432993942    2.887e-06
-	  10        18.233432832199    8.245e-07
-	  11        18.233432917671    2.394e-07
+	   0        13.069164596988
+	   1        16.451914820424    4.754e-01
+	   2        18.210045061583    1.656e-01
+	   3        18.228206317089    1.761e-02
+	   4        18.232861495195    6.133e-03
+	   5        18.233517619662    7.884e-04
+	   6        18.233412794677    2.307e-04
+	   7        18.233427989030    3.953e-05
+	   8        18.233433213974    1.188e-05
+	   9        18.233432735563    2.887e-06
+	  10        18.233432573821    8.245e-07
+	  11        18.233432659292    2.394e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 6.055e-08
 
 	Computing L_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.417820605588
-	   1         3.324263605577    3.187e-01
-	   2         4.083972328288    1.549e-01
-	   3         4.107116389054    3.248e-02
-	   4         4.122343243544    1.794e-02
-	   5         4.124892947600    6.529e-03
-	   6         4.124856323725    2.006e-03
-	   7         4.124952683600    6.955e-04
-	   8         4.124954033412    2.621e-04
-	   9         4.124934611275    1.091e-04
-	  10         4.124933829026    3.585e-05
-	  11         4.124936470025    8.386e-06
-	  12         4.124938655284    3.061e-06
-	  13         4.124939356565    8.126e-07
-	  14         4.124939892423    4.035e-07
-	  15         4.124940079297    1.792e-07
-	  16         4.124940200966    1.045e-07
+	   0         2.417820592240
+	   1         3.324263585293    3.187e-01
+	   2         4.083972298669    1.549e-01
+	   3         4.107116358535    3.248e-02
+	   4         4.122343212428    1.794e-02
+	   5         4.124892916354    6.529e-03
+	   6         4.124856292471    2.006e-03
+	   7         4.124952652341    6.955e-04
+	   8         4.124954002153    2.621e-04
+	   9         4.124934580017    1.091e-04
+	  10         4.124933797768    3.585e-05
+	  11         4.124936438767    8.386e-06
+	  12         4.124938624026    3.061e-06
+	  13         4.124939325307    8.126e-07
+	  14         4.124939861165    4.035e-07
+	  15         4.124940048038    1.792e-07
+	  16         4.124940169707    1.045e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 3.243e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.852729644755
-	   1        12.772930237506    3.300e-01
-	   2        13.566509687765    9.767e-02
-	   3        13.600663248993    1.681e-02
-	   4        13.604478924822    4.889e-03
-	   5        13.604928478027    7.473e-04
-	   6        13.604887977930    1.955e-04
-	   7        13.604903433505    3.878e-05
-	   8        13.604906647552    1.100e-05
-	   9        13.604906642028    2.592e-06
-	  10        13.604906705583    8.474e-07
-	  11        13.604906790915    1.986e-07
+	   0        10.852729522161
+	   1        12.772930091167    3.300e-01
+	   2        13.566509527675    9.767e-02
+	   3        13.600663087369    1.681e-02
+	   4        13.604478763042    4.889e-03
+	   5        13.604928316217    7.473e-04
+	   6        13.604887816120    1.955e-04
+	   7        13.604903271694    3.878e-05
+	   8        13.604906485741    1.100e-05
+	   9        13.604906480217    2.592e-06
+	  10        13.604906543772    8.474e-07
+	  11        13.604906629104    1.986e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.435e-08
 
 	Computing L_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.807222717179
-	   1         9.100811162161    4.648e-01
-	   2        10.625064102384    2.156e-01
-	   3        10.728212517018    7.486e-02
-	   4        10.791534360687    3.597e-02
-	   5        10.796584463246    8.641e-03
-	   6        10.796192652530    2.106e-03
-	   7        10.796362864020    6.665e-04
-	   8        10.796348371311    1.656e-04
-	   9        10.796349922803    6.546e-05
-	  10        10.796345396873    2.779e-05
-	  11        10.796347660818    7.734e-06
-	  12        10.796348885815    3.271e-06
-	  13        10.796349583385    1.071e-06
-	  14        10.796350149728    4.833e-07
-	  15        10.796350421065    1.929e-07
+	   0         6.807222691042
+	   1         9.100811124853    4.648e-01
+	   2        10.625064053888    2.156e-01
+	   3        10.728212466431    7.486e-02
+	   4        10.791534308288    3.597e-02
+	   5        10.796584410558    8.641e-03
+	   6        10.796192599837    2.106e-03
+	   7        10.796362811319    6.665e-04
+	   8        10.796348318611    1.656e-04
+	   9        10.796349870103    6.546e-05
+	  10        10.796345344173    2.779e-05
+	  11        10.796347608118    7.734e-06
+	  12        10.796348833115    3.271e-06
+	  13        10.796349530685    1.071e-06
+	  14        10.796350097027    4.833e-07
+	  15        10.796350368364    1.929e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 7.701e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.909505814402
-	   1        13.295810404024    3.489e-01
-	   2        14.208707654348    9.956e-02
-	   3        14.220830477806    1.236e-02
-	   4        14.223886240155    4.932e-03
-	   5        14.224193252004    5.134e-04
-	   6        14.224160762666    1.473e-04
-	   7        14.224165772152    3.090e-05
-	   8        14.224166218421    9.426e-06
-	   9        14.224165992728    2.291e-06
-	  10        14.224165927951    6.462e-07
-	  11        14.224165995978    1.197e-07
+	   0        10.909505695641
+	   1        13.295810252928    3.489e-01
+	   2        14.208707486698    9.956e-02
+	   3        14.220830309558    1.236e-02
+	   4        14.223886071774    4.932e-03
+	   5        14.224193083603    5.134e-04
+	   6        14.224160594266    1.473e-04
+	   7        14.224165603752    3.090e-05
+	   8        14.224166050020    9.426e-06
+	   9        14.224165824327    2.291e-06
+	  10        14.224165759551    6.462e-07
+	  11        14.224165827578    1.197e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 3.084e-08
 
 	Computing L_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.957245650592
-	   1         9.264997580904    4.736e-01
-	   2        10.852239014278    2.110e-01
-	   3        10.917504047663    4.735e-02
-	   4        10.943832616339    2.426e-02
-	   5        10.948855525776    9.575e-03
-	   6        10.948244454781    3.422e-03
-	   7        10.948591794333    8.406e-04
-	   8        10.948635071383    2.656e-04
-	   9        10.948619094901    9.644e-05
-	  10        10.948621166233    4.363e-05
-	  11        10.948623024014    1.303e-05
-	  12        10.948626889150    4.656e-06
-	  13        10.948627707602    1.594e-06
-	  14        10.948628103818    5.597e-07
-	  15        10.948628197401    2.243e-07
-	  16        10.948628277096    1.169e-07
+	   0         6.957245625341
+	   1         9.264997545107    4.736e-01
+	   2        10.852238966511    2.110e-01
+	   3        10.917503998345    4.735e-02
+	   4        10.943832566292    2.426e-02
+	   5        10.948855475501    9.575e-03
+	   6        10.948244404491    3.422e-03
+	   7        10.948591744033    8.406e-04
+	   8        10.948635021080    2.656e-04
+	   9        10.948619044600    9.644e-05
+	  10        10.948621115931    4.363e-05
+	  11        10.948622973712    1.303e-05
+	  12        10.948626838848    4.656e-06
+	  13        10.948627657300    1.594e-06
+	  14        10.948628053516    5.597e-07
+	  15        10.948628147099    2.243e-07
+	  16        10.948628226793    1.169e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 4.969e-08
 
 	Computing 1/2 <<Mu;L>>_(0.128) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008614927932901 -0.046442352400056  0.027924113420848 -0.003342105613042 -0.019198187280149 -0.043605993010684  0.000124507843934 -0.017903232775755 -0.064037761769677
-    1  (  1) -0.004023859954382  0.002812567241188 -0.015355365220565  0.063211982369858  0.033868800032563 -0.011581015700219 -0.004465574115878 -0.047030919129079 -0.048793907716228
-    2  (  2)  0.028525640721225  0.068120190051797 -0.016739332483522 -0.005073216914996  0.071940864110972 -0.066733646998345 -0.019605473406179 -0.001610556181541  0.004701378003057
-    3  (  3) -0.054155290592472 -0.054244334984755 -0.021962628004576 -0.018282485083091 -0.037028274309951  0.016786978556275  0.022024618578561  0.004302299401540 -0.167953274084101
-    4  (  4) -0.063182596929128 -0.128748808697011  0.121465113794596  0.160938411624414 -0.233917278334855  0.054052147786148  0.025334190025568  0.127021105025468 -0.261448831371970
-    5  (  5)  0.148864678539144  0.254187426901849 -0.169654893765005  0.284620623487219  0.104152411510991  0.359543809296571  0.133744009364038  0.041861549395911  0.169452799563311
-    6  (  6) -0.084956716693293  0.126613830958100 -0.017431389376921 -0.048281125785785  0.083267553859489 -0.206713853889007  0.428812335356187  0.005011018790693  0.061186511244325
-    7  (  7)  0.173630436499038  0.181276581467465 -0.440332497406727 -0.059456065314793  0.303618967332177  0.080016792150091 -0.104444652264320  0.251866044362601  0.089940979754426
-    8  (  8)  0.057697740265636  0.070180597319316 -0.383387445877903  0.514874723728167  0.465292274425094 -0.060917787458673  0.016262524997932  0.068972295825028 -0.265391565564862
-    9  (  9) -0.279247635392508  0.560707539445326  0.044547355247966  0.161505455840491 -0.002588377300620  0.219223272852673  0.096307931275233  0.176467158787115 -0.104344971075325
-   10  ( 10) -0.977075550189082  0.176418272338824  0.228294317792423 -0.099370607761785  0.027777959043915 -0.149348953174007  0.027413414685573 -0.102632226214496  0.005531527026329
-   11  ( 11) -0.211429004068205  0.082644794913083 -0.055680052865830  0.289018099852967 -0.067789578528906  0.064107786895450  0.141855082713117  0.071186757345684 -0.332576681432119
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071990946341156
-    1  (  1)  0.010142476746200
-    2  (  2) -0.112423878596356
-    3  (  3) -0.059253840833002
-    4  (  4) -0.014639189231197
-    5  (  5)  0.248038168374966
-    6  (  6) -0.055159646937661
-    7  (  7)  0.115432903674626
-    8  (  8) -0.135363224547124
-    9  (  9)  0.174678345310946
-   10  ( 10) -0.086140984938274
-   11  ( 11)  0.161723358519153
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.197572413114517 -0.541318632877371  0.139927415914873 -0.359578444130330 -0.398937843975486 -0.026586872167534 -0.139627977382516 -0.005896246491228 -0.003746644388905
-    1  (  1) -0.541058731973333 -2.034801242188507  0.920540457917585  1.016218584629480  0.729164689940962  0.054412526301737  0.235971924521468  0.315223615831553  0.096208087340554
-    2  (  2)  0.139828960639396  0.920734025049694  1.243601677781983 -0.974300649425054 -0.758553357750500  0.024609548649431  0.513266755137957 -0.116926330823923  0.094501440802452
-    3  (  3) -0.358970389612551  1.015833032444632 -0.974440229907822 -0.266348920037382 -0.133799224826450 -1.276907891719884  0.042984364188955 -0.410608972745146 -0.602345206758872
-    4  (  4) -0.398323035382104  0.727797072638099 -0.759857932028957 -0.133858878725855  0.575448485405805  0.056475665846990 -0.484493838094732 -1.583666059960473 -0.976878960945650
-    5  (  5) -0.027166282529876  0.055084907439528  0.024891154244808 -1.275543890392068  0.058746221115305  0.155399297624787 -0.236023461595880  0.812878944882876 -1.048535633945681
-    6  (  6) -0.139452284652001  0.236223353106611  0.513262677276795  0.042879631015553 -0.482819583744289 -0.235933155306163 -2.554180022039243  0.492117808091915  0.545404391969618
-    7  (  7) -0.005841417486080  0.316274368087248 -0.116163386132942 -0.410094172620351 -1.579571504351393  0.813774264702327  0.492423579055058 -1.700719634572147  0.685529426222534
-    8  (  8) -0.003628131523111  0.096035529406495  0.094131958822655 -0.602680558554738 -0.970206233042967 -1.045482011639248  0.544249830480973  0.683514460656999 -0.254958894521937
-    9  (  9)  0.326098978034070 -0.130935443755898 -0.379595166178810 -0.575990923913880 -0.393471965772156 -0.365686482354661 -1.227740649572571 -0.905826585766955  0.039987575439783
-   10  ( 10)  0.008103557010829 -0.039575543043785 -0.358664813530415  0.339232504235094  0.207222390004838  0.025784782686722 -0.874465143496950  0.752110557173402  0.140644707838520
-   11  ( 11)  0.161744201604777 -0.084371238126416 -0.371150000615002 -0.062082553987999 -0.264710244109502 -0.257261524594595 -0.444570825837596  0.002821912169167 -0.878431482758543
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.327854256723191  0.009019714201806  0.162710661594080
-    1  (  1) -0.133091859401188 -0.040697608916971 -0.085480013261477
-    2  (  2) -0.381849466582258 -0.359835698966555 -0.372555502654032
-    3  (  3) -0.579249329460985  0.337242930789026 -0.062083381101115
-    4  (  4) -0.396591932227294  0.208613968377681 -0.263534161447186
-    5  (  5) -0.365098796840620  0.027806203875135 -0.265146511184336
-    6  (  6) -1.230804866141472 -0.879767261427487 -0.448789926588722
-    7  (  7) -0.904635210810701  0.753869376128870 -0.007723762422951
-    8  (  8)  0.040323953888643  0.145561462630237 -0.894627985530935
-    9  (  9)  0.423095730032689 -0.296000598729972 -0.177730944535255
-   10  ( 10) -0.299463152132731  0.634536265412446 -0.073348108781663
-   11  ( 11) -0.175836972560684 -0.076105887981834  1.184769463941312
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.567008918440454  0.722443194224100  0.422402078329773  0.057554368538511 -0.068012024097596 -0.451975147608540  0.709419418128490 -0.110422168786063  0.095704108927647
-    1  (  1)  0.720885472964738  0.332527211352729  0.737390933664557  0.281750515995843  0.280761290393686 -0.598548871078422 -1.146750917560074 -0.177301134607867  0.234694928374046
-    2  (  2)  0.422183102929830  0.736485274543817  0.007829109729841 -0.365399185160488 -0.965501991519851  1.065090224342325 -0.394390877157068  0.239359282041345 -1.218182428400336
-    3  (  3)  0.059687201587689  0.280769829516347 -0.363255319277090 -0.833720445234328 -1.345952507284314 -0.189309823206009 -0.179890587463359  1.060334267261244  0.772514544005070
-    4  (  4) -0.069257393950461  0.281296543593726 -0.966923508415862 -1.344162403478837  1.514830798821686  0.013670590813123  0.227285042195308 -0.333966365834383  0.386248727994588
-    5  (  5) -0.449135841837750 -0.599397616398023  1.066820631137579 -0.189649110609729  0.013795397601274 -0.565008204089947  0.487292179201877  0.306200785308481  0.347063761059997
-    6  (  6)  0.708465668575064 -1.146562417015747 -0.391890894794961 -0.180811610825629  0.226633708337573  0.487729597603209 -2.767088081148377 -0.044613761228256 -0.000972346438746
-    7  (  7) -0.108981479701481 -0.177538422258191  0.240499334967173  1.059842333943978 -0.334391646412731  0.306249622802239 -0.044471110656761 -3.232660954268523  0.514839123397967
-    8  (  8)  0.094277588726801  0.235043460722862 -1.221823739304416  0.774952681271118  0.386077819008107  0.344858044218004 -0.000341133693178  0.514916107143190  0.507086715271392
-    9  (  9) -0.063381219775898  0.233965663654109 -0.093343357924906 -0.360354041999586 -1.006820146552738  1.344825106449130  0.268434803850821  0.315156353069794 -0.332938610236887
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.063808920787530
-    1  (  1)  0.235710820172182
-    2  (  2) -0.096202914418848
-    3  (  3) -0.360121798161892
-    4  (  4) -1.006476097602190
-    5  (  5)  1.343619008167611
-    6  (  6)  0.268106090274240
-    7  (  7)  0.315242334513133
-    8  (  8) -0.332481313383264
-    9  (  9) -0.175400025059932
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010284048494255 -0.022581971135931  0.025184528241746  0.002553505114185 -0.007866760216735 -0.035704112150886 -0.002766394497905 -0.015588851752449 -0.054894237910669
-    1  (  1)  0.001129370063260 -0.004341567056713 -0.012471737690510  0.068518821494219  0.037428649672491 -0.002857552975536 -0.002731409738209 -0.051935588474977 -0.049204102006071
-    2  (  2)  0.045340581598934  0.060774626672080 -0.014665202394902 -0.013163382447340  0.085552378847967 -0.055885373659009 -0.012884187954087 -0.000025912808653  0.007546289398551
-    3  (  3) -0.053518724373857 -0.051858316930917 -0.015829576226974  0.002308038466593 -0.033376912491914  0.026566608759227  0.020736863226261  0.017163432001033 -0.156611857939886
-    4  (  4) -0.057073647917578 -0.121620677730040  0.116559461318180  0.152459611673760 -0.224360677266659  0.063635487600126  0.025109630293686  0.123561544969923 -0.260705677431782
-    5  (  5)  0.132736043071323  0.228873275971275 -0.157588806451895  0.278203525609905  0.112411249713211  0.339424025956772  0.132778586915835  0.041442079822076  0.144607854949093
-    6  (  6) -0.099037108772820  0.133050971019321 -0.016390463092699 -0.047994853534082  0.082590754367535 -0.196599146843337  0.423704532236322  0.002588517799838  0.062442412924455
-    7  (  7)  0.164573996270568  0.174187584517111 -0.442718231735592 -0.055107629768529  0.292277213599590  0.090352016025029 -0.100915507153634  0.242008735185081  0.079009239652453
-    8  (  8)  0.059450407301305  0.065508844735816 -0.375580889101448  0.518979554864539  0.457917802055341 -0.070408637451188  0.013466768623613  0.072872586601375 -0.257559025462184
-    9  (  9) -0.246894722162695  0.551859769243373  0.044670824987361  0.162240888664295 -0.012774136938901  0.203595879781061  0.102036778576897  0.168067562706153 -0.111682944808914
-   10  ( 10) -0.913654455951997  0.155328532380750  0.215519674293101 -0.100970035089767  0.021969337557273 -0.148862369984030  0.046525143909590 -0.100083990349210  0.020780587060978
-   11  ( 11) -0.198781019683999  0.090074442467030 -0.050453210014304  0.292395282220077 -0.068054938936099  0.077531780115388  0.149511822875939  0.072921096134366 -0.357789764657410
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.062212803584986
-    1  (  1)  0.008222801612735
-    2  (  2) -0.107232253166961
-    3  (  3) -0.058083892735771
-    4  (  4) -0.001519088368734
-    5  (  5)  0.232883930798086
-    6  (  6) -0.056471183426688
-    7  (  7)  0.097796104480775
-    8  (  8) -0.126488666884472
-    9  (  9)  0.156849504238605
-   10  ( 10) -0.081446420280763
-   11  ( 11)  0.176341903152824
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007749096020893 -0.085883219860789 -0.036741821640513 -0.003365465554254 -0.013826624434967  0.045778129863205  0.040669337017936  0.010509742963645  0.029540605017242
-    1  (  1) -0.033323633544771  0.071013231293301  0.009381535649954  0.001865195819276 -0.004385218315905 -0.001145589403992 -0.107240463714063 -0.004928891794835 -0.020784313339082
-    2  (  2)  0.052107391808055  0.092519548352413  0.009858355445846  0.037319719751115 -0.023857034470632 -0.010135084101246  0.037769988668842 -0.015917832336735  0.090581268987334
-    3  (  3) -0.109820166860700  0.034268818868662  0.003318299125654 -0.047343590144125  0.049224764312370 -0.055554817528594  0.048303583350885 -0.021295778567536 -0.056731125392159
-    4  (  4) -0.007052162455570 -0.070092516335627 -0.001616209300804  0.100452686687340 -0.017125496300488  0.011804649620296  0.317168773449601 -0.015679790140276  0.134810835290821
-    5  (  5) -0.101789034987347  0.450242114045570  0.095257897029759  0.154575128248214 -0.107484330343030 -0.276349446627330 -0.224432437333530  0.138878619319231 -0.069374899620443
-    6  (  6)  0.129481070378189  0.190214182802185 -0.111482363704469 -0.289845791886638 -0.214082604248960  0.130539668518305  0.176627871859896  0.507792819613372 -0.145016045312478
-    7  (  7) -0.031015915682170  0.467808966358201  0.323231774623313  0.163051942437066 -0.027878152128557 -0.222130149400228  0.355582804042090 -0.345169178258104 -0.117503613032291
-    8  (  8) -0.081114418656010 -0.129458136695794  0.321266021811150 -0.116738859709862  0.112997348404402  0.150149613835924  0.100022037588641 -0.009859219508172 -0.185497355865147
-    9  (  9) -0.840897499603665 -0.103193956572518 -0.262141263376961 -0.179652800220136  0.091540284698060  0.263027818637292  0.232988427097700  0.132664590100508  0.080643129784317
-   10  ( 10)  0.396138270139100  0.527358178663247  0.115585436142149 -0.350404487392900  0.098592337861551  0.056041756240516 -0.132708614971811  0.130232826037073  0.024142145251939
-   11  ( 11)  0.048038049575401  0.184019168140566 -0.243899393243605  0.184449948512382  0.067903231499648 -0.173184976481832  0.074519873620110  0.122524072160336  0.175482839393722
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.029757291821339
-    1  (  1) -0.000721108481725
-    2  (  2)  0.081115665687732
-    3  (  3)  0.028764622397233
-    4  (  4) -0.020368316409772
-    5  (  5) -0.173632225317480
-    6  (  6) -0.281328230047800
-    7  (  7) -0.030401209370270
-    8  (  8)  0.093738850403327
-    9  (  9)  0.138017132925940
-   10  ( 10)  0.057334975405403
-   11  ( 11) -0.087072361680799
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.718905282963311 -0.301300066815098 -0.767801784865940  0.078512808825352 -0.203134864329395  0.241932163232250  0.058076631858574  0.196398858308336 -0.039008858124194
-    1  (  1) -0.301256490728193 -0.157440548180653 -0.036029555945222  0.243436823804201 -0.005929795652985  0.115486356935965  0.826228436942721 -0.465135369554618  0.058491264513800
-    2  (  2) -0.767289827428610 -0.036275730111077 -0.756926663794728  0.450133498634738  0.207784604973971 -0.828712724024022 -0.324647417359493 -0.353270502638369  0.092835605795882
-    3  (  3)  0.078579571414042  0.243310568002833  0.450095063336851 -0.208139431363607 -0.062202704649669  0.279001105370900 -0.076077558481815  0.262112030046533 -0.378810215172718
-    4  (  4) -0.202510304245595 -0.006692039856945  0.206011713498273 -0.062773519685661 -0.370731419489490 -0.256994084769574 -0.019543706164301  0.220490721787851  0.607096866069924
-    5  (  5)  0.239969372403163  0.117504635997786 -0.825053657412313  0.279484173569987 -0.255386254541418 -0.397595357673452 -0.135369610755389  0.236221247146237  0.269522215039686
-    6  (  6)  0.058390572588279  0.825859124407247 -0.324193078352693 -0.076854690390370 -0.019228317672495 -0.137735601227498 -0.351485727273275 -0.487761380462257 -0.103056409920122
-    7  (  7)  0.194458563409000 -0.463590717501173 -0.349817673328107  0.262678828099312  0.220495817360137  0.236701749060628 -0.486100377719484  0.043036203375607 -0.169360995578035
-    8  (  8) -0.038844766636175  0.058006360789407  0.092452034322386 -0.377838465048525  0.603441383275525  0.267460191997309 -0.103192305796676 -0.168696834715057 -0.618488124049516
-    9  (  9) -0.174642021637819  0.179686913958803  0.584519432729807 -0.531375857305351 -0.237827440080434  0.122408493834100 -0.350613084838644 -0.156778679126698 -0.027661506214973
-   10  ( 10)  0.043298420781037 -0.218837511618004 -0.611680553974653 -0.687832529301005 -0.249683832986975  0.553064660821027 -0.144105807777605  0.115245275900936 -0.084193131593124
-   11  ( 11)  0.061064657985430 -0.108300572115386 -0.188797311905296 -0.022208683609426 -0.827900622936499 -0.341922472618851  0.022718392329079  0.232401592689427  0.164619669402136
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.175684511601603  0.045513516298602  0.061672515006080
-    1  (  1)  0.179323083833167 -0.221567937419786 -0.109140577543022
-    2  (  2)  0.587827397093136 -0.616289532030193 -0.190305864672640
-    3  (  3) -0.534590179358002 -0.689583787093839 -0.022209033963942
-    4  (  4) -0.239000891867221 -0.249187499059157 -0.832603923332527
-    5  (  5)  0.122010791877518  0.553620901013401 -0.348332351708050
-    6  (  6) -0.352732495297565 -0.145056644635348  0.023781601660354
-    7  (  7) -0.157242165562723  0.112854519200918  0.232190589319976
-    8  (  8) -0.027709907045481 -0.086030263039170  0.172274707819854
-    9  (  9)  0.207109600584589  0.096837430686223 -0.023218950236813
-   10  ( 10)  0.100164655230671  0.138181178066476 -0.148224446144570
-   11  ( 11) -0.022320179734203 -0.148849259998097  0.901205762410303
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.179939828491769 -0.273263983919761 -0.077241939802207 -0.131310571537764 -0.452108955794121 -0.373710053222736  0.012756857043078  0.188686131296855 -0.281717657996437
-    1  (  1) -0.271865636595074  0.080204205184229  0.237736668579935  0.053954037181141  0.088144371186311  0.094298665169508 -0.396703489007358 -0.164374392009126 -0.012743809563993
-    2  (  2) -0.076549157175288  0.237611423410488 -0.235916884249811  0.330279805489172  0.156363656188217 -0.135525945480897  0.113532621668593 -0.192996543934043  0.505097349395040
-    3  (  3) -0.133008481204441  0.051978470711429  0.330705317892875 -0.689079279022158  0.681025162416434  0.230126506813665  0.220012049909173 -0.221793013382862 -0.415574431905058
-    4  (  4) -0.450299145657576  0.087908600365275  0.156309970041408  0.681002122520780 -1.360248251424318  0.202273753159192 -0.167570810051337  0.246051223487190  0.206738411458247
-    5  (  5) -0.373567193155845  0.094555329734040 -0.136731584498100  0.229377893488984  0.202581599883435 -0.322498154757568 -0.226671631570763  0.408374954790996  0.307423751717641
-    6  (  6)  0.013230492577454 -0.395220303624150  0.113830041131736  0.218897296842682 -0.167381205612527 -0.226319762003687 -0.422981172464967 -0.882122931150610  0.208582936748456
-    7  (  7)  0.187587553988559 -0.164973338711578 -0.192266029819867 -0.222193739599766  0.245811643454060  0.408813624326959 -0.882511768104148 -0.161881530949274 -0.197931622292553
-    8  (  8) -0.280045996340605 -0.013187886145669  0.507423753200987 -0.417462155137855  0.206022606034107  0.308302993473083  0.207495521066743 -0.198012373935716 -0.598880759668382
-    9  (  9) -0.299128216307527  0.222289305708678 -0.374826664894612 -0.022250761597490  0.198104512558476 -0.291885255576850  0.011569749529353 -0.150670269953426  0.186378706038956
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301492091129213
-    1  (  1)  0.222023461274417
-    2  (  2) -0.373275862159688
-    3  (  3) -0.022769731837422
-    4  (  4)  0.197531018509810
-    5  (  5) -0.291038388606400
-    6  (  6)  0.011766677818707
-    7  (  7) -0.150956367275849
-    8  (  8)  0.186282415361357
-    9  (  9) -0.408641391244209
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006541040222368 -0.029135588169222 -0.017330822595744  0.002628911660037 -0.012344009141809  0.034496132624923  0.021629830242309  0.010441885402291  0.025478364815458
-    1  (  1) -0.038275138470075  0.054424566886903  0.005683589031010  0.001642391288003 -0.005493648653247  0.001124544236485 -0.102028934451313 -0.004961744404475 -0.019198498257850
-    2  (  2)  0.053024456913342  0.083754722151204  0.014366999014575  0.045684709272444 -0.045425854355333 -0.015659092798954  0.035306515857362 -0.013688960188417  0.082596341754868
-    3  (  3) -0.125696090540634  0.031717757592640 -0.000802365038104 -0.050871771309593  0.061705711345850 -0.045742890419344  0.045450419445688 -0.021064845035616 -0.054716959844684
-    4  (  4) -0.016613018731749 -0.059371668786672 -0.003754167403423  0.095982620955076 -0.007240466240122  0.008043456529988  0.296808016923276 -0.015369394286441  0.136610478911713
-    5  (  5) -0.093091489377706  0.398657588863068  0.074430182364354  0.149030211928108 -0.108745535372234 -0.256250392240536 -0.205814737045222  0.134201000957220 -0.055103512993348
-    6  (  6)  0.103501697780443  0.185147067962843 -0.104829304475355 -0.273669393328239 -0.199802423052909  0.136710211986565  0.166053639619828  0.483268157942075 -0.135434527757446
-    7  (  7) -0.041456689404135  0.416662529525886  0.296499443846860  0.151835770270295 -0.027648961071683 -0.196853254585748  0.346148931870815 -0.324194030503122 -0.108656389838073
-    8  (  8) -0.069099920157317 -0.122455303618133  0.312946042218845 -0.115185983609626  0.104240832235501  0.145175805702234  0.095088539986730 -0.010672631592564 -0.187147060865154
-    9  (  9) -0.712671855893174 -0.096350152389786 -0.234711067777686 -0.171596024164591  0.065322769896798  0.213466874289907  0.226529390715592  0.118201066093080  0.055528795004367
-   10  ( 10)  0.365512212430565  0.443597144956858  0.088760713787529 -0.336294489487780  0.089380999156301  0.050585935158758 -0.112358935032342  0.122526344346197  0.011836823928278
-   11  ( 11)  0.046393846223224  0.165011629057398 -0.228781961279396  0.178941949643574  0.063752947031584 -0.164789871590981  0.073726138142668  0.117333811839271  0.181371275992210
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.026880621041360
-    1  (  1) -0.000642066544117
-    2  (  2)  0.075046583216661
-    3  (  3)  0.030887223304929
-    4  (  4) -0.027083357083367
-    5  (  5) -0.161323349919549
-    6  (  6) -0.260652499025702
-    7  (  7) -0.019658118713907
-    8  (  8)  0.093794795124770
-    9  (  9)  0.110456626093643
-   10  ( 10)  0.048798146100140
-   11  ( 11) -0.097571556382824
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001432746297450 -0.032810674091764 -0.033331937480253  0.023032547083763 -0.002808019310921 -0.039246266926320  0.018692018505171  0.008842597191367 -0.029091078569617
-    1  (  1) -0.008821922403183 -0.001742272088788  0.082771016704519 -0.022297486221974  0.039163604166239 -0.010818853488427 -0.047294425339584  0.013135326021221  0.049034393857867
-    2  (  2)  0.024274942916815  0.027096978669207  0.097516386902391 -0.041392368694666 -0.004119390757880  0.075691552303805 -0.023677742397495 -0.003953261558318 -0.122163189427397
-    3  (  3) -0.047038460283817 -0.039422636027069  0.017791086341758  0.115660160117630 -0.067224158887899  0.095036576800958  0.032022129167533  0.022732157345389  0.120912741709036
-    4  (  4) -0.041035802352368  0.001934742020068 -0.201409668003493 -0.406246991276172  0.228435905047063 -0.366034413601436  0.036563318346743 -0.036692328708082 -0.082010843429842
-    5  (  5)  0.098338733570095  0.243746073973362  0.282884501181602 -0.425804208023662  0.108408993563040  0.505586602390370  0.102717653176241 -0.183779423720787  0.023433267817945
-    6  (  6)  0.135336854760563 -0.062874421564495  0.076338309095403 -0.023002937162434 -0.130902824611473 -0.185164583438217  0.398907643233867  0.217551510448046 -0.032105677017803
-    7  (  7) -0.035062191357078 -0.113858796831119  0.431604299875852 -0.029482805357536 -0.029652466640804 -0.242847719350325 -0.077765311277989  0.367073496056810  0.139022006906444
-    8  (  8) -0.068272847454715  0.294672021175633 -0.568959581650588 -0.125921031197012 -0.707592810771387  0.017806583156209 -0.015845746565047 -0.212947645825718  0.125196335187716
-    9  (  9) -0.288858276698774  0.093713692739213  0.209035012311688  0.075382622510660  0.083405488851542  0.016184965058288  0.000548295704545  0.266294088315547  0.380874642506837
-   10  ( 10) -0.378738518488000  0.204837316203508 -0.069415360994347  0.062065163074324  0.029622876137723 -0.058750752587050 -0.120574645247794  0.008130897374692  0.009265965929469
-   11  ( 11) -0.080018520143771  0.225808316863723 -0.312311376663230 -0.316597637367698  0.125757542829493 -0.146130016020174  0.016179298260010 -0.136308703902615 -0.120756904157899
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.036093305578397
-    1  (  1) -0.001707679185378
-    2  (  2)  0.005295607540268
-    3  (  3) -0.304573937377439
-    4  (  4) -0.014287077020118
-    5  (  5) -0.068885443054321
-    6  (  6)  0.111979958895137
-    7  (  7)  0.321243115116497
-    8  (  8)  0.158205355334404
-    9  (  9) -0.080091690471286
-   10  ( 10) -0.065074315967804
-   11  ( 11)  0.075517488980888
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.151581395944457 -0.159877768539019 -0.191397517423370 -0.495232284867177  0.365561840480614  0.240680277087037 -0.079714342464060 -0.017889526464511  0.054577038131019
-    1  (  1) -0.159795957250344 -0.047735218799445 -0.125025973520529 -0.592230248738643  0.329204795623399 -0.563899565056737  0.474518384859258  0.371816427010336 -0.204007450193307
-    2  (  2) -0.191333337555164 -0.125299228178318  0.032743525999057 -0.248173196102997  0.424015573762028  0.373304795371779 -0.124367805075759 -0.383343230710404 -0.176623528718579
-    3  (  3) -0.494849488362154 -0.592714843248357 -0.248959287226432 -0.423717062956694  0.236470791317215 -0.415768039926139 -0.007927078894393 -0.295339114007336  1.138817517977087
-    4  (  4)  0.365842786381904  0.329912791129377  0.425309312530905  0.236284335454773 -0.297797609245548  0.287162197148014 -0.015195390583447  0.149575460395682 -0.352881082019632
-    5  (  5)  0.239666720470004 -0.562521840762128  0.375748994888085 -0.414021321385147  0.283842862620087  0.299376587010529 -0.122721640145877 -0.329969308300871  0.156494792176823
-    6  (  6) -0.079132044596257  0.473605179791134 -0.125255855635513 -0.008774504854422 -0.015965010341322 -0.123144104694353 -0.040262615853229  0.053291869268360 -0.230047243580867
-    7  (  7) -0.018210362041773  0.371975596266125 -0.382949144540519 -0.295062546320220  0.147969605902060 -0.330844143538271  0.053247875304319  0.437054225002062 -0.295575334707162
-    8  (  8)  0.054384972764257 -0.203042333758326 -0.176317356102570  1.137981680675850 -0.349930528471567  0.158219435758802 -0.229361079354617 -0.295174183029699 -0.201170965133917
-    9  (  9)  0.162593186917498 -0.096068090323904 -0.131721885594255 -0.537260876669133  0.048165192812382 -0.386108653062500  0.083321052788424  0.067822247358744  0.259623842469249
-   10  ( 10)  0.093086276325347 -0.110390627511003 -0.528311347000350  0.014888006239538 -0.100997055269664  0.192126958830561  0.038787614394956  0.063975054988451  0.077127488930246
-   11  ( 11) -0.248608674285678  0.166558436146830  0.438779225583925  0.334557445644043 -0.324782623645273  0.179928478753780  0.012126762707773  0.006418605871888 -0.316369462085207
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.163245257155421  0.094276717552644 -0.249582936616881
-    1  (  1) -0.097089753942058 -0.112180528774260  0.167323530234027
-    2  (  2) -0.131901378869784 -0.530116652654623  0.440616284282449
-    3  (  3) -0.539218683643804  0.014310072965047  0.335266942696954
-    4  (  4)  0.048635984706568 -0.103433325040069 -0.331331261588337
-    5  (  5) -0.385516013729792  0.187104305011894  0.193398800890046
-    6  (  6)  0.082991815026247  0.037352860323020  0.011014682786961
-    7  (  7)  0.067841455828072  0.062642922337485  0.014204699225385
-    8  (  8)  0.258473930207162  0.077886035701004 -0.325054438919389
-    9  (  9)  0.001773142889432 -0.053105768300802  0.034600115019000
-   10  ( 10) -0.053689547832438 -0.018246255837546 -0.196162567936867
-   11  ( 11)  0.031756575503292 -0.193298510202671  0.164652237069869
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.236069150423928  0.221583137218639  0.087467481976269 -0.023767225350154 -0.157884977853517 -0.128673956390029 -0.176595879969474  0.001131012317203 -0.181143452404233
-    1  (  1)  0.220430431059073  0.112052435313968  0.015869249151473  0.264485428778921 -0.165982030219470  0.159260926468858 -0.018854654828287 -0.249502649443057  0.052130725228418
-    2  (  2)  0.087694752982164  0.015013031218300 -0.683310722703039 -0.454889777527338  0.270539149606414 -0.876133156261866  0.064372104092668  0.069959767509230 -0.359585122327188
-    3  (  3) -0.022349867884997  0.265917774305981 -0.459885376820098  0.156118351029157 -0.442698949429053 -0.633164352365545 -0.123599096035318 -0.000681276488754  0.329408685832541
-    4  (  4) -0.157925484616889 -0.166044552973515  0.271218387113143 -0.443885849212600 -0.013362398764761 -0.176284165832649 -0.004716950323026  0.078109759941717 -0.609000288591445
-    5  (  5) -0.127616278770967  0.158011849801079 -0.876037618276795 -0.629854882079848 -0.177186230678137  0.012211398531521  0.059425698366986 -0.774979266274861 -0.486618182967767
-    6  (  6) -0.178241606252947 -0.017090192450387  0.064522373941146 -0.124240074207901 -0.004293285267873  0.059087683211698 -0.104000927528902 -0.330829052901522 -0.038045687603335
-    7  (  7)  0.002208432976113 -0.248689840257510  0.068573896371648  0.000014323070255  0.078530114044465 -0.775881123063332 -0.330687300606162  0.375687386105441  0.140607455827148
-    8  (  8) -0.178615853440425  0.052090468900394 -0.360562489485138  0.330978975217506 -0.607342070790934 -0.487347100955227 -0.037705399031252  0.140808054960246 -0.394251292282697
-    9  (  9) -0.046812023124734 -0.356025366669854  0.690811815119252  0.312933605279832  0.666333150435849  0.222468929331266  0.069111321865738  0.559435147572457  0.132671563084754
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045842278134109
-    1  (  1) -0.355929482932053
-    2  (  2)  0.690401613030498
-    3  (  3)  0.314450068453419
-    4  (  4)  0.667992312261241
-    5  (  5)  0.221641972273241
-    6  (  6)  0.069286377187356
-    7  (  7)  0.560338391968248
-    8  (  8)  0.132249466359632
-    9  (  9) -0.305201514350595
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003531322887475 -0.011853964282953 -0.013997173425702  0.018382792154192  0.000899996441170 -0.027829789222902  0.010946278656521  0.009416135608630 -0.023987807904262
-    1  (  1) -0.006388621957170 -0.005171201061298  0.075116414644925 -0.012351518893597  0.041297277094542 -0.006441657661851 -0.042094675941536  0.014500044658877  0.045272474380981
-    2  (  2)  0.036883171135873  0.025743377437805  0.085964964522995 -0.036572128405842  0.000741779132517  0.071901849285639 -0.017612259522947 -0.002857549793791 -0.114428225581804
-    3  (  3) -0.050379148878904 -0.038280516537017  0.018275237269774  0.118578575241743 -0.057964689431887  0.100743381549064  0.031817975653707  0.026538904209037  0.119963525599056
-    4  (  4) -0.040259568572502  0.011229705198348 -0.188809172609568 -0.380757486353216  0.215445879830049 -0.344569392827444  0.033187603168238 -0.033507608911701 -0.079582925346094
-    5  (  5)  0.087141198545524  0.216785041786672  0.270610048744647 -0.398997177058604  0.102170025016676  0.478625848854116  0.098949415070036 -0.170373600936987  0.015652914812384
-    6  (  6)  0.115394650619668 -0.055172374414511  0.068645251662214 -0.021005537436634 -0.120222938768552 -0.172201054646963  0.377862520931175  0.205771786365183 -0.028486300590321
-    7  (  7) -0.040171141537119 -0.121048023653740  0.403132598347777 -0.027760474590503 -0.026374510769541 -0.228317794220799 -0.070878790612320  0.346601006753617  0.129893637962627
-    8  (  8) -0.063034884678852  0.280866798080653 -0.540496031356204 -0.119391576371009 -0.673073389093966  0.010663808807394 -0.016147690801371 -0.200745867995305  0.117394935881043
-    9  (  9) -0.239823863619059  0.087614347419962  0.205995256328994  0.074059708937832  0.068748575207548 -0.000454096504958  0.003028317523563  0.249475422318809  0.352711368821821
-   10  ( 10) -0.336588165834448  0.173514331887659 -0.070029614207528  0.058791676167547  0.024501304819872 -0.052124336325614 -0.104213155529188  0.008639636736157  0.013496509549194
-   11  ( 11) -0.070036515714458  0.195530601320237 -0.305644951639726 -0.322831866596268  0.121530762471617 -0.141977993846978  0.021998928318675 -0.134440837975978 -0.127122644721006
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.030353030422789
-    1  (  1) -0.003358262791905
-    2  (  2)  0.006176160600104
-    3  (  3) -0.295046081788652
-    4  (  4) -0.003816440522472
-    5  (  5) -0.074325961201587
-    6  (  6)  0.109014636987132
-    7  (  7)  0.303731536940852
-    8  (  8)  0.152250258689580
-    9  (  9) -0.089511140585649
-   10  ( 10) -0.060789805292351
-   11  ( 11)  0.082293619260989
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.057770723551805 -0.007686176362995  0.037676874102239 -0.021875314889184  0.005506967440553  0.033731453254856 -0.019605915987929 -0.000153810358456 -0.020480209762043
-    1  (  1)  0.007936092328855 -0.008454757012618 -0.010966637507272  0.001712970012603  0.003491085971866 -0.000515536715359 -0.020166951580993  0.003537118918414  0.007401819292438
-    2  (  2)  0.004823273660701  0.024918096949402  0.013456316532648 -0.018061040723257 -0.007928867774181  0.029348077247204  0.008305651855965 -0.003787093111853 -0.048173394734837
-    3  (  3)  0.011675775125104 -0.107663431050362 -0.048399528007616  0.036525102270435 -0.040730641356466  0.022154401905676  0.022459222262206  0.014732815012435  0.056193647103106
-    4  (  4) -0.087218313447135  0.162702625594382  0.040016358931151 -0.090893257640902  0.161526551014906 -0.070532962320029 -0.041494660476799 -0.036307465283525 -0.053954994619678
-    5  (  5)  0.299080380154522  0.047071149143854  0.050599107356677 -0.086076035660096  0.105747613370625 -0.016291716828988 -0.035370479977499 -0.024570880182810 -0.019740472062472
-    6  (  6) -0.064660820062842 -0.041897488689090  0.115036198620178 -0.009494466980017 -0.021741244197439 -0.082050622741463  0.041036304002792  0.093842813724870  0.099009311380003
-    7  (  7)  0.041406109005398  0.013292096025031 -0.015299070066933  0.090658889471223 -0.096664535474361 -0.020138730803122  0.181635797654581  0.008096043748855  0.043219320460348
-    8  (  8) -0.213166983290885 -0.019961961605909 -0.071163032757987  0.089566388255459 -0.187567657300030  0.059322694628756 -0.181371262434162  0.031805535782928  0.037438192749058
-    9  (  9)  0.029081682004423 -0.052377114086944  0.016598919354525 -0.054121123864817  0.005943121322964 -0.052845962329270  0.099913404453613  0.011257505074012 -0.046946017590445
-   10  ( 10)  0.029775807936917  0.011144658296549 -0.123616713069900  0.069048925266029 -0.072425392135727 -0.175724644218768 -0.020473761865880  0.027329304597195 -0.030635509122054
-   11  ( 11) -0.065686621670288 -0.046175058814983 -0.054739230530016 -0.067089838730126  0.085213076503212 -0.033327993779702 -0.039100303871838 -0.006432393458887 -0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007846989553355
-    1  (  1)  0.003599492488651
-    2  (  2)  0.050462951485827
-    3  (  3) -0.025590884562196
-    4  (  4) -0.058023095683205
-    5  (  5) -0.032774222915836
-    6  (  6)  0.063967275967677
-    7  (  7)  0.008682341559207
-    8  (  8)  0.054096899442108
-    9  (  9)  0.060114344610370
-   10  ( 10)  0.027778486812577
-   11  ( 11) -0.026791075407401
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000027040423887  0.011060683872803  0.004793456647899  0.073481718860181 -0.071504628495016 -0.043329380984548  0.025554578097106  0.020981780177699 -0.009741644195740
-    1  (  1) -0.011009750762997 -0.000007607240151  0.023558132508086 -0.077101510719000  0.072464798814331  0.012890143420536 -0.005683277430906 -0.006920173400283  0.002574145843753
-    2  (  2) -0.004842956248702 -0.023538681455719  0.000165226839542 -0.207870652255993  0.210753100259611  0.104860036207310 -0.066732822825146 -0.046426833468215 -0.005606364639263
-    3  (  3) -0.072846425542822  0.076633967419021  0.207131819599136 -0.000363002499158 -0.003747206858118 -0.078444561827851 -0.135702906183535  0.013002670417717  0.066080178603036
-    4  (  4)  0.070600283658190 -0.071629978927021 -0.209426851727876  0.004131403945752  0.000622007773293  0.030404083775686  0.072573499649568 -0.005804369418180  0.017256603820917
-    5  (  5)  0.042938103533211 -0.012767138266668 -0.104089521411634  0.078509088982138 -0.031589837534126 -0.000702189622727 -0.234416668036359 -0.006073164073880 -0.085676616502380
-    6  (  6) -0.025301081140471  0.005670371975564  0.066621493148361  0.135369815380962 -0.072186642283625  0.233429156027521  0.000193153533248 -0.257186865053465  0.080618496507255
-    7  (  7) -0.020822354558258  0.006724508724119  0.045993762455479 -0.012965367547761  0.005443358605263  0.006173477804865  0.257050229473736  0.000107746294773 -0.140355654948263
-    8  (  8)  0.009433315806276 -0.002386871891496  0.004905034102302 -0.065444732417879 -0.016877777772437  0.086229493149666 -0.079936884810997  0.140925849197376 -0.000032973152365
-    9  (  9)  0.050122316171813 -0.043792237275169 -0.089139695085719 -0.017498120874682 -0.031599257819379 -0.003933044438540 -0.023956851013655  0.023591093022906  0.231355322027963
-   10  ( 10)  0.021733936110572 -0.028861084661254 -0.012680330783905 -0.120427356784394  0.061995107162282  0.110107780731446  0.044522956915282  0.044154909833586  0.092344585382497
-   11  ( 11) -0.054009861310889  0.049060128861341  0.116101359422429  0.043743279836749  0.090347856826429 -0.186254068915307  0.010091097621831 -0.182439821622372  0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.050351452990167 -0.022080091821478  0.055614920128739
-    1  (  1)  0.043523152379598  0.028913570586242 -0.049281187081852
-    2  (  2)  0.088800989050704  0.012387284429283 -0.115844546053497
-    3  (  3)  0.017174780224652  0.120766108673226 -0.043936127494914
-    4  (  4)  0.030870076304731 -0.062251132422338 -0.090680792727787
-    5  (  5)  0.006295822004517 -0.109602420736026  0.187179028172583
-    6  (  6)  0.023342165877015 -0.045357751936196 -0.008109043414047
-    7  (  7) -0.023116687534610 -0.043892116907456  0.180954962224114
-    8  (  8) -0.233341712412303 -0.091442003006516 -0.004136900096905
-    9  (  9)  0.000301754743843  0.311200434843549 -0.071746006250031
-   10  ( 10) -0.310579381122594  0.001146128096000  0.337175845358798
-   11  ( 11)  0.071759110731455 -0.341710402101474 -0.000514995746851
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000373475564698  0.036374284715410 -0.020675408038120 -0.041938611278043  0.014954064130636 -0.008670693741941 -0.001941666498966  0.002175213653671 -0.081223953533966
-    1  (  1) -0.035409311090430 -0.000583412494499  0.021912114995751  0.019686191919175  0.001337756516393 -0.101410043872272 -0.013539530463413 -0.021085032009130 -0.104140442794578
-    2  (  2)  0.022476650279619 -0.020869170321065  0.000623148668542  0.026925059222749 -0.022600045203783 -0.054500059821995 -0.019747085432266 -0.002197258536137 -0.059803959084815
-    3  (  3)  0.040527884961938 -0.020785023904239 -0.026269813130118 -0.000471315833621  0.011435927824319  0.005094359128676  0.021078069661848 -0.001900689912103  0.049285996887456
-    4  (  4) -0.014876995236008 -0.001935832477363  0.021280417512247 -0.011112950356736  0.000010954074914 -0.001375736589678 -0.021071346294591  0.002540388393255 -0.057176443725449
-    5  (  5)  0.009413911140341  0.101590521816804  0.054440250203052 -0.004479146413684  0.000983185589705  0.000044886603863  0.008942266041566 -0.007734744988056 -0.012623227871857
-    6  (  6)  0.001228199632690  0.013460754514196  0.019370737847276 -0.021147815413154  0.021180440912387 -0.009078596190780 -0.000060187992369  0.021757615671251  0.021546696625458
-    7  (  7) -0.002386621109668  0.020697715049428  0.002142304032572  0.001889845237358 -0.002502377714011  0.007891184567460 -0.021671667697211  0.000014467640044  0.019485620614445
-    8  (  8)  0.082726042327291  0.104120679625015  0.059410287861643 -0.049170685661379  0.057558349352742  0.011952514103015 -0.021313492463386 -0.019559674827960 -0.000280085719614
-    9  (  9) -0.081272328726009  0.110754135563007  0.028218762900775  0.005318083145326 -0.020981856638396 -0.014567561104212 -0.097856532501808 -0.003185861516469 -0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.080531031337273
-    1  (  1) -0.111220099551316
-    2  (  2) -0.028332370195928
-    3  (  3) -0.005372945270244
-    4  (  4)  0.020768901638641
-    5  (  5)  0.014982546342664
-    6  (  6)  0.097582479807565
-    7  (  7)  0.003277826561639
-    8  (  8)  0.003260780284830
-    9  (  9)  0.000186812021876
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055078142867828  0.005804719299681 -0.036780646353647  0.020745008939831 -0.005631321838333 -0.032388434299089  0.019554696167851  0.000026315290494  0.020764618651157
-    1  (  1) -0.007062764870854  0.009531925050962  0.009339128991500 -0.000585332198702 -0.003536715157378 -0.000717716084393  0.020997702694190 -0.003197609406412 -0.007543205569196
-    2  (  2) -0.003273721829615 -0.024127785783056 -0.019803917766004  0.021792459075320  0.009225997435944 -0.033280936086821 -0.008357612389432  0.004534634518823  0.049752671423908
-    3  (  3) -0.009467819748219  0.109846311430058  0.049077069582499 -0.038067479834844  0.041344367688361 -0.023164856965512 -0.023494777837550 -0.015492414054440 -0.057415728354703
-    4  (  4)  0.087998530211411 -0.166680738017738 -0.040492236619192  0.094854089537164 -0.166732509395464  0.071703004448668  0.042087550249065  0.037122017300705  0.054342710801435
-    5  (  5) -0.299229806278301 -0.048658757713325 -0.047129705842446  0.086908947365866 -0.109728878663932  0.016789363568018  0.035383410684614  0.025335321764417  0.020816334753998
-    6  (  6)  0.066809370303780  0.045194542515417 -0.116536125053039  0.010429907504714  0.024187359392906  0.082665971873618 -0.044425337546003 -0.096427706292236 -0.099634759729367
-    7  (  7) -0.040692585686945 -0.010414403444448  0.019197392244389 -0.094603783326762  0.099044517012418  0.021567521501408 -0.184530946067710 -0.010140666068000 -0.044429992698867
-    8  (  8)  0.213871489773344  0.016533777636027  0.072796199007045 -0.091991735348903  0.195396773842710 -0.059284334625803  0.184339397290396 -0.031894612373968 -0.038856272349111
-    9  (  9) -0.030682243044227  0.041775517875249 -0.024602057980135  0.057287290343526 -0.006772740334119  0.055735826221076 -0.097648839100779 -0.011580457295414  0.048271645082472
-   10  ( 10) -0.033182564179255 -0.014791814568441  0.134627953730393 -0.074303509883212  0.072048570540947  0.178297714606306  0.018972497943516 -0.029382172234938  0.026191954922422
-   11  ( 11)  0.065304385216644  0.054065687922946  0.058978656197155  0.069527138693935 -0.087278294466894  0.031923025189413  0.037244505404452  0.006712268565440  0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007990021156235
-    1  (  1) -0.003543862611170
-    2  (  2) -0.051263654644270
-    3  (  3)  0.026303130686066
-    4  (  4)  0.059400171065937
-    5  (  5)  0.033889468632128
-    6  (  6) -0.063573026890197
-    7  (  7) -0.010425863419296
-    8  (  8) -0.056178737365981
-    9  (  9) -0.060112542127891
-   10  ( 10) -0.033303474011037
-   11  ( 11)  0.026602109435667
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.023607177491195 -0.019696611969885 -0.037221212000385  0.015590319696057 -0.002020189842990 -0.021016653547429  0.007873916136755 -0.003448340610807 -0.079821954504390
-    1  (  1)  0.007327805297828  0.018867534486269 -0.042212469078496  0.001447360534353 -0.028939866752754  0.077938653083341  0.061948383376365 -0.004945505795557 -0.075894556663474
-    2  (  2)  0.009007071740861  0.016177005802987  0.068312932673240 -0.041184857036759 -0.003023256838844  0.009849571097863 -0.004290386808972 -0.004340519661127 -0.085840789796801
-    3  (  3) -0.026077185963910 -0.012520558385893 -0.023360353465929  0.029787599349062 -0.027312833784239 -0.081100062029021 -0.033406666012159  0.054430078300136  0.042036783131155
-    4  (  4) -0.044521029970710 -0.101548028530885 -0.092152577419686  0.036969661342643  0.235975964790827  0.022489800485005  0.018037809327809 -0.163273258200919 -0.255997686637622
-    5  (  5)  0.075082806179399 -0.059495559215694  0.178951166772656 -0.134634824114366  0.237022622504406 -0.054772185517501 -0.024504277147484  0.150049663229407 -0.003365655895118
-    6  (  6)  0.075564373604390 -0.030719217759732 -0.086498148733354  0.160325933966896 -0.064234285643905  0.161900908445555 -0.266146706738358 -0.238096934941697 -0.054011663901563
-    7  (  7)  0.117049393955643  0.184359827232724 -0.154835473828309  0.196676571259727 -0.209716028817009  0.429620861048445  0.096138950091600 -0.371356959007903 -0.058084061024513
-    8  (  8)  0.116322044765828 -0.134673176933366  0.115490121530453  0.372419146214479 -0.134366059259054 -0.090977060566167  0.047847126119104  0.349531731511066 -0.026343643532612
-    9  (  9) -0.016166361653787  0.064655468388956 -0.096603309196917  0.102141195994536  0.004689543577322  0.174053614560893 -0.096535422651742 -0.179574162178272  0.093140031286430
-   10  ( 10) -0.038118657992317  0.011712936317703  0.109233641260348 -0.041948680427994 -0.067033240911419 -0.043789144467457 -0.119198984082488 -0.019961916251994 -0.046236232124822
-   11  ( 11) -0.202537936665755 -0.041865413038804  0.001109842658197  0.036047997932446  0.209039172907281  0.039634162843452 -0.042796449278664  0.037154632643052 -0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001464671751436
-    1  (  1) -0.092168971837118
-    2  (  2)  0.096834154775615
-    3  (  3)  0.085232004143247
-    4  (  4) -0.224276823308218
-    5  (  5)  0.037070717977035
-    6  (  6)  0.017788678150516
-    7  (  7) -0.125655013910958
-    8  (  8)  0.036753750028807
-    9  (  9) -0.104788947042948
-   10  ( 10)  0.055723652563089
-   11  ( 11) -0.029086171780033
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000103943053471 -0.020502980666838 -0.044487026908476 -0.112522389921676  0.115190927698806  0.086304427533430 -0.028732798000328 -0.005755262072674  0.052707374815472
-    1  (  1)  0.020396732597728 -0.000175507711089  0.066631576709106  0.188566511167110 -0.188604507023904  0.081802717690830 -0.123212599282903 -0.146580404278728  0.063843813395139
-    2  (  2)  0.044224363892114 -0.066688325942716  0.000328779542201 -0.131627364199491  0.085838688001563 -0.039792906367986  0.071990397116460  0.041811204620793 -0.129151440044184
-    3  (  3)  0.112356491847955 -0.188595812422395  0.131743983691740 -0.000034238258909 -0.146405835083834 -0.293116155503685  0.174354593749844  0.234740190959724 -0.068400431241803
-    4  (  4) -0.114478156906703  0.187880772610577 -0.086711640119064  0.146345707242046  0.000351413466984 -0.200401380550659  0.118118144680811  0.106599388398520 -0.027535193682288
-    5  (  5) -0.086013769068620 -0.081687368012874  0.039811317138268  0.293720012918757  0.199751621453618 -0.000779002249077  0.029574633012291  0.100809576430270 -0.310087999943630
-    6  (  6)  0.028593362634754  0.122990647052479 -0.071886866993686 -0.174357265134888 -0.118164594946332 -0.029455932226559 -0.000323502179386 -0.067588972736558 -0.054838186724730
-    7  (  7)  0.005405231783831  0.146637005514722 -0.041701223809144 -0.234444344892692 -0.106310138998589 -0.100760684833959  0.067340032280388 -0.000050446895501 -0.206356025427645
-    8  (  8) -0.052734404217526 -0.064663294136106  0.127867798766573  0.067686878519552  0.027452578317565  0.311518253800823  0.053511305641188  0.206912543882787  0.000090733997612
-    9  (  9) -0.040822323151076  0.050351126620632 -0.033443030139718 -0.028678071562223  0.070729562284205 -0.035204318394559  0.035088801145452  0.003858253384271 -0.209126878103916
-   10  ( 10) -0.043554697985060  0.034029200702705  0.113396889510888 -0.025104351967769 -0.057922093461755 -0.050331966245759  0.113578028555237 -0.006845000513571  0.183899295084893
-   11  ( 11)  0.104445737487499 -0.085327185159750 -0.138831980783855 -0.068059267872915 -0.045287984054307  0.106421559557756 -0.126370094892912  0.085884676801538  0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.040472375428214  0.043732687824618 -0.105326662293090
-    1  (  1) -0.050113148730272 -0.033553830886801  0.085228632878169
-    2  (  2)  0.033648303602896 -0.113430364410931  0.140304701766262
-    3  (  3)  0.028908821271170  0.025577280295259  0.067243263311150
-    4  (  4) -0.070488811800233  0.058243639304596  0.043815524401846
-    5  (  5)  0.035954881502730  0.048633621823234 -0.102557737449989
-    6  (  6) -0.034599692943826 -0.112216626584703  0.126288398892548
-    7  (  7) -0.003737404887253  0.007316223089443 -0.087031799969318
-    8  (  8)  0.210522602449556 -0.181960897898471 -0.040780655119777
-    9  (  9) -0.000486792078199  0.154877597629272 -0.324381992896252
-   10  ( 10) -0.154731729402294 -0.001003846432056 -0.227757018056261
-   11  ( 11)  0.321308213629134  0.230320716710505 -0.000521529871008
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000267990887146  0.017094909685382 -0.026886221509252  0.009154729792392  0.028447394308811 -0.043026223139973  0.007934241734193 -0.017529929372393  0.048064409198736
-    1  (  1) -0.019165257539447  0.000577613190074  0.023971643573307 -0.023362002438445  0.020466955482562 -0.074368923093670 -0.021220838937975 -0.006899315294507 -0.004345205689582
-    2  (  2)  0.030573367311208 -0.023520686332899  0.000895230171902  0.026482533037414 -0.055578356600337 -0.061212128793543 -0.006033035982650  0.029878597421323 -0.067713186454891
-    3  (  3) -0.011556055604803  0.022912214561881 -0.028040995483179  0.000806143570890  0.016669730389240  0.057830279830177  0.001162806518994 -0.022110531165998  0.132937508894661
-    4  (  4) -0.029247962187325 -0.019722933579604  0.053631431975867 -0.015590855142050  0.000406564753787  0.013151443352440 -0.005583751708839  0.048344741694769 -0.058950645196782
-    5  (  5)  0.044502924478349  0.074343902828738  0.059891074519534 -0.057011647107618 -0.013642181191740 -0.000660380157385 -0.021619837229525 -0.066247874288904  0.026658775788480
-    6  (  6) -0.008416217090956  0.021046309429680  0.006522358687724 -0.001270652730649  0.005678899154477  0.021925039235368 -0.000233190982568 -0.044213316193167  0.019149792461568
-    7  (  7)  0.017220078580887  0.007669026797702 -0.030414088472195  0.022279636607030 -0.047947045698118  0.066391322818188  0.044159499520014  0.000036612147908  0.012788358083278
-    8  (  8) -0.049286641691243  0.005157181302332  0.067669102261374 -0.134137839836174  0.059598226202850 -0.026736423898111 -0.019691121432993 -0.012900597372237  0.000145671342113
-    9  (  9)  0.013771428368881 -0.001534324314609  0.097208563857550  0.041538777135659 -0.016922202614382 -0.071792645864290 -0.010700525463409  0.088926800959210 -0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.013388445223016
-    1  (  1)  0.001743269961120
-    2  (  2) -0.097384653394849
-    3  (  3) -0.041118719872747
-    4  (  4)  0.017104740675403
-    5  (  5)  0.071235600573670
-    6  (  6)  0.010744046806778
-    7  (  7) -0.088045104682667
-    8  (  8)  0.027915642785476
-    9  (  9)  0.000257740691093
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.024087436020668  0.024234923487922  0.034655069016827 -0.013002508462274  0.003506876735183  0.019138226509165 -0.008729154622077  0.004126516633947  0.080810387962203
-    1  (  1) -0.007340388106341 -0.022740162593799  0.047399213843079 -0.000077807499313  0.029710781800549 -0.077091731467965 -0.063337905707382  0.003225301246506  0.076935684639064
-    2  (  2) -0.008533292606078 -0.014866249844284 -0.069414473601385  0.039067032188858  0.004447555351962 -0.009557153079335  0.003933218079563  0.004684619630234  0.087696717260759
-    3  (  3)  0.022970088927143  0.014796917693540  0.027844101865804 -0.035221698386289  0.026363064761687  0.090054977556852  0.034727496736464 -0.055362273105074 -0.041999796595917
-    4  (  4)  0.041840045940810  0.108064430049583  0.094169303786903 -0.038045467810124 -0.242703284807102 -0.022096059239039 -0.018423933000872  0.169152570163926  0.255707171958253
-    5  (  5) -0.076575292532566  0.064169513057282 -0.187842221364997  0.139017281082776 -0.239663562780447  0.056101309100792  0.026864961939161 -0.152773054853442  0.000863550220823
-    6  (  6) -0.082619291232389  0.034129866388443  0.092672858212650 -0.166047996934064  0.066033557533197 -0.164979644828487  0.279604374284854  0.245415146187524  0.057275952528883
-    7  (  7) -0.119525510255884 -0.192558180615050  0.157479601093184 -0.199612815310399  0.216488749413977 -0.438370355171240 -0.097840156788249  0.385286937285113  0.058774287435548
-    8  (  8) -0.115070416909243  0.142091116044252 -0.125572997790340 -0.378869543679260  0.139572537143277  0.093921809248974 -0.047279124915748 -0.359195083957732  0.024443650320069
-    9  (  9)  0.023211259159309 -0.064251202673602  0.092489429719048 -0.099069758679955 -0.005272254913816 -0.184087259640687  0.103465084079069  0.187259798043465 -0.097400286560574
-   10  ( 10)  0.039092748606065 -0.013006586457309 -0.115772480099790  0.044153430983449  0.068039357936569  0.040474168285568  0.124671276809929  0.020291967592974  0.043718085717437
-   11  ( 11)  0.205517300660670  0.035576186745690 -0.000856944671273 -0.036648470964825 -0.217305799958921 -0.037828885346138  0.045859373489911 -0.037554955798535  0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001311477468569
-    1  (  1)  0.093224324445080
-    2  (  2) -0.099200064811294
-    3  (  3) -0.086458921973920
-    4  (  4)  0.229446975291319
-    5  (  5) -0.035136747289852
-    6  (  6) -0.019108151626501
-    7  (  7)  0.127376470092273
-    8  (  8) -0.036832911731868
-    9  (  9)  0.106598068979743
-   10  ( 10) -0.058544237541584
-   11  ( 11)  0.029477471817291
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.089840465204225  0.055253525883540  0.050839656601929 -0.011592120168853 -0.028453073767485 -0.033272498563027 -0.013123122183092 -0.010376152774617 -0.046773274930095
-    1  (  1) -0.019180458750845  0.004406050242553 -0.021028155566967 -0.011538680320289  0.014109247012132  0.033202867729220 -0.146724711919951  0.006291497986158 -0.032816512639240
-    2  (  2) -0.008004935891454 -0.083588166091295  0.024500417662889  0.004976479402859  0.015361678869856 -0.027030028650554  0.075999531355577 -0.040388417899799 -0.092155828534757
-    3  (  3)  0.072751395760345  0.101339872261880  0.027554632505315  0.017104143799594 -0.009883810143648 -0.054325029446985  0.038424568195001  0.007564948769101  0.050859249479548
-    4  (  4)  0.116869612062058  0.168448689602172  0.076045170807919 -0.039076911238534  0.141061895780680 -0.082089594379007  0.096305838370831 -0.090937592520626 -0.089867596085833
-    5  (  5) -0.362411548066203 -0.116301468610581 -0.067304641586918 -0.178833394354847  0.120526935264372  0.077690766748935 -0.087853646530869  0.131583743921650 -0.005449987066682
-    6  (  6) -0.023022243577310  0.091878291587840 -0.168295716396468 -0.360782087280141 -0.197772285105134  0.118427120672179  0.100301554555422  0.545992767837121 -0.002274268616602
-    7  (  7) -0.332469089310140 -0.094037896803367 -0.021326282942452  0.202588446745432  0.003095262967230  0.074773576198707  0.261809753005545 -0.312310926113466  0.101271338039676
-    8  (  8) -0.102262443511968 -0.018323432973791  0.030286707735275  0.141132962784100 -0.140087132441384 -0.016144892573022 -0.105178803101546  0.077042517784067  0.061204405030880
-    9  (  9)  0.062921845500970  0.223934495766079  0.055471945329417  0.006791304491310 -0.142947280894142 -0.007991932919943  0.047858230706461  0.145718178913241 -0.072195393114585
-   10  ( 10) -0.062281498028430 -0.059385022217194 -0.196384149116451 -0.042900612771916  0.059951865879116  0.109494756681462  0.025377610533051  0.255425379720525 -0.006903138405362
-   11  ( 11) -0.109893814765672 -0.036299338598219 -0.008950289795172 -0.103979082032925  0.089663281746559  0.076642658317109  0.017386558594104  0.075203103677764 -0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015115955084904
-    1  (  1) -0.030649150844450
-    2  (  2)  0.004117081641871
-    3  (  3)  0.011275331966881
-    4  (  4) -0.082379096749867
-    5  (  5) -0.010925397739678
-    6  (  6) -0.209001724905895
-    7  (  7)  0.094421017044117
-    8  (  8)  0.009881568354141
-    9  (  9) -0.113416879853688
-   10  ( 10) -0.045856944277529
-   11  ( 11)  0.007202279712064
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000220708940429  0.002285125103983  0.191707004311250 -0.079176547202062 -0.015343724284655 -0.090762856917070 -0.035966370439669 -0.080228715251931  0.022632088832219
-    1  (  1) -0.002270884902228  0.000127565392507 -0.181504505051190  0.084301622984598 -0.019134286473150  0.136527597935967  0.291828838790707 -0.086935165867290 -0.003153353795357
-    2  (  2) -0.190790178739451  0.181286631653937 -0.000456958950263  0.098736144982791  0.201937120878681  0.060858985812145 -0.102547416191644  0.128157455079926 -0.052263022287278
-    3  (  3)  0.078674978461285 -0.083802623610643 -0.098399673810258 -0.000007811365746 -0.051373438075815 -0.073262818066183 -0.213681674768555  0.159362252554929  0.021801220424175
-    4  (  4)  0.014664072597960  0.019624839214450 -0.200908806156840  0.051706138267892  0.000345872163641 -0.060049554881332 -0.188299165959522  0.122222075869351  0.002767654097179
-    5  (  5)  0.090883158144736 -0.136634126073923 -0.061672946710902  0.074085610649007  0.059059222367226 -0.000127348357414 -0.089421360456473  0.068061409120582 -0.127845689145142
-    6  (  6)  0.036070137194869 -0.291478881075219  0.101913218910275  0.213840026067922  0.188217301311726  0.090313292624869  0.000227988253159  0.211121150654972  0.048790729392591
-    7  (  7)  0.080292928774450  0.086502244153537 -0.129683189759572 -0.159077086898913 -0.122727489493275 -0.066634459735053 -0.210168861536432  0.000749252129634 -0.114771568876213
-    8  (  8) -0.022833189301314  0.003149552694449  0.051809982276026 -0.021432628906503 -0.002600755913054  0.127892598520278 -0.048118709288206  0.114794510187460  0.000092800261922
-    9  (  9) -0.153861672366712  0.063959309581427  0.276686698038017  0.018129236980868  0.051934404023196  0.023341508326279  0.078386885605064  0.038564733458116  0.117925763161383
-   10  ( 10)  0.030779230036139 -0.047764824598951 -0.139550834348758  0.058848096986720  0.072156858928456  0.071321440087986 -0.120905085647966  0.006516751215124  0.144681807612295
-   11  ( 11) -0.005585664265456  0.000647324323586  0.016353426872082  0.045937924242292  0.003353711579607 -0.138994412824604 -0.062414171800322 -0.018128246119697  0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.154066232086317 -0.030728257975556  0.006318091498164
-    1  (  1) -0.063643818147584  0.047463638962418 -0.000566548572565
-    2  (  2) -0.275258773270295  0.138888616959566 -0.015969350630016
-    3  (  3) -0.017345671201066 -0.059189082677904 -0.046475381464176
-    4  (  4) -0.050392875387071 -0.072424486885238 -0.004459708301674
-    5  (  5) -0.026836133802329 -0.070805989588457  0.140760690762251
-    6  (  6) -0.078585377266712  0.120742726291724  0.064292229739042
-    7  (  7) -0.041858894695365 -0.005665298794286  0.017186389956069
-    8  (  8) -0.118429783701800 -0.144155118064025 -0.113213711259466
-    9  (  9)  0.000756388118591 -0.455654623157072 -0.231432578787543
-   10  ( 10)  0.453567841489266  0.001497567906129  0.172275686133391
-   11  ( 11)  0.230120702539645 -0.175050207490782  0.001480251815160
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000516219946816 -0.034778633659956 -0.032999546928151  0.009629039776278 -0.052966719633617  0.030450001531878  0.014875222246015  0.072128990177077 -0.048218822417803
-    1  (  1)  0.030877691560804 -0.001883541097772 -0.071434334115879  0.019325009721534  0.017452039030100  0.158145751795333  0.010537309557875  0.021583100108147  0.169934651056250
-    2  (  2)  0.033565318682613  0.071200997372983 -0.000581071534985  0.036850040138101 -0.007310816547227  0.008797901115406  0.029229533057666  0.016744128499400  0.070455787497455
-    3  (  3) -0.011004884819686 -0.019179310791618 -0.034909263032370 -0.000523661128158  0.007125267622899  0.017666281606150  0.025274953349027 -0.006048522524524  0.042959205727090
-    4  (  4)  0.052383681601535 -0.016788640224883  0.007028507044452 -0.007472760866637  0.000164741631073  0.026820745242549 -0.000005495327564  0.022752424410877 -0.031410113616428
-    5  (  5) -0.028924597602342 -0.155705177520586 -0.009708873936879 -0.016613543931604 -0.026890889200954 -0.000863820528475  0.026461589325309 -0.030900211040800 -0.024762473040831
-    6  (  6) -0.014335467827216 -0.010396285650159 -0.029624823660296 -0.025462090585912 -0.000149096444494 -0.026996065218364  0.000042625626758  0.107465667965402 -0.101121105248233
-    7  (  7) -0.071280711647029 -0.021473260264964 -0.016888851213230  0.005990055447048 -0.022650874097521  0.030884846999677 -0.107059671381934 -0.000085380718295 -0.001222830424055
-    8  (  8)  0.049124632890092 -0.169889327710618 -0.068826403708743 -0.044339001017875  0.031493314676472  0.025080049766767  0.100845039831255  0.001167614688641 -0.000278385825403
-    9  (  9) -0.004591463397670 -0.224641690035662 -0.054391854978822  0.000520714575472 -0.041379699430161  0.035041097267503  0.048865193892848  0.034233303767760 -0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.004372643490859
-    1  (  1)  0.225448428944350
-    2  (  2)  0.053543340635201
-    3  (  3) -0.000029286176363
-    4  (  4)  0.041473098636741
-    5  (  5) -0.035500700267141
-    6  (  6) -0.049415179037896
-    7  (  7) -0.033722251526408
-    8  (  8)  0.002108270875613
-    9  (  9)  0.000059855095180
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.083178189184036 -0.063320502543375 -0.053448860291133  0.010119942476578  0.027962494700737  0.033408156898410  0.016646686372055  0.009688142905594  0.047753876913682
-    1  (  1)  0.015436953954369 -0.001484194684011  0.023035398887205  0.013457869405466 -0.013993527195521 -0.033943979767543  0.150850131221437 -0.006054179455746  0.032861777904130
-    2  (  2)  0.007416632072171  0.085535883632607 -0.031035920631781 -0.004414026005139 -0.010136741110915  0.029006493089287 -0.078308410406643  0.042862583013635  0.094615352193845
-    3  (  3) -0.060864804294684 -0.107990348400789 -0.029334441164075 -0.017074561166948  0.006770814971091  0.056161219994893 -0.038880977880177 -0.007186858274067 -0.050898617184209
-    4  (  4) -0.109193273208522 -0.178421304573120 -0.074992061457995  0.038015102633012 -0.147910228795514  0.087181398607820 -0.098582275644141  0.093570766915846  0.088687564658624
-    5  (  5)  0.362309556227904  0.121304099182945  0.074968023841376  0.180660703600124 -0.122438585672172 -0.079096894998506  0.085876030826778 -0.136109864287558  0.002214631278523
-    6  (  6)  0.026835628168075 -0.104282391359254  0.172843582770517  0.372105341696267  0.200623348657875 -0.124556824110224 -0.101871864602057 -0.564196462169744  0.000688785089474
-    7  (  7)  0.344945182303497  0.095060217852336  0.019692892185405 -0.208607222836184 -0.002627647973779 -0.075715664253568 -0.273373001503080  0.322679649636761 -0.103750880742886
-    8  (  8)  0.103243578213400  0.018995126733818 -0.033613347666093 -0.143946559071139  0.146180680800982  0.017308359580339  0.107684620440504 -0.078982837453949 -0.062496256435255
-    9  (  9) -0.085648241806344 -0.209611729409149 -0.056224829650480 -0.004822853433113  0.155473341074989  0.012971266670028 -0.058097898147224 -0.150335378963730  0.078057323449305
-   10  ( 10)  0.070132629148842  0.074702785463534  0.209329818275843  0.042566217114534 -0.058034325280006 -0.102370728009941 -0.025801004099357 -0.264561180085366  0.017482708757363
-   11  ( 11)  0.113963029107499  0.045073298009464  0.000413587765283  0.112463923253522 -0.089423608765749 -0.081287727377731 -0.019439635907878 -0.076622183257520  0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015270950350973
-    1  (  1)  0.030946721870550
-    2  (  2) -0.003707642076146
-    3  (  3) -0.011960041321321
-    4  (  4)  0.086083869661608
-    5  (  5)  0.009867768215709
-    6  (  6)  0.209680707316341
-    7  (  7) -0.097843271017668
-    8  (  8) -0.010325909660635
-    9  (  9)  0.121632163838855
-   10  ( 10)  0.058275044600178
-   11  ( 11) -0.003021331907582
-
 	Computing Mu_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        16.768400636718
-	   1        22.238899323198    7.657e-01
-	   2        26.326603032135    3.442e-01
-	   3        26.402828138172    5.204e-02
-	   4        26.436612034770    2.459e-02
-	   5        26.441960308295    4.103e-03
-	   6        26.440596203782    1.628e-03
-	   7        26.440721962866    5.123e-04
-	   8        26.440796407034    2.487e-04
-	   9        26.440755970568    1.070e-04
-	  10        26.440741562191    4.242e-05
-	  11        26.440753214125    1.114e-05
-	  12        26.440764472568    3.188e-06
-	  13        26.440767810998    1.225e-06
-	  14        26.440768088730    4.406e-07
-	  15        26.440767755083    2.032e-07
+	   0        16.768400460754
+	   1        22.238899083040    7.657e-01
+	   2        26.326602732924    3.442e-01
+	   3        26.402827834814    5.204e-02
+	   4        26.436611730619    2.459e-02
+	   5        26.441960003840    4.103e-03
+	   6        26.440595899324    1.628e-03
+	   7        26.440721658400    5.123e-04
+	   8        26.440796102560    2.487e-04
+	   9        26.440755666096    1.070e-04
+	  10        26.440741257721    4.242e-05
+	  11        26.440752909654    1.114e-05
+	  12        26.440764168096    3.188e-06
+	  13        26.440767506526    1.225e-06
+	  14        26.440767784258    4.406e-07
+	  15        26.440767450611    2.032e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 7.696e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         1.926105631328
-	   1         2.501393275744    2.028e-01
-	   2         2.834079249600    7.722e-02
-	   3         2.838350733665    9.377e-03
-	   4         2.839897253245    3.735e-03
-	   5         2.839974125340    8.176e-04
-	   6         2.839961789554    1.986e-04
-	   7         2.839965280678    3.975e-05
-	   8         2.839964831372    1.141e-05
-	   9         2.839964548641    2.885e-06
-	  10         2.839964458947    9.825e-07
-	  11         2.839964534618    1.402e-07
+	   0         1.926105616932
+	   1         2.501393254687    2.028e-01
+	   2         2.834079222307    7.722e-02
+	   3         2.838350706141    9.377e-03
+	   4         2.839897225633    3.735e-03
+	   5         2.839974097721    8.176e-04
+	   6         2.839961761936    1.986e-04
+	   7         2.839965253059    3.975e-05
+	   8         2.839964803753    1.141e-05
+	   9         2.839964521022    2.885e-06
+	  10         2.839964431328    9.825e-07
+	  11         2.839964506999    1.402e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 4.466e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.791920319186
-	   1        16.799278109459    5.100e-01
-	   2        18.450083178728    1.931e-01
-	   3        18.566084740683    4.406e-02
-	   4        18.584310426486    1.722e-02
-	   5        18.587536227798    3.424e-03
-	   6        18.587011347588    1.160e-03
-	   7        18.587126796613    3.058e-04
-	   8        18.587161120157    1.080e-04
-	   9        18.587156888766    4.128e-05
-	  10        18.587157303412    2.114e-05
-	  11        18.587158834247    7.210e-06
-	  12        18.587162027489    2.847e-06
-	  13        18.587162381644    1.013e-06
-	  14        18.587162490736    4.203e-07
-	  15        18.587162336589    1.752e-07
+	   0        13.791920191379
+	   1        16.799277957395    5.100e-01
+	   2        18.450083010364    1.931e-01
+	   3        18.566084568244    4.406e-02
+	   4        18.584310253644    1.722e-02
+	   5        18.587536054803    3.424e-03
+	   6        18.587011174586    1.160e-03
+	   7        18.587126623604    3.058e-04
+	   8        18.587160947145    1.080e-04
+	   9        18.587156715754    4.128e-05
+	  10        18.587157130400    2.114e-05
+	  11        18.587158661235    7.210e-06
+	  12        18.587161854476    2.847e-06
+	  13        18.587162208631    1.013e-06
+	  14        18.587162317723    4.203e-07
+	  15        18.587162163577    1.752e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.350e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.491473815782
-	   1         6.979859581709    2.986e-01
-	   2         7.683240637464    1.049e-01
-	   3         7.697438041472    1.990e-02
-	   4         7.702325633219    6.916e-03
-	   5         7.702390793952    1.115e-03
-	   6         7.702332324942    2.339e-04
-	   7         7.702339286683    5.198e-05
-	   8         7.702338399160    1.155e-05
-	   9         7.702338304051    2.547e-06
-	  10         7.702338208944    8.454e-07
-	  11         7.702338298400    1.431e-07
+	   0         5.491473784368
+	   1         6.979859537397    2.986e-01
+	   2         7.683240583311    1.049e-01
+	   3         7.697437986707    1.990e-02
+	   4         7.702325578225    6.916e-03
+	   5         7.702390738947    1.115e-03
+	   6         7.702332269940    2.339e-04
+	   7         7.702339231680    5.198e-05
+	   8         7.702338344158    1.155e-05
+	   9         7.702338249049    2.547e-06
+	  10         7.702338153942    8.454e-07
+	  11         7.702338243398    1.431e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 4.269e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.624759066304
-	   1        17.300274786165    5.349e-01
-	   2        19.191725177085    1.939e-01
-	   3        19.236330690295    3.405e-02
-	   4        19.254798304655    1.757e-02
-	   5        19.257236321965    2.512e-03
-	   6        19.256952059230    1.061e-03
-	   7        19.257006072772    3.749e-04
-	   8        19.257011184337    1.438e-04
-	   9        19.257003264835    4.440e-05
-	  10        19.257001940202    1.593e-05
-	  11        19.257003901137    3.739e-06
-	  12        19.257005421265    1.240e-06
-	  13        19.257005821231    5.354e-07
-	  14        19.257005951816    2.664e-07
-	  15        19.257005918929    1.205e-07
+	   0        13.624758944742
+	   1        17.300274629337    5.349e-01
+	   2        19.191724998587    1.939e-01
+	   3        19.236330510146    3.405e-02
+	   4        19.254798124059    1.757e-02
+	   5        19.257236141264    2.512e-03
+	   6        19.256951878523    1.061e-03
+	   7        19.257005892064    3.749e-04
+	   8        19.257011003629    1.438e-04
+	   9        19.257003084127    4.440e-05
+	  10        19.257001759494    1.593e-05
+	  11        19.257003720430    3.739e-06
+	  12        19.257005240557    1.240e-06
+	  13        19.257005640523    5.354e-07
+	  14        19.257005771108    2.664e-07
+	  15        19.257005738221    1.205e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.553e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.581975924718
-	   1         7.067898007904    3.046e-01
-	   2         7.794265031693    1.062e-01
-	   3         7.808016253108    1.466e-02
-	   4         7.810897754854    5.344e-03
-	   5         7.811100118181    1.188e-03
-	   6         7.811024707321    3.499e-04
-	   7         7.811038479913    5.690e-05
-	   8         7.811038896808    1.440e-05
-	   9         7.811038612320    3.086e-06
-	  10         7.811038592057    1.047e-06
-	  11         7.811038682689    2.223e-07
+	   0         5.581975894178
+	   1         7.067897965016    3.046e-01
+	   2         7.794264978727    1.062e-01
+	   3         7.808016199621    1.466e-02
+	   4         7.810897701239    5.344e-03
+	   5         7.811100064550    1.188e-03
+	   6         7.811024653692    3.499e-04
+	   7         7.811038426283    5.690e-05
+	   8         7.811038843179    1.440e-05
+	   9         7.811038558691    3.086e-06
+	  10         7.811038538428    1.047e-06
+	  11         7.811038629060    2.223e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 6.177e-08
 
@@ -5448,12 +1096,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.199315154813160    -0.236145105691945    -0.075627034598294
-    1      0.033233678625649     0.078305709819069    -0.216237849937923
-    2     -0.318543396835040     0.348340079087816    -0.247304234560634
+    0      0.199315154624056    -0.236145103741689    -0.075627033594829
+    1      0.033233678887394     0.078305709057096    -0.216237850819074
+    2     -0.318543397461720     0.348340079668771    -0.247304234462590
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) = -144.48475 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -144.48473 deg/[dm (g/cm^3)]
 
    ------------------------------------------
        CC2 Length-Gauge Optical Rotation
@@ -5461,17 +1109,10 @@ Total time:
        Omega           alpha
     E_h      nm   deg/[dm (g/cm^3)]
    -----   ------ ------------------
-   0.077   589.00       -49.62375
-   0.128   355.00      -144.48475
+   0.077   589.00       -49.62374
+   0.128   355.00      -144.48473
 
-*** tstop() called on psinet at Mon May 15 15:34:46 2017
-Module time:
-	user time   =       1.33 seconds =       0.02 minutes
-	system time =       1.37 seconds =       0.02 minutes
-	total time  =          3 seconds =       0.05 minutes
-Total time:
-	user time   =       2.34 seconds =       0.04 minutes
-	system time =       1.65 seconds =       0.03 minutes
-	total time  =          5 seconds =       0.08 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:26PM
+    Psi4 wall time for execution: 0:00:09.00
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc43/output.ref
+++ b/tests/cc43/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:25PM
 
-    Process ID:  12877
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65726
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -53,25 +66,26 @@ set {
   omega [589, 355, nm]
 }
 
-property('cc2',properties=['rotation'])
+properties('cc2',properties=['rotation'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:41 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:02 2022
 
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-3  entry C          line    60 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 4    entry O          line    80 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 5-10 entry H          line    18 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 1-3  entry C          line    61 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 4    entry O          line    81 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 5-10 entry H          line    19 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/sto-3g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -85,22 +99,22 @@ property('cc2',properties=['rotation'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.201751522566     0.002392992405     0.490202120079    12.000000000000
-           C         -0.989856477434     0.654130992405    -0.056843879921    12.000000000000
-           C          1.556762522566     0.135998992405    -0.144054879921    12.000000000000
-           O         -0.778596477434    -0.750055007595    -0.235025879921    15.994914619560
-           H          0.203343522566    -0.211065007595     1.556541120079     1.007825032070
-           H         -1.813559477434     0.920113992405     0.597738120079     1.007825032070
-           H         -0.900188477434     1.252402992405    -0.958365879921     1.007825032070
-           H          2.126424522566    -0.787996007595    -0.032265879921     1.007825032070
-           H          2.124083522566     0.939980992405     0.329511120079     1.007825032070
-           H          1.464513522566     0.354044992405    -1.207812879921     1.007825032070
+         C            0.201751522558     0.002392992399     0.490202120078    12.000000000000
+         C           -0.989856477442     0.654130992399    -0.056843879922    12.000000000000
+         C            1.556762522558     0.135998992399    -0.144054879922    12.000000000000
+         O           -0.778596477442    -0.750055007601    -0.235025879922    15.994914619570
+         H            0.203343522558    -0.211065007601     1.556541120078     1.007825032230
+         H           -1.813559477442     0.920113992399     0.597738120078     1.007825032230
+         H           -0.900188477442     1.252402992399    -0.958365879922     1.007825032230
+         H            2.126424522558    -0.787996007601    -0.032265879922     1.007825032230
+         H            2.124083522558     0.939980992399     0.329511120078     1.007825032230
+         H            1.464513522558     0.354044992399    -1.207812879922     1.007825032230
 
   Running in c1 symmetry.
 
   Rotational constants: A =      0.60799  B =      0.22239  C =      0.19815 [cm^-1]
-  Rotational constants: A =  18226.99774  B =   6666.95622  C =   5940.33276 [MHz]
-  Nuclear repulsion =  124.788534121264803
+  Rotational constants: A =  18226.99788  B =   6666.95627  C =   5940.33280 [MHz]
+  Nuclear repulsion =  124.788534611762472
 
   Charge       = 0
   Multiplicity = 1
@@ -117,27 +131,17 @@ property('cc2',properties=['rotation'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: STO-3G
     Blend: STO-3G
     Number of shells: 18
-    Number of basis function: 26
+    Number of basis functions: 26
     Number of Cartesian functions: 26
     Spherical Harmonics?: true
     Max angular momentum: 1
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         26      26       0       0       0       0
-   -------------------------------------------------------
-    Total      26      26      16      16      16       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -156,45 +160,59 @@ property('cc2',properties=['rotation'])
   Using 123552 doubles for integral storage.
   We computed 14355 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.0902507179E-01.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.0902506889E-01.
+  Reciprocal condition number of the overlap matrix is 8.4122044079E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         26      26 
+   -------------------------
+    Total      26      26
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -189.41976534870165   -1.89420e+02   1.12671e-01 
-   @RHF iter   1:  -189.30558765724510    1.14178e-01   1.85610e-02 
-   @RHF iter   2:  -189.48177566679436   -1.76188e-01   8.26145e-03 DIIS
-   @RHF iter   3:  -189.51053786197357   -2.87622e-02   1.68511e-03 DIIS
-   @RHF iter   4:  -189.51325091536503   -2.71305e-03   3.54210e-04 DIIS
-   @RHF iter   5:  -189.51339254673462   -1.41631e-04   1.35641e-04 DIIS
-   @RHF iter   6:  -189.51341598866529   -2.34419e-05   3.17752e-05 DIIS
-   @RHF iter   7:  -189.51341716329620   -1.17463e-06   7.70830e-06 DIIS
-   @RHF iter   8:  -189.51341723494519   -7.16490e-08   1.60970e-06 DIIS
-   @RHF iter   9:  -189.51341723731156   -2.36636e-09   4.74878e-07 DIIS
-   @RHF iter  10:  -189.51341723756769   -2.56136e-10   9.86183e-08 DIIS
-   @RHF iter  11:  -189.51341723757949   -1.17950e-11   2.15603e-08 DIIS
-   @RHF iter  12:  -189.51341723758003   -5.40012e-13   4.05424e-09 DIIS
-   @RHF iter  13:  -189.51341723758009   -5.68434e-14   7.10239e-10 DIIS
-   @RHF iter  14:  -189.51341723758000    8.52651e-14   2.10640e-10 DIIS
-   @RHF iter  15:  -189.51341723758000    0.00000e+00   6.72374e-11 DIIS
+   @RHF iter SAD:  -186.43072166022984   -1.86431e+02   0.00000e+00 
+   @RHF iter   1:  -189.43266126778377   -3.00194e+00   1.28222e-02 ADIIS/DIIS
+   @RHF iter   2:  -189.50256237003040   -6.99011e-02   5.10734e-03 ADIIS/DIIS
+   @RHF iter   3:  -189.51308752257808   -1.05252e-02   6.61403e-04 ADIIS/DIIS
+   @RHF iter   4:  -189.51341362083542   -3.26098e-04   6.54297e-05 DIIS
+   @RHF iter   5:  -189.51341710353631   -3.48270e-06   1.19638e-05 DIIS
+   @RHF iter   6:  -189.51341723375194   -1.30216e-07   1.91468e-06 DIIS
+   @RHF iter   7:  -189.51341723649381   -2.74187e-09   7.28366e-07 DIIS
+   @RHF iter   8:  -189.51341723702984   -5.36033e-10   2.37098e-07 DIIS
+   @RHF iter   9:  -189.51341723710047   -7.06279e-11   4.41139e-08 DIIS
+   @RHF iter  10:  -189.51341723710254   -2.07478e-12   7.00241e-09 DIIS
+   @RHF iter  11:  -189.51341723710254    0.00000e+00   1.79171e-09 DIIS
+   @RHF iter  12:  -189.51341723710249    5.68434e-14   4.46110e-10 DIIS
+   @RHF iter  13:  -189.51341723710263   -1.42109e-13   1.14589e-10 DIIS
+   @RHF iter  14:  -189.51341723710254    8.52651e-14   1.75049e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -216,48 +234,43 @@ property('cc2',properties=['rotation'])
               A 
     DOCC [    16 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -189.51341723758000
+  @RHF Final Energy:  -189.51341723710254
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =            124.7885341212648029
-    One-Electron Energy =                -505.7302694787643986
-    Two-Electron Energy =                 191.4283181199196235
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -189.5134172375800006
+    Nuclear Repulsion Energy =            124.7885346117624721
+    One-Electron Energy =                -505.7302704013803805
+    Two-Electron Energy =                 191.4283185525153499
+    Total Energy =                       -189.5134172371025443
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     3.0005      Y:     2.3096      Z:     0.2664
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:    -2.7337      Y:    -1.8166      Z:    -0.0674
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.2668      Y:     0.4930      Z:     0.1990     Total:     0.5948
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.6781      Y:     1.2530      Z:     0.5057     Total:     1.5118
 
 
-*** tstop() called on psinet at Mon May 15 15:34:42 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:03 2022
 Module time:
-	user time   =       0.68 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.31 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.68 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.31 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -272,19 +285,19 @@ Total time:
       Number of basis functions:        26
 
       Number of irreps:                  1
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  26 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 61560 non-zero two-electron integrals.
+      Computed 60690 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:03 2022
 
 
 	Wfn Parameters:
@@ -306,7 +319,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -342,7 +355,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -209.07983613514321
+	Frozen core energy     =   -209.07983635006943
 
 	Size of irrep 0 of <ab|cd> integrals:      0.010 (MW) /      0.080 (MB)
 	Total:                                     0.010 (MW) /      0.080 (MB)
@@ -353,34 +366,30 @@ Total time:
 	Size of irrep 0 of tijab amplitudes:       0.014 (MW) /      0.115 (MB)
 	Total:                                     0.014 (MW) /      0.115 (MB)
 
-	Nuclear Rep. energy          =    124.78853412126480
-	SCF energy                   =   -189.51341723758000
-	One-electron energy          =   -194.60728307304521
-	Two-electron energy          =     89.38516784934311
-	Reference energy             =   -189.51341723758051
+	Nuclear Rep. energy          =    124.78853461176247
+	SCF energy                   =   -189.51341723710254
+	One-electron energy          =   -194.60728356878917
+	Two-electron energy          =     89.38516806999395
+	Reference energy             =   -189.51341723710217
 
-*** tstop() called on psinet at Mon May 15 15:34:42 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:04 2022
 Module time:
-	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.85 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
-
+Total time:
+	user time   =       1.55 seconds =       0.03 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =  124.788534121264803
-    SCF energy          (wfn)     = -189.513417237580001
-    Reference energy    (file100) = -189.513417237580512
+    Nuclear Rep. energy (wfn)     =  124.788534611762472
+    SCF energy          (wfn)     = -189.513417237102544
+    Reference energy    (file100) = -189.513417237102175
 
     Input parameters:
     -----------------
@@ -408,74 +417,61 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.1984983538101992
+MP2 correlation energy -0.1984983521050260
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.198498353810199    0.000e+00    0.000000    0.000000    0.000000    0.124632
-     1        -0.198386689299877    2.456e-02    0.005013    0.019208    0.019208    0.124632
-     2        -0.199744020160671    7.393e-03    0.005756    0.022873    0.022873    0.125832
-     3        -0.200084920619632    3.729e-03    0.006768    0.027963    0.027963    0.126111
-     4        -0.200115319676321    6.852e-04    0.006878    0.028762    0.028762    0.126089
-     5        -0.200118669301748    1.694e-04    0.006896    0.028947    0.028947    0.126086
-     6        -0.200118439802851    3.259e-05    0.006898    0.028967    0.028967    0.126084
-     7        -0.200118408188058    1.039e-05    0.006898    0.028968    0.028968    0.126083
-     8        -0.200118429865298    3.934e-06    0.006898    0.028968    0.028968    0.126083
-     9        -0.200118429204315    1.144e-06    0.006898    0.028968    0.028968    0.126083
-    10        -0.200118431545464    4.391e-07    0.006898    0.028968    0.028968    0.126083
-    11        -0.200118431235805    9.823e-08    0.006898    0.028968    0.028968    0.126083
+     0        -0.198498352105026    0.000e+00    0.000000    0.000000    0.000000    0.124632
+     1        -0.198386687596309    2.456e-02    0.005013    0.019208    0.019208    0.124632
+     2        -0.199744018436219    7.393e-03    0.005756    0.022873    0.022873    0.125832
+     3        -0.200084918887300    3.729e-03    0.006768    0.027963    0.027963    0.126111
+     4        -0.200115317942039    6.852e-04    0.006878    0.028762    0.028762    0.126089
+     5        -0.200118667567232    1.694e-04    0.006896    0.028947    0.028947    0.126085
+     6        -0.200118438068357    3.259e-05    0.006898    0.028967    0.028967    0.126084
+     7        -0.200118406453567    1.039e-05    0.006898    0.028968    0.028968    0.126083
+     8        -0.200118428130805    3.934e-06    0.006898    0.028968    0.028968    0.126083
+     9        -0.200118427469824    1.144e-06    0.006898    0.028968    0.028968    0.126083
+    10        -0.200118429810973    4.391e-07    0.006898    0.028968    0.028968    0.126083
+    11        -0.200118429501313    9.823e-08    0.006898    0.028968    0.028968    0.126083
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-             11   2         0.0197255943
-             11   3        -0.0114902911
-             11   5         0.0092063278
-             11   1        -0.0075665081
-              9   0         0.0074808409
-              4   2        -0.0071415173
-              2   1         0.0060498066
-             10   2        -0.0059927841
+             11   2         0.0197255945
+             11   3        -0.0114902909
+             11   5         0.0092063267
+             11   1        -0.0075665073
+              9   0         0.0074808408
+              4   2        -0.0071415172
+              2   1         0.0060498064
+             10   2        -0.0059927839
              10   1        -0.0055990860
-             11   4        -0.0047844227
+             11   4        -0.0047844241
 
     Largest TIjAb Amplitudes:
-     10  10   0   0        -0.0499696178
-      9   9   0   0        -0.0472348458
-      6   6   6   6        -0.0323415531
-      9  10   0   1         0.0282266083
-     10   9   1   0         0.0282266083
-     10  10   1   1        -0.0276616351
-      0   0   1   1        -0.0190922677
-      9  10   1   0         0.0182861875
-     10   9   0   1         0.0182861875
-      8   8   8   8        -0.0174521682
+     10  10   0   0        -0.0499696175
+      9   9   0   0        -0.0472348452
+      6   6   6   6        -0.0323415524
+      9  10   0   1         0.0282266079
+     10   9   1   0         0.0282266079
+     10  10   1   1        -0.0276616345
+      0   0   1   1        -0.0190922674
+      9  10   1   0         0.0182861872
+     10   9   0   1         0.0182861872
+      8   8   8   8        -0.0174521683
 
-    SCF energy       (wfn)                    = -189.513417237580001
-    Reference energy (file100)                = -189.513417237580512
+    SCF energy       (wfn)                    = -189.513417237102544
+    Reference energy (file100)                = -189.513417237102175
 
-    Opposite-spin MP2 correlation energy      =   -0.172369086880245
-    Same-spin MP2 correlation energy          =   -0.026129266929954
-    MP2 correlation energy                    =   -0.198498353810199
-      * MP2 total energy                      = -189.711915591390721
-    CC2 correlation energy                    =   -0.200118431235805
-      * CC2 total energy                      = -189.713535668816320
-
-
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
-Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.97 seconds =       0.02 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
+    Opposite-spin MP2 correlation energy      =   -0.172369085425346
+    Same-spin MP2 correlation energy          =   -0.026129266679680
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.198498352105026
+      * MP2 total energy                      = -189.711915589207194
+    CC2 correlation energy                    =   -0.200118429501313
+      * CC2 total energy                      = -189.713535666603491
 
 
 			**************************
@@ -485,31 +481,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
-Module time:
-	user time   =       0.00 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.97 seconds =       0.02 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =  124.788534121264803
+	Nuclear Rep. energy (wfn)     =  124.788534611762472
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -189.513417237580001
-	Reference energy    (CC_INFO) = -189.513417237580512
-	CC2 energy          (CC_INFO) =   -0.200118431235805
-	Total CC2 energy    (CC_INFO) = -189.713535668816320
+	SCF energy          (wfn)     = -189.513417237102544
+	Reference energy    (CC_INFO) = -189.513417237102175
+	CC2 energy          (CC_INFO) =   -0.200118429501313
+	Total CC2 energy    (CC_INFO) = -189.713535666603491
 
 	Input parameters:
 	-----------------
@@ -522,7 +504,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -535,59 +517,45 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.200255252097002    0.000e+00
-	   1        -0.200237820765584    1.045e-02
-	   2        -0.199973107551451    1.485e-03
-	   3        -0.199954623633709    4.864e-04
-	   4        -0.199946897293502    1.053e-04
-	   5        -0.199946308537976    2.929e-05
-	   6        -0.199946157936786    6.703e-06
-	   7        -0.199946138584980    1.596e-06
-	   8        -0.199946137030889    5.076e-07
-	   9        -0.199946135249655    1.768e-07
-	  10        -0.199946134664678    6.638e-08
+	   0        -0.200255250360407    0.000e+00
+	   1        -0.200237819029770    1.045e-02
+	   2        -0.199973105822700    1.485e-03
+	   3        -0.199954621905730    4.864e-04
+	   4        -0.199946895565814    1.053e-04
+	   5        -0.199946306810320    2.929e-05
+	   6        -0.199946156209135    6.703e-06
+	   7        -0.199946136857328    1.596e-06
+	   8        -0.199946135303239    5.076e-07
+	   9        -0.199946133522006    1.768e-07
+	  10        -0.199946132937027    6.638e-08
 
 	Largest LIA Amplitudes:
-	         11   2         0.0187278535
-	         11   3        -0.0108160630
-	         11   5         0.0086709062
-	          4   2        -0.0067631543
-	         11   1        -0.0064539502
-	          2   1         0.0057797146
-	         10   2        -0.0046309835
-	         11   4        -0.0044345897
-	          1   1         0.0039297406
-	          0   1        -0.0038896347
+	         11   2         0.0187278537
+	         11   3        -0.0108160627
+	         11   5         0.0086709051
+	          4   2        -0.0067631542
+	         11   1        -0.0064539495
+	          2   1         0.0057797144
+	         10   2        -0.0046309834
+	         11   4        -0.0044345910
+	          1   1         0.0039297405
+	          0   1        -0.0038896346
 
 	Largest LIjAb Amplitudes:
-	 10  10   0   0        -0.0498652177
-	  9   9   0   0        -0.0470033203
-	  6   6   6   6        -0.0323371349
-	  9  10   0   1         0.0281551854
-	 10   9   1   0         0.0281551854
-	 10  10   1   1        -0.0276581001
-	  0   0   1   1        -0.0190238470
-	  9  10   1   0         0.0181945355
-	 10   9   0   1         0.0181945355
+	 10  10   0   0        -0.0498652174
+	  9   9   0   0        -0.0470033197
+	  6   6   6   6        -0.0323371342
+	  9  10   0   1         0.0281551850
+	 10   9   1   0         0.0281551850
+	 10  10   1   1        -0.0276580994
+	  0   0   1   1        -0.0190238467
+	  9  10   1   0         0.0181945352
+	 10   9   0   1         0.0181945352
 	  8   8   8   8        -0.0174424905
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.91534388508
-
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
-Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.00 seconds =       0.02 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
-
+	Overlap <L|e^T> =        0.91534388636
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -621,1198 +589,118 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016948570972613  0.054109880888837 -0.021135784265575 -0.002313233156337  0.028103296077604  0.079447973740205  0.002956852851677  0.021913708071079  0.092707789804150
-    1  (  1) -0.006461113403501 -0.006009670223774  0.006912589645128 -0.092573919328396 -0.040488535615147 -0.004255397696456  0.001825638351976  0.025873653657309  0.054959118002991
-    2  (  2) -0.031331544873159 -0.021241168145027  0.017129702121868  0.019395427099523 -0.035285598576221  0.072935692322985  0.012410630409385 -0.000869702308377  0.008015902055911
-    3  (  3)  0.024878718719799  0.025868121230654  0.005405353640122  0.004239945233349  0.042856541334318  0.005201344918358 -0.012288417201910 -0.030208301210711  0.125325395177801
-    4  (  4)  0.025785958698499  0.063980691498117 -0.073598667061032 -0.115501747702081  0.164822674147024 -0.010612384733594 -0.011577872820172 -0.114519752578224  0.189906673361740
-    5  (  5) -0.055556441114085 -0.137396825466669  0.095615332658029 -0.165972658367973 -0.107298365798081 -0.238527327390248 -0.081212554772841 -0.063709822276343 -0.111105007194853
-    6  (  6)  0.039392027543678 -0.042131630239803  0.019507343007951  0.031681902994480 -0.051489401416932  0.103596811576048 -0.235358679315166 -0.007221910465763 -0.034349807961782
-    7  (  7) -0.065836178815642 -0.094909606609938  0.220876622755124  0.015059455980391 -0.193611601065905 -0.070646838068217  0.043039430003875 -0.187401754034075 -0.048410779717487
-    8  (  8) -0.031684946163714 -0.037730087504351  0.186156646607922 -0.254646362799555 -0.271156762093932 -0.000387787259569 -0.024433068698376 -0.071450437934107  0.140846979003438
-    9  (  9)  0.084633662124775 -0.255488997024621 -0.026205007862790 -0.093994792938777 -0.025613688623644 -0.118121227074271 -0.051164537443405 -0.122992981774053  0.058164329433773
-   10  ( 10)  0.311792105223363 -0.086266548695923 -0.100581825486069  0.027645372765871  0.030325864964669  0.084727340300286 -0.008122017336910  0.056541723787744  0.001789230697787
-   11  ( 11)  0.065426291083003 -0.078665723239531  0.001736951632506 -0.128876911317495  0.027700220473420 -0.024959429550215 -0.037516506165893 -0.053272012233112  0.158952768314791
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.101753702406755
-    1  (  1) -0.017313059038111
-    2  (  2)  0.101825332796567
-    3  (  3)  0.046545573336527
-    4  (  4)  0.020412053345531
-    5  (  5) -0.174151422241113
-    6  (  6)  0.031247623880847
-    7  (  7) -0.081019948031908
-    8  (  8)  0.058254959468121
-    9  (  9) -0.102303876794014
-   10  ( 10)  0.049924523752296
-   11  ( 11) -0.075525972870746
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000125242728652  0.167195127529492 -0.056123303969470  0.168150627862986  0.199820827488140  0.006623842711744  0.083849175432758  0.006045895732050 -0.001251364845770
-    1  (  1) -0.166774393973286  0.000050108097355 -0.080714006337441 -0.158384893960458 -0.170632381263561 -0.022705538420815 -0.068262733314185 -0.100593352732071 -0.028750568711108
-    2  (  2)  0.056229020612168  0.080612207963297 -0.000319173254151  0.066387047727631  0.099495071766653 -0.005173360753909 -0.113435632074142  0.028897807757084 -0.031705991700745
-    3  (  3) -0.167678159270092  0.158683508487030 -0.065913815468277  0.000249734983867  0.003148005831140  0.156650391969335 -0.003319412683622  0.076996711806060  0.120344951995522
-    4  (  4) -0.199454748142053  0.170759345082550 -0.099469221211006 -0.002551454280228  0.000773886045054 -0.018686662746212  0.033100672959698  0.121887804954424  0.106797700418754
-    5  (  5) -0.006478249114673  0.021770745773300  0.005161753017351 -0.157975992221428  0.016380865873467 -0.000525726707385  0.009662973185984 -0.040170645002731  0.072417783927543
-    6  (  6) -0.083743292092373  0.068302347407764  0.113643630138679  0.003584139545109 -0.033360726847565 -0.010056643067212 -0.000096953687507 -0.013754999535778 -0.022913811866200
-    7  (  7) -0.005934789716209  0.100152235257288 -0.028714239339716 -0.077512132071698 -0.124503679540823  0.039365364835397  0.013764502288195  0.000180876976509 -0.012227152395047
-    8  (  8)  0.001252911154497  0.028874957240891  0.031437882577012 -0.119989379615825 -0.109273108573834 -0.074290660285147  0.022855339074817  0.012168993677105 -0.000462665884709
-    9  (  9)  0.203227152828002 -0.052485985798040 -0.129801089628845 -0.136141281459481 -0.065085125998612 -0.011352243649991 -0.086206555714525 -0.025668240031329  0.000953339185401
-   10  ( 10)  0.017663100569732 -0.012450214343934 -0.116177784025215  0.099935881710944  0.054793001926237  0.009017289614393 -0.082995680333069  0.068546362432187  0.010579042812723
-   11  ( 11)  0.116181838629295 -0.044517983740016 -0.150706036920128 -0.032577504630229 -0.048215712631815 -0.017042393348597 -0.052941121555075  0.017922753511187 -0.062577005194743
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.202593155221573 -0.017575879500322 -0.116307852916242
-    1  (  1)  0.051519507233614  0.011549119939392  0.045820851989693
-    2  (  2)  0.128159049336363  0.115585636177618  0.151359481294950
-    3  (  3)  0.134953502481695 -0.100933227346633  0.031949792725006
-    4  (  4)  0.063859931160852 -0.055317708494750  0.046074544888569
-    5  (  5)  0.011830479350239 -0.008881125854761  0.020210091121139
-    6  (  6)  0.085128481579730  0.081569095643572  0.054417852481447
-    7  (  7)  0.026086609962421 -0.069224862060329 -0.012195140209492
-    8  (  8) -0.000678319781602 -0.012471916838811  0.071159871058140
-    9  (  9)  0.000819518740474  0.045422336765459  0.019150849930670
-   10  ( 10) -0.042260420338391  0.001814961764223 -0.033976133870612
-   11  ( 11) -0.016728332900175  0.032414763485709  0.001978177060231
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000983782142481 -0.011124830147172 -0.012629378315808  0.024035154666400 -0.023065379134223  0.045710192314813 -0.107167060216496  0.027462764041011 -0.031515346399462
-    1  (  1)  0.014910063958614 -0.001359157823420 -0.030733082384744  0.019659721688393  0.009988965433840  0.056476882006057  0.086868153591365  0.027118954968710 -0.020111602536483
-    2  (  2)  0.013560973004051  0.032277644601759 -0.000558091321303  0.031608555416779  0.040262773871770 -0.039517595873987  0.008529102471728 -0.015019360045155  0.098314783259817
-    3  (  3) -0.023649721587845 -0.020118169175247 -0.030610171886610 -0.000350229335722  0.012485025400198 -0.061831636996218  0.007360517014456  0.020533699107494 -0.121125902320152
-    4  (  4)  0.023653135590417 -0.011024958414626 -0.040020875859244 -0.012638451269626 -0.000303446235581  0.039117573677270  0.028265656547984  0.042181285668281 -0.051214110379900
-    5  (  5) -0.045133076040651 -0.057161250752777  0.039343611119004  0.062428421797334 -0.039565506596663 -0.000136824832782 -0.002584969716509  0.016708941328372 -0.072879955596616
-    6  (  6)  0.106505496216286 -0.086364895206289 -0.008150243943918 -0.007611894739464 -0.028147100099079  0.003022121444643 -0.000203669685880  0.002510614548550 -0.011878393768514
-    7  (  7) -0.027112672456296 -0.027077462764235  0.015425844110164 -0.020594818217305 -0.042172669827196 -0.016338775255452 -0.002434838415100  0.000089029182611 -0.017463248477439
-    8  (  8)  0.031656276623231  0.019719565610509 -0.100860419907018  0.123299997114838  0.052015418367335  0.071940119122082  0.012364797759804  0.017989601258840 -0.000459902016922
-    9  (  9) -0.009520290499381  0.022267140636896 -0.003094175387367  0.010303251098885 -0.097174601333758  0.097786893048291  0.015199034071913  0.052630350765338 -0.034203233126427
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.010278877487205
-    1  (  1) -0.024100566367630
-    2  (  2)  0.004662205178286
-    3  (  3) -0.011080772146621
-    4  (  4)  0.096116977362317
-    5  (  5) -0.097255829352037
-    6  (  6) -0.015024357830545
-    7  (  7) -0.052513597187948
-    8  (  8)  0.034242058243121
-    9  (  9) -0.000071427193828
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.021462702377840 -0.058609304986263  0.015277082640202  0.003588508466775 -0.029160920616631 -0.083108081100347 -0.001276540885573 -0.021892833224427 -0.094847379110200
-    1  (  1)  0.007381037964715  0.005863657253688 -0.003698438732125  0.089241023982742  0.038284755695481  0.000242471073392 -0.003462666004729 -0.024254060890744 -0.054255658141393
-    2  (  2)  0.028789493389469  0.021034273638112 -0.015759179620292 -0.016880406379978  0.029564270241667 -0.075699259080315 -0.015222849490441  0.000165407073994 -0.009535205798866
-    3  (  3) -0.022522624621755 -0.025183731584898 -0.006246635644453 -0.011954555325543 -0.044324634330057 -0.008966012606668  0.011838270463808  0.025186144853786 -0.129587118903909
-    4  (  4) -0.027278246959126 -0.067306256079496  0.081195596321175  0.116387540315424 -0.168952317262089  0.005408102733272  0.009102915279315  0.114909773648686 -0.181841314973109
-    5  (  5)  0.061523869623373  0.148379112602599 -0.099858075157622  0.167623835533734  0.102565185360584  0.247065081865864  0.081017208043104  0.063123082298018  0.125076333021719
-    6  (  6) -0.033597893568908  0.039834794585931 -0.017503613262801 -0.032860851330180  0.052602131787128 -0.107800944359286  0.233932603910558  0.008404826542760  0.033043735155831
-    7  (  7)  0.070933561522966  0.099409127660202 -0.220355143796242 -0.017909988072788  0.200469521486937  0.066219172137076 -0.043845430589746  0.192769183200970  0.053043735796183
-    8  (  8)  0.031467417081633  0.038067047239557 -0.186574292412207  0.251635426547577  0.276398972104307  0.005573316819495  0.024827793389672  0.069746818919629 -0.142347486299646
-    9  (  9) -0.099591518033223  0.261294622221711  0.027264053477196  0.094406359241798  0.029407574246243  0.125903095774733  0.051208103024876  0.127846157357285 -0.056089461080389
-   10  ( 10) -0.342117397283536  0.096154260862934  0.107466277478619 -0.028734389414544 -0.028891686984979 -0.086820145756038  0.003652067648454 -0.059057626339762 -0.003362266069713
-   11  ( 11) -0.071536902730284  0.080845824211427 -0.010817173110070  0.135869650211322 -0.031366930890364  0.023168476862022  0.040179651854624  0.056331586353381 -0.165962619403637
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.103572144747435
-    1  (  1)  0.016763539950930
-    2  (  2) -0.104006607185189
-    3  (  3) -0.046374714497242
-    4  (  4) -0.027556807097170
-    5  (  5)  0.176590727028647
-    6  (  6) -0.030192309767508
-    7  (  7)  0.090742251579819
-    8  (  8) -0.063736127736872
-    9  (  9)  0.109060255331570
-   10  ( 10) -0.052388979852748
-   11  ( 11)  0.078361680425232
-
 	Computing P_X-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.067008753784
-	   1         5.182448769744    2.905e-01
-	   2         5.815928614333    1.071e-01
-	   3         5.825674839447    1.270e-02
-	   4         5.827130471114    4.929e-03
-	   5         5.827513836699    1.050e-03
-	   6         5.827439490729    3.878e-04
-	   7         5.827453858886    9.819e-05
-	   8         5.827458139533    2.992e-05
-	   9         5.827456916744    6.300e-06
-	  10         5.827456867712    1.608e-06
-	  11         5.827457023313    4.661e-07
-	  12         5.827457169245    1.382e-07
+	   0         4.067008774635
+	   1         5.182448794000    2.905e-01
+	   2         5.815928637426    1.071e-01
+	   3         5.825674862156    1.270e-02
+	   4         5.827130493782    4.929e-03
+	   5         5.827513859348    1.050e-03
+	   6         5.827439513378    3.878e-04
+	   7         5.827453881534    9.819e-05
+	   8         5.827458162181    2.992e-05
+	   9         5.827456939393    6.300e-06
+	  10         5.827456890360    1.608e-06
+	  11         5.827457045961    4.661e-07
+	  12         5.827457191893    1.382e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 4.436e-08
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057770723551805  0.007686176362995 -0.037676874102239  0.021875314889184 -0.005506967440553 -0.033731453254856  0.019605915987929  0.000153810358456  0.020480209762043
-    1  (  1) -0.007936092328855  0.008454757012618  0.010966637507272 -0.001712970012603 -0.003491085971866  0.000515536715359  0.020166951580993 -0.003537118918414 -0.007401819292438
-    2  (  2) -0.004823273660701 -0.024918096949402 -0.013456316532648  0.018061040723257  0.007928867774181 -0.029348077247204 -0.008305651855965  0.003787093111853  0.048173394734837
-    3  (  3) -0.011675775125104  0.107663431050362  0.048399528007616 -0.036525102270435  0.040730641356466 -0.022154401905676 -0.022459222262206 -0.014732815012435 -0.056193647103106
-    4  (  4)  0.087218313447135 -0.162702625594382 -0.040016358931151  0.090893257640902 -0.161526551014906  0.070532962320029  0.041494660476799  0.036307465283525  0.053954994619678
-    5  (  5) -0.299080380154522 -0.047071149143854 -0.050599107356677  0.086076035660096 -0.105747613370625  0.016291716828988  0.035370479977499  0.024570880182810  0.019740472062472
-    6  (  6)  0.064660820062842  0.041897488689090 -0.115036198620178  0.009494466980017  0.021741244197439  0.082050622741463 -0.041036304002792 -0.093842813724870 -0.099009311380003
-    7  (  7) -0.041406109005398 -0.013292096025031  0.015299070066933 -0.090658889471223  0.096664535474361  0.020138730803122 -0.181635797654581 -0.008096043748855 -0.043219320460348
-    8  (  8)  0.213166983290885  0.019961961605909  0.071163032757987 -0.089566388255459  0.187567657300030 -0.059322694628756  0.181371262434162 -0.031805535782928 -0.037438192749058
-    9  (  9) -0.029081682004423  0.052377114086944 -0.016598919354525  0.054121123864817 -0.005943121322964  0.052845962329270 -0.099913404453613 -0.011257505074012  0.046946017590445
-   10  ( 10) -0.029775807936917 -0.011144658296549  0.123616713069900 -0.069048925266029  0.072425392135727  0.175724644218768  0.020473761865880 -0.027329304597195  0.030635509122054
-   11  ( 11)  0.065686621670288  0.046175058814983  0.054739230530016  0.067089838730126 -0.085213076503212  0.033327993779702  0.039100303871838  0.006432393458887  0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007846989553355
-    1  (  1) -0.003599492488651
-    2  (  2) -0.050462951485827
-    3  (  3)  0.025590884562196
-    4  (  4)  0.058023095683205
-    5  (  5)  0.032774222915836
-    6  (  6) -0.063967275967677
-    7  (  7) -0.008682341559207
-    8  (  8) -0.054096899442108
-    9  (  9) -0.060114344610370
-   10  ( 10) -0.027778486812577
-   11  ( 11)  0.026791075407401
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000027040423887 -0.011060683872803 -0.004793456647899 -0.073481718860181  0.071504628495016  0.043329380984548 -0.025554578097106 -0.020981780177699  0.009741644195740
-    1  (  1)  0.011009750762997  0.000007607240151 -0.023558132508086  0.077101510719000 -0.072464798814331 -0.012890143420536  0.005683277430906  0.006920173400283 -0.002574145843753
-    2  (  2)  0.004842956248702  0.023538681455719 -0.000165226839542  0.207870652255993 -0.210753100259611 -0.104860036207310  0.066732822825146  0.046426833468215  0.005606364639263
-    3  (  3)  0.072846425542822 -0.076633967419021 -0.207131819599136  0.000363002499158  0.003747206858118  0.078444561827851  0.135702906183535 -0.013002670417717 -0.066080178603036
-    4  (  4) -0.070600283658190  0.071629978927021  0.209426851727876 -0.004131403945752 -0.000622007773293 -0.030404083775686 -0.072573499649568  0.005804369418180 -0.017256603820917
-    5  (  5) -0.042938103533211  0.012767138266668  0.104089521411634 -0.078509088982138  0.031589837534126  0.000702189622727  0.234416668036359  0.006073164073880  0.085676616502380
-    6  (  6)  0.025301081140471 -0.005670371975564 -0.066621493148361 -0.135369815380962  0.072186642283625 -0.233429156027521 -0.000193153533248  0.257186865053465 -0.080618496507255
-    7  (  7)  0.020822354558258 -0.006724508724119 -0.045993762455479  0.012965367547761 -0.005443358605263 -0.006173477804865 -0.257050229473736 -0.000107746294773  0.140355654948263
-    8  (  8) -0.009433315806276  0.002386871891496 -0.004905034102302  0.065444732417879  0.016877777772437 -0.086229493149666  0.079936884810997 -0.140925849197376  0.000032973152365
-    9  (  9) -0.050122316171813  0.043792237275169  0.089139695085719  0.017498120874682  0.031599257819379  0.003933044438540  0.023956851013655 -0.023591093022906 -0.231355322027963
-   10  ( 10) -0.021733936110572  0.028861084661254  0.012680330783905  0.120427356784394 -0.061995107162282 -0.110107780731446 -0.044522956915282 -0.044154909833586 -0.092344585382497
-   11  ( 11)  0.054009861310889 -0.049060128861341 -0.116101359422429 -0.043743279836749 -0.090347856826429  0.186254068915307 -0.010091097621831  0.182439821622372 -0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.050351452990167  0.022080091821478 -0.055614920128739
-    1  (  1) -0.043523152379598 -0.028913570586242  0.049281187081852
-    2  (  2) -0.088800989050704 -0.012387284429283  0.115844546053497
-    3  (  3) -0.017174780224652 -0.120766108673226  0.043936127494914
-    4  (  4) -0.030870076304731  0.062251132422338  0.090680792727787
-    5  (  5) -0.006295822004517  0.109602420736026 -0.187179028172583
-    6  (  6) -0.023342165877015  0.045357751936196  0.008109043414047
-    7  (  7)  0.023116687534610  0.043892116907456 -0.180954962224114
-    8  (  8)  0.233341712412303  0.091442003006516  0.004136900096905
-    9  (  9) -0.000301754743843 -0.311200434843549  0.071746006250031
-   10  ( 10)  0.310579381122594 -0.001146128096000 -0.337175845358798
-   11  ( 11) -0.071759110731455  0.341710402101474  0.000514995746851
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000373475564698 -0.036374284715410  0.020675408038120  0.041938611278043 -0.014954064130636  0.008670693741941  0.001941666498966 -0.002175213653671  0.081223953533966
-    1  (  1)  0.035409311090430  0.000583412494499 -0.021912114995751 -0.019686191919175 -0.001337756516393  0.101410043872272  0.013539530463413  0.021085032009130  0.104140442794578
-    2  (  2) -0.022476650279619  0.020869170321065 -0.000623148668542 -0.026925059222749  0.022600045203783  0.054500059821995  0.019747085432266  0.002197258536137  0.059803959084815
-    3  (  3) -0.040527884961938  0.020785023904239  0.026269813130118  0.000471315833621 -0.011435927824319 -0.005094359128676 -0.021078069661848  0.001900689912103 -0.049285996887456
-    4  (  4)  0.014876995236008  0.001935832477363 -0.021280417512247  0.011112950356736 -0.000010954074914  0.001375736589678  0.021071346294591 -0.002540388393255  0.057176443725449
-    5  (  5) -0.009413911140341 -0.101590521816804 -0.054440250203052  0.004479146413684 -0.000983185589705 -0.000044886603863 -0.008942266041566  0.007734744988056  0.012623227871857
-    6  (  6) -0.001228199632690 -0.013460754514196 -0.019370737847276  0.021147815413154 -0.021180440912387  0.009078596190780  0.000060187992369 -0.021757615671251 -0.021546696625458
-    7  (  7)  0.002386621109668 -0.020697715049428 -0.002142304032572 -0.001889845237358  0.002502377714011 -0.007891184567460  0.021671667697211 -0.000014467640044 -0.019485620614445
-    8  (  8) -0.082726042327291 -0.104120679625015 -0.059410287861643  0.049170685661379 -0.057558349352742 -0.011952514103015  0.021313492463386  0.019559674827960  0.000280085719614
-    9  (  9)  0.081272328726009 -0.110754135563007 -0.028218762900775 -0.005318083145326  0.020981856638396  0.014567561104212  0.097856532501808  0.003185861516469  0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.080531031337273
-    1  (  1)  0.111220099551316
-    2  (  2)  0.028332370195928
-    3  (  3)  0.005372945270244
-    4  (  4) -0.020768901638641
-    5  (  5) -0.014982546342664
-    6  (  6) -0.097582479807565
-    7  (  7) -0.003277826561639
-    8  (  8) -0.003260780284830
-    9  (  9) -0.000186812021876
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055078142867828 -0.005804719299681  0.036780646353647 -0.020745008939831  0.005631321838333  0.032388434299089 -0.019554696167851 -0.000026315290494 -0.020764618651157
-    1  (  1)  0.007062764870854 -0.009531925050962 -0.009339128991500  0.000585332198702  0.003536715157378  0.000717716084393 -0.020997702694190  0.003197609406412  0.007543205569196
-    2  (  2)  0.003273721829615  0.024127785783056  0.019803917766004 -0.021792459075320 -0.009225997435944  0.033280936086821  0.008357612389432 -0.004534634518823 -0.049752671423908
-    3  (  3)  0.009467819748219 -0.109846311430058 -0.049077069582499  0.038067479834844 -0.041344367688361  0.023164856965512  0.023494777837550  0.015492414054440  0.057415728354703
-    4  (  4) -0.087998530211411  0.166680738017738  0.040492236619192 -0.094854089537164  0.166732509395464 -0.071703004448668 -0.042087550249065 -0.037122017300705 -0.054342710801435
-    5  (  5)  0.299229806278301  0.048658757713325  0.047129705842446 -0.086908947365866  0.109728878663932 -0.016789363568018 -0.035383410684614 -0.025335321764417 -0.020816334753998
-    6  (  6) -0.066809370303780 -0.045194542515417  0.116536125053039 -0.010429907504714 -0.024187359392906 -0.082665971873618  0.044425337546003  0.096427706292236  0.099634759729367
-    7  (  7)  0.040692585686945  0.010414403444448 -0.019197392244389  0.094603783326762 -0.099044517012418 -0.021567521501408  0.184530946067710  0.010140666068000  0.044429992698867
-    8  (  8) -0.213871489773344 -0.016533777636027 -0.072796199007045  0.091991735348903 -0.195396773842710  0.059284334625803 -0.184339397290396  0.031894612373968  0.038856272349111
-    9  (  9)  0.030682243044227 -0.041775517875249  0.024602057980135 -0.057287290343526  0.006772740334119 -0.055735826221076  0.097648839100779  0.011580457295414 -0.048271645082472
-   10  ( 10)  0.033182564179255  0.014791814568441 -0.134627953730393  0.074303509883212 -0.072048570540947 -0.178297714606306 -0.018972497943516  0.029382172234938 -0.026191954922422
-   11  ( 11) -0.065304385216644 -0.054065687922946 -0.058978656197155 -0.069527138693935  0.087278294466894 -0.031923025189413 -0.037244505404452 -0.006712268565440 -0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007990021156235
-    1  (  1)  0.003543862611170
-    2  (  2)  0.051263654644270
-    3  (  3) -0.026303130686066
-    4  (  4) -0.059400171065937
-    5  (  5) -0.033889468632128
-    6  (  6)  0.063573026890197
-    7  (  7)  0.010425863419296
-    8  (  8)  0.056178737365981
-    9  (  9)  0.060112542127891
-   10  ( 10)  0.033303474011037
-   11  ( 11) -0.026602109435667
 
 	Computing L_X-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.143593232628
-	   1         2.855892523339    2.506e-01
-	   2         3.342911611894    1.068e-01
-	   3         3.351918548475    1.645e-02
-	   4         3.356249470058    7.564e-03
-	   5         3.356624891749    2.059e-03
-	   6         3.356583058873    5.462e-04
-	   7         3.356596510972    1.399e-04
-	   8         3.356595416907    4.469e-05
-	   9         3.356593516727    1.462e-05
-	  10         3.356593184742    4.960e-06
-	  11         3.356593578154    8.497e-07
-	  12         3.356593811867    2.935e-07
+	   0         2.143593218454
+	   1         2.855892502146    2.506e-01
+	   2         3.342911582895    1.068e-01
+	   3         3.351918519035    1.645e-02
+	   4         3.356249440403    7.564e-03
+	   5         3.356624862066    2.059e-03
+	   6         3.356583029191    5.462e-04
+	   7         3.356596481289    1.399e-04
+	   8         3.356595387224    4.469e-05
+	   9         3.356593487044    1.462e-05
+	  10         3.356593155060    4.960e-06
+	  11         3.356593548471    8.497e-07
+	  12         3.356593782185    2.935e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 6.157e-08
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.013921975065565  0.103381315829109  0.056389355096898  0.011768947816972  0.004121807955223 -0.057298678485070 -0.051432105076231 -0.011071595100990 -0.044909476246755
-    1  (  1)  0.013324613924162 -0.028079810676541  0.007070559814787 -0.008005471198395  0.006018453330844 -0.015973349330415  0.092922359472783 -0.001623775394348  0.017733631990947
-    2  (  2) -0.019765781914701 -0.033032250658388 -0.004007042176849 -0.050166385756319  0.029906079194408 -0.009704933667000 -0.038620452933162  0.002807692103963 -0.070071101745418
-    3  (  3)  0.070805556804984 -0.003068938942251  0.006504595257348  0.039373898202160 -0.036927092655665  0.030322281820042 -0.048817421108637  0.011305308050902  0.032860541612150
-    4  (  4)  0.014313386316708  0.043972310793415  0.013921813392036 -0.066387730109469  0.002442397138038 -0.016086934562225 -0.179664439851381  0.006464519349973 -0.090040691856223
-    5  (  5)  0.045155577186191 -0.247427178481659 -0.058353258995683 -0.094628927569757  0.090493402552644  0.185320260507422  0.131090788508292 -0.093104350867894  0.060872458952884
-    6  (  6) -0.038584331307231 -0.080297227608230  0.071473886019715  0.143170489853226  0.104560768686072 -0.046154653747240 -0.096338078586582 -0.334907808030702  0.111571007227725
-    7  (  7)  0.029042222296753 -0.237223314371562 -0.174932299186948 -0.080316826107909  0.040506264905804  0.119977478400892 -0.161451558991029  0.215735211087246  0.060177585905520
-    8  (  8)  0.025904244265209  0.058524341310476 -0.144685830322387  0.050264276045864 -0.072805327886092 -0.086206688333215 -0.053604324132359 -0.007863564270736  0.095576963924380
-    9  (  9)  0.256508945269226  0.052730013654633  0.124834441481755  0.085733906231975 -0.088393899635438 -0.140853295492133 -0.139492059284684 -0.083015088260315 -0.042052092330032
-   10  ( 10) -0.128333935578074 -0.263327859036735 -0.068329655679101  0.087024591997986 -0.057039935036965 -0.051621611298698  0.073645648424309 -0.107556560489238 -0.002537116902128
-   11  ( 11) -0.014388047963903 -0.095897531557492  0.075761746736829 -0.083654757188919 -0.030891133031091  0.061475545358308 -0.020586611930162 -0.065614997905860 -0.075825389492545
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.046633267353021
-    1  (  1) -0.000248773711794
-    2  (  2) -0.058940238082046
-    3  (  3) -0.028215078659147
-    4  (  4)  0.009693071380795
-    5  (  5)  0.114025765710299
-    6  (  6)  0.149932383186960
-    7  (  7)  0.029309043140763
-    8  (  8) -0.056468406833596
-    9  (  9) -0.080845904093313
-   10  ( 10) -0.031944380388807
-   11  ( 11)  0.038072643167866
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000412292330125  0.089973601331934  0.299831566929396 -0.035035339281938  0.102534416749163 -0.139160673237755 -0.022726794108668 -0.127186946220527  0.025258681551895
-    1  (  1) -0.089435365325252 -0.000179018409619 -0.000575799904893 -0.036397358696681 -0.000077605512592 -0.027763068926142 -0.235329561156625  0.149048042365481 -0.020748539941476
-    2  (  2) -0.298742449986735  0.000117532207539 -0.000001365547946 -0.030750645565914 -0.035092304813822  0.156637931403196  0.074944775632850  0.084030365627553 -0.029024110989879
-    3  (  3)  0.035083534268240  0.036212512324819  0.030659339328188 -0.000140940179517  0.000968456927916 -0.032572407071500  0.017530821556219 -0.040913042583287  0.072860913708021
-    4  (  4) -0.102571067786625  0.000186672877588  0.035613278772227 -0.000984301508163 -0.000083284505465  0.006675066086515  0.008092161812671 -0.022927931588032 -0.061863833474700
-    5  (  5)  0.139766487530579  0.026940126885898 -0.158769710672111  0.032620148977718 -0.008447998102452  0.000109266532081 -0.002529804726067 -0.011694293836355 -0.013434968660314
-    6  (  6)  0.023123393533703  0.235158830889094 -0.075094645607883 -0.017636517707368 -0.007886799997649  0.001572260884544  0.000097447401663  0.019414476223635  0.005807231271628
-    7  (  7)  0.127556864975777 -0.149585463815487 -0.085819990046561  0.040749094743077  0.022487818487125  0.013521945874053 -0.020097198716066  0.000802314554648  0.005625145325134
-    8  (  8) -0.025298741297676  0.021022944558544  0.028995189539972 -0.073180879828651  0.063113474589722  0.013554956351232 -0.005975480503955 -0.005930971726208  0.000800554325514
-    9  (  9) -0.112700264643845  0.073437341408674  0.164270709854341 -0.104952328655436 -0.027707355858660 -0.001091847596269 -0.013360757417668 -0.016602481071790  0.000305982559018
-   10  ( 10)  0.061794958624484 -0.084043685363021 -0.190307519851821 -0.184568056526643 -0.046373613192876  0.061509024448409 -0.022601229760496  0.000957508970510 -0.004225767450876
-   11  ( 11)  0.048625937545448 -0.043275944873041 -0.072889882486030 -0.022571956848243 -0.129861302445486 -0.036376964004426 -0.007420842536071  0.027716174562617  0.009223617021504
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.112403684053299 -0.061844266359582 -0.048595688328450
-    1  (  1) -0.073289438710481  0.083115738233247  0.043020697969992
-    2  (  2) -0.163076133270358  0.188328773885241  0.073201670147403
-    3  (  3)  0.104459841985857  0.183989325360910  0.022816670642033
-    4  (  4)  0.027396737691172  0.045295479134009  0.129115557967778
-    5  (  5)  0.000453294188389 -0.059142853300762  0.038676049893677
-    6  (  6)  0.012371321314524  0.021833349857811  0.007208017450018
-    7  (  7)  0.015425630197400  0.001848995755235 -0.027351698922038
-    8  (  8)  0.000188535381821  0.004971799266654 -0.013988330055868
-    9  (  9)  0.002500332480999 -0.018263398716747  0.000166576528748
-   10  ( 10)  0.017029282729959  0.001958362912370 -0.009978757223056
-   11  ( 11)  0.000136976274521  0.009294880869252  0.003968240988117
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001614610532278 -0.000442574931184  0.002484843724335 -0.011617230485838  0.003558333116152 -0.008348902874223 -0.003232631795727 -0.035474959748436  0.033113190058216
-    1  (  1) -0.000925459790748 -0.002756415978539  0.003671717190974  0.027737733508484 -0.046977278124977 -0.010834189586698  0.039059419738438  0.012041835747932 -0.002521971555221
-    2  (  2) -0.003459035434675 -0.003977336342235 -0.002397115178596  0.018307436778833 -0.034854228953805  0.010228254395608 -0.015345849161942  0.005957982277486 -0.035439629368503
-    3  (  3)  0.011412707516267 -0.027632363855031 -0.015411420139492 -0.000653998533291 -0.003171166784775  0.010061032918207  0.036835076234213  0.006892251008290  0.051742329375438
-    4  (  4) -0.002517172902630  0.045696438310625  0.035505499284382  0.002530384085850 -0.000253636208605 -0.042894004341368  0.014146809697220 -0.013420506783873 -0.046216668076946
-    5  (  5)  0.010111413240912  0.013164521551321 -0.011774998630568 -0.009111026904833  0.043299806769081 -0.001105938056711  0.021679173976934  0.006497350404042 -0.032564751151170
-    6  (  6)  0.003572744448066 -0.037660563650739  0.015981449923599 -0.037360518379434 -0.013810638672119 -0.021864723269171 -0.000142160187409 -0.064951874935402  0.010074940303513
-    7  (  7)  0.035166313105451 -0.011117323575587 -0.004943664183497 -0.007105865391641  0.013161333406594 -0.006687507585744  0.064466547112747 -0.000008929989578  0.021120345923087
-    8  (  8) -0.032509023911163  0.002177177339651  0.037021275355168 -0.052629293793154  0.046088465137947  0.032895946707180 -0.009967848101922 -0.021497535040403 -0.000352351163086
-    9  (  9) -0.046618687808640  0.037317727430997 -0.035589549384149 -0.025010790590209  0.028730927164894 -0.032022748116099  0.011580581352781 -0.023706215184994  0.002053813335462
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.047931933872975
-    1  (  1) -0.037047707028514
-    2  (  2)  0.035085472287032
-    3  (  3)  0.025182750300990
-    4  (  4) -0.028820432773372
-    5  (  5)  0.031275953086245
-    6  (  6) -0.011353625053442
-    7  (  7)  0.023384944254726
-    8  (  8) -0.002155438322651
-    9  (  9) -0.000134462394627
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.017096508292429 -0.120272055653498 -0.064777511074434 -0.013939283933308 -0.004251250821330  0.059136973839352  0.058075430708834  0.010753929155031  0.046095863651254
-    1  (  1) -0.009080853524756  0.030472101004599 -0.005253613736105  0.008033743953506 -0.006571724145552  0.017271428965569 -0.096045717241910  0.001899586023459 -0.018803255158658
-    2  (  2)  0.015273557408716  0.033827870425321  0.002389839271830  0.049309614559235 -0.022714875551557  0.013412250204381  0.039215858182843 -0.002671798725080  0.073595316258831
-    3  (  3) -0.061397351425600  0.002542014700822 -0.006723003856764 -0.036114072726144  0.031891831787348 -0.035470170376113  0.050339849642367 -0.011227685711093 -0.032863858710597
-    4  (  4) -0.010418037759007 -0.052312507311500 -0.003108263430226  0.063054388106328 -0.009131466039430  0.023063009355567  0.186998825704419 -0.007656193265988  0.085937490516795
-    5  (  5) -0.049618070764987  0.269816796530382  0.071812132158805  0.093909466368595 -0.090964919694381 -0.192302531462338 -0.140007312222197  0.095346589436075 -0.068662718351823
-    6  (  6)  0.050705074903890  0.083507573951399 -0.075121836066492 -0.150175624907254 -0.110901140548139  0.044187464402636  0.100826757127919  0.348159602318287 -0.115791138943855
-    7  (  7) -0.024247361034940  0.261502177446179  0.185335196490176  0.086407538269004 -0.040595405612183 -0.132471756059254  0.167354565247558 -0.226853259555790 -0.063338369472266
-    8  (  8) -0.031044409528402 -0.062420557845031  0.150070034340745 -0.052228051583476  0.077587419735710  0.089629913379487  0.056032626281614  0.008151827554649 -0.096931788597858
-    9  (  9) -0.317132702814373 -0.055314612013316 -0.137754640120023 -0.090773612718365  0.100625469824133  0.163650859440807  0.143669062909266  0.090566852675112  0.052322376391313
-   10  ( 10)  0.142709053237480  0.301053034065592  0.082895903712517 -0.097157063403116  0.061479199300513  0.055989010255340 -0.082779787274017  0.112598796382161  0.005058093098571
-   11  ( 11)  0.016299349881188  0.110322948765521 -0.098821973474101  0.099107211043419  0.036545717852368 -0.075028438099748  0.024327846026163  0.071464427045319  0.082135257183916
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.047447570064905
-    1  (  1)  0.000600353714311
-    2  (  2)  0.061561394612175
-    3  (  3)  0.026518358614439
-    4  (  4) -0.004924249256689
-    5  (  5) -0.118873243448111
-    6  (  6) -0.158683429135866
-    7  (  7) -0.034364315517391
-    8  (  8)  0.057789177012035
-    9  (  9)  0.092690338450207
-   10  ( 10)  0.035646580943718
-   11  ( 11) -0.038984516104221
 
 	Computing P_Y-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.200307154747
-	   1         4.951546222602    2.282e-01
-	   2         5.301523711881    7.321e-02
-	   3         5.325053809996    1.715e-02
-	   4         5.327236038732    5.483e-03
-	   5         5.327519435638    9.692e-04
-	   6         5.327454619914    2.507e-04
-	   7         5.327454661587    6.852e-05
-	   8         5.327455450577    2.490e-05
-	   9         5.327454532036    7.355e-06
-	  10         5.327454718322    2.213e-06
-	  11         5.327454952663    4.514e-07
-	  12         5.327455097100    1.527e-07
+	   0         4.200307170817
+	   1         4.951546241626    2.282e-01
+	   2         5.301523730529    7.321e-02
+	   3         5.325053828044    1.715e-02
+	   4         5.327236056734    5.483e-03
+	   5         5.327519453628    9.692e-04
+	   6         5.327454637905    2.507e-04
+	   7         5.327454679578    6.852e-05
+	   8         5.327455468568    2.490e-05
+	   9         5.327454550027    7.355e-06
+	  10         5.327454736313    2.213e-06
+	  11         5.327454970655    4.514e-07
+	  12         5.327455115092    1.527e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 4.520e-08
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.023607177491195  0.019696611969885  0.037221212000385 -0.015590319696057  0.002020189842990  0.021016653547429 -0.007873916136755  0.003448340610807  0.079821954504390
-    1  (  1) -0.007327805297828 -0.018867534486269  0.042212469078496 -0.001447360534353  0.028939866752754 -0.077938653083341 -0.061948383376365  0.004945505795557  0.075894556663474
-    2  (  2) -0.009007071740861 -0.016177005802987 -0.068312932673240  0.041184857036759  0.003023256838844 -0.009849571097863  0.004290386808972  0.004340519661127  0.085840789796801
-    3  (  3)  0.026077185963910  0.012520558385893  0.023360353465929 -0.029787599349062  0.027312833784239  0.081100062029021  0.033406666012159 -0.054430078300136 -0.042036783131155
-    4  (  4)  0.044521029970710  0.101548028530885  0.092152577419686 -0.036969661342643 -0.235975964790827 -0.022489800485005 -0.018037809327809  0.163273258200919  0.255997686637622
-    5  (  5) -0.075082806179399  0.059495559215694 -0.178951166772656  0.134634824114366 -0.237022622504406  0.054772185517501  0.024504277147484 -0.150049663229407  0.003365655895118
-    6  (  6) -0.075564373604390  0.030719217759732  0.086498148733354 -0.160325933966896  0.064234285643905 -0.161900908445555  0.266146706738358  0.238096934941697  0.054011663901563
-    7  (  7) -0.117049393955643 -0.184359827232724  0.154835473828309 -0.196676571259727  0.209716028817009 -0.429620861048445 -0.096138950091600  0.371356959007903  0.058084061024513
-    8  (  8) -0.116322044765828  0.134673176933366 -0.115490121530453 -0.372419146214479  0.134366059259054  0.090977060566167 -0.047847126119104 -0.349531731511066  0.026343643532612
-    9  (  9)  0.016166361653787 -0.064655468388956  0.096603309196917 -0.102141195994536 -0.004689543577322 -0.174053614560893  0.096535422651742  0.179574162178272 -0.093140031286430
-   10  ( 10)  0.038118657992317 -0.011712936317703 -0.109233641260348  0.041948680427994  0.067033240911419  0.043789144467457  0.119198984082488  0.019961916251994  0.046236232124822
-   11  ( 11)  0.202537936665755  0.041865413038804 -0.001109842658197 -0.036047997932446 -0.209039172907281 -0.039634162843452  0.042796449278664 -0.037154632643052  0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001464671751436
-    1  (  1)  0.092168971837118
-    2  (  2) -0.096834154775615
-    3  (  3) -0.085232004143247
-    4  (  4)  0.224276823308218
-    5  (  5) -0.037070717977035
-    6  (  6) -0.017788678150516
-    7  (  7)  0.125655013910958
-    8  (  8) -0.036753750028807
-    9  (  9)  0.104788947042948
-   10  ( 10) -0.055723652563089
-   11  ( 11)  0.029086171780033
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000103943053471  0.020502980666838  0.044487026908476  0.112522389921676 -0.115190927698806 -0.086304427533430  0.028732798000328  0.005755262072674 -0.052707374815472
-    1  (  1) -0.020396732597728  0.000175507711089 -0.066631576709106 -0.188566511167110  0.188604507023904 -0.081802717690830  0.123212599282903  0.146580404278728 -0.063843813395139
-    2  (  2) -0.044224363892114  0.066688325942716 -0.000328779542201  0.131627364199491 -0.085838688001563  0.039792906367986 -0.071990397116460 -0.041811204620793  0.129151440044184
-    3  (  3) -0.112356491847955  0.188595812422395 -0.131743983691740  0.000034238258909  0.146405835083834  0.293116155503685 -0.174354593749844 -0.234740190959724  0.068400431241803
-    4  (  4)  0.114478156906703 -0.187880772610577  0.086711640119064 -0.146345707242046 -0.000351413466984  0.200401380550659 -0.118118144680811 -0.106599388398520  0.027535193682288
-    5  (  5)  0.086013769068620  0.081687368012874 -0.039811317138268 -0.293720012918757 -0.199751621453618  0.000779002249077 -0.029574633012291 -0.100809576430270  0.310087999943630
-    6  (  6) -0.028593362634754 -0.122990647052479  0.071886866993686  0.174357265134888  0.118164594946332  0.029455932226559  0.000323502179386  0.067588972736558  0.054838186724730
-    7  (  7) -0.005405231783831 -0.146637005514722  0.041701223809144  0.234444344892692  0.106310138998589  0.100760684833959 -0.067340032280388  0.000050446895501  0.206356025427645
-    8  (  8)  0.052734404217526  0.064663294136106 -0.127867798766573 -0.067686878519552 -0.027452578317565 -0.311518253800823 -0.053511305641188 -0.206912543882787 -0.000090733997612
-    9  (  9)  0.040822323151076 -0.050351126620632  0.033443030139718  0.028678071562223 -0.070729562284205  0.035204318394559 -0.035088801145452 -0.003858253384271  0.209126878103916
-   10  ( 10)  0.043554697985060 -0.034029200702705 -0.113396889510888  0.025104351967769  0.057922093461755  0.050331966245759 -0.113578028555237  0.006845000513571 -0.183899295084893
-   11  ( 11) -0.104445737487499  0.085327185159750  0.138831980783855  0.068059267872915  0.045287984054307 -0.106421559557756  0.126370094892912 -0.085884676801538 -0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.040472375428214 -0.043732687824618  0.105326662293090
-    1  (  1)  0.050113148730272  0.033553830886801 -0.085228632878169
-    2  (  2) -0.033648303602896  0.113430364410931 -0.140304701766262
-    3  (  3) -0.028908821271170 -0.025577280295259 -0.067243263311150
-    4  (  4)  0.070488811800233 -0.058243639304596 -0.043815524401846
-    5  (  5) -0.035954881502730 -0.048633621823234  0.102557737449989
-    6  (  6)  0.034599692943826  0.112216626584703 -0.126288398892548
-    7  (  7)  0.003737404887253 -0.007316223089443  0.087031799969318
-    8  (  8) -0.210522602449556  0.181960897898471  0.040780655119777
-    9  (  9)  0.000486792078199 -0.154877597629272  0.324381992896252
-   10  ( 10)  0.154731729402294  0.001003846432056  0.227757018056261
-   11  ( 11) -0.321308213629134 -0.230320716710505  0.000521529871008
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000267990887146 -0.017094909685382  0.026886221509252 -0.009154729792392 -0.028447394308811  0.043026223139973 -0.007934241734193  0.017529929372393 -0.048064409198736
-    1  (  1)  0.019165257539447 -0.000577613190074 -0.023971643573307  0.023362002438445 -0.020466955482562  0.074368923093670  0.021220838937975  0.006899315294507  0.004345205689582
-    2  (  2) -0.030573367311208  0.023520686332899 -0.000895230171902 -0.026482533037414  0.055578356600337  0.061212128793543  0.006033035982650 -0.029878597421323  0.067713186454891
-    3  (  3)  0.011556055604803 -0.022912214561881  0.028040995483179 -0.000806143570890 -0.016669730389240 -0.057830279830177 -0.001162806518994  0.022110531165998 -0.132937508894661
-    4  (  4)  0.029247962187325  0.019722933579604 -0.053631431975867  0.015590855142050 -0.000406564753787 -0.013151443352440  0.005583751708839 -0.048344741694769  0.058950645196782
-    5  (  5) -0.044502924478349 -0.074343902828738 -0.059891074519534  0.057011647107618  0.013642181191740  0.000660380157385  0.021619837229525  0.066247874288904 -0.026658775788480
-    6  (  6)  0.008416217090956 -0.021046309429680 -0.006522358687724  0.001270652730649 -0.005678899154477 -0.021925039235368  0.000233190982568  0.044213316193167 -0.019149792461568
-    7  (  7) -0.017220078580887 -0.007669026797702  0.030414088472195 -0.022279636607030  0.047947045698118 -0.066391322818188 -0.044159499520014 -0.000036612147908 -0.012788358083278
-    8  (  8)  0.049286641691243 -0.005157181302332 -0.067669102261374  0.134137839836174 -0.059598226202850  0.026736423898111  0.019691121432993  0.012900597372237 -0.000145671342113
-    9  (  9) -0.013771428368881  0.001534324314609 -0.097208563857550 -0.041538777135659  0.016922202614382  0.071792645864290  0.010700525463409 -0.088926800959210  0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.013388445223016
-    1  (  1) -0.001743269961120
-    2  (  2)  0.097384653394849
-    3  (  3)  0.041118719872747
-    4  (  4) -0.017104740675403
-    5  (  5) -0.071235600573670
-    6  (  6) -0.010744046806778
-    7  (  7)  0.088045104682667
-    8  (  8) -0.027915642785476
-    9  (  9) -0.000257740691093
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.024087436020668 -0.024234923487922 -0.034655069016827  0.013002508462274 -0.003506876735183 -0.019138226509165  0.008729154622077 -0.004126516633947 -0.080810387962203
-    1  (  1)  0.007340388106341  0.022740162593799 -0.047399213843079  0.000077807499313 -0.029710781800549  0.077091731467965  0.063337905707382 -0.003225301246506 -0.076935684639064
-    2  (  2)  0.008533292606078  0.014866249844284  0.069414473601385 -0.039067032188858 -0.004447555351962  0.009557153079335 -0.003933218079563 -0.004684619630234 -0.087696717260759
-    3  (  3) -0.022970088927143 -0.014796917693540 -0.027844101865804  0.035221698386289 -0.026363064761687 -0.090054977556852 -0.034727496736464  0.055362273105074  0.041999796595917
-    4  (  4) -0.041840045940810 -0.108064430049583 -0.094169303786903  0.038045467810124  0.242703284807102  0.022096059239039  0.018423933000872 -0.169152570163926 -0.255707171958253
-    5  (  5)  0.076575292532566 -0.064169513057282  0.187842221364997 -0.139017281082776  0.239663562780447 -0.056101309100792 -0.026864961939161  0.152773054853442 -0.000863550220823
-    6  (  6)  0.082619291232389 -0.034129866388443 -0.092672858212650  0.166047996934064 -0.066033557533197  0.164979644828487 -0.279604374284854 -0.245415146187524 -0.057275952528883
-    7  (  7)  0.119525510255884  0.192558180615050 -0.157479601093184  0.199612815310399 -0.216488749413977  0.438370355171240  0.097840156788249 -0.385286937285113 -0.058774287435548
-    8  (  8)  0.115070416909243 -0.142091116044252  0.125572997790340  0.378869543679260 -0.139572537143277 -0.093921809248974  0.047279124915748  0.359195083957732 -0.024443650320069
-    9  (  9) -0.023211259159309  0.064251202673602 -0.092489429719048  0.099069758679955  0.005272254913816  0.184087259640687 -0.103465084079069 -0.187259798043465  0.097400286560574
-   10  ( 10) -0.039092748606065  0.013006586457309  0.115772480099790 -0.044153430983449 -0.068039357936569 -0.040474168285568 -0.124671276809929 -0.020291967592974 -0.043718085717437
-   11  ( 11) -0.205517300660670 -0.035576186745690  0.000856944671273  0.036648470964825  0.217305799958921  0.037828885346138 -0.045859373489911  0.037554955798535 -0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001311477468569
-    1  (  1) -0.093224324445080
-    2  (  2)  0.099200064811294
-    3  (  3)  0.086458921973920
-    4  (  4) -0.229446975291319
-    5  (  5)  0.035136747289852
-    6  (  6)  0.019108151626501
-    7  (  7) -0.127376470092273
-    8  (  8)  0.036832911731868
-    9  (  9) -0.106598068979743
-   10  ( 10)  0.058544237541584
-   11  ( 11) -0.029477471817291
 
 	Computing L_Y-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.077597266993
-	   1         7.902302894867    3.672e-01
-	   2         8.909909301629    1.463e-01
-	   3         8.944393521017    3.633e-02
-	   4         8.959504425311    1.439e-02
-	   5         8.960042626072    2.748e-03
-	   6         8.959874910586    6.154e-04
-	   7         8.959901221233    1.622e-04
-	   8         8.959898472933    3.719e-05
-	   9         8.959898227126    1.073e-05
-	  10         8.959897754460    3.982e-06
-	  11         8.959898132250    8.208e-07
-	  12         8.959898330518    2.997e-07
+	   0         6.077597237300
+	   1         7.902302852420    3.672e-01
+	   2         8.909909247910    1.463e-01
+	   3         8.944393466121    3.633e-02
+	   4         8.959504369812    1.439e-02
+	   5         8.960042570523    2.748e-03
+	   6         8.959874855042    6.154e-04
+	   7         8.959901165688    1.622e-04
+	   8         8.959898417388    3.719e-05
+	   9         8.959898171581    1.073e-05
+	  10         8.959897698915    3.982e-06
+	  11         8.959898076705    8.208e-07
+	  12         8.959898274973    2.997e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 8.206e-08
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006230857276436  0.048797056399666  0.012716116252621 -0.005739964124866  0.013481384616698  0.042689584077060 -0.017270348738051  0.000419243135126  0.040443254435763
-    1  (  1)  0.001630425204596  0.020575306800344 -0.074043146154741  0.016576990359565 -0.024266588171945  0.025003638188733  0.041229879168230 -0.009096713997008 -0.048943522201480
-    2  (  2) -0.021449672787194 -0.004533663013035 -0.064512297360970  0.026056320112975  0.012311600212379 -0.057705244730510  0.006103097277552  0.007629023643838  0.100142202402752
-    3  (  3)  0.024506116908941  0.014405190116035 -0.023988780893855 -0.096344308015785  0.049822440345522 -0.076920537167928 -0.020583335246490 -0.007240688074708 -0.088817051721264
-    4  (  4)  0.016982681746660  0.005612968048325  0.130937709169030  0.258341025931177 -0.140085239410274  0.222842232178951 -0.024820716730135  0.026325168673687  0.055547617569483
-    5  (  5) -0.037879155414163 -0.128090386002125 -0.141870995017207  0.234587600888966 -0.098914790788390 -0.305800275284305 -0.055598905633593  0.131805449829431 -0.041081235097661
-    6  (  6) -0.043168564703436  0.030010861129281 -0.029114697539830  0.006214587904626  0.071804351546120  0.111206250824606 -0.202125985301076 -0.151209805862799  0.037927022313810
-    7  (  7)  0.020929918098688  0.040166703104938 -0.207928074963598 -0.005063717904073  0.015982060703677  0.122893504730377  0.039398473312957 -0.243542435447176 -0.058898622679243
-    8  (  8)  0.035897100247807 -0.130947966136576  0.251331455270193  0.079974479173535  0.413130980507748  0.044171581238907  0.028005185833489  0.165066997038960 -0.062489289780689
-    9  (  9)  0.085514193547145 -0.054930855523547 -0.094296152584403 -0.050328255510316 -0.067641033769805 -0.023318053487733 -0.006464024057725 -0.152704070253429 -0.195690762137195
-   10  ( 10)  0.121783132454786 -0.121649518544985 -0.001288572370528 -0.044670432803679  0.008034312045081  0.029879089305665  0.065139715799550 -0.014008708897036  0.002845810213058
-   11  ( 11)  0.023815006694348 -0.014334287141683  0.141630066387855  0.145326344089203 -0.037857456986322  0.058499598917858 -0.030801987861182  0.076045397273525  0.051718689270491
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.052021099116092
-    1  (  1) -0.000375019046341
-    2  (  2)  0.005095441550314
-    3  (  3)  0.212700400741322
-    4  (  4)  0.008054755280988
-    5  (  5)  0.023289560627031
-    6  (  6) -0.062134458371494
-    7  (  7) -0.183963154970289
-    8  (  8) -0.064610383082142
-    9  (  9)  0.033969497782711
-   10  ( 10)  0.034207553536027
-   11  ( 11) -0.027487667010859
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000165454282488  0.050277476849634  0.072265886779903  0.219046110490914 -0.170649240297555 -0.129272117676281  0.046129561714749  0.006317178179283 -0.031628796061177
-    1  (  1) -0.049926970343888 -0.000066751428030  0.008605428716391  0.088466711253630 -0.066209204064307  0.157896361055452 -0.137975283709074 -0.116685446085702  0.066609214976363
-    2  (  2) -0.071930707909687 -0.008646608001517 -0.000252105095070  0.010529809483454 -0.048142356541763 -0.064293359314159  0.026509274318636  0.087307307132468  0.055490250957849
-    3  (  3) -0.218638932403761 -0.088400431595603 -0.010362259249877  0.000161808465947 -0.006831656503924  0.050359143062454  0.002950107894051  0.043414691353781 -0.231632275337861
-    4  (  4)  0.170408151565692  0.066676104740888  0.048741085770175  0.007781046963117 -0.000858319634312  0.017393073562842 -0.004806366800845  0.002128732121080  0.034666156637510
-    5  (  5)  0.129353639616675 -0.158198145877926  0.063792237373481 -0.051918849505394 -0.015159666578669  0.002164443359528  0.004048396359766  0.028258116638309 -0.019204959902610
-    6  (  6) -0.046105252486005  0.138278098772584 -0.026048974354469 -0.002423377188050  0.004804777279161 -0.005123584343751  0.000505492048966 -0.004681249428299  0.016114426086496
-    7  (  7) -0.006108731746456  0.116491031311707 -0.087525580101622 -0.043947283481964 -0.000746891253088 -0.028211685279895  0.004399353185530 -0.000226937079603  0.001563554764084
-    8  (  8)  0.031635416967255 -0.066903366010132 -0.055032255173046  0.231683009312988 -0.036206711489392  0.019839043489615 -0.016402673760561 -0.000838534461521 -0.000669878290914
-    9  (  9)  0.101001614493512 -0.035831143017804 -0.051001612315387 -0.120753800379163 -0.001670851222790 -0.022069869139317  0.000180056135152  0.007894743612700  0.004712239169077
-   10  ( 10)  0.077799422553552 -0.050172827558475 -0.178180262760682  0.011809496949311 -0.042695780330294  0.018100828459930  0.003739392396915  0.021764215771311 -0.004254325334512
-   11  ( 11) -0.170574833391475  0.090218966161298  0.186165933844747  0.106592282303210 -0.035685321173548 -0.005531846565163  0.019468178901053 -0.028819942408996 -0.018249838127253
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.100729285954756 -0.077818756543715  0.170553425058221
-    1  (  1)  0.035210403182738  0.050067933089505 -0.091777926183755
-    2  (  2)  0.050619295779235  0.177821703580419 -0.188186480685002
-    3  (  3)  0.120238811273927 -0.012548687236120 -0.107146423121442
-    4  (  4)  0.001472161299553  0.042086791480199  0.037190721415684
-    5  (  5)  0.022276355941346 -0.015313888242227 -0.001378381953714
-    6  (  6) -0.001377652740630 -0.005127424181781 -0.019087401021940
-    7  (  7) -0.008204594963178 -0.020563680487320  0.026290026069629
-    8  (  8) -0.004730566883743  0.003787060797718  0.021343901910363
-    9  (  9)  0.000654068579583  0.020656394329926 -0.003094384610269
-   10  ( 10) -0.019022274800240  0.000759677344253  0.055278729862632
-   11  ( 11)  0.002626982476879 -0.053971886669755  0.001915083825045
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000967260159080  0.002202446432524  0.004511183444430  0.016374841316601 -0.010910776906997  0.001418525150323  0.006755217615277  0.000427817126425  0.035846025325519
-    1  (  1) -0.000391246067407 -0.000877310728950  0.036241037300273  0.001407367638059  0.003934213075234  0.029267906970015  0.005602239959753  0.010795263272597  0.003740186293266
-    2  (  2) -0.003829576674383 -0.036990457610833 -0.001398441262724 -0.029943520801568 -0.002038487479024  0.023272259992080  0.008230578537541  0.007682382933230  0.017088399951020
-    3  (  3) -0.016032914359479 -0.000368568996962  0.031158252703803 -0.000059940788557 -0.028967799575646  0.026891964655620  0.003191177418001 -0.012156707421423 -0.040980572338667
-    4  (  4)  0.011582657878517 -0.004557355848480  0.002754831890239  0.029254644747513  0.000056895383566  0.010447389828344  0.011227363550004  0.017276460075010  0.082609995830667
-    5  (  5) -0.000873189786955 -0.030297579893434 -0.024073075343027 -0.026022721348298 -0.010366640393980 -0.000392801080983  0.006236144036416 -0.025488940454099  0.075546848613138
-    6  (  6) -0.007828000597579 -0.004715416733939 -0.007204534812621 -0.003548053014936 -0.011139775691561 -0.005780043754072 -0.000209890995218 -0.022093647786116  0.021521213110625
-    7  (  7) -0.000136712832700 -0.010084233633668 -0.007596217834139  0.012002297241493 -0.016971650696249  0.025598072815601  0.022061499371271 -0.000030924207599 -0.027480037260575
-    8  (  8) -0.034517163034967 -0.003881690632474 -0.018182293711114  0.041467916178783 -0.083381816772957 -0.076400917002772 -0.021226287037618  0.027577743559442  0.000308523373358
-    9  (  9)  0.006887640002591 -0.038004114862362  0.068066991173237  0.074540859178153  0.096325885879967  0.063826495228134  0.021741321038929  0.075328539771934  0.015720438309394
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.006955591851981
-    1  (  1)  0.037011716243653
-    2  (  2) -0.066925876832342
-    3  (  3) -0.074849385969586
-    4  (  4) -0.096213956733721
-    5  (  5) -0.063907467407383
-    6  (  6) -0.021571044568900
-    7  (  7) -0.075014265081936
-    8  (  8) -0.015443164438173
-    9  (  9) -0.000349977346717
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008473601581619 -0.058320078803013 -0.009499899472232  0.001088259135238 -0.016242997407558 -0.041642820354273  0.019281478381302 -0.001541696314659 -0.042254273858150
-    1  (  1) -0.000334490440486 -0.020235443091975  0.074874760692952 -0.017019076387196  0.023949159076861 -0.029015987792742 -0.043482201692770  0.008653533652648  0.050609003215613
-    2  (  2)  0.017649927420035  0.005466470543623  0.062819872537720 -0.024335617743925 -0.013549365831462  0.057638943360770 -0.007946525598619 -0.007453269935932 -0.104441618231136
-    3  (  3) -0.020783291637709 -0.012738132257300  0.020888891645260  0.097905028236283 -0.052672606431380  0.073196008154541  0.021238374576188  0.005922717755271  0.087456377608286
-    4  (  4) -0.016996530387751 -0.011882557110211 -0.133285493089740 -0.270904493255005  0.144936247136341 -0.230612270825641  0.025999484339616 -0.027186445681165 -0.054335849730519
-    5  (  5)  0.043265455211536  0.139979958816237  0.149715430516995 -0.247713647604899  0.102410559077642  0.319151604186489  0.057805788052851 -0.138415193321428  0.046014997665461
-    6  (  6)  0.052880707652045 -0.033123002053909  0.032014076939227 -0.006298867450682 -0.077062313270277 -0.118246557884146  0.214649227435815  0.157387472815374 -0.039780533308888
-    7  (  7) -0.019315588907448 -0.037515736358395  0.221610727048942  0.003867379753041 -0.018038584173024 -0.130726889432006 -0.043210067374229  0.255244255063184  0.061970702798214
-    8  (  8) -0.039457544550719  0.137467753709456 -0.263418210746405 -0.083532282441423 -0.434570179765344 -0.040715456256394 -0.028807073739423 -0.172129116920192  0.067053424144521
-    9  (  9) -0.108821808763067  0.058176331616836  0.096181779066212  0.052585164814310  0.074960862104189  0.030411666230606  0.005322365866114  0.162638108566386  0.208900911424941
-   10  ( 10) -0.143141318703370  0.135644721237897  0.004816763589682  0.046370390666413 -0.007684027070582 -0.031560700160296 -0.073644359681820  0.014497709274558 -0.002720022476073
-   11  ( 11) -0.028228442161314  0.029546966066375 -0.156785160510693 -0.149588448608652  0.045289290724147 -0.066420712374432  0.030566776449830 -0.079826396018234 -0.056206720757084
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.054452002537081
-    1  (  1)  0.000507638322506
-    2  (  2) -0.005540126912246
-    3  (  3) -0.215642625069238
-    4  (  4) -0.015797761320826
-    5  (  5) -0.020861352515884
-    6  (  6)  0.063379663837058
-    7  (  7)  0.192560463271225
-    8  (  8)  0.066391989253748
-    9  (  9) -0.030368405143431
-   10  ( 10) -0.036776046301376
-   11  ( 11)  0.030367451420999
 
 	Computing P_Z-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.427313313353
-	   1         5.474883418080    2.509e-01
-	   2         5.920569181281    7.689e-02
-	   3         5.928098901554    1.225e-02
-	   4         5.929843270951    5.756e-03
-	   5         5.930187228643    1.111e-03
-	   6         5.930130805807    3.587e-04
-	   7         5.930137531508    8.480e-05
-	   8         5.930137866489    2.238e-05
-	   9         5.930137587569    4.858e-06
-	  10         5.930137635369    1.399e-06
-	  11         5.930137764207    3.899e-07
-	  12         5.930137840929    1.526e-07
+	   0         4.427313328367
+	   1         5.474883435006    2.509e-01
+	   2         5.920569197333    7.689e-02
+	   3         5.928098917382    1.225e-02
+	   4         5.929843286733    5.756e-03
+	   5         5.930187244408    1.111e-03
+	   6         5.930130821573    3.587e-04
+	   7         5.930137547274    8.480e-05
+	   8         5.930137882256    2.238e-05
+	   9         5.930137603335    4.858e-06
+	  10         5.930137651135    1.399e-06
+	  11         5.930137779974    3.899e-07
+	  12         5.930137856696    1.526e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 5.147e-08
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.089840465204225 -0.055253525883540 -0.050839656601929  0.011592120168853  0.028453073767485  0.033272498563027  0.013123122183092  0.010376152774617  0.046773274930095
-    1  (  1)  0.019180458750845 -0.004406050242553  0.021028155566967  0.011538680320289 -0.014109247012132 -0.033202867729220  0.146724711919951 -0.006291497986158  0.032816512639240
-    2  (  2)  0.008004935891454  0.083588166091295 -0.024500417662889 -0.004976479402859 -0.015361678869856  0.027030028650554 -0.075999531355577  0.040388417899799  0.092155828534757
-    3  (  3) -0.072751395760345 -0.101339872261880 -0.027554632505315 -0.017104143799594  0.009883810143648  0.054325029446985 -0.038424568195001 -0.007564948769101 -0.050859249479548
-    4  (  4) -0.116869612062058 -0.168448689602172 -0.076045170807919  0.039076911238534 -0.141061895780680  0.082089594379007 -0.096305838370831  0.090937592520626  0.089867596085833
-    5  (  5)  0.362411548066203  0.116301468610581  0.067304641586918  0.178833394354847 -0.120526935264372 -0.077690766748935  0.087853646530869 -0.131583743921650  0.005449987066682
-    6  (  6)  0.023022243577310 -0.091878291587840  0.168295716396468  0.360782087280141  0.197772285105134 -0.118427120672179 -0.100301554555422 -0.545992767837121  0.002274268616602
-    7  (  7)  0.332469089310140  0.094037896803367  0.021326282942452 -0.202588446745432 -0.003095262967230 -0.074773576198707 -0.261809753005545  0.312310926113466 -0.101271338039676
-    8  (  8)  0.102262443511968  0.018323432973791 -0.030286707735275 -0.141132962784100  0.140087132441384  0.016144892573022  0.105178803101546 -0.077042517784067 -0.061204405030880
-    9  (  9) -0.062921845500970 -0.223934495766079 -0.055471945329417 -0.006791304491310  0.142947280894142  0.007991932919943 -0.047858230706461 -0.145718178913241  0.072195393114585
-   10  ( 10)  0.062281498028430  0.059385022217194  0.196384149116451  0.042900612771916 -0.059951865879116 -0.109494756681462 -0.025377610533051 -0.255425379720525  0.006903138405362
-   11  ( 11)  0.109893814765672  0.036299338598219  0.008950289795172  0.103979082032925 -0.089663281746559 -0.076642658317109 -0.017386558594104 -0.075203103677764  0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015115955084904
-    1  (  1)  0.030649150844450
-    2  (  2) -0.004117081641871
-    3  (  3) -0.011275331966881
-    4  (  4)  0.082379096749867
-    5  (  5)  0.010925397739678
-    6  (  6)  0.209001724905895
-    7  (  7) -0.094421017044117
-    8  (  8) -0.009881568354141
-    9  (  9)  0.113416879853688
-   10  ( 10)  0.045856944277529
-   11  ( 11) -0.007202279712064
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000220708940429 -0.002285125103983 -0.191707004311250  0.079176547202062  0.015343724284655  0.090762856917070  0.035966370439669  0.080228715251931 -0.022632088832219
-    1  (  1)  0.002270884902228 -0.000127565392507  0.181504505051190 -0.084301622984598  0.019134286473150 -0.136527597935967 -0.291828838790707  0.086935165867290  0.003153353795357
-    2  (  2)  0.190790178739451 -0.181286631653937  0.000456958950263 -0.098736144982791 -0.201937120878681 -0.060858985812145  0.102547416191644 -0.128157455079926  0.052263022287278
-    3  (  3) -0.078674978461285  0.083802623610643  0.098399673810258  0.000007811365746  0.051373438075815  0.073262818066183  0.213681674768555 -0.159362252554929 -0.021801220424175
-    4  (  4) -0.014664072597960 -0.019624839214450  0.200908806156840 -0.051706138267892 -0.000345872163641  0.060049554881332  0.188299165959522 -0.122222075869351 -0.002767654097179
-    5  (  5) -0.090883158144736  0.136634126073923  0.061672946710902 -0.074085610649007 -0.059059222367226  0.000127348357414  0.089421360456473 -0.068061409120582  0.127845689145142
-    6  (  6) -0.036070137194869  0.291478881075219 -0.101913218910275 -0.213840026067922 -0.188217301311726 -0.090313292624869 -0.000227988253159 -0.211121150654972 -0.048790729392591
-    7  (  7) -0.080292928774450 -0.086502244153537  0.129683189759572  0.159077086898913  0.122727489493275  0.066634459735053  0.210168861536432 -0.000749252129634  0.114771568876213
-    8  (  8)  0.022833189301314 -0.003149552694449 -0.051809982276026  0.021432628906503  0.002600755913054 -0.127892598520278  0.048118709288206 -0.114794510187460 -0.000092800261922
-    9  (  9)  0.153861672366712 -0.063959309581427 -0.276686698038017 -0.018129236980868 -0.051934404023196 -0.023341508326279 -0.078386885605064 -0.038564733458116 -0.117925763161383
-   10  ( 10) -0.030779230036139  0.047764824598951  0.139550834348758 -0.058848096986720 -0.072156858928456 -0.071321440087986  0.120905085647966 -0.006516751215124 -0.144681807612295
-   11  ( 11)  0.005585664265456 -0.000647324323586 -0.016353426872082 -0.045937924242292 -0.003353711579607  0.138994412824604  0.062414171800322  0.018128246119697 -0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.154066232086317  0.030728257975556 -0.006318091498164
-    1  (  1)  0.063643818147584 -0.047463638962418  0.000566548572565
-    2  (  2)  0.275258773270295 -0.138888616959566  0.015969350630016
-    3  (  3)  0.017345671201066  0.059189082677904  0.046475381464176
-    4  (  4)  0.050392875387071  0.072424486885238  0.004459708301674
-    5  (  5)  0.026836133802329  0.070805989588457 -0.140760690762251
-    6  (  6)  0.078585377266712 -0.120742726291724 -0.064292229739042
-    7  (  7)  0.041858894695365  0.005665298794286 -0.017186389956069
-    8  (  8)  0.118429783701800  0.144155118064025  0.113213711259466
-    9  (  9) -0.000756388118591  0.455654623157072  0.231432578787543
-   10  ( 10) -0.453567841489266 -0.001497567906129 -0.172275686133391
-   11  ( 11) -0.230120702539645  0.175050207490782 -0.001480251815160
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000516219946816  0.034778633659956  0.032999546928151 -0.009629039776278  0.052966719633617 -0.030450001531878 -0.014875222246015 -0.072128990177077  0.048218822417803
-    1  (  1) -0.030877691560804  0.001883541097772  0.071434334115879 -0.019325009721534 -0.017452039030100 -0.158145751795333 -0.010537309557875 -0.021583100108147 -0.169934651056250
-    2  (  2) -0.033565318682613 -0.071200997372983  0.000581071534985 -0.036850040138101  0.007310816547227 -0.008797901115406 -0.029229533057666 -0.016744128499400 -0.070455787497455
-    3  (  3)  0.011004884819686  0.019179310791618  0.034909263032370  0.000523661128158 -0.007125267622899 -0.017666281606150 -0.025274953349027  0.006048522524524 -0.042959205727090
-    4  (  4) -0.052383681601535  0.016788640224883 -0.007028507044452  0.007472760866637 -0.000164741631073 -0.026820745242549  0.000005495327564 -0.022752424410877  0.031410113616428
-    5  (  5)  0.028924597602342  0.155705177520586  0.009708873936879  0.016613543931604  0.026890889200954  0.000863820528475 -0.026461589325309  0.030900211040800  0.024762473040831
-    6  (  6)  0.014335467827216  0.010396285650159  0.029624823660297  0.025462090585912  0.000149096444494  0.026996065218364 -0.000042625626758 -0.107465667965402  0.101121105248233
-    7  (  7)  0.071280711647029  0.021473260264964  0.016888851213230 -0.005990055447048  0.022650874097521 -0.030884846999677  0.107059671381934  0.000085380718295  0.001222830424055
-    8  (  8) -0.049124632890092  0.169889327710618  0.068826403708743  0.044339001017875 -0.031493314676472 -0.025080049766767 -0.100845039831255 -0.001167614688641  0.000278385825403
-    9  (  9)  0.004591463397670  0.224641690035662  0.054391854978822 -0.000520714575472  0.041379699430161 -0.035041097267503 -0.048865193892848 -0.034233303767760  0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.004372643490859
-    1  (  1) -0.225448428944350
-    2  (  2) -0.053543340635201
-    3  (  3)  0.000029286176363
-    4  (  4) -0.041473098636741
-    5  (  5)  0.035500700267141
-    6  (  6)  0.049415179037896
-    7  (  7)  0.033722251526408
-    8  (  8) -0.002108270875613
-    9  (  9) -0.000059855095180
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.083178189184036  0.063320502543375  0.053448860291133 -0.010119942476578 -0.027962494700737 -0.033408156898410 -0.016646686372055 -0.009688142905594 -0.047753876913682
-    1  (  1) -0.015436953954369  0.001484194684011 -0.023035398887205 -0.013457869405466  0.013993527195521  0.033943979767543 -0.150850131221437  0.006054179455746 -0.032861777904130
-    2  (  2) -0.007416632072171 -0.085535883632607  0.031035920631781  0.004414026005139  0.010136741110915 -0.029006493089287  0.078308410406643 -0.042862583013635 -0.094615352193845
-    3  (  3)  0.060864804294684  0.107990348400789  0.029334441164075  0.017074561166948 -0.006770814971091 -0.056161219994893  0.038880977880177  0.007186858274067  0.050898617184209
-    4  (  4)  0.109193273208522  0.178421304573120  0.074992061457995 -0.038015102633012  0.147910228795514 -0.087181398607820  0.098582275644141 -0.093570766915846 -0.088687564658624
-    5  (  5) -0.362309556227904 -0.121304099182945 -0.074968023841376 -0.180660703600124  0.122438585672172  0.079096894998506 -0.085876030826778  0.136109864287558 -0.002214631278523
-    6  (  6) -0.026835628168075  0.104282391359254 -0.172843582770517 -0.372105341696267 -0.200623348657875  0.124556824110224  0.101871864602057  0.564196462169744 -0.000688785089474
-    7  (  7) -0.344945182303497 -0.095060217852336 -0.019692892185405  0.208607222836184  0.002627647973779  0.075715664253568  0.273373001503080 -0.322679649636761  0.103750880742886
-    8  (  8) -0.103243578213400 -0.018995126733818  0.033613347666093  0.143946559071139 -0.146180680800982 -0.017308359580339 -0.107684620440504  0.078982837453949  0.062496256435255
-    9  (  9)  0.085648241806344  0.209611729409149  0.056224829650480  0.004822853433113 -0.155473341074989 -0.012971266670028  0.058097898147224  0.150335378963730 -0.078057323449305
-   10  ( 10) -0.070132629148842 -0.074702785463534 -0.209329818275843 -0.042566217114534  0.058034325280006  0.102370728009941  0.025801004099357  0.264561180085366 -0.017482708757363
-   11  ( 11) -0.113963029107499 -0.045073298009464 -0.000413587765283 -0.112463923253522  0.089423608765749  0.081287727377731  0.019439635907878  0.076622183257520 -0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015270950350973
-    1  (  1) -0.030946721870550
-    2  (  2)  0.003707642076146
-    3  (  3)  0.011960041321321
-    4  (  4) -0.086083869661608
-    5  (  5) -0.009867768215709
-    6  (  6) -0.209680707316341
-    7  (  7)  0.097843271017668
-    8  (  8)  0.010325909660635
-    9  (  9) -0.121632163838855
-   10  ( 10) -0.058275044600178
-   11  ( 11)  0.003021331907582
 
 	Computing L_Z-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.192772499333
-	   1         8.020992052868    3.746e-01
-	   2         9.064876887133    1.463e-01
-	   3         9.092542165262    2.494e-02
-	   4         9.100392821353    1.055e-02
-	   5         9.101242099487    3.031e-03
-	   6         9.101005906359    9.594e-04
-	   7         9.101060676487    1.863e-04
-	   8         9.101064725272    5.149e-05
-	   9         9.101063038401    1.393e-05
-	  10         9.101063072288    5.471e-06
-	  11         9.101063469210    1.344e-06
-	  12         9.101063827515    4.169e-07
-	  13         9.101063922429    1.232e-07
+	   0         6.192772470504
+	   1         8.020992011870    3.746e-01
+	   2         9.064876834470    1.463e-01
+	   3         9.092542111702    2.494e-02
+	   4         9.100392767496    1.055e-02
+	   5         9.101242045575    3.031e-03
+	   6         9.101005852452    9.594e-04
+	   7         9.101060622578    1.863e-04
+	   8         9.101064671363    5.149e-05
+	   9         9.101062984492    1.393e-05
+	  10         9.101063018378    5.471e-06
+	  11         9.101063415300    1.344e-06
+	  12         9.101063773606    4.169e-07
+	  13         9.101063868520    1.232e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 3.903e-08
 
@@ -1825,3600 +713,360 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.599417708737341    -0.006763273721600     0.354599224144412
-    1      0.195458156265963     0.180453505627885    -1.188631898175206
-    2     -1.396841544880362     1.447529397145240    -0.768769772188687
-
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008614927932901 -0.046442352400056  0.027924113420848 -0.003342105613042 -0.019198187280149 -0.043605993010684  0.000124507843934 -0.017903232775755 -0.064037761769677
-    1  (  1) -0.004023859954382  0.002812567241188 -0.015355365220565  0.063211982369858  0.033868800032563 -0.011581015700219 -0.004465574115878 -0.047030919129079 -0.048793907716228
-    2  (  2)  0.028525640721225  0.068120190051797 -0.016739332483522 -0.005073216914996  0.071940864110972 -0.066733646998345 -0.019605473406179 -0.001610556181541  0.004701378003057
-    3  (  3) -0.054155290592472 -0.054244334984755 -0.021962628004576 -0.018282485083091 -0.037028274309951  0.016786978556275  0.022024618578561  0.004302299401540 -0.167953274084101
-    4  (  4) -0.063182596929128 -0.128748808697011  0.121465113794596  0.160938411624414 -0.233917278334855  0.054052147786148  0.025334190025568  0.127021105025468 -0.261448831371970
-    5  (  5)  0.148864678539144  0.254187426901849 -0.169654893765005  0.284620623487219  0.104152411510991  0.359543809296571  0.133744009364038  0.041861549395911  0.169452799563311
-    6  (  6) -0.084956716693293  0.126613830958100 -0.017431389376921 -0.048281125785785  0.083267553859489 -0.206713853889007  0.428812335356187  0.005011018790693  0.061186511244325
-    7  (  7)  0.173630436499038  0.181276581467465 -0.440332497406727 -0.059456065314793  0.303618967332177  0.080016792150091 -0.104444652264320  0.251866044362601  0.089940979754426
-    8  (  8)  0.057697740265636  0.070180597319316 -0.383387445877903  0.514874723728167  0.465292274425094 -0.060917787458673  0.016262524997932  0.068972295825028 -0.265391565564862
-    9  (  9) -0.279247635392508  0.560707539445326  0.044547355247966  0.161505455840491 -0.002588377300620  0.219223272852673  0.096307931275233  0.176467158787115 -0.104344971075325
-   10  ( 10) -0.977075550189082  0.176418272338824  0.228294317792423 -0.099370607761785  0.027777959043915 -0.149348953174007  0.027413414685573 -0.102632226214496  0.005531527026329
-   11  ( 11) -0.211429004068205  0.082644794913083 -0.055680052865830  0.289018099852967 -0.067789578528906  0.064107786895450  0.141855082713117  0.071186757345684 -0.332576681432119
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071990946341156
-    1  (  1)  0.010142476746200
-    2  (  2) -0.112423878596356
-    3  (  3) -0.059253840833002
-    4  (  4) -0.014639189231197
-    5  (  5)  0.248038168374966
-    6  (  6) -0.055159646937661
-    7  (  7)  0.115432903674626
-    8  (  8) -0.135363224547124
-    9  (  9)  0.174678345310946
-   10  ( 10) -0.086140984938274
-   11  ( 11)  0.161723358519153
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.197572413114517 -0.541318632877371  0.139927415914873 -0.359578444130330 -0.398937843975486 -0.026586872167534 -0.139627977382516 -0.005896246491228 -0.003746644388905
-    1  (  1) -0.541058731973333 -2.034801242188507  0.920540457917585  1.016218584629480  0.729164689940962  0.054412526301737  0.235971924521468  0.315223615831553  0.096208087340554
-    2  (  2)  0.139828960639396  0.920734025049694  1.243601677781983 -0.974300649425054 -0.758553357750500  0.024609548649431  0.513266755137957 -0.116926330823923  0.094501440802452
-    3  (  3) -0.358970389612551  1.015833032444632 -0.974440229907822 -0.266348920037382 -0.133799224826450 -1.276907891719884  0.042984364188955 -0.410608972745146 -0.602345206758872
-    4  (  4) -0.398323035382104  0.727797072638099 -0.759857932028957 -0.133858878725855  0.575448485405805  0.056475665846990 -0.484493838094732 -1.583666059960473 -0.976878960945650
-    5  (  5) -0.027166282529876  0.055084907439528  0.024891154244808 -1.275543890392068  0.058746221115305  0.155399297624787 -0.236023461595880  0.812878944882876 -1.048535633945681
-    6  (  6) -0.139452284652001  0.236223353106611  0.513262677276795  0.042879631015553 -0.482819583744289 -0.235933155306163 -2.554180022039243  0.492117808091915  0.545404391969618
-    7  (  7) -0.005841417486080  0.316274368087248 -0.116163386132942 -0.410094172620351 -1.579571504351393  0.813774264702327  0.492423579055058 -1.700719634572147  0.685529426222534
-    8  (  8) -0.003628131523111  0.096035529406495  0.094131958822655 -0.602680558554738 -0.970206233042967 -1.045482011639248  0.544249830480973  0.683514460656999 -0.254958894521937
-    9  (  9)  0.326098978034070 -0.130935443755898 -0.379595166178810 -0.575990923913880 -0.393471965772156 -0.365686482354661 -1.227740649572571 -0.905826585766955  0.039987575439783
-   10  ( 10)  0.008103557010829 -0.039575543043785 -0.358664813530415  0.339232504235094  0.207222390004838  0.025784782686722 -0.874465143496950  0.752110557173402  0.140644707838520
-   11  ( 11)  0.161744201604777 -0.084371238126416 -0.371150000615002 -0.062082553987999 -0.264710244109502 -0.257261524594595 -0.444570825837596  0.002821912169167 -0.878431482758543
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.327854256723191  0.009019714201806  0.162710661594080
-    1  (  1) -0.133091859401188 -0.040697608916971 -0.085480013261477
-    2  (  2) -0.381849466582258 -0.359835698966555 -0.372555502654032
-    3  (  3) -0.579249329460985  0.337242930789026 -0.062083381101115
-    4  (  4) -0.396591932227294  0.208613968377681 -0.263534161447186
-    5  (  5) -0.365098796840620  0.027806203875135 -0.265146511184336
-    6  (  6) -1.230804866141472 -0.879767261427487 -0.448789926588722
-    7  (  7) -0.904635210810701  0.753869376128870 -0.007723762422951
-    8  (  8)  0.040323953888643  0.145561462630237 -0.894627985530935
-    9  (  9)  0.423095730032689 -0.296000598729972 -0.177730944535255
-   10  ( 10) -0.299463152132731  0.634536265412446 -0.073348108781663
-   11  ( 11) -0.175836972560684 -0.076105887981834  1.184769463941312
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.567008918440454  0.722443194224100  0.422402078329773  0.057554368538511 -0.068012024097596 -0.451975147608540  0.709419418128490 -0.110422168786063  0.095704108927647
-    1  (  1)  0.720885472964738  0.332527211352729  0.737390933664557  0.281750515995843  0.280761290393686 -0.598548871078422 -1.146750917560074 -0.177301134607867  0.234694928374046
-    2  (  2)  0.422183102929830  0.736485274543817  0.007829109729841 -0.365399185160488 -0.965501991519851  1.065090224342325 -0.394390877157068  0.239359282041345 -1.218182428400336
-    3  (  3)  0.059687201587689  0.280769829516347 -0.363255319277090 -0.833720445234328 -1.345952507284314 -0.189309823206009 -0.179890587463359  1.060334267261244  0.772514544005070
-    4  (  4) -0.069257393950461  0.281296543593726 -0.966923508415862 -1.344162403478837  1.514830798821686  0.013670590813123  0.227285042195308 -0.333966365834383  0.386248727994588
-    5  (  5) -0.449135841837750 -0.599397616398023  1.066820631137579 -0.189649110609729  0.013795397601274 -0.565008204089947  0.487292179201877  0.306200785308481  0.347063761059997
-    6  (  6)  0.708465668575064 -1.146562417015747 -0.391890894794961 -0.180811610825629  0.226633708337573  0.487729597603209 -2.767088081148377 -0.044613761228256 -0.000972346438746
-    7  (  7) -0.108981479701481 -0.177538422258191  0.240499334967173  1.059842333943978 -0.334391646412731  0.306249622802239 -0.044471110656761 -3.232660954268523  0.514839123397967
-    8  (  8)  0.094277588726801  0.235043460722862 -1.221823739304416  0.774952681271118  0.386077819008107  0.344858044218004 -0.000341133693178  0.514916107143190  0.507086715271392
-    9  (  9) -0.063381219775898  0.233965663654109 -0.093343357924906 -0.360354041999586 -1.006820146552738  1.344825106449130  0.268434803850821  0.315156353069794 -0.332938610236887
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.063808920787530
-    1  (  1)  0.235710820172182
-    2  (  2) -0.096202914418848
-    3  (  3) -0.360121798161892
-    4  (  4) -1.006476097602190
-    5  (  5)  1.343619008167611
-    6  (  6)  0.268106090274240
-    7  (  7)  0.315242334513133
-    8  (  8) -0.332481313383264
-    9  (  9) -0.175400025059932
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010284048494255 -0.022581971135931  0.025184528241746  0.002553505114185 -0.007866760216735 -0.035704112150886 -0.002766394497905 -0.015588851752449 -0.054894237910669
-    1  (  1)  0.001129370063260 -0.004341567056713 -0.012471737690510  0.068518821494219  0.037428649672491 -0.002857552975536 -0.002731409738209 -0.051935588474977 -0.049204102006071
-    2  (  2)  0.045340581598934  0.060774626672080 -0.014665202394902 -0.013163382447340  0.085552378847967 -0.055885373659009 -0.012884187954087 -0.000025912808653  0.007546289398551
-    3  (  3) -0.053518724373857 -0.051858316930917 -0.015829576226974  0.002308038466593 -0.033376912491914  0.026566608759227  0.020736863226261  0.017163432001033 -0.156611857939886
-    4  (  4) -0.057073647917578 -0.121620677730040  0.116559461318180  0.152459611673760 -0.224360677266659  0.063635487600126  0.025109630293686  0.123561544969923 -0.260705677431782
-    5  (  5)  0.132736043071323  0.228873275971275 -0.157588806451895  0.278203525609905  0.112411249713211  0.339424025956772  0.132778586915835  0.041442079822076  0.144607854949093
-    6  (  6) -0.099037108772820  0.133050971019321 -0.016390463092699 -0.047994853534082  0.082590754367535 -0.196599146843337  0.423704532236322  0.002588517799838  0.062442412924455
-    7  (  7)  0.164573996270568  0.174187584517111 -0.442718231735592 -0.055107629768529  0.292277213599590  0.090352016025028 -0.100915507153634  0.242008735185081  0.079009239652453
-    8  (  8)  0.059450407301305  0.065508844735816 -0.375580889101448  0.518979554864539  0.457917802055341 -0.070408637451188  0.013466768623613  0.072872586601375 -0.257559025462184
-    9  (  9) -0.246894722162695  0.551859769243373  0.044670824987361  0.162240888664295 -0.012774136938901  0.203595879781061  0.102036778576897  0.168067562706153 -0.111682944808914
-   10  ( 10) -0.913654455951997  0.155328532380750  0.215519674293101 -0.100970035089767  0.021969337557273 -0.148862369984030  0.046525143909590 -0.100083990349210  0.020780587060978
-   11  ( 11) -0.198781019683999  0.090074442467030 -0.050453210014304  0.292395282220077 -0.068054938936099  0.077531780115388  0.149511822875939  0.072921096134366 -0.357789764657410
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.062212803584986
-    1  (  1)  0.008222801612735
-    2  (  2) -0.107232253166961
-    3  (  3) -0.058083892735771
-    4  (  4) -0.001519088368734
-    5  (  5)  0.232883930798086
-    6  (  6) -0.056471183426688
-    7  (  7)  0.097796104480775
-    8  (  8) -0.126488666884472
-    9  (  9)  0.156849504238605
-   10  ( 10) -0.081446420280763
-   11  ( 11)  0.176341903152824
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007749096020893 -0.085883219860789 -0.036741821640513 -0.003365465554254 -0.013826624434967  0.045778129863205  0.040669337017936  0.010509742963645  0.029540605017242
-    1  (  1) -0.033323633544771  0.071013231293301  0.009381535649954  0.001865195819276 -0.004385218315905 -0.001145589403992 -0.107240463714063 -0.004928891794835 -0.020784313339082
-    2  (  2)  0.052107391808055  0.092519548352413  0.009858355445846  0.037319719751115 -0.023857034470632 -0.010135084101246  0.037769988668842 -0.015917832336735  0.090581268987334
-    3  (  3) -0.109820166860700  0.034268818868662  0.003318299125654 -0.047343590144125  0.049224764312370 -0.055554817528594  0.048303583350885 -0.021295778567536 -0.056731125392159
-    4  (  4) -0.007052162455570 -0.070092516335627 -0.001616209300804  0.100452686687340 -0.017125496300488  0.011804649620296  0.317168773449601 -0.015679790140276  0.134810835290821
-    5  (  5) -0.101789034987347  0.450242114045570  0.095257897029759  0.154575128248214 -0.107484330343030 -0.276349446627330 -0.224432437333530  0.138878619319231 -0.069374899620443
-    6  (  6)  0.129481070378189  0.190214182802185 -0.111482363704469 -0.289845791886638 -0.214082604248960  0.130539668518305  0.176627871859896  0.507792819613372 -0.145016045312478
-    7  (  7) -0.031015915682170  0.467808966358201  0.323231774623313  0.163051942437066 -0.027878152128557 -0.222130149400228  0.355582804042090 -0.345169178258104 -0.117503613032291
-    8  (  8) -0.081114418656010 -0.129458136695794  0.321266021811150 -0.116738859709862  0.112997348404402  0.150149613835924  0.100022037588641 -0.009859219508172 -0.185497355865147
-    9  (  9) -0.840897499603665 -0.103193956572518 -0.262141263376961 -0.179652800220136  0.091540284698060  0.263027818637292  0.232988427097700  0.132664590100508  0.080643129784317
-   10  ( 10)  0.396138270139100  0.527358178663247  0.115585436142149 -0.350404487392900  0.098592337861551  0.056041756240516 -0.132708614971811  0.130232826037073  0.024142145251939
-   11  ( 11)  0.048038049575401  0.184019168140566 -0.243899393243605  0.184449948512382  0.067903231499648 -0.173184976481832  0.074519873620110  0.122524072160336  0.175482839393722
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.029757291821339
-    1  (  1) -0.000721108481725
-    2  (  2)  0.081115665687732
-    3  (  3)  0.028764622397233
-    4  (  4) -0.020368316409772
-    5  (  5) -0.173632225317480
-    6  (  6) -0.281328230047800
-    7  (  7) -0.030401209370270
-    8  (  8)  0.093738850403327
-    9  (  9)  0.138017132925940
-   10  ( 10)  0.057334975405403
-   11  ( 11) -0.087072361680799
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.718905282963311 -0.301300066815098 -0.767801784865940  0.078512808825352 -0.203134864329395  0.241932163232250  0.058076631858574  0.196398858308336 -0.039008858124194
-    1  (  1) -0.301256490728193 -0.157440548180653 -0.036029555945222  0.243436823804201 -0.005929795652985  0.115486356935965  0.826228436942721 -0.465135369554618  0.058491264513800
-    2  (  2) -0.767289827428610 -0.036275730111077 -0.756926663794728  0.450133498634738  0.207784604973971 -0.828712724024022 -0.324647417359493 -0.353270502638369  0.092835605795882
-    3  (  3)  0.078579571414042  0.243310568002833  0.450095063336851 -0.208139431363607 -0.062202704649669  0.279001105370900 -0.076077558481815  0.262112030046533 -0.378810215172718
-    4  (  4) -0.202510304245595 -0.006692039856945  0.206011713498273 -0.062773519685661 -0.370731419489490 -0.256994084769574 -0.019543706164301  0.220490721787851  0.607096866069924
-    5  (  5)  0.239969372403163  0.117504635997786 -0.825053657412313  0.279484173569987 -0.255386254541418 -0.397595357673452 -0.135369610755389  0.236221247146237  0.269522215039686
-    6  (  6)  0.058390572588279  0.825859124407247 -0.324193078352693 -0.076854690390370 -0.019228317672495 -0.137735601227498 -0.351485727273275 -0.487761380462257 -0.103056409920122
-    7  (  7)  0.194458563409000 -0.463590717501173 -0.349817673328107  0.262678828099312  0.220495817360137  0.236701749060628 -0.486100377719484  0.043036203375607 -0.169360995578035
-    8  (  8) -0.038844766636175  0.058006360789407  0.092452034322386 -0.377838465048525  0.603441383275525  0.267460191997309 -0.103192305796676 -0.168696834715057 -0.618488124049516
-    9  (  9) -0.174642021637819  0.179686913958803  0.584519432729807 -0.531375857305351 -0.237827440080434  0.122408493834100 -0.350613084838644 -0.156778679126698 -0.027661506214973
-   10  ( 10)  0.043298420781037 -0.218837511618004 -0.611680553974653 -0.687832529301005 -0.249683832986975  0.553064660821027 -0.144105807777605  0.115245275900936 -0.084193131593124
-   11  ( 11)  0.061064657985430 -0.108300572115386 -0.188797311905296 -0.022208683609426 -0.827900622936499 -0.341922472618851  0.022718392329079  0.232401592689427  0.164619669402136
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.175684511601603  0.045513516298602  0.061672515006080
-    1  (  1)  0.179323083833167 -0.221567937419786 -0.109140577543022
-    2  (  2)  0.587827397093136 -0.616289532030193 -0.190305864672640
-    3  (  3) -0.534590179358002 -0.689583787093839 -0.022209033963942
-    4  (  4) -0.239000891867221 -0.249187499059157 -0.832603923332527
-    5  (  5)  0.122010791877518  0.553620901013401 -0.348332351708050
-    6  (  6) -0.352732495297565 -0.145056644635348  0.023781601660354
-    7  (  7) -0.157242165562723  0.112854519200918  0.232190589319976
-    8  (  8) -0.027709907045481 -0.086030263039170  0.172274707819854
-    9  (  9)  0.207109600584589  0.096837430686223 -0.023218950236813
-   10  ( 10)  0.100164655230671  0.138181178066476 -0.148224446144570
-   11  ( 11) -0.022320179734203 -0.148849259998097  0.901205762410303
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.179939828491769 -0.273263983919761 -0.077241939802207 -0.131310571537764 -0.452108955794121 -0.373710053222736  0.012756857043078  0.188686131296855 -0.281717657996437
-    1  (  1) -0.271865636595074  0.080204205184229  0.237736668579935  0.053954037181141  0.088144371186311  0.094298665169508 -0.396703489007358 -0.164374392009126 -0.012743809563993
-    2  (  2) -0.076549157175288  0.237611423410488 -0.235916884249811  0.330279805489172  0.156363656188217 -0.135525945480897  0.113532621668593 -0.192996543934043  0.505097349395040
-    3  (  3) -0.133008481204441  0.051978470711429  0.330705317892875 -0.689079279022158  0.681025162416434  0.230126506813665  0.220012049909173 -0.221793013382862 -0.415574431905058
-    4  (  4) -0.450299145657576  0.087908600365275  0.156309970041408  0.681002122520780 -1.360248251424318  0.202273753159192 -0.167570810051337  0.246051223487190  0.206738411458247
-    5  (  5) -0.373567193155845  0.094555329734040 -0.136731584498100  0.229377893488984  0.202581599883435 -0.322498154757568 -0.226671631570763  0.408374954790996  0.307423751717641
-    6  (  6)  0.013230492577454 -0.395220303624150  0.113830041131736  0.218897296842682 -0.167381205612527 -0.226319762003687 -0.422981172464967 -0.882122931150610  0.208582936748456
-    7  (  7)  0.187587553988559 -0.164973338711578 -0.192266029819867 -0.222193739599766  0.245811643454060  0.408813624326959 -0.882511768104148 -0.161881530949274 -0.197931622292553
-    8  (  8) -0.280045996340605 -0.013187886145669  0.507423753200987 -0.417462155137855  0.206022606034107  0.308302993473083  0.207495521066743 -0.198012373935716 -0.598880759668382
-    9  (  9) -0.299128216307527  0.222289305708678 -0.374826664894612 -0.022250761597490  0.198104512558476 -0.291885255576850  0.011569749529353 -0.150670269953426  0.186378706038956
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301492091129213
-    1  (  1)  0.222023461274417
-    2  (  2) -0.373275862159688
-    3  (  3) -0.022769731837422
-    4  (  4)  0.197531018509810
-    5  (  5) -0.291038388606400
-    6  (  6)  0.011766677818707
-    7  (  7) -0.150956367275849
-    8  (  8)  0.186282415361357
-    9  (  9) -0.408641391244209
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006541040222368 -0.029135588169222 -0.017330822595744  0.002628911660037 -0.012344009141809  0.034496132624923  0.021629830242309  0.010441885402291  0.025478364815458
-    1  (  1) -0.038275138470075  0.054424566886903  0.005683589031010  0.001642391288003 -0.005493648653247  0.001124544236485 -0.102028934451313 -0.004961744404475 -0.019198498257850
-    2  (  2)  0.053024456913342  0.083754722151204  0.014366999014575  0.045684709272444 -0.045425854355333 -0.015659092798954  0.035306515857362 -0.013688960188417  0.082596341754868
-    3  (  3) -0.125696090540634  0.031717757592640 -0.000802365038104 -0.050871771309593  0.061705711345850 -0.045742890419344  0.045450419445688 -0.021064845035616 -0.054716959844684
-    4  (  4) -0.016613018731749 -0.059371668786672 -0.003754167403423  0.095982620955076 -0.007240466240122  0.008043456529988  0.296808016923276 -0.015369394286441  0.136610478911713
-    5  (  5) -0.093091489377706  0.398657588863068  0.074430182364354  0.149030211928108 -0.108745535372234 -0.256250392240536 -0.205814737045222  0.134201000957220 -0.055103512993348
-    6  (  6)  0.103501697780443  0.185147067962843 -0.104829304475355 -0.273669393328239 -0.199802423052909  0.136710211986565  0.166053639619828  0.483268157942075 -0.135434527757446
-    7  (  7) -0.041456689404135  0.416662529525886  0.296499443846860  0.151835770270295 -0.027648961071683 -0.196853254585748  0.346148931870815 -0.324194030503122 -0.108656389838073
-    8  (  8) -0.069099920157317 -0.122455303618133  0.312946042218845 -0.115185983609626  0.104240832235501  0.145175805702234  0.095088539986730 -0.010672631592564 -0.187147060865154
-    9  (  9) -0.712671855893174 -0.096350152389786 -0.234711067777686 -0.171596024164591  0.065322769896798  0.213466874289907  0.226529390715592  0.118201066093080  0.055528795004367
-   10  ( 10)  0.365512212430565  0.443597144956858  0.088760713787529 -0.336294489487780  0.089380999156301  0.050585935158758 -0.112358935032342  0.122526344346197  0.011836823928278
-   11  ( 11)  0.046393846223224  0.165011629057398 -0.228781961279396  0.178941949643574  0.063752947031584 -0.164789871590981  0.073726138142668  0.117333811839271  0.181371275992210
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.026880621041360
-    1  (  1) -0.000642066544117
-    2  (  2)  0.075046583216661
-    3  (  3)  0.030887223304929
-    4  (  4) -0.027083357083367
-    5  (  5) -0.161323349919549
-    6  (  6) -0.260652499025702
-    7  (  7) -0.019658118713907
-    8  (  8)  0.093794795124770
-    9  (  9)  0.110456626093643
-   10  ( 10)  0.048798146100140
-   11  ( 11) -0.097571556382824
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001432746297450 -0.032810674091764 -0.033331937480253  0.023032547083763 -0.002808019310921 -0.039246266926320  0.018692018505171  0.008842597191367 -0.029091078569617
-    1  (  1) -0.008821922403183 -0.001742272088788  0.082771016704519 -0.022297486221974  0.039163604166239 -0.010818853488427 -0.047294425339584  0.013135326021221  0.049034393857867
-    2  (  2)  0.024274942916815  0.027096978669207  0.097516386902391 -0.041392368694666 -0.004119390757880  0.075691552303805 -0.023677742397495 -0.003953261558318 -0.122163189427397
-    3  (  3) -0.047038460283817 -0.039422636027069  0.017791086341758  0.115660160117630 -0.067224158887899  0.095036576800958  0.032022129167533  0.022732157345389  0.120912741709036
-    4  (  4) -0.041035802352368  0.001934742020068 -0.201409668003493 -0.406246991276172  0.228435905047063 -0.366034413601436  0.036563318346743 -0.036692328708082 -0.082010843429842
-    5  (  5)  0.098338733570095  0.243746073973362  0.282884501181602 -0.425804208023662  0.108408993563040  0.505586602390370  0.102717653176241 -0.183779423720787  0.023433267817945
-    6  (  6)  0.135336854760563 -0.062874421564495  0.076338309095403 -0.023002937162434 -0.130902824611473 -0.185164583438217  0.398907643233867  0.217551510448046 -0.032105677017803
-    7  (  7) -0.035062191357078 -0.113858796831119  0.431604299875852 -0.029482805357536 -0.029652466640804 -0.242847719350325 -0.077765311277989  0.367073496056810  0.139022006906444
-    8  (  8) -0.068272847454715  0.294672021175633 -0.568959581650588 -0.125921031197012 -0.707592810771387  0.017806583156209 -0.015845746565047 -0.212947645825718  0.125196335187716
-    9  (  9) -0.288858276698774  0.093713692739213  0.209035012311688  0.075382622510660  0.083405488851542  0.016184965058288  0.000548295704545  0.266294088315547  0.380874642506837
-   10  ( 10) -0.378738518488000  0.204837316203508 -0.069415360994347  0.062065163074324  0.029622876137723 -0.058750752587050 -0.120574645247794  0.008130897374692  0.009265965929469
-   11  ( 11) -0.080018520143771  0.225808316863723 -0.312311376663230 -0.316597637367698  0.125757542829493 -0.146130016020174  0.016179298260010 -0.136308703902615 -0.120756904157899
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.036093305578397
-    1  (  1) -0.001707679185378
-    2  (  2)  0.005295607540268
-    3  (  3) -0.304573937377439
-    4  (  4) -0.014287077020118
-    5  (  5) -0.068885443054321
-    6  (  6)  0.111979958895137
-    7  (  7)  0.321243115116497
-    8  (  8)  0.158205355334404
-    9  (  9) -0.080091690471286
-   10  ( 10) -0.065074315967804
-   11  ( 11)  0.075517488980888
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.151581395944457 -0.159877768539019 -0.191397517423370 -0.495232284867177  0.365561840480614  0.240680277087037 -0.079714342464060 -0.017889526464511  0.054577038131019
-    1  (  1) -0.159795957250344 -0.047735218799445 -0.125025973520529 -0.592230248738643  0.329204795623399 -0.563899565056737  0.474518384859258  0.371816427010336 -0.204007450193307
-    2  (  2) -0.191333337555164 -0.125299228178318  0.032743525999057 -0.248173196102997  0.424015573762028  0.373304795371779 -0.124367805075759 -0.383343230710404 -0.176623528718579
-    3  (  3) -0.494849488362154 -0.592714843248357 -0.248959287226432 -0.423717062956694  0.236470791317215 -0.415768039926139 -0.007927078894393 -0.295339114007336  1.138817517977087
-    4  (  4)  0.365842786381904  0.329912791129377  0.425309312530905  0.236284335454773 -0.297797609245548  0.287162197148014 -0.015195390583447  0.149575460395682 -0.352881082019632
-    5  (  5)  0.239666720470004 -0.562521840762128  0.375748994888085 -0.414021321385147  0.283842862620087  0.299376587010529 -0.122721640145877 -0.329969308300871  0.156494792176823
-    6  (  6) -0.079132044596257  0.473605179791134 -0.125255855635513 -0.008774504854422 -0.015965010341322 -0.123144104694353 -0.040262615853229  0.053291869268360 -0.230047243580867
-    7  (  7) -0.018210362041773  0.371975596266125 -0.382949144540519 -0.295062546320220  0.147969605902060 -0.330844143538271  0.053247875304319  0.437054225002062 -0.295575334707162
-    8  (  8)  0.054384972764257 -0.203042333758326 -0.176317356102570  1.137981680675850 -0.349930528471567  0.158219435758802 -0.229361079354617 -0.295174183029699 -0.201170965133917
-    9  (  9)  0.162593186917498 -0.096068090323904 -0.131721885594255 -0.537260876669133  0.048165192812382 -0.386108653062500  0.083321052788424  0.067822247358744  0.259623842469249
-   10  ( 10)  0.093086276325347 -0.110390627511003 -0.528311347000350  0.014888006239538 -0.100997055269664  0.192126958830561  0.038787614394956  0.063975054988451  0.077127488930246
-   11  ( 11) -0.248608674285678  0.166558436146830  0.438779225583925  0.334557445644043 -0.324782623645273  0.179928478753780  0.012126762707773  0.006418605871888 -0.316369462085207
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.163245257155421  0.094276717552644 -0.249582936616881
-    1  (  1) -0.097089753942058 -0.112180528774260  0.167323530234027
-    2  (  2) -0.131901378869784 -0.530116652654623  0.440616284282449
-    3  (  3) -0.539218683643804  0.014310072965047  0.335266942696954
-    4  (  4)  0.048635984706568 -0.103433325040069 -0.331331261588337
-    5  (  5) -0.385516013729792  0.187104305011894  0.193398800890046
-    6  (  6)  0.082991815026247  0.037352860323020  0.011014682786961
-    7  (  7)  0.067841455828072  0.062642922337485  0.014204699225385
-    8  (  8)  0.258473930207162  0.077886035701004 -0.325054438919389
-    9  (  9)  0.001773142889432 -0.053105768300802  0.034600115019000
-   10  ( 10) -0.053689547832438 -0.018246255837546 -0.196162567936867
-   11  ( 11)  0.031756575503292 -0.193298510202671  0.164652237069869
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.236069150423928  0.221583137218639  0.087467481976269 -0.023767225350154 -0.157884977853517 -0.128673956390029 -0.176595879969474  0.001131012317203 -0.181143452404233
-    1  (  1)  0.220430431059073  0.112052435313968  0.015869249151473  0.264485428778921 -0.165982030219470  0.159260926468858 -0.018854654828287 -0.249502649443057  0.052130725228418
-    2  (  2)  0.087694752982164  0.015013031218300 -0.683310722703039 -0.454889777527338  0.270539149606414 -0.876133156261866  0.064372104092668  0.069959767509230 -0.359585122327188
-    3  (  3) -0.022349867884997  0.265917774305981 -0.459885376820098  0.156118351029157 -0.442698949429053 -0.633164352365545 -0.123599096035318 -0.000681276488754  0.329408685832541
-    4  (  4) -0.157925484616889 -0.166044552973515  0.271218387113143 -0.443885849212600 -0.013362398764761 -0.176284165832649 -0.004716950323026  0.078109759941717 -0.609000288591445
-    5  (  5) -0.127616278770967  0.158011849801079 -0.876037618276795 -0.629854882079848 -0.177186230678137  0.012211398531521  0.059425698366986 -0.774979266274861 -0.486618182967767
-    6  (  6) -0.178241606252947 -0.017090192450387  0.064522373941146 -0.124240074207901 -0.004293285267873  0.059087683211698 -0.104000927528902 -0.330829052901522 -0.038045687603335
-    7  (  7)  0.002208432976113 -0.248689840257510  0.068573896371648  0.000014323070255  0.078530114044465 -0.775881123063332 -0.330687300606162  0.375687386105441  0.140607455827148
-    8  (  8) -0.178615853440425  0.052090468900394 -0.360562489485138  0.330978975217506 -0.607342070790934 -0.487347100955227 -0.037705399031252  0.140808054960246 -0.394251292282697
-    9  (  9) -0.046812023124734 -0.356025366669854  0.690811815119252  0.312933605279832  0.666333150435849  0.222468929331266  0.069111321865738  0.559435147572457  0.132671563084754
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045842278134109
-    1  (  1) -0.355929482932053
-    2  (  2)  0.690401613030498
-    3  (  3)  0.314450068453419
-    4  (  4)  0.667992312261241
-    5  (  5)  0.221641972273241
-    6  (  6)  0.069286377187356
-    7  (  7)  0.560338391968248
-    8  (  8)  0.132249466359632
-    9  (  9) -0.305201514350595
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003531322887475 -0.011853964282953 -0.013997173425702  0.018382792154192  0.000899996441170 -0.027829789222902  0.010946278656521  0.009416135608630 -0.023987807904262
-    1  (  1) -0.006388621957170 -0.005171201061298  0.075116414644925 -0.012351518893597  0.041297277094542 -0.006441657661851 -0.042094675941536  0.014500044658877  0.045272474380981
-    2  (  2)  0.036883171135873  0.025743377437805  0.085964964522995 -0.036572128405843  0.000741779132517  0.071901849285639 -0.017612259522947 -0.002857549793791 -0.114428225581804
-    3  (  3) -0.050379148878904 -0.038280516537017  0.018275237269774  0.118578575241743 -0.057964689431887  0.100743381549064  0.031817975653707  0.026538904209037  0.119963525599056
-    4  (  4) -0.040259568572502  0.011229705198348 -0.188809172609568 -0.380757486353216  0.215445879830049 -0.344569392827444  0.033187603168238 -0.033507608911701 -0.079582925346094
-    5  (  5)  0.087141198545524  0.216785041786672  0.270610048744647 -0.398997177058604  0.102170025016676  0.478625848854116  0.098949415070036 -0.170373600936987  0.015652914812384
-    6  (  6)  0.115394650619668 -0.055172374414512  0.068645251662214 -0.021005537436634 -0.120222938768552 -0.172201054646963  0.377862520931175  0.205771786365183 -0.028486300590321
-    7  (  7) -0.040171141537119 -0.121048023653740  0.403132598347777 -0.027760474590503 -0.026374510769541 -0.228317794220799 -0.070878790612320  0.346601006753617  0.129893637962627
-    8  (  8) -0.063034884678852  0.280866798080653 -0.540496031356204 -0.119391576371009 -0.673073389093966  0.010663808807394 -0.016147690801371 -0.200745867995305  0.117394935881043
-    9  (  9) -0.239823863619059  0.087614347419962  0.205995256328994  0.074059708937832  0.068748575207548 -0.000454096504958  0.003028317523563  0.249475422318809  0.352711368821821
-   10  ( 10) -0.336588165834448  0.173514331887659 -0.070029614207528  0.058791676167547  0.024501304819872 -0.052124336325614 -0.104213155529188  0.008639636736157  0.013496509549194
-   11  ( 11) -0.070036515714458  0.195530601320237 -0.305644951639726 -0.322831866596268  0.121530762471617 -0.141977993846978  0.021998928318675 -0.134440837975978 -0.127122644721006
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.030353030422789
-    1  (  1) -0.003358262791905
-    2  (  2)  0.006176160600104
-    3  (  3) -0.295046081788652
-    4  (  4) -0.003816440522472
-    5  (  5) -0.074325961201587
-    6  (  6)  0.109014636987132
-    7  (  7)  0.303731536940852
-    8  (  8)  0.152250258689580
-    9  (  9) -0.089511140585649
-   10  ( 10) -0.060789805292351
-   11  ( 11)  0.082293619260989
-
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016948570972613  0.054109880888837 -0.021135784265575 -0.002313233156337  0.028103296077604  0.079447973740205  0.002956852851677  0.021913708071079  0.092707789804150
-    1  (  1) -0.006461113403501 -0.006009670223774  0.006912589645128 -0.092573919328396 -0.040488535615147 -0.004255397696456  0.001825638351976  0.025873653657309  0.054959118002991
-    2  (  2) -0.031331544873159 -0.021241168145027  0.017129702121868  0.019395427099523 -0.035285598576221  0.072935692322985  0.012410630409385 -0.000869702308377  0.008015902055911
-    3  (  3)  0.024878718719799  0.025868121230654  0.005405353640122  0.004239945233349  0.042856541334318  0.005201344918358 -0.012288417201910 -0.030208301210711  0.125325395177801
-    4  (  4)  0.025785958698499  0.063980691498117 -0.073598667061032 -0.115501747702081  0.164822674147024 -0.010612384733594 -0.011577872820172 -0.114519752578224  0.189906673361740
-    5  (  5) -0.055556441114085 -0.137396825466669  0.095615332658029 -0.165972658367973 -0.107298365798081 -0.238527327390248 -0.081212554772841 -0.063709822276343 -0.111105007194853
-    6  (  6)  0.039392027543678 -0.042131630239803  0.019507343007951  0.031681902994480 -0.051489401416932  0.103596811576048 -0.235358679315166 -0.007221910465763 -0.034349807961782
-    7  (  7) -0.065836178815642 -0.094909606609938  0.220876622755124  0.015059455980391 -0.193611601065905 -0.070646838068217  0.043039430003875 -0.187401754034075 -0.048410779717487
-    8  (  8) -0.031684946163714 -0.037730087504351  0.186156646607922 -0.254646362799555 -0.271156762093932 -0.000387787259569 -0.024433068698376 -0.071450437934107  0.140846979003438
-    9  (  9)  0.084633662124775 -0.255488997024621 -0.026205007862790 -0.093994792938777 -0.025613688623644 -0.118121227074271 -0.051164537443405 -0.122992981774053  0.058164329433773
-   10  ( 10)  0.311792105223363 -0.086266548695923 -0.100581825486069  0.027645372765871  0.030325864964669  0.084727340300286 -0.008122017336910  0.056541723787744  0.001789230697787
-   11  ( 11)  0.065426291083003 -0.078665723239531  0.001736951632506 -0.128876911317495  0.027700220473420 -0.024959429550215 -0.037516506165893 -0.053272012233112  0.158952768314791
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.101753702406755
-    1  (  1) -0.017313059038111
-    2  (  2)  0.101825332796567
-    3  (  3)  0.046545573336527
-    4  (  4)  0.020412053345531
-    5  (  5) -0.174151422241113
-    6  (  6)  0.031247623880847
-    7  (  7) -0.081019948031908
-    8  (  8)  0.058254959468121
-    9  (  9) -0.102303876794014
-   10  ( 10)  0.049924523752296
-   11  ( 11) -0.075525972870746
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000125242728652  0.167195127529492 -0.056123303969470  0.168150627862986  0.199820827488140  0.006623842711744  0.083849175432758  0.006045895732050 -0.001251364845770
-    1  (  1) -0.166774393973286  0.000050108097355 -0.080714006337441 -0.158384893960458 -0.170632381263561 -0.022705538420815 -0.068262733314185 -0.100593352732071 -0.028750568711108
-    2  (  2)  0.056229020612168  0.080612207963297 -0.000319173254151  0.066387047727631  0.099495071766653 -0.005173360753909 -0.113435632074142  0.028897807757084 -0.031705991700745
-    3  (  3) -0.167678159270092  0.158683508487030 -0.065913815468277  0.000249734983867  0.003148005831140  0.156650391969335 -0.003319412683622  0.076996711806060  0.120344951995522
-    4  (  4) -0.199454748142053  0.170759345082550 -0.099469221211006 -0.002551454280228  0.000773886045054 -0.018686662746212  0.033100672959698  0.121887804954424  0.106797700418754
-    5  (  5) -0.006478249114673  0.021770745773300  0.005161753017351 -0.157975992221428  0.016380865873467 -0.000525726707385  0.009662973185984 -0.040170645002731  0.072417783927543
-    6  (  6) -0.083743292092373  0.068302347407764  0.113643630138679  0.003584139545109 -0.033360726847565 -0.010056643067212 -0.000096953687507 -0.013754999535778 -0.022913811866200
-    7  (  7) -0.005934789716209  0.100152235257288 -0.028714239339716 -0.077512132071698 -0.124503679540823  0.039365364835397  0.013764502288195  0.000180876976509 -0.012227152395047
-    8  (  8)  0.001252911154497  0.028874957240891  0.031437882577012 -0.119989379615825 -0.109273108573834 -0.074290660285147  0.022855339074817  0.012168993677105 -0.000462665884709
-    9  (  9)  0.203227152828002 -0.052485985798040 -0.129801089628845 -0.136141281459481 -0.065085125998612 -0.011352243649991 -0.086206555714525 -0.025668240031329  0.000953339185401
-   10  ( 10)  0.017663100569732 -0.012450214343934 -0.116177784025215  0.099935881710944  0.054793001926237  0.009017289614393 -0.082995680333069  0.068546362432187  0.010579042812723
-   11  ( 11)  0.116181838629295 -0.044517983740016 -0.150706036920128 -0.032577504630229 -0.048215712631815 -0.017042393348597 -0.052941121555075  0.017922753511187 -0.062577005194743
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.202593155221573 -0.017575879500322 -0.116307852916242
-    1  (  1)  0.051519507233614  0.011549119939392  0.045820851989693
-    2  (  2)  0.128159049336363  0.115585636177618  0.151359481294950
-    3  (  3)  0.134953502481695 -0.100933227346633  0.031949792725006
-    4  (  4)  0.063859931160852 -0.055317708494750  0.046074544888569
-    5  (  5)  0.011830479350239 -0.008881125854761  0.020210091121139
-    6  (  6)  0.085128481579730  0.081569095643572  0.054417852481447
-    7  (  7)  0.026086609962421 -0.069224862060329 -0.012195140209492
-    8  (  8) -0.000678319781602 -0.012471916838811  0.071159871058140
-    9  (  9)  0.000819518740474  0.045422336765459  0.019150849930670
-   10  ( 10) -0.042260420338391  0.001814961764223 -0.033976133870612
-   11  ( 11) -0.016728332900175  0.032414763485709  0.001978177060231
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000983782142481 -0.011124830147172 -0.012629378315808  0.024035154666400 -0.023065379134223  0.045710192314813 -0.107167060216496  0.027462764041011 -0.031515346399462
-    1  (  1)  0.014910063958614 -0.001359157823420 -0.030733082384744  0.019659721688393  0.009988965433840  0.056476882006057  0.086868153591365  0.027118954968710 -0.020111602536483
-    2  (  2)  0.013560973004051  0.032277644601759 -0.000558091321303  0.031608555416779  0.040262773871770 -0.039517595873987  0.008529102471728 -0.015019360045155  0.098314783259817
-    3  (  3) -0.023649721587845 -0.020118169175247 -0.030610171886610 -0.000350229335722  0.012485025400198 -0.061831636996218  0.007360517014456  0.020533699107494 -0.121125902320152
-    4  (  4)  0.023653135590417 -0.011024958414626 -0.040020875859244 -0.012638451269626 -0.000303446235581  0.039117573677270  0.028265656547984  0.042181285668281 -0.051214110379900
-    5  (  5) -0.045133076040651 -0.057161250752777  0.039343611119004  0.062428421797334 -0.039565506596663 -0.000136824832782 -0.002584969716509  0.016708941328372 -0.072879955596616
-    6  (  6)  0.106505496216286 -0.086364895206289 -0.008150243943918 -0.007611894739464 -0.028147100099079  0.003022121444643 -0.000203669685880  0.002510614548550 -0.011878393768514
-    7  (  7) -0.027112672456296 -0.027077462764235  0.015425844110164 -0.020594818217305 -0.042172669827196 -0.016338775255452 -0.002434838415100  0.000089029182611 -0.017463248477439
-    8  (  8)  0.031656276623231  0.019719565610509 -0.100860419907018  0.123299997114838  0.052015418367335  0.071940119122082  0.012364797759804  0.017989601258840 -0.000459902016922
-    9  (  9) -0.009520290499381  0.022267140636896 -0.003094175387367  0.010303251098885 -0.097174601333758  0.097786893048291  0.015199034071913  0.052630350765338 -0.034203233126427
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.010278877487205
-    1  (  1) -0.024100566367630
-    2  (  2)  0.004662205178286
-    3  (  3) -0.011080772146621
-    4  (  4)  0.096116977362317
-    5  (  5) -0.097255829352037
-    6  (  6) -0.015024357830545
-    7  (  7) -0.052513597187948
-    8  (  8)  0.034242058243121
-    9  (  9) -0.000071427193828
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.021462702377840 -0.058609304986263  0.015277082640202  0.003588508466775 -0.029160920616631 -0.083108081100347 -0.001276540885573 -0.021892833224427 -0.094847379110200
-    1  (  1)  0.007381037964715  0.005863657253688 -0.003698438732125  0.089241023982742  0.038284755695481  0.000242471073392 -0.003462666004729 -0.024254060890744 -0.054255658141393
-    2  (  2)  0.028789493389469  0.021034273638112 -0.015759179620292 -0.016880406379978  0.029564270241667 -0.075699259080315 -0.015222849490441  0.000165407073994 -0.009535205798866
-    3  (  3) -0.022522624621755 -0.025183731584898 -0.006246635644453 -0.011954555325543 -0.044324634330057 -0.008966012606668  0.011838270463808  0.025186144853786 -0.129587118903909
-    4  (  4) -0.027278246959126 -0.067306256079496  0.081195596321175  0.116387540315424 -0.168952317262089  0.005408102733272  0.009102915279315  0.114909773648686 -0.181841314973109
-    5  (  5)  0.061523869623373  0.148379112602599 -0.099858075157622  0.167623835533734  0.102565185360584  0.247065081865864  0.081017208043104  0.063123082298018  0.125076333021719
-    6  (  6) -0.033597893568908  0.039834794585931 -0.017503613262801 -0.032860851330180  0.052602131787128 -0.107800944359286  0.233932603910558  0.008404826542760  0.033043735155831
-    7  (  7)  0.070933561522966  0.099409127660202 -0.220355143796242 -0.017909988072788  0.200469521486937  0.066219172137076 -0.043845430589746  0.192769183200970  0.053043735796183
-    8  (  8)  0.031467417081633  0.038067047239557 -0.186574292412207  0.251635426547577  0.276398972104307  0.005573316819495  0.024827793389672  0.069746818919629 -0.142347486299646
-    9  (  9) -0.099591518033223  0.261294622221711  0.027264053477196  0.094406359241798  0.029407574246243  0.125903095774733  0.051208103024876  0.127846157357285 -0.056089461080389
-   10  ( 10) -0.342117397283536  0.096154260862934  0.107466277478619 -0.028734389414544 -0.028891686984979 -0.086820145756038  0.003652067648454 -0.059057626339762 -0.003362266069713
-   11  ( 11) -0.071536902730284  0.080845824211427 -0.010817173110070  0.135869650211322 -0.031366930890364  0.023168476862022  0.040179651854624  0.056331586353381 -0.165962619403637
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.103572144747435
-    1  (  1)  0.016763539950930
-    2  (  2) -0.104006607185189
-    3  (  3) -0.046374714497242
-    4  (  4) -0.027556807097170
-    5  (  5)  0.176590727028647
-    6  (  6) -0.030192309767508
-    7  (  7)  0.090742251579819
-    8  (  8) -0.063736127736872
-    9  (  9)  0.109060255331570
-   10  ( 10) -0.052388979852748
-   11  ( 11)  0.078361680425232
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.013921975065565  0.103381315829109  0.056389355096898  0.011768947816972  0.004121807955223 -0.057298678485070 -0.051432105076231 -0.011071595100990 -0.044909476246755
-    1  (  1)  0.013324613924162 -0.028079810676541  0.007070559814787 -0.008005471198395  0.006018453330844 -0.015973349330415  0.092922359472783 -0.001623775394348  0.017733631990947
-    2  (  2) -0.019765781914701 -0.033032250658388 -0.004007042176849 -0.050166385756319  0.029906079194408 -0.009704933667000 -0.038620452933162  0.002807692103963 -0.070071101745418
-    3  (  3)  0.070805556804984 -0.003068938942251  0.006504595257348  0.039373898202160 -0.036927092655665  0.030322281820042 -0.048817421108637  0.011305308050902  0.032860541612150
-    4  (  4)  0.014313386316708  0.043972310793415  0.013921813392036 -0.066387730109469  0.002442397138038 -0.016086934562225 -0.179664439851381  0.006464519349973 -0.090040691856223
-    5  (  5)  0.045155577186191 -0.247427178481659 -0.058353258995683 -0.094628927569757  0.090493402552644  0.185320260507422  0.131090788508292 -0.093104350867894  0.060872458952884
-    6  (  6) -0.038584331307231 -0.080297227608230  0.071473886019715  0.143170489853226  0.104560768686072 -0.046154653747240 -0.096338078586582 -0.334907808030702  0.111571007227725
-    7  (  7)  0.029042222296753 -0.237223314371562 -0.174932299186948 -0.080316826107909  0.040506264905804  0.119977478400892 -0.161451558991029  0.215735211087246  0.060177585905520
-    8  (  8)  0.025904244265209  0.058524341310476 -0.144685830322387  0.050264276045864 -0.072805327886092 -0.086206688333215 -0.053604324132359 -0.007863564270736  0.095576963924380
-    9  (  9)  0.256508945269226  0.052730013654633  0.124834441481755  0.085733906231975 -0.088393899635438 -0.140853295492133 -0.139492059284684 -0.083015088260315 -0.042052092330032
-   10  ( 10) -0.128333935578074 -0.263327859036735 -0.068329655679101  0.087024591997986 -0.057039935036965 -0.051621611298698  0.073645648424309 -0.107556560489238 -0.002537116902128
-   11  ( 11) -0.014388047963903 -0.095897531557492  0.075761746736829 -0.083654757188919 -0.030891133031091  0.061475545358308 -0.020586611930162 -0.065614997905860 -0.075825389492545
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.046633267353021
-    1  (  1) -0.000248773711794
-    2  (  2) -0.058940238082046
-    3  (  3) -0.028215078659147
-    4  (  4)  0.009693071380795
-    5  (  5)  0.114025765710299
-    6  (  6)  0.149932383186960
-    7  (  7)  0.029309043140763
-    8  (  8) -0.056468406833596
-    9  (  9) -0.080845904093313
-   10  ( 10) -0.031944380388807
-   11  ( 11)  0.038072643167866
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000412292330125  0.089973601331934  0.299831566929396 -0.035035339281938  0.102534416749163 -0.139160673237755 -0.022726794108668 -0.127186946220527  0.025258681551895
-    1  (  1) -0.089435365325252 -0.000179018409619 -0.000575799904893 -0.036397358696681 -0.000077605512592 -0.027763068926142 -0.235329561156625  0.149048042365481 -0.020748539941476
-    2  (  2) -0.298742449986735  0.000117532207539 -0.000001365547946 -0.030750645565914 -0.035092304813822  0.156637931403196  0.074944775632850  0.084030365627553 -0.029024110989879
-    3  (  3)  0.035083534268240  0.036212512324819  0.030659339328188 -0.000140940179517  0.000968456927916 -0.032572407071500  0.017530821556219 -0.040913042583287  0.072860913708021
-    4  (  4) -0.102571067786625  0.000186672877588  0.035613278772227 -0.000984301508163 -0.000083284505465  0.006675066086515  0.008092161812671 -0.022927931588032 -0.061863833474700
-    5  (  5)  0.139766487530579  0.026940126885898 -0.158769710672111  0.032620148977718 -0.008447998102452  0.000109266532081 -0.002529804726067 -0.011694293836355 -0.013434968660314
-    6  (  6)  0.023123393533703  0.235158830889094 -0.075094645607883 -0.017636517707368 -0.007886799997649  0.001572260884544  0.000097447401663  0.019414476223635  0.005807231271628
-    7  (  7)  0.127556864975777 -0.149585463815487 -0.085819990046561  0.040749094743077  0.022487818487125  0.013521945874053 -0.020097198716066  0.000802314554648  0.005625145325134
-    8  (  8) -0.025298741297676  0.021022944558544  0.028995189539972 -0.073180879828651  0.063113474589722  0.013554956351232 -0.005975480503955 -0.005930971726208  0.000800554325514
-    9  (  9) -0.112700264643845  0.073437341408674  0.164270709854341 -0.104952328655436 -0.027707355858660 -0.001091847596269 -0.013360757417668 -0.016602481071790  0.000305982559018
-   10  ( 10)  0.061794958624484 -0.084043685363021 -0.190307519851821 -0.184568056526643 -0.046373613192876  0.061509024448409 -0.022601229760496  0.000957508970510 -0.004225767450876
-   11  ( 11)  0.048625937545448 -0.043275944873041 -0.072889882486030 -0.022571956848243 -0.129861302445486 -0.036376964004426 -0.007420842536071  0.027716174562617  0.009223617021504
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.112403684053299 -0.061844266359582 -0.048595688328450
-    1  (  1) -0.073289438710481  0.083115738233247  0.043020697969992
-    2  (  2) -0.163076133270358  0.188328773885241  0.073201670147403
-    3  (  3)  0.104459841985857  0.183989325360910  0.022816670642033
-    4  (  4)  0.027396737691172  0.045295479134009  0.129115557967778
-    5  (  5)  0.000453294188389 -0.059142853300762  0.038676049893677
-    6  (  6)  0.012371321314524  0.021833349857811  0.007208017450018
-    7  (  7)  0.015425630197400  0.001848995755235 -0.027351698922038
-    8  (  8)  0.000188535381821  0.004971799266654 -0.013988330055868
-    9  (  9)  0.002500332480999 -0.018263398716747  0.000166576528748
-   10  ( 10)  0.017029282729959  0.001958362912370 -0.009978757223056
-   11  ( 11)  0.000136976274521  0.009294880869252  0.003968240988117
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001614610532278 -0.000442574931184  0.002484843724335 -0.011617230485838  0.003558333116152 -0.008348902874223 -0.003232631795727 -0.035474959748436  0.033113190058216
-    1  (  1) -0.000925459790748 -0.002756415978539  0.003671717190974  0.027737733508484 -0.046977278124977 -0.010834189586698  0.039059419738438  0.012041835747932 -0.002521971555221
-    2  (  2) -0.003459035434675 -0.003977336342235 -0.002397115178596  0.018307436778833 -0.034854228953805  0.010228254395608 -0.015345849161942  0.005957982277486 -0.035439629368503
-    3  (  3)  0.011412707516267 -0.027632363855031 -0.015411420139492 -0.000653998533291 -0.003171166784775  0.010061032918207  0.036835076234213  0.006892251008290  0.051742329375438
-    4  (  4) -0.002517172902630  0.045696438310625  0.035505499284382  0.002530384085850 -0.000253636208605 -0.042894004341368  0.014146809697220 -0.013420506783873 -0.046216668076946
-    5  (  5)  0.010111413240912  0.013164521551321 -0.011774998630568 -0.009111026904833  0.043299806769081 -0.001105938056711  0.021679173976934  0.006497350404042 -0.032564751151170
-    6  (  6)  0.003572744448066 -0.037660563650739  0.015981449923599 -0.037360518379434 -0.013810638672119 -0.021864723269171 -0.000142160187409 -0.064951874935402  0.010074940303513
-    7  (  7)  0.035166313105451 -0.011117323575587 -0.004943664183497 -0.007105865391641  0.013161333406594 -0.006687507585744  0.064466547112747 -0.000008929989578  0.021120345923087
-    8  (  8) -0.032509023911163  0.002177177339651  0.037021275355168 -0.052629293793154  0.046088465137947  0.032895946707180 -0.009967848101922 -0.021497535040403 -0.000352351163086
-    9  (  9) -0.046618687808640  0.037317727430997 -0.035589549384149 -0.025010790590209  0.028730927164894 -0.032022748116099  0.011580581352781 -0.023706215184994  0.002053813335462
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.047931933872975
-    1  (  1) -0.037047707028514
-    2  (  2)  0.035085472287032
-    3  (  3)  0.025182750300990
-    4  (  4) -0.028820432773372
-    5  (  5)  0.031275953086245
-    6  (  6) -0.011353625053442
-    7  (  7)  0.023384944254726
-    8  (  8) -0.002155438322651
-    9  (  9) -0.000134462394627
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.017096508292429 -0.120272055653498 -0.064777511074434 -0.013939283933308 -0.004251250821330  0.059136973839352  0.058075430708834  0.010753929155031  0.046095863651254
-    1  (  1) -0.009080853524756  0.030472101004599 -0.005253613736105  0.008033743953506 -0.006571724145552  0.017271428965569 -0.096045717241910  0.001899586023459 -0.018803255158658
-    2  (  2)  0.015273557408716  0.033827870425321  0.002389839271830  0.049309614559235 -0.022714875551557  0.013412250204381  0.039215858182843 -0.002671798725080  0.073595316258831
-    3  (  3) -0.061397351425600  0.002542014700822 -0.006723003856764 -0.036114072726144  0.031891831787348 -0.035470170376113  0.050339849642367 -0.011227685711093 -0.032863858710597
-    4  (  4) -0.010418037759007 -0.052312507311500 -0.003108263430226  0.063054388106328 -0.009131466039430  0.023063009355567  0.186998825704419 -0.007656193265988  0.085937490516795
-    5  (  5) -0.049618070764987  0.269816796530382  0.071812132158805  0.093909466368595 -0.090964919694381 -0.192302531462338 -0.140007312222197  0.095346589436075 -0.068662718351823
-    6  (  6)  0.050705074903890  0.083507573951399 -0.075121836066492 -0.150175624907254 -0.110901140548139  0.044187464402636  0.100826757127919  0.348159602318287 -0.115791138943855
-    7  (  7) -0.024247361034940  0.261502177446179  0.185335196490176  0.086407538269004 -0.040595405612183 -0.132471756059254  0.167354565247558 -0.226853259555790 -0.063338369472266
-    8  (  8) -0.031044409528402 -0.062420557845031  0.150070034340745 -0.052228051583476  0.077587419735710  0.089629913379487  0.056032626281614  0.008151827554649 -0.096931788597858
-    9  (  9) -0.317132702814373 -0.055314612013316 -0.137754640120023 -0.090773612718365  0.100625469824133  0.163650859440807  0.143669062909266  0.090566852675112  0.052322376391313
-   10  ( 10)  0.142709053237480  0.301053034065592  0.082895903712517 -0.097157063403116  0.061479199300513  0.055989010255340 -0.082779787274017  0.112598796382161  0.005058093098571
-   11  ( 11)  0.016299349881188  0.110322948765521 -0.098821973474101  0.099107211043419  0.036545717852368 -0.075028438099748  0.024327846026163  0.071464427045319  0.082135257183916
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.047447570064905
-    1  (  1)  0.000600353714311
-    2  (  2)  0.061561394612175
-    3  (  3)  0.026518358614439
-    4  (  4) -0.004924249256689
-    5  (  5) -0.118873243448111
-    6  (  6) -0.158683429135866
-    7  (  7) -0.034364315517391
-    8  (  8)  0.057789177012035
-    9  (  9)  0.092690338450207
-   10  ( 10)  0.035646580943718
-   11  ( 11) -0.038984516104221
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006230857276436  0.048797056399666  0.012716116252621 -0.005739964124866  0.013481384616698  0.042689584077060 -0.017270348738051  0.000419243135126  0.040443254435763
-    1  (  1)  0.001630425204596  0.020575306800344 -0.074043146154741  0.016576990359565 -0.024266588171945  0.025003638188733  0.041229879168230 -0.009096713997008 -0.048943522201480
-    2  (  2) -0.021449672787194 -0.004533663013035 -0.064512297360970  0.026056320112975  0.012311600212379 -0.057705244730510  0.006103097277552  0.007629023643838  0.100142202402752
-    3  (  3)  0.024506116908941  0.014405190116035 -0.023988780893855 -0.096344308015785  0.049822440345522 -0.076920537167928 -0.020583335246490 -0.007240688074708 -0.088817051721264
-    4  (  4)  0.016982681746660  0.005612968048325  0.130937709169030  0.258341025931177 -0.140085239410274  0.222842232178951 -0.024820716730135  0.026325168673687  0.055547617569483
-    5  (  5) -0.037879155414163 -0.128090386002125 -0.141870995017207  0.234587600888966 -0.098914790788390 -0.305800275284305 -0.055598905633593  0.131805449829431 -0.041081235097661
-    6  (  6) -0.043168564703436  0.030010861129281 -0.029114697539830  0.006214587904626  0.071804351546120  0.111206250824606 -0.202125985301076 -0.151209805862799  0.037927022313810
-    7  (  7)  0.020929918098688  0.040166703104938 -0.207928074963598 -0.005063717904073  0.015982060703677  0.122893504730377  0.039398473312957 -0.243542435447176 -0.058898622679243
-    8  (  8)  0.035897100247807 -0.130947966136576  0.251331455270193  0.079974479173535  0.413130980507748  0.044171581238907  0.028005185833489  0.165066997038960 -0.062489289780689
-    9  (  9)  0.085514193547145 -0.054930855523547 -0.094296152584403 -0.050328255510316 -0.067641033769805 -0.023318053487733 -0.006464024057725 -0.152704070253429 -0.195690762137195
-   10  ( 10)  0.121783132454786 -0.121649518544985 -0.001288572370528 -0.044670432803679  0.008034312045081  0.029879089305665  0.065139715799550 -0.014008708897036  0.002845810213058
-   11  ( 11)  0.023815006694348 -0.014334287141683  0.141630066387855  0.145326344089203 -0.037857456986322  0.058499598917858 -0.030801987861182  0.076045397273525  0.051718689270491
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.052021099116092
-    1  (  1) -0.000375019046341
-    2  (  2)  0.005095441550314
-    3  (  3)  0.212700400741322
-    4  (  4)  0.008054755280988
-    5  (  5)  0.023289560627031
-    6  (  6) -0.062134458371494
-    7  (  7) -0.183963154970289
-    8  (  8) -0.064610383082142
-    9  (  9)  0.033969497782711
-   10  ( 10)  0.034207553536027
-   11  ( 11) -0.027487667010859
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000165454282488  0.050277476849634  0.072265886779903  0.219046110490914 -0.170649240297555 -0.129272117676281  0.046129561714749  0.006317178179283 -0.031628796061177
-    1  (  1) -0.049926970343888 -0.000066751428030  0.008605428716391  0.088466711253630 -0.066209204064307  0.157896361055452 -0.137975283709074 -0.116685446085702  0.066609214976363
-    2  (  2) -0.071930707909687 -0.008646608001517 -0.000252105095070  0.010529809483454 -0.048142356541763 -0.064293359314159  0.026509274318636  0.087307307132468  0.055490250957849
-    3  (  3) -0.218638932403761 -0.088400431595603 -0.010362259249877  0.000161808465947 -0.006831656503924  0.050359143062454  0.002950107894051  0.043414691353781 -0.231632275337861
-    4  (  4)  0.170408151565692  0.066676104740888  0.048741085770175  0.007781046963117 -0.000858319634312  0.017393073562842 -0.004806366800845  0.002128732121080  0.034666156637510
-    5  (  5)  0.129353639616675 -0.158198145877926  0.063792237373481 -0.051918849505394 -0.015159666578669  0.002164443359528  0.004048396359766  0.028258116638309 -0.019204959902610
-    6  (  6) -0.046105252486005  0.138278098772584 -0.026048974354469 -0.002423377188050  0.004804777279161 -0.005123584343751  0.000505492048966 -0.004681249428299  0.016114426086496
-    7  (  7) -0.006108731746456  0.116491031311707 -0.087525580101622 -0.043947283481964 -0.000746891253088 -0.028211685279895  0.004399353185530 -0.000226937079603  0.001563554764084
-    8  (  8)  0.031635416967255 -0.066903366010132 -0.055032255173046  0.231683009312988 -0.036206711489392  0.019839043489615 -0.016402673760561 -0.000838534461521 -0.000669878290914
-    9  (  9)  0.101001614493512 -0.035831143017804 -0.051001612315387 -0.120753800379163 -0.001670851222790 -0.022069869139317  0.000180056135152  0.007894743612700  0.004712239169077
-   10  ( 10)  0.077799422553552 -0.050172827558475 -0.178180262760682  0.011809496949311 -0.042695780330294  0.018100828459930  0.003739392396915  0.021764215771311 -0.004254325334512
-   11  ( 11) -0.170574833391475  0.090218966161298  0.186165933844747  0.106592282303210 -0.035685321173548 -0.005531846565163  0.019468178901053 -0.028819942408996 -0.018249838127253
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.100729285954756 -0.077818756543715  0.170553425058221
-    1  (  1)  0.035210403182738  0.050067933089505 -0.091777926183755
-    2  (  2)  0.050619295779235  0.177821703580419 -0.188186480685002
-    3  (  3)  0.120238811273927 -0.012548687236120 -0.107146423121442
-    4  (  4)  0.001472161299553  0.042086791480199  0.037190721415684
-    5  (  5)  0.022276355941346 -0.015313888242227 -0.001378381953714
-    6  (  6) -0.001377652740630 -0.005127424181781 -0.019087401021940
-    7  (  7) -0.008204594963178 -0.020563680487320  0.026290026069629
-    8  (  8) -0.004730566883743  0.003787060797718  0.021343901910363
-    9  (  9)  0.000654068579583  0.020656394329926 -0.003094384610269
-   10  ( 10) -0.019022274800240  0.000759677344253  0.055278729862632
-   11  ( 11)  0.002626982476879 -0.053971886669755  0.001915083825045
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000967260159080  0.002202446432524  0.004511183444430  0.016374841316601 -0.010910776906997  0.001418525150323  0.006755217615277  0.000427817126425  0.035846025325519
-    1  (  1) -0.000391246067407 -0.000877310728950  0.036241037300273  0.001407367638059  0.003934213075234  0.029267906970015  0.005602239959753  0.010795263272597  0.003740186293266
-    2  (  2) -0.003829576674383 -0.036990457610833 -0.001398441262724 -0.029943520801568 -0.002038487479024  0.023272259992080  0.008230578537541  0.007682382933230  0.017088399951020
-    3  (  3) -0.016032914359479 -0.000368568996962  0.031158252703803 -0.000059940788557 -0.028967799575646  0.026891964655620  0.003191177418001 -0.012156707421423 -0.040980572338667
-    4  (  4)  0.011582657878517 -0.004557355848480  0.002754831890239  0.029254644747513  0.000056895383566  0.010447389828344  0.011227363550004  0.017276460075010  0.082609995830667
-    5  (  5) -0.000873189786955 -0.030297579893434 -0.024073075343027 -0.026022721348298 -0.010366640393980 -0.000392801080983  0.006236144036416 -0.025488940454099  0.075546848613138
-    6  (  6) -0.007828000597579 -0.004715416733939 -0.007204534812621 -0.003548053014936 -0.011139775691561 -0.005780043754072 -0.000209890995218 -0.022093647786116  0.021521213110625
-    7  (  7) -0.000136712832700 -0.010084233633668 -0.007596217834139  0.012002297241493 -0.016971650696249  0.025598072815601  0.022061499371271 -0.000030924207599 -0.027480037260575
-    8  (  8) -0.034517163034967 -0.003881690632474 -0.018182293711114  0.041467916178783 -0.083381816772957 -0.076400917002772 -0.021226287037618  0.027577743559442  0.000308523373358
-    9  (  9)  0.006887640002591 -0.038004114862362  0.068066991173237  0.074540859178153  0.096325885879967  0.063826495228134  0.021741321038929  0.075328539771934  0.015720438309394
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.006955591851981
-    1  (  1)  0.037011716243653
-    2  (  2) -0.066925876832342
-    3  (  3) -0.074849385969586
-    4  (  4) -0.096213956733721
-    5  (  5) -0.063907467407383
-    6  (  6) -0.021571044568900
-    7  (  7) -0.075014265081936
-    8  (  8) -0.015443164438173
-    9  (  9) -0.000349977346717
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008473601581619 -0.058320078803013 -0.009499899472232  0.001088259135238 -0.016242997407558 -0.041642820354273  0.019281478381302 -0.001541696314659 -0.042254273858150
-    1  (  1) -0.000334490440486 -0.020235443091975  0.074874760692952 -0.017019076387196  0.023949159076861 -0.029015987792742 -0.043482201692770  0.008653533652648  0.050609003215613
-    2  (  2)  0.017649927420035  0.005466470543623  0.062819872537720 -0.024335617743925 -0.013549365831462  0.057638943360770 -0.007946525598619 -0.007453269935932 -0.104441618231136
-    3  (  3) -0.020783291637709 -0.012738132257300  0.020888891645260  0.097905028236283 -0.052672606431380  0.073196008154541  0.021238374576188  0.005922717755271  0.087456377608286
-    4  (  4) -0.016996530387751 -0.011882557110211 -0.133285493089740 -0.270904493255005  0.144936247136341 -0.230612270825641  0.025999484339616 -0.027186445681165 -0.054335849730519
-    5  (  5)  0.043265455211536  0.139979958816237  0.149715430516995 -0.247713647604899  0.102410559077642  0.319151604186489  0.057805788052851 -0.138415193321428  0.046014997665461
-    6  (  6)  0.052880707652045 -0.033123002053909  0.032014076939227 -0.006298867450682 -0.077062313270277 -0.118246557884146  0.214649227435815  0.157387472815374 -0.039780533308888
-    7  (  7) -0.019315588907448 -0.037515736358395  0.221610727048942  0.003867379753041 -0.018038584173024 -0.130726889432006 -0.043210067374229  0.255244255063184  0.061970702798214
-    8  (  8) -0.039457544550719  0.137467753709456 -0.263418210746405 -0.083532282441423 -0.434570179765344 -0.040715456256394 -0.028807073739423 -0.172129116920192  0.067053424144521
-    9  (  9) -0.108821808763067  0.058176331616836  0.096181779066212  0.052585164814310  0.074960862104189  0.030411666230606  0.005322365866114  0.162638108566386  0.208900911424941
-   10  ( 10) -0.143141318703370  0.135644721237897  0.004816763589682  0.046370390666413 -0.007684027070582 -0.031560700160296 -0.073644359681820  0.014497709274558 -0.002720022476073
-   11  ( 11) -0.028228442161314  0.029546966066375 -0.156785160510693 -0.149588448608652  0.045289290724147 -0.066420712374432  0.030566776449830 -0.079826396018234 -0.056206720757084
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.054452002537081
-    1  (  1)  0.000507638322506
-    2  (  2) -0.005540126912246
-    3  (  3) -0.215642625069238
-    4  (  4) -0.015797761320826
-    5  (  5) -0.020861352515884
-    6  (  6)  0.063379663837058
-    7  (  7)  0.192560463271225
-    8  (  8)  0.066391989253748
-    9  (  9) -0.030368405143431
-   10  ( 10) -0.036776046301376
-   11  ( 11)  0.030367451420999
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057770723551805  0.007686176362995 -0.037676874102239  0.021875314889184 -0.005506967440553 -0.033731453254856  0.019605915987929  0.000153810358456  0.020480209762043
-    1  (  1) -0.007936092328855  0.008454757012618  0.010966637507272 -0.001712970012603 -0.003491085971866  0.000515536715359  0.020166951580993 -0.003537118918414 -0.007401819292438
-    2  (  2) -0.004823273660701 -0.024918096949402 -0.013456316532648  0.018061040723257  0.007928867774181 -0.029348077247204 -0.008305651855965  0.003787093111853  0.048173394734837
-    3  (  3) -0.011675775125104  0.107663431050362  0.048399528007616 -0.036525102270435  0.040730641356466 -0.022154401905676 -0.022459222262206 -0.014732815012435 -0.056193647103106
-    4  (  4)  0.087218313447135 -0.162702625594382 -0.040016358931151  0.090893257640902 -0.161526551014906  0.070532962320029  0.041494660476799  0.036307465283525  0.053954994619678
-    5  (  5) -0.299080380154522 -0.047071149143854 -0.050599107356677  0.086076035660096 -0.105747613370625  0.016291716828988  0.035370479977499  0.024570880182810  0.019740472062472
-    6  (  6)  0.064660820062842  0.041897488689090 -0.115036198620178  0.009494466980017  0.021741244197439  0.082050622741463 -0.041036304002792 -0.093842813724870 -0.099009311380003
-    7  (  7) -0.041406109005398 -0.013292096025031  0.015299070066933 -0.090658889471223  0.096664535474361  0.020138730803122 -0.181635797654581 -0.008096043748855 -0.043219320460348
-    8  (  8)  0.213166983290885  0.019961961605909  0.071163032757987 -0.089566388255459  0.187567657300030 -0.059322694628756  0.181371262434162 -0.031805535782928 -0.037438192749058
-    9  (  9) -0.029081682004423  0.052377114086944 -0.016598919354525  0.054121123864817 -0.005943121322964  0.052845962329270 -0.099913404453613 -0.011257505074012  0.046946017590445
-   10  ( 10) -0.029775807936917 -0.011144658296549  0.123616713069900 -0.069048925266029  0.072425392135727  0.175724644218768  0.020473761865880 -0.027329304597195  0.030635509122054
-   11  ( 11)  0.065686621670288  0.046175058814983  0.054739230530016  0.067089838730126 -0.085213076503212  0.033327993779702  0.039100303871838  0.006432393458887  0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007846989553355
-    1  (  1) -0.003599492488651
-    2  (  2) -0.050462951485827
-    3  (  3)  0.025590884562196
-    4  (  4)  0.058023095683205
-    5  (  5)  0.032774222915836
-    6  (  6) -0.063967275967677
-    7  (  7) -0.008682341559207
-    8  (  8) -0.054096899442108
-    9  (  9) -0.060114344610370
-   10  ( 10) -0.027778486812577
-   11  ( 11)  0.026791075407401
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000027040423887 -0.011060683872803 -0.004793456647899 -0.073481718860181  0.071504628495016  0.043329380984548 -0.025554578097106 -0.020981780177699  0.009741644195740
-    1  (  1)  0.011009750762997  0.000007607240151 -0.023558132508086  0.077101510719000 -0.072464798814331 -0.012890143420536  0.005683277430906  0.006920173400283 -0.002574145843753
-    2  (  2)  0.004842956248702  0.023538681455719 -0.000165226839542  0.207870652255993 -0.210753100259611 -0.104860036207310  0.066732822825146  0.046426833468215  0.005606364639263
-    3  (  3)  0.072846425542822 -0.076633967419021 -0.207131819599136  0.000363002499158  0.003747206858118  0.078444561827851  0.135702906183535 -0.013002670417717 -0.066080178603036
-    4  (  4) -0.070600283658190  0.071629978927021  0.209426851727876 -0.004131403945752 -0.000622007773293 -0.030404083775686 -0.072573499649568  0.005804369418180 -0.017256603820917
-    5  (  5) -0.042938103533211  0.012767138266668  0.104089521411634 -0.078509088982138  0.031589837534126  0.000702189622727  0.234416668036359  0.006073164073880  0.085676616502380
-    6  (  6)  0.025301081140471 -0.005670371975564 -0.066621493148361 -0.135369815380962  0.072186642283625 -0.233429156027521 -0.000193153533248  0.257186865053465 -0.080618496507255
-    7  (  7)  0.020822354558258 -0.006724508724119 -0.045993762455479  0.012965367547761 -0.005443358605263 -0.006173477804865 -0.257050229473736 -0.000107746294773  0.140355654948263
-    8  (  8) -0.009433315806276  0.002386871891496 -0.004905034102302  0.065444732417879  0.016877777772437 -0.086229493149666  0.079936884810997 -0.140925849197376  0.000032973152365
-    9  (  9) -0.050122316171813  0.043792237275169  0.089139695085719  0.017498120874682  0.031599257819379  0.003933044438540  0.023956851013655 -0.023591093022906 -0.231355322027963
-   10  ( 10) -0.021733936110572  0.028861084661254  0.012680330783905  0.120427356784394 -0.061995107162282 -0.110107780731446 -0.044522956915282 -0.044154909833586 -0.092344585382497
-   11  ( 11)  0.054009861310889 -0.049060128861341 -0.116101359422429 -0.043743279836749 -0.090347856826429  0.186254068915307 -0.010091097621831  0.182439821622372 -0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.050351452990167  0.022080091821478 -0.055614920128739
-    1  (  1) -0.043523152379598 -0.028913570586242  0.049281187081852
-    2  (  2) -0.088800989050704 -0.012387284429283  0.115844546053497
-    3  (  3) -0.017174780224652 -0.120766108673226  0.043936127494914
-    4  (  4) -0.030870076304731  0.062251132422338  0.090680792727787
-    5  (  5) -0.006295822004517  0.109602420736026 -0.187179028172583
-    6  (  6) -0.023342165877015  0.045357751936196  0.008109043414047
-    7  (  7)  0.023116687534610  0.043892116907456 -0.180954962224114
-    8  (  8)  0.233341712412303  0.091442003006516  0.004136900096905
-    9  (  9) -0.000301754743843 -0.311200434843549  0.071746006250031
-   10  ( 10)  0.310579381122594 -0.001146128096000 -0.337175845358798
-   11  ( 11) -0.071759110731455  0.341710402101474  0.000514995746851
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000373475564698 -0.036374284715410  0.020675408038120  0.041938611278043 -0.014954064130636  0.008670693741941  0.001941666498966 -0.002175213653671  0.081223953533966
-    1  (  1)  0.035409311090430  0.000583412494499 -0.021912114995751 -0.019686191919175 -0.001337756516393  0.101410043872272  0.013539530463413  0.021085032009130  0.104140442794578
-    2  (  2) -0.022476650279619  0.020869170321065 -0.000623148668542 -0.026925059222749  0.022600045203783  0.054500059821995  0.019747085432266  0.002197258536137  0.059803959084815
-    3  (  3) -0.040527884961938  0.020785023904239  0.026269813130118  0.000471315833621 -0.011435927824319 -0.005094359128676 -0.021078069661848  0.001900689912103 -0.049285996887456
-    4  (  4)  0.014876995236008  0.001935832477363 -0.021280417512247  0.011112950356736 -0.000010954074914  0.001375736589678  0.021071346294591 -0.002540388393255  0.057176443725449
-    5  (  5) -0.009413911140341 -0.101590521816804 -0.054440250203052  0.004479146413684 -0.000983185589705 -0.000044886603863 -0.008942266041566  0.007734744988056  0.012623227871857
-    6  (  6) -0.001228199632690 -0.013460754514196 -0.019370737847276  0.021147815413154 -0.021180440912387  0.009078596190780  0.000060187992369 -0.021757615671251 -0.021546696625458
-    7  (  7)  0.002386621109668 -0.020697715049428 -0.002142304032572 -0.001889845237358  0.002502377714011 -0.007891184567460  0.021671667697211 -0.000014467640044 -0.019485620614445
-    8  (  8) -0.082726042327291 -0.104120679625015 -0.059410287861643  0.049170685661379 -0.057558349352742 -0.011952514103015  0.021313492463386  0.019559674827960  0.000280085719614
-    9  (  9)  0.081272328726009 -0.110754135563007 -0.028218762900775 -0.005318083145326  0.020981856638396  0.014567561104212  0.097856532501808  0.003185861516469  0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.080531031337273
-    1  (  1)  0.111220099551316
-    2  (  2)  0.028332370195928
-    3  (  3)  0.005372945270244
-    4  (  4) -0.020768901638641
-    5  (  5) -0.014982546342664
-    6  (  6) -0.097582479807565
-    7  (  7) -0.003277826561639
-    8  (  8) -0.003260780284830
-    9  (  9) -0.000186812021876
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055078142867828 -0.005804719299681  0.036780646353647 -0.020745008939831  0.005631321838333  0.032388434299089 -0.019554696167851 -0.000026315290494 -0.020764618651157
-    1  (  1)  0.007062764870854 -0.009531925050962 -0.009339128991500  0.000585332198702  0.003536715157378  0.000717716084393 -0.020997702694190  0.003197609406412  0.007543205569196
-    2  (  2)  0.003273721829615  0.024127785783056  0.019803917766004 -0.021792459075320 -0.009225997435944  0.033280936086821  0.008357612389432 -0.004534634518823 -0.049752671423908
-    3  (  3)  0.009467819748219 -0.109846311430058 -0.049077069582499  0.038067479834844 -0.041344367688361  0.023164856965512  0.023494777837550  0.015492414054440  0.057415728354703
-    4  (  4) -0.087998530211411  0.166680738017738  0.040492236619192 -0.094854089537164  0.166732509395464 -0.071703004448668 -0.042087550249065 -0.037122017300705 -0.054342710801435
-    5  (  5)  0.299229806278301  0.048658757713325  0.047129705842446 -0.086908947365866  0.109728878663932 -0.016789363568018 -0.035383410684614 -0.025335321764417 -0.020816334753998
-    6  (  6) -0.066809370303780 -0.045194542515417  0.116536125053039 -0.010429907504714 -0.024187359392906 -0.082665971873618  0.044425337546003  0.096427706292236  0.099634759729367
-    7  (  7)  0.040692585686945  0.010414403444448 -0.019197392244389  0.094603783326762 -0.099044517012418 -0.021567521501408  0.184530946067710  0.010140666068000  0.044429992698867
-    8  (  8) -0.213871489773344 -0.016533777636027 -0.072796199007045  0.091991735348903 -0.195396773842710  0.059284334625803 -0.184339397290396  0.031894612373968  0.038856272349111
-    9  (  9)  0.030682243044227 -0.041775517875249  0.024602057980135 -0.057287290343526  0.006772740334119 -0.055735826221076  0.097648839100779  0.011580457295414 -0.048271645082472
-   10  ( 10)  0.033182564179255  0.014791814568441 -0.134627953730393  0.074303509883212 -0.072048570540947 -0.178297714606306 -0.018972497943516  0.029382172234938 -0.026191954922422
-   11  ( 11) -0.065304385216644 -0.054065687922946 -0.058978656197155 -0.069527138693935  0.087278294466894 -0.031923025189413 -0.037244505404452 -0.006712268565440 -0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007990021156235
-    1  (  1)  0.003543862611170
-    2  (  2)  0.051263654644270
-    3  (  3) -0.026303130686066
-    4  (  4) -0.059400171065937
-    5  (  5) -0.033889468632128
-    6  (  6)  0.063573026890197
-    7  (  7)  0.010425863419296
-    8  (  8)  0.056178737365981
-    9  (  9)  0.060112542127891
-   10  ( 10)  0.033303474011037
-   11  ( 11) -0.026602109435667
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.023607177491195  0.019696611969885  0.037221212000385 -0.015590319696057  0.002020189842990  0.021016653547429 -0.007873916136755  0.003448340610807  0.079821954504390
-    1  (  1) -0.007327805297828 -0.018867534486269  0.042212469078496 -0.001447360534353  0.028939866752754 -0.077938653083341 -0.061948383376365  0.004945505795557  0.075894556663474
-    2  (  2) -0.009007071740861 -0.016177005802987 -0.068312932673240  0.041184857036759  0.003023256838844 -0.009849571097863  0.004290386808972  0.004340519661127  0.085840789796801
-    3  (  3)  0.026077185963910  0.012520558385893  0.023360353465929 -0.029787599349062  0.027312833784239  0.081100062029021  0.033406666012159 -0.054430078300136 -0.042036783131155
-    4  (  4)  0.044521029970710  0.101548028530885  0.092152577419686 -0.036969661342643 -0.235975964790827 -0.022489800485005 -0.018037809327809  0.163273258200919  0.255997686637622
-    5  (  5) -0.075082806179399  0.059495559215694 -0.178951166772656  0.134634824114366 -0.237022622504406  0.054772185517501  0.024504277147484 -0.150049663229407  0.003365655895118
-    6  (  6) -0.075564373604390  0.030719217759732  0.086498148733354 -0.160325933966896  0.064234285643905 -0.161900908445555  0.266146706738358  0.238096934941697  0.054011663901563
-    7  (  7) -0.117049393955643 -0.184359827232724  0.154835473828309 -0.196676571259727  0.209716028817009 -0.429620861048445 -0.096138950091600  0.371356959007903  0.058084061024513
-    8  (  8) -0.116322044765828  0.134673176933366 -0.115490121530453 -0.372419146214479  0.134366059259054  0.090977060566167 -0.047847126119104 -0.349531731511066  0.026343643532612
-    9  (  9)  0.016166361653787 -0.064655468388956  0.096603309196917 -0.102141195994536 -0.004689543577322 -0.174053614560893  0.096535422651742  0.179574162178272 -0.093140031286430
-   10  ( 10)  0.038118657992317 -0.011712936317703 -0.109233641260348  0.041948680427994  0.067033240911419  0.043789144467457  0.119198984082488  0.019961916251994  0.046236232124822
-   11  ( 11)  0.202537936665755  0.041865413038804 -0.001109842658197 -0.036047997932446 -0.209039172907281 -0.039634162843452  0.042796449278664 -0.037154632643052  0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001464671751436
-    1  (  1)  0.092168971837118
-    2  (  2) -0.096834154775615
-    3  (  3) -0.085232004143247
-    4  (  4)  0.224276823308218
-    5  (  5) -0.037070717977035
-    6  (  6) -0.017788678150516
-    7  (  7)  0.125655013910958
-    8  (  8) -0.036753750028807
-    9  (  9)  0.104788947042948
-   10  ( 10) -0.055723652563089
-   11  ( 11)  0.029086171780033
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000103943053471  0.020502980666838  0.044487026908476  0.112522389921676 -0.115190927698806 -0.086304427533430  0.028732798000328  0.005755262072674 -0.052707374815472
-    1  (  1) -0.020396732597728  0.000175507711089 -0.066631576709106 -0.188566511167110  0.188604507023904 -0.081802717690830  0.123212599282903  0.146580404278728 -0.063843813395139
-    2  (  2) -0.044224363892114  0.066688325942716 -0.000328779542201  0.131627364199491 -0.085838688001563  0.039792906367986 -0.071990397116460 -0.041811204620793  0.129151440044184
-    3  (  3) -0.112356491847955  0.188595812422395 -0.131743983691740  0.000034238258909  0.146405835083834  0.293116155503685 -0.174354593749844 -0.234740190959724  0.068400431241803
-    4  (  4)  0.114478156906703 -0.187880772610577  0.086711640119064 -0.146345707242046 -0.000351413466984  0.200401380550659 -0.118118144680811 -0.106599388398520  0.027535193682288
-    5  (  5)  0.086013769068620  0.081687368012874 -0.039811317138268 -0.293720012918757 -0.199751621453618  0.000779002249077 -0.029574633012291 -0.100809576430270  0.310087999943630
-    6  (  6) -0.028593362634754 -0.122990647052479  0.071886866993686  0.174357265134888  0.118164594946332  0.029455932226559  0.000323502179386  0.067588972736558  0.054838186724730
-    7  (  7) -0.005405231783831 -0.146637005514722  0.041701223809144  0.234444344892692  0.106310138998589  0.100760684833959 -0.067340032280388  0.000050446895501  0.206356025427645
-    8  (  8)  0.052734404217526  0.064663294136106 -0.127867798766573 -0.067686878519552 -0.027452578317565 -0.311518253800823 -0.053511305641188 -0.206912543882787 -0.000090733997612
-    9  (  9)  0.040822323151076 -0.050351126620632  0.033443030139718  0.028678071562223 -0.070729562284205  0.035204318394559 -0.035088801145452 -0.003858253384271  0.209126878103916
-   10  ( 10)  0.043554697985060 -0.034029200702705 -0.113396889510888  0.025104351967769  0.057922093461755  0.050331966245759 -0.113578028555237  0.006845000513571 -0.183899295084893
-   11  ( 11) -0.104445737487499  0.085327185159750  0.138831980783855  0.068059267872915  0.045287984054307 -0.106421559557756  0.126370094892912 -0.085884676801538 -0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.040472375428214 -0.043732687824618  0.105326662293090
-    1  (  1)  0.050113148730272  0.033553830886801 -0.085228632878169
-    2  (  2) -0.033648303602896  0.113430364410931 -0.140304701766262
-    3  (  3) -0.028908821271170 -0.025577280295259 -0.067243263311150
-    4  (  4)  0.070488811800233 -0.058243639304596 -0.043815524401846
-    5  (  5) -0.035954881502730 -0.048633621823234  0.102557737449989
-    6  (  6)  0.034599692943826  0.112216626584703 -0.126288398892548
-    7  (  7)  0.003737404887253 -0.007316223089443  0.087031799969318
-    8  (  8) -0.210522602449556  0.181960897898471  0.040780655119777
-    9  (  9)  0.000486792078199 -0.154877597629272  0.324381992896252
-   10  ( 10)  0.154731729402294  0.001003846432056  0.227757018056261
-   11  ( 11) -0.321308213629134 -0.230320716710505  0.000521529871008
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000267990887146 -0.017094909685382  0.026886221509252 -0.009154729792392 -0.028447394308811  0.043026223139973 -0.007934241734193  0.017529929372393 -0.048064409198736
-    1  (  1)  0.019165257539447 -0.000577613190074 -0.023971643573307  0.023362002438445 -0.020466955482562  0.074368923093670  0.021220838937975  0.006899315294507  0.004345205689582
-    2  (  2) -0.030573367311208  0.023520686332899 -0.000895230171902 -0.026482533037414  0.055578356600337  0.061212128793543  0.006033035982650 -0.029878597421323  0.067713186454891
-    3  (  3)  0.011556055604803 -0.022912214561881  0.028040995483179 -0.000806143570890 -0.016669730389240 -0.057830279830177 -0.001162806518994  0.022110531165998 -0.132937508894661
-    4  (  4)  0.029247962187325  0.019722933579604 -0.053631431975867  0.015590855142050 -0.000406564753787 -0.013151443352440  0.005583751708839 -0.048344741694769  0.058950645196782
-    5  (  5) -0.044502924478349 -0.074343902828738 -0.059891074519534  0.057011647107618  0.013642181191740  0.000660380157385  0.021619837229525  0.066247874288904 -0.026658775788480
-    6  (  6)  0.008416217090956 -0.021046309429680 -0.006522358687724  0.001270652730649 -0.005678899154477 -0.021925039235368  0.000233190982568  0.044213316193167 -0.019149792461568
-    7  (  7) -0.017220078580887 -0.007669026797702  0.030414088472195 -0.022279636607030  0.047947045698118 -0.066391322818188 -0.044159499520014 -0.000036612147908 -0.012788358083278
-    8  (  8)  0.049286641691243 -0.005157181302332 -0.067669102261374  0.134137839836174 -0.059598226202850  0.026736423898111  0.019691121432993  0.012900597372237 -0.000145671342113
-    9  (  9) -0.013771428368881  0.001534324314609 -0.097208563857550 -0.041538777135659  0.016922202614382  0.071792645864290  0.010700525463409 -0.088926800959210  0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.013388445223016
-    1  (  1) -0.001743269961120
-    2  (  2)  0.097384653394849
-    3  (  3)  0.041118719872747
-    4  (  4) -0.017104740675403
-    5  (  5) -0.071235600573670
-    6  (  6) -0.010744046806778
-    7  (  7)  0.088045104682667
-    8  (  8) -0.027915642785476
-    9  (  9) -0.000257740691093
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.024087436020668 -0.024234923487922 -0.034655069016827  0.013002508462274 -0.003506876735183 -0.019138226509165  0.008729154622077 -0.004126516633947 -0.080810387962203
-    1  (  1)  0.007340388106341  0.022740162593799 -0.047399213843079  0.000077807499313 -0.029710781800549  0.077091731467965  0.063337905707382 -0.003225301246506 -0.076935684639064
-    2  (  2)  0.008533292606078  0.014866249844284  0.069414473601385 -0.039067032188858 -0.004447555351962  0.009557153079335 -0.003933218079563 -0.004684619630234 -0.087696717260759
-    3  (  3) -0.022970088927143 -0.014796917693540 -0.027844101865804  0.035221698386289 -0.026363064761687 -0.090054977556852 -0.034727496736464  0.055362273105074  0.041999796595917
-    4  (  4) -0.041840045940810 -0.108064430049583 -0.094169303786903  0.038045467810124  0.242703284807102  0.022096059239039  0.018423933000872 -0.169152570163926 -0.255707171958253
-    5  (  5)  0.076575292532566 -0.064169513057282  0.187842221364997 -0.139017281082776  0.239663562780447 -0.056101309100792 -0.026864961939161  0.152773054853442 -0.000863550220823
-    6  (  6)  0.082619291232389 -0.034129866388443 -0.092672858212650  0.166047996934064 -0.066033557533197  0.164979644828487 -0.279604374284854 -0.245415146187524 -0.057275952528883
-    7  (  7)  0.119525510255884  0.192558180615050 -0.157479601093184  0.199612815310399 -0.216488749413977  0.438370355171240  0.097840156788249 -0.385286937285113 -0.058774287435548
-    8  (  8)  0.115070416909243 -0.142091116044252  0.125572997790340  0.378869543679260 -0.139572537143277 -0.093921809248974  0.047279124915748  0.359195083957732 -0.024443650320069
-    9  (  9) -0.023211259159309  0.064251202673602 -0.092489429719048  0.099069758679955  0.005272254913816  0.184087259640687 -0.103465084079069 -0.187259798043465  0.097400286560574
-   10  ( 10) -0.039092748606065  0.013006586457309  0.115772480099790 -0.044153430983449 -0.068039357936569 -0.040474168285568 -0.124671276809929 -0.020291967592974 -0.043718085717437
-   11  ( 11) -0.205517300660670 -0.035576186745690  0.000856944671273  0.036648470964825  0.217305799958921  0.037828885346138 -0.045859373489911  0.037554955798535 -0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001311477468569
-    1  (  1) -0.093224324445080
-    2  (  2)  0.099200064811294
-    3  (  3)  0.086458921973920
-    4  (  4) -0.229446975291319
-    5  (  5)  0.035136747289852
-    6  (  6)  0.019108151626501
-    7  (  7) -0.127376470092273
-    8  (  8)  0.036832911731868
-    9  (  9) -0.106598068979743
-   10  ( 10)  0.058544237541584
-   11  ( 11) -0.029477471817291
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.089840465204225 -0.055253525883540 -0.050839656601929  0.011592120168853  0.028453073767485  0.033272498563027  0.013123122183092  0.010376152774617  0.046773274930095
-    1  (  1)  0.019180458750845 -0.004406050242553  0.021028155566967  0.011538680320289 -0.014109247012132 -0.033202867729220  0.146724711919951 -0.006291497986158  0.032816512639240
-    2  (  2)  0.008004935891454  0.083588166091295 -0.024500417662889 -0.004976479402859 -0.015361678869856  0.027030028650554 -0.075999531355577  0.040388417899799  0.092155828534757
-    3  (  3) -0.072751395760345 -0.101339872261880 -0.027554632505315 -0.017104143799594  0.009883810143648  0.054325029446985 -0.038424568195001 -0.007564948769101 -0.050859249479548
-    4  (  4) -0.116869612062058 -0.168448689602172 -0.076045170807919  0.039076911238534 -0.141061895780680  0.082089594379007 -0.096305838370831  0.090937592520626  0.089867596085833
-    5  (  5)  0.362411548066203  0.116301468610581  0.067304641586918  0.178833394354847 -0.120526935264372 -0.077690766748935  0.087853646530869 -0.131583743921650  0.005449987066682
-    6  (  6)  0.023022243577310 -0.091878291587840  0.168295716396468  0.360782087280141  0.197772285105134 -0.118427120672179 -0.100301554555422 -0.545992767837121  0.002274268616602
-    7  (  7)  0.332469089310140  0.094037896803367  0.021326282942452 -0.202588446745432 -0.003095262967230 -0.074773576198707 -0.261809753005545  0.312310926113466 -0.101271338039676
-    8  (  8)  0.102262443511968  0.018323432973791 -0.030286707735275 -0.141132962784100  0.140087132441384  0.016144892573022  0.105178803101546 -0.077042517784067 -0.061204405030880
-    9  (  9) -0.062921845500970 -0.223934495766079 -0.055471945329417 -0.006791304491310  0.142947280894142  0.007991932919943 -0.047858230706461 -0.145718178913241  0.072195393114585
-   10  ( 10)  0.062281498028430  0.059385022217194  0.196384149116451  0.042900612771916 -0.059951865879116 -0.109494756681462 -0.025377610533051 -0.255425379720525  0.006903138405362
-   11  ( 11)  0.109893814765672  0.036299338598219  0.008950289795172  0.103979082032925 -0.089663281746559 -0.076642658317109 -0.017386558594104 -0.075203103677764  0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015115955084904
-    1  (  1)  0.030649150844450
-    2  (  2) -0.004117081641871
-    3  (  3) -0.011275331966881
-    4  (  4)  0.082379096749867
-    5  (  5)  0.010925397739678
-    6  (  6)  0.209001724905895
-    7  (  7) -0.094421017044117
-    8  (  8) -0.009881568354141
-    9  (  9)  0.113416879853688
-   10  ( 10)  0.045856944277529
-   11  ( 11) -0.007202279712064
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000220708940429 -0.002285125103983 -0.191707004311250  0.079176547202062  0.015343724284655  0.090762856917070  0.035966370439669  0.080228715251931 -0.022632088832219
-    1  (  1)  0.002270884902228 -0.000127565392507  0.181504505051190 -0.084301622984598  0.019134286473150 -0.136527597935967 -0.291828838790707  0.086935165867290  0.003153353795357
-    2  (  2)  0.190790178739451 -0.181286631653937  0.000456958950263 -0.098736144982791 -0.201937120878681 -0.060858985812145  0.102547416191644 -0.128157455079926  0.052263022287278
-    3  (  3) -0.078674978461285  0.083802623610643  0.098399673810258  0.000007811365746  0.051373438075815  0.073262818066183  0.213681674768555 -0.159362252554929 -0.021801220424175
-    4  (  4) -0.014664072597960 -0.019624839214450  0.200908806156840 -0.051706138267892 -0.000345872163641  0.060049554881332  0.188299165959522 -0.122222075869351 -0.002767654097179
-    5  (  5) -0.090883158144736  0.136634126073923  0.061672946710902 -0.074085610649007 -0.059059222367226  0.000127348357414  0.089421360456473 -0.068061409120582  0.127845689145142
-    6  (  6) -0.036070137194869  0.291478881075219 -0.101913218910275 -0.213840026067922 -0.188217301311726 -0.090313292624869 -0.000227988253159 -0.211121150654972 -0.048790729392591
-    7  (  7) -0.080292928774450 -0.086502244153537  0.129683189759572  0.159077086898913  0.122727489493275  0.066634459735053  0.210168861536432 -0.000749252129634  0.114771568876213
-    8  (  8)  0.022833189301314 -0.003149552694449 -0.051809982276026  0.021432628906503  0.002600755913054 -0.127892598520278  0.048118709288206 -0.114794510187460 -0.000092800261922
-    9  (  9)  0.153861672366712 -0.063959309581427 -0.276686698038017 -0.018129236980868 -0.051934404023196 -0.023341508326279 -0.078386885605064 -0.038564733458116 -0.117925763161383
-   10  ( 10) -0.030779230036139  0.047764824598951  0.139550834348758 -0.058848096986720 -0.072156858928456 -0.071321440087986  0.120905085647966 -0.006516751215124 -0.144681807612295
-   11  ( 11)  0.005585664265456 -0.000647324323586 -0.016353426872082 -0.045937924242292 -0.003353711579607  0.138994412824604  0.062414171800322  0.018128246119697 -0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.154066232086317  0.030728257975556 -0.006318091498164
-    1  (  1)  0.063643818147584 -0.047463638962418  0.000566548572565
-    2  (  2)  0.275258773270295 -0.138888616959566  0.015969350630016
-    3  (  3)  0.017345671201066  0.059189082677904  0.046475381464176
-    4  (  4)  0.050392875387071  0.072424486885238  0.004459708301674
-    5  (  5)  0.026836133802329  0.070805989588457 -0.140760690762251
-    6  (  6)  0.078585377266712 -0.120742726291724 -0.064292229739042
-    7  (  7)  0.041858894695365  0.005665298794286 -0.017186389956069
-    8  (  8)  0.118429783701800  0.144155118064025  0.113213711259466
-    9  (  9) -0.000756388118591  0.455654623157072  0.231432578787543
-   10  ( 10) -0.453567841489266 -0.001497567906129 -0.172275686133391
-   11  ( 11) -0.230120702539645  0.175050207490782 -0.001480251815160
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000516219946816  0.034778633659956  0.032999546928151 -0.009629039776278  0.052966719633617 -0.030450001531878 -0.014875222246015 -0.072128990177077  0.048218822417803
-    1  (  1) -0.030877691560804  0.001883541097772  0.071434334115879 -0.019325009721534 -0.017452039030100 -0.158145751795333 -0.010537309557875 -0.021583100108147 -0.169934651056250
-    2  (  2) -0.033565318682613 -0.071200997372983  0.000581071534985 -0.036850040138101  0.007310816547227 -0.008797901115406 -0.029229533057666 -0.016744128499400 -0.070455787497455
-    3  (  3)  0.011004884819686  0.019179310791618  0.034909263032370  0.000523661128158 -0.007125267622899 -0.017666281606150 -0.025274953349027  0.006048522524524 -0.042959205727090
-    4  (  4) -0.052383681601535  0.016788640224883 -0.007028507044452  0.007472760866637 -0.000164741631073 -0.026820745242549  0.000005495327564 -0.022752424410877  0.031410113616428
-    5  (  5)  0.028924597602342  0.155705177520586  0.009708873936879  0.016613543931604  0.026890889200954  0.000863820528475 -0.026461589325309  0.030900211040800  0.024762473040831
-    6  (  6)  0.014335467827216  0.010396285650159  0.029624823660297  0.025462090585912  0.000149096444494  0.026996065218364 -0.000042625626758 -0.107465667965402  0.101121105248233
-    7  (  7)  0.071280711647029  0.021473260264964  0.016888851213230 -0.005990055447048  0.022650874097521 -0.030884846999677  0.107059671381934  0.000085380718295  0.001222830424055
-    8  (  8) -0.049124632890092  0.169889327710618  0.068826403708743  0.044339001017875 -0.031493314676472 -0.025080049766767 -0.100845039831255 -0.001167614688641  0.000278385825403
-    9  (  9)  0.004591463397670  0.224641690035662  0.054391854978822 -0.000520714575472  0.041379699430161 -0.035041097267503 -0.048865193892848 -0.034233303767760  0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.004372643490859
-    1  (  1) -0.225448428944350
-    2  (  2) -0.053543340635201
-    3  (  3)  0.000029286176363
-    4  (  4) -0.041473098636741
-    5  (  5)  0.035500700267141
-    6  (  6)  0.049415179037896
-    7  (  7)  0.033722251526408
-    8  (  8) -0.002108270875613
-    9  (  9) -0.000059855095180
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.083178189184036  0.063320502543375  0.053448860291133 -0.010119942476578 -0.027962494700737 -0.033408156898410 -0.016646686372055 -0.009688142905594 -0.047753876913682
-    1  (  1) -0.015436953954369  0.001484194684011 -0.023035398887205 -0.013457869405466  0.013993527195521  0.033943979767543 -0.150850131221437  0.006054179455746 -0.032861777904130
-    2  (  2) -0.007416632072171 -0.085535883632607  0.031035920631781  0.004414026005139  0.010136741110915 -0.029006493089287  0.078308410406643 -0.042862583013635 -0.094615352193845
-    3  (  3)  0.060864804294684  0.107990348400789  0.029334441164075  0.017074561166948 -0.006770814971091 -0.056161219994893  0.038880977880177  0.007186858274067  0.050898617184209
-    4  (  4)  0.109193273208522  0.178421304573120  0.074992061457995 -0.038015102633012  0.147910228795514 -0.087181398607820  0.098582275644141 -0.093570766915846 -0.088687564658624
-    5  (  5) -0.362309556227904 -0.121304099182945 -0.074968023841376 -0.180660703600124  0.122438585672172  0.079096894998506 -0.085876030826778  0.136109864287558 -0.002214631278523
-    6  (  6) -0.026835628168075  0.104282391359254 -0.172843582770517 -0.372105341696267 -0.200623348657875  0.124556824110224  0.101871864602057  0.564196462169744 -0.000688785089474
-    7  (  7) -0.344945182303497 -0.095060217852336 -0.019692892185405  0.208607222836184  0.002627647973779  0.075715664253568  0.273373001503080 -0.322679649636761  0.103750880742886
-    8  (  8) -0.103243578213400 -0.018995126733818  0.033613347666093  0.143946559071139 -0.146180680800982 -0.017308359580339 -0.107684620440504  0.078982837453949  0.062496256435255
-    9  (  9)  0.085648241806344  0.209611729409149  0.056224829650480  0.004822853433113 -0.155473341074989 -0.012971266670028  0.058097898147224  0.150335378963730 -0.078057323449305
-   10  ( 10) -0.070132629148842 -0.074702785463534 -0.209329818275843 -0.042566217114534  0.058034325280006  0.102370728009941  0.025801004099357  0.264561180085366 -0.017482708757363
-   11  ( 11) -0.113963029107499 -0.045073298009464 -0.000413587765283 -0.112463923253522  0.089423608765749  0.081287727377731  0.019439635907878  0.076622183257520 -0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015270950350973
-    1  (  1) -0.030946721870550
-    2  (  2)  0.003707642076146
-    3  (  3)  0.011960041321321
-    4  (  4) -0.086083869661608
-    5  (  5) -0.009867768215709
-    6  (  6) -0.209680707316341
-    7  (  7)  0.097843271017668
-    8  (  8)  0.010325909660635
-    9  (  9) -0.121632163838855
-   10  ( 10) -0.058275044600178
-   11  ( 11)  0.003021331907582
+    0      0.599417708350833    -0.006763277754054     0.354599221230776
+    1      0.195458157565533     0.180453504648553    -1.188631892419457
+    2     -1.396841541365808     1.447529394734753    -0.768769770994022
 
 	Computing Mu_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.663852495952
-	   1        17.349316646619    5.172e-01
-	   2        19.385113345909    1.883e-01
-	   3        19.407847597477    2.113e-02
-	   4        19.414241734665    7.755e-03
-	   5        19.415176455114    1.032e-03
-	   6        19.415012990662    3.160e-04
-	   7        19.415033958417    5.837e-05
-	   8        19.415041993874    1.888e-05
-	   9        19.415040949666    5.204e-06
-	  10        19.415040546963    1.666e-06
-	  11        19.415040734904    4.928e-07
-	  12        19.415040994304    1.203e-07
+	   0        13.663852328482
+	   1        17.349316422742    5.172e-01
+	   2        19.385113079902    1.883e-01
+	   3        19.407847329965    2.113e-02
+	   4        19.414241466868    7.755e-03
+	   5        19.415176187248    1.032e-03
+	   6        19.415012722798    3.160e-04
+	   7        19.415033690551    5.837e-05
+	   8        19.415041726007    1.888e-05
+	   9        19.415040681799    5.204e-06
+	  10        19.415040279096    1.666e-06
+	  11        19.415040467037    4.928e-07
+	  12        19.415040726437    1.203e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 3.402e-08
 
 	Computing P_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.806423221167
-	   1         4.786266865070    2.557e-01
-	   2         5.293724274959    8.808e-02
-	   3         5.300611085662    9.537e-03
-	   4         5.301483696173    3.346e-03
-	   5         5.301695507491    6.519e-04
-	   6         5.301657366303    2.184e-04
-	   7         5.301663658208    4.868e-05
-	   8         5.301665267766    1.417e-05
-	   9         5.301664757051    2.843e-06
-	  10         5.301664740408    6.502e-07
-	  11         5.301664799273    1.765e-07
+	   0         3.806423238849
+	   1         4.786266884786    2.557e-01
+	   2         5.293724292903    8.808e-02
+	   3         5.300611103324    9.537e-03
+	   4         5.301483713806    3.346e-03
+	   5         5.301695525113    6.519e-04
+	   6         5.301657383925    2.184e-04
+	   7         5.301663675830    4.868e-05
+	   8         5.301665285388    1.417e-05
+	   9         5.301664774673    2.843e-06
+	  10         5.301664758030    6.502e-07
+	  11         5.301664816895    1.765e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 5.023e-08
 
 	Computing L_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.300703482645
-	   1         3.121289906292    2.885e-01
-	   2         3.752310252093    1.328e-01
-	   3         3.767783325289    2.436e-02
-	   4         3.776714913955    1.243e-02
-	   5         3.777836484382    3.983e-03
-	   6         3.777768504411    1.141e-03
-	   7         3.777808011524    3.482e-04
-	   8         3.777806751835    1.218e-04
-	   9         3.777799472842    4.621e-05
-	  10         3.777798809266    1.539e-05
-	  11         3.777800013552    3.124e-06
-	  12         3.777800855667    1.120e-06
-	  13         3.777801091414    2.688e-07
-	  14         3.777801254163    1.261e-07
+	   0         2.300703468868
+	   1         3.121289885462    2.885e-01
+	   2         3.752310222470    1.328e-01
+	   3         3.767783294992    2.436e-02
+	   4         3.776714883264    1.243e-02
+	   5         3.777836453622    3.983e-03
+	   6         3.777768473650    1.141e-03
+	   7         3.777807980762    3.482e-04
+	   8         3.777806721072    1.218e-04
+	   9         3.777799442080    4.621e-05
+	  10         3.777798778504    1.539e-05
+	  11         3.777799982789    3.124e-06
+	  12         3.777800824905    1.120e-06
+	  13         3.777801060651    2.688e-07
+	  14         3.777801223401    1.261e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.107e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.329948285773
-	   1        13.411421217298    3.567e-01
-	   2        14.315309207607    1.102e-01
-	   3        14.357443663129    1.983e-02
-	   4        14.362381922354    6.059e-03
-	   5        14.363016926461    9.670e-04
-	   6        14.362953466067    2.647e-04
-	   7        14.362975622137    5.528e-05
-	   8        14.362980629521    1.635e-05
-	   9        14.362980593940    4.161e-06
-	  10        14.362980698305    1.472e-06
-	  11        14.362980838668    3.685e-07
-	  12        14.362980972689    1.227e-07
+	   0        11.329948161504
+	   1        13.411421068744    3.567e-01
+	   2        14.315309044441    1.102e-01
+	   3        14.357443498125    1.983e-02
+	   4        14.362381757162    6.059e-03
+	   5        14.363016761229    9.670e-04
+	   6        14.362953300836    2.647e-04
+	   7        14.362975456904    5.528e-05
+	   8        14.362980464287    1.635e-05
+	   9        14.362980428706    4.161e-06
+	  10        14.362980533071    1.472e-06
+	  11        14.362980673434    3.685e-07
+	  12        14.362980807455    1.227e-07
 	-----------------------------------------
-	Converged Mu_Y-Perturbed Wfn to 2.971e-08
+	Converged Mu_Y-Perturbed Wfn to 2.970e-08
 
 	Computing P_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.931027147423
-	   1         4.593559034926    2.022e-01
-	   2         4.879920669597    6.076e-02
-	   3         4.896820052019    1.314e-02
-	   4         4.898170045782    3.838e-03
-	   5         4.898318470947    6.191e-04
-	   6         4.898282967197    1.456e-04
-	   7         4.898282853511    3.527e-05
-	   8         4.898282994670    1.182e-05
-	   9         4.898282618664    3.173e-06
-	  10         4.898282691261    8.886e-07
-	  11         4.898282780763    1.649e-07
+	   0         3.931027160516
+	   1         4.593559049913    2.022e-01
+	   2         4.879920683746    6.076e-02
+	   3         4.896820065696    1.314e-02
+	   4         4.898170059424    3.838e-03
+	   5         4.898318484583    6.191e-04
+	   6         4.898282980833    1.456e-04
+	   7         4.898282867148    3.527e-05
+	   8         4.898283008306    1.182e-05
+	   9         4.898282632300    3.173e-06
+	  10         4.898282704898    8.886e-07
+	  11         4.898282794400    1.649e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 5.135e-08
 
 	Computing L_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.496880118727
-	   1         8.584125224274    4.215e-01
-	   2         9.867718731120    1.834e-01
-	   3         9.932572455386    5.520e-02
-	   4         9.966701252967    2.429e-02
-	   5         9.968657722528    5.269e-03
-	   6         9.968350196991    1.238e-03
-	   7         9.968424289999    3.637e-04
-	   8         9.968417466383    8.674e-05
-	   9         9.968417381026    3.012e-05
-	  10         9.968415729223    1.207e-05
-	  11         9.968416777999    2.944e-06
-	  12         9.968417365925    1.184e-06
-	  13         9.968417596207    3.589e-07
-	  14         9.968417751615    1.515e-07
+	   0         6.496880090884
+	   1         8.584125184372    4.215e-01
+	   2         9.867718679631    1.834e-01
+	   3         9.932572402175    5.520e-02
+	   4         9.966701198597    2.429e-02
+	   5         9.968657668021    5.269e-03
+	   6         9.968350142488    1.238e-03
+	   7         9.968424235493    3.637e-04
+	   8         9.968417411876    8.674e-05
+	   9         9.968417326520    3.012e-05
+	  10         9.968415674717    1.207e-05
+	  11         9.968416723492    2.944e-06
+	  12         9.968417311419    1.184e-06
+	  13         9.968417541701    3.589e-07
+	  14         9.968417697109    1.515e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 5.471e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        11.357414759766
-	   1        13.937822077621    3.768e-01
-	   2        14.977230543975    1.121e-01
-	   3        14.992312975776    1.472e-02
-	   4        14.996460695181    6.152e-03
-	   5        14.996903745094    6.700e-04
-	   6        14.996856800909    2.049e-04
-	   7        14.996864223215    4.712e-05
-	   8        14.996864928986    1.506e-05
-	   9        14.996864499750    3.809e-06
-	  10        14.996864384462    1.116e-06
-	  11        14.996864502208    2.116e-07
+	   0        11.357414639791
+	   1        13.937821924355    3.768e-01
+	   2        14.977230372953    1.121e-01
+	   3        14.992312804032    1.472e-02
+	   4        14.996460523268    6.152e-03
+	   5        14.996903573155    6.700e-04
+	   6        14.996856628970    2.049e-04
+	   7        14.996864051275    4.712e-05
+	   8        14.996864757046    1.506e-05
+	   9        14.996864327810    3.809e-06
+	  10        14.996864212522    1.116e-06
+	  11        14.996864330269    2.116e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 5.589e-08
 
 	Computing P_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.160191155364
-	   1         5.087378575033    2.225e-01
-	   2         5.451338805442    6.393e-02
-	   3         5.456678665205    9.116e-03
-	   4         5.457664798942    3.927e-03
-	   5         5.457840633744    6.801e-04
-	   6         5.457808204846    2.003e-04
-	   7         5.457811034240    4.253e-05
-	   8         5.457811066010    1.078e-05
-	   9         5.457810950955    2.185e-06
-	  10         5.457810972545    5.669e-07
-	  11         5.457811024231    1.309e-07
+	   0         4.160191167415
+	   1         5.087378587854    2.225e-01
+	   2         5.451338816957    6.393e-02
+	   3         5.456678676550    9.116e-03
+	   4         5.457664810259    3.927e-03
+	   5         5.457840645052    6.801e-04
+	   6         5.457808216154    2.003e-04
+	   7         5.457811045549    4.253e-05
+	   8         5.457811077318    1.078e-05
+	   9         5.457810962263    2.185e-06
+	  10         5.457810983853    5.669e-07
+	  11         5.457811035539    1.309e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 4.601e-08
 
 	Computing L_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.631525392543
-	   1         8.727961461472    4.299e-01
-	   2        10.061240342645    1.812e-01
-	   3        10.106609313520    3.611e-02
-	   4        10.122396493451    1.704e-02
-	   5        10.124736815494    5.870e-03
-	   6        10.124280001559    1.978e-03
-	   7        10.124433854178    4.386e-04
-	   8        10.124449799174    1.303e-04
-	   9        10.124443685199    4.187e-05
-	  10        10.124444176979    1.792e-05
-	  11        10.124445213477    4.900e-06
-	  12        10.124446595285    1.647e-06
-	  13        10.124446932567    5.315e-07
-	  14        10.124447071579    1.789e-07
+	   0         6.631525365571
+	   1         8.727961423050    4.299e-01
+	   2        10.061240292053    1.812e-01
+	   3        10.106609261672    3.611e-02
+	   4        10.122396441092    1.704e-02
+	   5        10.124736763008    5.870e-03
+	   6        10.124279949075    1.978e-03
+	   7        10.124433801688    4.386e-04
+	   8        10.124449746683    1.303e-04
+	   9        10.124443632709    4.187e-05
+	  10        10.124444124490    1.792e-05
+	  11        10.124445160987    4.900e-06
+	  12        10.124446542795    1.647e-06
+	  13        10.124446880076    5.315e-07
+	  14        10.124447019088    1.789e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 6.879e-08
 
 	Computing 1/2 <<Mu;L>>_(0.077) tensor.
 	Computing 1/2 <<P;L>>_(0.077) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008614927932901 -0.046442352400056  0.027924113420848 -0.003342105613042 -0.019198187280149 -0.043605993010684  0.000124507843934 -0.017903232775755 -0.064037761769677
-    1  (  1) -0.004023859954382  0.002812567241188 -0.015355365220565  0.063211982369858  0.033868800032563 -0.011581015700219 -0.004465574115878 -0.047030919129079 -0.048793907716228
-    2  (  2)  0.028525640721225  0.068120190051797 -0.016739332483522 -0.005073216914996  0.071940864110972 -0.066733646998345 -0.019605473406179 -0.001610556181541  0.004701378003057
-    3  (  3) -0.054155290592472 -0.054244334984755 -0.021962628004576 -0.018282485083091 -0.037028274309951  0.016786978556275  0.022024618578561  0.004302299401540 -0.167953274084101
-    4  (  4) -0.063182596929128 -0.128748808697011  0.121465113794596  0.160938411624414 -0.233917278334855  0.054052147786148  0.025334190025568  0.127021105025468 -0.261448831371970
-    5  (  5)  0.148864678539144  0.254187426901849 -0.169654893765005  0.284620623487219  0.104152411510991  0.359543809296571  0.133744009364038  0.041861549395911  0.169452799563311
-    6  (  6) -0.084956716693293  0.126613830958100 -0.017431389376921 -0.048281125785785  0.083267553859489 -0.206713853889007  0.428812335356187  0.005011018790693  0.061186511244325
-    7  (  7)  0.173630436499038  0.181276581467465 -0.440332497406727 -0.059456065314793  0.303618967332177  0.080016792150091 -0.104444652264320  0.251866044362601  0.089940979754426
-    8  (  8)  0.057697740265636  0.070180597319316 -0.383387445877903  0.514874723728167  0.465292274425094 -0.060917787458673  0.016262524997932  0.068972295825028 -0.265391565564862
-    9  (  9) -0.279247635392508  0.560707539445326  0.044547355247966  0.161505455840491 -0.002588377300620  0.219223272852673  0.096307931275233  0.176467158787115 -0.104344971075325
-   10  ( 10) -0.977075550189082  0.176418272338824  0.228294317792423 -0.099370607761785  0.027777959043915 -0.149348953174007  0.027413414685573 -0.102632226214496  0.005531527026329
-   11  ( 11) -0.211429004068205  0.082644794913083 -0.055680052865830  0.289018099852967 -0.067789578528906  0.064107786895450  0.141855082713117  0.071186757345684 -0.332576681432119
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071990946341156
-    1  (  1)  0.010142476746200
-    2  (  2) -0.112423878596356
-    3  (  3) -0.059253840833002
-    4  (  4) -0.014639189231197
-    5  (  5)  0.248038168374966
-    6  (  6) -0.055159646937661
-    7  (  7)  0.115432903674626
-    8  (  8) -0.135363224547124
-    9  (  9)  0.174678345310946
-   10  ( 10) -0.086140984938274
-   11  ( 11)  0.161723358519153
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.197572413114517 -0.541318632877371  0.139927415914873 -0.359578444130330 -0.398937843975486 -0.026586872167534 -0.139627977382516 -0.005896246491228 -0.003746644388905
-    1  (  1) -0.541058731973333 -2.034801242188507  0.920540457917585  1.016218584629480  0.729164689940962  0.054412526301737  0.235971924521468  0.315223615831553  0.096208087340554
-    2  (  2)  0.139828960639396  0.920734025049694  1.243601677781983 -0.974300649425054 -0.758553357750500  0.024609548649431  0.513266755137957 -0.116926330823923  0.094501440802452
-    3  (  3) -0.358970389612551  1.015833032444632 -0.974440229907822 -0.266348920037382 -0.133799224826450 -1.276907891719884  0.042984364188955 -0.410608972745146 -0.602345206758872
-    4  (  4) -0.398323035382104  0.727797072638099 -0.759857932028957 -0.133858878725855  0.575448485405805  0.056475665846990 -0.484493838094732 -1.583666059960473 -0.976878960945650
-    5  (  5) -0.027166282529876  0.055084907439528  0.024891154244808 -1.275543890392068  0.058746221115305  0.155399297624787 -0.236023461595880  0.812878944882876 -1.048535633945681
-    6  (  6) -0.139452284652001  0.236223353106611  0.513262677276795  0.042879631015553 -0.482819583744289 -0.235933155306163 -2.554180022039243  0.492117808091915  0.545404391969618
-    7  (  7) -0.005841417486080  0.316274368087248 -0.116163386132942 -0.410094172620351 -1.579571504351393  0.813774264702327  0.492423579055058 -1.700719634572147  0.685529426222534
-    8  (  8) -0.003628131523111  0.096035529406495  0.094131958822655 -0.602680558554738 -0.970206233042967 -1.045482011639248  0.544249830480973  0.683514460656999 -0.254958894521937
-    9  (  9)  0.326098978034070 -0.130935443755898 -0.379595166178810 -0.575990923913880 -0.393471965772156 -0.365686482354661 -1.227740649572571 -0.905826585766955  0.039987575439783
-   10  ( 10)  0.008103557010829 -0.039575543043785 -0.358664813530415  0.339232504235094  0.207222390004838  0.025784782686722 -0.874465143496950  0.752110557173402  0.140644707838520
-   11  ( 11)  0.161744201604777 -0.084371238126416 -0.371150000615002 -0.062082553987999 -0.264710244109502 -0.257261524594595 -0.444570825837596  0.002821912169167 -0.878431482758543
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.327854256723191  0.009019714201806  0.162710661594080
-    1  (  1) -0.133091859401188 -0.040697608916971 -0.085480013261477
-    2  (  2) -0.381849466582258 -0.359835698966555 -0.372555502654032
-    3  (  3) -0.579249329460985  0.337242930789026 -0.062083381101115
-    4  (  4) -0.396591932227294  0.208613968377681 -0.263534161447186
-    5  (  5) -0.365098796840620  0.027806203875135 -0.265146511184336
-    6  (  6) -1.230804866141472 -0.879767261427487 -0.448789926588722
-    7  (  7) -0.904635210810701  0.753869376128870 -0.007723762422951
-    8  (  8)  0.040323953888643  0.145561462630237 -0.894627985530935
-    9  (  9)  0.423095730032689 -0.296000598729972 -0.177730944535255
-   10  ( 10) -0.299463152132731  0.634536265412446 -0.073348108781663
-   11  ( 11) -0.175836972560684 -0.076105887981834  1.184769463941312
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.567008918440454  0.722443194224100  0.422402078329773  0.057554368538511 -0.068012024097596 -0.451975147608540  0.709419418128490 -0.110422168786063  0.095704108927647
-    1  (  1)  0.720885472964738  0.332527211352729  0.737390933664557  0.281750515995843  0.280761290393686 -0.598548871078422 -1.146750917560074 -0.177301134607867  0.234694928374046
-    2  (  2)  0.422183102929830  0.736485274543817  0.007829109729841 -0.365399185160488 -0.965501991519851  1.065090224342325 -0.394390877157068  0.239359282041345 -1.218182428400336
-    3  (  3)  0.059687201587689  0.280769829516347 -0.363255319277090 -0.833720445234328 -1.345952507284314 -0.189309823206009 -0.179890587463359  1.060334267261244  0.772514544005070
-    4  (  4) -0.069257393950461  0.281296543593726 -0.966923508415862 -1.344162403478837  1.514830798821686  0.013670590813123  0.227285042195308 -0.333966365834383  0.386248727994588
-    5  (  5) -0.449135841837750 -0.599397616398023  1.066820631137579 -0.189649110609729  0.013795397601274 -0.565008204089947  0.487292179201877  0.306200785308481  0.347063761059997
-    6  (  6)  0.708465668575064 -1.146562417015747 -0.391890894794961 -0.180811610825629  0.226633708337573  0.487729597603209 -2.767088081148377 -0.044613761228256 -0.000972346438746
-    7  (  7) -0.108981479701481 -0.177538422258191  0.240499334967173  1.059842333943978 -0.334391646412731  0.306249622802239 -0.044471110656761 -3.232660954268523  0.514839123397967
-    8  (  8)  0.094277588726801  0.235043460722862 -1.221823739304416  0.774952681271118  0.386077819008107  0.344858044218004 -0.000341133693178  0.514916107143190  0.507086715271392
-    9  (  9) -0.063381219775898  0.233965663654109 -0.093343357924906 -0.360354041999586 -1.006820146552738  1.344825106449130  0.268434803850821  0.315156353069794 -0.332938610236887
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.063808920787530
-    1  (  1)  0.235710820172182
-    2  (  2) -0.096202914418848
-    3  (  3) -0.360121798161892
-    4  (  4) -1.006476097602190
-    5  (  5)  1.343619008167611
-    6  (  6)  0.268106090274240
-    7  (  7)  0.315242334513133
-    8  (  8) -0.332481313383264
-    9  (  9) -0.175400025059932
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010284048494255 -0.022581971135931  0.025184528241746  0.002553505114185 -0.007866760216735 -0.035704112150886 -0.002766394497905 -0.015588851752449 -0.054894237910669
-    1  (  1)  0.001129370063260 -0.004341567056713 -0.012471737690510  0.068518821494219  0.037428649672491 -0.002857552975536 -0.002731409738209 -0.051935588474977 -0.049204102006071
-    2  (  2)  0.045340581598934  0.060774626672080 -0.014665202394902 -0.013163382447340  0.085552378847967 -0.055885373659009 -0.012884187954087 -0.000025912808653  0.007546289398551
-    3  (  3) -0.053518724373857 -0.051858316930917 -0.015829576226974  0.002308038466593 -0.033376912491914  0.026566608759227  0.020736863226261  0.017163432001033 -0.156611857939886
-    4  (  4) -0.057073647917578 -0.121620677730040  0.116559461318180  0.152459611673760 -0.224360677266659  0.063635487600126  0.025109630293686  0.123561544969923 -0.260705677431782
-    5  (  5)  0.132736043071323  0.228873275971275 -0.157588806451895  0.278203525609905  0.112411249713211  0.339424025956772  0.132778586915835  0.041442079822076  0.144607854949093
-    6  (  6) -0.099037108772820  0.133050971019321 -0.016390463092699 -0.047994853534082  0.082590754367535 -0.196599146843337  0.423704532236322  0.002588517799838  0.062442412924455
-    7  (  7)  0.164573996270568  0.174187584517111 -0.442718231735592 -0.055107629768529  0.292277213599590  0.090352016025028 -0.100915507153634  0.242008735185081  0.079009239652453
-    8  (  8)  0.059450407301305  0.065508844735816 -0.375580889101448  0.518979554864539  0.457917802055341 -0.070408637451188  0.013466768623613  0.072872586601375 -0.257559025462184
-    9  (  9) -0.246894722162695  0.551859769243373  0.044670824987361  0.162240888664295 -0.012774136938901  0.203595879781061  0.102036778576897  0.168067562706153 -0.111682944808914
-   10  ( 10) -0.913654455951997  0.155328532380750  0.215519674293101 -0.100970035089767  0.021969337557273 -0.148862369984030  0.046525143909590 -0.100083990349210  0.020780587060978
-   11  ( 11) -0.198781019683999  0.090074442467030 -0.050453210014304  0.292395282220077 -0.068054938936099  0.077531780115388  0.149511822875939  0.072921096134366 -0.357789764657410
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.062212803584986
-    1  (  1)  0.008222801612735
-    2  (  2) -0.107232253166961
-    3  (  3) -0.058083892735771
-    4  (  4) -0.001519088368734
-    5  (  5)  0.232883930798086
-    6  (  6) -0.056471183426688
-    7  (  7)  0.097796104480775
-    8  (  8) -0.126488666884472
-    9  (  9)  0.156849504238605
-   10  ( 10) -0.081446420280763
-   11  ( 11)  0.176341903152824
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007749096020893 -0.085883219860789 -0.036741821640513 -0.003365465554254 -0.013826624434967  0.045778129863205  0.040669337017936  0.010509742963645  0.029540605017242
-    1  (  1) -0.033323633544771  0.071013231293301  0.009381535649954  0.001865195819276 -0.004385218315905 -0.001145589403992 -0.107240463714063 -0.004928891794835 -0.020784313339082
-    2  (  2)  0.052107391808055  0.092519548352413  0.009858355445846  0.037319719751115 -0.023857034470632 -0.010135084101246  0.037769988668842 -0.015917832336735  0.090581268987334
-    3  (  3) -0.109820166860700  0.034268818868662  0.003318299125654 -0.047343590144125  0.049224764312370 -0.055554817528594  0.048303583350885 -0.021295778567536 -0.056731125392159
-    4  (  4) -0.007052162455570 -0.070092516335627 -0.001616209300804  0.100452686687340 -0.017125496300488  0.011804649620296  0.317168773449601 -0.015679790140276  0.134810835290821
-    5  (  5) -0.101789034987347  0.450242114045570  0.095257897029759  0.154575128248214 -0.107484330343030 -0.276349446627330 -0.224432437333530  0.138878619319231 -0.069374899620443
-    6  (  6)  0.129481070378189  0.190214182802185 -0.111482363704469 -0.289845791886638 -0.214082604248960  0.130539668518305  0.176627871859896  0.507792819613372 -0.145016045312478
-    7  (  7) -0.031015915682170  0.467808966358201  0.323231774623313  0.163051942437066 -0.027878152128557 -0.222130149400228  0.355582804042090 -0.345169178258104 -0.117503613032291
-    8  (  8) -0.081114418656010 -0.129458136695794  0.321266021811150 -0.116738859709862  0.112997348404402  0.150149613835924  0.100022037588641 -0.009859219508172 -0.185497355865147
-    9  (  9) -0.840897499603665 -0.103193956572518 -0.262141263376961 -0.179652800220136  0.091540284698060  0.263027818637292  0.232988427097700  0.132664590100508  0.080643129784317
-   10  ( 10)  0.396138270139100  0.527358178663247  0.115585436142149 -0.350404487392900  0.098592337861551  0.056041756240516 -0.132708614971811  0.130232826037073  0.024142145251939
-   11  ( 11)  0.048038049575401  0.184019168140566 -0.243899393243605  0.184449948512382  0.067903231499648 -0.173184976481832  0.074519873620110  0.122524072160336  0.175482839393722
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.029757291821339
-    1  (  1) -0.000721108481725
-    2  (  2)  0.081115665687732
-    3  (  3)  0.028764622397233
-    4  (  4) -0.020368316409772
-    5  (  5) -0.173632225317480
-    6  (  6) -0.281328230047800
-    7  (  7) -0.030401209370270
-    8  (  8)  0.093738850403327
-    9  (  9)  0.138017132925940
-   10  ( 10)  0.057334975405403
-   11  ( 11) -0.087072361680799
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.718905282963311 -0.301300066815098 -0.767801784865940  0.078512808825352 -0.203134864329395  0.241932163232250  0.058076631858574  0.196398858308336 -0.039008858124194
-    1  (  1) -0.301256490728193 -0.157440548180653 -0.036029555945222  0.243436823804201 -0.005929795652985  0.115486356935965  0.826228436942721 -0.465135369554618  0.058491264513800
-    2  (  2) -0.767289827428610 -0.036275730111077 -0.756926663794728  0.450133498634738  0.207784604973971 -0.828712724024022 -0.324647417359493 -0.353270502638369  0.092835605795882
-    3  (  3)  0.078579571414042  0.243310568002833  0.450095063336851 -0.208139431363607 -0.062202704649669  0.279001105370900 -0.076077558481815  0.262112030046533 -0.378810215172718
-    4  (  4) -0.202510304245595 -0.006692039856945  0.206011713498273 -0.062773519685661 -0.370731419489490 -0.256994084769574 -0.019543706164301  0.220490721787851  0.607096866069924
-    5  (  5)  0.239969372403163  0.117504635997786 -0.825053657412313  0.279484173569987 -0.255386254541418 -0.397595357673452 -0.135369610755389  0.236221247146237  0.269522215039686
-    6  (  6)  0.058390572588279  0.825859124407247 -0.324193078352693 -0.076854690390370 -0.019228317672495 -0.137735601227498 -0.351485727273275 -0.487761380462257 -0.103056409920122
-    7  (  7)  0.194458563409000 -0.463590717501173 -0.349817673328107  0.262678828099312  0.220495817360137  0.236701749060628 -0.486100377719484  0.043036203375607 -0.169360995578035
-    8  (  8) -0.038844766636175  0.058006360789407  0.092452034322386 -0.377838465048525  0.603441383275525  0.267460191997309 -0.103192305796676 -0.168696834715057 -0.618488124049516
-    9  (  9) -0.174642021637819  0.179686913958803  0.584519432729807 -0.531375857305351 -0.237827440080434  0.122408493834100 -0.350613084838644 -0.156778679126698 -0.027661506214973
-   10  ( 10)  0.043298420781037 -0.218837511618004 -0.611680553974653 -0.687832529301005 -0.249683832986975  0.553064660821027 -0.144105807777605  0.115245275900936 -0.084193131593124
-   11  ( 11)  0.061064657985430 -0.108300572115386 -0.188797311905296 -0.022208683609426 -0.827900622936499 -0.341922472618851  0.022718392329079  0.232401592689427  0.164619669402136
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.175684511601603  0.045513516298602  0.061672515006080
-    1  (  1)  0.179323083833167 -0.221567937419786 -0.109140577543022
-    2  (  2)  0.587827397093136 -0.616289532030193 -0.190305864672640
-    3  (  3) -0.534590179358002 -0.689583787093839 -0.022209033963942
-    4  (  4) -0.239000891867221 -0.249187499059157 -0.832603923332527
-    5  (  5)  0.122010791877518  0.553620901013401 -0.348332351708050
-    6  (  6) -0.352732495297565 -0.145056644635348  0.023781601660354
-    7  (  7) -0.157242165562723  0.112854519200918  0.232190589319976
-    8  (  8) -0.027709907045481 -0.086030263039170  0.172274707819854
-    9  (  9)  0.207109600584589  0.096837430686223 -0.023218950236813
-   10  ( 10)  0.100164655230671  0.138181178066476 -0.148224446144570
-   11  ( 11) -0.022320179734203 -0.148849259998097  0.901205762410303
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.179939828491769 -0.273263983919761 -0.077241939802207 -0.131310571537764 -0.452108955794121 -0.373710053222736  0.012756857043078  0.188686131296855 -0.281717657996437
-    1  (  1) -0.271865636595074  0.080204205184229  0.237736668579935  0.053954037181141  0.088144371186311  0.094298665169508 -0.396703489007358 -0.164374392009126 -0.012743809563993
-    2  (  2) -0.076549157175288  0.237611423410488 -0.235916884249811  0.330279805489172  0.156363656188217 -0.135525945480897  0.113532621668593 -0.192996543934043  0.505097349395040
-    3  (  3) -0.133008481204441  0.051978470711429  0.330705317892875 -0.689079279022158  0.681025162416434  0.230126506813665  0.220012049909173 -0.221793013382862 -0.415574431905058
-    4  (  4) -0.450299145657576  0.087908600365275  0.156309970041408  0.681002122520780 -1.360248251424318  0.202273753159192 -0.167570810051337  0.246051223487190  0.206738411458247
-    5  (  5) -0.373567193155845  0.094555329734040 -0.136731584498100  0.229377893488984  0.202581599883435 -0.322498154757568 -0.226671631570763  0.408374954790996  0.307423751717641
-    6  (  6)  0.013230492577454 -0.395220303624150  0.113830041131736  0.218897296842682 -0.167381205612527 -0.226319762003687 -0.422981172464967 -0.882122931150610  0.208582936748456
-    7  (  7)  0.187587553988559 -0.164973338711578 -0.192266029819867 -0.222193739599766  0.245811643454060  0.408813624326959 -0.882511768104148 -0.161881530949274 -0.197931622292553
-    8  (  8) -0.280045996340605 -0.013187886145669  0.507423753200987 -0.417462155137855  0.206022606034107  0.308302993473083  0.207495521066743 -0.198012373935716 -0.598880759668382
-    9  (  9) -0.299128216307527  0.222289305708678 -0.374826664894612 -0.022250761597490  0.198104512558476 -0.291885255576850  0.011569749529353 -0.150670269953426  0.186378706038956
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301492091129213
-    1  (  1)  0.222023461274417
-    2  (  2) -0.373275862159688
-    3  (  3) -0.022769731837422
-    4  (  4)  0.197531018509810
-    5  (  5) -0.291038388606400
-    6  (  6)  0.011766677818707
-    7  (  7) -0.150956367275849
-    8  (  8)  0.186282415361357
-    9  (  9) -0.408641391244209
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006541040222368 -0.029135588169222 -0.017330822595744  0.002628911660037 -0.012344009141809  0.034496132624923  0.021629830242309  0.010441885402291  0.025478364815458
-    1  (  1) -0.038275138470075  0.054424566886903  0.005683589031010  0.001642391288003 -0.005493648653247  0.001124544236485 -0.102028934451313 -0.004961744404475 -0.019198498257850
-    2  (  2)  0.053024456913342  0.083754722151204  0.014366999014575  0.045684709272444 -0.045425854355333 -0.015659092798954  0.035306515857362 -0.013688960188417  0.082596341754868
-    3  (  3) -0.125696090540634  0.031717757592640 -0.000802365038104 -0.050871771309593  0.061705711345850 -0.045742890419344  0.045450419445688 -0.021064845035616 -0.054716959844684
-    4  (  4) -0.016613018731749 -0.059371668786672 -0.003754167403423  0.095982620955076 -0.007240466240122  0.008043456529988  0.296808016923276 -0.015369394286441  0.136610478911713
-    5  (  5) -0.093091489377706  0.398657588863068  0.074430182364354  0.149030211928108 -0.108745535372234 -0.256250392240536 -0.205814737045222  0.134201000957220 -0.055103512993348
-    6  (  6)  0.103501697780443  0.185147067962843 -0.104829304475355 -0.273669393328239 -0.199802423052909  0.136710211986565  0.166053639619828  0.483268157942075 -0.135434527757446
-    7  (  7) -0.041456689404135  0.416662529525886  0.296499443846860  0.151835770270295 -0.027648961071683 -0.196853254585748  0.346148931870815 -0.324194030503122 -0.108656389838073
-    8  (  8) -0.069099920157317 -0.122455303618133  0.312946042218845 -0.115185983609626  0.104240832235501  0.145175805702234  0.095088539986730 -0.010672631592564 -0.187147060865154
-    9  (  9) -0.712671855893174 -0.096350152389786 -0.234711067777686 -0.171596024164591  0.065322769896798  0.213466874289907  0.226529390715592  0.118201066093080  0.055528795004367
-   10  ( 10)  0.365512212430565  0.443597144956858  0.088760713787529 -0.336294489487780  0.089380999156301  0.050585935158758 -0.112358935032342  0.122526344346197  0.011836823928278
-   11  ( 11)  0.046393846223224  0.165011629057398 -0.228781961279396  0.178941949643574  0.063752947031584 -0.164789871590981  0.073726138142668  0.117333811839271  0.181371275992210
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.026880621041360
-    1  (  1) -0.000642066544117
-    2  (  2)  0.075046583216661
-    3  (  3)  0.030887223304929
-    4  (  4) -0.027083357083367
-    5  (  5) -0.161323349919549
-    6  (  6) -0.260652499025702
-    7  (  7) -0.019658118713907
-    8  (  8)  0.093794795124770
-    9  (  9)  0.110456626093643
-   10  ( 10)  0.048798146100140
-   11  ( 11) -0.097571556382824
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001432746297450 -0.032810674091764 -0.033331937480253  0.023032547083763 -0.002808019310921 -0.039246266926320  0.018692018505171  0.008842597191367 -0.029091078569617
-    1  (  1) -0.008821922403183 -0.001742272088788  0.082771016704519 -0.022297486221974  0.039163604166239 -0.010818853488427 -0.047294425339584  0.013135326021221  0.049034393857867
-    2  (  2)  0.024274942916815  0.027096978669207  0.097516386902391 -0.041392368694666 -0.004119390757880  0.075691552303805 -0.023677742397495 -0.003953261558318 -0.122163189427397
-    3  (  3) -0.047038460283817 -0.039422636027069  0.017791086341758  0.115660160117630 -0.067224158887899  0.095036576800958  0.032022129167533  0.022732157345389  0.120912741709036
-    4  (  4) -0.041035802352368  0.001934742020068 -0.201409668003493 -0.406246991276172  0.228435905047063 -0.366034413601436  0.036563318346743 -0.036692328708082 -0.082010843429842
-    5  (  5)  0.098338733570095  0.243746073973362  0.282884501181602 -0.425804208023662  0.108408993563040  0.505586602390370  0.102717653176241 -0.183779423720787  0.023433267817945
-    6  (  6)  0.135336854760563 -0.062874421564495  0.076338309095403 -0.023002937162434 -0.130902824611473 -0.185164583438217  0.398907643233867  0.217551510448046 -0.032105677017803
-    7  (  7) -0.035062191357078 -0.113858796831119  0.431604299875852 -0.029482805357536 -0.029652466640804 -0.242847719350325 -0.077765311277989  0.367073496056810  0.139022006906444
-    8  (  8) -0.068272847454715  0.294672021175633 -0.568959581650588 -0.125921031197012 -0.707592810771387  0.017806583156209 -0.015845746565047 -0.212947645825718  0.125196335187716
-    9  (  9) -0.288858276698774  0.093713692739213  0.209035012311688  0.075382622510660  0.083405488851542  0.016184965058288  0.000548295704545  0.266294088315547  0.380874642506837
-   10  ( 10) -0.378738518488000  0.204837316203508 -0.069415360994347  0.062065163074324  0.029622876137723 -0.058750752587050 -0.120574645247794  0.008130897374692  0.009265965929469
-   11  ( 11) -0.080018520143771  0.225808316863723 -0.312311376663230 -0.316597637367698  0.125757542829493 -0.146130016020174  0.016179298260010 -0.136308703902615 -0.120756904157899
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.036093305578397
-    1  (  1) -0.001707679185378
-    2  (  2)  0.005295607540268
-    3  (  3) -0.304573937377439
-    4  (  4) -0.014287077020118
-    5  (  5) -0.068885443054321
-    6  (  6)  0.111979958895137
-    7  (  7)  0.321243115116497
-    8  (  8)  0.158205355334404
-    9  (  9) -0.080091690471286
-   10  ( 10) -0.065074315967804
-   11  ( 11)  0.075517488980888
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.151581395944457 -0.159877768539019 -0.191397517423370 -0.495232284867177  0.365561840480614  0.240680277087037 -0.079714342464060 -0.017889526464511  0.054577038131019
-    1  (  1) -0.159795957250344 -0.047735218799445 -0.125025973520529 -0.592230248738643  0.329204795623399 -0.563899565056737  0.474518384859258  0.371816427010336 -0.204007450193307
-    2  (  2) -0.191333337555164 -0.125299228178318  0.032743525999057 -0.248173196102997  0.424015573762028  0.373304795371779 -0.124367805075759 -0.383343230710404 -0.176623528718579
-    3  (  3) -0.494849488362154 -0.592714843248357 -0.248959287226432 -0.423717062956694  0.236470791317215 -0.415768039926139 -0.007927078894393 -0.295339114007336  1.138817517977087
-    4  (  4)  0.365842786381904  0.329912791129377  0.425309312530905  0.236284335454773 -0.297797609245548  0.287162197148014 -0.015195390583447  0.149575460395682 -0.352881082019632
-    5  (  5)  0.239666720470004 -0.562521840762128  0.375748994888085 -0.414021321385147  0.283842862620087  0.299376587010529 -0.122721640145877 -0.329969308300871  0.156494792176823
-    6  (  6) -0.079132044596257  0.473605179791134 -0.125255855635513 -0.008774504854422 -0.015965010341322 -0.123144104694353 -0.040262615853229  0.053291869268360 -0.230047243580867
-    7  (  7) -0.018210362041773  0.371975596266125 -0.382949144540519 -0.295062546320220  0.147969605902060 -0.330844143538271  0.053247875304319  0.437054225002062 -0.295575334707162
-    8  (  8)  0.054384972764257 -0.203042333758326 -0.176317356102570  1.137981680675850 -0.349930528471567  0.158219435758802 -0.229361079354617 -0.295174183029699 -0.201170965133917
-    9  (  9)  0.162593186917498 -0.096068090323904 -0.131721885594255 -0.537260876669133  0.048165192812382 -0.386108653062500  0.083321052788424  0.067822247358744  0.259623842469249
-   10  ( 10)  0.093086276325347 -0.110390627511003 -0.528311347000350  0.014888006239538 -0.100997055269664  0.192126958830561  0.038787614394956  0.063975054988451  0.077127488930246
-   11  ( 11) -0.248608674285678  0.166558436146830  0.438779225583925  0.334557445644043 -0.324782623645273  0.179928478753780  0.012126762707773  0.006418605871888 -0.316369462085207
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.163245257155421  0.094276717552644 -0.249582936616881
-    1  (  1) -0.097089753942058 -0.112180528774260  0.167323530234027
-    2  (  2) -0.131901378869784 -0.530116652654623  0.440616284282449
-    3  (  3) -0.539218683643804  0.014310072965047  0.335266942696954
-    4  (  4)  0.048635984706568 -0.103433325040069 -0.331331261588337
-    5  (  5) -0.385516013729792  0.187104305011894  0.193398800890046
-    6  (  6)  0.082991815026247  0.037352860323020  0.011014682786961
-    7  (  7)  0.067841455828072  0.062642922337485  0.014204699225385
-    8  (  8)  0.258473930207162  0.077886035701004 -0.325054438919389
-    9  (  9)  0.001773142889432 -0.053105768300802  0.034600115019000
-   10  ( 10) -0.053689547832438 -0.018246255837546 -0.196162567936867
-   11  ( 11)  0.031756575503292 -0.193298510202671  0.164652237069869
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.236069150423928  0.221583137218639  0.087467481976269 -0.023767225350154 -0.157884977853517 -0.128673956390029 -0.176595879969474  0.001131012317203 -0.181143452404233
-    1  (  1)  0.220430431059073  0.112052435313968  0.015869249151473  0.264485428778921 -0.165982030219470  0.159260926468858 -0.018854654828287 -0.249502649443057  0.052130725228418
-    2  (  2)  0.087694752982164  0.015013031218300 -0.683310722703039 -0.454889777527338  0.270539149606414 -0.876133156261866  0.064372104092668  0.069959767509230 -0.359585122327188
-    3  (  3) -0.022349867884997  0.265917774305981 -0.459885376820098  0.156118351029157 -0.442698949429053 -0.633164352365545 -0.123599096035318 -0.000681276488754  0.329408685832541
-    4  (  4) -0.157925484616889 -0.166044552973515  0.271218387113143 -0.443885849212600 -0.013362398764761 -0.176284165832649 -0.004716950323026  0.078109759941717 -0.609000288591445
-    5  (  5) -0.127616278770967  0.158011849801079 -0.876037618276795 -0.629854882079848 -0.177186230678137  0.012211398531521  0.059425698366986 -0.774979266274861 -0.486618182967767
-    6  (  6) -0.178241606252947 -0.017090192450387  0.064522373941146 -0.124240074207901 -0.004293285267873  0.059087683211698 -0.104000927528902 -0.330829052901522 -0.038045687603335
-    7  (  7)  0.002208432976113 -0.248689840257510  0.068573896371648  0.000014323070255  0.078530114044465 -0.775881123063332 -0.330687300606162  0.375687386105441  0.140607455827148
-    8  (  8) -0.178615853440425  0.052090468900394 -0.360562489485138  0.330978975217506 -0.607342070790934 -0.487347100955227 -0.037705399031252  0.140808054960246 -0.394251292282697
-    9  (  9) -0.046812023124734 -0.356025366669854  0.690811815119252  0.312933605279832  0.666333150435849  0.222468929331266  0.069111321865738  0.559435147572457  0.132671563084754
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045842278134109
-    1  (  1) -0.355929482932053
-    2  (  2)  0.690401613030498
-    3  (  3)  0.314450068453419
-    4  (  4)  0.667992312261241
-    5  (  5)  0.221641972273241
-    6  (  6)  0.069286377187356
-    7  (  7)  0.560338391968248
-    8  (  8)  0.132249466359632
-    9  (  9) -0.305201514350595
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003531322887475 -0.011853964282953 -0.013997173425702  0.018382792154192  0.000899996441170 -0.027829789222902  0.010946278656521  0.009416135608630 -0.023987807904262
-    1  (  1) -0.006388621957170 -0.005171201061298  0.075116414644925 -0.012351518893597  0.041297277094542 -0.006441657661851 -0.042094675941536  0.014500044658877  0.045272474380981
-    2  (  2)  0.036883171135873  0.025743377437805  0.085964964522995 -0.036572128405843  0.000741779132517  0.071901849285639 -0.017612259522947 -0.002857549793791 -0.114428225581804
-    3  (  3) -0.050379148878904 -0.038280516537017  0.018275237269774  0.118578575241743 -0.057964689431887  0.100743381549064  0.031817975653707  0.026538904209037  0.119963525599056
-    4  (  4) -0.040259568572502  0.011229705198348 -0.188809172609568 -0.380757486353216  0.215445879830049 -0.344569392827444  0.033187603168238 -0.033507608911701 -0.079582925346094
-    5  (  5)  0.087141198545524  0.216785041786672  0.270610048744647 -0.398997177058604  0.102170025016676  0.478625848854116  0.098949415070036 -0.170373600936987  0.015652914812384
-    6  (  6)  0.115394650619668 -0.055172374414512  0.068645251662214 -0.021005537436634 -0.120222938768552 -0.172201054646963  0.377862520931175  0.205771786365183 -0.028486300590321
-    7  (  7) -0.040171141537119 -0.121048023653740  0.403132598347777 -0.027760474590503 -0.026374510769541 -0.228317794220799 -0.070878790612320  0.346601006753617  0.129893637962627
-    8  (  8) -0.063034884678852  0.280866798080653 -0.540496031356204 -0.119391576371009 -0.673073389093966  0.010663808807394 -0.016147690801371 -0.200745867995305  0.117394935881043
-    9  (  9) -0.239823863619059  0.087614347419962  0.205995256328994  0.074059708937832  0.068748575207548 -0.000454096504958  0.003028317523563  0.249475422318809  0.352711368821821
-   10  ( 10) -0.336588165834448  0.173514331887659 -0.070029614207528  0.058791676167547  0.024501304819872 -0.052124336325614 -0.104213155529188  0.008639636736157  0.013496509549194
-   11  ( 11) -0.070036515714458  0.195530601320237 -0.305644951639726 -0.322831866596268  0.121530762471617 -0.141977993846978  0.021998928318675 -0.134440837975978 -0.127122644721006
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.030353030422789
-    1  (  1) -0.003358262791905
-    2  (  2)  0.006176160600104
-    3  (  3) -0.295046081788652
-    4  (  4) -0.003816440522472
-    5  (  5) -0.074325961201587
-    6  (  6)  0.109014636987132
-    7  (  7)  0.303731536940852
-    8  (  8)  0.152250258689580
-    9  (  9) -0.089511140585649
-   10  ( 10) -0.060789805292351
-   11  ( 11)  0.082293619260989
-
-	DPD File2: P*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.016948570972613 -0.054109880888837  0.021135784265575  0.002313233156337 -0.028103296077604 -0.079447973740205 -0.002956852851677 -0.021913708071079 -0.092707789804150
-    1  (  1)  0.006461113403501  0.006009670223774 -0.006912589645128  0.092573919328396  0.040488535615147  0.004255397696456 -0.001825638351976 -0.025873653657309 -0.054959118002991
-    2  (  2)  0.031331544873159  0.021241168145027 -0.017129702121868 -0.019395427099523  0.035285598576221 -0.072935692322985 -0.012410630409385  0.000869702308377 -0.008015902055911
-    3  (  3) -0.024878718719799 -0.025868121230654 -0.005405353640122 -0.004239945233349 -0.042856541334318 -0.005201344918358  0.012288417201910  0.030208301210711 -0.125325395177801
-    4  (  4) -0.025785958698499 -0.063980691498117  0.073598667061032  0.115501747702081 -0.164822674147024  0.010612384733594  0.011577872820172  0.114519752578224 -0.189906673361740
-    5  (  5)  0.055556441114085  0.137396825466669 -0.095615332658029  0.165972658367973  0.107298365798081  0.238527327390248  0.081212554772841  0.063709822276343  0.111105007194853
-    6  (  6) -0.039392027543678  0.042131630239803 -0.019507343007951 -0.031681902994480  0.051489401416932 -0.103596811576048  0.235358679315166  0.007221910465763  0.034349807961782
-    7  (  7)  0.065836178815642  0.094909606609938 -0.220876622755124 -0.015059455980391  0.193611601065905  0.070646838068217 -0.043039430003875  0.187401754034075  0.048410779717487
-    8  (  8)  0.031684946163714  0.037730087504351 -0.186156646607922  0.254646362799555  0.271156762093932  0.000387787259569  0.024433068698376  0.071450437934107 -0.140846979003438
-    9  (  9) -0.084633662124775  0.255488997024621  0.026205007862790  0.093994792938777  0.025613688623644  0.118121227074271  0.051164537443405  0.122992981774053 -0.058164329433773
-   10  ( 10) -0.311792105223363  0.086266548695923  0.100581825486069 -0.027645372765871 -0.030325864964669 -0.084727340300286  0.008122017336910 -0.056541723787744 -0.001789230697787
-   11  ( 11) -0.065426291083003  0.078665723239531 -0.001736951632506  0.128876911317495 -0.027700220473420  0.024959429550215  0.037516506165893  0.053272012233112 -0.158952768314791
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.101753702406755
-    1  (  1)  0.017313059038111
-    2  (  2) -0.101825332796567
-    3  (  3) -0.046545573336527
-    4  (  4) -0.020412053345531
-    5  (  5)  0.174151422241113
-    6  (  6) -0.031247623880847
-    7  (  7)  0.081019948031908
-    8  (  8) -0.058254959468121
-    9  (  9)  0.102303876794014
-   10  ( 10) -0.049924523752296
-   11  ( 11)  0.075525972870746
-
-	DPD File2: P*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000125242728652 -0.167195127529492  0.056123303969470 -0.168150627862986 -0.199820827488140 -0.006623842711744 -0.083849175432758 -0.006045895732050  0.001251364845770
-    1  (  1)  0.166774393973286 -0.000050108097355  0.080714006337441  0.158384893960458  0.170632381263561  0.022705538420815  0.068262733314185  0.100593352732071  0.028750568711108
-    2  (  2) -0.056229020612168 -0.080612207963297  0.000319173254151 -0.066387047727631 -0.099495071766653  0.005173360753909  0.113435632074142 -0.028897807757084  0.031705991700745
-    3  (  3)  0.167678159270092 -0.158683508487030  0.065913815468277 -0.000249734983867 -0.003148005831140 -0.156650391969335  0.003319412683622 -0.076996711806060 -0.120344951995522
-    4  (  4)  0.199454748142053 -0.170759345082550  0.099469221211006  0.002551454280228 -0.000773886045054  0.018686662746212 -0.033100672959698 -0.121887804954424 -0.106797700418754
-    5  (  5)  0.006478249114673 -0.021770745773300 -0.005161753017351  0.157975992221428 -0.016380865873467  0.000525726707385 -0.009662973185984  0.040170645002731 -0.072417783927543
-    6  (  6)  0.083743292092373 -0.068302347407764 -0.113643630138679 -0.003584139545109  0.033360726847565  0.010056643067212  0.000096953687507  0.013754999535778  0.022913811866200
-    7  (  7)  0.005934789716209 -0.100152235257288  0.028714239339716  0.077512132071698  0.124503679540823 -0.039365364835397 -0.013764502288195 -0.000180876976509  0.012227152395047
-    8  (  8) -0.001252911154497 -0.028874957240891 -0.031437882577012  0.119989379615825  0.109273108573834  0.074290660285147 -0.022855339074817 -0.012168993677105  0.000462665884709
-    9  (  9) -0.203227152828002  0.052485985798040  0.129801089628845  0.136141281459481  0.065085125998612  0.011352243649991  0.086206555714525  0.025668240031329 -0.000953339185401
-   10  ( 10) -0.017663100569732  0.012450214343934  0.116177784025215 -0.099935881710944 -0.054793001926237 -0.009017289614393  0.082995680333069 -0.068546362432187 -0.010579042812723
-   11  ( 11) -0.116181838629295  0.044517983740016  0.150706036920128  0.032577504630229  0.048215712631815  0.017042393348597  0.052941121555075 -0.017922753511187  0.062577005194743
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.202593155221573  0.017575879500322  0.116307852916242
-    1  (  1) -0.051519507233614 -0.011549119939392 -0.045820851989693
-    2  (  2) -0.128159049336363 -0.115585636177618 -0.151359481294950
-    3  (  3) -0.134953502481695  0.100933227346633 -0.031949792725006
-    4  (  4) -0.063859931160852  0.055317708494750 -0.046074544888569
-    5  (  5) -0.011830479350239  0.008881125854761 -0.020210091121139
-    6  (  6) -0.085128481579730 -0.081569095643572 -0.054417852481447
-    7  (  7) -0.026086609962421  0.069224862060329  0.012195140209492
-    8  (  8)  0.000678319781602  0.012471916838811 -0.071159871058140
-    9  (  9) -0.000819518740474 -0.045422336765459 -0.019150849930670
-   10  ( 10)  0.042260420338391 -0.001814961764223  0.033976133870612
-   11  ( 11)  0.016728332900175 -0.032414763485709 -0.001978177060231
-
-	DPD File2: P*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000983782142481  0.011124830147172  0.012629378315808 -0.024035154666400  0.023065379134223 -0.045710192314813  0.107167060216496 -0.027462764041011  0.031515346399462
-    1  (  1) -0.014910063958614  0.001359157823420  0.030733082384744 -0.019659721688393 -0.009988965433840 -0.056476882006057 -0.086868153591365 -0.027118954968710  0.020111602536483
-    2  (  2) -0.013560973004051 -0.032277644601759  0.000558091321303 -0.031608555416779 -0.040262773871770  0.039517595873987 -0.008529102471728  0.015019360045155 -0.098314783259817
-    3  (  3)  0.023649721587845  0.020118169175247  0.030610171886610  0.000350229335722 -0.012485025400198  0.061831636996218 -0.007360517014456 -0.020533699107494  0.121125902320152
-    4  (  4) -0.023653135590417  0.011024958414626  0.040020875859244  0.012638451269626  0.000303446235581 -0.039117573677270 -0.028265656547984 -0.042181285668281  0.051214110379900
-    5  (  5)  0.045133076040651  0.057161250752777 -0.039343611119004 -0.062428421797334  0.039565506596663  0.000136824832782  0.002584969716509 -0.016708941328372  0.072879955596616
-    6  (  6) -0.106505496216286  0.086364895206289  0.008150243943918  0.007611894739464  0.028147100099079 -0.003022121444643  0.000203669685880 -0.002510614548550  0.011878393768514
-    7  (  7)  0.027112672456296  0.027077462764235 -0.015425844110164  0.020594818217305  0.042172669827196  0.016338775255452  0.002434838415100 -0.000089029182611  0.017463248477439
-    8  (  8) -0.031656276623231 -0.019719565610509  0.100860419907018 -0.123299997114838 -0.052015418367335 -0.071940119122082 -0.012364797759804 -0.017989601258840  0.000459902016922
-    9  (  9)  0.009520290499381 -0.022267140636896  0.003094175387367 -0.010303251098885  0.097174601333758 -0.097786893048291 -0.015199034071913 -0.052630350765338  0.034203233126427
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010278877487205
-    1  (  1)  0.024100566367630
-    2  (  2) -0.004662205178286
-    3  (  3)  0.011080772146621
-    4  (  4) -0.096116977362317
-    5  (  5)  0.097255829352037
-    6  (  6)  0.015024357830545
-    7  (  7)  0.052513597187948
-    8  (  8) -0.034242058243121
-    9  (  9)  0.000071427193828
-
-	DPD File2: P*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.021462702377840  0.058609304986263 -0.015277082640202 -0.003588508466775  0.029160920616631  0.083108081100347  0.001276540885573  0.021892833224427  0.094847379110200
-    1  (  1) -0.007381037964715 -0.005863657253688  0.003698438732125 -0.089241023982742 -0.038284755695481 -0.000242471073392  0.003462666004729  0.024254060890744  0.054255658141393
-    2  (  2) -0.028789493389469 -0.021034273638112  0.015759179620292  0.016880406379978 -0.029564270241667  0.075699259080315  0.015222849490441 -0.000165407073994  0.009535205798866
-    3  (  3)  0.022522624621755  0.025183731584898  0.006246635644453  0.011954555325543  0.044324634330057  0.008966012606668 -0.011838270463808 -0.025186144853786  0.129587118903909
-    4  (  4)  0.027278246959126  0.067306256079496 -0.081195596321175 -0.116387540315424  0.168952317262089 -0.005408102733272 -0.009102915279315 -0.114909773648686  0.181841314973109
-    5  (  5) -0.061523869623373 -0.148379112602599  0.099858075157622 -0.167623835533734 -0.102565185360584 -0.247065081865864 -0.081017208043104 -0.063123082298018 -0.125076333021719
-    6  (  6)  0.033597893568908 -0.039834794585931  0.017503613262801  0.032860851330180 -0.052602131787128  0.107800944359286 -0.233932603910558 -0.008404826542760 -0.033043735155831
-    7  (  7) -0.070933561522966 -0.099409127660202  0.220355143796242  0.017909988072788 -0.200469521486937 -0.066219172137076  0.043845430589746 -0.192769183200970 -0.053043735796183
-    8  (  8) -0.031467417081633 -0.038067047239557  0.186574292412207 -0.251635426547577 -0.276398972104307 -0.005573316819495 -0.024827793389672 -0.069746818919629  0.142347486299646
-    9  (  9)  0.099591518033223 -0.261294622221711 -0.027264053477196 -0.094406359241798 -0.029407574246243 -0.125903095774733 -0.051208103024876 -0.127846157357285  0.056089461080389
-   10  ( 10)  0.342117397283536 -0.096154260862934 -0.107466277478619  0.028734389414544  0.028891686984979  0.086820145756038 -0.003652067648454  0.059057626339762  0.003362266069713
-   11  ( 11)  0.071536902730284 -0.080845824211427  0.010817173110070 -0.135869650211322  0.031366930890364 -0.023168476862022 -0.040179651854624 -0.056331586353381  0.165962619403637
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.103572144747435
-    1  (  1) -0.016763539950930
-    2  (  2)  0.104006607185189
-    3  (  3)  0.046374714497242
-    4  (  4)  0.027556807097170
-    5  (  5) -0.176590727028647
-    6  (  6)  0.030192309767508
-    7  (  7) -0.090742251579819
-    8  (  8)  0.063736127736872
-    9  (  9) -0.109060255331570
-   10  ( 10)  0.052388979852748
-   11  ( 11) -0.078361680425232
-
-	DPD File2: P*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.013921975065565 -0.103381315829109 -0.056389355096898 -0.011768947816972 -0.004121807955223  0.057298678485070  0.051432105076231  0.011071595100990  0.044909476246755
-    1  (  1) -0.013324613924162  0.028079810676541 -0.007070559814787  0.008005471198395 -0.006018453330844  0.015973349330415 -0.092922359472783  0.001623775394348 -0.017733631990947
-    2  (  2)  0.019765781914701  0.033032250658388  0.004007042176849  0.050166385756319 -0.029906079194408  0.009704933667000  0.038620452933162 -0.002807692103963  0.070071101745418
-    3  (  3) -0.070805556804984  0.003068938942251 -0.006504595257348 -0.039373898202160  0.036927092655665 -0.030322281820042  0.048817421108637 -0.011305308050902 -0.032860541612150
-    4  (  4) -0.014313386316708 -0.043972310793415 -0.013921813392036  0.066387730109469 -0.002442397138038  0.016086934562225  0.179664439851381 -0.006464519349973  0.090040691856223
-    5  (  5) -0.045155577186191  0.247427178481659  0.058353258995683  0.094628927569757 -0.090493402552644 -0.185320260507422 -0.131090788508292  0.093104350867894 -0.060872458952884
-    6  (  6)  0.038584331307231  0.080297227608230 -0.071473886019715 -0.143170489853226 -0.104560768686072  0.046154653747240  0.096338078586582  0.334907808030702 -0.111571007227725
-    7  (  7) -0.029042222296753  0.237223314371562  0.174932299186948  0.080316826107909 -0.040506264905804 -0.119977478400892  0.161451558991029 -0.215735211087246 -0.060177585905520
-    8  (  8) -0.025904244265209 -0.058524341310476  0.144685830322387 -0.050264276045864  0.072805327886092  0.086206688333215  0.053604324132359  0.007863564270736 -0.095576963924380
-    9  (  9) -0.256508945269226 -0.052730013654633 -0.124834441481755 -0.085733906231975  0.088393899635438  0.140853295492133  0.139492059284684  0.083015088260315  0.042052092330032
-   10  ( 10)  0.128333935578074  0.263327859036735  0.068329655679101 -0.087024591997986  0.057039935036965  0.051621611298698 -0.073645648424309  0.107556560489238  0.002537116902128
-   11  ( 11)  0.014388047963903  0.095897531557492 -0.075761746736829  0.083654757188919  0.030891133031091 -0.061475545358308  0.020586611930162  0.065614997905860  0.075825389492545
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.046633267353021
-    1  (  1)  0.000248773711794
-    2  (  2)  0.058940238082046
-    3  (  3)  0.028215078659147
-    4  (  4) -0.009693071380795
-    5  (  5) -0.114025765710299
-    6  (  6) -0.149932383186960
-    7  (  7) -0.029309043140763
-    8  (  8)  0.056468406833596
-    9  (  9)  0.080845904093313
-   10  ( 10)  0.031944380388807
-   11  ( 11) -0.038072643167866
-
-	DPD File2: P*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000412292330125 -0.089973601331934 -0.299831566929396  0.035035339281938 -0.102534416749163  0.139160673237755  0.022726794108668  0.127186946220527 -0.025258681551895
-    1  (  1)  0.089435365325252  0.000179018409619  0.000575799904893  0.036397358696681  0.000077605512592  0.027763068926142  0.235329561156625 -0.149048042365481  0.020748539941476
-    2  (  2)  0.298742449986735 -0.000117532207539  0.000001365547946  0.030750645565914  0.035092304813822 -0.156637931403196 -0.074944775632850 -0.084030365627553  0.029024110989879
-    3  (  3) -0.035083534268240 -0.036212512324819 -0.030659339328188  0.000140940179517 -0.000968456927916  0.032572407071500 -0.017530821556219  0.040913042583287 -0.072860913708021
-    4  (  4)  0.102571067786625 -0.000186672877588 -0.035613278772227  0.000984301508163  0.000083284505465 -0.006675066086515 -0.008092161812671  0.022927931588032  0.061863833474700
-    5  (  5) -0.139766487530579 -0.026940126885898  0.158769710672111 -0.032620148977718  0.008447998102452 -0.000109266532081  0.002529804726067  0.011694293836355  0.013434968660314
-    6  (  6) -0.023123393533703 -0.235158830889094  0.075094645607883  0.017636517707368  0.007886799997649 -0.001572260884544 -0.000097447401663 -0.019414476223635 -0.005807231271628
-    7  (  7) -0.127556864975777  0.149585463815487  0.085819990046561 -0.040749094743077 -0.022487818487125 -0.013521945874053  0.020097198716066 -0.000802314554648 -0.005625145325134
-    8  (  8)  0.025298741297676 -0.021022944558544 -0.028995189539972  0.073180879828651 -0.063113474589722 -0.013554956351232  0.005975480503955  0.005930971726208 -0.000800554325514
-    9  (  9)  0.112700264643845 -0.073437341408674 -0.164270709854341  0.104952328655436  0.027707355858660  0.001091847596269  0.013360757417668  0.016602481071790 -0.000305982559018
-   10  ( 10) -0.061794958624484  0.084043685363021  0.190307519851821  0.184568056526643  0.046373613192876 -0.061509024448409  0.022601229760496 -0.000957508970510  0.004225767450876
-   11  ( 11) -0.048625937545448  0.043275944873041  0.072889882486030  0.022571956848243  0.129861302445486  0.036376964004426  0.007420842536071 -0.027716174562617 -0.009223617021504
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.112403684053299  0.061844266359582  0.048595688328450
-    1  (  1)  0.073289438710481 -0.083115738233247 -0.043020697969992
-    2  (  2)  0.163076133270358 -0.188328773885241 -0.073201670147403
-    3  (  3) -0.104459841985857 -0.183989325360910 -0.022816670642033
-    4  (  4) -0.027396737691172 -0.045295479134009 -0.129115557967778
-    5  (  5) -0.000453294188389  0.059142853300762 -0.038676049893677
-    6  (  6) -0.012371321314524 -0.021833349857811 -0.007208017450018
-    7  (  7) -0.015425630197400 -0.001848995755235  0.027351698922038
-    8  (  8) -0.000188535381821 -0.004971799266654  0.013988330055868
-    9  (  9) -0.002500332480999  0.018263398716747 -0.000166576528748
-   10  ( 10) -0.017029282729959 -0.001958362912370  0.009978757223056
-   11  ( 11) -0.000136976274521 -0.009294880869252 -0.003968240988117
-
-	DPD File2: P*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.001614610532278  0.000442574931184 -0.002484843724335  0.011617230485838 -0.003558333116152  0.008348902874223  0.003232631795727  0.035474959748436 -0.033113190058216
-    1  (  1)  0.000925459790748  0.002756415978539 -0.003671717190974 -0.027737733508484  0.046977278124977  0.010834189586698 -0.039059419738438 -0.012041835747932  0.002521971555221
-    2  (  2)  0.003459035434675  0.003977336342235  0.002397115178596 -0.018307436778833  0.034854228953805 -0.010228254395608  0.015345849161942 -0.005957982277486  0.035439629368503
-    3  (  3) -0.011412707516267  0.027632363855031  0.015411420139492  0.000653998533291  0.003171166784775 -0.010061032918207 -0.036835076234213 -0.006892251008290 -0.051742329375438
-    4  (  4)  0.002517172902630 -0.045696438310625 -0.035505499284382 -0.002530384085850  0.000253636208605  0.042894004341368 -0.014146809697220  0.013420506783873  0.046216668076946
-    5  (  5) -0.010111413240912 -0.013164521551321  0.011774998630568  0.009111026904833 -0.043299806769081  0.001105938056711 -0.021679173976934 -0.006497350404042  0.032564751151170
-    6  (  6) -0.003572744448066  0.037660563650739 -0.015981449923599  0.037360518379434  0.013810638672119  0.021864723269171  0.000142160187409  0.064951874935402 -0.010074940303513
-    7  (  7) -0.035166313105451  0.011117323575587  0.004943664183497  0.007105865391641 -0.013161333406594  0.006687507585744 -0.064466547112747  0.000008929989578 -0.021120345923087
-    8  (  8)  0.032509023911163 -0.002177177339651 -0.037021275355168  0.052629293793154 -0.046088465137947 -0.032895946707180  0.009967848101922  0.021497535040403  0.000352351163086
-    9  (  9)  0.046618687808640 -0.037317727430997  0.035589549384149  0.025010790590209 -0.028730927164894  0.032022748116099 -0.011580581352781  0.023706215184994 -0.002053813335462
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.047931933872975
-    1  (  1)  0.037047707028514
-    2  (  2) -0.035085472287032
-    3  (  3) -0.025182750300990
-    4  (  4)  0.028820432773372
-    5  (  5) -0.031275953086245
-    6  (  6)  0.011353625053442
-    7  (  7) -0.023384944254726
-    8  (  8)  0.002155438322651
-    9  (  9)  0.000134462394627
-
-	DPD File2: P*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.017096508292429  0.120272055653498  0.064777511074434  0.013939283933308  0.004251250821330 -0.059136973839352 -0.058075430708834 -0.010753929155031 -0.046095863651254
-    1  (  1)  0.009080853524756 -0.030472101004599  0.005253613736105 -0.008033743953506  0.006571724145552 -0.017271428965569  0.096045717241910 -0.001899586023459  0.018803255158658
-    2  (  2) -0.015273557408716 -0.033827870425321 -0.002389839271830 -0.049309614559235  0.022714875551557 -0.013412250204381 -0.039215858182843  0.002671798725080 -0.073595316258831
-    3  (  3)  0.061397351425600 -0.002542014700822  0.006723003856764  0.036114072726144 -0.031891831787348  0.035470170376113 -0.050339849642367  0.011227685711093  0.032863858710597
-    4  (  4)  0.010418037759007  0.052312507311500  0.003108263430226 -0.063054388106328  0.009131466039430 -0.023063009355567 -0.186998825704419  0.007656193265988 -0.085937490516795
-    5  (  5)  0.049618070764987 -0.269816796530382 -0.071812132158805 -0.093909466368595  0.090964919694381  0.192302531462338  0.140007312222197 -0.095346589436075  0.068662718351823
-    6  (  6) -0.050705074903890 -0.083507573951399  0.075121836066492  0.150175624907254  0.110901140548139 -0.044187464402636 -0.100826757127919 -0.348159602318287  0.115791138943855
-    7  (  7)  0.024247361034940 -0.261502177446179 -0.185335196490176 -0.086407538269004  0.040595405612183  0.132471756059254 -0.167354565247558  0.226853259555790  0.063338369472266
-    8  (  8)  0.031044409528402  0.062420557845031 -0.150070034340745  0.052228051583476 -0.077587419735710 -0.089629913379487 -0.056032626281614 -0.008151827554649  0.096931788597858
-    9  (  9)  0.317132702814373  0.055314612013316  0.137754640120023  0.090773612718365 -0.100625469824133 -0.163650859440807 -0.143669062909266 -0.090566852675112 -0.052322376391313
-   10  ( 10) -0.142709053237480 -0.301053034065592 -0.082895903712517  0.097157063403116 -0.061479199300513 -0.055989010255340  0.082779787274017 -0.112598796382161 -0.005058093098571
-   11  ( 11) -0.016299349881188 -0.110322948765521  0.098821973474101 -0.099107211043419 -0.036545717852368  0.075028438099748 -0.024327846026163 -0.071464427045319 -0.082135257183916
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.047447570064905
-    1  (  1) -0.000600353714311
-    2  (  2) -0.061561394612175
-    3  (  3) -0.026518358614439
-    4  (  4)  0.004924249256689
-    5  (  5)  0.118873243448111
-    6  (  6)  0.158683429135866
-    7  (  7)  0.034364315517391
-    8  (  8) -0.057789177012035
-    9  (  9) -0.092690338450207
-   10  ( 10) -0.035646580943718
-   11  ( 11)  0.038984516104221
-
-	DPD File2: P*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006230857276436 -0.048797056399666 -0.012716116252621  0.005739964124866 -0.013481384616698 -0.042689584077060  0.017270348738051 -0.000419243135126 -0.040443254435763
-    1  (  1) -0.001630425204596 -0.020575306800344  0.074043146154741 -0.016576990359565  0.024266588171945 -0.025003638188733 -0.041229879168230  0.009096713997008  0.048943522201480
-    2  (  2)  0.021449672787194  0.004533663013035  0.064512297360970 -0.026056320112975 -0.012311600212379  0.057705244730510 -0.006103097277552 -0.007629023643838 -0.100142202402752
-    3  (  3) -0.024506116908941 -0.014405190116035  0.023988780893855  0.096344308015785 -0.049822440345522  0.076920537167928  0.020583335246490  0.007240688074708  0.088817051721264
-    4  (  4) -0.016982681746660 -0.005612968048325 -0.130937709169030 -0.258341025931177  0.140085239410274 -0.222842232178951  0.024820716730135 -0.026325168673687 -0.055547617569483
-    5  (  5)  0.037879155414163  0.128090386002125  0.141870995017207 -0.234587600888966  0.098914790788390  0.305800275284305  0.055598905633593 -0.131805449829431  0.041081235097661
-    6  (  6)  0.043168564703436 -0.030010861129281  0.029114697539830 -0.006214587904626 -0.071804351546120 -0.111206250824606  0.202125985301076  0.151209805862799 -0.037927022313810
-    7  (  7) -0.020929918098688 -0.040166703104938  0.207928074963598  0.005063717904073 -0.015982060703677 -0.122893504730377 -0.039398473312957  0.243542435447176  0.058898622679243
-    8  (  8) -0.035897100247807  0.130947966136576 -0.251331455270193 -0.079974479173535 -0.413130980507748 -0.044171581238907 -0.028005185833489 -0.165066997038960  0.062489289780689
-    9  (  9) -0.085514193547145  0.054930855523547  0.094296152584403  0.050328255510316  0.067641033769805  0.023318053487733  0.006464024057725  0.152704070253429  0.195690762137195
-   10  ( 10) -0.121783132454786  0.121649518544985  0.001288572370528  0.044670432803679 -0.008034312045081 -0.029879089305665 -0.065139715799550  0.014008708897036 -0.002845810213058
-   11  ( 11) -0.023815006694348  0.014334287141683 -0.141630066387855 -0.145326344089203  0.037857456986322 -0.058499598917858  0.030801987861182 -0.076045397273525 -0.051718689270491
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.052021099116092
-    1  (  1)  0.000375019046341
-    2  (  2) -0.005095441550314
-    3  (  3) -0.212700400741322
-    4  (  4) -0.008054755280988
-    5  (  5) -0.023289560627031
-    6  (  6)  0.062134458371494
-    7  (  7)  0.183963154970289
-    8  (  8)  0.064610383082142
-    9  (  9) -0.033969497782711
-   10  ( 10) -0.034207553536027
-   11  ( 11)  0.027487667010859
-
-	DPD File2: P*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000165454282488 -0.050277476849634 -0.072265886779903 -0.219046110490914  0.170649240297555  0.129272117676281 -0.046129561714749 -0.006317178179283  0.031628796061177
-    1  (  1)  0.049926970343888  0.000066751428030 -0.008605428716391 -0.088466711253630  0.066209204064307 -0.157896361055452  0.137975283709074  0.116685446085702 -0.066609214976363
-    2  (  2)  0.071930707909687  0.008646608001517  0.000252105095070 -0.010529809483454  0.048142356541763  0.064293359314159 -0.026509274318636 -0.087307307132468 -0.055490250957849
-    3  (  3)  0.218638932403761  0.088400431595603  0.010362259249877 -0.000161808465947  0.006831656503924 -0.050359143062454 -0.002950107894051 -0.043414691353781  0.231632275337861
-    4  (  4) -0.170408151565692 -0.066676104740888 -0.048741085770175 -0.007781046963117  0.000858319634312 -0.017393073562842  0.004806366800845 -0.002128732121080 -0.034666156637510
-    5  (  5) -0.129353639616675  0.158198145877926 -0.063792237373481  0.051918849505394  0.015159666578669 -0.002164443359528 -0.004048396359766 -0.028258116638309  0.019204959902610
-    6  (  6)  0.046105252486005 -0.138278098772584  0.026048974354469  0.002423377188050 -0.004804777279161  0.005123584343751 -0.000505492048966  0.004681249428299 -0.016114426086496
-    7  (  7)  0.006108731746456 -0.116491031311707  0.087525580101622  0.043947283481964  0.000746891253088  0.028211685279895 -0.004399353185530  0.000226937079603 -0.001563554764084
-    8  (  8) -0.031635416967255  0.066903366010132  0.055032255173046 -0.231683009312988  0.036206711489392 -0.019839043489615  0.016402673760561  0.000838534461521  0.000669878290914
-    9  (  9) -0.101001614493512  0.035831143017804  0.051001612315387  0.120753800379163  0.001670851222790  0.022069869139317 -0.000180056135152 -0.007894743612700 -0.004712239169077
-   10  ( 10) -0.077799422553552  0.050172827558475  0.178180262760682 -0.011809496949311  0.042695780330294 -0.018100828459930 -0.003739392396915 -0.021764215771311  0.004254325334512
-   11  ( 11)  0.170574833391475 -0.090218966161298 -0.186165933844747 -0.106592282303210  0.035685321173548  0.005531846565163 -0.019468178901053  0.028819942408996  0.018249838127253
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.100729285954756  0.077818756543715 -0.170553425058221
-    1  (  1) -0.035210403182738 -0.050067933089505  0.091777926183755
-    2  (  2) -0.050619295779235 -0.177821703580419  0.188186480685002
-    3  (  3) -0.120238811273927  0.012548687236120  0.107146423121442
-    4  (  4) -0.001472161299553 -0.042086791480199 -0.037190721415684
-    5  (  5) -0.022276355941346  0.015313888242227  0.001378381953714
-    6  (  6)  0.001377652740630  0.005127424181781  0.019087401021940
-    7  (  7)  0.008204594963178  0.020563680487320 -0.026290026069629
-    8  (  8)  0.004730566883743 -0.003787060797718 -0.021343901910363
-    9  (  9) -0.000654068579583 -0.020656394329926  0.003094384610269
-   10  ( 10)  0.019022274800240 -0.000759677344253 -0.055278729862632
-   11  ( 11) -0.002626982476879  0.053971886669755 -0.001915083825045
-
-	DPD File2: P*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000967260159080 -0.002202446432524 -0.004511183444430 -0.016374841316601  0.010910776906997 -0.001418525150323 -0.006755217615277 -0.000427817126425 -0.035846025325519
-    1  (  1)  0.000391246067407  0.000877310728950 -0.036241037300273 -0.001407367638059 -0.003934213075234 -0.029267906970015 -0.005602239959753 -0.010795263272597 -0.003740186293266
-    2  (  2)  0.003829576674383  0.036990457610833  0.001398441262724  0.029943520801568  0.002038487479024 -0.023272259992080 -0.008230578537541 -0.007682382933230 -0.017088399951020
-    3  (  3)  0.016032914359479  0.000368568996962 -0.031158252703803  0.000059940788557  0.028967799575646 -0.026891964655620 -0.003191177418001  0.012156707421423  0.040980572338667
-    4  (  4) -0.011582657878517  0.004557355848480 -0.002754831890239 -0.029254644747513 -0.000056895383566 -0.010447389828344 -0.011227363550004 -0.017276460075010 -0.082609995830667
-    5  (  5)  0.000873189786955  0.030297579893434  0.024073075343027  0.026022721348298  0.010366640393980  0.000392801080983 -0.006236144036416  0.025488940454099 -0.075546848613138
-    6  (  6)  0.007828000597579  0.004715416733939  0.007204534812621  0.003548053014936  0.011139775691561  0.005780043754072  0.000209890995218  0.022093647786116 -0.021521213110625
-    7  (  7)  0.000136712832700  0.010084233633668  0.007596217834139 -0.012002297241493  0.016971650696249 -0.025598072815601 -0.022061499371271  0.000030924207599  0.027480037260575
-    8  (  8)  0.034517163034967  0.003881690632474  0.018182293711114 -0.041467916178783  0.083381816772957  0.076400917002772  0.021226287037618 -0.027577743559442 -0.000308523373358
-    9  (  9) -0.006887640002591  0.038004114862362 -0.068066991173237 -0.074540859178153 -0.096325885879967 -0.063826495228134 -0.021741321038929 -0.075328539771934 -0.015720438309394
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.006955591851981
-    1  (  1) -0.037011716243653
-    2  (  2)  0.066925876832342
-    3  (  3)  0.074849385969586
-    4  (  4)  0.096213956733721
-    5  (  5)  0.063907467407383
-    6  (  6)  0.021571044568900
-    7  (  7)  0.075014265081936
-    8  (  8)  0.015443164438173
-    9  (  9)  0.000349977346717
-
-	DPD File2: P*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.008473601581619  0.058320078803013  0.009499899472232 -0.001088259135238  0.016242997407558  0.041642820354273 -0.019281478381302  0.001541696314659  0.042254273858150
-    1  (  1)  0.000334490440486  0.020235443091975 -0.074874760692952  0.017019076387196 -0.023949159076861  0.029015987792742  0.043482201692770 -0.008653533652648 -0.050609003215613
-    2  (  2) -0.017649927420035 -0.005466470543623 -0.062819872537720  0.024335617743925  0.013549365831462 -0.057638943360770  0.007946525598619  0.007453269935932  0.104441618231136
-    3  (  3)  0.020783291637709  0.012738132257300 -0.020888891645260 -0.097905028236283  0.052672606431380 -0.073196008154541 -0.021238374576188 -0.005922717755271 -0.087456377608286
-    4  (  4)  0.016996530387751  0.011882557110211  0.133285493089740  0.270904493255005 -0.144936247136341  0.230612270825641 -0.025999484339616  0.027186445681165  0.054335849730519
-    5  (  5) -0.043265455211536 -0.139979958816237 -0.149715430516995  0.247713647604899 -0.102410559077642 -0.319151604186489 -0.057805788052851  0.138415193321428 -0.046014997665461
-    6  (  6) -0.052880707652045  0.033123002053909 -0.032014076939227  0.006298867450682  0.077062313270277  0.118246557884146 -0.214649227435815 -0.157387472815374  0.039780533308888
-    7  (  7)  0.019315588907448  0.037515736358395 -0.221610727048942 -0.003867379753041  0.018038584173024  0.130726889432006  0.043210067374229 -0.255244255063184 -0.061970702798214
-    8  (  8)  0.039457544550719 -0.137467753709456  0.263418210746405  0.083532282441423  0.434570179765344  0.040715456256394  0.028807073739423  0.172129116920192 -0.067053424144521
-    9  (  9)  0.108821808763067 -0.058176331616836 -0.096181779066212 -0.052585164814310 -0.074960862104189 -0.030411666230606 -0.005322365866114 -0.162638108566386 -0.208900911424941
-   10  ( 10)  0.143141318703370 -0.135644721237897 -0.004816763589682 -0.046370390666413  0.007684027070582  0.031560700160296  0.073644359681820 -0.014497709274558  0.002720022476073
-   11  ( 11)  0.028228442161314 -0.029546966066375  0.156785160510693  0.149588448608652 -0.045289290724147  0.066420712374432 -0.030566776449830  0.079826396018234  0.056206720757084
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.054452002537081
-    1  (  1) -0.000507638322506
-    2  (  2)  0.005540126912246
-    3  (  3)  0.215642625069238
-    4  (  4)  0.015797761320826
-    5  (  5)  0.020861352515884
-    6  (  6) -0.063379663837058
-    7  (  7) -0.192560463271225
-    8  (  8) -0.066391989253748
-    9  (  9)  0.030368405143431
-   10  ( 10)  0.036776046301376
-   11  ( 11) -0.030367451420999
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.057770723551805 -0.007686176362995  0.037676874102239 -0.021875314889184  0.005506967440553  0.033731453254856 -0.019605915987929 -0.000153810358456 -0.020480209762043
-    1  (  1)  0.007936092328855 -0.008454757012618 -0.010966637507272  0.001712970012603  0.003491085971866 -0.000515536715359 -0.020166951580993  0.003537118918414  0.007401819292438
-    2  (  2)  0.004823273660701  0.024918096949402  0.013456316532648 -0.018061040723257 -0.007928867774181  0.029348077247204  0.008305651855965 -0.003787093111853 -0.048173394734837
-    3  (  3)  0.011675775125104 -0.107663431050362 -0.048399528007616  0.036525102270435 -0.040730641356466  0.022154401905676  0.022459222262206  0.014732815012435  0.056193647103106
-    4  (  4) -0.087218313447135  0.162702625594382  0.040016358931151 -0.090893257640902  0.161526551014906 -0.070532962320029 -0.041494660476799 -0.036307465283525 -0.053954994619678
-    5  (  5)  0.299080380154522  0.047071149143854  0.050599107356677 -0.086076035660096  0.105747613370625 -0.016291716828988 -0.035370479977499 -0.024570880182810 -0.019740472062472
-    6  (  6) -0.064660820062842 -0.041897488689090  0.115036198620178 -0.009494466980017 -0.021741244197439 -0.082050622741463  0.041036304002792  0.093842813724870  0.099009311380003
-    7  (  7)  0.041406109005398  0.013292096025031 -0.015299070066933  0.090658889471223 -0.096664535474361 -0.020138730803122  0.181635797654581  0.008096043748855  0.043219320460348
-    8  (  8) -0.213166983290885 -0.019961961605909 -0.071163032757987  0.089566388255459 -0.187567657300030  0.059322694628756 -0.181371262434162  0.031805535782928  0.037438192749058
-    9  (  9)  0.029081682004423 -0.052377114086944  0.016598919354525 -0.054121123864817  0.005943121322964 -0.052845962329270  0.099913404453613  0.011257505074012 -0.046946017590445
-   10  ( 10)  0.029775807936917  0.011144658296549 -0.123616713069900  0.069048925266029 -0.072425392135727 -0.175724644218768 -0.020473761865880  0.027329304597195 -0.030635509122054
-   11  ( 11) -0.065686621670288 -0.046175058814983 -0.054739230530016 -0.067089838730126  0.085213076503212 -0.033327993779702 -0.039100303871838 -0.006432393458887 -0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007846989553355
-    1  (  1)  0.003599492488651
-    2  (  2)  0.050462951485827
-    3  (  3) -0.025590884562196
-    4  (  4) -0.058023095683205
-    5  (  5) -0.032774222915836
-    6  (  6)  0.063967275967677
-    7  (  7)  0.008682341559207
-    8  (  8)  0.054096899442108
-    9  (  9)  0.060114344610370
-   10  ( 10)  0.027778486812577
-   11  ( 11) -0.026791075407401
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000027040423887  0.011060683872803  0.004793456647899  0.073481718860181 -0.071504628495016 -0.043329380984548  0.025554578097106  0.020981780177699 -0.009741644195740
-    1  (  1) -0.011009750762997 -0.000007607240151  0.023558132508086 -0.077101510719000  0.072464798814331  0.012890143420536 -0.005683277430906 -0.006920173400283  0.002574145843753
-    2  (  2) -0.004842956248702 -0.023538681455719  0.000165226839542 -0.207870652255993  0.210753100259611  0.104860036207310 -0.066732822825146 -0.046426833468215 -0.005606364639263
-    3  (  3) -0.072846425542822  0.076633967419021  0.207131819599136 -0.000363002499158 -0.003747206858118 -0.078444561827851 -0.135702906183535  0.013002670417717  0.066080178603036
-    4  (  4)  0.070600283658190 -0.071629978927021 -0.209426851727876  0.004131403945752  0.000622007773293  0.030404083775686  0.072573499649568 -0.005804369418180  0.017256603820917
-    5  (  5)  0.042938103533211 -0.012767138266668 -0.104089521411634  0.078509088982138 -0.031589837534126 -0.000702189622727 -0.234416668036359 -0.006073164073880 -0.085676616502380
-    6  (  6) -0.025301081140471  0.005670371975564  0.066621493148361  0.135369815380962 -0.072186642283625  0.233429156027521  0.000193153533248 -0.257186865053465  0.080618496507255
-    7  (  7) -0.020822354558258  0.006724508724119  0.045993762455479 -0.012965367547761  0.005443358605263  0.006173477804865  0.257050229473736  0.000107746294773 -0.140355654948263
-    8  (  8)  0.009433315806276 -0.002386871891496  0.004905034102302 -0.065444732417879 -0.016877777772437  0.086229493149666 -0.079936884810997  0.140925849197376 -0.000032973152365
-    9  (  9)  0.050122316171813 -0.043792237275169 -0.089139695085719 -0.017498120874682 -0.031599257819379 -0.003933044438540 -0.023956851013655  0.023591093022906  0.231355322027963
-   10  ( 10)  0.021733936110572 -0.028861084661254 -0.012680330783905 -0.120427356784394  0.061995107162282  0.110107780731446  0.044522956915282  0.044154909833586  0.092344585382497
-   11  ( 11) -0.054009861310889  0.049060128861341  0.116101359422429  0.043743279836749  0.090347856826429 -0.186254068915307  0.010091097621831 -0.182439821622372  0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.050351452990167 -0.022080091821478  0.055614920128739
-    1  (  1)  0.043523152379598  0.028913570586242 -0.049281187081852
-    2  (  2)  0.088800989050704  0.012387284429283 -0.115844546053497
-    3  (  3)  0.017174780224652  0.120766108673226 -0.043936127494914
-    4  (  4)  0.030870076304731 -0.062251132422338 -0.090680792727787
-    5  (  5)  0.006295822004517 -0.109602420736026  0.187179028172583
-    6  (  6)  0.023342165877015 -0.045357751936196 -0.008109043414047
-    7  (  7) -0.023116687534610 -0.043892116907456  0.180954962224114
-    8  (  8) -0.233341712412303 -0.091442003006516 -0.004136900096905
-    9  (  9)  0.000301754743843  0.311200434843549 -0.071746006250031
-   10  ( 10) -0.310579381122594  0.001146128096000  0.337175845358798
-   11  ( 11)  0.071759110731455 -0.341710402101474 -0.000514995746851
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000373475564698  0.036374284715410 -0.020675408038120 -0.041938611278043  0.014954064130636 -0.008670693741941 -0.001941666498966  0.002175213653671 -0.081223953533966
-    1  (  1) -0.035409311090430 -0.000583412494499  0.021912114995751  0.019686191919175  0.001337756516393 -0.101410043872272 -0.013539530463413 -0.021085032009130 -0.104140442794578
-    2  (  2)  0.022476650279619 -0.020869170321065  0.000623148668542  0.026925059222749 -0.022600045203783 -0.054500059821995 -0.019747085432266 -0.002197258536137 -0.059803959084815
-    3  (  3)  0.040527884961938 -0.020785023904239 -0.026269813130118 -0.000471315833621  0.011435927824319  0.005094359128676  0.021078069661848 -0.001900689912103  0.049285996887456
-    4  (  4) -0.014876995236008 -0.001935832477363  0.021280417512247 -0.011112950356736  0.000010954074914 -0.001375736589678 -0.021071346294591  0.002540388393255 -0.057176443725449
-    5  (  5)  0.009413911140341  0.101590521816804  0.054440250203052 -0.004479146413684  0.000983185589705  0.000044886603863  0.008942266041566 -0.007734744988056 -0.012623227871857
-    6  (  6)  0.001228199632690  0.013460754514196  0.019370737847276 -0.021147815413154  0.021180440912387 -0.009078596190780 -0.000060187992369  0.021757615671251  0.021546696625458
-    7  (  7) -0.002386621109668  0.020697715049428  0.002142304032572  0.001889845237358 -0.002502377714011  0.007891184567460 -0.021671667697211  0.000014467640044  0.019485620614445
-    8  (  8)  0.082726042327291  0.104120679625015  0.059410287861643 -0.049170685661379  0.057558349352742  0.011952514103015 -0.021313492463386 -0.019559674827960 -0.000280085719614
-    9  (  9) -0.081272328726009  0.110754135563007  0.028218762900775  0.005318083145326 -0.020981856638396 -0.014567561104212 -0.097856532501808 -0.003185861516469 -0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.080531031337273
-    1  (  1) -0.111220099551316
-    2  (  2) -0.028332370195928
-    3  (  3) -0.005372945270244
-    4  (  4)  0.020768901638641
-    5  (  5)  0.014982546342664
-    6  (  6)  0.097582479807565
-    7  (  7)  0.003277826561639
-    8  (  8)  0.003260780284830
-    9  (  9)  0.000186812021876
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055078142867828  0.005804719299681 -0.036780646353647  0.020745008939831 -0.005631321838333 -0.032388434299089  0.019554696167851  0.000026315290494  0.020764618651157
-    1  (  1) -0.007062764870854  0.009531925050962  0.009339128991500 -0.000585332198702 -0.003536715157378 -0.000717716084393  0.020997702694190 -0.003197609406412 -0.007543205569196
-    2  (  2) -0.003273721829615 -0.024127785783056 -0.019803917766004  0.021792459075320  0.009225997435944 -0.033280936086821 -0.008357612389432  0.004534634518823  0.049752671423908
-    3  (  3) -0.009467819748219  0.109846311430058  0.049077069582499 -0.038067479834844  0.041344367688361 -0.023164856965512 -0.023494777837550 -0.015492414054440 -0.057415728354703
-    4  (  4)  0.087998530211411 -0.166680738017738 -0.040492236619192  0.094854089537164 -0.166732509395464  0.071703004448668  0.042087550249065  0.037122017300705  0.054342710801435
-    5  (  5) -0.299229806278301 -0.048658757713325 -0.047129705842446  0.086908947365866 -0.109728878663932  0.016789363568018  0.035383410684614  0.025335321764417  0.020816334753998
-    6  (  6)  0.066809370303780  0.045194542515417 -0.116536125053039  0.010429907504714  0.024187359392906  0.082665971873618 -0.044425337546003 -0.096427706292236 -0.099634759729367
-    7  (  7) -0.040692585686945 -0.010414403444448  0.019197392244389 -0.094603783326762  0.099044517012418  0.021567521501408 -0.184530946067710 -0.010140666068000 -0.044429992698867
-    8  (  8)  0.213871489773344  0.016533777636027  0.072796199007045 -0.091991735348903  0.195396773842710 -0.059284334625803  0.184339397290396 -0.031894612373968 -0.038856272349111
-    9  (  9) -0.030682243044227  0.041775517875249 -0.024602057980135  0.057287290343526 -0.006772740334119  0.055735826221076 -0.097648839100779 -0.011580457295414  0.048271645082472
-   10  ( 10) -0.033182564179255 -0.014791814568441  0.134627953730393 -0.074303509883212  0.072048570540947  0.178297714606306  0.018972497943516 -0.029382172234938  0.026191954922422
-   11  ( 11)  0.065304385216644  0.054065687922946  0.058978656197155  0.069527138693935 -0.087278294466894  0.031923025189413  0.037244505404452  0.006712268565440  0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007990021156235
-    1  (  1) -0.003543862611170
-    2  (  2) -0.051263654644270
-    3  (  3)  0.026303130686066
-    4  (  4)  0.059400171065937
-    5  (  5)  0.033889468632128
-    6  (  6) -0.063573026890197
-    7  (  7) -0.010425863419296
-    8  (  8) -0.056178737365981
-    9  (  9) -0.060112542127891
-   10  ( 10) -0.033303474011037
-   11  ( 11)  0.026602109435667
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.023607177491195 -0.019696611969885 -0.037221212000385  0.015590319696057 -0.002020189842990 -0.021016653547429  0.007873916136755 -0.003448340610807 -0.079821954504390
-    1  (  1)  0.007327805297828  0.018867534486269 -0.042212469078496  0.001447360534353 -0.028939866752754  0.077938653083341  0.061948383376365 -0.004945505795557 -0.075894556663474
-    2  (  2)  0.009007071740861  0.016177005802987  0.068312932673240 -0.041184857036759 -0.003023256838844  0.009849571097863 -0.004290386808972 -0.004340519661127 -0.085840789796801
-    3  (  3) -0.026077185963910 -0.012520558385893 -0.023360353465929  0.029787599349062 -0.027312833784239 -0.081100062029021 -0.033406666012159  0.054430078300136  0.042036783131155
-    4  (  4) -0.044521029970710 -0.101548028530885 -0.092152577419686  0.036969661342643  0.235975964790827  0.022489800485005  0.018037809327809 -0.163273258200919 -0.255997686637622
-    5  (  5)  0.075082806179399 -0.059495559215694  0.178951166772656 -0.134634824114366  0.237022622504406 -0.054772185517501 -0.024504277147484  0.150049663229407 -0.003365655895118
-    6  (  6)  0.075564373604390 -0.030719217759732 -0.086498148733354  0.160325933966896 -0.064234285643905  0.161900908445555 -0.266146706738358 -0.238096934941697 -0.054011663901563
-    7  (  7)  0.117049393955643  0.184359827232724 -0.154835473828309  0.196676571259727 -0.209716028817009  0.429620861048445  0.096138950091600 -0.371356959007903 -0.058084061024513
-    8  (  8)  0.116322044765828 -0.134673176933366  0.115490121530453  0.372419146214479 -0.134366059259054 -0.090977060566167  0.047847126119104  0.349531731511066 -0.026343643532612
-    9  (  9) -0.016166361653787  0.064655468388956 -0.096603309196917  0.102141195994536  0.004689543577322  0.174053614560893 -0.096535422651742 -0.179574162178272  0.093140031286430
-   10  ( 10) -0.038118657992317  0.011712936317703  0.109233641260348 -0.041948680427994 -0.067033240911419 -0.043789144467457 -0.119198984082488 -0.019961916251994 -0.046236232124822
-   11  ( 11) -0.202537936665755 -0.041865413038804  0.001109842658197  0.036047997932446  0.209039172907281  0.039634162843452 -0.042796449278664  0.037154632643052 -0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001464671751436
-    1  (  1) -0.092168971837118
-    2  (  2)  0.096834154775615
-    3  (  3)  0.085232004143247
-    4  (  4) -0.224276823308218
-    5  (  5)  0.037070717977035
-    6  (  6)  0.017788678150516
-    7  (  7) -0.125655013910958
-    8  (  8)  0.036753750028807
-    9  (  9) -0.104788947042948
-   10  ( 10)  0.055723652563089
-   11  ( 11) -0.029086171780033
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000103943053471 -0.020502980666838 -0.044487026908476 -0.112522389921676  0.115190927698806  0.086304427533430 -0.028732798000328 -0.005755262072674  0.052707374815472
-    1  (  1)  0.020396732597728 -0.000175507711089  0.066631576709106  0.188566511167110 -0.188604507023904  0.081802717690830 -0.123212599282903 -0.146580404278728  0.063843813395139
-    2  (  2)  0.044224363892114 -0.066688325942716  0.000328779542201 -0.131627364199491  0.085838688001563 -0.039792906367986  0.071990397116460  0.041811204620793 -0.129151440044184
-    3  (  3)  0.112356491847955 -0.188595812422395  0.131743983691740 -0.000034238258909 -0.146405835083834 -0.293116155503685  0.174354593749844  0.234740190959724 -0.068400431241803
-    4  (  4) -0.114478156906703  0.187880772610577 -0.086711640119064  0.146345707242046  0.000351413466984 -0.200401380550659  0.118118144680811  0.106599388398520 -0.027535193682288
-    5  (  5) -0.086013769068620 -0.081687368012874  0.039811317138268  0.293720012918757  0.199751621453618 -0.000779002249077  0.029574633012291  0.100809576430270 -0.310087999943630
-    6  (  6)  0.028593362634754  0.122990647052479 -0.071886866993686 -0.174357265134888 -0.118164594946332 -0.029455932226559 -0.000323502179386 -0.067588972736558 -0.054838186724730
-    7  (  7)  0.005405231783831  0.146637005514722 -0.041701223809144 -0.234444344892692 -0.106310138998589 -0.100760684833959  0.067340032280388 -0.000050446895501 -0.206356025427645
-    8  (  8) -0.052734404217526 -0.064663294136106  0.127867798766573  0.067686878519552  0.027452578317565  0.311518253800823  0.053511305641188  0.206912543882787  0.000090733997612
-    9  (  9) -0.040822323151076  0.050351126620632 -0.033443030139718 -0.028678071562223  0.070729562284205 -0.035204318394559  0.035088801145452  0.003858253384271 -0.209126878103916
-   10  ( 10) -0.043554697985060  0.034029200702705  0.113396889510888 -0.025104351967769 -0.057922093461755 -0.050331966245759  0.113578028555237 -0.006845000513571  0.183899295084893
-   11  ( 11)  0.104445737487499 -0.085327185159750 -0.138831980783855 -0.068059267872915 -0.045287984054307  0.106421559557756 -0.126370094892912  0.085884676801538  0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.040472375428214  0.043732687824618 -0.105326662293090
-    1  (  1) -0.050113148730272 -0.033553830886801  0.085228632878169
-    2  (  2)  0.033648303602896 -0.113430364410931  0.140304701766262
-    3  (  3)  0.028908821271170  0.025577280295259  0.067243263311150
-    4  (  4) -0.070488811800233  0.058243639304596  0.043815524401846
-    5  (  5)  0.035954881502730  0.048633621823234 -0.102557737449989
-    6  (  6) -0.034599692943826 -0.112216626584703  0.126288398892548
-    7  (  7) -0.003737404887253  0.007316223089443 -0.087031799969318
-    8  (  8)  0.210522602449556 -0.181960897898471 -0.040780655119777
-    9  (  9) -0.000486792078199  0.154877597629272 -0.324381992896252
-   10  ( 10) -0.154731729402294 -0.001003846432056 -0.227757018056261
-   11  ( 11)  0.321308213629134  0.230320716710505 -0.000521529871008
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000267990887146  0.017094909685382 -0.026886221509252  0.009154729792392  0.028447394308811 -0.043026223139973  0.007934241734193 -0.017529929372393  0.048064409198736
-    1  (  1) -0.019165257539447  0.000577613190074  0.023971643573307 -0.023362002438445  0.020466955482562 -0.074368923093670 -0.021220838937975 -0.006899315294507 -0.004345205689582
-    2  (  2)  0.030573367311208 -0.023520686332899  0.000895230171902  0.026482533037414 -0.055578356600337 -0.061212128793543 -0.006033035982650  0.029878597421323 -0.067713186454891
-    3  (  3) -0.011556055604803  0.022912214561881 -0.028040995483179  0.000806143570890  0.016669730389240  0.057830279830177  0.001162806518994 -0.022110531165998  0.132937508894661
-    4  (  4) -0.029247962187325 -0.019722933579604  0.053631431975867 -0.015590855142050  0.000406564753787  0.013151443352440 -0.005583751708839  0.048344741694769 -0.058950645196782
-    5  (  5)  0.044502924478349  0.074343902828738  0.059891074519534 -0.057011647107618 -0.013642181191740 -0.000660380157385 -0.021619837229525 -0.066247874288904  0.026658775788480
-    6  (  6) -0.008416217090956  0.021046309429680  0.006522358687724 -0.001270652730649  0.005678899154477  0.021925039235368 -0.000233190982568 -0.044213316193167  0.019149792461568
-    7  (  7)  0.017220078580887  0.007669026797702 -0.030414088472195  0.022279636607030 -0.047947045698118  0.066391322818188  0.044159499520014  0.000036612147908  0.012788358083278
-    8  (  8) -0.049286641691243  0.005157181302332  0.067669102261374 -0.134137839836174  0.059598226202850 -0.026736423898111 -0.019691121432993 -0.012900597372237  0.000145671342113
-    9  (  9)  0.013771428368881 -0.001534324314609  0.097208563857550  0.041538777135659 -0.016922202614382 -0.071792645864290 -0.010700525463409  0.088926800959210 -0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.013388445223016
-    1  (  1)  0.001743269961120
-    2  (  2) -0.097384653394849
-    3  (  3) -0.041118719872747
-    4  (  4)  0.017104740675403
-    5  (  5)  0.071235600573670
-    6  (  6)  0.010744046806778
-    7  (  7) -0.088045104682667
-    8  (  8)  0.027915642785476
-    9  (  9)  0.000257740691093
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.024087436020668  0.024234923487922  0.034655069016827 -0.013002508462274  0.003506876735183  0.019138226509165 -0.008729154622077  0.004126516633947  0.080810387962203
-    1  (  1) -0.007340388106341 -0.022740162593799  0.047399213843079 -0.000077807499313  0.029710781800549 -0.077091731467965 -0.063337905707382  0.003225301246506  0.076935684639064
-    2  (  2) -0.008533292606078 -0.014866249844284 -0.069414473601385  0.039067032188858  0.004447555351962 -0.009557153079335  0.003933218079563  0.004684619630234  0.087696717260759
-    3  (  3)  0.022970088927143  0.014796917693540  0.027844101865804 -0.035221698386289  0.026363064761687  0.090054977556852  0.034727496736464 -0.055362273105074 -0.041999796595917
-    4  (  4)  0.041840045940810  0.108064430049583  0.094169303786903 -0.038045467810124 -0.242703284807102 -0.022096059239039 -0.018423933000872  0.169152570163926  0.255707171958253
-    5  (  5) -0.076575292532566  0.064169513057282 -0.187842221364997  0.139017281082776 -0.239663562780447  0.056101309100792  0.026864961939161 -0.152773054853442  0.000863550220823
-    6  (  6) -0.082619291232389  0.034129866388443  0.092672858212650 -0.166047996934064  0.066033557533197 -0.164979644828487  0.279604374284854  0.245415146187524  0.057275952528883
-    7  (  7) -0.119525510255884 -0.192558180615050  0.157479601093184 -0.199612815310399  0.216488749413977 -0.438370355171240 -0.097840156788249  0.385286937285113  0.058774287435548
-    8  (  8) -0.115070416909243  0.142091116044252 -0.125572997790340 -0.378869543679260  0.139572537143277  0.093921809248974 -0.047279124915748 -0.359195083957732  0.024443650320069
-    9  (  9)  0.023211259159309 -0.064251202673602  0.092489429719048 -0.099069758679955 -0.005272254913816 -0.184087259640687  0.103465084079069  0.187259798043465 -0.097400286560574
-   10  ( 10)  0.039092748606065 -0.013006586457309 -0.115772480099790  0.044153430983449  0.068039357936569  0.040474168285568  0.124671276809929  0.020291967592974  0.043718085717437
-   11  ( 11)  0.205517300660670  0.035576186745690 -0.000856944671273 -0.036648470964825 -0.217305799958921 -0.037828885346138  0.045859373489911 -0.037554955798535  0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001311477468569
-    1  (  1)  0.093224324445080
-    2  (  2) -0.099200064811294
-    3  (  3) -0.086458921973920
-    4  (  4)  0.229446975291319
-    5  (  5) -0.035136747289852
-    6  (  6) -0.019108151626501
-    7  (  7)  0.127376470092273
-    8  (  8) -0.036832911731868
-    9  (  9)  0.106598068979743
-   10  ( 10) -0.058544237541584
-   11  ( 11)  0.029477471817291
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.089840465204225  0.055253525883540  0.050839656601929 -0.011592120168853 -0.028453073767485 -0.033272498563027 -0.013123122183092 -0.010376152774617 -0.046773274930095
-    1  (  1) -0.019180458750845  0.004406050242553 -0.021028155566967 -0.011538680320289  0.014109247012132  0.033202867729220 -0.146724711919951  0.006291497986158 -0.032816512639240
-    2  (  2) -0.008004935891454 -0.083588166091295  0.024500417662889  0.004976479402859  0.015361678869856 -0.027030028650554  0.075999531355577 -0.040388417899799 -0.092155828534757
-    3  (  3)  0.072751395760345  0.101339872261880  0.027554632505315  0.017104143799594 -0.009883810143648 -0.054325029446985  0.038424568195001  0.007564948769101  0.050859249479548
-    4  (  4)  0.116869612062058  0.168448689602172  0.076045170807919 -0.039076911238534  0.141061895780680 -0.082089594379007  0.096305838370831 -0.090937592520626 -0.089867596085833
-    5  (  5) -0.362411548066203 -0.116301468610581 -0.067304641586918 -0.178833394354847  0.120526935264372  0.077690766748935 -0.087853646530869  0.131583743921650 -0.005449987066682
-    6  (  6) -0.023022243577310  0.091878291587840 -0.168295716396468 -0.360782087280141 -0.197772285105134  0.118427120672179  0.100301554555422  0.545992767837121 -0.002274268616602
-    7  (  7) -0.332469089310140 -0.094037896803367 -0.021326282942452  0.202588446745432  0.003095262967230  0.074773576198707  0.261809753005545 -0.312310926113466  0.101271338039676
-    8  (  8) -0.102262443511968 -0.018323432973791  0.030286707735275  0.141132962784100 -0.140087132441384 -0.016144892573022 -0.105178803101546  0.077042517784067  0.061204405030880
-    9  (  9)  0.062921845500970  0.223934495766079  0.055471945329417  0.006791304491310 -0.142947280894142 -0.007991932919943  0.047858230706461  0.145718178913241 -0.072195393114585
-   10  ( 10) -0.062281498028430 -0.059385022217194 -0.196384149116451 -0.042900612771916  0.059951865879116  0.109494756681462  0.025377610533051  0.255425379720525 -0.006903138405362
-   11  ( 11) -0.109893814765672 -0.036299338598219 -0.008950289795172 -0.103979082032925  0.089663281746559  0.076642658317109  0.017386558594104  0.075203103677764 -0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015115955084904
-    1  (  1) -0.030649150844450
-    2  (  2)  0.004117081641871
-    3  (  3)  0.011275331966881
-    4  (  4) -0.082379096749867
-    5  (  5) -0.010925397739678
-    6  (  6) -0.209001724905895
-    7  (  7)  0.094421017044117
-    8  (  8)  0.009881568354141
-    9  (  9) -0.113416879853688
-   10  ( 10) -0.045856944277529
-   11  ( 11)  0.007202279712064
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000220708940429  0.002285125103983  0.191707004311250 -0.079176547202062 -0.015343724284655 -0.090762856917070 -0.035966370439669 -0.080228715251931  0.022632088832219
-    1  (  1) -0.002270884902228  0.000127565392507 -0.181504505051190  0.084301622984598 -0.019134286473150  0.136527597935967  0.291828838790707 -0.086935165867290 -0.003153353795357
-    2  (  2) -0.190790178739451  0.181286631653937 -0.000456958950263  0.098736144982791  0.201937120878681  0.060858985812145 -0.102547416191644  0.128157455079926 -0.052263022287278
-    3  (  3)  0.078674978461285 -0.083802623610643 -0.098399673810258 -0.000007811365746 -0.051373438075815 -0.073262818066183 -0.213681674768555  0.159362252554929  0.021801220424175
-    4  (  4)  0.014664072597960  0.019624839214450 -0.200908806156840  0.051706138267892  0.000345872163641 -0.060049554881332 -0.188299165959522  0.122222075869351  0.002767654097179
-    5  (  5)  0.090883158144736 -0.136634126073923 -0.061672946710902  0.074085610649007  0.059059222367226 -0.000127348357414 -0.089421360456473  0.068061409120582 -0.127845689145142
-    6  (  6)  0.036070137194869 -0.291478881075219  0.101913218910275  0.213840026067922  0.188217301311726  0.090313292624869  0.000227988253159  0.211121150654972  0.048790729392591
-    7  (  7)  0.080292928774450  0.086502244153537 -0.129683189759572 -0.159077086898913 -0.122727489493275 -0.066634459735053 -0.210168861536432  0.000749252129634 -0.114771568876213
-    8  (  8) -0.022833189301314  0.003149552694449  0.051809982276026 -0.021432628906503 -0.002600755913054  0.127892598520278 -0.048118709288206  0.114794510187460  0.000092800261922
-    9  (  9) -0.153861672366712  0.063959309581427  0.276686698038017  0.018129236980868  0.051934404023196  0.023341508326279  0.078386885605064  0.038564733458116  0.117925763161383
-   10  ( 10)  0.030779230036139 -0.047764824598951 -0.139550834348758  0.058848096986720  0.072156858928456  0.071321440087986 -0.120905085647966  0.006516751215124  0.144681807612295
-   11  ( 11) -0.005585664265456  0.000647324323586  0.016353426872082  0.045937924242292  0.003353711579607 -0.138994412824604 -0.062414171800322 -0.018128246119697  0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.154066232086317 -0.030728257975556  0.006318091498164
-    1  (  1) -0.063643818147584  0.047463638962418 -0.000566548572565
-    2  (  2) -0.275258773270295  0.138888616959566 -0.015969350630016
-    3  (  3) -0.017345671201066 -0.059189082677904 -0.046475381464176
-    4  (  4) -0.050392875387071 -0.072424486885238 -0.004459708301674
-    5  (  5) -0.026836133802329 -0.070805989588457  0.140760690762251
-    6  (  6) -0.078585377266712  0.120742726291724  0.064292229739042
-    7  (  7) -0.041858894695365 -0.005665298794286  0.017186389956069
-    8  (  8) -0.118429783701800 -0.144155118064025 -0.113213711259466
-    9  (  9)  0.000756388118591 -0.455654623157072 -0.231432578787543
-   10  ( 10)  0.453567841489266  0.001497567906129  0.172275686133391
-   11  ( 11)  0.230120702539645 -0.175050207490782  0.001480251815160
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000516219946816 -0.034778633659956 -0.032999546928151  0.009629039776278 -0.052966719633617  0.030450001531878  0.014875222246015  0.072128990177077 -0.048218822417803
-    1  (  1)  0.030877691560804 -0.001883541097772 -0.071434334115879  0.019325009721534  0.017452039030100  0.158145751795333  0.010537309557875  0.021583100108147  0.169934651056250
-    2  (  2)  0.033565318682613  0.071200997372983 -0.000581071534985  0.036850040138101 -0.007310816547227  0.008797901115406  0.029229533057666  0.016744128499400  0.070455787497455
-    3  (  3) -0.011004884819686 -0.019179310791618 -0.034909263032370 -0.000523661128158  0.007125267622899  0.017666281606150  0.025274953349027 -0.006048522524524  0.042959205727090
-    4  (  4)  0.052383681601535 -0.016788640224883  0.007028507044452 -0.007472760866637  0.000164741631073  0.026820745242549 -0.000005495327564  0.022752424410877 -0.031410113616428
-    5  (  5) -0.028924597602342 -0.155705177520586 -0.009708873936879 -0.016613543931604 -0.026890889200954 -0.000863820528475  0.026461589325309 -0.030900211040800 -0.024762473040831
-    6  (  6) -0.014335467827216 -0.010396285650159 -0.029624823660297 -0.025462090585912 -0.000149096444494 -0.026996065218364  0.000042625626758  0.107465667965402 -0.101121105248233
-    7  (  7) -0.071280711647029 -0.021473260264964 -0.016888851213230  0.005990055447048 -0.022650874097521  0.030884846999677 -0.107059671381934 -0.000085380718295 -0.001222830424055
-    8  (  8)  0.049124632890092 -0.169889327710618 -0.068826403708743 -0.044339001017875  0.031493314676472  0.025080049766767  0.100845039831255  0.001167614688641 -0.000278385825403
-    9  (  9) -0.004591463397670 -0.224641690035662 -0.054391854978822  0.000520714575472 -0.041379699430161  0.035041097267503  0.048865193892848  0.034233303767760 -0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.004372643490859
-    1  (  1)  0.225448428944350
-    2  (  2)  0.053543340635201
-    3  (  3) -0.000029286176363
-    4  (  4)  0.041473098636741
-    5  (  5) -0.035500700267141
-    6  (  6) -0.049415179037896
-    7  (  7) -0.033722251526408
-    8  (  8)  0.002108270875613
-    9  (  9)  0.000059855095180
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.083178189184036 -0.063320502543375 -0.053448860291133  0.010119942476578  0.027962494700737  0.033408156898410  0.016646686372055  0.009688142905594  0.047753876913682
-    1  (  1)  0.015436953954369 -0.001484194684011  0.023035398887205  0.013457869405466 -0.013993527195521 -0.033943979767543  0.150850131221437 -0.006054179455746  0.032861777904130
-    2  (  2)  0.007416632072171  0.085535883632607 -0.031035920631781 -0.004414026005139 -0.010136741110915  0.029006493089287 -0.078308410406643  0.042862583013635  0.094615352193845
-    3  (  3) -0.060864804294684 -0.107990348400789 -0.029334441164075 -0.017074561166948  0.006770814971091  0.056161219994893 -0.038880977880177 -0.007186858274067 -0.050898617184209
-    4  (  4) -0.109193273208522 -0.178421304573120 -0.074992061457995  0.038015102633012 -0.147910228795514  0.087181398607820 -0.098582275644141  0.093570766915846  0.088687564658624
-    5  (  5)  0.362309556227904  0.121304099182945  0.074968023841376  0.180660703600124 -0.122438585672172 -0.079096894998506  0.085876030826778 -0.136109864287558  0.002214631278523
-    6  (  6)  0.026835628168075 -0.104282391359254  0.172843582770517  0.372105341696267  0.200623348657875 -0.124556824110224 -0.101871864602057 -0.564196462169744  0.000688785089474
-    7  (  7)  0.344945182303497  0.095060217852336  0.019692892185405 -0.208607222836184 -0.002627647973779 -0.075715664253568 -0.273373001503080  0.322679649636761 -0.103750880742886
-    8  (  8)  0.103243578213400  0.018995126733818 -0.033613347666093 -0.143946559071139  0.146180680800982  0.017308359580339  0.107684620440504 -0.078982837453949 -0.062496256435255
-    9  (  9) -0.085648241806344 -0.209611729409149 -0.056224829650480 -0.004822853433113  0.155473341074989  0.012971266670028 -0.058097898147224 -0.150335378963730  0.078057323449305
-   10  ( 10)  0.070132629148842  0.074702785463534  0.209329818275843  0.042566217114534 -0.058034325280006 -0.102370728009941 -0.025801004099357 -0.264561180085366  0.017482708757363
-   11  ( 11)  0.113963029107499  0.045073298009464  0.000413587765283  0.112463923253522 -0.089423608765749 -0.081287727377731 -0.019439635907878 -0.076622183257520  0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015270950350973
-    1  (  1)  0.030946721870550
-    2  (  2) -0.003707642076146
-    3  (  3) -0.011960041321321
-    4  (  4)  0.086083869661608
-    5  (  5)  0.009867768215709
-    6  (  6)  0.209680707316341
-    7  (  7) -0.097843271017668
-    8  (  8) -0.010325909660635
-    9  (  9)  0.121632163838855
-   10  ( 10)  0.058275044600178
-   11  ( 11) -0.003021331907582
-
 	Computing Mu_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        15.869051530939
-	   1        20.786899881722    6.883e-01
-	   2        24.160856182321    2.921e-01
-	   3        24.214077985635    4.032e-02
-	   4        24.234866574896    1.778e-02
-	   5        24.238122127501    2.752e-03
-	   6        24.237360543965    1.007e-03
-	   7        24.237431173771    2.677e-04
-	   8        24.237469322293    1.165e-04
-	   9        24.237453949005    4.587e-05
-	  10        24.237448088609    1.762e-05
-	  11        24.237451893497    4.708e-06
-	  12        24.237455859643    1.235e-06
-	  13        24.237457012494    4.415e-07
-	  14        24.237457127586    1.411e-07
+	   0        15.869051356245
+	   1        20.786899644170    6.883e-01
+	   2        24.160855889547    2.921e-01
+	   3        24.214077689704    4.032e-02
+	   4        24.234866278337    1.778e-02
+	   5        24.238121830738    2.752e-03
+	   6        24.237360247203    1.007e-03
+	   7        24.237430877005    2.677e-04
+	   8        24.237469025521    1.165e-04
+	   9        24.237453652235    4.587e-05
+	  10        24.237447791839    1.762e-05
+	  11        24.237451596727    4.708e-06
+	  12        24.237455562873    1.235e-06
+	  13        24.237456715724    4.415e-07
+	  14        24.237456830816    1.411e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.856e-08
 
 	Computing P*_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.367558528746
-	   1         5.650162531339    3.336e-01
-	   2         6.457940861593    1.325e-01
-	   3         6.472511328762    1.757e-02
-	   4         6.475192020373    7.614e-03
-	   5         6.475940238195    1.792e-03
-	   6         6.475787026509    7.378e-04
-	   7         6.475824401068    2.157e-04
-	   8         6.475836829326    6.918e-05
-	   9         6.475833574466    1.568e-05
-	  10         6.475833411069    4.562e-06
-	  11         6.475833910412    1.369e-06
-	  12         6.475834413620    4.013e-07
-	  13         6.475834583173    1.376e-07
+	   0         4.367558553591
+	   1         5.650162561568    3.336e-01
+	   2         6.457940891972    1.325e-01
+	   3         6.472511358609    1.757e-02
+	   4         6.475192050165    7.614e-03
+	   5         6.475940267952    1.792e-03
+	   6         6.475787056264    7.378e-04
+	   7         6.475824430823    2.157e-04
+	   8         6.475836859080    6.918e-05
+	   9         6.475833604221    1.568e-05
+	  10         6.475833440823    4.562e-06
+	  11         6.475833940167    1.369e-06
+	  12         6.475834443374    4.013e-07
+	  13         6.475834612927    1.376e-07
 	-----------------------------------------
 	Converged P*_X-Perturbed Wfn to 6.408e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.006909625581
-	   1         2.631364137145    2.199e-01
-	   2         3.015958456546    8.743e-02
-	   3         3.021590337169    1.159e-02
-	   4         3.023869152757    4.870e-03
-	   5         3.024010490790    1.155e-03
-	   6         3.023989980728    2.895e-04
-	   7         3.023995665293    6.351e-05
-	   8         3.023995017830    1.892e-05
-	   9         3.023994440811    5.303e-06
-	  10         3.023994289739    1.812e-06
-	  11         3.023994431149    2.747e-07
+	   0         2.006909611223
+	   1         2.631364115956    2.199e-01
+	   2         3.015958428527    8.743e-02
+	   3         3.021590308855    1.159e-02
+	   4         3.023869124319    4.870e-03
+	   5         3.024010462340    1.155e-03
+	   6         3.023989952279    2.895e-04
+	   7         3.023995636844    6.351e-05
+	   8         3.023994989381    1.892e-05
+	   9         3.023994412362    5.303e-06
+	  10         3.023994261289    1.812e-06
+	  11         3.023994402700    2.747e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 9.057e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.083964277537
-	   1        15.809006020552    4.632e-01
-	   2        17.211731140649    1.659e-01
-	   3        17.299274188752    3.528e-02
-	   4        17.311773652253    1.285e-02
-	   5        17.313826939489    2.395e-03
-	   6        17.313531500215    7.644e-04
-	   7        17.313604980304    1.895e-04
-	   8        17.313625719230    6.399e-05
-	   9        17.313624293811    2.184e-05
-	  10        17.313624723147    1.014e-05
-	  11        17.313625508640    3.150e-06
-	  12        17.313626820549    1.169e-06
-	  13        17.313626962982    3.666e-07
-	  14        17.313627007228    1.344e-07
+	   0        13.083964149864
+	   1        15.809005868071    4.632e-01
+	   2        17.211730971700    1.659e-01
+	   3        17.299274016488    3.528e-02
+	   4        17.311773479648    1.285e-02
+	   5        17.313826766776    2.395e-03
+	   6        17.313531327500    7.644e-04
+	   7        17.313604807584    1.895e-04
+	   8        17.313625546508    6.399e-05
+	   9        17.313624121089    2.184e-05
+	  10        17.313624550426    1.014e-05
+	  11        17.313625335918    3.150e-06
+	  12        17.313626647827    1.169e-06
+	  13        17.313626790260    3.666e-07
+	  14        17.313626834506    1.344e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 5.146e-08
 
 	Computing P*_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.510434126190
-	   1         5.370100132065    2.599e-01
-	   2         5.804695006658    8.957e-02
-	   3         5.838526680908    2.298e-02
-	   4         5.842277723022    8.126e-03
-	   5         5.842850686457    1.595e-03
-	   6         5.842726985321    4.604e-04
-	   7         5.842728543938    1.441e-04
-	   8         5.842731803680    5.721e-05
-	   9         5.842729273297    1.890e-05
-	  10         5.842729784344    6.164e-06
-	  11         5.842730464696    1.388e-06
-	  12         5.842730938916    5.140e-07
-	  13         5.842731017305    1.795e-07
+	   0         4.510434146040
+	   1         5.370100156359    2.599e-01
+	   2         5.804695031438    8.957e-02
+	   3         5.838526704930    2.298e-02
+	   4         5.842277746983    8.126e-03
+	   5         5.842850710398    1.595e-03
+	   6         5.842727009263    4.604e-04
+	   7         5.842728567880    1.441e-04
+	   8         5.842731827622    5.721e-05
+	   9         5.842729297239    1.890e-05
+	  10         5.842729808285    6.164e-06
+	  11         5.842730488638    1.388e-06
+	  12         5.842730962858    5.140e-07
+	  13         5.842731041247    1.795e-07
 	-----------------------------------------
 	Converged P*_Y-Perturbed Wfn to 8.971e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.710020248878
-	   1         7.319667271611    3.232e-01
-	   2         8.126425682381    1.191e-01
-	   3         8.146199077783    2.497e-02
-	   4         8.153650604466    9.101e-03
-	   5         8.153807029244    1.562e-03
-	   6         8.153718651435    3.357e-04
-	   7         8.153729933933    7.971e-05
-	   8         8.153728597148    1.788e-05
-	   9         8.153728453440    4.361e-06
-	  10         8.153728282719    1.510e-06
-	  11         8.153728436457    2.733e-07
+	   0         5.710020217989
+	   1         7.319667227775    3.232e-01
+	   2         8.126425628080    1.191e-01
+	   3         8.146199022690    2.497e-02
+	   4         8.153650549044    9.101e-03
+	   5         8.153806973802    1.562e-03
+	   6         8.153718595996    3.357e-04
+	   7         8.153729878494    7.971e-05
+	   8         8.153728541710    1.788e-05
+	   9         8.153728398001    4.361e-06
+	  10         8.153728227281    1.510e-06
+	  11         8.153728381018    2.733e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 8.869e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        12.980210840681
-	   1        16.325277174360    4.870e-01
-	   2        17.934636706494    1.673e-01
-	   3        17.967479198896    2.699e-02
-	   4        17.979626846479    1.316e-02
-	   5        17.981154761762    1.725e-03
-	   6        17.980983099038    6.650e-04
-	   7        17.981013594168    2.098e-04
-	   8        17.981016594467    7.681e-05
-	   9        17.981012951514    2.221e-05
-	  10        17.981012225583    7.452e-06
-	  11        17.981013079625    1.569e-06
-	  12        17.981013666240    4.439e-07
-	  13        17.981013808580    1.269e-07
+	   0        12.980210718789
+	   1        16.325277017211    4.870e-01
+	   2        17.934636528240    1.673e-01
+	   3        17.967479019304    2.699e-02
+	   4        17.979626666531    1.316e-02
+	   5        17.981154581740    1.725e-03
+	   6        17.980982919014    6.650e-04
+	   7        17.981013414143    2.098e-04
+	   8        17.981016414442    7.681e-05
+	   9        17.981012771489    2.221e-05
+	  10        17.981012045558    7.452e-06
+	  11        17.981012899600    1.569e-06
+	  12        17.981013486215    4.439e-07
+	  13        17.981013628555    1.269e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.837e-08
 
 	Computing P*_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.731881111705
-	   1         5.925423003056    2.853e-01
-	   2         6.480098070106    9.381e-02
-	   3         6.491143477815    1.697e-02
-	   4         6.494443199112    8.751e-03
-	   5         6.495167799946    1.932e-03
-	   6         6.495069620690    6.929e-04
-	   7         6.495088275087    1.841e-04
-	   8         6.495089796825    5.056e-05
-	   9         6.495089027444    1.206e-05
-	  10         6.495089121498    4.007e-06
-	  11         6.495089481506    1.407e-06
-	  12         6.495089757501    6.123e-07
-	  13         6.495089785692    2.297e-07
+	   0         4.731881130430
+	   1         5.925423025320    2.853e-01
+	   2         6.480098092339    9.381e-02
+	   3         6.491143499753    1.697e-02
+	   4         6.494443220974    8.751e-03
+	   5         6.495167821777    1.932e-03
+	   6         6.495069642521    6.929e-04
+	   7         6.495088296918    1.841e-04
+	   8         6.495089818656    5.056e-05
+	   9         6.495089049275    1.206e-05
+	  10         6.495089143329    4.007e-06
+	  11         6.495089503338    1.407e-06
+	  12         6.495089779332    6.123e-07
+	  13         6.495089807523    2.297e-07
 	-----------------------------------------
 	Converged P*_Z-Perturbed Wfn to 8.021e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.809373768687
-	   1         7.418526227871    3.298e-01
-	   2         8.252645021965    1.200e-01
-	   3         8.270512894258    1.792e-02
-	   4         8.274719776150    6.902e-03
-	   5         8.275068072751    1.689e-03
-	   6         8.274949992802    5.106e-04
-	   7         8.274972926554    8.864e-05
-	   8         8.274973997682    2.315e-05
-	   9         8.274973446583    5.399e-06
-	  10         8.274973427009    1.941e-06
-	  11         8.274973586213    4.355e-07
-	  12         8.274973697920    1.261e-07
+	   0         5.809373738666
+	   1         7.418526185466    3.298e-01
+	   2         8.252644968811    1.200e-01
+	   3         8.270512840460    1.792e-02
+	   4         8.274719722175    6.902e-03
+	   5         8.275068018750    1.689e-03
+	   6         8.274949938805    5.106e-04
+	   7         8.274972872556    8.864e-05
+	   8         8.274973943684    2.315e-05
+	   9         8.274973392585    5.399e-06
+	  10         8.274973373011    1.941e-06
+	  11         8.274973532215    4.355e-07
+	  12         8.274973643923    1.261e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 3.425e-08
 
@@ -5433,12 +1081,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.116653158375433    -0.136050295574527    -0.040317664550606
-    1      0.020178810379770     0.045708806656960    -0.130530471482357
-    2     -0.189602214127483     0.207372490736804    -0.145086273515407
+    0      0.116653158229350    -0.136050294376206    -0.040317663907168
+    1      0.020178810546506     0.045708806213428    -0.130530471978785
+    2     -0.189602214456136     0.207372491035560    -0.145086273406846
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.077) =  -49.62375 deg/[dm (g/cm^3)]
+	[alpha]_(0.077) =  -49.62374 deg/[dm (g/cm^3)]
 
           CC2 Optical Rotation Tensor (Velocity Gauge):
   -------------------------------------------------------------------------
@@ -5447,12 +1095,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.607184272422173    -0.014351248976342     0.352297895457671
-    1      0.196734695883559     0.182867446268759    -1.194452126618606
-    2     -1.408568815574137     1.458658665816019    -0.777642641006180
+    0      0.607184272100691    -0.014351253052423     0.352297892486097
+    1      0.196734697210501     0.182867445331298    -1.194452120951313
+    2     -1.408568812154372     1.458658663542903    -0.777642639902379
 
    Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.077) = -460.77964 deg/[dm (g/cm^3)]
+	[alpha]_(0.077) = -460.77957 deg/[dm (g/cm^3)]
 
         CC2 Optical Rotation Tensor (Modified Velocity Gauge):
   -------------------------------------------------------------------------
@@ -5461,3613 +1109,373 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.007766563684832    -0.007587975254742    -0.002301328686741
-    1      0.001276539617596     0.002413940640873    -0.005820228443400
-    2     -0.011727270693775     0.011129268670779    -0.008872868817493
+    0      0.007766563749858    -0.007587975298369    -0.002301328744680
+    1      0.001276539644968     0.002413940682744    -0.005820228531856
+    2     -0.011727270788564     0.011129268808151    -0.008872868908357
 
    Specific rotation using modified velocity-gauge Rosenfeld tensor.
-	[alpha]_(0.077) =  -48.55573 deg/[dm (g/cm^3)]
+	[alpha]_(0.077) =  -48.55572 deg/[dm (g/cm^3)]
 
    Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.
      Delta_x =  -1.64   Delta_y =   2.79   Delta_z =  -3.24
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008614927932901 -0.046442352400056  0.027924113420848 -0.003342105613042 -0.019198187280149 -0.043605993010684  0.000124507843934 -0.017903232775755 -0.064037761769677
-    1  (  1) -0.004023859954382  0.002812567241188 -0.015355365220565  0.063211982369858  0.033868800032563 -0.011581015700219 -0.004465574115878 -0.047030919129079 -0.048793907716228
-    2  (  2)  0.028525640721225  0.068120190051797 -0.016739332483522 -0.005073216914996  0.071940864110972 -0.066733646998345 -0.019605473406179 -0.001610556181541  0.004701378003057
-    3  (  3) -0.054155290592472 -0.054244334984755 -0.021962628004576 -0.018282485083091 -0.037028274309951  0.016786978556275  0.022024618578561  0.004302299401540 -0.167953274084101
-    4  (  4) -0.063182596929128 -0.128748808697011  0.121465113794596  0.160938411624414 -0.233917278334855  0.054052147786148  0.025334190025568  0.127021105025468 -0.261448831371970
-    5  (  5)  0.148864678539144  0.254187426901849 -0.169654893765005  0.284620623487219  0.104152411510991  0.359543809296571  0.133744009364038  0.041861549395911  0.169452799563311
-    6  (  6) -0.084956716693293  0.126613830958100 -0.017431389376921 -0.048281125785785  0.083267553859489 -0.206713853889007  0.428812335356187  0.005011018790693  0.061186511244325
-    7  (  7)  0.173630436499038  0.181276581467465 -0.440332497406727 -0.059456065314793  0.303618967332177  0.080016792150091 -0.104444652264320  0.251866044362601  0.089940979754426
-    8  (  8)  0.057697740265636  0.070180597319316 -0.383387445877903  0.514874723728167  0.465292274425094 -0.060917787458673  0.016262524997932  0.068972295825028 -0.265391565564862
-    9  (  9) -0.279247635392508  0.560707539445326  0.044547355247966  0.161505455840491 -0.002588377300620  0.219223272852673  0.096307931275233  0.176467158787115 -0.104344971075325
-   10  ( 10) -0.977075550189082  0.176418272338824  0.228294317792423 -0.099370607761785  0.027777959043915 -0.149348953174007  0.027413414685573 -0.102632226214496  0.005531527026329
-   11  ( 11) -0.211429004068205  0.082644794913083 -0.055680052865830  0.289018099852967 -0.067789578528906  0.064107786895450  0.141855082713117  0.071186757345684 -0.332576681432119
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071990946341156
-    1  (  1)  0.010142476746200
-    2  (  2) -0.112423878596356
-    3  (  3) -0.059253840833002
-    4  (  4) -0.014639189231197
-    5  (  5)  0.248038168374966
-    6  (  6) -0.055159646937661
-    7  (  7)  0.115432903674626
-    8  (  8) -0.135363224547124
-    9  (  9)  0.174678345310946
-   10  ( 10) -0.086140984938274
-   11  ( 11)  0.161723358519153
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.197572413114517 -0.541318632877371  0.139927415914873 -0.359578444130330 -0.398937843975486 -0.026586872167534 -0.139627977382516 -0.005896246491228 -0.003746644388905
-    1  (  1) -0.541058731973333 -2.034801242188507  0.920540457917585  1.016218584629480  0.729164689940962  0.054412526301737  0.235971924521468  0.315223615831553  0.096208087340554
-    2  (  2)  0.139828960639396  0.920734025049694  1.243601677781983 -0.974300649425054 -0.758553357750500  0.024609548649431  0.513266755137957 -0.116926330823923  0.094501440802452
-    3  (  3) -0.358970389612551  1.015833032444632 -0.974440229907822 -0.266348920037382 -0.133799224826450 -1.276907891719884  0.042984364188955 -0.410608972745146 -0.602345206758872
-    4  (  4) -0.398323035382104  0.727797072638099 -0.759857932028957 -0.133858878725855  0.575448485405805  0.056475665846990 -0.484493838094732 -1.583666059960473 -0.976878960945650
-    5  (  5) -0.027166282529876  0.055084907439528  0.024891154244808 -1.275543890392068  0.058746221115305  0.155399297624787 -0.236023461595880  0.812878944882876 -1.048535633945681
-    6  (  6) -0.139452284652001  0.236223353106611  0.513262677276795  0.042879631015553 -0.482819583744289 -0.235933155306163 -2.554180022039243  0.492117808091915  0.545404391969618
-    7  (  7) -0.005841417486080  0.316274368087248 -0.116163386132942 -0.410094172620351 -1.579571504351393  0.813774264702327  0.492423579055058 -1.700719634572147  0.685529426222534
-    8  (  8) -0.003628131523111  0.096035529406495  0.094131958822655 -0.602680558554738 -0.970206233042967 -1.045482011639248  0.544249830480973  0.683514460656999 -0.254958894521937
-    9  (  9)  0.326098978034070 -0.130935443755898 -0.379595166178810 -0.575990923913880 -0.393471965772156 -0.365686482354661 -1.227740649572571 -0.905826585766955  0.039987575439783
-   10  ( 10)  0.008103557010829 -0.039575543043785 -0.358664813530415  0.339232504235094  0.207222390004838  0.025784782686722 -0.874465143496950  0.752110557173402  0.140644707838520
-   11  ( 11)  0.161744201604777 -0.084371238126416 -0.371150000615002 -0.062082553987999 -0.264710244109502 -0.257261524594595 -0.444570825837596  0.002821912169167 -0.878431482758543
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.327854256723191  0.009019714201806  0.162710661594080
-    1  (  1) -0.133091859401188 -0.040697608916971 -0.085480013261477
-    2  (  2) -0.381849466582258 -0.359835698966555 -0.372555502654032
-    3  (  3) -0.579249329460985  0.337242930789026 -0.062083381101115
-    4  (  4) -0.396591932227294  0.208613968377681 -0.263534161447186
-    5  (  5) -0.365098796840620  0.027806203875135 -0.265146511184336
-    6  (  6) -1.230804866141472 -0.879767261427487 -0.448789926588722
-    7  (  7) -0.904635210810701  0.753869376128870 -0.007723762422951
-    8  (  8)  0.040323953888643  0.145561462630237 -0.894627985530935
-    9  (  9)  0.423095730032689 -0.296000598729972 -0.177730944535255
-   10  ( 10) -0.299463152132731  0.634536265412446 -0.073348108781663
-   11  ( 11) -0.175836972560684 -0.076105887981834  1.184769463941312
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.567008918440454  0.722443194224100  0.422402078329773  0.057554368538511 -0.068012024097596 -0.451975147608540  0.709419418128490 -0.110422168786063  0.095704108927647
-    1  (  1)  0.720885472964738  0.332527211352729  0.737390933664557  0.281750515995843  0.280761290393686 -0.598548871078422 -1.146750917560074 -0.177301134607867  0.234694928374046
-    2  (  2)  0.422183102929830  0.736485274543817  0.007829109729841 -0.365399185160488 -0.965501991519851  1.065090224342325 -0.394390877157068  0.239359282041345 -1.218182428400336
-    3  (  3)  0.059687201587689  0.280769829516347 -0.363255319277090 -0.833720445234328 -1.345952507284314 -0.189309823206009 -0.179890587463359  1.060334267261244  0.772514544005070
-    4  (  4) -0.069257393950461  0.281296543593726 -0.966923508415862 -1.344162403478837  1.514830798821686  0.013670590813123  0.227285042195308 -0.333966365834383  0.386248727994588
-    5  (  5) -0.449135841837750 -0.599397616398023  1.066820631137579 -0.189649110609729  0.013795397601274 -0.565008204089947  0.487292179201877  0.306200785308481  0.347063761059997
-    6  (  6)  0.708465668575064 -1.146562417015747 -0.391890894794961 -0.180811610825629  0.226633708337573  0.487729597603209 -2.767088081148377 -0.044613761228256 -0.000972346438746
-    7  (  7) -0.108981479701481 -0.177538422258191  0.240499334967173  1.059842333943978 -0.334391646412731  0.306249622802239 -0.044471110656761 -3.232660954268523  0.514839123397967
-    8  (  8)  0.094277588726801  0.235043460722862 -1.221823739304416  0.774952681271118  0.386077819008107  0.344858044218004 -0.000341133693178  0.514916107143190  0.507086715271392
-    9  (  9) -0.063381219775898  0.233965663654109 -0.093343357924906 -0.360354041999586 -1.006820146552738  1.344825106449130  0.268434803850821  0.315156353069794 -0.332938610236887
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.063808920787530
-    1  (  1)  0.235710820172182
-    2  (  2) -0.096202914418848
-    3  (  3) -0.360121798161892
-    4  (  4) -1.006476097602190
-    5  (  5)  1.343619008167611
-    6  (  6)  0.268106090274240
-    7  (  7)  0.315242334513133
-    8  (  8) -0.332481313383264
-    9  (  9) -0.175400025059932
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010284048494255 -0.022581971135931  0.025184528241746  0.002553505114185 -0.007866760216735 -0.035704112150886 -0.002766394497905 -0.015588851752449 -0.054894237910669
-    1  (  1)  0.001129370063260 -0.004341567056713 -0.012471737690510  0.068518821494219  0.037428649672491 -0.002857552975536 -0.002731409738209 -0.051935588474977 -0.049204102006071
-    2  (  2)  0.045340581598934  0.060774626672080 -0.014665202394902 -0.013163382447340  0.085552378847967 -0.055885373659009 -0.012884187954087 -0.000025912808653  0.007546289398551
-    3  (  3) -0.053518724373857 -0.051858316930917 -0.015829576226974  0.002308038466593 -0.033376912491914  0.026566608759227  0.020736863226261  0.017163432001033 -0.156611857939886
-    4  (  4) -0.057073647917578 -0.121620677730040  0.116559461318180  0.152459611673760 -0.224360677266659  0.063635487600126  0.025109630293686  0.123561544969923 -0.260705677431782
-    5  (  5)  0.132736043071323  0.228873275971275 -0.157588806451895  0.278203525609905  0.112411249713211  0.339424025956772  0.132778586915835  0.041442079822076  0.144607854949093
-    6  (  6) -0.099037108772820  0.133050971019321 -0.016390463092699 -0.047994853534082  0.082590754367535 -0.196599146843337  0.423704532236322  0.002588517799838  0.062442412924455
-    7  (  7)  0.164573996270568  0.174187584517111 -0.442718231735592 -0.055107629768529  0.292277213599590  0.090352016025028 -0.100915507153634  0.242008735185081  0.079009239652453
-    8  (  8)  0.059450407301305  0.065508844735816 -0.375580889101448  0.518979554864539  0.457917802055341 -0.070408637451188  0.013466768623613  0.072872586601375 -0.257559025462184
-    9  (  9) -0.246894722162695  0.551859769243373  0.044670824987361  0.162240888664295 -0.012774136938901  0.203595879781061  0.102036778576897  0.168067562706153 -0.111682944808914
-   10  ( 10) -0.913654455951997  0.155328532380750  0.215519674293101 -0.100970035089767  0.021969337557273 -0.148862369984030  0.046525143909590 -0.100083990349210  0.020780587060978
-   11  ( 11) -0.198781019683999  0.090074442467030 -0.050453210014304  0.292395282220077 -0.068054938936099  0.077531780115388  0.149511822875939  0.072921096134366 -0.357789764657410
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.062212803584986
-    1  (  1)  0.008222801612735
-    2  (  2) -0.107232253166961
-    3  (  3) -0.058083892735771
-    4  (  4) -0.001519088368734
-    5  (  5)  0.232883930798086
-    6  (  6) -0.056471183426688
-    7  (  7)  0.097796104480775
-    8  (  8) -0.126488666884472
-    9  (  9)  0.156849504238605
-   10  ( 10) -0.081446420280763
-   11  ( 11)  0.176341903152824
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007749096020893 -0.085883219860789 -0.036741821640513 -0.003365465554254 -0.013826624434967  0.045778129863205  0.040669337017936  0.010509742963645  0.029540605017242
-    1  (  1) -0.033323633544771  0.071013231293301  0.009381535649954  0.001865195819276 -0.004385218315905 -0.001145589403992 -0.107240463714063 -0.004928891794835 -0.020784313339082
-    2  (  2)  0.052107391808055  0.092519548352413  0.009858355445846  0.037319719751115 -0.023857034470632 -0.010135084101246  0.037769988668842 -0.015917832336735  0.090581268987334
-    3  (  3) -0.109820166860700  0.034268818868662  0.003318299125654 -0.047343590144125  0.049224764312370 -0.055554817528594  0.048303583350885 -0.021295778567536 -0.056731125392159
-    4  (  4) -0.007052162455570 -0.070092516335627 -0.001616209300804  0.100452686687340 -0.017125496300488  0.011804649620296  0.317168773449601 -0.015679790140276  0.134810835290821
-    5  (  5) -0.101789034987347  0.450242114045570  0.095257897029759  0.154575128248214 -0.107484330343030 -0.276349446627330 -0.224432437333530  0.138878619319231 -0.069374899620443
-    6  (  6)  0.129481070378189  0.190214182802185 -0.111482363704469 -0.289845791886638 -0.214082604248960  0.130539668518305  0.176627871859896  0.507792819613372 -0.145016045312478
-    7  (  7) -0.031015915682170  0.467808966358201  0.323231774623313  0.163051942437066 -0.027878152128557 -0.222130149400228  0.355582804042090 -0.345169178258104 -0.117503613032291
-    8  (  8) -0.081114418656010 -0.129458136695794  0.321266021811150 -0.116738859709862  0.112997348404402  0.150149613835924  0.100022037588641 -0.009859219508172 -0.185497355865147
-    9  (  9) -0.840897499603665 -0.103193956572518 -0.262141263376961 -0.179652800220136  0.091540284698060  0.263027818637292  0.232988427097700  0.132664590100508  0.080643129784317
-   10  ( 10)  0.396138270139100  0.527358178663247  0.115585436142149 -0.350404487392900  0.098592337861551  0.056041756240516 -0.132708614971811  0.130232826037073  0.024142145251939
-   11  ( 11)  0.048038049575401  0.184019168140566 -0.243899393243605  0.184449948512382  0.067903231499648 -0.173184976481832  0.074519873620110  0.122524072160336  0.175482839393722
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.029757291821339
-    1  (  1) -0.000721108481725
-    2  (  2)  0.081115665687732
-    3  (  3)  0.028764622397233
-    4  (  4) -0.020368316409772
-    5  (  5) -0.173632225317480
-    6  (  6) -0.281328230047800
-    7  (  7) -0.030401209370270
-    8  (  8)  0.093738850403327
-    9  (  9)  0.138017132925940
-   10  ( 10)  0.057334975405403
-   11  ( 11) -0.087072361680799
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.718905282963311 -0.301300066815098 -0.767801784865940  0.078512808825352 -0.203134864329395  0.241932163232250  0.058076631858574  0.196398858308336 -0.039008858124194
-    1  (  1) -0.301256490728193 -0.157440548180653 -0.036029555945222  0.243436823804201 -0.005929795652985  0.115486356935965  0.826228436942721 -0.465135369554618  0.058491264513800
-    2  (  2) -0.767289827428610 -0.036275730111077 -0.756926663794728  0.450133498634738  0.207784604973971 -0.828712724024022 -0.324647417359493 -0.353270502638369  0.092835605795882
-    3  (  3)  0.078579571414042  0.243310568002833  0.450095063336851 -0.208139431363607 -0.062202704649669  0.279001105370900 -0.076077558481815  0.262112030046533 -0.378810215172718
-    4  (  4) -0.202510304245595 -0.006692039856945  0.206011713498273 -0.062773519685661 -0.370731419489490 -0.256994084769574 -0.019543706164301  0.220490721787851  0.607096866069924
-    5  (  5)  0.239969372403163  0.117504635997786 -0.825053657412313  0.279484173569987 -0.255386254541418 -0.397595357673452 -0.135369610755389  0.236221247146237  0.269522215039686
-    6  (  6)  0.058390572588279  0.825859124407247 -0.324193078352693 -0.076854690390370 -0.019228317672495 -0.137735601227498 -0.351485727273275 -0.487761380462257 -0.103056409920122
-    7  (  7)  0.194458563409000 -0.463590717501173 -0.349817673328107  0.262678828099312  0.220495817360137  0.236701749060628 -0.486100377719484  0.043036203375607 -0.169360995578035
-    8  (  8) -0.038844766636175  0.058006360789407  0.092452034322386 -0.377838465048525  0.603441383275525  0.267460191997309 -0.103192305796676 -0.168696834715057 -0.618488124049516
-    9  (  9) -0.174642021637819  0.179686913958803  0.584519432729807 -0.531375857305351 -0.237827440080434  0.122408493834100 -0.350613084838644 -0.156778679126698 -0.027661506214973
-   10  ( 10)  0.043298420781037 -0.218837511618004 -0.611680553974653 -0.687832529301005 -0.249683832986975  0.553064660821027 -0.144105807777605  0.115245275900936 -0.084193131593124
-   11  ( 11)  0.061064657985430 -0.108300572115386 -0.188797311905296 -0.022208683609426 -0.827900622936499 -0.341922472618851  0.022718392329079  0.232401592689427  0.164619669402136
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.175684511601603  0.045513516298602  0.061672515006080
-    1  (  1)  0.179323083833167 -0.221567937419786 -0.109140577543022
-    2  (  2)  0.587827397093136 -0.616289532030193 -0.190305864672640
-    3  (  3) -0.534590179358002 -0.689583787093839 -0.022209033963942
-    4  (  4) -0.239000891867221 -0.249187499059157 -0.832603923332527
-    5  (  5)  0.122010791877518  0.553620901013401 -0.348332351708050
-    6  (  6) -0.352732495297565 -0.145056644635348  0.023781601660354
-    7  (  7) -0.157242165562723  0.112854519200918  0.232190589319976
-    8  (  8) -0.027709907045481 -0.086030263039170  0.172274707819854
-    9  (  9)  0.207109600584589  0.096837430686223 -0.023218950236813
-   10  ( 10)  0.100164655230671  0.138181178066476 -0.148224446144570
-   11  ( 11) -0.022320179734203 -0.148849259998097  0.901205762410303
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.179939828491769 -0.273263983919761 -0.077241939802207 -0.131310571537764 -0.452108955794121 -0.373710053222736  0.012756857043078  0.188686131296855 -0.281717657996437
-    1  (  1) -0.271865636595074  0.080204205184229  0.237736668579935  0.053954037181141  0.088144371186311  0.094298665169508 -0.396703489007358 -0.164374392009126 -0.012743809563993
-    2  (  2) -0.076549157175288  0.237611423410488 -0.235916884249811  0.330279805489172  0.156363656188217 -0.135525945480897  0.113532621668593 -0.192996543934043  0.505097349395040
-    3  (  3) -0.133008481204441  0.051978470711429  0.330705317892875 -0.689079279022158  0.681025162416434  0.230126506813665  0.220012049909173 -0.221793013382862 -0.415574431905058
-    4  (  4) -0.450299145657576  0.087908600365275  0.156309970041408  0.681002122520780 -1.360248251424318  0.202273753159192 -0.167570810051337  0.246051223487190  0.206738411458247
-    5  (  5) -0.373567193155845  0.094555329734040 -0.136731584498100  0.229377893488984  0.202581599883435 -0.322498154757568 -0.226671631570763  0.408374954790996  0.307423751717641
-    6  (  6)  0.013230492577454 -0.395220303624150  0.113830041131736  0.218897296842682 -0.167381205612527 -0.226319762003687 -0.422981172464967 -0.882122931150610  0.208582936748456
-    7  (  7)  0.187587553988559 -0.164973338711578 -0.192266029819867 -0.222193739599766  0.245811643454060  0.408813624326959 -0.882511768104148 -0.161881530949274 -0.197931622292553
-    8  (  8) -0.280045996340605 -0.013187886145669  0.507423753200987 -0.417462155137855  0.206022606034107  0.308302993473083  0.207495521066743 -0.198012373935716 -0.598880759668382
-    9  (  9) -0.299128216307527  0.222289305708678 -0.374826664894612 -0.022250761597490  0.198104512558476 -0.291885255576850  0.011569749529353 -0.150670269953426  0.186378706038956
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301492091129213
-    1  (  1)  0.222023461274417
-    2  (  2) -0.373275862159688
-    3  (  3) -0.022769731837422
-    4  (  4)  0.197531018509810
-    5  (  5) -0.291038388606400
-    6  (  6)  0.011766677818707
-    7  (  7) -0.150956367275849
-    8  (  8)  0.186282415361357
-    9  (  9) -0.408641391244209
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006541040222368 -0.029135588169222 -0.017330822595744  0.002628911660037 -0.012344009141809  0.034496132624923  0.021629830242309  0.010441885402291  0.025478364815458
-    1  (  1) -0.038275138470075  0.054424566886903  0.005683589031010  0.001642391288003 -0.005493648653247  0.001124544236485 -0.102028934451313 -0.004961744404475 -0.019198498257850
-    2  (  2)  0.053024456913342  0.083754722151204  0.014366999014575  0.045684709272444 -0.045425854355333 -0.015659092798954  0.035306515857362 -0.013688960188417  0.082596341754868
-    3  (  3) -0.125696090540634  0.031717757592640 -0.000802365038104 -0.050871771309593  0.061705711345850 -0.045742890419344  0.045450419445688 -0.021064845035616 -0.054716959844684
-    4  (  4) -0.016613018731749 -0.059371668786672 -0.003754167403423  0.095982620955076 -0.007240466240122  0.008043456529988  0.296808016923276 -0.015369394286441  0.136610478911713
-    5  (  5) -0.093091489377706  0.398657588863068  0.074430182364354  0.149030211928108 -0.108745535372234 -0.256250392240536 -0.205814737045222  0.134201000957220 -0.055103512993348
-    6  (  6)  0.103501697780443  0.185147067962843 -0.104829304475355 -0.273669393328239 -0.199802423052909  0.136710211986565  0.166053639619828  0.483268157942075 -0.135434527757446
-    7  (  7) -0.041456689404135  0.416662529525886  0.296499443846860  0.151835770270295 -0.027648961071683 -0.196853254585748  0.346148931870815 -0.324194030503122 -0.108656389838073
-    8  (  8) -0.069099920157317 -0.122455303618133  0.312946042218845 -0.115185983609626  0.104240832235501  0.145175805702234  0.095088539986730 -0.010672631592564 -0.187147060865154
-    9  (  9) -0.712671855893174 -0.096350152389786 -0.234711067777686 -0.171596024164591  0.065322769896798  0.213466874289907  0.226529390715592  0.118201066093080  0.055528795004367
-   10  ( 10)  0.365512212430565  0.443597144956858  0.088760713787529 -0.336294489487780  0.089380999156301  0.050585935158758 -0.112358935032342  0.122526344346197  0.011836823928278
-   11  ( 11)  0.046393846223224  0.165011629057398 -0.228781961279396  0.178941949643574  0.063752947031584 -0.164789871590981  0.073726138142668  0.117333811839271  0.181371275992210
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.026880621041360
-    1  (  1) -0.000642066544117
-    2  (  2)  0.075046583216661
-    3  (  3)  0.030887223304929
-    4  (  4) -0.027083357083367
-    5  (  5) -0.161323349919549
-    6  (  6) -0.260652499025702
-    7  (  7) -0.019658118713907
-    8  (  8)  0.093794795124770
-    9  (  9)  0.110456626093643
-   10  ( 10)  0.048798146100140
-   11  ( 11) -0.097571556382824
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001432746297450 -0.032810674091764 -0.033331937480253  0.023032547083763 -0.002808019310921 -0.039246266926320  0.018692018505171  0.008842597191367 -0.029091078569617
-    1  (  1) -0.008821922403183 -0.001742272088788  0.082771016704519 -0.022297486221974  0.039163604166239 -0.010818853488427 -0.047294425339584  0.013135326021221  0.049034393857867
-    2  (  2)  0.024274942916815  0.027096978669207  0.097516386902391 -0.041392368694666 -0.004119390757880  0.075691552303805 -0.023677742397495 -0.003953261558318 -0.122163189427397
-    3  (  3) -0.047038460283817 -0.039422636027069  0.017791086341758  0.115660160117630 -0.067224158887899  0.095036576800958  0.032022129167533  0.022732157345389  0.120912741709036
-    4  (  4) -0.041035802352368  0.001934742020068 -0.201409668003493 -0.406246991276172  0.228435905047063 -0.366034413601436  0.036563318346743 -0.036692328708082 -0.082010843429842
-    5  (  5)  0.098338733570095  0.243746073973362  0.282884501181602 -0.425804208023662  0.108408993563040  0.505586602390370  0.102717653176241 -0.183779423720787  0.023433267817945
-    6  (  6)  0.135336854760563 -0.062874421564495  0.076338309095403 -0.023002937162434 -0.130902824611473 -0.185164583438217  0.398907643233867  0.217551510448046 -0.032105677017803
-    7  (  7) -0.035062191357078 -0.113858796831119  0.431604299875852 -0.029482805357536 -0.029652466640804 -0.242847719350325 -0.077765311277989  0.367073496056810  0.139022006906444
-    8  (  8) -0.068272847454715  0.294672021175633 -0.568959581650588 -0.125921031197012 -0.707592810771387  0.017806583156209 -0.015845746565047 -0.212947645825718  0.125196335187716
-    9  (  9) -0.288858276698774  0.093713692739213  0.209035012311688  0.075382622510660  0.083405488851542  0.016184965058288  0.000548295704545  0.266294088315547  0.380874642506837
-   10  ( 10) -0.378738518488000  0.204837316203508 -0.069415360994347  0.062065163074324  0.029622876137723 -0.058750752587050 -0.120574645247794  0.008130897374692  0.009265965929469
-   11  ( 11) -0.080018520143771  0.225808316863723 -0.312311376663230 -0.316597637367698  0.125757542829493 -0.146130016020174  0.016179298260010 -0.136308703902615 -0.120756904157899
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.036093305578397
-    1  (  1) -0.001707679185378
-    2  (  2)  0.005295607540268
-    3  (  3) -0.304573937377439
-    4  (  4) -0.014287077020118
-    5  (  5) -0.068885443054321
-    6  (  6)  0.111979958895137
-    7  (  7)  0.321243115116497
-    8  (  8)  0.158205355334404
-    9  (  9) -0.080091690471286
-   10  ( 10) -0.065074315967804
-   11  ( 11)  0.075517488980888
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.151581395944457 -0.159877768539019 -0.191397517423370 -0.495232284867177  0.365561840480614  0.240680277087037 -0.079714342464060 -0.017889526464511  0.054577038131019
-    1  (  1) -0.159795957250344 -0.047735218799445 -0.125025973520529 -0.592230248738643  0.329204795623399 -0.563899565056737  0.474518384859258  0.371816427010336 -0.204007450193307
-    2  (  2) -0.191333337555164 -0.125299228178318  0.032743525999057 -0.248173196102997  0.424015573762028  0.373304795371779 -0.124367805075759 -0.383343230710404 -0.176623528718579
-    3  (  3) -0.494849488362154 -0.592714843248357 -0.248959287226432 -0.423717062956694  0.236470791317215 -0.415768039926139 -0.007927078894393 -0.295339114007336  1.138817517977087
-    4  (  4)  0.365842786381904  0.329912791129377  0.425309312530905  0.236284335454773 -0.297797609245548  0.287162197148014 -0.015195390583447  0.149575460395682 -0.352881082019632
-    5  (  5)  0.239666720470004 -0.562521840762128  0.375748994888085 -0.414021321385147  0.283842862620087  0.299376587010529 -0.122721640145877 -0.329969308300871  0.156494792176823
-    6  (  6) -0.079132044596257  0.473605179791134 -0.125255855635513 -0.008774504854422 -0.015965010341322 -0.123144104694353 -0.040262615853229  0.053291869268360 -0.230047243580867
-    7  (  7) -0.018210362041773  0.371975596266125 -0.382949144540519 -0.295062546320220  0.147969605902060 -0.330844143538271  0.053247875304319  0.437054225002062 -0.295575334707162
-    8  (  8)  0.054384972764257 -0.203042333758326 -0.176317356102570  1.137981680675850 -0.349930528471567  0.158219435758802 -0.229361079354617 -0.295174183029699 -0.201170965133917
-    9  (  9)  0.162593186917498 -0.096068090323904 -0.131721885594255 -0.537260876669133  0.048165192812382 -0.386108653062500  0.083321052788424  0.067822247358744  0.259623842469249
-   10  ( 10)  0.093086276325347 -0.110390627511003 -0.528311347000350  0.014888006239538 -0.100997055269664  0.192126958830561  0.038787614394956  0.063975054988451  0.077127488930246
-   11  ( 11) -0.248608674285678  0.166558436146830  0.438779225583925  0.334557445644043 -0.324782623645273  0.179928478753780  0.012126762707773  0.006418605871888 -0.316369462085207
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.163245257155421  0.094276717552644 -0.249582936616881
-    1  (  1) -0.097089753942058 -0.112180528774260  0.167323530234027
-    2  (  2) -0.131901378869784 -0.530116652654623  0.440616284282449
-    3  (  3) -0.539218683643804  0.014310072965047  0.335266942696954
-    4  (  4)  0.048635984706568 -0.103433325040069 -0.331331261588337
-    5  (  5) -0.385516013729792  0.187104305011894  0.193398800890046
-    6  (  6)  0.082991815026247  0.037352860323020  0.011014682786961
-    7  (  7)  0.067841455828072  0.062642922337485  0.014204699225385
-    8  (  8)  0.258473930207162  0.077886035701004 -0.325054438919389
-    9  (  9)  0.001773142889432 -0.053105768300802  0.034600115019000
-   10  ( 10) -0.053689547832438 -0.018246255837546 -0.196162567936867
-   11  ( 11)  0.031756575503292 -0.193298510202671  0.164652237069869
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.236069150423928  0.221583137218639  0.087467481976269 -0.023767225350154 -0.157884977853517 -0.128673956390029 -0.176595879969474  0.001131012317203 -0.181143452404233
-    1  (  1)  0.220430431059073  0.112052435313968  0.015869249151473  0.264485428778921 -0.165982030219470  0.159260926468858 -0.018854654828287 -0.249502649443057  0.052130725228418
-    2  (  2)  0.087694752982164  0.015013031218300 -0.683310722703039 -0.454889777527338  0.270539149606414 -0.876133156261866  0.064372104092668  0.069959767509230 -0.359585122327188
-    3  (  3) -0.022349867884997  0.265917774305981 -0.459885376820098  0.156118351029157 -0.442698949429053 -0.633164352365545 -0.123599096035318 -0.000681276488754  0.329408685832541
-    4  (  4) -0.157925484616889 -0.166044552973515  0.271218387113143 -0.443885849212600 -0.013362398764761 -0.176284165832649 -0.004716950323026  0.078109759941717 -0.609000288591445
-    5  (  5) -0.127616278770967  0.158011849801079 -0.876037618276795 -0.629854882079848 -0.177186230678137  0.012211398531521  0.059425698366986 -0.774979266274861 -0.486618182967767
-    6  (  6) -0.178241606252947 -0.017090192450387  0.064522373941146 -0.124240074207901 -0.004293285267873  0.059087683211698 -0.104000927528902 -0.330829052901522 -0.038045687603335
-    7  (  7)  0.002208432976113 -0.248689840257510  0.068573896371648  0.000014323070255  0.078530114044465 -0.775881123063332 -0.330687300606162  0.375687386105441  0.140607455827148
-    8  (  8) -0.178615853440425  0.052090468900394 -0.360562489485138  0.330978975217506 -0.607342070790934 -0.487347100955227 -0.037705399031252  0.140808054960246 -0.394251292282697
-    9  (  9) -0.046812023124734 -0.356025366669854  0.690811815119252  0.312933605279832  0.666333150435849  0.222468929331266  0.069111321865738  0.559435147572457  0.132671563084754
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045842278134109
-    1  (  1) -0.355929482932053
-    2  (  2)  0.690401613030498
-    3  (  3)  0.314450068453419
-    4  (  4)  0.667992312261241
-    5  (  5)  0.221641972273241
-    6  (  6)  0.069286377187356
-    7  (  7)  0.560338391968248
-    8  (  8)  0.132249466359632
-    9  (  9) -0.305201514350595
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003531322887475 -0.011853964282953 -0.013997173425702  0.018382792154192  0.000899996441170 -0.027829789222902  0.010946278656521  0.009416135608630 -0.023987807904262
-    1  (  1) -0.006388621957170 -0.005171201061298  0.075116414644925 -0.012351518893597  0.041297277094542 -0.006441657661851 -0.042094675941536  0.014500044658877  0.045272474380981
-    2  (  2)  0.036883171135873  0.025743377437805  0.085964964522995 -0.036572128405843  0.000741779132517  0.071901849285639 -0.017612259522947 -0.002857549793791 -0.114428225581804
-    3  (  3) -0.050379148878904 -0.038280516537017  0.018275237269774  0.118578575241743 -0.057964689431887  0.100743381549064  0.031817975653707  0.026538904209037  0.119963525599056
-    4  (  4) -0.040259568572502  0.011229705198348 -0.188809172609568 -0.380757486353216  0.215445879830049 -0.344569392827444  0.033187603168238 -0.033507608911701 -0.079582925346094
-    5  (  5)  0.087141198545524  0.216785041786672  0.270610048744647 -0.398997177058604  0.102170025016676  0.478625848854116  0.098949415070036 -0.170373600936987  0.015652914812384
-    6  (  6)  0.115394650619668 -0.055172374414512  0.068645251662214 -0.021005537436634 -0.120222938768552 -0.172201054646963  0.377862520931175  0.205771786365183 -0.028486300590321
-    7  (  7) -0.040171141537119 -0.121048023653740  0.403132598347777 -0.027760474590503 -0.026374510769541 -0.228317794220799 -0.070878790612320  0.346601006753617  0.129893637962627
-    8  (  8) -0.063034884678852  0.280866798080653 -0.540496031356204 -0.119391576371009 -0.673073389093966  0.010663808807394 -0.016147690801371 -0.200745867995305  0.117394935881043
-    9  (  9) -0.239823863619059  0.087614347419962  0.205995256328994  0.074059708937832  0.068748575207548 -0.000454096504958  0.003028317523563  0.249475422318809  0.352711368821821
-   10  ( 10) -0.336588165834448  0.173514331887659 -0.070029614207528  0.058791676167547  0.024501304819872 -0.052124336325614 -0.104213155529188  0.008639636736157  0.013496509549194
-   11  ( 11) -0.070036515714458  0.195530601320237 -0.305644951639726 -0.322831866596268  0.121530762471617 -0.141977993846978  0.021998928318675 -0.134440837975978 -0.127122644721006
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.030353030422789
-    1  (  1) -0.003358262791905
-    2  (  2)  0.006176160600104
-    3  (  3) -0.295046081788652
-    4  (  4) -0.003816440522472
-    5  (  5) -0.074325961201587
-    6  (  6)  0.109014636987132
-    7  (  7)  0.303731536940852
-    8  (  8)  0.152250258689580
-    9  (  9) -0.089511140585649
-   10  ( 10) -0.060789805292351
-   11  ( 11)  0.082293619260989
-
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016948570972613  0.054109880888837 -0.021135784265575 -0.002313233156337  0.028103296077604  0.079447973740205  0.002956852851677  0.021913708071079  0.092707789804150
-    1  (  1) -0.006461113403501 -0.006009670223774  0.006912589645128 -0.092573919328396 -0.040488535615147 -0.004255397696456  0.001825638351976  0.025873653657309  0.054959118002991
-    2  (  2) -0.031331544873159 -0.021241168145027  0.017129702121868  0.019395427099523 -0.035285598576221  0.072935692322985  0.012410630409385 -0.000869702308377  0.008015902055911
-    3  (  3)  0.024878718719799  0.025868121230654  0.005405353640122  0.004239945233349  0.042856541334318  0.005201344918358 -0.012288417201910 -0.030208301210711  0.125325395177801
-    4  (  4)  0.025785958698499  0.063980691498117 -0.073598667061032 -0.115501747702081  0.164822674147024 -0.010612384733594 -0.011577872820172 -0.114519752578224  0.189906673361740
-    5  (  5) -0.055556441114085 -0.137396825466669  0.095615332658029 -0.165972658367973 -0.107298365798081 -0.238527327390248 -0.081212554772841 -0.063709822276343 -0.111105007194853
-    6  (  6)  0.039392027543678 -0.042131630239803  0.019507343007951  0.031681902994480 -0.051489401416932  0.103596811576048 -0.235358679315166 -0.007221910465763 -0.034349807961782
-    7  (  7) -0.065836178815642 -0.094909606609938  0.220876622755124  0.015059455980391 -0.193611601065905 -0.070646838068217  0.043039430003875 -0.187401754034075 -0.048410779717487
-    8  (  8) -0.031684946163714 -0.037730087504351  0.186156646607922 -0.254646362799555 -0.271156762093932 -0.000387787259569 -0.024433068698376 -0.071450437934107  0.140846979003438
-    9  (  9)  0.084633662124775 -0.255488997024621 -0.026205007862790 -0.093994792938777 -0.025613688623644 -0.118121227074271 -0.051164537443405 -0.122992981774053  0.058164329433773
-   10  ( 10)  0.311792105223363 -0.086266548695923 -0.100581825486069  0.027645372765871  0.030325864964669  0.084727340300286 -0.008122017336910  0.056541723787744  0.001789230697787
-   11  ( 11)  0.065426291083003 -0.078665723239531  0.001736951632506 -0.128876911317495  0.027700220473420 -0.024959429550215 -0.037516506165893 -0.053272012233112  0.158952768314791
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.101753702406755
-    1  (  1) -0.017313059038111
-    2  (  2)  0.101825332796567
-    3  (  3)  0.046545573336527
-    4  (  4)  0.020412053345531
-    5  (  5) -0.174151422241113
-    6  (  6)  0.031247623880847
-    7  (  7) -0.081019948031908
-    8  (  8)  0.058254959468121
-    9  (  9) -0.102303876794014
-   10  ( 10)  0.049924523752296
-   11  ( 11) -0.075525972870746
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000125242728652  0.167195127529492 -0.056123303969470  0.168150627862986  0.199820827488140  0.006623842711744  0.083849175432758  0.006045895732050 -0.001251364845770
-    1  (  1) -0.166774393973286  0.000050108097355 -0.080714006337441 -0.158384893960458 -0.170632381263561 -0.022705538420815 -0.068262733314185 -0.100593352732071 -0.028750568711108
-    2  (  2)  0.056229020612168  0.080612207963297 -0.000319173254151  0.066387047727631  0.099495071766653 -0.005173360753909 -0.113435632074142  0.028897807757084 -0.031705991700745
-    3  (  3) -0.167678159270092  0.158683508487030 -0.065913815468277  0.000249734983867  0.003148005831140  0.156650391969335 -0.003319412683622  0.076996711806060  0.120344951995522
-    4  (  4) -0.199454748142053  0.170759345082550 -0.099469221211006 -0.002551454280228  0.000773886045054 -0.018686662746212  0.033100672959698  0.121887804954424  0.106797700418754
-    5  (  5) -0.006478249114673  0.021770745773300  0.005161753017351 -0.157975992221428  0.016380865873467 -0.000525726707385  0.009662973185984 -0.040170645002731  0.072417783927543
-    6  (  6) -0.083743292092373  0.068302347407764  0.113643630138679  0.003584139545109 -0.033360726847565 -0.010056643067212 -0.000096953687507 -0.013754999535778 -0.022913811866200
-    7  (  7) -0.005934789716209  0.100152235257288 -0.028714239339716 -0.077512132071698 -0.124503679540823  0.039365364835397  0.013764502288195  0.000180876976509 -0.012227152395047
-    8  (  8)  0.001252911154497  0.028874957240891  0.031437882577012 -0.119989379615825 -0.109273108573834 -0.074290660285147  0.022855339074817  0.012168993677105 -0.000462665884709
-    9  (  9)  0.203227152828002 -0.052485985798040 -0.129801089628845 -0.136141281459481 -0.065085125998612 -0.011352243649991 -0.086206555714525 -0.025668240031329  0.000953339185401
-   10  ( 10)  0.017663100569732 -0.012450214343934 -0.116177784025215  0.099935881710944  0.054793001926237  0.009017289614393 -0.082995680333069  0.068546362432187  0.010579042812723
-   11  ( 11)  0.116181838629295 -0.044517983740016 -0.150706036920128 -0.032577504630229 -0.048215712631815 -0.017042393348597 -0.052941121555075  0.017922753511187 -0.062577005194743
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.202593155221573 -0.017575879500322 -0.116307852916242
-    1  (  1)  0.051519507233614  0.011549119939392  0.045820851989693
-    2  (  2)  0.128159049336363  0.115585636177618  0.151359481294950
-    3  (  3)  0.134953502481695 -0.100933227346633  0.031949792725006
-    4  (  4)  0.063859931160852 -0.055317708494750  0.046074544888569
-    5  (  5)  0.011830479350239 -0.008881125854761  0.020210091121139
-    6  (  6)  0.085128481579730  0.081569095643572  0.054417852481447
-    7  (  7)  0.026086609962421 -0.069224862060329 -0.012195140209492
-    8  (  8) -0.000678319781602 -0.012471916838811  0.071159871058140
-    9  (  9)  0.000819518740474  0.045422336765459  0.019150849930670
-   10  ( 10) -0.042260420338391  0.001814961764223 -0.033976133870612
-   11  ( 11) -0.016728332900175  0.032414763485709  0.001978177060231
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000983782142481 -0.011124830147172 -0.012629378315808  0.024035154666400 -0.023065379134223  0.045710192314813 -0.107167060216496  0.027462764041011 -0.031515346399462
-    1  (  1)  0.014910063958614 -0.001359157823420 -0.030733082384744  0.019659721688393  0.009988965433840  0.056476882006057  0.086868153591365  0.027118954968710 -0.020111602536483
-    2  (  2)  0.013560973004051  0.032277644601759 -0.000558091321303  0.031608555416779  0.040262773871770 -0.039517595873987  0.008529102471728 -0.015019360045155  0.098314783259817
-    3  (  3) -0.023649721587845 -0.020118169175247 -0.030610171886610 -0.000350229335722  0.012485025400198 -0.061831636996218  0.007360517014456  0.020533699107494 -0.121125902320152
-    4  (  4)  0.023653135590417 -0.011024958414626 -0.040020875859244 -0.012638451269626 -0.000303446235581  0.039117573677270  0.028265656547984  0.042181285668281 -0.051214110379900
-    5  (  5) -0.045133076040651 -0.057161250752777  0.039343611119004  0.062428421797334 -0.039565506596663 -0.000136824832782 -0.002584969716509  0.016708941328372 -0.072879955596616
-    6  (  6)  0.106505496216286 -0.086364895206289 -0.008150243943918 -0.007611894739464 -0.028147100099079  0.003022121444643 -0.000203669685880  0.002510614548550 -0.011878393768514
-    7  (  7) -0.027112672456296 -0.027077462764235  0.015425844110164 -0.020594818217305 -0.042172669827196 -0.016338775255452 -0.002434838415100  0.000089029182611 -0.017463248477439
-    8  (  8)  0.031656276623231  0.019719565610509 -0.100860419907018  0.123299997114838  0.052015418367335  0.071940119122082  0.012364797759804  0.017989601258840 -0.000459902016922
-    9  (  9) -0.009520290499381  0.022267140636896 -0.003094175387367  0.010303251098885 -0.097174601333758  0.097786893048291  0.015199034071913  0.052630350765338 -0.034203233126427
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.010278877487205
-    1  (  1) -0.024100566367630
-    2  (  2)  0.004662205178286
-    3  (  3) -0.011080772146621
-    4  (  4)  0.096116977362317
-    5  (  5) -0.097255829352037
-    6  (  6) -0.015024357830545
-    7  (  7) -0.052513597187948
-    8  (  8)  0.034242058243121
-    9  (  9) -0.000071427193828
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.021462702377840 -0.058609304986263  0.015277082640202  0.003588508466775 -0.029160920616631 -0.083108081100347 -0.001276540885573 -0.021892833224427 -0.094847379110200
-    1  (  1)  0.007381037964715  0.005863657253688 -0.003698438732125  0.089241023982742  0.038284755695481  0.000242471073392 -0.003462666004729 -0.024254060890744 -0.054255658141393
-    2  (  2)  0.028789493389469  0.021034273638112 -0.015759179620292 -0.016880406379978  0.029564270241667 -0.075699259080315 -0.015222849490441  0.000165407073994 -0.009535205798866
-    3  (  3) -0.022522624621755 -0.025183731584898 -0.006246635644453 -0.011954555325543 -0.044324634330057 -0.008966012606668  0.011838270463808  0.025186144853786 -0.129587118903909
-    4  (  4) -0.027278246959126 -0.067306256079496  0.081195596321175  0.116387540315424 -0.168952317262089  0.005408102733272  0.009102915279315  0.114909773648686 -0.181841314973109
-    5  (  5)  0.061523869623373  0.148379112602599 -0.099858075157622  0.167623835533734  0.102565185360584  0.247065081865864  0.081017208043104  0.063123082298018  0.125076333021719
-    6  (  6) -0.033597893568908  0.039834794585931 -0.017503613262801 -0.032860851330180  0.052602131787128 -0.107800944359286  0.233932603910558  0.008404826542760  0.033043735155831
-    7  (  7)  0.070933561522966  0.099409127660202 -0.220355143796242 -0.017909988072788  0.200469521486937  0.066219172137076 -0.043845430589746  0.192769183200970  0.053043735796183
-    8  (  8)  0.031467417081633  0.038067047239557 -0.186574292412207  0.251635426547577  0.276398972104307  0.005573316819495  0.024827793389672  0.069746818919629 -0.142347486299646
-    9  (  9) -0.099591518033223  0.261294622221711  0.027264053477196  0.094406359241798  0.029407574246243  0.125903095774733  0.051208103024876  0.127846157357285 -0.056089461080389
-   10  ( 10) -0.342117397283536  0.096154260862934  0.107466277478619 -0.028734389414544 -0.028891686984979 -0.086820145756038  0.003652067648454 -0.059057626339762 -0.003362266069713
-   11  ( 11) -0.071536902730284  0.080845824211427 -0.010817173110070  0.135869650211322 -0.031366930890364  0.023168476862022  0.040179651854624  0.056331586353381 -0.165962619403637
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.103572144747435
-    1  (  1)  0.016763539950930
-    2  (  2) -0.104006607185189
-    3  (  3) -0.046374714497242
-    4  (  4) -0.027556807097170
-    5  (  5)  0.176590727028647
-    6  (  6) -0.030192309767508
-    7  (  7)  0.090742251579819
-    8  (  8) -0.063736127736872
-    9  (  9)  0.109060255331570
-   10  ( 10) -0.052388979852748
-   11  ( 11)  0.078361680425232
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.013921975065565  0.103381315829109  0.056389355096898  0.011768947816972  0.004121807955223 -0.057298678485070 -0.051432105076231 -0.011071595100990 -0.044909476246755
-    1  (  1)  0.013324613924162 -0.028079810676541  0.007070559814787 -0.008005471198395  0.006018453330844 -0.015973349330415  0.092922359472783 -0.001623775394348  0.017733631990947
-    2  (  2) -0.019765781914701 -0.033032250658388 -0.004007042176849 -0.050166385756319  0.029906079194408 -0.009704933667000 -0.038620452933162  0.002807692103963 -0.070071101745418
-    3  (  3)  0.070805556804984 -0.003068938942251  0.006504595257348  0.039373898202160 -0.036927092655665  0.030322281820042 -0.048817421108637  0.011305308050902  0.032860541612150
-    4  (  4)  0.014313386316708  0.043972310793415  0.013921813392036 -0.066387730109469  0.002442397138038 -0.016086934562225 -0.179664439851381  0.006464519349973 -0.090040691856223
-    5  (  5)  0.045155577186191 -0.247427178481659 -0.058353258995683 -0.094628927569757  0.090493402552644  0.185320260507422  0.131090788508292 -0.093104350867894  0.060872458952884
-    6  (  6) -0.038584331307231 -0.080297227608230  0.071473886019715  0.143170489853226  0.104560768686072 -0.046154653747240 -0.096338078586582 -0.334907808030702  0.111571007227725
-    7  (  7)  0.029042222296753 -0.237223314371562 -0.174932299186948 -0.080316826107909  0.040506264905804  0.119977478400892 -0.161451558991029  0.215735211087246  0.060177585905520
-    8  (  8)  0.025904244265209  0.058524341310476 -0.144685830322387  0.050264276045864 -0.072805327886092 -0.086206688333215 -0.053604324132359 -0.007863564270736  0.095576963924380
-    9  (  9)  0.256508945269226  0.052730013654633  0.124834441481755  0.085733906231975 -0.088393899635438 -0.140853295492133 -0.139492059284684 -0.083015088260315 -0.042052092330032
-   10  ( 10) -0.128333935578074 -0.263327859036735 -0.068329655679101  0.087024591997986 -0.057039935036965 -0.051621611298698  0.073645648424309 -0.107556560489238 -0.002537116902128
-   11  ( 11) -0.014388047963903 -0.095897531557492  0.075761746736829 -0.083654757188919 -0.030891133031091  0.061475545358308 -0.020586611930162 -0.065614997905860 -0.075825389492545
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.046633267353021
-    1  (  1) -0.000248773711794
-    2  (  2) -0.058940238082046
-    3  (  3) -0.028215078659147
-    4  (  4)  0.009693071380795
-    5  (  5)  0.114025765710299
-    6  (  6)  0.149932383186960
-    7  (  7)  0.029309043140763
-    8  (  8) -0.056468406833596
-    9  (  9) -0.080845904093313
-   10  ( 10) -0.031944380388807
-   11  ( 11)  0.038072643167866
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000412292330125  0.089973601331934  0.299831566929396 -0.035035339281938  0.102534416749163 -0.139160673237755 -0.022726794108668 -0.127186946220527  0.025258681551895
-    1  (  1) -0.089435365325252 -0.000179018409619 -0.000575799904893 -0.036397358696681 -0.000077605512592 -0.027763068926142 -0.235329561156625  0.149048042365481 -0.020748539941476
-    2  (  2) -0.298742449986735  0.000117532207539 -0.000001365547946 -0.030750645565914 -0.035092304813822  0.156637931403196  0.074944775632850  0.084030365627553 -0.029024110989879
-    3  (  3)  0.035083534268240  0.036212512324819  0.030659339328188 -0.000140940179517  0.000968456927916 -0.032572407071500  0.017530821556219 -0.040913042583287  0.072860913708021
-    4  (  4) -0.102571067786625  0.000186672877588  0.035613278772227 -0.000984301508163 -0.000083284505465  0.006675066086515  0.008092161812671 -0.022927931588032 -0.061863833474700
-    5  (  5)  0.139766487530579  0.026940126885898 -0.158769710672111  0.032620148977718 -0.008447998102452  0.000109266532081 -0.002529804726067 -0.011694293836355 -0.013434968660314
-    6  (  6)  0.023123393533703  0.235158830889094 -0.075094645607883 -0.017636517707368 -0.007886799997649  0.001572260884544  0.000097447401663  0.019414476223635  0.005807231271628
-    7  (  7)  0.127556864975777 -0.149585463815487 -0.085819990046561  0.040749094743077  0.022487818487125  0.013521945874053 -0.020097198716066  0.000802314554648  0.005625145325134
-    8  (  8) -0.025298741297676  0.021022944558544  0.028995189539972 -0.073180879828651  0.063113474589722  0.013554956351232 -0.005975480503955 -0.005930971726208  0.000800554325514
-    9  (  9) -0.112700264643845  0.073437341408674  0.164270709854341 -0.104952328655436 -0.027707355858660 -0.001091847596269 -0.013360757417668 -0.016602481071790  0.000305982559018
-   10  ( 10)  0.061794958624484 -0.084043685363021 -0.190307519851821 -0.184568056526643 -0.046373613192876  0.061509024448409 -0.022601229760496  0.000957508970510 -0.004225767450876
-   11  ( 11)  0.048625937545448 -0.043275944873041 -0.072889882486030 -0.022571956848243 -0.129861302445486 -0.036376964004426 -0.007420842536071  0.027716174562617  0.009223617021504
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.112403684053299 -0.061844266359582 -0.048595688328450
-    1  (  1) -0.073289438710481  0.083115738233247  0.043020697969992
-    2  (  2) -0.163076133270358  0.188328773885241  0.073201670147403
-    3  (  3)  0.104459841985857  0.183989325360910  0.022816670642033
-    4  (  4)  0.027396737691172  0.045295479134009  0.129115557967778
-    5  (  5)  0.000453294188389 -0.059142853300762  0.038676049893677
-    6  (  6)  0.012371321314524  0.021833349857811  0.007208017450018
-    7  (  7)  0.015425630197400  0.001848995755235 -0.027351698922038
-    8  (  8)  0.000188535381821  0.004971799266654 -0.013988330055868
-    9  (  9)  0.002500332480999 -0.018263398716747  0.000166576528748
-   10  ( 10)  0.017029282729959  0.001958362912370 -0.009978757223056
-   11  ( 11)  0.000136976274521  0.009294880869252  0.003968240988117
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001614610532278 -0.000442574931184  0.002484843724335 -0.011617230485838  0.003558333116152 -0.008348902874223 -0.003232631795727 -0.035474959748436  0.033113190058216
-    1  (  1) -0.000925459790748 -0.002756415978539  0.003671717190974  0.027737733508484 -0.046977278124977 -0.010834189586698  0.039059419738438  0.012041835747932 -0.002521971555221
-    2  (  2) -0.003459035434675 -0.003977336342235 -0.002397115178596  0.018307436778833 -0.034854228953805  0.010228254395608 -0.015345849161942  0.005957982277486 -0.035439629368503
-    3  (  3)  0.011412707516267 -0.027632363855031 -0.015411420139492 -0.000653998533291 -0.003171166784775  0.010061032918207  0.036835076234213  0.006892251008290  0.051742329375438
-    4  (  4) -0.002517172902630  0.045696438310625  0.035505499284382  0.002530384085850 -0.000253636208605 -0.042894004341368  0.014146809697220 -0.013420506783873 -0.046216668076946
-    5  (  5)  0.010111413240912  0.013164521551321 -0.011774998630568 -0.009111026904833  0.043299806769081 -0.001105938056711  0.021679173976934  0.006497350404042 -0.032564751151170
-    6  (  6)  0.003572744448066 -0.037660563650739  0.015981449923599 -0.037360518379434 -0.013810638672119 -0.021864723269171 -0.000142160187409 -0.064951874935402  0.010074940303513
-    7  (  7)  0.035166313105451 -0.011117323575587 -0.004943664183497 -0.007105865391641  0.013161333406594 -0.006687507585744  0.064466547112747 -0.000008929989578  0.021120345923087
-    8  (  8) -0.032509023911163  0.002177177339651  0.037021275355168 -0.052629293793154  0.046088465137947  0.032895946707180 -0.009967848101922 -0.021497535040403 -0.000352351163086
-    9  (  9) -0.046618687808640  0.037317727430997 -0.035589549384149 -0.025010790590209  0.028730927164894 -0.032022748116099  0.011580581352781 -0.023706215184994  0.002053813335462
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.047931933872975
-    1  (  1) -0.037047707028514
-    2  (  2)  0.035085472287032
-    3  (  3)  0.025182750300990
-    4  (  4) -0.028820432773372
-    5  (  5)  0.031275953086245
-    6  (  6) -0.011353625053442
-    7  (  7)  0.023384944254726
-    8  (  8) -0.002155438322651
-    9  (  9) -0.000134462394627
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.017096508292429 -0.120272055653498 -0.064777511074434 -0.013939283933308 -0.004251250821330  0.059136973839352  0.058075430708834  0.010753929155031  0.046095863651254
-    1  (  1) -0.009080853524756  0.030472101004599 -0.005253613736105  0.008033743953506 -0.006571724145552  0.017271428965569 -0.096045717241910  0.001899586023459 -0.018803255158658
-    2  (  2)  0.015273557408716  0.033827870425321  0.002389839271830  0.049309614559235 -0.022714875551557  0.013412250204381  0.039215858182843 -0.002671798725080  0.073595316258831
-    3  (  3) -0.061397351425600  0.002542014700822 -0.006723003856764 -0.036114072726144  0.031891831787348 -0.035470170376113  0.050339849642367 -0.011227685711093 -0.032863858710597
-    4  (  4) -0.010418037759007 -0.052312507311500 -0.003108263430226  0.063054388106328 -0.009131466039430  0.023063009355567  0.186998825704419 -0.007656193265988  0.085937490516795
-    5  (  5) -0.049618070764987  0.269816796530382  0.071812132158805  0.093909466368595 -0.090964919694381 -0.192302531462338 -0.140007312222197  0.095346589436075 -0.068662718351823
-    6  (  6)  0.050705074903890  0.083507573951399 -0.075121836066492 -0.150175624907254 -0.110901140548139  0.044187464402636  0.100826757127919  0.348159602318287 -0.115791138943855
-    7  (  7) -0.024247361034940  0.261502177446179  0.185335196490176  0.086407538269004 -0.040595405612183 -0.132471756059254  0.167354565247558 -0.226853259555790 -0.063338369472266
-    8  (  8) -0.031044409528402 -0.062420557845031  0.150070034340745 -0.052228051583476  0.077587419735710  0.089629913379487  0.056032626281614  0.008151827554649 -0.096931788597858
-    9  (  9) -0.317132702814373 -0.055314612013316 -0.137754640120023 -0.090773612718365  0.100625469824133  0.163650859440807  0.143669062909266  0.090566852675112  0.052322376391313
-   10  ( 10)  0.142709053237480  0.301053034065592  0.082895903712517 -0.097157063403116  0.061479199300513  0.055989010255340 -0.082779787274017  0.112598796382161  0.005058093098571
-   11  ( 11)  0.016299349881188  0.110322948765521 -0.098821973474101  0.099107211043419  0.036545717852368 -0.075028438099748  0.024327846026163  0.071464427045319  0.082135257183916
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.047447570064905
-    1  (  1)  0.000600353714311
-    2  (  2)  0.061561394612175
-    3  (  3)  0.026518358614439
-    4  (  4) -0.004924249256689
-    5  (  5) -0.118873243448111
-    6  (  6) -0.158683429135866
-    7  (  7) -0.034364315517391
-    8  (  8)  0.057789177012035
-    9  (  9)  0.092690338450207
-   10  ( 10)  0.035646580943718
-   11  ( 11) -0.038984516104221
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006230857276436  0.048797056399666  0.012716116252621 -0.005739964124866  0.013481384616698  0.042689584077060 -0.017270348738051  0.000419243135126  0.040443254435763
-    1  (  1)  0.001630425204596  0.020575306800344 -0.074043146154741  0.016576990359565 -0.024266588171945  0.025003638188733  0.041229879168230 -0.009096713997008 -0.048943522201480
-    2  (  2) -0.021449672787194 -0.004533663013035 -0.064512297360970  0.026056320112975  0.012311600212379 -0.057705244730510  0.006103097277552  0.007629023643838  0.100142202402752
-    3  (  3)  0.024506116908941  0.014405190116035 -0.023988780893855 -0.096344308015785  0.049822440345522 -0.076920537167928 -0.020583335246490 -0.007240688074708 -0.088817051721264
-    4  (  4)  0.016982681746660  0.005612968048325  0.130937709169030  0.258341025931177 -0.140085239410274  0.222842232178951 -0.024820716730135  0.026325168673687  0.055547617569483
-    5  (  5) -0.037879155414163 -0.128090386002125 -0.141870995017207  0.234587600888966 -0.098914790788390 -0.305800275284305 -0.055598905633593  0.131805449829431 -0.041081235097661
-    6  (  6) -0.043168564703436  0.030010861129281 -0.029114697539830  0.006214587904626  0.071804351546120  0.111206250824606 -0.202125985301076 -0.151209805862799  0.037927022313810
-    7  (  7)  0.020929918098688  0.040166703104938 -0.207928074963598 -0.005063717904073  0.015982060703677  0.122893504730377  0.039398473312957 -0.243542435447176 -0.058898622679243
-    8  (  8)  0.035897100247807 -0.130947966136576  0.251331455270193  0.079974479173535  0.413130980507748  0.044171581238907  0.028005185833489  0.165066997038960 -0.062489289780689
-    9  (  9)  0.085514193547145 -0.054930855523547 -0.094296152584403 -0.050328255510316 -0.067641033769805 -0.023318053487733 -0.006464024057725 -0.152704070253429 -0.195690762137195
-   10  ( 10)  0.121783132454786 -0.121649518544985 -0.001288572370528 -0.044670432803679  0.008034312045081  0.029879089305665  0.065139715799550 -0.014008708897036  0.002845810213058
-   11  ( 11)  0.023815006694348 -0.014334287141683  0.141630066387855  0.145326344089203 -0.037857456986322  0.058499598917858 -0.030801987861182  0.076045397273525  0.051718689270491
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.052021099116092
-    1  (  1) -0.000375019046341
-    2  (  2)  0.005095441550314
-    3  (  3)  0.212700400741322
-    4  (  4)  0.008054755280988
-    5  (  5)  0.023289560627031
-    6  (  6) -0.062134458371494
-    7  (  7) -0.183963154970289
-    8  (  8) -0.064610383082142
-    9  (  9)  0.033969497782711
-   10  ( 10)  0.034207553536027
-   11  ( 11) -0.027487667010859
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000165454282488  0.050277476849634  0.072265886779903  0.219046110490914 -0.170649240297555 -0.129272117676281  0.046129561714749  0.006317178179283 -0.031628796061177
-    1  (  1) -0.049926970343888 -0.000066751428030  0.008605428716391  0.088466711253630 -0.066209204064307  0.157896361055452 -0.137975283709074 -0.116685446085702  0.066609214976363
-    2  (  2) -0.071930707909687 -0.008646608001517 -0.000252105095070  0.010529809483454 -0.048142356541763 -0.064293359314159  0.026509274318636  0.087307307132468  0.055490250957849
-    3  (  3) -0.218638932403761 -0.088400431595603 -0.010362259249877  0.000161808465947 -0.006831656503924  0.050359143062454  0.002950107894051  0.043414691353781 -0.231632275337861
-    4  (  4)  0.170408151565692  0.066676104740888  0.048741085770175  0.007781046963117 -0.000858319634312  0.017393073562842 -0.004806366800845  0.002128732121080  0.034666156637510
-    5  (  5)  0.129353639616675 -0.158198145877926  0.063792237373481 -0.051918849505394 -0.015159666578669  0.002164443359528  0.004048396359766  0.028258116638309 -0.019204959902610
-    6  (  6) -0.046105252486005  0.138278098772584 -0.026048974354469 -0.002423377188050  0.004804777279161 -0.005123584343751  0.000505492048966 -0.004681249428299  0.016114426086496
-    7  (  7) -0.006108731746456  0.116491031311707 -0.087525580101622 -0.043947283481964 -0.000746891253088 -0.028211685279895  0.004399353185530 -0.000226937079603  0.001563554764084
-    8  (  8)  0.031635416967255 -0.066903366010132 -0.055032255173046  0.231683009312988 -0.036206711489392  0.019839043489615 -0.016402673760561 -0.000838534461521 -0.000669878290914
-    9  (  9)  0.101001614493512 -0.035831143017804 -0.051001612315387 -0.120753800379163 -0.001670851222790 -0.022069869139317  0.000180056135152  0.007894743612700  0.004712239169077
-   10  ( 10)  0.077799422553552 -0.050172827558475 -0.178180262760682  0.011809496949311 -0.042695780330294  0.018100828459930  0.003739392396915  0.021764215771311 -0.004254325334512
-   11  ( 11) -0.170574833391475  0.090218966161298  0.186165933844747  0.106592282303210 -0.035685321173548 -0.005531846565163  0.019468178901053 -0.028819942408996 -0.018249838127253
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.100729285954756 -0.077818756543715  0.170553425058221
-    1  (  1)  0.035210403182738  0.050067933089505 -0.091777926183755
-    2  (  2)  0.050619295779235  0.177821703580419 -0.188186480685002
-    3  (  3)  0.120238811273927 -0.012548687236120 -0.107146423121442
-    4  (  4)  0.001472161299553  0.042086791480199  0.037190721415684
-    5  (  5)  0.022276355941346 -0.015313888242227 -0.001378381953714
-    6  (  6) -0.001377652740630 -0.005127424181781 -0.019087401021940
-    7  (  7) -0.008204594963178 -0.020563680487320  0.026290026069629
-    8  (  8) -0.004730566883743  0.003787060797718  0.021343901910363
-    9  (  9)  0.000654068579583  0.020656394329926 -0.003094384610269
-   10  ( 10) -0.019022274800240  0.000759677344253  0.055278729862632
-   11  ( 11)  0.002626982476879 -0.053971886669755  0.001915083825045
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000967260159080  0.002202446432524  0.004511183444430  0.016374841316601 -0.010910776906997  0.001418525150323  0.006755217615277  0.000427817126425  0.035846025325519
-    1  (  1) -0.000391246067407 -0.000877310728950  0.036241037300273  0.001407367638059  0.003934213075234  0.029267906970015  0.005602239959753  0.010795263272597  0.003740186293266
-    2  (  2) -0.003829576674383 -0.036990457610833 -0.001398441262724 -0.029943520801568 -0.002038487479024  0.023272259992080  0.008230578537541  0.007682382933230  0.017088399951020
-    3  (  3) -0.016032914359479 -0.000368568996962  0.031158252703803 -0.000059940788557 -0.028967799575646  0.026891964655620  0.003191177418001 -0.012156707421423 -0.040980572338667
-    4  (  4)  0.011582657878517 -0.004557355848480  0.002754831890239  0.029254644747513  0.000056895383566  0.010447389828344  0.011227363550004  0.017276460075010  0.082609995830667
-    5  (  5) -0.000873189786955 -0.030297579893434 -0.024073075343027 -0.026022721348298 -0.010366640393980 -0.000392801080983  0.006236144036416 -0.025488940454099  0.075546848613138
-    6  (  6) -0.007828000597579 -0.004715416733939 -0.007204534812621 -0.003548053014936 -0.011139775691561 -0.005780043754072 -0.000209890995218 -0.022093647786116  0.021521213110625
-    7  (  7) -0.000136712832700 -0.010084233633668 -0.007596217834139  0.012002297241493 -0.016971650696249  0.025598072815601  0.022061499371271 -0.000030924207599 -0.027480037260575
-    8  (  8) -0.034517163034967 -0.003881690632474 -0.018182293711114  0.041467916178783 -0.083381816772957 -0.076400917002772 -0.021226287037618  0.027577743559442  0.000308523373358
-    9  (  9)  0.006887640002591 -0.038004114862362  0.068066991173237  0.074540859178153  0.096325885879967  0.063826495228134  0.021741321038929  0.075328539771934  0.015720438309394
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.006955591851981
-    1  (  1)  0.037011716243653
-    2  (  2) -0.066925876832342
-    3  (  3) -0.074849385969586
-    4  (  4) -0.096213956733721
-    5  (  5) -0.063907467407383
-    6  (  6) -0.021571044568900
-    7  (  7) -0.075014265081936
-    8  (  8) -0.015443164438173
-    9  (  9) -0.000349977346717
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008473601581619 -0.058320078803013 -0.009499899472232  0.001088259135238 -0.016242997407558 -0.041642820354273  0.019281478381302 -0.001541696314659 -0.042254273858150
-    1  (  1) -0.000334490440486 -0.020235443091975  0.074874760692952 -0.017019076387196  0.023949159076861 -0.029015987792742 -0.043482201692770  0.008653533652648  0.050609003215613
-    2  (  2)  0.017649927420035  0.005466470543623  0.062819872537720 -0.024335617743925 -0.013549365831462  0.057638943360770 -0.007946525598619 -0.007453269935932 -0.104441618231136
-    3  (  3) -0.020783291637709 -0.012738132257300  0.020888891645260  0.097905028236283 -0.052672606431380  0.073196008154541  0.021238374576188  0.005922717755271  0.087456377608286
-    4  (  4) -0.016996530387751 -0.011882557110211 -0.133285493089740 -0.270904493255005  0.144936247136341 -0.230612270825641  0.025999484339616 -0.027186445681165 -0.054335849730519
-    5  (  5)  0.043265455211536  0.139979958816237  0.149715430516995 -0.247713647604899  0.102410559077642  0.319151604186489  0.057805788052851 -0.138415193321428  0.046014997665461
-    6  (  6)  0.052880707652045 -0.033123002053909  0.032014076939227 -0.006298867450682 -0.077062313270277 -0.118246557884146  0.214649227435815  0.157387472815374 -0.039780533308888
-    7  (  7) -0.019315588907448 -0.037515736358395  0.221610727048942  0.003867379753041 -0.018038584173024 -0.130726889432006 -0.043210067374229  0.255244255063184  0.061970702798214
-    8  (  8) -0.039457544550719  0.137467753709456 -0.263418210746405 -0.083532282441423 -0.434570179765344 -0.040715456256394 -0.028807073739423 -0.172129116920192  0.067053424144521
-    9  (  9) -0.108821808763067  0.058176331616836  0.096181779066212  0.052585164814310  0.074960862104189  0.030411666230606  0.005322365866114  0.162638108566386  0.208900911424941
-   10  ( 10) -0.143141318703370  0.135644721237897  0.004816763589682  0.046370390666413 -0.007684027070582 -0.031560700160296 -0.073644359681820  0.014497709274558 -0.002720022476073
-   11  ( 11) -0.028228442161314  0.029546966066375 -0.156785160510693 -0.149588448608652  0.045289290724147 -0.066420712374432  0.030566776449830 -0.079826396018234 -0.056206720757084
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.054452002537081
-    1  (  1)  0.000507638322506
-    2  (  2) -0.005540126912246
-    3  (  3) -0.215642625069238
-    4  (  4) -0.015797761320826
-    5  (  5) -0.020861352515884
-    6  (  6)  0.063379663837058
-    7  (  7)  0.192560463271225
-    8  (  8)  0.066391989253748
-    9  (  9) -0.030368405143431
-   10  ( 10) -0.036776046301376
-   11  ( 11)  0.030367451420999
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.057770723551805  0.007686176362995 -0.037676874102239  0.021875314889184 -0.005506967440553 -0.033731453254856  0.019605915987929  0.000153810358456  0.020480209762043
-    1  (  1) -0.007936092328855  0.008454757012618  0.010966637507272 -0.001712970012603 -0.003491085971866  0.000515536715359  0.020166951580993 -0.003537118918414 -0.007401819292438
-    2  (  2) -0.004823273660701 -0.024918096949402 -0.013456316532648  0.018061040723257  0.007928867774181 -0.029348077247204 -0.008305651855965  0.003787093111853  0.048173394734837
-    3  (  3) -0.011675775125104  0.107663431050362  0.048399528007616 -0.036525102270435  0.040730641356466 -0.022154401905676 -0.022459222262206 -0.014732815012435 -0.056193647103106
-    4  (  4)  0.087218313447135 -0.162702625594382 -0.040016358931151  0.090893257640902 -0.161526551014906  0.070532962320029  0.041494660476799  0.036307465283525  0.053954994619678
-    5  (  5) -0.299080380154522 -0.047071149143854 -0.050599107356677  0.086076035660096 -0.105747613370625  0.016291716828988  0.035370479977499  0.024570880182810  0.019740472062472
-    6  (  6)  0.064660820062842  0.041897488689090 -0.115036198620178  0.009494466980017  0.021741244197439  0.082050622741463 -0.041036304002792 -0.093842813724870 -0.099009311380003
-    7  (  7) -0.041406109005398 -0.013292096025031  0.015299070066933 -0.090658889471223  0.096664535474361  0.020138730803122 -0.181635797654581 -0.008096043748855 -0.043219320460348
-    8  (  8)  0.213166983290885  0.019961961605909  0.071163032757987 -0.089566388255459  0.187567657300030 -0.059322694628756  0.181371262434162 -0.031805535782928 -0.037438192749058
-    9  (  9) -0.029081682004423  0.052377114086944 -0.016598919354525  0.054121123864817 -0.005943121322964  0.052845962329270 -0.099913404453613 -0.011257505074012  0.046946017590445
-   10  ( 10) -0.029775807936917 -0.011144658296549  0.123616713069900 -0.069048925266029  0.072425392135727  0.175724644218768  0.020473761865880 -0.027329304597195  0.030635509122054
-   11  ( 11)  0.065686621670288  0.046175058814983  0.054739230530016  0.067089838730126 -0.085213076503212  0.033327993779702  0.039100303871838  0.006432393458887  0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007846989553355
-    1  (  1) -0.003599492488651
-    2  (  2) -0.050462951485827
-    3  (  3)  0.025590884562196
-    4  (  4)  0.058023095683205
-    5  (  5)  0.032774222915836
-    6  (  6) -0.063967275967677
-    7  (  7) -0.008682341559207
-    8  (  8) -0.054096899442108
-    9  (  9) -0.060114344610370
-   10  ( 10) -0.027778486812577
-   11  ( 11)  0.026791075407401
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000027040423887 -0.011060683872803 -0.004793456647899 -0.073481718860181  0.071504628495016  0.043329380984548 -0.025554578097106 -0.020981780177699  0.009741644195740
-    1  (  1)  0.011009750762997  0.000007607240151 -0.023558132508086  0.077101510719000 -0.072464798814331 -0.012890143420536  0.005683277430906  0.006920173400283 -0.002574145843753
-    2  (  2)  0.004842956248702  0.023538681455719 -0.000165226839542  0.207870652255993 -0.210753100259611 -0.104860036207310  0.066732822825146  0.046426833468215  0.005606364639263
-    3  (  3)  0.072846425542822 -0.076633967419021 -0.207131819599136  0.000363002499158  0.003747206858118  0.078444561827851  0.135702906183535 -0.013002670417717 -0.066080178603036
-    4  (  4) -0.070600283658190  0.071629978927021  0.209426851727876 -0.004131403945752 -0.000622007773293 -0.030404083775686 -0.072573499649568  0.005804369418180 -0.017256603820917
-    5  (  5) -0.042938103533211  0.012767138266668  0.104089521411634 -0.078509088982138  0.031589837534126  0.000702189622727  0.234416668036359  0.006073164073880  0.085676616502380
-    6  (  6)  0.025301081140471 -0.005670371975564 -0.066621493148361 -0.135369815380962  0.072186642283625 -0.233429156027521 -0.000193153533248  0.257186865053465 -0.080618496507255
-    7  (  7)  0.020822354558258 -0.006724508724119 -0.045993762455479  0.012965367547761 -0.005443358605263 -0.006173477804865 -0.257050229473736 -0.000107746294773  0.140355654948263
-    8  (  8) -0.009433315806276  0.002386871891496 -0.004905034102302  0.065444732417879  0.016877777772437 -0.086229493149666  0.079936884810997 -0.140925849197376  0.000032973152365
-    9  (  9) -0.050122316171813  0.043792237275169  0.089139695085719  0.017498120874682  0.031599257819379  0.003933044438540  0.023956851013655 -0.023591093022906 -0.231355322027963
-   10  ( 10) -0.021733936110572  0.028861084661254  0.012680330783905  0.120427356784394 -0.061995107162282 -0.110107780731446 -0.044522956915282 -0.044154909833586 -0.092344585382497
-   11  ( 11)  0.054009861310889 -0.049060128861341 -0.116101359422429 -0.043743279836749 -0.090347856826429  0.186254068915307 -0.010091097621831  0.182439821622372 -0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.050351452990167  0.022080091821478 -0.055614920128739
-    1  (  1) -0.043523152379598 -0.028913570586242  0.049281187081852
-    2  (  2) -0.088800989050704 -0.012387284429283  0.115844546053497
-    3  (  3) -0.017174780224652 -0.120766108673226  0.043936127494914
-    4  (  4) -0.030870076304731  0.062251132422338  0.090680792727787
-    5  (  5) -0.006295822004517  0.109602420736026 -0.187179028172583
-    6  (  6) -0.023342165877015  0.045357751936196  0.008109043414047
-    7  (  7)  0.023116687534610  0.043892116907456 -0.180954962224114
-    8  (  8)  0.233341712412303  0.091442003006516  0.004136900096905
-    9  (  9) -0.000301754743843 -0.311200434843549  0.071746006250031
-   10  ( 10)  0.310579381122594 -0.001146128096000 -0.337175845358798
-   11  ( 11) -0.071759110731455  0.341710402101474  0.000514995746851
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000373475564698 -0.036374284715410  0.020675408038120  0.041938611278043 -0.014954064130636  0.008670693741941  0.001941666498966 -0.002175213653671  0.081223953533966
-    1  (  1)  0.035409311090430  0.000583412494499 -0.021912114995751 -0.019686191919175 -0.001337756516393  0.101410043872272  0.013539530463413  0.021085032009130  0.104140442794578
-    2  (  2) -0.022476650279619  0.020869170321065 -0.000623148668542 -0.026925059222749  0.022600045203783  0.054500059821995  0.019747085432266  0.002197258536137  0.059803959084815
-    3  (  3) -0.040527884961938  0.020785023904239  0.026269813130118  0.000471315833621 -0.011435927824319 -0.005094359128676 -0.021078069661848  0.001900689912103 -0.049285996887456
-    4  (  4)  0.014876995236008  0.001935832477363 -0.021280417512247  0.011112950356736 -0.000010954074914  0.001375736589678  0.021071346294591 -0.002540388393255  0.057176443725449
-    5  (  5) -0.009413911140341 -0.101590521816804 -0.054440250203052  0.004479146413684 -0.000983185589705 -0.000044886603863 -0.008942266041566  0.007734744988056  0.012623227871857
-    6  (  6) -0.001228199632690 -0.013460754514196 -0.019370737847276  0.021147815413154 -0.021180440912387  0.009078596190780  0.000060187992369 -0.021757615671251 -0.021546696625458
-    7  (  7)  0.002386621109668 -0.020697715049428 -0.002142304032572 -0.001889845237358  0.002502377714011 -0.007891184567460  0.021671667697211 -0.000014467640044 -0.019485620614445
-    8  (  8) -0.082726042327291 -0.104120679625015 -0.059410287861643  0.049170685661379 -0.057558349352742 -0.011952514103015  0.021313492463386  0.019559674827960  0.000280085719614
-    9  (  9)  0.081272328726009 -0.110754135563007 -0.028218762900775 -0.005318083145326  0.020981856638396  0.014567561104212  0.097856532501808  0.003185861516469  0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.080531031337273
-    1  (  1)  0.111220099551316
-    2  (  2)  0.028332370195928
-    3  (  3)  0.005372945270244
-    4  (  4) -0.020768901638641
-    5  (  5) -0.014982546342664
-    6  (  6) -0.097582479807565
-    7  (  7) -0.003277826561639
-    8  (  8) -0.003260780284830
-    9  (  9) -0.000186812021876
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.055078142867828 -0.005804719299681  0.036780646353647 -0.020745008939831  0.005631321838333  0.032388434299089 -0.019554696167851 -0.000026315290494 -0.020764618651157
-    1  (  1)  0.007062764870854 -0.009531925050962 -0.009339128991500  0.000585332198702  0.003536715157378  0.000717716084393 -0.020997702694190  0.003197609406412  0.007543205569196
-    2  (  2)  0.003273721829615  0.024127785783056  0.019803917766004 -0.021792459075320 -0.009225997435944  0.033280936086821  0.008357612389432 -0.004534634518823 -0.049752671423908
-    3  (  3)  0.009467819748219 -0.109846311430058 -0.049077069582499  0.038067479834844 -0.041344367688361  0.023164856965512  0.023494777837550  0.015492414054440  0.057415728354703
-    4  (  4) -0.087998530211411  0.166680738017738  0.040492236619192 -0.094854089537164  0.166732509395464 -0.071703004448668 -0.042087550249065 -0.037122017300705 -0.054342710801435
-    5  (  5)  0.299229806278301  0.048658757713325  0.047129705842446 -0.086908947365866  0.109728878663932 -0.016789363568018 -0.035383410684614 -0.025335321764417 -0.020816334753998
-    6  (  6) -0.066809370303780 -0.045194542515417  0.116536125053039 -0.010429907504714 -0.024187359392906 -0.082665971873618  0.044425337546003  0.096427706292236  0.099634759729367
-    7  (  7)  0.040692585686945  0.010414403444448 -0.019197392244389  0.094603783326762 -0.099044517012418 -0.021567521501408  0.184530946067710  0.010140666068000  0.044429992698867
-    8  (  8) -0.213871489773344 -0.016533777636027 -0.072796199007045  0.091991735348903 -0.195396773842710  0.059284334625803 -0.184339397290396  0.031894612373968  0.038856272349111
-    9  (  9)  0.030682243044227 -0.041775517875249  0.024602057980135 -0.057287290343526  0.006772740334119 -0.055735826221076  0.097648839100779  0.011580457295414 -0.048271645082472
-   10  ( 10)  0.033182564179255  0.014791814568441 -0.134627953730393  0.074303509883212 -0.072048570540947 -0.178297714606306 -0.018972497943516  0.029382172234938 -0.026191954922422
-   11  ( 11) -0.065304385216644 -0.054065687922946 -0.058978656197155 -0.069527138693935  0.087278294466894 -0.031923025189413 -0.037244505404452 -0.006712268565440 -0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007990021156235
-    1  (  1)  0.003543862611170
-    2  (  2)  0.051263654644270
-    3  (  3) -0.026303130686066
-    4  (  4) -0.059400171065937
-    5  (  5) -0.033889468632128
-    6  (  6)  0.063573026890197
-    7  (  7)  0.010425863419296
-    8  (  8)  0.056178737365981
-    9  (  9)  0.060112542127891
-   10  ( 10)  0.033303474011037
-   11  ( 11) -0.026602109435667
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.023607177491195  0.019696611969885  0.037221212000385 -0.015590319696057  0.002020189842990  0.021016653547429 -0.007873916136755  0.003448340610807  0.079821954504390
-    1  (  1) -0.007327805297828 -0.018867534486269  0.042212469078496 -0.001447360534353  0.028939866752754 -0.077938653083341 -0.061948383376365  0.004945505795557  0.075894556663474
-    2  (  2) -0.009007071740861 -0.016177005802987 -0.068312932673240  0.041184857036759  0.003023256838844 -0.009849571097863  0.004290386808972  0.004340519661127  0.085840789796801
-    3  (  3)  0.026077185963910  0.012520558385893  0.023360353465929 -0.029787599349062  0.027312833784239  0.081100062029021  0.033406666012159 -0.054430078300136 -0.042036783131155
-    4  (  4)  0.044521029970710  0.101548028530885  0.092152577419686 -0.036969661342643 -0.235975964790827 -0.022489800485005 -0.018037809327809  0.163273258200919  0.255997686637622
-    5  (  5) -0.075082806179399  0.059495559215694 -0.178951166772656  0.134634824114366 -0.237022622504406  0.054772185517501  0.024504277147484 -0.150049663229407  0.003365655895118
-    6  (  6) -0.075564373604390  0.030719217759732  0.086498148733354 -0.160325933966896  0.064234285643905 -0.161900908445555  0.266146706738358  0.238096934941697  0.054011663901563
-    7  (  7) -0.117049393955643 -0.184359827232724  0.154835473828309 -0.196676571259727  0.209716028817009 -0.429620861048445 -0.096138950091600  0.371356959007903  0.058084061024513
-    8  (  8) -0.116322044765828  0.134673176933366 -0.115490121530453 -0.372419146214479  0.134366059259054  0.090977060566167 -0.047847126119104 -0.349531731511066  0.026343643532612
-    9  (  9)  0.016166361653787 -0.064655468388956  0.096603309196917 -0.102141195994536 -0.004689543577322 -0.174053614560893  0.096535422651742  0.179574162178272 -0.093140031286430
-   10  ( 10)  0.038118657992317 -0.011712936317703 -0.109233641260348  0.041948680427994  0.067033240911419  0.043789144467457  0.119198984082488  0.019961916251994  0.046236232124822
-   11  ( 11)  0.202537936665755  0.041865413038804 -0.001109842658197 -0.036047997932446 -0.209039172907281 -0.039634162843452  0.042796449278664 -0.037154632643052  0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001464671751436
-    1  (  1)  0.092168971837118
-    2  (  2) -0.096834154775615
-    3  (  3) -0.085232004143247
-    4  (  4)  0.224276823308218
-    5  (  5) -0.037070717977035
-    6  (  6) -0.017788678150516
-    7  (  7)  0.125655013910958
-    8  (  8) -0.036753750028807
-    9  (  9)  0.104788947042948
-   10  ( 10) -0.055723652563089
-   11  ( 11)  0.029086171780033
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000103943053471  0.020502980666838  0.044487026908476  0.112522389921676 -0.115190927698806 -0.086304427533430  0.028732798000328  0.005755262072674 -0.052707374815472
-    1  (  1) -0.020396732597728  0.000175507711089 -0.066631576709106 -0.188566511167110  0.188604507023904 -0.081802717690830  0.123212599282903  0.146580404278728 -0.063843813395139
-    2  (  2) -0.044224363892114  0.066688325942716 -0.000328779542201  0.131627364199491 -0.085838688001563  0.039792906367986 -0.071990397116460 -0.041811204620793  0.129151440044184
-    3  (  3) -0.112356491847955  0.188595812422395 -0.131743983691740  0.000034238258909  0.146405835083834  0.293116155503685 -0.174354593749844 -0.234740190959724  0.068400431241803
-    4  (  4)  0.114478156906703 -0.187880772610577  0.086711640119064 -0.146345707242046 -0.000351413466984  0.200401380550659 -0.118118144680811 -0.106599388398520  0.027535193682288
-    5  (  5)  0.086013769068620  0.081687368012874 -0.039811317138268 -0.293720012918757 -0.199751621453618  0.000779002249077 -0.029574633012291 -0.100809576430270  0.310087999943630
-    6  (  6) -0.028593362634754 -0.122990647052479  0.071886866993686  0.174357265134888  0.118164594946332  0.029455932226559  0.000323502179386  0.067588972736558  0.054838186724730
-    7  (  7) -0.005405231783831 -0.146637005514722  0.041701223809144  0.234444344892692  0.106310138998589  0.100760684833959 -0.067340032280388  0.000050446895501  0.206356025427645
-    8  (  8)  0.052734404217526  0.064663294136106 -0.127867798766573 -0.067686878519552 -0.027452578317565 -0.311518253800823 -0.053511305641188 -0.206912543882787 -0.000090733997612
-    9  (  9)  0.040822323151076 -0.050351126620632  0.033443030139718  0.028678071562223 -0.070729562284205  0.035204318394559 -0.035088801145452 -0.003858253384271  0.209126878103916
-   10  ( 10)  0.043554697985060 -0.034029200702705 -0.113396889510888  0.025104351967769  0.057922093461755  0.050331966245759 -0.113578028555237  0.006845000513571 -0.183899295084893
-   11  ( 11) -0.104445737487499  0.085327185159750  0.138831980783855  0.068059267872915  0.045287984054307 -0.106421559557756  0.126370094892912 -0.085884676801538 -0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.040472375428214 -0.043732687824618  0.105326662293090
-    1  (  1)  0.050113148730272  0.033553830886801 -0.085228632878169
-    2  (  2) -0.033648303602896  0.113430364410931 -0.140304701766262
-    3  (  3) -0.028908821271170 -0.025577280295259 -0.067243263311150
-    4  (  4)  0.070488811800233 -0.058243639304596 -0.043815524401846
-    5  (  5) -0.035954881502730 -0.048633621823234  0.102557737449989
-    6  (  6)  0.034599692943826  0.112216626584703 -0.126288398892548
-    7  (  7)  0.003737404887253 -0.007316223089443  0.087031799969318
-    8  (  8) -0.210522602449556  0.181960897898471  0.040780655119777
-    9  (  9)  0.000486792078199 -0.154877597629272  0.324381992896252
-   10  ( 10)  0.154731729402294  0.001003846432056  0.227757018056261
-   11  ( 11) -0.321308213629134 -0.230320716710505  0.000521529871008
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000267990887146 -0.017094909685382  0.026886221509252 -0.009154729792392 -0.028447394308811  0.043026223139973 -0.007934241734193  0.017529929372393 -0.048064409198736
-    1  (  1)  0.019165257539447 -0.000577613190074 -0.023971643573307  0.023362002438445 -0.020466955482562  0.074368923093670  0.021220838937975  0.006899315294507  0.004345205689582
-    2  (  2) -0.030573367311208  0.023520686332899 -0.000895230171902 -0.026482533037414  0.055578356600337  0.061212128793543  0.006033035982650 -0.029878597421323  0.067713186454891
-    3  (  3)  0.011556055604803 -0.022912214561881  0.028040995483179 -0.000806143570890 -0.016669730389240 -0.057830279830177 -0.001162806518994  0.022110531165998 -0.132937508894661
-    4  (  4)  0.029247962187325  0.019722933579604 -0.053631431975867  0.015590855142050 -0.000406564753787 -0.013151443352440  0.005583751708839 -0.048344741694769  0.058950645196782
-    5  (  5) -0.044502924478349 -0.074343902828738 -0.059891074519534  0.057011647107618  0.013642181191740  0.000660380157385  0.021619837229525  0.066247874288904 -0.026658775788480
-    6  (  6)  0.008416217090956 -0.021046309429680 -0.006522358687724  0.001270652730649 -0.005678899154477 -0.021925039235368  0.000233190982568  0.044213316193167 -0.019149792461568
-    7  (  7) -0.017220078580887 -0.007669026797702  0.030414088472195 -0.022279636607030  0.047947045698118 -0.066391322818188 -0.044159499520014 -0.000036612147908 -0.012788358083278
-    8  (  8)  0.049286641691243 -0.005157181302332 -0.067669102261374  0.134137839836174 -0.059598226202850  0.026736423898111  0.019691121432993  0.012900597372237 -0.000145671342113
-    9  (  9) -0.013771428368881  0.001534324314609 -0.097208563857550 -0.041538777135659  0.016922202614382  0.071792645864290  0.010700525463409 -0.088926800959210  0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.013388445223016
-    1  (  1) -0.001743269961120
-    2  (  2)  0.097384653394849
-    3  (  3)  0.041118719872747
-    4  (  4) -0.017104740675403
-    5  (  5) -0.071235600573670
-    6  (  6) -0.010744046806778
-    7  (  7)  0.088045104682667
-    8  (  8) -0.027915642785476
-    9  (  9) -0.000257740691093
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.024087436020668 -0.024234923487922 -0.034655069016827  0.013002508462274 -0.003506876735183 -0.019138226509165  0.008729154622077 -0.004126516633947 -0.080810387962203
-    1  (  1)  0.007340388106341  0.022740162593799 -0.047399213843079  0.000077807499313 -0.029710781800549  0.077091731467965  0.063337905707382 -0.003225301246506 -0.076935684639064
-    2  (  2)  0.008533292606078  0.014866249844284  0.069414473601385 -0.039067032188858 -0.004447555351962  0.009557153079335 -0.003933218079563 -0.004684619630234 -0.087696717260759
-    3  (  3) -0.022970088927143 -0.014796917693540 -0.027844101865804  0.035221698386289 -0.026363064761687 -0.090054977556852 -0.034727496736464  0.055362273105074  0.041999796595917
-    4  (  4) -0.041840045940810 -0.108064430049583 -0.094169303786903  0.038045467810124  0.242703284807102  0.022096059239039  0.018423933000872 -0.169152570163926 -0.255707171958253
-    5  (  5)  0.076575292532566 -0.064169513057282  0.187842221364997 -0.139017281082776  0.239663562780447 -0.056101309100792 -0.026864961939161  0.152773054853442 -0.000863550220823
-    6  (  6)  0.082619291232389 -0.034129866388443 -0.092672858212650  0.166047996934064 -0.066033557533197  0.164979644828487 -0.279604374284854 -0.245415146187524 -0.057275952528883
-    7  (  7)  0.119525510255884  0.192558180615050 -0.157479601093184  0.199612815310399 -0.216488749413977  0.438370355171240  0.097840156788249 -0.385286937285113 -0.058774287435548
-    8  (  8)  0.115070416909243 -0.142091116044252  0.125572997790340  0.378869543679260 -0.139572537143277 -0.093921809248974  0.047279124915748  0.359195083957732 -0.024443650320069
-    9  (  9) -0.023211259159309  0.064251202673602 -0.092489429719048  0.099069758679955  0.005272254913816  0.184087259640687 -0.103465084079069 -0.187259798043465  0.097400286560574
-   10  ( 10) -0.039092748606065  0.013006586457309  0.115772480099790 -0.044153430983449 -0.068039357936569 -0.040474168285568 -0.124671276809929 -0.020291967592974 -0.043718085717437
-   11  ( 11) -0.205517300660670 -0.035576186745690  0.000856944671273  0.036648470964825  0.217305799958921  0.037828885346138 -0.045859373489911  0.037554955798535 -0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001311477468569
-    1  (  1) -0.093224324445080
-    2  (  2)  0.099200064811294
-    3  (  3)  0.086458921973920
-    4  (  4) -0.229446975291319
-    5  (  5)  0.035136747289852
-    6  (  6)  0.019108151626501
-    7  (  7) -0.127376470092273
-    8  (  8)  0.036832911731868
-    9  (  9) -0.106598068979743
-   10  ( 10)  0.058544237541584
-   11  ( 11) -0.029477471817291
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.089840465204225 -0.055253525883540 -0.050839656601929  0.011592120168853  0.028453073767485  0.033272498563027  0.013123122183092  0.010376152774617  0.046773274930095
-    1  (  1)  0.019180458750845 -0.004406050242553  0.021028155566967  0.011538680320289 -0.014109247012132 -0.033202867729220  0.146724711919951 -0.006291497986158  0.032816512639240
-    2  (  2)  0.008004935891454  0.083588166091295 -0.024500417662889 -0.004976479402859 -0.015361678869856  0.027030028650554 -0.075999531355577  0.040388417899799  0.092155828534757
-    3  (  3) -0.072751395760345 -0.101339872261880 -0.027554632505315 -0.017104143799594  0.009883810143648  0.054325029446985 -0.038424568195001 -0.007564948769101 -0.050859249479548
-    4  (  4) -0.116869612062058 -0.168448689602172 -0.076045170807919  0.039076911238534 -0.141061895780680  0.082089594379007 -0.096305838370831  0.090937592520626  0.089867596085833
-    5  (  5)  0.362411548066203  0.116301468610581  0.067304641586918  0.178833394354847 -0.120526935264372 -0.077690766748935  0.087853646530869 -0.131583743921650  0.005449987066682
-    6  (  6)  0.023022243577310 -0.091878291587840  0.168295716396468  0.360782087280141  0.197772285105134 -0.118427120672179 -0.100301554555422 -0.545992767837121  0.002274268616602
-    7  (  7)  0.332469089310140  0.094037896803367  0.021326282942452 -0.202588446745432 -0.003095262967230 -0.074773576198707 -0.261809753005545  0.312310926113466 -0.101271338039676
-    8  (  8)  0.102262443511968  0.018323432973791 -0.030286707735275 -0.141132962784100  0.140087132441384  0.016144892573022  0.105178803101546 -0.077042517784067 -0.061204405030880
-    9  (  9) -0.062921845500970 -0.223934495766079 -0.055471945329417 -0.006791304491310  0.142947280894142  0.007991932919943 -0.047858230706461 -0.145718178913241  0.072195393114585
-   10  ( 10)  0.062281498028430  0.059385022217194  0.196384149116451  0.042900612771916 -0.059951865879116 -0.109494756681462 -0.025377610533051 -0.255425379720525  0.006903138405362
-   11  ( 11)  0.109893814765672  0.036299338598219  0.008950289795172  0.103979082032925 -0.089663281746559 -0.076642658317109 -0.017386558594104 -0.075203103677764  0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015115955084904
-    1  (  1)  0.030649150844450
-    2  (  2) -0.004117081641871
-    3  (  3) -0.011275331966881
-    4  (  4)  0.082379096749867
-    5  (  5)  0.010925397739678
-    6  (  6)  0.209001724905895
-    7  (  7) -0.094421017044117
-    8  (  8) -0.009881568354141
-    9  (  9)  0.113416879853688
-   10  ( 10)  0.045856944277529
-   11  ( 11) -0.007202279712064
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000220708940429 -0.002285125103983 -0.191707004311250  0.079176547202062  0.015343724284655  0.090762856917070  0.035966370439669  0.080228715251931 -0.022632088832219
-    1  (  1)  0.002270884902228 -0.000127565392507  0.181504505051190 -0.084301622984598  0.019134286473150 -0.136527597935967 -0.291828838790707  0.086935165867290  0.003153353795357
-    2  (  2)  0.190790178739451 -0.181286631653937  0.000456958950263 -0.098736144982791 -0.201937120878681 -0.060858985812145  0.102547416191644 -0.128157455079926  0.052263022287278
-    3  (  3) -0.078674978461285  0.083802623610643  0.098399673810258  0.000007811365746  0.051373438075815  0.073262818066183  0.213681674768555 -0.159362252554929 -0.021801220424175
-    4  (  4) -0.014664072597960 -0.019624839214450  0.200908806156840 -0.051706138267892 -0.000345872163641  0.060049554881332  0.188299165959522 -0.122222075869351 -0.002767654097179
-    5  (  5) -0.090883158144736  0.136634126073923  0.061672946710902 -0.074085610649007 -0.059059222367226  0.000127348357414  0.089421360456473 -0.068061409120582  0.127845689145142
-    6  (  6) -0.036070137194869  0.291478881075219 -0.101913218910275 -0.213840026067922 -0.188217301311726 -0.090313292624869 -0.000227988253159 -0.211121150654972 -0.048790729392591
-    7  (  7) -0.080292928774450 -0.086502244153537  0.129683189759572  0.159077086898913  0.122727489493275  0.066634459735053  0.210168861536432 -0.000749252129634  0.114771568876213
-    8  (  8)  0.022833189301314 -0.003149552694449 -0.051809982276026  0.021432628906503  0.002600755913054 -0.127892598520278  0.048118709288206 -0.114794510187460 -0.000092800261922
-    9  (  9)  0.153861672366712 -0.063959309581427 -0.276686698038017 -0.018129236980868 -0.051934404023196 -0.023341508326279 -0.078386885605064 -0.038564733458116 -0.117925763161383
-   10  ( 10) -0.030779230036139  0.047764824598951  0.139550834348758 -0.058848096986720 -0.072156858928456 -0.071321440087986  0.120905085647966 -0.006516751215124 -0.144681807612295
-   11  ( 11)  0.005585664265456 -0.000647324323586 -0.016353426872082 -0.045937924242292 -0.003353711579607  0.138994412824604  0.062414171800322  0.018128246119697 -0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.154066232086317  0.030728257975556 -0.006318091498164
-    1  (  1)  0.063643818147584 -0.047463638962418  0.000566548572565
-    2  (  2)  0.275258773270295 -0.138888616959566  0.015969350630016
-    3  (  3)  0.017345671201066  0.059189082677904  0.046475381464176
-    4  (  4)  0.050392875387071  0.072424486885238  0.004459708301674
-    5  (  5)  0.026836133802329  0.070805989588457 -0.140760690762251
-    6  (  6)  0.078585377266712 -0.120742726291724 -0.064292229739042
-    7  (  7)  0.041858894695365  0.005665298794286 -0.017186389956069
-    8  (  8)  0.118429783701800  0.144155118064025  0.113213711259466
-    9  (  9) -0.000756388118591  0.455654623157072  0.231432578787543
-   10  ( 10) -0.453567841489266 -0.001497567906129 -0.172275686133391
-   11  ( 11) -0.230120702539645  0.175050207490782 -0.001480251815160
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000516219946816  0.034778633659956  0.032999546928151 -0.009629039776278  0.052966719633617 -0.030450001531878 -0.014875222246015 -0.072128990177077  0.048218822417803
-    1  (  1) -0.030877691560804  0.001883541097772  0.071434334115879 -0.019325009721534 -0.017452039030100 -0.158145751795333 -0.010537309557875 -0.021583100108147 -0.169934651056250
-    2  (  2) -0.033565318682613 -0.071200997372983  0.000581071534985 -0.036850040138101  0.007310816547227 -0.008797901115406 -0.029229533057666 -0.016744128499400 -0.070455787497455
-    3  (  3)  0.011004884819686  0.019179310791618  0.034909263032370  0.000523661128158 -0.007125267622899 -0.017666281606150 -0.025274953349027  0.006048522524524 -0.042959205727090
-    4  (  4) -0.052383681601535  0.016788640224883 -0.007028507044452  0.007472760866637 -0.000164741631073 -0.026820745242549  0.000005495327564 -0.022752424410877  0.031410113616428
-    5  (  5)  0.028924597602342  0.155705177520586  0.009708873936879  0.016613543931604  0.026890889200954  0.000863820528475 -0.026461589325309  0.030900211040800  0.024762473040831
-    6  (  6)  0.014335467827216  0.010396285650159  0.029624823660297  0.025462090585912  0.000149096444494  0.026996065218364 -0.000042625626758 -0.107465667965402  0.101121105248233
-    7  (  7)  0.071280711647029  0.021473260264964  0.016888851213230 -0.005990055447048  0.022650874097521 -0.030884846999677  0.107059671381934  0.000085380718295  0.001222830424055
-    8  (  8) -0.049124632890092  0.169889327710618  0.068826403708743  0.044339001017875 -0.031493314676472 -0.025080049766767 -0.100845039831255 -0.001167614688641  0.000278385825403
-    9  (  9)  0.004591463397670  0.224641690035662  0.054391854978822 -0.000520714575472  0.041379699430161 -0.035041097267503 -0.048865193892848 -0.034233303767760  0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.004372643490859
-    1  (  1) -0.225448428944350
-    2  (  2) -0.053543340635201
-    3  (  3)  0.000029286176363
-    4  (  4) -0.041473098636741
-    5  (  5)  0.035500700267141
-    6  (  6)  0.049415179037896
-    7  (  7)  0.033722251526408
-    8  (  8) -0.002108270875613
-    9  (  9) -0.000059855095180
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.083178189184036  0.063320502543375  0.053448860291133 -0.010119942476578 -0.027962494700737 -0.033408156898410 -0.016646686372055 -0.009688142905594 -0.047753876913682
-    1  (  1) -0.015436953954369  0.001484194684011 -0.023035398887205 -0.013457869405466  0.013993527195521  0.033943979767543 -0.150850131221437  0.006054179455746 -0.032861777904130
-    2  (  2) -0.007416632072171 -0.085535883632607  0.031035920631781  0.004414026005139  0.010136741110915 -0.029006493089287  0.078308410406643 -0.042862583013635 -0.094615352193845
-    3  (  3)  0.060864804294684  0.107990348400789  0.029334441164075  0.017074561166948 -0.006770814971091 -0.056161219994893  0.038880977880177  0.007186858274067  0.050898617184209
-    4  (  4)  0.109193273208522  0.178421304573120  0.074992061457995 -0.038015102633012  0.147910228795514 -0.087181398607820  0.098582275644141 -0.093570766915846 -0.088687564658624
-    5  (  5) -0.362309556227904 -0.121304099182945 -0.074968023841376 -0.180660703600124  0.122438585672172  0.079096894998506 -0.085876030826778  0.136109864287558 -0.002214631278523
-    6  (  6) -0.026835628168075  0.104282391359254 -0.172843582770517 -0.372105341696267 -0.200623348657875  0.124556824110224  0.101871864602057  0.564196462169744 -0.000688785089474
-    7  (  7) -0.344945182303497 -0.095060217852336 -0.019692892185405  0.208607222836184  0.002627647973779  0.075715664253568  0.273373001503080 -0.322679649636761  0.103750880742886
-    8  (  8) -0.103243578213400 -0.018995126733818  0.033613347666093  0.143946559071139 -0.146180680800982 -0.017308359580339 -0.107684620440504  0.078982837453949  0.062496256435255
-    9  (  9)  0.085648241806344  0.209611729409149  0.056224829650480  0.004822853433113 -0.155473341074989 -0.012971266670028  0.058097898147224  0.150335378963730 -0.078057323449305
-   10  ( 10) -0.070132629148842 -0.074702785463534 -0.209329818275843 -0.042566217114534  0.058034325280006  0.102370728009941  0.025801004099357  0.264561180085366 -0.017482708757363
-   11  ( 11) -0.113963029107499 -0.045073298009464 -0.000413587765283 -0.112463923253522  0.089423608765749  0.081287727377731  0.019439635907878  0.076622183257520 -0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015270950350973
-    1  (  1) -0.030946721870550
-    2  (  2)  0.003707642076146
-    3  (  3)  0.011960041321321
-    4  (  4) -0.086083869661608
-    5  (  5) -0.009867768215709
-    6  (  6) -0.209680707316341
-    7  (  7)  0.097843271017668
-    8  (  8)  0.010325909660635
-    9  (  9) -0.121632163838855
-   10  ( 10) -0.058275044600178
-   11  ( 11)  0.003021331907582
-
 	Computing Mu_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.069164761529
-	   1        16.451915039014    4.754e-01
-	   2        18.210045318474    1.656e-01
-	   3        18.228206575195    1.761e-02
-	   4        18.232861753523    6.133e-03
-	   5        18.233517878040    7.884e-04
-	   6        18.233413053054    2.307e-04
-	   7        18.233428247409    3.953e-05
-	   8        18.233433472353    1.188e-05
-	   9        18.233432993942    2.887e-06
-	  10        18.233432832199    8.245e-07
-	  11        18.233432917671    2.394e-07
+	   0        13.069164596988
+	   1        16.451914820424    4.754e-01
+	   2        18.210045061583    1.656e-01
+	   3        18.228206317089    1.761e-02
+	   4        18.232861495195    6.133e-03
+	   5        18.233517619662    7.884e-04
+	   6        18.233412794677    2.307e-04
+	   7        18.233427989030    3.953e-05
+	   8        18.233433213974    1.188e-05
+	   9        18.233432735563    2.887e-06
+	  10        18.233432573821    8.245e-07
+	  11        18.233432659292    2.394e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 6.055e-08
 
 	Computing P_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.652700287038
-	   1         4.556605848191    2.362e-01
-	   2         4.999337399771    7.805e-02
-	   3         5.004942382976    8.022e-03
-	   4         5.005591469036    2.647e-03
-	   5         5.005739260335    4.887e-04
-	   6         5.005714005994    1.543e-04
-	   7         5.005717891625    3.185e-05
-	   8         5.005718769238    8.993e-06
-	   9         5.005718468968    1.762e-06
-	  10         5.005718460428    3.787e-07
+	   0         3.652700302976
+	   1         4.556605865490    2.362e-01
+	   2         4.999337415108    7.805e-02
+	   3         5.004942398080    8.022e-03
+	   4         5.005591484118    2.647e-03
+	   5         5.005739275409    4.887e-04
+	   6         5.005714021068    1.543e-04
+	   7         5.005717906698    3.185e-05
+	   8         5.005718784311    8.993e-06
+	   9         5.005718484042    1.762e-06
+	  10         5.005718475501    3.787e-07
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 9.759e-08
 
 	Computing L_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         2.417820605588
-	   1         3.324263605577    3.187e-01
-	   2         4.083972328288    1.549e-01
-	   3         4.107116389054    3.248e-02
-	   4         4.122343243544    1.794e-02
-	   5         4.124892947600    6.529e-03
-	   6         4.124856323725    2.006e-03
-	   7         4.124952683600    6.955e-04
-	   8         4.124954033412    2.621e-04
-	   9         4.124934611275    1.091e-04
-	  10         4.124933829026    3.585e-05
-	  11         4.124936470025    8.386e-06
-	  12         4.124938655284    3.061e-06
-	  13         4.124939356565    8.126e-07
-	  14         4.124939892423    4.035e-07
-	  15         4.124940079297    1.792e-07
-	  16         4.124940200966    1.045e-07
+	   0         2.417820592240
+	   1         3.324263585293    3.187e-01
+	   2         4.083972298669    1.549e-01
+	   3         4.107116358535    3.248e-02
+	   4         4.122343212428    1.794e-02
+	   5         4.124892916354    6.529e-03
+	   6         4.124856292471    2.006e-03
+	   7         4.124952652341    6.955e-04
+	   8         4.124954002153    2.621e-04
+	   9         4.124934580017    1.091e-04
+	  10         4.124933797768    3.585e-05
+	  11         4.124936438767    8.386e-06
+	  12         4.124938624026    3.061e-06
+	  13         4.124939325307    8.126e-07
+	  14         4.124939861165    4.035e-07
+	  15         4.124940048038    1.792e-07
+	  16         4.124940169707    1.045e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 3.243e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.852729644755
-	   1        12.772930237506    3.300e-01
-	   2        13.566509687765    9.767e-02
-	   3        13.600663248993    1.681e-02
-	   4        13.604478924822    4.889e-03
-	   5        13.604928478027    7.473e-04
-	   6        13.604887977930    1.955e-04
-	   7        13.604903433505    3.878e-05
-	   8        13.604906647552    1.100e-05
-	   9        13.604906642028    2.592e-06
-	  10        13.604906705583    8.474e-07
-	  11        13.604906790915    1.986e-07
+	   0        10.852729522161
+	   1        12.772930091167    3.300e-01
+	   2        13.566509527675    9.767e-02
+	   3        13.600663087369    1.681e-02
+	   4        13.604478763042    4.889e-03
+	   5        13.604928316217    7.473e-04
+	   6        13.604887816120    1.955e-04
+	   7        13.604903271694    3.878e-05
+	   8        13.604906485741    1.100e-05
+	   9        13.604906480217    2.592e-06
+	  10        13.604906543772    8.474e-07
+	  11        13.604906629104    1.986e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.435e-08
 
 	Computing P_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.772040242925
-	   1         4.384595309233    1.875e-01
-	   2         4.637393957258    5.411e-02
-	   3         4.651183532160    1.115e-02
-	   4         4.652194288028    3.084e-03
-	   5         4.652293343804    4.711e-04
-	   6         4.652268934348    1.047e-04
-	   7         4.652268856634    2.360e-05
-	   8         4.652268867350    7.522e-06
-	   9         4.652268647305    1.907e-06
-	  10         4.652268687382    5.118e-07
+	   0         3.772040254389
+	   1         4.384595322063    1.875e-01
+	   2         4.637393969077    5.411e-02
+	   3         4.651183543575    1.115e-02
+	   4         4.652194299414    3.084e-03
+	   5         4.652293355185    4.711e-04
+	   6         4.652268945730    1.047e-04
+	   7         4.652268868016    2.360e-05
+	   8         4.652268878732    7.522e-06
+	   9         4.652268658687    1.907e-06
+	  10         4.652268698764    5.118e-07
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 8.949e-08
 
 	Computing L_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.807222717179
-	   1         9.100811162161    4.648e-01
-	   2        10.625064102384    2.156e-01
-	   3        10.728212517018    7.486e-02
-	   4        10.791534360687    3.597e-02
-	   5        10.796584463246    8.641e-03
-	   6        10.796192652530    2.106e-03
-	   7        10.796362864020    6.665e-04
-	   8        10.796348371311    1.656e-04
-	   9        10.796349922803    6.546e-05
-	  10        10.796345396873    2.779e-05
-	  11        10.796347660818    7.734e-06
-	  12        10.796348885815    3.271e-06
-	  13        10.796349583385    1.071e-06
-	  14        10.796350149728    4.833e-07
-	  15        10.796350421065    1.929e-07
+	   0         6.807222691042
+	   1         9.100811124853    4.648e-01
+	   2        10.625064053888    2.156e-01
+	   3        10.728212466431    7.486e-02
+	   4        10.791534308288    3.597e-02
+	   5        10.796584410558    8.641e-03
+	   6        10.796192599837    2.106e-03
+	   7        10.796362811319    6.665e-04
+	   8        10.796348318611    1.656e-04
+	   9        10.796349870103    6.546e-05
+	  10        10.796345344173    2.779e-05
+	  11        10.796347608118    7.734e-06
+	  12        10.796348833115    3.271e-06
+	  13        10.796349530685    1.071e-06
+	  14        10.796350097027    4.833e-07
+	  15        10.796350368364    1.929e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 7.701e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.909505814402
-	   1        13.295810404024    3.489e-01
-	   2        14.208707654348    9.956e-02
-	   3        14.220830477806    1.236e-02
-	   4        14.223886240155    4.932e-03
-	   5        14.224193252004    5.134e-04
-	   6        14.224160762666    1.473e-04
-	   7        14.224165772152    3.090e-05
-	   8        14.224166218421    9.426e-06
-	   9        14.224165992728    2.291e-06
-	  10        14.224165927951    6.462e-07
-	  11        14.224165995978    1.197e-07
+	   0        10.909505695641
+	   1        13.295810252928    3.489e-01
+	   2        14.208707486698    9.956e-02
+	   3        14.220830309558    1.236e-02
+	   4        14.223886071774    4.932e-03
+	   5        14.224193083603    5.134e-04
+	   6        14.224160594266    1.473e-04
+	   7        14.224165603752    3.090e-05
+	   8        14.224166050020    9.426e-06
+	   9        14.224165824327    2.291e-06
+	  10        14.224165759551    6.462e-07
+	  11        14.224165827578    1.197e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 3.084e-08
 
 	Computing P_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.001324298446
-	   1         4.860309150318    2.064e-01
-	   2         5.181236877639    5.698e-02
-	   3         5.185572388373    7.609e-03
-	   4         5.186271028151    3.105e-03
-	   5         5.186387501112    5.054e-04
-	   6         5.186364709527    1.411e-04
-	   7         5.186366425165    2.802e-05
-	   8         5.186366398645    6.906e-06
-	   9         5.186366330331    1.348e-06
-	  10         5.186366342825    3.310e-07
+	   0         4.001324308863
+	   1         4.860309160942    2.064e-01
+	   2         5.181236886807    5.698e-02
+	   3         5.185572397398    7.609e-03
+	   4         5.186271037155    3.105e-03
+	   5         5.186387510109    5.054e-04
+	   6         5.186364718526    1.411e-04
+	   7         5.186366434164    2.802e-05
+	   8         5.186366407643    6.906e-06
+	   9         5.186366339329    1.348e-06
+	  10         5.186366351823    3.310e-07
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 6.914e-08
 
 	Computing L_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.957245650592
-	   1         9.264997580904    4.736e-01
-	   2        10.852239014278    2.110e-01
-	   3        10.917504047663    4.735e-02
-	   4        10.943832616339    2.426e-02
-	   5        10.948855525776    9.575e-03
-	   6        10.948244454781    3.422e-03
-	   7        10.948591794333    8.406e-04
-	   8        10.948635071383    2.656e-04
-	   9        10.948619094901    9.644e-05
-	  10        10.948621166233    4.363e-05
-	  11        10.948623024014    1.303e-05
-	  12        10.948626889150    4.656e-06
-	  13        10.948627707602    1.594e-06
-	  14        10.948628103818    5.597e-07
-	  15        10.948628197401    2.243e-07
-	  16        10.948628277096    1.169e-07
+	   0         6.957245625341
+	   1         9.264997545107    4.736e-01
+	   2        10.852238966511    2.110e-01
+	   3        10.917503998345    4.735e-02
+	   4        10.943832566292    2.426e-02
+	   5        10.948855475501    9.575e-03
+	   6        10.948244404491    3.422e-03
+	   7        10.948591744033    8.406e-04
+	   8        10.948635021080    2.656e-04
+	   9        10.948619044600    9.644e-05
+	  10        10.948621115931    4.363e-05
+	  11        10.948622973712    1.303e-05
+	  12        10.948626838848    4.656e-06
+	  13        10.948627657300    1.594e-06
+	  14        10.948628053516    5.597e-07
+	  15        10.948628147099    2.243e-07
+	  16        10.948628226793    1.169e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 4.969e-08
 
 	Computing 1/2 <<Mu;L>>_(0.128) tensor.
 	Computing 1/2 <<P;L>>_(0.128) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008614927932901 -0.046442352400056  0.027924113420848 -0.003342105613042 -0.019198187280149 -0.043605993010684  0.000124507843934 -0.017903232775755 -0.064037761769677
-    1  (  1) -0.004023859954382  0.002812567241188 -0.015355365220565  0.063211982369858  0.033868800032563 -0.011581015700219 -0.004465574115878 -0.047030919129079 -0.048793907716228
-    2  (  2)  0.028525640721225  0.068120190051797 -0.016739332483522 -0.005073216914996  0.071940864110972 -0.066733646998345 -0.019605473406179 -0.001610556181541  0.004701378003057
-    3  (  3) -0.054155290592472 -0.054244334984755 -0.021962628004576 -0.018282485083091 -0.037028274309951  0.016786978556275  0.022024618578561  0.004302299401540 -0.167953274084101
-    4  (  4) -0.063182596929128 -0.128748808697011  0.121465113794596  0.160938411624414 -0.233917278334855  0.054052147786148  0.025334190025568  0.127021105025468 -0.261448831371970
-    5  (  5)  0.148864678539144  0.254187426901849 -0.169654893765005  0.284620623487219  0.104152411510991  0.359543809296571  0.133744009364038  0.041861549395911  0.169452799563311
-    6  (  6) -0.084956716693293  0.126613830958100 -0.017431389376921 -0.048281125785785  0.083267553859489 -0.206713853889007  0.428812335356187  0.005011018790693  0.061186511244325
-    7  (  7)  0.173630436499038  0.181276581467465 -0.440332497406727 -0.059456065314793  0.303618967332177  0.080016792150091 -0.104444652264320  0.251866044362601  0.089940979754426
-    8  (  8)  0.057697740265636  0.070180597319316 -0.383387445877903  0.514874723728167  0.465292274425094 -0.060917787458673  0.016262524997932  0.068972295825028 -0.265391565564862
-    9  (  9) -0.279247635392508  0.560707539445326  0.044547355247966  0.161505455840491 -0.002588377300620  0.219223272852673  0.096307931275233  0.176467158787115 -0.104344971075325
-   10  ( 10) -0.977075550189082  0.176418272338824  0.228294317792423 -0.099370607761785  0.027777959043915 -0.149348953174007  0.027413414685573 -0.102632226214496  0.005531527026329
-   11  ( 11) -0.211429004068205  0.082644794913083 -0.055680052865830  0.289018099852967 -0.067789578528906  0.064107786895450  0.141855082713117  0.071186757345684 -0.332576681432119
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.071990946341156
-    1  (  1)  0.010142476746200
-    2  (  2) -0.112423878596356
-    3  (  3) -0.059253840833002
-    4  (  4) -0.014639189231197
-    5  (  5)  0.248038168374966
-    6  (  6) -0.055159646937661
-    7  (  7)  0.115432903674626
-    8  (  8) -0.135363224547124
-    9  (  9)  0.174678345310946
-   10  ( 10) -0.086140984938274
-   11  ( 11)  0.161723358519153
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.197572413114517 -0.541318632877371  0.139927415914873 -0.359578444130330 -0.398937843975486 -0.026586872167534 -0.139627977382516 -0.005896246491228 -0.003746644388905
-    1  (  1) -0.541058731973333 -2.034801242188507  0.920540457917585  1.016218584629480  0.729164689940962  0.054412526301737  0.235971924521468  0.315223615831553  0.096208087340554
-    2  (  2)  0.139828960639396  0.920734025049694  1.243601677781983 -0.974300649425054 -0.758553357750500  0.024609548649431  0.513266755137957 -0.116926330823923  0.094501440802452
-    3  (  3) -0.358970389612551  1.015833032444632 -0.974440229907822 -0.266348920037382 -0.133799224826450 -1.276907891719884  0.042984364188955 -0.410608972745146 -0.602345206758872
-    4  (  4) -0.398323035382104  0.727797072638099 -0.759857932028957 -0.133858878725855  0.575448485405805  0.056475665846990 -0.484493838094732 -1.583666059960473 -0.976878960945650
-    5  (  5) -0.027166282529876  0.055084907439528  0.024891154244808 -1.275543890392068  0.058746221115305  0.155399297624787 -0.236023461595880  0.812878944882876 -1.048535633945681
-    6  (  6) -0.139452284652001  0.236223353106611  0.513262677276795  0.042879631015553 -0.482819583744289 -0.235933155306163 -2.554180022039243  0.492117808091915  0.545404391969618
-    7  (  7) -0.005841417486080  0.316274368087248 -0.116163386132942 -0.410094172620351 -1.579571504351393  0.813774264702327  0.492423579055058 -1.700719634572147  0.685529426222534
-    8  (  8) -0.003628131523111  0.096035529406495  0.094131958822655 -0.602680558554738 -0.970206233042967 -1.045482011639248  0.544249830480973  0.683514460656999 -0.254958894521937
-    9  (  9)  0.326098978034070 -0.130935443755898 -0.379595166178810 -0.575990923913880 -0.393471965772156 -0.365686482354661 -1.227740649572571 -0.905826585766955  0.039987575439783
-   10  ( 10)  0.008103557010829 -0.039575543043785 -0.358664813530415  0.339232504235094  0.207222390004838  0.025784782686722 -0.874465143496950  0.752110557173402  0.140644707838520
-   11  ( 11)  0.161744201604777 -0.084371238126416 -0.371150000615002 -0.062082553987999 -0.264710244109502 -0.257261524594595 -0.444570825837596  0.002821912169167 -0.878431482758543
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.327854256723191  0.009019714201806  0.162710661594080
-    1  (  1) -0.133091859401188 -0.040697608916971 -0.085480013261477
-    2  (  2) -0.381849466582258 -0.359835698966555 -0.372555502654032
-    3  (  3) -0.579249329460985  0.337242930789026 -0.062083381101115
-    4  (  4) -0.396591932227294  0.208613968377681 -0.263534161447186
-    5  (  5) -0.365098796840620  0.027806203875135 -0.265146511184336
-    6  (  6) -1.230804866141472 -0.879767261427487 -0.448789926588722
-    7  (  7) -0.904635210810701  0.753869376128870 -0.007723762422951
-    8  (  8)  0.040323953888643  0.145561462630237 -0.894627985530935
-    9  (  9)  0.423095730032689 -0.296000598729972 -0.177730944535255
-   10  ( 10) -0.299463152132731  0.634536265412446 -0.073348108781663
-   11  ( 11) -0.175836972560684 -0.076105887981834  1.184769463941312
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.567008918440454  0.722443194224100  0.422402078329773  0.057554368538511 -0.068012024097596 -0.451975147608540  0.709419418128490 -0.110422168786063  0.095704108927647
-    1  (  1)  0.720885472964738  0.332527211352729  0.737390933664557  0.281750515995843  0.280761290393686 -0.598548871078422 -1.146750917560074 -0.177301134607867  0.234694928374046
-    2  (  2)  0.422183102929830  0.736485274543817  0.007829109729841 -0.365399185160488 -0.965501991519851  1.065090224342325 -0.394390877157068  0.239359282041345 -1.218182428400336
-    3  (  3)  0.059687201587689  0.280769829516347 -0.363255319277090 -0.833720445234328 -1.345952507284314 -0.189309823206009 -0.179890587463359  1.060334267261244  0.772514544005070
-    4  (  4) -0.069257393950461  0.281296543593726 -0.966923508415862 -1.344162403478837  1.514830798821686  0.013670590813123  0.227285042195308 -0.333966365834383  0.386248727994588
-    5  (  5) -0.449135841837750 -0.599397616398023  1.066820631137579 -0.189649110609729  0.013795397601274 -0.565008204089947  0.487292179201877  0.306200785308481  0.347063761059997
-    6  (  6)  0.708465668575064 -1.146562417015747 -0.391890894794961 -0.180811610825629  0.226633708337573  0.487729597603209 -2.767088081148377 -0.044613761228256 -0.000972346438746
-    7  (  7) -0.108981479701481 -0.177538422258191  0.240499334967173  1.059842333943978 -0.334391646412731  0.306249622802239 -0.044471110656761 -3.232660954268523  0.514839123397967
-    8  (  8)  0.094277588726801  0.235043460722862 -1.221823739304416  0.774952681271118  0.386077819008107  0.344858044218004 -0.000341133693178  0.514916107143190  0.507086715271392
-    9  (  9) -0.063381219775898  0.233965663654109 -0.093343357924906 -0.360354041999586 -1.006820146552738  1.344825106449130  0.268434803850821  0.315156353069794 -0.332938610236887
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.063808920787530
-    1  (  1)  0.235710820172182
-    2  (  2) -0.096202914418848
-    3  (  3) -0.360121798161892
-    4  (  4) -1.006476097602190
-    5  (  5)  1.343619008167611
-    6  (  6)  0.268106090274240
-    7  (  7)  0.315242334513133
-    8  (  8) -0.332481313383264
-    9  (  9) -0.175400025059932
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.010284048494255 -0.022581971135931  0.025184528241746  0.002553505114185 -0.007866760216735 -0.035704112150886 -0.002766394497905 -0.015588851752449 -0.054894237910669
-    1  (  1)  0.001129370063260 -0.004341567056713 -0.012471737690510  0.068518821494219  0.037428649672491 -0.002857552975536 -0.002731409738209 -0.051935588474977 -0.049204102006071
-    2  (  2)  0.045340581598934  0.060774626672080 -0.014665202394902 -0.013163382447340  0.085552378847967 -0.055885373659009 -0.012884187954087 -0.000025912808653  0.007546289398551
-    3  (  3) -0.053518724373857 -0.051858316930917 -0.015829576226974  0.002308038466593 -0.033376912491914  0.026566608759227  0.020736863226261  0.017163432001033 -0.156611857939886
-    4  (  4) -0.057073647917578 -0.121620677730040  0.116559461318180  0.152459611673760 -0.224360677266659  0.063635487600126  0.025109630293686  0.123561544969923 -0.260705677431782
-    5  (  5)  0.132736043071323  0.228873275971275 -0.157588806451895  0.278203525609905  0.112411249713211  0.339424025956772  0.132778586915835  0.041442079822076  0.144607854949093
-    6  (  6) -0.099037108772820  0.133050971019321 -0.016390463092699 -0.047994853534082  0.082590754367535 -0.196599146843337  0.423704532236322  0.002588517799838  0.062442412924455
-    7  (  7)  0.164573996270568  0.174187584517111 -0.442718231735592 -0.055107629768529  0.292277213599590  0.090352016025028 -0.100915507153634  0.242008735185081  0.079009239652453
-    8  (  8)  0.059450407301305  0.065508844735816 -0.375580889101448  0.518979554864539  0.457917802055341 -0.070408637451188  0.013466768623613  0.072872586601375 -0.257559025462184
-    9  (  9) -0.246894722162695  0.551859769243373  0.044670824987361  0.162240888664295 -0.012774136938901  0.203595879781061  0.102036778576897  0.168067562706153 -0.111682944808914
-   10  ( 10) -0.913654455951997  0.155328532380750  0.215519674293101 -0.100970035089767  0.021969337557273 -0.148862369984030  0.046525143909590 -0.100083990349210  0.020780587060978
-   11  ( 11) -0.198781019683999  0.090074442467030 -0.050453210014304  0.292395282220077 -0.068054938936099  0.077531780115388  0.149511822875939  0.072921096134366 -0.357789764657410
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.062212803584986
-    1  (  1)  0.008222801612735
-    2  (  2) -0.107232253166961
-    3  (  3) -0.058083892735771
-    4  (  4) -0.001519088368734
-    5  (  5)  0.232883930798086
-    6  (  6) -0.056471183426688
-    7  (  7)  0.097796104480775
-    8  (  8) -0.126488666884472
-    9  (  9)  0.156849504238605
-   10  ( 10) -0.081446420280763
-   11  ( 11)  0.176341903152824
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.007749096020893 -0.085883219860789 -0.036741821640513 -0.003365465554254 -0.013826624434967  0.045778129863205  0.040669337017936  0.010509742963645  0.029540605017242
-    1  (  1) -0.033323633544771  0.071013231293301  0.009381535649954  0.001865195819276 -0.004385218315905 -0.001145589403992 -0.107240463714063 -0.004928891794835 -0.020784313339082
-    2  (  2)  0.052107391808055  0.092519548352413  0.009858355445846  0.037319719751115 -0.023857034470632 -0.010135084101246  0.037769988668842 -0.015917832336735  0.090581268987334
-    3  (  3) -0.109820166860700  0.034268818868662  0.003318299125654 -0.047343590144125  0.049224764312370 -0.055554817528594  0.048303583350885 -0.021295778567536 -0.056731125392159
-    4  (  4) -0.007052162455570 -0.070092516335627 -0.001616209300804  0.100452686687340 -0.017125496300488  0.011804649620296  0.317168773449601 -0.015679790140276  0.134810835290821
-    5  (  5) -0.101789034987347  0.450242114045570  0.095257897029759  0.154575128248214 -0.107484330343030 -0.276349446627330 -0.224432437333530  0.138878619319231 -0.069374899620443
-    6  (  6)  0.129481070378189  0.190214182802185 -0.111482363704469 -0.289845791886638 -0.214082604248960  0.130539668518305  0.176627871859896  0.507792819613372 -0.145016045312478
-    7  (  7) -0.031015915682170  0.467808966358201  0.323231774623313  0.163051942437066 -0.027878152128557 -0.222130149400228  0.355582804042090 -0.345169178258104 -0.117503613032291
-    8  (  8) -0.081114418656010 -0.129458136695794  0.321266021811150 -0.116738859709862  0.112997348404402  0.150149613835924  0.100022037588641 -0.009859219508172 -0.185497355865147
-    9  (  9) -0.840897499603665 -0.103193956572518 -0.262141263376961 -0.179652800220136  0.091540284698060  0.263027818637292  0.232988427097700  0.132664590100508  0.080643129784317
-   10  ( 10)  0.396138270139100  0.527358178663247  0.115585436142149 -0.350404487392900  0.098592337861551  0.056041756240516 -0.132708614971811  0.130232826037073  0.024142145251939
-   11  ( 11)  0.048038049575401  0.184019168140566 -0.243899393243605  0.184449948512382  0.067903231499648 -0.173184976481832  0.074519873620110  0.122524072160336  0.175482839393722
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.029757291821339
-    1  (  1) -0.000721108481725
-    2  (  2)  0.081115665687732
-    3  (  3)  0.028764622397233
-    4  (  4) -0.020368316409772
-    5  (  5) -0.173632225317480
-    6  (  6) -0.281328230047800
-    7  (  7) -0.030401209370270
-    8  (  8)  0.093738850403327
-    9  (  9)  0.138017132925940
-   10  ( 10)  0.057334975405403
-   11  ( 11) -0.087072361680799
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.718905282963311 -0.301300066815098 -0.767801784865940  0.078512808825352 -0.203134864329395  0.241932163232250  0.058076631858574  0.196398858308336 -0.039008858124194
-    1  (  1) -0.301256490728193 -0.157440548180653 -0.036029555945222  0.243436823804201 -0.005929795652985  0.115486356935965  0.826228436942721 -0.465135369554618  0.058491264513800
-    2  (  2) -0.767289827428610 -0.036275730111077 -0.756926663794728  0.450133498634738  0.207784604973971 -0.828712724024022 -0.324647417359493 -0.353270502638369  0.092835605795882
-    3  (  3)  0.078579571414042  0.243310568002833  0.450095063336851 -0.208139431363607 -0.062202704649669  0.279001105370900 -0.076077558481815  0.262112030046533 -0.378810215172718
-    4  (  4) -0.202510304245595 -0.006692039856945  0.206011713498273 -0.062773519685661 -0.370731419489490 -0.256994084769574 -0.019543706164301  0.220490721787851  0.607096866069924
-    5  (  5)  0.239969372403163  0.117504635997786 -0.825053657412313  0.279484173569987 -0.255386254541418 -0.397595357673452 -0.135369610755389  0.236221247146237  0.269522215039686
-    6  (  6)  0.058390572588279  0.825859124407247 -0.324193078352693 -0.076854690390370 -0.019228317672495 -0.137735601227498 -0.351485727273275 -0.487761380462257 -0.103056409920122
-    7  (  7)  0.194458563409000 -0.463590717501173 -0.349817673328107  0.262678828099312  0.220495817360137  0.236701749060628 -0.486100377719484  0.043036203375607 -0.169360995578035
-    8  (  8) -0.038844766636175  0.058006360789407  0.092452034322386 -0.377838465048525  0.603441383275525  0.267460191997309 -0.103192305796676 -0.168696834715057 -0.618488124049516
-    9  (  9) -0.174642021637819  0.179686913958803  0.584519432729807 -0.531375857305351 -0.237827440080434  0.122408493834100 -0.350613084838644 -0.156778679126698 -0.027661506214973
-   10  ( 10)  0.043298420781037 -0.218837511618004 -0.611680553974653 -0.687832529301005 -0.249683832986975  0.553064660821027 -0.144105807777605  0.115245275900936 -0.084193131593124
-   11  ( 11)  0.061064657985430 -0.108300572115386 -0.188797311905296 -0.022208683609426 -0.827900622936499 -0.341922472618851  0.022718392329079  0.232401592689427  0.164619669402136
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.175684511601603  0.045513516298602  0.061672515006080
-    1  (  1)  0.179323083833167 -0.221567937419786 -0.109140577543022
-    2  (  2)  0.587827397093136 -0.616289532030193 -0.190305864672640
-    3  (  3) -0.534590179358002 -0.689583787093839 -0.022209033963942
-    4  (  4) -0.239000891867221 -0.249187499059157 -0.832603923332527
-    5  (  5)  0.122010791877518  0.553620901013401 -0.348332351708050
-    6  (  6) -0.352732495297565 -0.145056644635348  0.023781601660354
-    7  (  7) -0.157242165562723  0.112854519200918  0.232190589319976
-    8  (  8) -0.027709907045481 -0.086030263039170  0.172274707819854
-    9  (  9)  0.207109600584589  0.096837430686223 -0.023218950236813
-   10  ( 10)  0.100164655230671  0.138181178066476 -0.148224446144570
-   11  ( 11) -0.022320179734203 -0.148849259998097  0.901205762410303
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.179939828491769 -0.273263983919761 -0.077241939802207 -0.131310571537764 -0.452108955794121 -0.373710053222736  0.012756857043078  0.188686131296855 -0.281717657996437
-    1  (  1) -0.271865636595074  0.080204205184229  0.237736668579935  0.053954037181141  0.088144371186311  0.094298665169508 -0.396703489007358 -0.164374392009126 -0.012743809563993
-    2  (  2) -0.076549157175288  0.237611423410488 -0.235916884249811  0.330279805489172  0.156363656188217 -0.135525945480897  0.113532621668593 -0.192996543934043  0.505097349395040
-    3  (  3) -0.133008481204441  0.051978470711429  0.330705317892875 -0.689079279022158  0.681025162416434  0.230126506813665  0.220012049909173 -0.221793013382862 -0.415574431905058
-    4  (  4) -0.450299145657576  0.087908600365275  0.156309970041408  0.681002122520780 -1.360248251424318  0.202273753159192 -0.167570810051337  0.246051223487190  0.206738411458247
-    5  (  5) -0.373567193155845  0.094555329734040 -0.136731584498100  0.229377893488984  0.202581599883435 -0.322498154757568 -0.226671631570763  0.408374954790996  0.307423751717641
-    6  (  6)  0.013230492577454 -0.395220303624150  0.113830041131736  0.218897296842682 -0.167381205612527 -0.226319762003687 -0.422981172464967 -0.882122931150610  0.208582936748456
-    7  (  7)  0.187587553988559 -0.164973338711578 -0.192266029819867 -0.222193739599766  0.245811643454060  0.408813624326959 -0.882511768104148 -0.161881530949274 -0.197931622292553
-    8  (  8) -0.280045996340605 -0.013187886145669  0.507423753200987 -0.417462155137855  0.206022606034107  0.308302993473083  0.207495521066743 -0.198012373935716 -0.598880759668382
-    9  (  9) -0.299128216307527  0.222289305708678 -0.374826664894612 -0.022250761597490  0.198104512558476 -0.291885255576850  0.011569749529353 -0.150670269953426  0.186378706038956
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.301492091129213
-    1  (  1)  0.222023461274417
-    2  (  2) -0.373275862159688
-    3  (  3) -0.022769731837422
-    4  (  4)  0.197531018509810
-    5  (  5) -0.291038388606400
-    6  (  6)  0.011766677818707
-    7  (  7) -0.150956367275849
-    8  (  8)  0.186282415361357
-    9  (  9) -0.408641391244209
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.006541040222368 -0.029135588169222 -0.017330822595744  0.002628911660037 -0.012344009141809  0.034496132624923  0.021629830242309  0.010441885402291  0.025478364815458
-    1  (  1) -0.038275138470075  0.054424566886903  0.005683589031010  0.001642391288003 -0.005493648653247  0.001124544236485 -0.102028934451313 -0.004961744404475 -0.019198498257850
-    2  (  2)  0.053024456913342  0.083754722151204  0.014366999014575  0.045684709272444 -0.045425854355333 -0.015659092798954  0.035306515857362 -0.013688960188417  0.082596341754868
-    3  (  3) -0.125696090540634  0.031717757592640 -0.000802365038104 -0.050871771309593  0.061705711345850 -0.045742890419344  0.045450419445688 -0.021064845035616 -0.054716959844684
-    4  (  4) -0.016613018731749 -0.059371668786672 -0.003754167403423  0.095982620955076 -0.007240466240122  0.008043456529988  0.296808016923276 -0.015369394286441  0.136610478911713
-    5  (  5) -0.093091489377706  0.398657588863068  0.074430182364354  0.149030211928108 -0.108745535372234 -0.256250392240536 -0.205814737045222  0.134201000957220 -0.055103512993348
-    6  (  6)  0.103501697780443  0.185147067962843 -0.104829304475355 -0.273669393328239 -0.199802423052909  0.136710211986565  0.166053639619828  0.483268157942075 -0.135434527757446
-    7  (  7) -0.041456689404135  0.416662529525886  0.296499443846860  0.151835770270295 -0.027648961071683 -0.196853254585748  0.346148931870815 -0.324194030503122 -0.108656389838073
-    8  (  8) -0.069099920157317 -0.122455303618133  0.312946042218845 -0.115185983609626  0.104240832235501  0.145175805702234  0.095088539986730 -0.010672631592564 -0.187147060865154
-    9  (  9) -0.712671855893174 -0.096350152389786 -0.234711067777686 -0.171596024164591  0.065322769896798  0.213466874289907  0.226529390715592  0.118201066093080  0.055528795004367
-   10  ( 10)  0.365512212430565  0.443597144956858  0.088760713787529 -0.336294489487780  0.089380999156301  0.050585935158758 -0.112358935032342  0.122526344346197  0.011836823928278
-   11  ( 11)  0.046393846223224  0.165011629057398 -0.228781961279396  0.178941949643574  0.063752947031584 -0.164789871590981  0.073726138142668  0.117333811839271  0.181371275992210
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.026880621041360
-    1  (  1) -0.000642066544117
-    2  (  2)  0.075046583216661
-    3  (  3)  0.030887223304929
-    4  (  4) -0.027083357083367
-    5  (  5) -0.161323349919549
-    6  (  6) -0.260652499025702
-    7  (  7) -0.019658118713907
-    8  (  8)  0.093794795124770
-    9  (  9)  0.110456626093643
-   10  ( 10)  0.048798146100140
-   11  ( 11) -0.097571556382824
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.001432746297450 -0.032810674091764 -0.033331937480253  0.023032547083763 -0.002808019310921 -0.039246266926320  0.018692018505171  0.008842597191367 -0.029091078569617
-    1  (  1) -0.008821922403183 -0.001742272088788  0.082771016704519 -0.022297486221974  0.039163604166239 -0.010818853488427 -0.047294425339584  0.013135326021221  0.049034393857867
-    2  (  2)  0.024274942916815  0.027096978669207  0.097516386902391 -0.041392368694666 -0.004119390757880  0.075691552303805 -0.023677742397495 -0.003953261558318 -0.122163189427397
-    3  (  3) -0.047038460283817 -0.039422636027069  0.017791086341758  0.115660160117630 -0.067224158887899  0.095036576800958  0.032022129167533  0.022732157345389  0.120912741709036
-    4  (  4) -0.041035802352368  0.001934742020068 -0.201409668003493 -0.406246991276172  0.228435905047063 -0.366034413601436  0.036563318346743 -0.036692328708082 -0.082010843429842
-    5  (  5)  0.098338733570095  0.243746073973362  0.282884501181602 -0.425804208023662  0.108408993563040  0.505586602390370  0.102717653176241 -0.183779423720787  0.023433267817945
-    6  (  6)  0.135336854760563 -0.062874421564495  0.076338309095403 -0.023002937162434 -0.130902824611473 -0.185164583438217  0.398907643233867  0.217551510448046 -0.032105677017803
-    7  (  7) -0.035062191357078 -0.113858796831119  0.431604299875852 -0.029482805357536 -0.029652466640804 -0.242847719350325 -0.077765311277989  0.367073496056810  0.139022006906444
-    8  (  8) -0.068272847454715  0.294672021175633 -0.568959581650588 -0.125921031197012 -0.707592810771387  0.017806583156209 -0.015845746565047 -0.212947645825718  0.125196335187716
-    9  (  9) -0.288858276698774  0.093713692739213  0.209035012311688  0.075382622510660  0.083405488851542  0.016184965058288  0.000548295704545  0.266294088315547  0.380874642506837
-   10  ( 10) -0.378738518488000  0.204837316203508 -0.069415360994347  0.062065163074324  0.029622876137723 -0.058750752587050 -0.120574645247794  0.008130897374692  0.009265965929469
-   11  ( 11) -0.080018520143771  0.225808316863723 -0.312311376663230 -0.316597637367698  0.125757542829493 -0.146130016020174  0.016179298260010 -0.136308703902615 -0.120756904157899
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.036093305578397
-    1  (  1) -0.001707679185378
-    2  (  2)  0.005295607540268
-    3  (  3) -0.304573937377439
-    4  (  4) -0.014287077020118
-    5  (  5) -0.068885443054321
-    6  (  6)  0.111979958895137
-    7  (  7)  0.321243115116497
-    8  (  8)  0.158205355334404
-    9  (  9) -0.080091690471286
-   10  ( 10) -0.065074315967804
-   11  ( 11)  0.075517488980888
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.151581395944457 -0.159877768539019 -0.191397517423370 -0.495232284867177  0.365561840480614  0.240680277087037 -0.079714342464060 -0.017889526464511  0.054577038131019
-    1  (  1) -0.159795957250344 -0.047735218799445 -0.125025973520529 -0.592230248738643  0.329204795623399 -0.563899565056737  0.474518384859258  0.371816427010336 -0.204007450193307
-    2  (  2) -0.191333337555164 -0.125299228178318  0.032743525999057 -0.248173196102997  0.424015573762028  0.373304795371779 -0.124367805075759 -0.383343230710404 -0.176623528718579
-    3  (  3) -0.494849488362154 -0.592714843248357 -0.248959287226432 -0.423717062956694  0.236470791317215 -0.415768039926139 -0.007927078894393 -0.295339114007336  1.138817517977087
-    4  (  4)  0.365842786381904  0.329912791129377  0.425309312530905  0.236284335454773 -0.297797609245548  0.287162197148014 -0.015195390583447  0.149575460395682 -0.352881082019632
-    5  (  5)  0.239666720470004 -0.562521840762128  0.375748994888085 -0.414021321385147  0.283842862620087  0.299376587010529 -0.122721640145877 -0.329969308300871  0.156494792176823
-    6  (  6) -0.079132044596257  0.473605179791134 -0.125255855635513 -0.008774504854422 -0.015965010341322 -0.123144104694353 -0.040262615853229  0.053291869268360 -0.230047243580867
-    7  (  7) -0.018210362041773  0.371975596266125 -0.382949144540519 -0.295062546320220  0.147969605902060 -0.330844143538271  0.053247875304319  0.437054225002062 -0.295575334707162
-    8  (  8)  0.054384972764257 -0.203042333758326 -0.176317356102570  1.137981680675850 -0.349930528471567  0.158219435758802 -0.229361079354617 -0.295174183029699 -0.201170965133917
-    9  (  9)  0.162593186917498 -0.096068090323904 -0.131721885594255 -0.537260876669133  0.048165192812382 -0.386108653062500  0.083321052788424  0.067822247358744  0.259623842469249
-   10  ( 10)  0.093086276325347 -0.110390627511003 -0.528311347000350  0.014888006239538 -0.100997055269664  0.192126958830561  0.038787614394956  0.063975054988451  0.077127488930246
-   11  ( 11) -0.248608674285678  0.166558436146830  0.438779225583925  0.334557445644043 -0.324782623645273  0.179928478753780  0.012126762707773  0.006418605871888 -0.316369462085207
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.163245257155421  0.094276717552644 -0.249582936616881
-    1  (  1) -0.097089753942058 -0.112180528774260  0.167323530234027
-    2  (  2) -0.131901378869784 -0.530116652654623  0.440616284282449
-    3  (  3) -0.539218683643804  0.014310072965047  0.335266942696954
-    4  (  4)  0.048635984706568 -0.103433325040069 -0.331331261588337
-    5  (  5) -0.385516013729792  0.187104305011894  0.193398800890046
-    6  (  6)  0.082991815026247  0.037352860323020  0.011014682786961
-    7  (  7)  0.067841455828072  0.062642922337485  0.014204699225385
-    8  (  8)  0.258473930207162  0.077886035701004 -0.325054438919389
-    9  (  9)  0.001773142889432 -0.053105768300802  0.034600115019000
-   10  ( 10) -0.053689547832438 -0.018246255837546 -0.196162567936867
-   11  ( 11)  0.031756575503292 -0.193298510202671  0.164652237069869
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.236069150423928  0.221583137218639  0.087467481976269 -0.023767225350154 -0.157884977853517 -0.128673956390029 -0.176595879969474  0.001131012317203 -0.181143452404233
-    1  (  1)  0.220430431059073  0.112052435313968  0.015869249151473  0.264485428778921 -0.165982030219470  0.159260926468858 -0.018854654828287 -0.249502649443057  0.052130725228418
-    2  (  2)  0.087694752982164  0.015013031218300 -0.683310722703039 -0.454889777527338  0.270539149606414 -0.876133156261866  0.064372104092668  0.069959767509230 -0.359585122327188
-    3  (  3) -0.022349867884997  0.265917774305981 -0.459885376820098  0.156118351029157 -0.442698949429053 -0.633164352365545 -0.123599096035318 -0.000681276488754  0.329408685832541
-    4  (  4) -0.157925484616889 -0.166044552973515  0.271218387113143 -0.443885849212600 -0.013362398764761 -0.176284165832649 -0.004716950323026  0.078109759941717 -0.609000288591445
-    5  (  5) -0.127616278770967  0.158011849801079 -0.876037618276795 -0.629854882079848 -0.177186230678137  0.012211398531521  0.059425698366986 -0.774979266274861 -0.486618182967767
-    6  (  6) -0.178241606252947 -0.017090192450387  0.064522373941146 -0.124240074207901 -0.004293285267873  0.059087683211698 -0.104000927528902 -0.330829052901522 -0.038045687603335
-    7  (  7)  0.002208432976113 -0.248689840257510  0.068573896371648  0.000014323070255  0.078530114044465 -0.775881123063332 -0.330687300606162  0.375687386105441  0.140607455827148
-    8  (  8) -0.178615853440425  0.052090468900394 -0.360562489485138  0.330978975217506 -0.607342070790934 -0.487347100955227 -0.037705399031252  0.140808054960246 -0.394251292282697
-    9  (  9) -0.046812023124734 -0.356025366669854  0.690811815119252  0.312933605279832  0.666333150435849  0.222468929331266  0.069111321865738  0.559435147572457  0.132671563084754
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.045842278134109
-    1  (  1) -0.355929482932053
-    2  (  2)  0.690401613030498
-    3  (  3)  0.314450068453419
-    4  (  4)  0.667992312261241
-    5  (  5)  0.221641972273241
-    6  (  6)  0.069286377187356
-    7  (  7)  0.560338391968248
-    8  (  8)  0.132249466359632
-    9  (  9) -0.305201514350595
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.003531322887475 -0.011853964282953 -0.013997173425702  0.018382792154192  0.000899996441170 -0.027829789222902  0.010946278656521  0.009416135608630 -0.023987807904262
-    1  (  1) -0.006388621957170 -0.005171201061298  0.075116414644925 -0.012351518893597  0.041297277094542 -0.006441657661851 -0.042094675941536  0.014500044658877  0.045272474380981
-    2  (  2)  0.036883171135873  0.025743377437805  0.085964964522995 -0.036572128405843  0.000741779132517  0.071901849285639 -0.017612259522947 -0.002857549793791 -0.114428225581804
-    3  (  3) -0.050379148878904 -0.038280516537017  0.018275237269774  0.118578575241743 -0.057964689431887  0.100743381549064  0.031817975653707  0.026538904209037  0.119963525599056
-    4  (  4) -0.040259568572502  0.011229705198348 -0.188809172609568 -0.380757486353216  0.215445879830049 -0.344569392827444  0.033187603168238 -0.033507608911701 -0.079582925346094
-    5  (  5)  0.087141198545524  0.216785041786672  0.270610048744647 -0.398997177058604  0.102170025016676  0.478625848854116  0.098949415070036 -0.170373600936987  0.015652914812384
-    6  (  6)  0.115394650619668 -0.055172374414512  0.068645251662214 -0.021005537436634 -0.120222938768552 -0.172201054646963  0.377862520931175  0.205771786365183 -0.028486300590321
-    7  (  7) -0.040171141537119 -0.121048023653740  0.403132598347777 -0.027760474590503 -0.026374510769541 -0.228317794220799 -0.070878790612320  0.346601006753617  0.129893637962627
-    8  (  8) -0.063034884678852  0.280866798080653 -0.540496031356204 -0.119391576371009 -0.673073389093966  0.010663808807394 -0.016147690801371 -0.200745867995305  0.117394935881043
-    9  (  9) -0.239823863619059  0.087614347419962  0.205995256328994  0.074059708937832  0.068748575207548 -0.000454096504958  0.003028317523563  0.249475422318809  0.352711368821821
-   10  ( 10) -0.336588165834448  0.173514331887659 -0.070029614207528  0.058791676167547  0.024501304819872 -0.052124336325614 -0.104213155529188  0.008639636736157  0.013496509549194
-   11  ( 11) -0.070036515714458  0.195530601320237 -0.305644951639726 -0.322831866596268  0.121530762471617 -0.141977993846978  0.021998928318675 -0.134440837975978 -0.127122644721006
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.030353030422789
-    1  (  1) -0.003358262791905
-    2  (  2)  0.006176160600104
-    3  (  3) -0.295046081788652
-    4  (  4) -0.003816440522472
-    5  (  5) -0.074325961201587
-    6  (  6)  0.109014636987132
-    7  (  7)  0.303731536940852
-    8  (  8)  0.152250258689580
-    9  (  9) -0.089511140585649
-   10  ( 10) -0.060789805292351
-   11  ( 11)  0.082293619260989
-
-	DPD File2: P*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.016948570972613 -0.054109880888837  0.021135784265575  0.002313233156337 -0.028103296077604 -0.079447973740205 -0.002956852851677 -0.021913708071079 -0.092707789804150
-    1  (  1)  0.006461113403501  0.006009670223774 -0.006912589645128  0.092573919328396  0.040488535615147  0.004255397696456 -0.001825638351976 -0.025873653657309 -0.054959118002991
-    2  (  2)  0.031331544873159  0.021241168145027 -0.017129702121868 -0.019395427099523  0.035285598576221 -0.072935692322985 -0.012410630409385  0.000869702308377 -0.008015902055911
-    3  (  3) -0.024878718719799 -0.025868121230654 -0.005405353640122 -0.004239945233349 -0.042856541334318 -0.005201344918358  0.012288417201910  0.030208301210711 -0.125325395177801
-    4  (  4) -0.025785958698499 -0.063980691498117  0.073598667061032  0.115501747702081 -0.164822674147024  0.010612384733594  0.011577872820172  0.114519752578224 -0.189906673361740
-    5  (  5)  0.055556441114085  0.137396825466669 -0.095615332658029  0.165972658367973  0.107298365798081  0.238527327390248  0.081212554772841  0.063709822276343  0.111105007194853
-    6  (  6) -0.039392027543678  0.042131630239803 -0.019507343007951 -0.031681902994480  0.051489401416932 -0.103596811576048  0.235358679315166  0.007221910465763  0.034349807961782
-    7  (  7)  0.065836178815642  0.094909606609938 -0.220876622755124 -0.015059455980391  0.193611601065905  0.070646838068217 -0.043039430003875  0.187401754034075  0.048410779717487
-    8  (  8)  0.031684946163714  0.037730087504351 -0.186156646607922  0.254646362799555  0.271156762093932  0.000387787259569  0.024433068698376  0.071450437934107 -0.140846979003438
-    9  (  9) -0.084633662124775  0.255488997024621  0.026205007862790  0.093994792938777  0.025613688623644  0.118121227074271  0.051164537443405  0.122992981774053 -0.058164329433773
-   10  ( 10) -0.311792105223363  0.086266548695923  0.100581825486069 -0.027645372765871 -0.030325864964669 -0.084727340300286  0.008122017336910 -0.056541723787744 -0.001789230697787
-   11  ( 11) -0.065426291083003  0.078665723239531 -0.001736951632506  0.128876911317495 -0.027700220473420  0.024959429550215  0.037516506165893  0.053272012233112 -0.158952768314791
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.101753702406755
-    1  (  1)  0.017313059038111
-    2  (  2) -0.101825332796567
-    3  (  3) -0.046545573336527
-    4  (  4) -0.020412053345531
-    5  (  5)  0.174151422241113
-    6  (  6) -0.031247623880847
-    7  (  7)  0.081019948031908
-    8  (  8) -0.058254959468121
-    9  (  9)  0.102303876794014
-   10  ( 10) -0.049924523752296
-   11  ( 11)  0.075525972870746
-
-	DPD File2: P*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000125242728652 -0.167195127529492  0.056123303969470 -0.168150627862986 -0.199820827488140 -0.006623842711744 -0.083849175432758 -0.006045895732050  0.001251364845770
-    1  (  1)  0.166774393973286 -0.000050108097355  0.080714006337441  0.158384893960458  0.170632381263561  0.022705538420815  0.068262733314185  0.100593352732071  0.028750568711108
-    2  (  2) -0.056229020612168 -0.080612207963297  0.000319173254151 -0.066387047727631 -0.099495071766653  0.005173360753909  0.113435632074142 -0.028897807757084  0.031705991700745
-    3  (  3)  0.167678159270092 -0.158683508487030  0.065913815468277 -0.000249734983867 -0.003148005831140 -0.156650391969335  0.003319412683622 -0.076996711806060 -0.120344951995522
-    4  (  4)  0.199454748142053 -0.170759345082550  0.099469221211006  0.002551454280228 -0.000773886045054  0.018686662746212 -0.033100672959698 -0.121887804954424 -0.106797700418754
-    5  (  5)  0.006478249114673 -0.021770745773300 -0.005161753017351  0.157975992221428 -0.016380865873467  0.000525726707385 -0.009662973185984  0.040170645002731 -0.072417783927543
-    6  (  6)  0.083743292092373 -0.068302347407764 -0.113643630138679 -0.003584139545109  0.033360726847565  0.010056643067212  0.000096953687507  0.013754999535778  0.022913811866200
-    7  (  7)  0.005934789716209 -0.100152235257288  0.028714239339716  0.077512132071698  0.124503679540823 -0.039365364835397 -0.013764502288195 -0.000180876976509  0.012227152395047
-    8  (  8) -0.001252911154497 -0.028874957240891 -0.031437882577012  0.119989379615825  0.109273108573834  0.074290660285147 -0.022855339074817 -0.012168993677105  0.000462665884709
-    9  (  9) -0.203227152828002  0.052485985798040  0.129801089628845  0.136141281459481  0.065085125998612  0.011352243649991  0.086206555714525  0.025668240031329 -0.000953339185401
-   10  ( 10) -0.017663100569732  0.012450214343934  0.116177784025215 -0.099935881710944 -0.054793001926237 -0.009017289614393  0.082995680333069 -0.068546362432187 -0.010579042812723
-   11  ( 11) -0.116181838629295  0.044517983740016  0.150706036920128  0.032577504630229  0.048215712631815  0.017042393348597  0.052941121555075 -0.017922753511187  0.062577005194743
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.202593155221573  0.017575879500322  0.116307852916242
-    1  (  1) -0.051519507233614 -0.011549119939392 -0.045820851989693
-    2  (  2) -0.128159049336363 -0.115585636177618 -0.151359481294950
-    3  (  3) -0.134953502481695  0.100933227346633 -0.031949792725006
-    4  (  4) -0.063859931160852  0.055317708494750 -0.046074544888569
-    5  (  5) -0.011830479350239  0.008881125854761 -0.020210091121139
-    6  (  6) -0.085128481579730 -0.081569095643572 -0.054417852481447
-    7  (  7) -0.026086609962421  0.069224862060329  0.012195140209492
-    8  (  8)  0.000678319781602  0.012471916838811 -0.071159871058140
-    9  (  9) -0.000819518740474 -0.045422336765459 -0.019150849930670
-   10  ( 10)  0.042260420338391 -0.001814961764223  0.033976133870612
-   11  ( 11)  0.016728332900175 -0.032414763485709 -0.001978177060231
-
-	DPD File2: P*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000983782142481  0.011124830147172  0.012629378315808 -0.024035154666400  0.023065379134223 -0.045710192314813  0.107167060216496 -0.027462764041011  0.031515346399462
-    1  (  1) -0.014910063958614  0.001359157823420  0.030733082384744 -0.019659721688393 -0.009988965433840 -0.056476882006057 -0.086868153591365 -0.027118954968710  0.020111602536483
-    2  (  2) -0.013560973004051 -0.032277644601759  0.000558091321303 -0.031608555416779 -0.040262773871770  0.039517595873987 -0.008529102471728  0.015019360045155 -0.098314783259817
-    3  (  3)  0.023649721587845  0.020118169175247  0.030610171886610  0.000350229335722 -0.012485025400198  0.061831636996218 -0.007360517014456 -0.020533699107494  0.121125902320152
-    4  (  4) -0.023653135590417  0.011024958414626  0.040020875859244  0.012638451269626  0.000303446235581 -0.039117573677270 -0.028265656547984 -0.042181285668281  0.051214110379900
-    5  (  5)  0.045133076040651  0.057161250752777 -0.039343611119004 -0.062428421797334  0.039565506596663  0.000136824832782  0.002584969716509 -0.016708941328372  0.072879955596616
-    6  (  6) -0.106505496216286  0.086364895206289  0.008150243943918  0.007611894739464  0.028147100099079 -0.003022121444643  0.000203669685880 -0.002510614548550  0.011878393768514
-    7  (  7)  0.027112672456296  0.027077462764235 -0.015425844110164  0.020594818217305  0.042172669827196  0.016338775255452  0.002434838415100 -0.000089029182611  0.017463248477439
-    8  (  8) -0.031656276623231 -0.019719565610509  0.100860419907018 -0.123299997114838 -0.052015418367335 -0.071940119122082 -0.012364797759804 -0.017989601258840  0.000459902016922
-    9  (  9)  0.009520290499381 -0.022267140636896  0.003094175387367 -0.010303251098885  0.097174601333758 -0.097786893048291 -0.015199034071913 -0.052630350765338  0.034203233126427
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.010278877487205
-    1  (  1)  0.024100566367630
-    2  (  2) -0.004662205178286
-    3  (  3)  0.011080772146621
-    4  (  4) -0.096116977362317
-    5  (  5)  0.097255829352037
-    6  (  6)  0.015024357830545
-    7  (  7)  0.052513597187948
-    8  (  8) -0.034242058243121
-    9  (  9)  0.000071427193828
-
-	DPD File2: P*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.021462702377840  0.058609304986263 -0.015277082640202 -0.003588508466775  0.029160920616631  0.083108081100347  0.001276540885573  0.021892833224427  0.094847379110200
-    1  (  1) -0.007381037964715 -0.005863657253688  0.003698438732125 -0.089241023982742 -0.038284755695481 -0.000242471073392  0.003462666004729  0.024254060890744  0.054255658141393
-    2  (  2) -0.028789493389469 -0.021034273638112  0.015759179620292  0.016880406379978 -0.029564270241667  0.075699259080315  0.015222849490441 -0.000165407073994  0.009535205798866
-    3  (  3)  0.022522624621755  0.025183731584898  0.006246635644453  0.011954555325543  0.044324634330057  0.008966012606668 -0.011838270463808 -0.025186144853786  0.129587118903909
-    4  (  4)  0.027278246959126  0.067306256079496 -0.081195596321175 -0.116387540315424  0.168952317262089 -0.005408102733272 -0.009102915279315 -0.114909773648686  0.181841314973109
-    5  (  5) -0.061523869623373 -0.148379112602599  0.099858075157622 -0.167623835533734 -0.102565185360584 -0.247065081865864 -0.081017208043104 -0.063123082298018 -0.125076333021719
-    6  (  6)  0.033597893568908 -0.039834794585931  0.017503613262801  0.032860851330180 -0.052602131787128  0.107800944359286 -0.233932603910558 -0.008404826542760 -0.033043735155831
-    7  (  7) -0.070933561522966 -0.099409127660202  0.220355143796242  0.017909988072788 -0.200469521486937 -0.066219172137076  0.043845430589746 -0.192769183200970 -0.053043735796183
-    8  (  8) -0.031467417081633 -0.038067047239557  0.186574292412207 -0.251635426547577 -0.276398972104307 -0.005573316819495 -0.024827793389672 -0.069746818919629  0.142347486299646
-    9  (  9)  0.099591518033223 -0.261294622221711 -0.027264053477196 -0.094406359241798 -0.029407574246243 -0.125903095774733 -0.051208103024876 -0.127846157357285  0.056089461080389
-   10  ( 10)  0.342117397283536 -0.096154260862934 -0.107466277478619  0.028734389414544  0.028891686984979  0.086820145756038 -0.003652067648454  0.059057626339762  0.003362266069713
-   11  ( 11)  0.071536902730284 -0.080845824211427  0.010817173110070 -0.135869650211322  0.031366930890364 -0.023168476862022 -0.040179651854624 -0.056331586353381  0.165962619403637
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.103572144747435
-    1  (  1) -0.016763539950930
-    2  (  2)  0.104006607185189
-    3  (  3)  0.046374714497242
-    4  (  4)  0.027556807097170
-    5  (  5) -0.176590727028647
-    6  (  6)  0.030192309767508
-    7  (  7) -0.090742251579819
-    8  (  8)  0.063736127736872
-    9  (  9) -0.109060255331570
-   10  ( 10)  0.052388979852748
-   11  ( 11) -0.078361680425232
-
-	DPD File2: P*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.013921975065565 -0.103381315829109 -0.056389355096898 -0.011768947816972 -0.004121807955223  0.057298678485070  0.051432105076231  0.011071595100990  0.044909476246755
-    1  (  1) -0.013324613924162  0.028079810676541 -0.007070559814787  0.008005471198395 -0.006018453330844  0.015973349330415 -0.092922359472783  0.001623775394348 -0.017733631990947
-    2  (  2)  0.019765781914701  0.033032250658388  0.004007042176849  0.050166385756319 -0.029906079194408  0.009704933667000  0.038620452933162 -0.002807692103963  0.070071101745418
-    3  (  3) -0.070805556804984  0.003068938942251 -0.006504595257348 -0.039373898202160  0.036927092655665 -0.030322281820042  0.048817421108637 -0.011305308050902 -0.032860541612150
-    4  (  4) -0.014313386316708 -0.043972310793415 -0.013921813392036  0.066387730109469 -0.002442397138038  0.016086934562225  0.179664439851381 -0.006464519349973  0.090040691856223
-    5  (  5) -0.045155577186191  0.247427178481659  0.058353258995683  0.094628927569757 -0.090493402552644 -0.185320260507422 -0.131090788508292  0.093104350867894 -0.060872458952884
-    6  (  6)  0.038584331307231  0.080297227608230 -0.071473886019715 -0.143170489853226 -0.104560768686072  0.046154653747240  0.096338078586582  0.334907808030702 -0.111571007227725
-    7  (  7) -0.029042222296753  0.237223314371562  0.174932299186948  0.080316826107909 -0.040506264905804 -0.119977478400892  0.161451558991029 -0.215735211087246 -0.060177585905520
-    8  (  8) -0.025904244265209 -0.058524341310476  0.144685830322387 -0.050264276045864  0.072805327886092  0.086206688333215  0.053604324132359  0.007863564270736 -0.095576963924380
-    9  (  9) -0.256508945269226 -0.052730013654633 -0.124834441481755 -0.085733906231975  0.088393899635438  0.140853295492133  0.139492059284684  0.083015088260315  0.042052092330032
-   10  ( 10)  0.128333935578074  0.263327859036735  0.068329655679101 -0.087024591997986  0.057039935036965  0.051621611298698 -0.073645648424309  0.107556560489238  0.002537116902128
-   11  ( 11)  0.014388047963903  0.095897531557492 -0.075761746736829  0.083654757188919  0.030891133031091 -0.061475545358308  0.020586611930162  0.065614997905860  0.075825389492545
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.046633267353021
-    1  (  1)  0.000248773711794
-    2  (  2)  0.058940238082046
-    3  (  3)  0.028215078659147
-    4  (  4) -0.009693071380795
-    5  (  5) -0.114025765710299
-    6  (  6) -0.149932383186960
-    7  (  7) -0.029309043140763
-    8  (  8)  0.056468406833596
-    9  (  9)  0.080845904093313
-   10  ( 10)  0.031944380388807
-   11  ( 11) -0.038072643167866
-
-	DPD File2: P*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000412292330125 -0.089973601331934 -0.299831566929396  0.035035339281938 -0.102534416749163  0.139160673237755  0.022726794108668  0.127186946220527 -0.025258681551895
-    1  (  1)  0.089435365325252  0.000179018409619  0.000575799904893  0.036397358696681  0.000077605512592  0.027763068926142  0.235329561156625 -0.149048042365481  0.020748539941476
-    2  (  2)  0.298742449986735 -0.000117532207539  0.000001365547946  0.030750645565914  0.035092304813822 -0.156637931403196 -0.074944775632850 -0.084030365627553  0.029024110989879
-    3  (  3) -0.035083534268240 -0.036212512324819 -0.030659339328188  0.000140940179517 -0.000968456927916  0.032572407071500 -0.017530821556219  0.040913042583287 -0.072860913708021
-    4  (  4)  0.102571067786625 -0.000186672877588 -0.035613278772227  0.000984301508163  0.000083284505465 -0.006675066086515 -0.008092161812671  0.022927931588032  0.061863833474700
-    5  (  5) -0.139766487530579 -0.026940126885898  0.158769710672111 -0.032620148977718  0.008447998102452 -0.000109266532081  0.002529804726067  0.011694293836355  0.013434968660314
-    6  (  6) -0.023123393533703 -0.235158830889094  0.075094645607883  0.017636517707368  0.007886799997649 -0.001572260884544 -0.000097447401663 -0.019414476223635 -0.005807231271628
-    7  (  7) -0.127556864975777  0.149585463815487  0.085819990046561 -0.040749094743077 -0.022487818487125 -0.013521945874053  0.020097198716066 -0.000802314554648 -0.005625145325134
-    8  (  8)  0.025298741297676 -0.021022944558544 -0.028995189539972  0.073180879828651 -0.063113474589722 -0.013554956351232  0.005975480503955  0.005930971726208 -0.000800554325514
-    9  (  9)  0.112700264643845 -0.073437341408674 -0.164270709854341  0.104952328655436  0.027707355858660  0.001091847596269  0.013360757417668  0.016602481071790 -0.000305982559018
-   10  ( 10) -0.061794958624484  0.084043685363021  0.190307519851821  0.184568056526643  0.046373613192876 -0.061509024448409  0.022601229760496 -0.000957508970510  0.004225767450876
-   11  ( 11) -0.048625937545448  0.043275944873041  0.072889882486030  0.022571956848243  0.129861302445486  0.036376964004426  0.007420842536071 -0.027716174562617 -0.009223617021504
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.112403684053299  0.061844266359582  0.048595688328450
-    1  (  1)  0.073289438710481 -0.083115738233247 -0.043020697969992
-    2  (  2)  0.163076133270358 -0.188328773885241 -0.073201670147403
-    3  (  3) -0.104459841985857 -0.183989325360910 -0.022816670642033
-    4  (  4) -0.027396737691172 -0.045295479134009 -0.129115557967778
-    5  (  5) -0.000453294188389  0.059142853300762 -0.038676049893677
-    6  (  6) -0.012371321314524 -0.021833349857811 -0.007208017450018
-    7  (  7) -0.015425630197400 -0.001848995755235  0.027351698922038
-    8  (  8) -0.000188535381821 -0.004971799266654  0.013988330055868
-    9  (  9) -0.002500332480999  0.018263398716747 -0.000166576528748
-   10  ( 10) -0.017029282729959 -0.001958362912370  0.009978757223056
-   11  ( 11) -0.000136976274521 -0.009294880869252 -0.003968240988117
-
-	DPD File2: P*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.001614610532278  0.000442574931184 -0.002484843724335  0.011617230485838 -0.003558333116152  0.008348902874223  0.003232631795727  0.035474959748436 -0.033113190058216
-    1  (  1)  0.000925459790748  0.002756415978539 -0.003671717190974 -0.027737733508484  0.046977278124977  0.010834189586698 -0.039059419738438 -0.012041835747932  0.002521971555221
-    2  (  2)  0.003459035434675  0.003977336342235  0.002397115178596 -0.018307436778833  0.034854228953805 -0.010228254395608  0.015345849161942 -0.005957982277486  0.035439629368503
-    3  (  3) -0.011412707516267  0.027632363855031  0.015411420139492  0.000653998533291  0.003171166784775 -0.010061032918207 -0.036835076234213 -0.006892251008290 -0.051742329375438
-    4  (  4)  0.002517172902630 -0.045696438310625 -0.035505499284382 -0.002530384085850  0.000253636208605  0.042894004341368 -0.014146809697220  0.013420506783873  0.046216668076946
-    5  (  5) -0.010111413240912 -0.013164521551321  0.011774998630568  0.009111026904833 -0.043299806769081  0.001105938056711 -0.021679173976934 -0.006497350404042  0.032564751151170
-    6  (  6) -0.003572744448066  0.037660563650739 -0.015981449923599  0.037360518379434  0.013810638672119  0.021864723269171  0.000142160187409  0.064951874935402 -0.010074940303513
-    7  (  7) -0.035166313105451  0.011117323575587  0.004943664183497  0.007105865391641 -0.013161333406594  0.006687507585744 -0.064466547112747  0.000008929989578 -0.021120345923087
-    8  (  8)  0.032509023911163 -0.002177177339651 -0.037021275355168  0.052629293793154 -0.046088465137947 -0.032895946707180  0.009967848101922  0.021497535040403  0.000352351163086
-    9  (  9)  0.046618687808640 -0.037317727430997  0.035589549384149  0.025010790590209 -0.028730927164894  0.032022748116099 -0.011580581352781  0.023706215184994 -0.002053813335462
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.047931933872975
-    1  (  1)  0.037047707028514
-    2  (  2) -0.035085472287032
-    3  (  3) -0.025182750300990
-    4  (  4)  0.028820432773372
-    5  (  5) -0.031275953086245
-    6  (  6)  0.011353625053442
-    7  (  7) -0.023384944254726
-    8  (  8)  0.002155438322651
-    9  (  9)  0.000134462394627
-
-	DPD File2: P*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.017096508292429  0.120272055653498  0.064777511074434  0.013939283933308  0.004251250821330 -0.059136973839352 -0.058075430708834 -0.010753929155031 -0.046095863651254
-    1  (  1)  0.009080853524756 -0.030472101004599  0.005253613736105 -0.008033743953506  0.006571724145552 -0.017271428965569  0.096045717241910 -0.001899586023459  0.018803255158658
-    2  (  2) -0.015273557408716 -0.033827870425321 -0.002389839271830 -0.049309614559235  0.022714875551557 -0.013412250204381 -0.039215858182843  0.002671798725080 -0.073595316258831
-    3  (  3)  0.061397351425600 -0.002542014700822  0.006723003856764  0.036114072726144 -0.031891831787348  0.035470170376113 -0.050339849642367  0.011227685711093  0.032863858710597
-    4  (  4)  0.010418037759007  0.052312507311500  0.003108263430226 -0.063054388106328  0.009131466039430 -0.023063009355567 -0.186998825704419  0.007656193265988 -0.085937490516795
-    5  (  5)  0.049618070764987 -0.269816796530382 -0.071812132158805 -0.093909466368595  0.090964919694381  0.192302531462338  0.140007312222197 -0.095346589436075  0.068662718351823
-    6  (  6) -0.050705074903890 -0.083507573951399  0.075121836066492  0.150175624907254  0.110901140548139 -0.044187464402636 -0.100826757127919 -0.348159602318287  0.115791138943855
-    7  (  7)  0.024247361034940 -0.261502177446179 -0.185335196490176 -0.086407538269004  0.040595405612183  0.132471756059254 -0.167354565247558  0.226853259555790  0.063338369472266
-    8  (  8)  0.031044409528402  0.062420557845031 -0.150070034340745  0.052228051583476 -0.077587419735710 -0.089629913379487 -0.056032626281614 -0.008151827554649  0.096931788597858
-    9  (  9)  0.317132702814373  0.055314612013316  0.137754640120023  0.090773612718365 -0.100625469824133 -0.163650859440807 -0.143669062909266 -0.090566852675112 -0.052322376391313
-   10  ( 10) -0.142709053237480 -0.301053034065592 -0.082895903712517  0.097157063403116 -0.061479199300513 -0.055989010255340  0.082779787274017 -0.112598796382161 -0.005058093098571
-   11  ( 11) -0.016299349881188 -0.110322948765521  0.098821973474101 -0.099107211043419 -0.036545717852368  0.075028438099748 -0.024327846026163 -0.071464427045319 -0.082135257183916
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.047447570064905
-    1  (  1) -0.000600353714311
-    2  (  2) -0.061561394612175
-    3  (  3) -0.026518358614439
-    4  (  4)  0.004924249256689
-    5  (  5)  0.118873243448111
-    6  (  6)  0.158683429135866
-    7  (  7)  0.034364315517391
-    8  (  8) -0.057789177012035
-    9  (  9) -0.092690338450207
-   10  ( 10) -0.035646580943718
-   11  ( 11)  0.038984516104221
-
-	DPD File2: P*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.006230857276436 -0.048797056399666 -0.012716116252621  0.005739964124866 -0.013481384616698 -0.042689584077060  0.017270348738051 -0.000419243135126 -0.040443254435763
-    1  (  1) -0.001630425204596 -0.020575306800344  0.074043146154741 -0.016576990359565  0.024266588171945 -0.025003638188733 -0.041229879168230  0.009096713997008  0.048943522201480
-    2  (  2)  0.021449672787194  0.004533663013035  0.064512297360970 -0.026056320112975 -0.012311600212379  0.057705244730510 -0.006103097277552 -0.007629023643838 -0.100142202402752
-    3  (  3) -0.024506116908941 -0.014405190116035  0.023988780893855  0.096344308015785 -0.049822440345522  0.076920537167928  0.020583335246490  0.007240688074708  0.088817051721264
-    4  (  4) -0.016982681746660 -0.005612968048325 -0.130937709169030 -0.258341025931177  0.140085239410274 -0.222842232178951  0.024820716730135 -0.026325168673687 -0.055547617569483
-    5  (  5)  0.037879155414163  0.128090386002125  0.141870995017207 -0.234587600888966  0.098914790788390  0.305800275284305  0.055598905633593 -0.131805449829431  0.041081235097661
-    6  (  6)  0.043168564703436 -0.030010861129281  0.029114697539830 -0.006214587904626 -0.071804351546120 -0.111206250824606  0.202125985301076  0.151209805862799 -0.037927022313810
-    7  (  7) -0.020929918098688 -0.040166703104938  0.207928074963598  0.005063717904073 -0.015982060703677 -0.122893504730377 -0.039398473312957  0.243542435447176  0.058898622679243
-    8  (  8) -0.035897100247807  0.130947966136576 -0.251331455270193 -0.079974479173535 -0.413130980507748 -0.044171581238907 -0.028005185833489 -0.165066997038960  0.062489289780689
-    9  (  9) -0.085514193547145  0.054930855523547  0.094296152584403  0.050328255510316  0.067641033769805  0.023318053487733  0.006464024057725  0.152704070253429  0.195690762137195
-   10  ( 10) -0.121783132454786  0.121649518544985  0.001288572370528  0.044670432803679 -0.008034312045081 -0.029879089305665 -0.065139715799550  0.014008708897036 -0.002845810213058
-   11  ( 11) -0.023815006694348  0.014334287141683 -0.141630066387855 -0.145326344089203  0.037857456986322 -0.058499598917858  0.030801987861182 -0.076045397273525 -0.051718689270491
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.052021099116092
-    1  (  1)  0.000375019046341
-    2  (  2) -0.005095441550314
-    3  (  3) -0.212700400741322
-    4  (  4) -0.008054755280988
-    5  (  5) -0.023289560627031
-    6  (  6)  0.062134458371494
-    7  (  7)  0.183963154970289
-    8  (  8)  0.064610383082142
-    9  (  9) -0.033969497782711
-   10  ( 10) -0.034207553536027
-   11  ( 11)  0.027487667010859
-
-	DPD File2: P*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000165454282488 -0.050277476849634 -0.072265886779903 -0.219046110490914  0.170649240297555  0.129272117676281 -0.046129561714749 -0.006317178179283  0.031628796061177
-    1  (  1)  0.049926970343888  0.000066751428030 -0.008605428716391 -0.088466711253630  0.066209204064307 -0.157896361055452  0.137975283709074  0.116685446085702 -0.066609214976363
-    2  (  2)  0.071930707909687  0.008646608001517  0.000252105095070 -0.010529809483454  0.048142356541763  0.064293359314159 -0.026509274318636 -0.087307307132468 -0.055490250957849
-    3  (  3)  0.218638932403761  0.088400431595603  0.010362259249877 -0.000161808465947  0.006831656503924 -0.050359143062454 -0.002950107894051 -0.043414691353781  0.231632275337861
-    4  (  4) -0.170408151565692 -0.066676104740888 -0.048741085770175 -0.007781046963117  0.000858319634312 -0.017393073562842  0.004806366800845 -0.002128732121080 -0.034666156637510
-    5  (  5) -0.129353639616675  0.158198145877926 -0.063792237373481  0.051918849505394  0.015159666578669 -0.002164443359528 -0.004048396359766 -0.028258116638309  0.019204959902610
-    6  (  6)  0.046105252486005 -0.138278098772584  0.026048974354469  0.002423377188050 -0.004804777279161  0.005123584343751 -0.000505492048966  0.004681249428299 -0.016114426086496
-    7  (  7)  0.006108731746456 -0.116491031311707  0.087525580101622  0.043947283481964  0.000746891253088  0.028211685279895 -0.004399353185530  0.000226937079603 -0.001563554764084
-    8  (  8) -0.031635416967255  0.066903366010132  0.055032255173046 -0.231683009312988  0.036206711489392 -0.019839043489615  0.016402673760561  0.000838534461521  0.000669878290914
-    9  (  9) -0.101001614493512  0.035831143017804  0.051001612315387  0.120753800379163  0.001670851222790  0.022069869139317 -0.000180056135152 -0.007894743612700 -0.004712239169077
-   10  ( 10) -0.077799422553552  0.050172827558475  0.178180262760682 -0.011809496949311  0.042695780330294 -0.018100828459930 -0.003739392396915 -0.021764215771311  0.004254325334512
-   11  ( 11)  0.170574833391475 -0.090218966161298 -0.186165933844747 -0.106592282303210  0.035685321173548  0.005531846565163 -0.019468178901053  0.028819942408996  0.018249838127253
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.100729285954756  0.077818756543715 -0.170553425058221
-    1  (  1) -0.035210403182738 -0.050067933089505  0.091777926183755
-    2  (  2) -0.050619295779235 -0.177821703580419  0.188186480685002
-    3  (  3) -0.120238811273927  0.012548687236120  0.107146423121442
-    4  (  4) -0.001472161299553 -0.042086791480199 -0.037190721415684
-    5  (  5) -0.022276355941346  0.015313888242227  0.001378381953714
-    6  (  6)  0.001377652740630  0.005127424181781  0.019087401021940
-    7  (  7)  0.008204594963178  0.020563680487320 -0.026290026069629
-    8  (  8)  0.004730566883743 -0.003787060797718 -0.021343901910363
-    9  (  9) -0.000654068579583 -0.020656394329926  0.003094384610269
-   10  ( 10)  0.019022274800240 -0.000759677344253 -0.055278729862632
-   11  ( 11) -0.002626982476879  0.053971886669755 -0.001915083825045
-
-	DPD File2: P*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000967260159080 -0.002202446432524 -0.004511183444430 -0.016374841316601  0.010910776906997 -0.001418525150323 -0.006755217615277 -0.000427817126425 -0.035846025325519
-    1  (  1)  0.000391246067407  0.000877310728950 -0.036241037300273 -0.001407367638059 -0.003934213075234 -0.029267906970015 -0.005602239959753 -0.010795263272597 -0.003740186293266
-    2  (  2)  0.003829576674383  0.036990457610833  0.001398441262724  0.029943520801568  0.002038487479024 -0.023272259992080 -0.008230578537541 -0.007682382933230 -0.017088399951020
-    3  (  3)  0.016032914359479  0.000368568996962 -0.031158252703803  0.000059940788557  0.028967799575646 -0.026891964655620 -0.003191177418001  0.012156707421423  0.040980572338667
-    4  (  4) -0.011582657878517  0.004557355848480 -0.002754831890239 -0.029254644747513 -0.000056895383566 -0.010447389828344 -0.011227363550004 -0.017276460075010 -0.082609995830667
-    5  (  5)  0.000873189786955  0.030297579893434  0.024073075343027  0.026022721348298  0.010366640393980  0.000392801080983 -0.006236144036416  0.025488940454099 -0.075546848613138
-    6  (  6)  0.007828000597579  0.004715416733939  0.007204534812621  0.003548053014936  0.011139775691561  0.005780043754072  0.000209890995218  0.022093647786116 -0.021521213110625
-    7  (  7)  0.000136712832700  0.010084233633668  0.007596217834139 -0.012002297241493  0.016971650696249 -0.025598072815601 -0.022061499371271  0.000030924207599  0.027480037260575
-    8  (  8)  0.034517163034967  0.003881690632474  0.018182293711114 -0.041467916178783  0.083381816772957  0.076400917002772  0.021226287037618 -0.027577743559442 -0.000308523373358
-    9  (  9) -0.006887640002591  0.038004114862362 -0.068066991173237 -0.074540859178153 -0.096325885879967 -0.063826495228134 -0.021741321038929 -0.075328539771934 -0.015720438309394
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.006955591851981
-    1  (  1) -0.037011716243653
-    2  (  2)  0.066925876832342
-    3  (  3)  0.074849385969586
-    4  (  4)  0.096213956733721
-    5  (  5)  0.063907467407383
-    6  (  6)  0.021571044568900
-    7  (  7)  0.075014265081936
-    8  (  8)  0.015443164438173
-    9  (  9)  0.000349977346717
-
-	DPD File2: P*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.008473601581619  0.058320078803013  0.009499899472232 -0.001088259135238  0.016242997407558  0.041642820354273 -0.019281478381302  0.001541696314659  0.042254273858150
-    1  (  1)  0.000334490440486  0.020235443091975 -0.074874760692952  0.017019076387196 -0.023949159076861  0.029015987792742  0.043482201692770 -0.008653533652648 -0.050609003215613
-    2  (  2) -0.017649927420035 -0.005466470543623 -0.062819872537720  0.024335617743925  0.013549365831462 -0.057638943360770  0.007946525598619  0.007453269935932  0.104441618231136
-    3  (  3)  0.020783291637709  0.012738132257300 -0.020888891645260 -0.097905028236283  0.052672606431380 -0.073196008154541 -0.021238374576188 -0.005922717755271 -0.087456377608286
-    4  (  4)  0.016996530387751  0.011882557110211  0.133285493089740  0.270904493255005 -0.144936247136341  0.230612270825641 -0.025999484339616  0.027186445681165  0.054335849730519
-    5  (  5) -0.043265455211536 -0.139979958816237 -0.149715430516995  0.247713647604899 -0.102410559077642 -0.319151604186489 -0.057805788052851  0.138415193321428 -0.046014997665461
-    6  (  6) -0.052880707652045  0.033123002053909 -0.032014076939227  0.006298867450682  0.077062313270277  0.118246557884146 -0.214649227435815 -0.157387472815374  0.039780533308888
-    7  (  7)  0.019315588907448  0.037515736358395 -0.221610727048942 -0.003867379753041  0.018038584173024  0.130726889432006  0.043210067374229 -0.255244255063184 -0.061970702798214
-    8  (  8)  0.039457544550719 -0.137467753709456  0.263418210746405  0.083532282441423  0.434570179765344  0.040715456256394  0.028807073739423  0.172129116920192 -0.067053424144521
-    9  (  9)  0.108821808763067 -0.058176331616836 -0.096181779066212 -0.052585164814310 -0.074960862104189 -0.030411666230606 -0.005322365866114 -0.162638108566386 -0.208900911424941
-   10  ( 10)  0.143141318703370 -0.135644721237897 -0.004816763589682 -0.046370390666413  0.007684027070582  0.031560700160296  0.073644359681820 -0.014497709274558  0.002720022476073
-   11  ( 11)  0.028228442161314 -0.029546966066375  0.156785160510693  0.149588448608652 -0.045289290724147  0.066420712374432 -0.030566776449830  0.079826396018234  0.056206720757084
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.054452002537081
-    1  (  1) -0.000507638322506
-    2  (  2)  0.005540126912246
-    3  (  3)  0.215642625069238
-    4  (  4)  0.015797761320826
-    5  (  5)  0.020861352515884
-    6  (  6) -0.063379663837058
-    7  (  7) -0.192560463271225
-    8  (  8) -0.066391989253748
-    9  (  9)  0.030368405143431
-   10  ( 10)  0.036776046301376
-   11  ( 11) -0.030367451420999
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.057770723551805 -0.007686176362995  0.037676874102239 -0.021875314889184  0.005506967440553  0.033731453254856 -0.019605915987929 -0.000153810358456 -0.020480209762043
-    1  (  1)  0.007936092328855 -0.008454757012618 -0.010966637507272  0.001712970012603  0.003491085971866 -0.000515536715359 -0.020166951580993  0.003537118918414  0.007401819292438
-    2  (  2)  0.004823273660701  0.024918096949402  0.013456316532648 -0.018061040723257 -0.007928867774181  0.029348077247204  0.008305651855965 -0.003787093111853 -0.048173394734837
-    3  (  3)  0.011675775125104 -0.107663431050362 -0.048399528007616  0.036525102270435 -0.040730641356466  0.022154401905676  0.022459222262206  0.014732815012435  0.056193647103106
-    4  (  4) -0.087218313447135  0.162702625594382  0.040016358931151 -0.090893257640902  0.161526551014906 -0.070532962320029 -0.041494660476799 -0.036307465283525 -0.053954994619678
-    5  (  5)  0.299080380154522  0.047071149143854  0.050599107356677 -0.086076035660096  0.105747613370625 -0.016291716828988 -0.035370479977499 -0.024570880182810 -0.019740472062472
-    6  (  6) -0.064660820062842 -0.041897488689090  0.115036198620178 -0.009494466980017 -0.021741244197439 -0.082050622741463  0.041036304002792  0.093842813724870  0.099009311380003
-    7  (  7)  0.041406109005398  0.013292096025031 -0.015299070066933  0.090658889471223 -0.096664535474361 -0.020138730803122  0.181635797654581  0.008096043748855  0.043219320460348
-    8  (  8) -0.213166983290885 -0.019961961605909 -0.071163032757987  0.089566388255459 -0.187567657300030  0.059322694628756 -0.181371262434162  0.031805535782928  0.037438192749058
-    9  (  9)  0.029081682004423 -0.052377114086944  0.016598919354525 -0.054121123864817  0.005943121322964 -0.052845962329270  0.099913404453613  0.011257505074012 -0.046946017590445
-   10  ( 10)  0.029775807936917  0.011144658296549 -0.123616713069900  0.069048925266029 -0.072425392135727 -0.175724644218768 -0.020473761865880  0.027329304597195 -0.030635509122054
-   11  ( 11) -0.065686621670288 -0.046175058814983 -0.054739230530016 -0.067089838730126  0.085213076503212 -0.033327993779702 -0.039100303871838 -0.006432393458887 -0.004793440843030
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.007846989553355
-    1  (  1)  0.003599492488651
-    2  (  2)  0.050462951485827
-    3  (  3) -0.025590884562196
-    4  (  4) -0.058023095683205
-    5  (  5) -0.032774222915836
-    6  (  6)  0.063967275967677
-    7  (  7)  0.008682341559207
-    8  (  8)  0.054096899442108
-    9  (  9)  0.060114344610370
-   10  ( 10)  0.027778486812577
-   11  ( 11) -0.026791075407401
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000027040423887  0.011060683872803  0.004793456647899  0.073481718860181 -0.071504628495016 -0.043329380984548  0.025554578097106  0.020981780177699 -0.009741644195740
-    1  (  1) -0.011009750762997 -0.000007607240151  0.023558132508086 -0.077101510719000  0.072464798814331  0.012890143420536 -0.005683277430906 -0.006920173400283  0.002574145843753
-    2  (  2) -0.004842956248702 -0.023538681455719  0.000165226839542 -0.207870652255993  0.210753100259611  0.104860036207310 -0.066732822825146 -0.046426833468215 -0.005606364639263
-    3  (  3) -0.072846425542822  0.076633967419021  0.207131819599136 -0.000363002499158 -0.003747206858118 -0.078444561827851 -0.135702906183535  0.013002670417717  0.066080178603036
-    4  (  4)  0.070600283658190 -0.071629978927021 -0.209426851727876  0.004131403945752  0.000622007773293  0.030404083775686  0.072573499649568 -0.005804369418180  0.017256603820917
-    5  (  5)  0.042938103533211 -0.012767138266668 -0.104089521411634  0.078509088982138 -0.031589837534126 -0.000702189622727 -0.234416668036359 -0.006073164073880 -0.085676616502380
-    6  (  6) -0.025301081140471  0.005670371975564  0.066621493148361  0.135369815380962 -0.072186642283625  0.233429156027521  0.000193153533248 -0.257186865053465  0.080618496507255
-    7  (  7) -0.020822354558258  0.006724508724119  0.045993762455479 -0.012965367547761  0.005443358605263  0.006173477804865  0.257050229473736  0.000107746294773 -0.140355654948263
-    8  (  8)  0.009433315806276 -0.002386871891496  0.004905034102302 -0.065444732417879 -0.016877777772437  0.086229493149666 -0.079936884810997  0.140925849197376 -0.000032973152365
-    9  (  9)  0.050122316171813 -0.043792237275169 -0.089139695085719 -0.017498120874682 -0.031599257819379 -0.003933044438540 -0.023956851013655  0.023591093022906  0.231355322027963
-   10  ( 10)  0.021733936110572 -0.028861084661254 -0.012680330783905 -0.120427356784394  0.061995107162282  0.110107780731446  0.044522956915282  0.044154909833586  0.092344585382497
-   11  ( 11) -0.054009861310889  0.049060128861341  0.116101359422429  0.043743279836749  0.090347856826429 -0.186254068915307  0.010091097621831 -0.182439821622372  0.003662369325971
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0) -0.050351452990167 -0.022080091821478  0.055614920128739
-    1  (  1)  0.043523152379598  0.028913570586242 -0.049281187081852
-    2  (  2)  0.088800989050704  0.012387284429283 -0.115844546053497
-    3  (  3)  0.017174780224652  0.120766108673226 -0.043936127494914
-    4  (  4)  0.030870076304731 -0.062251132422338 -0.090680792727787
-    5  (  5)  0.006295822004517 -0.109602420736026  0.187179028172583
-    6  (  6)  0.023342165877015 -0.045357751936196 -0.008109043414047
-    7  (  7) -0.023116687534610 -0.043892116907456  0.180954962224114
-    8  (  8) -0.233341712412303 -0.091442003006516 -0.004136900096905
-    9  (  9)  0.000301754743843  0.311200434843549 -0.071746006250031
-   10  ( 10) -0.310579381122594  0.001146128096000  0.337175845358798
-   11  ( 11)  0.071759110731455 -0.341710402101474 -0.000514995746851
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000373475564698  0.036374284715410 -0.020675408038120 -0.041938611278043  0.014954064130636 -0.008670693741941 -0.001941666498966  0.002175213653671 -0.081223953533966
-    1  (  1) -0.035409311090430 -0.000583412494499  0.021912114995751  0.019686191919175  0.001337756516393 -0.101410043872272 -0.013539530463413 -0.021085032009130 -0.104140442794578
-    2  (  2)  0.022476650279619 -0.020869170321065  0.000623148668542  0.026925059222749 -0.022600045203783 -0.054500059821995 -0.019747085432266 -0.002197258536137 -0.059803959084815
-    3  (  3)  0.040527884961938 -0.020785023904239 -0.026269813130118 -0.000471315833621  0.011435927824319  0.005094359128676  0.021078069661848 -0.001900689912103  0.049285996887456
-    4  (  4) -0.014876995236008 -0.001935832477363  0.021280417512247 -0.011112950356736  0.000010954074914 -0.001375736589678 -0.021071346294591  0.002540388393255 -0.057176443725449
-    5  (  5)  0.009413911140341  0.101590521816804  0.054440250203052 -0.004479146413684  0.000983185589705  0.000044886603863  0.008942266041566 -0.007734744988056 -0.012623227871857
-    6  (  6)  0.001228199632690  0.013460754514196  0.019370737847276 -0.021147815413154  0.021180440912387 -0.009078596190780 -0.000060187992369  0.021757615671251  0.021546696625458
-    7  (  7) -0.002386621109668  0.020697715049428  0.002142304032572  0.001889845237358 -0.002502377714011  0.007891184567460 -0.021671667697211  0.000014467640044  0.019485620614445
-    8  (  8)  0.082726042327291  0.104120679625015  0.059410287861643 -0.049170685661379  0.057558349352742  0.011952514103015 -0.021313492463386 -0.019559674827960 -0.000280085719614
-    9  (  9) -0.081272328726009  0.110754135563007  0.028218762900775  0.005318083145326 -0.020981856638396 -0.014567561104212 -0.097856532501808 -0.003185861516469 -0.003396420233766
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.080531031337273
-    1  (  1) -0.111220099551316
-    2  (  2) -0.028332370195928
-    3  (  3) -0.005372945270244
-    4  (  4)  0.020768901638641
-    5  (  5)  0.014982546342664
-    6  (  6)  0.097582479807565
-    7  (  7)  0.003277826561639
-    8  (  8)  0.003260780284830
-    9  (  9)  0.000186812021876
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055078142867828  0.005804719299681 -0.036780646353647  0.020745008939831 -0.005631321838333 -0.032388434299089  0.019554696167851  0.000026315290494  0.020764618651157
-    1  (  1) -0.007062764870854  0.009531925050962  0.009339128991500 -0.000585332198702 -0.003536715157378 -0.000717716084393  0.020997702694190 -0.003197609406412 -0.007543205569196
-    2  (  2) -0.003273721829615 -0.024127785783056 -0.019803917766004  0.021792459075320  0.009225997435944 -0.033280936086821 -0.008357612389432  0.004534634518823  0.049752671423908
-    3  (  3) -0.009467819748219  0.109846311430058  0.049077069582499 -0.038067479834844  0.041344367688361 -0.023164856965512 -0.023494777837550 -0.015492414054440 -0.057415728354703
-    4  (  4)  0.087998530211411 -0.166680738017738 -0.040492236619192  0.094854089537164 -0.166732509395464  0.071703004448668  0.042087550249065  0.037122017300705  0.054342710801435
-    5  (  5) -0.299229806278301 -0.048658757713325 -0.047129705842446  0.086908947365866 -0.109728878663932  0.016789363568018  0.035383410684614  0.025335321764417  0.020816334753998
-    6  (  6)  0.066809370303780  0.045194542515417 -0.116536125053039  0.010429907504714  0.024187359392906  0.082665971873618 -0.044425337546003 -0.096427706292236 -0.099634759729367
-    7  (  7) -0.040692585686945 -0.010414403444448  0.019197392244389 -0.094603783326762  0.099044517012418  0.021567521501408 -0.184530946067710 -0.010140666068000 -0.044429992698867
-    8  (  8)  0.213871489773344  0.016533777636027  0.072796199007045 -0.091991735348903  0.195396773842710 -0.059284334625803  0.184339397290396 -0.031894612373968 -0.038856272349111
-    9  (  9) -0.030682243044227  0.041775517875249 -0.024602057980135  0.057287290343526 -0.006772740334119  0.055735826221076 -0.097648839100779 -0.011580457295414  0.048271645082472
-   10  ( 10) -0.033182564179255 -0.014791814568441  0.134627953730393 -0.074303509883212  0.072048570540947  0.178297714606306  0.018972497943516 -0.029382172234938  0.026191954922422
-   11  ( 11)  0.065304385216644  0.054065687922946  0.058978656197155  0.069527138693935 -0.087278294466894  0.031923025189413  0.037244505404452  0.006712268565440  0.005721877407454
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.007990021156235
-    1  (  1) -0.003543862611170
-    2  (  2) -0.051263654644270
-    3  (  3)  0.026303130686066
-    4  (  4)  0.059400171065937
-    5  (  5)  0.033889468632128
-    6  (  6) -0.063573026890197
-    7  (  7) -0.010425863419296
-    8  (  8) -0.056178737365981
-    9  (  9) -0.060112542127891
-   10  ( 10) -0.033303474011037
-   11  ( 11)  0.026602109435667
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.023607177491195 -0.019696611969885 -0.037221212000385  0.015590319696057 -0.002020189842990 -0.021016653547429  0.007873916136755 -0.003448340610807 -0.079821954504390
-    1  (  1)  0.007327805297828  0.018867534486269 -0.042212469078496  0.001447360534353 -0.028939866752754  0.077938653083341  0.061948383376365 -0.004945505795557 -0.075894556663474
-    2  (  2)  0.009007071740861  0.016177005802987  0.068312932673240 -0.041184857036759 -0.003023256838844  0.009849571097863 -0.004290386808972 -0.004340519661127 -0.085840789796801
-    3  (  3) -0.026077185963910 -0.012520558385893 -0.023360353465929  0.029787599349062 -0.027312833784239 -0.081100062029021 -0.033406666012159  0.054430078300136  0.042036783131155
-    4  (  4) -0.044521029970710 -0.101548028530885 -0.092152577419686  0.036969661342643  0.235975964790827  0.022489800485005  0.018037809327809 -0.163273258200919 -0.255997686637622
-    5  (  5)  0.075082806179399 -0.059495559215694  0.178951166772656 -0.134634824114366  0.237022622504406 -0.054772185517501 -0.024504277147484  0.150049663229407 -0.003365655895118
-    6  (  6)  0.075564373604390 -0.030719217759732 -0.086498148733354  0.160325933966896 -0.064234285643905  0.161900908445555 -0.266146706738358 -0.238096934941697 -0.054011663901563
-    7  (  7)  0.117049393955643  0.184359827232724 -0.154835473828309  0.196676571259727 -0.209716028817009  0.429620861048445  0.096138950091600 -0.371356959007903 -0.058084061024513
-    8  (  8)  0.116322044765828 -0.134673176933366  0.115490121530453  0.372419146214479 -0.134366059259054 -0.090977060566167  0.047847126119104  0.349531731511066 -0.026343643532612
-    9  (  9) -0.016166361653787  0.064655468388956 -0.096603309196917  0.102141195994536  0.004689543577322  0.174053614560893 -0.096535422651742 -0.179574162178272  0.093140031286430
-   10  ( 10) -0.038118657992317  0.011712936317703  0.109233641260348 -0.041948680427994 -0.067033240911419 -0.043789144467457 -0.119198984082488 -0.019961916251994 -0.046236232124822
-   11  ( 11) -0.202537936665755 -0.041865413038804  0.001109842658197  0.036047997932446  0.209039172907281  0.039634162843452 -0.042796449278664  0.037154632643052 -0.094709860395635
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.001464671751436
-    1  (  1) -0.092168971837118
-    2  (  2)  0.096834154775615
-    3  (  3)  0.085232004143247
-    4  (  4) -0.224276823308218
-    5  (  5)  0.037070717977035
-    6  (  6)  0.017788678150516
-    7  (  7) -0.125655013910958
-    8  (  8)  0.036753750028807
-    9  (  9) -0.104788947042948
-   10  ( 10)  0.055723652563089
-   11  ( 11) -0.029086171780033
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000103943053471 -0.020502980666838 -0.044487026908476 -0.112522389921676  0.115190927698806  0.086304427533430 -0.028732798000328 -0.005755262072674  0.052707374815472
-    1  (  1)  0.020396732597728 -0.000175507711089  0.066631576709106  0.188566511167110 -0.188604507023904  0.081802717690830 -0.123212599282903 -0.146580404278728  0.063843813395139
-    2  (  2)  0.044224363892114 -0.066688325942716  0.000328779542201 -0.131627364199491  0.085838688001563 -0.039792906367986  0.071990397116460  0.041811204620793 -0.129151440044184
-    3  (  3)  0.112356491847955 -0.188595812422395  0.131743983691740 -0.000034238258909 -0.146405835083834 -0.293116155503685  0.174354593749844  0.234740190959724 -0.068400431241803
-    4  (  4) -0.114478156906703  0.187880772610577 -0.086711640119064  0.146345707242046  0.000351413466984 -0.200401380550659  0.118118144680811  0.106599388398520 -0.027535193682288
-    5  (  5) -0.086013769068620 -0.081687368012874  0.039811317138268  0.293720012918757  0.199751621453618 -0.000779002249077  0.029574633012291  0.100809576430270 -0.310087999943630
-    6  (  6)  0.028593362634754  0.122990647052479 -0.071886866993686 -0.174357265134888 -0.118164594946332 -0.029455932226559 -0.000323502179386 -0.067588972736558 -0.054838186724730
-    7  (  7)  0.005405231783831  0.146637005514722 -0.041701223809144 -0.234444344892692 -0.106310138998589 -0.100760684833959  0.067340032280388 -0.000050446895501 -0.206356025427645
-    8  (  8) -0.052734404217526 -0.064663294136106  0.127867798766573  0.067686878519552  0.027452578317565  0.311518253800823  0.053511305641188  0.206912543882787  0.000090733997612
-    9  (  9) -0.040822323151076  0.050351126620632 -0.033443030139718 -0.028678071562223  0.070729562284205 -0.035204318394559  0.035088801145452  0.003858253384271 -0.209126878103916
-   10  ( 10) -0.043554697985060  0.034029200702705  0.113396889510888 -0.025104351967769 -0.057922093461755 -0.050331966245759  0.113578028555237 -0.006845000513571  0.183899295084893
-   11  ( 11)  0.104445737487499 -0.085327185159750 -0.138831980783855 -0.068059267872915 -0.045287984054307  0.106421559557756 -0.126370094892912  0.085884676801538  0.038487188398792
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.040472375428214  0.043732687824618 -0.105326662293090
-    1  (  1) -0.050113148730272 -0.033553830886801  0.085228632878169
-    2  (  2)  0.033648303602896 -0.113430364410931  0.140304701766262
-    3  (  3)  0.028908821271170  0.025577280295259  0.067243263311150
-    4  (  4) -0.070488811800233  0.058243639304596  0.043815524401846
-    5  (  5)  0.035954881502730  0.048633621823234 -0.102557737449989
-    6  (  6) -0.034599692943826 -0.112216626584703  0.126288398892548
-    7  (  7) -0.003737404887253  0.007316223089443 -0.087031799969318
-    8  (  8)  0.210522602449556 -0.181960897898471 -0.040780655119777
-    9  (  9) -0.000486792078199  0.154877597629272 -0.324381992896252
-   10  ( 10) -0.154731729402294 -0.001003846432056 -0.227757018056261
-   11  ( 11)  0.321308213629134  0.230320716710505 -0.000521529871008
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000267990887146  0.017094909685382 -0.026886221509252  0.009154729792392  0.028447394308811 -0.043026223139973  0.007934241734193 -0.017529929372393  0.048064409198736
-    1  (  1) -0.019165257539447  0.000577613190074  0.023971643573307 -0.023362002438445  0.020466955482562 -0.074368923093670 -0.021220838937975 -0.006899315294507 -0.004345205689582
-    2  (  2)  0.030573367311208 -0.023520686332899  0.000895230171902  0.026482533037414 -0.055578356600337 -0.061212128793543 -0.006033035982650  0.029878597421323 -0.067713186454891
-    3  (  3) -0.011556055604803  0.022912214561881 -0.028040995483179  0.000806143570890  0.016669730389240  0.057830279830177  0.001162806518994 -0.022110531165998  0.132937508894661
-    4  (  4) -0.029247962187325 -0.019722933579604  0.053631431975867 -0.015590855142050  0.000406564753787  0.013151443352440 -0.005583751708839  0.048344741694769 -0.058950645196782
-    5  (  5)  0.044502924478349  0.074343902828738  0.059891074519534 -0.057011647107618 -0.013642181191740 -0.000660380157385 -0.021619837229525 -0.066247874288904  0.026658775788480
-    6  (  6) -0.008416217090956  0.021046309429680  0.006522358687724 -0.001270652730649  0.005678899154477  0.021925039235368 -0.000233190982568 -0.044213316193167  0.019149792461568
-    7  (  7)  0.017220078580887  0.007669026797702 -0.030414088472195  0.022279636607030 -0.047947045698118  0.066391322818188  0.044159499520014  0.000036612147908  0.012788358083278
-    8  (  8) -0.049286641691243  0.005157181302332  0.067669102261374 -0.134137839836174  0.059598226202850 -0.026736423898111 -0.019691121432993 -0.012900597372237  0.000145671342113
-    9  (  9)  0.013771428368881 -0.001534324314609  0.097208563857550  0.041538777135659 -0.016922202614382 -0.071792645864290 -0.010700525463409  0.088926800959210 -0.027499461022903
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.013388445223016
-    1  (  1)  0.001743269961120
-    2  (  2) -0.097384653394849
-    3  (  3) -0.041118719872747
-    4  (  4)  0.017104740675403
-    5  (  5)  0.071235600573670
-    6  (  6)  0.010744046806778
-    7  (  7) -0.088045104682667
-    8  (  8)  0.027915642785476
-    9  (  9)  0.000257740691093
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.024087436020668  0.024234923487922  0.034655069016827 -0.013002508462274  0.003506876735183  0.019138226509165 -0.008729154622077  0.004126516633947  0.080810387962203
-    1  (  1) -0.007340388106341 -0.022740162593799  0.047399213843079 -0.000077807499313  0.029710781800549 -0.077091731467965 -0.063337905707382  0.003225301246506  0.076935684639064
-    2  (  2) -0.008533292606078 -0.014866249844284 -0.069414473601385  0.039067032188858  0.004447555351962 -0.009557153079335  0.003933218079563  0.004684619630234  0.087696717260759
-    3  (  3)  0.022970088927143  0.014796917693540  0.027844101865804 -0.035221698386289  0.026363064761687  0.090054977556852  0.034727496736464 -0.055362273105074 -0.041999796595917
-    4  (  4)  0.041840045940810  0.108064430049583  0.094169303786903 -0.038045467810124 -0.242703284807102 -0.022096059239039 -0.018423933000872  0.169152570163926  0.255707171958253
-    5  (  5) -0.076575292532566  0.064169513057282 -0.187842221364997  0.139017281082776 -0.239663562780447  0.056101309100792  0.026864961939161 -0.152773054853442  0.000863550220823
-    6  (  6) -0.082619291232389  0.034129866388443  0.092672858212650 -0.166047996934064  0.066033557533197 -0.164979644828487  0.279604374284854  0.245415146187524  0.057275952528883
-    7  (  7) -0.119525510255884 -0.192558180615050  0.157479601093184 -0.199612815310399  0.216488749413977 -0.438370355171240 -0.097840156788249  0.385286937285113  0.058774287435548
-    8  (  8) -0.115070416909243  0.142091116044252 -0.125572997790340 -0.378869543679260  0.139572537143277  0.093921809248974 -0.047279124915748 -0.359195083957732  0.024443650320069
-    9  (  9)  0.023211259159309 -0.064251202673602  0.092489429719048 -0.099069758679955 -0.005272254913816 -0.184087259640687  0.103465084079069  0.187259798043465 -0.097400286560574
-   10  ( 10)  0.039092748606065 -0.013006586457309 -0.115772480099790  0.044153430983449  0.068039357936569  0.040474168285568  0.124671276809929  0.020291967592974  0.043718085717437
-   11  ( 11)  0.205517300660670  0.035576186745690 -0.000856944671273 -0.036648470964825 -0.217305799958921 -0.037828885346138  0.045859373489911 -0.037554955798535  0.095933394086859
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.001311477468569
-    1  (  1)  0.093224324445080
-    2  (  2) -0.099200064811294
-    3  (  3) -0.086458921973920
-    4  (  4)  0.229446975291319
-    5  (  5) -0.035136747289852
-    6  (  6) -0.019108151626501
-    7  (  7)  0.127376470092273
-    8  (  8) -0.036832911731868
-    9  (  9)  0.106598068979743
-   10  ( 10) -0.058544237541584
-   11  ( 11)  0.029477471817291
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.089840465204225  0.055253525883540  0.050839656601929 -0.011592120168853 -0.028453073767485 -0.033272498563027 -0.013123122183092 -0.010376152774617 -0.046773274930095
-    1  (  1) -0.019180458750845  0.004406050242553 -0.021028155566967 -0.011538680320289  0.014109247012132  0.033202867729220 -0.146724711919951  0.006291497986158 -0.032816512639240
-    2  (  2) -0.008004935891454 -0.083588166091295  0.024500417662889  0.004976479402859  0.015361678869856 -0.027030028650554  0.075999531355577 -0.040388417899799 -0.092155828534757
-    3  (  3)  0.072751395760345  0.101339872261880  0.027554632505315  0.017104143799594 -0.009883810143648 -0.054325029446985  0.038424568195001  0.007564948769101  0.050859249479548
-    4  (  4)  0.116869612062058  0.168448689602172  0.076045170807919 -0.039076911238534  0.141061895780680 -0.082089594379007  0.096305838370831 -0.090937592520626 -0.089867596085833
-    5  (  5) -0.362411548066203 -0.116301468610581 -0.067304641586918 -0.178833394354847  0.120526935264372  0.077690766748935 -0.087853646530869  0.131583743921650 -0.005449987066682
-    6  (  6) -0.023022243577310  0.091878291587840 -0.168295716396468 -0.360782087280141 -0.197772285105134  0.118427120672179  0.100301554555422  0.545992767837121 -0.002274268616602
-    7  (  7) -0.332469089310140 -0.094037896803367 -0.021326282942452  0.202588446745432  0.003095262967230  0.074773576198707  0.261809753005545 -0.312310926113466  0.101271338039676
-    8  (  8) -0.102262443511968 -0.018323432973791  0.030286707735275  0.141132962784100 -0.140087132441384 -0.016144892573022 -0.105178803101546  0.077042517784067  0.061204405030880
-    9  (  9)  0.062921845500970  0.223934495766079  0.055471945329417  0.006791304491310 -0.142947280894142 -0.007991932919943  0.047858230706461  0.145718178913241 -0.072195393114585
-   10  ( 10) -0.062281498028430 -0.059385022217194 -0.196384149116451 -0.042900612771916  0.059951865879116  0.109494756681462  0.025377610533051  0.255425379720525 -0.006903138405362
-   11  ( 11) -0.109893814765672 -0.036299338598219 -0.008950289795172 -0.103979082032925  0.089663281746559  0.076642658317109  0.017386558594104  0.075203103677764 -0.110232824290932
-
-                         9     
-                      (  9)    
-
-    0  (  0) -0.015115955084904
-    1  (  1) -0.030649150844450
-    2  (  2)  0.004117081641871
-    3  (  3)  0.011275331966881
-    4  (  4) -0.082379096749867
-    5  (  5) -0.010925397739678
-    6  (  6) -0.209001724905895
-    7  (  7)  0.094421017044117
-    8  (  8)  0.009881568354141
-    9  (  9) -0.113416879853688
-   10  ( 10) -0.045856944277529
-   11  ( 11)  0.007202279712064
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    12
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000220708940429  0.002285125103983  0.191707004311250 -0.079176547202062 -0.015343724284655 -0.090762856917070 -0.035966370439669 -0.080228715251931  0.022632088832219
-    1  (  1) -0.002270884902228  0.000127565392507 -0.181504505051190  0.084301622984598 -0.019134286473150  0.136527597935967  0.291828838790707 -0.086935165867290 -0.003153353795357
-    2  (  2) -0.190790178739451  0.181286631653937 -0.000456958950263  0.098736144982791  0.201937120878681  0.060858985812145 -0.102547416191644  0.128157455079926 -0.052263022287278
-    3  (  3)  0.078674978461285 -0.083802623610643 -0.098399673810258 -0.000007811365746 -0.051373438075815 -0.073262818066183 -0.213681674768555  0.159362252554929  0.021801220424175
-    4  (  4)  0.014664072597960  0.019624839214450 -0.200908806156840  0.051706138267892  0.000345872163641 -0.060049554881332 -0.188299165959522  0.122222075869351  0.002767654097179
-    5  (  5)  0.090883158144736 -0.136634126073923 -0.061672946710902  0.074085610649007  0.059059222367226 -0.000127348357414 -0.089421360456473  0.068061409120582 -0.127845689145142
-    6  (  6)  0.036070137194869 -0.291478881075219  0.101913218910275  0.213840026067922  0.188217301311726  0.090313292624869  0.000227988253159  0.211121150654972  0.048790729392591
-    7  (  7)  0.080292928774450  0.086502244153537 -0.129683189759572 -0.159077086898913 -0.122727489493275 -0.066634459735053 -0.210168861536432  0.000749252129634 -0.114771568876213
-    8  (  8) -0.022833189301314  0.003149552694449  0.051809982276026 -0.021432628906503 -0.002600755913054  0.127892598520278 -0.048118709288206  0.114794510187460  0.000092800261922
-    9  (  9) -0.153861672366712  0.063959309581427  0.276686698038017  0.018129236980868  0.051934404023196  0.023341508326279  0.078386885605064  0.038564733458116  0.117925763161383
-   10  ( 10)  0.030779230036139 -0.047764824598951 -0.139550834348758  0.058848096986720  0.072156858928456  0.071321440087986 -0.120905085647966  0.006516751215124  0.144681807612295
-   11  ( 11) -0.005585664265456  0.000647324323586  0.016353426872082  0.045937924242292  0.003353711579607 -0.138994412824604 -0.062414171800322 -0.018128246119697  0.112476761917092
-
-                         9                 10                 11     
-                      (  9)              ( 10)              ( 11)    
-
-    0  (  0)  0.154066232086317 -0.030728257975556  0.006318091498164
-    1  (  1) -0.063643818147584  0.047463638962418 -0.000566548572565
-    2  (  2) -0.275258773270295  0.138888616959566 -0.015969350630016
-    3  (  3) -0.017345671201066 -0.059189082677904 -0.046475381464176
-    4  (  4) -0.050392875387071 -0.072424486885238 -0.004459708301674
-    5  (  5) -0.026836133802329 -0.070805989588457  0.140760690762251
-    6  (  6) -0.078585377266712  0.120742726291724  0.064292229739042
-    7  (  7) -0.041858894695365 -0.005665298794286  0.017186389956069
-    8  (  8) -0.118429783701800 -0.144155118064025 -0.113213711259466
-    9  (  9)  0.000756388118591 -0.455654623157072 -0.231432578787543
-   10  ( 10)  0.453567841489266  0.001497567906129  0.172275686133391
-   11  ( 11)  0.230120702539645 -0.175050207490782  0.001480251815160
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    10	col =    10
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000516219946816 -0.034778633659956 -0.032999546928151  0.009629039776278 -0.052966719633617  0.030450001531878  0.014875222246015  0.072128990177077 -0.048218822417803
-    1  (  1)  0.030877691560804 -0.001883541097772 -0.071434334115879  0.019325009721534  0.017452039030100  0.158145751795333  0.010537309557875  0.021583100108147  0.169934651056250
-    2  (  2)  0.033565318682613  0.071200997372983 -0.000581071534985  0.036850040138101 -0.007310816547227  0.008797901115406  0.029229533057666  0.016744128499400  0.070455787497455
-    3  (  3) -0.011004884819686 -0.019179310791618 -0.034909263032370 -0.000523661128158  0.007125267622899  0.017666281606150  0.025274953349027 -0.006048522524524  0.042959205727090
-    4  (  4)  0.052383681601535 -0.016788640224883  0.007028507044452 -0.007472760866637  0.000164741631073  0.026820745242549 -0.000005495327564  0.022752424410877 -0.031410113616428
-    5  (  5) -0.028924597602342 -0.155705177520586 -0.009708873936879 -0.016613543931604 -0.026890889200954 -0.000863820528475  0.026461589325309 -0.030900211040800 -0.024762473040831
-    6  (  6) -0.014335467827216 -0.010396285650159 -0.029624823660297 -0.025462090585912 -0.000149096444494 -0.026996065218364  0.000042625626758  0.107465667965402 -0.101121105248233
-    7  (  7) -0.071280711647029 -0.021473260264964 -0.016888851213230  0.005990055447048 -0.022650874097521  0.030884846999677 -0.107059671381934 -0.000085380718295 -0.001222830424055
-    8  (  8)  0.049124632890092 -0.169889327710618 -0.068826403708743 -0.044339001017875  0.031493314676472  0.025080049766767  0.100845039831255  0.001167614688641 -0.000278385825403
-    9  (  9) -0.004591463397670 -0.224641690035662 -0.054391854978822  0.000520714575472 -0.041379699430161  0.035041097267503  0.048865193892848  0.034233303767760 -0.002323551097466
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.004372643490859
-    1  (  1)  0.225448428944350
-    2  (  2)  0.053543340635201
-    3  (  3) -0.000029286176363
-    4  (  4)  0.041473098636741
-    5  (  5) -0.035500700267141
-    6  (  6) -0.049415179037896
-    7  (  7) -0.033722251526408
-    8  (  8)  0.002108270875613
-    9  (  9)  0.000059855095180
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 1
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    12	col =    10
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.083178189184036 -0.063320502543375 -0.053448860291133  0.010119942476578  0.027962494700737  0.033408156898410  0.016646686372055  0.009688142905594  0.047753876913682
-    1  (  1)  0.015436953954369 -0.001484194684011  0.023035398887205  0.013457869405466 -0.013993527195521 -0.033943979767543  0.150850131221437 -0.006054179455746  0.032861777904130
-    2  (  2)  0.007416632072171  0.085535883632607 -0.031035920631781 -0.004414026005139 -0.010136741110915  0.029006493089287 -0.078308410406643  0.042862583013635  0.094615352193845
-    3  (  3) -0.060864804294684 -0.107990348400789 -0.029334441164075 -0.017074561166948  0.006770814971091  0.056161219994893 -0.038880977880177 -0.007186858274067 -0.050898617184209
-    4  (  4) -0.109193273208522 -0.178421304573120 -0.074992061457995  0.038015102633012 -0.147910228795514  0.087181398607820 -0.098582275644141  0.093570766915846  0.088687564658624
-    5  (  5)  0.362309556227904  0.121304099182945  0.074968023841376  0.180660703600124 -0.122438585672172 -0.079096894998506  0.085876030826778 -0.136109864287558  0.002214631278523
-    6  (  6)  0.026835628168075 -0.104282391359254  0.172843582770517  0.372105341696267  0.200623348657875 -0.124556824110224 -0.101871864602057 -0.564196462169744  0.000688785089474
-    7  (  7)  0.344945182303497  0.095060217852336  0.019692892185405 -0.208607222836184 -0.002627647973779 -0.075715664253568 -0.273373001503080  0.322679649636761 -0.103750880742886
-    8  (  8)  0.103243578213400  0.018995126733818 -0.033613347666093 -0.143946559071139  0.146180680800982  0.017308359580339  0.107684620440504 -0.078982837453949 -0.062496256435255
-    9  (  9) -0.085648241806344 -0.209611729409149 -0.056224829650480 -0.004822853433113  0.155473341074989  0.012971266670028 -0.058097898147224 -0.150335378963730  0.078057323449305
-   10  ( 10)  0.070132629148842  0.074702785463534  0.209329818275843  0.042566217114534 -0.058034325280006 -0.102370728009941 -0.025801004099357 -0.264561180085366  0.017482708757363
-   11  ( 11)  0.113963029107499  0.045073298009464  0.000413587765283  0.112463923253522 -0.089423608765749 -0.081287727377731 -0.019439635907878 -0.076622183257520  0.114273036439508
-
-                         9     
-                      (  9)    
-
-    0  (  0)  0.015270950350973
-    1  (  1)  0.030946721870550
-    2  (  2) -0.003707642076146
-    3  (  3) -0.011960041321321
-    4  (  4)  0.086083869661608
-    5  (  5)  0.009867768215709
-    6  (  6)  0.209680707316341
-    7  (  7) -0.097843271017668
-    8  (  8) -0.010325909660635
-    9  (  9)  0.121632163838855
-   10  ( 10)  0.058275044600178
-   11  ( 11) -0.003021331907582
-
 	Computing Mu_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        16.768400636718
-	   1        22.238899323198    7.657e-01
-	   2        26.326603032135    3.442e-01
-	   3        26.402828138172    5.204e-02
-	   4        26.436612034770    2.459e-02
-	   5        26.441960308295    4.103e-03
-	   6        26.440596203782    1.628e-03
-	   7        26.440721962866    5.123e-04
-	   8        26.440796407034    2.487e-04
-	   9        26.440755970568    1.070e-04
-	  10        26.440741562191    4.242e-05
-	  11        26.440753214125    1.114e-05
-	  12        26.440764472568    3.188e-06
-	  13        26.440767810998    1.225e-06
-	  14        26.440768088730    4.406e-07
-	  15        26.440767755083    2.032e-07
+	   0        16.768400460754
+	   1        22.238899083040    7.657e-01
+	   2        26.326602732924    3.442e-01
+	   3        26.402827834814    5.204e-02
+	   4        26.436611730619    2.459e-02
+	   5        26.441960003840    4.103e-03
+	   6        26.440595899324    1.628e-03
+	   7        26.440721658400    5.123e-04
+	   8        26.440796102560    2.487e-04
+	   9        26.440755666096    1.070e-04
+	  10        26.440741257721    4.242e-05
+	  11        26.440752909654    1.114e-05
+	  12        26.440764168096    3.188e-06
+	  13        26.440767506526    1.225e-06
+	  14        26.440767784258    4.406e-07
+	  15        26.440767450611    2.032e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 7.696e-08
 
 	Computing P*_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.592440082651
-	   1         6.007718140545    3.681e-01
-	   2         6.969266084788    1.542e-01
-	   3         6.989032138103    2.234e-02
-	   4         6.993331571234    1.047e-02
-	   5         6.994560710728    2.654e-03
-	   6         6.994306129009    1.181e-03
-	   7         6.994382504840    3.841e-04
-	   8         6.994409294194    1.287e-04
-	   9         6.994402583701    3.137e-05
-	  10         6.994402175404    1.008e-05
-	  11         6.994403412144    3.050e-06
-	  12         6.994404691629    8.385e-07
-	  13         6.994405124083    2.541e-07
-	  14         6.994405240632    1.011e-07
+	   0         4.592440110728
+	   1         6.007718175795    3.681e-01
+	   2         6.969266121762    1.542e-01
+	   3         6.989032174416    2.234e-02
+	   4         6.993331607487    1.047e-02
+	   5         6.994560746930    2.654e-03
+	   6         6.994306165206    1.181e-03
+	   7         6.994382541035    3.841e-04
+	   8         6.994409330388    1.287e-04
+	   9         6.994402619895    3.137e-05
+	  10         6.994402211599    1.008e-05
+	  11         6.994403448339    3.050e-06
+	  12         6.994404727824    8.385e-07
+	  13         6.994405160278    2.541e-07
+	  14         6.994405276827    1.011e-07
 	-----------------------------------------
 	Converged P*_X-Perturbed Wfn to 4.709e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         1.926105631328
-	   1         2.501393275744    2.028e-01
-	   2         2.834079249600    7.722e-02
-	   3         2.838350733665    9.377e-03
-	   4         2.839897253245    3.735e-03
-	   5         2.839974125340    8.176e-04
-	   6         2.839961789554    1.986e-04
-	   7         2.839965280678    3.975e-05
-	   8         2.839964831372    1.141e-05
-	   9         2.839964548641    2.885e-06
-	  10         2.839964458947    9.825e-07
-	  11         2.839964534618    1.402e-07
+	   0         1.926105616932
+	   1         2.501393254687    2.028e-01
+	   2         2.834079222307    7.722e-02
+	   3         2.838350706141    9.377e-03
+	   4         2.839897225633    3.735e-03
+	   5         2.839974097721    8.176e-04
+	   6         2.839961761936    1.986e-04
+	   7         2.839965253059    3.975e-05
+	   8         2.839964803753    1.141e-05
+	   9         2.839964521022    2.885e-06
+	  10         2.839964431328    9.825e-07
+	  11         2.839964506999    1.402e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 4.466e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.791920319186
-	   1        16.799278109459    5.100e-01
-	   2        18.450083178728    1.931e-01
-	   3        18.566084740683    4.406e-02
-	   4        18.584310426486    1.722e-02
-	   5        18.587536227798    3.424e-03
-	   6        18.587011347588    1.160e-03
-	   7        18.587126796613    3.058e-04
-	   8        18.587161120157    1.080e-04
-	   9        18.587156888766    4.128e-05
-	  10        18.587157303412    2.114e-05
-	  11        18.587158834247    7.210e-06
-	  12        18.587162027489    2.847e-06
-	  13        18.587162381644    1.013e-06
-	  14        18.587162490736    4.203e-07
-	  15        18.587162336589    1.752e-07
+	   0        13.791920191379
+	   1        16.799277957395    5.100e-01
+	   2        18.450083010364    1.931e-01
+	   3        18.566084568244    4.406e-02
+	   4        18.584310253644    1.722e-02
+	   5        18.587536054803    3.424e-03
+	   6        18.587011174586    1.160e-03
+	   7        18.587126623604    3.058e-04
+	   8        18.587160947145    1.080e-04
+	   9        18.587156715754    4.128e-05
+	  10        18.587157130400    2.114e-05
+	  11        18.587158661235    7.210e-06
+	  12        18.587161854476    2.847e-06
+	  13        18.587162208631    1.013e-06
+	  14        18.587162317723    4.203e-07
+	  15        18.587162163577    1.752e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.350e-08
 
 	Computing P*_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.742090058591
-	   1         5.687084336701    2.849e-01
-	   2         6.193454621848    1.033e-01
-	   3         6.237352865035    2.836e-02
-	   4         6.242945100586    1.079e-02
-	   5         6.243896998031    2.293e-03
-	   6         6.243702758231    7.182e-04
-	   7         6.243708375529    2.481e-04
-	   8         6.243716525317    1.052e-04
-	   9         6.243711180282    3.784e-05
-	  10         6.243712229305    1.308e-05
-	  11         6.243713706356    3.142e-06
-	  12         6.243714825713    1.240e-06
-	  13         6.243715023511    4.908e-07
-	  14         6.243715127402    2.711e-07
-	  15         6.243715095250    1.099e-07
+	   0         4.742090081511
+	   1         5.687084365385    2.849e-01
+	   2         6.193454651950    1.033e-01
+	   3         6.237352894264    2.836e-02
+	   4         6.242945129747    1.079e-02
+	   5         6.243897027163    2.293e-03
+	   6         6.243702787363    7.182e-04
+	   7         6.243708404661    2.481e-04
+	   8         6.243716554449    1.052e-04
+	   9         6.243711209414    3.784e-05
+	  10         6.243712258436    1.308e-05
+	  11         6.243713735488    3.142e-06
+	  12         6.243714854844    1.240e-06
+	  13         6.243715052643    4.908e-07
+	  14         6.243715156534    2.711e-07
+	  15         6.243715124381    1.099e-07
 	-----------------------------------------
 	Converged P*_Y-Perturbed Wfn to 3.726e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.491473815782
-	   1         6.979859581709    2.986e-01
-	   2         7.683240637464    1.049e-01
-	   3         7.697438041472    1.990e-02
-	   4         7.702325633219    6.916e-03
-	   5         7.702390793952    1.115e-03
-	   6         7.702332324942    2.339e-04
-	   7         7.702339286683    5.198e-05
-	   8         7.702338399160    1.155e-05
-	   9         7.702338304051    2.547e-06
-	  10         7.702338208944    8.454e-07
-	  11         7.702338298400    1.431e-07
+	   0         5.491473784368
+	   1         6.979859537397    2.986e-01
+	   2         7.683240583311    1.049e-01
+	   3         7.697437986707    1.990e-02
+	   4         7.702325578225    6.916e-03
+	   5         7.702390738947    1.115e-03
+	   6         7.702332269940    2.339e-04
+	   7         7.702339231680    5.198e-05
+	   8         7.702338344158    1.155e-05
+	   9         7.702338249049    2.547e-06
+	  10         7.702338153942    8.454e-07
+	  11         7.702338243398    1.431e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 4.269e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        13.624759066304
-	   1        17.300274786165    5.349e-01
-	   2        19.191725177085    1.939e-01
-	   3        19.236330690295    3.405e-02
-	   4        19.254798304655    1.757e-02
-	   5        19.257236321965    2.512e-03
-	   6        19.256952059230    1.061e-03
-	   7        19.257006072772    3.749e-04
-	   8        19.257011184337    1.438e-04
-	   9        19.257003264835    4.440e-05
-	  10        19.257001940202    1.593e-05
-	  11        19.257003901137    3.739e-06
-	  12        19.257005421265    1.240e-06
-	  13        19.257005821231    5.354e-07
-	  14        19.257005951816    2.664e-07
-	  15        19.257005918929    1.205e-07
+	   0        13.624758944742
+	   1        17.300274629337    5.349e-01
+	   2        19.191724998587    1.939e-01
+	   3        19.236330510146    3.405e-02
+	   4        19.254798124059    1.757e-02
+	   5        19.257236141264    2.512e-03
+	   6        19.256951878523    1.061e-03
+	   7        19.257005892064    3.749e-04
+	   8        19.257011003629    1.438e-04
+	   9        19.257003084127    4.440e-05
+	  10        19.257001759494    1.593e-05
+	  11        19.257003720430    3.739e-06
+	  12        19.257005240557    1.240e-06
+	  13        19.257005640523    5.354e-07
+	  14        19.257005771108    2.664e-07
+	  15        19.257005738221    1.205e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.553e-08
 
 	Computing P*_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.957217358241
-	   1         6.264725839078    3.123e-01
-	   2         6.912068319350    1.079e-01
-	   3         6.926659786415    2.145e-02
-	   4         6.931905446044    1.181e-02
-	   5         6.933156053285    2.904e-03
-	   6         6.933020724523    1.127e-03
-	   7         6.933061376292    3.255e-04
-	   8         6.933065349708    9.204e-05
-	   9         6.933063728940    2.395e-05
-	  10         6.933063846114    9.031e-06
-	  11         6.933064618370    3.749e-06
-	  12         6.933065351169    1.746e-06
-	  13         6.933065416212    7.046e-07
-	  14         6.933065385518    2.473e-07
+	   0         4.957217379941
+	   1         6.264725865762    3.123e-01
+	   2         6.912068346941    1.079e-01
+	   3         6.926659813653    2.145e-02
+	   4         6.931905473178    1.181e-02
+	   5         6.933156080369    2.904e-03
+	   6         6.933020751605    1.127e-03
+	   7         6.933061403374    3.255e-04
+	   8         6.933065376790    9.204e-05
+	   9         6.933063756022    2.395e-05
+	  10         6.933063873196    9.031e-06
+	  11         6.933064645452    3.749e-06
+	  12         6.933065378251    1.746e-06
+	  13         6.933065443294    7.046e-07
+	  14         6.933065412600    2.473e-07
 	-----------------------------------------
 	Converged P*_Z-Perturbed Wfn to 8.397e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.581975924718
-	   1         7.067898007904    3.046e-01
-	   2         7.794265031693    1.062e-01
-	   3         7.808016253108    1.466e-02
-	   4         7.810897754854    5.344e-03
-	   5         7.811100118181    1.188e-03
-	   6         7.811024707321    3.499e-04
-	   7         7.811038479913    5.690e-05
-	   8         7.811038896808    1.440e-05
-	   9         7.811038612320    3.086e-06
-	  10         7.811038592057    1.047e-06
-	  11         7.811038682689    2.223e-07
+	   0         5.581975894178
+	   1         7.067897965016    3.046e-01
+	   2         7.794264978727    1.062e-01
+	   3         7.808016199621    1.466e-02
+	   4         7.810897701239    5.344e-03
+	   5         7.811100064550    1.188e-03
+	   6         7.811024653692    3.499e-04
+	   7         7.811038426283    5.690e-05
+	   8         7.811038843179    1.440e-05
+	   9         7.811038558691    3.086e-06
+	  10         7.811038538428    1.047e-06
+	  11         7.811038629060    2.223e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 6.177e-08
 
@@ -9082,12 +1490,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.199315154813160    -0.236145105691946    -0.075627034598294
-    1      0.033233678625649     0.078305709819069    -0.216237849937922
-    2     -0.318543396835040     0.348340079087816    -0.247304234560634
+    0      0.199315154624056    -0.236145103741689    -0.075627033594829
+    1      0.033233678887394     0.078305709057096    -0.216237850819074
+    2     -0.318543397461720     0.348340079668771    -0.247304234462590
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) = -144.48475 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -144.48473 deg/[dm (g/cm^3)]
 
           CC2 Optical Rotation Tensor (Velocity Gauge):
   -------------------------------------------------------------------------
@@ -9096,12 +1504,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.621533097717047    -0.028559757807191     0.347561393516552
-    1      0.199001619811057     0.187293746994764    -1.204490306561494
-    2     -1.429769524846618     1.478547847635102    -0.793933811199032
+    0      0.621533097518792    -0.028559761973947     0.347561390418406
+    1      0.199001621185513     0.187293746140687    -1.204490301047232
+    2     -1.429769521594708     1.478547845609274    -0.793933810267324
 
    Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) = -553.01504 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -553.01496 deg/[dm (g/cm^3)]
 
         CC2 Optical Rotation Tensor (Modified Velocity Gauge):
   -------------------------------------------------------------------------
@@ -9110,12 +1518,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.022115388979706    -0.021796484085591    -0.007037830627860
-    1      0.003543463545093     0.006840241366879    -0.015858408386287
-    2     -0.032927979966257     0.031018450489863    -0.025164039010345
+    0      0.022115389167959    -0.021796484219893    -0.007037830812370
+    1      0.003543463619980     0.006840241492133    -0.015858408627775
+    2     -0.032927980228900     0.031018450874521    -0.025164039273302
 
    Specific rotation using modified velocity-gauge Rosenfeld tensor.
-	[alpha]_(0.128) = -140.79113 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -140.79111 deg/[dm (g/cm^3)]
 
    Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.
      Delta_x =  -4.82   Delta_y =   8.29   Delta_z =  -9.48
@@ -9127,8 +1535,8 @@ Total time:
     E_h      nm   deg/[dm (g/cm^3)]        deg/[dm (g/cm^3)]/bohr
    -----   ------ ------------------  ----------------------------------
                                           x           y           z      
-   0.077   589.00       -49.62375      -1.64277     2.79377    -3.24029
-   0.128   355.00      -144.48475      -4.81783     8.29088    -9.48327
+   0.077   589.00       -49.62374      -1.64277     2.79377    -3.24029
+   0.128   355.00      -144.48473      -4.81783     8.29087    -9.48327
 
    ------------------------------------------------------
             CC2 Velocity-Gauge Optical Rotation
@@ -9137,17 +1545,10 @@ Total time:
 
     E_h      nm   Velocity-Gauge  Modified Velocity-Gauge
    -----   ------ --------------  -----------------------
-   0.077   589.00   -460.77964           -48.55573
-   0.128   355.00   -553.01504          -140.79113
+   0.077   589.00   -460.77957           -48.55572
+   0.128   355.00   -553.01496          -140.79111
 
-*** tstop() called on psinet at Mon May 15 15:34:49 2017
-Module time:
-	user time   =       2.83 seconds =       0.05 minutes
-	system time =       2.81 seconds =       0.05 minutes
-	total time  =          6 seconds =       0.10 minutes
-Total time:
-	user time   =       3.83 seconds =       0.06 minutes
-	system time =       3.14 seconds =       0.05 minutes
-	total time  =          8 seconds =       0.13 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
+    Psi4 wall time for execution: 0:00:17.66
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc47/output.ref
+++ b/tests/cc47/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:25PM
 
-    Process ID:  12944
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65748
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -44,24 +57,25 @@ set {
   roots_per_irrep [2, 2]
 }
 
-property('eom-ccsd', properties=['oscillator_strength'])
+properties('eom-ccsd', properties=['oscillator_strength'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:47 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:26 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 3-4 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1-2 entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3-4 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -75,16 +89,16 @@ property('eom-ccsd', properties=['oscillator_strength'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000    -0.695000000000    -0.049338350190    15.994914619560
-           O          0.000000000000     0.695000000000    -0.049338350190    15.994914619560
-           H          0.388142264171    -0.895248563098     0.783035421467     1.007825032070
-           H         -0.388142264171     0.895248563098     0.783035421467     1.007825032070
+         O            0.000000000000    -0.695000000000    -0.049338350197    15.994914619570
+         O            0.000000000000     0.695000000000    -0.049338350197    15.994914619570
+         H            0.388142264171    -0.895248563098     0.783035421459     1.007825032230
+         H           -0.388142264171     0.895248563098     0.783035421459     1.007825032230
 
   Running in c2 symmetry.
 
   Rotational constants: A =     10.61423  B =      0.97044  C =      0.91566 [cm^-1]
-  Rotational constants: A = 318206.57462  B =  29093.19738  C =  27450.82444 [MHz]
-  Nuclear repulsion =   38.253968380680327
+  Rotational constants: A = 318206.57700  B =  29093.19760  C =  27450.82465 [MHz]
+  Nuclear repulsion =   38.253968531042538
 
   Charge       = 0
   Multiplicity = 1
@@ -101,28 +115,17 @@ property('eom-ccsd', properties=['oscillator_strength'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 18
-    Number of basis function: 38
+    Number of basis functions: 38
     Number of Cartesian functions: 40
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         19      19       0       0       0       0
-     B         19      19       0       0       0       0
-   -------------------------------------------------------
-    Total      38      38       9       9       9       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -141,44 +144,60 @@ property('eom-ccsd', properties=['oscillator_strength'])
   Using 549822 doubles for integral storage.
   We computed 14706 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.1870579153E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.1047221517E-02.
+  Reciprocal condition number of the overlap matrix is 8.7919776090E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+     B         19      19 
+   -------------------------
+    Total      38      38
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -150.83527118424107   -1.50835e+02   7.61669e-02 
-   @RHF iter   1:  -150.75300393196329    8.22673e-02   8.92814e-03 
-   @RHF iter   2:  -150.77674264680309   -2.37387e-02   2.23904e-03 DIIS
-   @RHF iter   3:  -150.77866726940414   -1.92462e-03   8.11583e-04 DIIS
-   @RHF iter   4:  -150.77908304190515   -4.15773e-04   3.09116e-04 DIIS
-   @RHF iter   5:  -150.77917159812222   -8.85562e-05   9.19744e-05 DIIS
-   @RHF iter   6:  -150.77918361494824   -1.20168e-05   1.37015e-05 DIIS
-   @RHF iter   7:  -150.77918386184561   -2.46897e-07   2.97198e-06 DIIS
-   @RHF iter   8:  -150.77918387199861   -1.01530e-08   5.75950e-07 DIIS
-   @RHF iter   9:  -150.77918387232646   -3.27844e-10   1.51394e-07 DIIS
-   @RHF iter  10:  -150.77918387235528   -2.88196e-11   4.48580e-08 DIIS
-   @RHF iter  11:  -150.77918387235843   -3.15481e-12   9.89275e-09 DIIS
-   @RHF iter  12:  -150.77918387235857   -1.42109e-13   1.77899e-09 DIIS
-   @RHF iter  13:  -150.77918387235849    8.52651e-14   2.61633e-10 DIIS
-   @RHF iter  14:  -150.77918387235846    2.84217e-14   6.83683e-11 DIIS
+   @RHF iter SAD:  -150.13109142562024   -1.50131e+02   0.00000e+00 
+   @RHF iter   1:  -150.72994418505689   -5.98853e-01   1.20798e-02 ADIIS/DIIS
+   @RHF iter   2:  -150.77474437542560   -4.48002e-02   3.93712e-03 ADIIS/DIIS
+   @RHF iter   3:  -150.77872862263547   -3.98425e-03   9.99210e-04 ADIIS/DIIS
+   @RHF iter   4:  -150.77914039140384   -4.11769e-04   2.79341e-04 ADIIS/DIIS
+   @RHF iter   5:  -150.77918120837066   -4.08170e-05   4.89524e-05 DIIS
+   @RHF iter   6:  -150.77918362626531   -2.41789e-06   1.25560e-05 DIIS
+   @RHF iter   7:  -150.77918384927895   -2.23014e-07   3.89300e-06 DIIS
+   @RHF iter   8:  -150.77918387131706   -2.20381e-08   8.16055e-07 DIIS
+   @RHF iter   9:  -150.77918387210650   -7.89441e-10   1.49865e-07 DIIS
+   @RHF iter  10:  -150.77918387212898   -2.24816e-11   3.10868e-08 DIIS
+   @RHF iter  11:  -150.77918387213006   -1.08002e-12   6.61624e-09 DIIS
+   @RHF iter  12:  -150.77918387213001    5.68434e-14   1.38474e-09 DIIS
+   @RHF iter  13:  -150.77918387213003   -2.84217e-14   3.05202e-10 DIIS
+   @RHF iter  14:  -150.77918387213003    0.00000e+00   6.31844e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -203,49 +222,44 @@ property('eom-ccsd', properties=['oscillator_strength'])
               A     B 
     DOCC [     5,    4 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -150.77918387235846
+  @RHF Final Energy:  -150.77918387213003
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             38.2539683806803268
-    One-Electron Energy =                -284.0698921465228750
-    Two-Electron Energy =                  95.0367398934840821
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -150.7791838723584590
+    Nuclear Repulsion Energy =             38.2539685310425384
+    One-Electron Energy =                -284.0698924306753952
+    Two-Electron Energy =                  95.0367400275028018
+    Total Energy =                       -150.7791838721300337
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.2602
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.2074     Total:     1.2074
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on psinet at Mon May 15 15:34:47 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:28 2022
 Module time:
-	user time   =       0.56 seconds =       0.01 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.19 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.56 seconds =       0.01 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.19 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -259,19 +273,19 @@ Total time:
       Number of basis functions:        38
 
       Number of irreps:                  2
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  19   19 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 117651 non-zero two-electron integrals.
+      Computed 107467 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:47 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:28 2022
 
 
 	Wfn Parameters:
@@ -294,7 +308,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -330,7 +344,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -132.27484824295880
+	Frozen core energy     =   -132.27484829822760
 
 	Size of irrep 0 of <ab|cd> integrals:      0.177 (MW) /      1.418 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.176 (MW) /      1.411 (MB)
@@ -344,34 +358,30 @@ Total time:
 	Size of irrep 1 of tijab amplitudes:       0.010 (MW) /      0.081 (MB)
 	Total:                                     0.021 (MW) /      0.165 (MB)
 
-	Nuclear Rep. energy          =     38.25396838068033
-	SCF energy                   =   -150.77918387235846
-	One-electron energy          =   -101.99691957132281
-	Two-electron energy          =     45.23861556124296
-	Reference energy             =   -150.77918387235832
+	Nuclear Rep. energy          =     38.25396853104254
+	SCF energy                   =   -150.77918387213003
+	One-electron energy          =   -101.99691974243427
+	Two-electron energy          =     45.23861563748924
+	Reference energy             =   -150.77918387213009
 
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:28 2022
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.75 seconds =       0.01 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:48 2017
-
+	user time   =       1.44 seconds =       0.02 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   38.253968380680327
-    SCF energy          (wfn)     = -150.779183872358459
-    Reference energy    (file100) = -150.779183872358317
+    Nuclear Rep. energy (wfn)     =   38.253968531042538
+    SCF energy          (wfn)     = -150.779183872130034
+    Reference energy    (file100) = -150.779183872130091
 
     Input parameters:
     -----------------
@@ -399,80 +409,68 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3802563054135764
+MP2 correlation energy -0.3802563047354116
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.380256305413576    0.000e+00    0.000000    0.000000    0.000000    0.143419
-     1        -0.384252700187875    4.172e-02    0.006281    0.014957    0.014957    0.146642
-     2        -0.393202764715056    1.580e-02    0.007156    0.016728    0.016728    0.156356
-     3        -0.394603278060569    5.260e-03    0.008061    0.018516    0.018516    0.160181
-     4        -0.394657650140995    1.398e-03    0.008198    0.018646    0.018646    0.161027
-     5        -0.394690572780893    5.030e-04    0.008266    0.018685    0.018685    0.161216
-     6        -0.394682677587012    1.898e-04    0.008293    0.018687    0.018687    0.161210
-     7        -0.394679309090240    5.979e-05    0.008301    0.018685    0.018685    0.161200
-     8        -0.394679268692329    2.095e-05    0.008303    0.018684    0.018684    0.161198
-     9        -0.394678919666649    7.909e-06    0.008304    0.018684    0.018684    0.161197
-    10        -0.394679205950676    3.344e-06    0.008304    0.018684    0.018684    0.161197
-    11        -0.394679180598580    1.110e-06    0.008304    0.018684    0.018684    0.161197
-    12        -0.394679218514583    3.658e-07    0.008304    0.018684    0.018684    0.161197
-    13        -0.394679216815987    1.105e-07    0.008304    0.018684    0.018684    0.161197
-    14        -0.394679217139842    3.761e-08    0.008304    0.018684    0.018684    0.161197
+     0        -0.380256304735412    0.000e+00    0.000000    0.000000    0.000000    0.143419
+     1        -0.384252699668223    4.172e-02    0.006281    0.014957    0.014957    0.146642
+     2        -0.393202764097124    1.580e-02    0.007156    0.016728    0.016728    0.156356
+     3        -0.394603277393149    5.260e-03    0.008061    0.018516    0.018516    0.160181
+     4        -0.394657649472679    1.398e-03    0.008198    0.018646    0.018646    0.161027
+     5        -0.394690572111229    5.030e-04    0.008266    0.018685    0.018685    0.161216
+     6        -0.394682676918496    1.898e-04    0.008293    0.018687    0.018687    0.161210
+     7        -0.394679308421909    5.979e-05    0.008301    0.018685    0.018685    0.161200
+     8        -0.394679268023979    2.095e-05    0.008303    0.018684    0.018684    0.161198
+     9        -0.394678918998321    7.909e-06    0.008304    0.018684    0.018684    0.161197
+    10        -0.394679205282325    3.344e-06    0.008304    0.018684    0.018684    0.161197
+    11        -0.394679179930230    1.110e-06    0.008304    0.018684    0.018684    0.161197
+    12        -0.394679217846231    3.658e-07    0.008304    0.018684    0.018684    0.161197
+    13        -0.394679216147637    1.105e-07    0.008304    0.018684    0.018684    0.161197
+    14        -0.394679216471492    3.761e-08    0.008304    0.018684    0.018684    0.161197
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              5  14        -0.0102219508
-              6  14        -0.0088239731
-              2   7        -0.0082621868
+              5  14        -0.0102219502
+              6  14        -0.0088239726
+              2   7        -0.0082621866
               2   9        -0.0079565239
-              2   4         0.0077446885
-              1   8        -0.0067312261
+              2   4         0.0077446884
+              1   8        -0.0067312260
               1   0        -0.0066839179
-              5  17         0.0064483659
-              1   3         0.0061907936
+              5  17         0.0064483657
+              1   3         0.0061907935
               6  16         0.0061070737
 
     Largest TIjAb Amplitudes:
-      2   2  15  15        -0.0682113914
-      2   2  14  15         0.0337460441
-      2   2  15  14         0.0337460441
-      1   2  15  15         0.0313513362
-      2   1  15  15         0.0313513362
+      2   2  15  15        -0.0682113907
+      2   2  14  15         0.0337460429
+      2   2  15  14         0.0337460429
+      1   2  15  15         0.0313513360
+      2   1  15  15         0.0313513360
       1   1  15  15        -0.0311200776
-      3   3  17  17        -0.0224518738
-      3   3  15  15        -0.0219509770
-      1   1   1   1        -0.0213098149
-      2   2  14  14        -0.0200419752
+      3   3  17  17        -0.0224518731
+      3   3  15  15        -0.0219509771
+      1   1   1   1        -0.0213098148
+      2   2  14  14        -0.0200419741
 
-    SCF energy       (wfn)                    = -150.779183872358459
-    Reference energy (file100)                = -150.779183872358317
+    SCF energy       (wfn)                    = -150.779183872130034
+    Reference energy (file100)                = -150.779183872130091
 
-    Opposite-spin MP2 correlation energy      =   -0.282698987529231
-    Same-spin MP2 correlation energy          =   -0.097557317884345
-    MP2 correlation energy                    =   -0.380256305413576
-      * MP2 total energy                      = -151.159440177771899
+    Opposite-spin MP2 correlation energy      =   -0.282698986958674
+    Same-spin MP2 correlation energy          =   -0.097557317776737
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.380256304735412
+      * MP2 total energy                      = -151.159440176865502
 
-    Opposite-spin CCSD correlation energy     =   -0.309012025076525
-    Same-spin CCSD correlation energy         =   -0.085667192058185
-    CCSD correlation energy                   =   -0.394679217139842
-      * CCSD total energy                     = -151.173863089498155
-
-
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
-Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.28 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.98 seconds =       0.02 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:48 2017
+    Opposite-spin CCSD correlation energy     =   -0.309012024407253
+    Same-spin CCSD correlation energy         =   -0.085667192064238
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.394679216471492
+      * CCSD total energy                     = -151.173863088601593
 
 
 			**************************
@@ -482,28 +480,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:49 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.00 seconds =       0.02 minutes
-	system time =       0.45 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:49 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
-	SCF energy          (wfn)     = -150.779183872358459
-	Reference energy    (file100) = -150.779183872358317
-	CCSD energy         (file100) =   -0.394679217139842
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
+	SCF energy          (wfn)     = -150.779183872130034
+	Reference energy    (file100) = -150.779183872130091
+	CCSD energy         (file100) =   -0.394679216471492
 
 	Input parameters:
 	-----------------
@@ -536,6 +520,14 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total  161.9913829038
+Fmi   dot Fmi   total    6.2814463882
+Fme   dot Fme   total    0.0000103500
+WMBIJ dot WMBIJ total    0.0000000000
+Wmbij dot Wmbij total    0.0000000000
+WMbIj dot WMbIj total    1.1743295568
+WmBiJ dot WmBiJ total    0.0000000000
 Symmetry of ground state: A
 Symmetry of excited state: A
 Symmetry of right eigenvector: A
@@ -543,80 +535,80 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3927828816   3.93e-01    5.25e-01      N
-                     2   0.4742779523   4.74e-01    5.94e-01      N
+                     1   0.3927828817   3.93e-01    5.25e-01      N
+                     2   0.4742779555   4.74e-01    5.94e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2631788289  -1.30e-01    8.49e-02      N
-                     2   0.3415342829  -1.33e-01    1.09e-01      N
+                     1   0.2631788291  -1.30e-01    8.49e-02      N
+                     2   0.3415342864  -1.33e-01    1.09e-01      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2586791550  -4.50e-03    4.76e-02      N
-                     2   0.3355703403  -5.96e-03    4.41e-02      N
+                     1   0.2586791552  -4.50e-03    4.76e-02      N
+                     2   0.3355703440  -5.96e-03    4.41e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2572583796  -1.42e-03    2.05e-02      N
-                     2   0.3344122100  -1.16e-03    1.67e-02      N
+                     1   0.2572583799  -1.42e-03    2.05e-02      N
+                     2   0.3344122137  -1.16e-03    1.67e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2569103672  -3.48e-04    1.01e-02      N
-                     2   0.3342176164  -1.95e-04    8.54e-03      N
+                     1   0.2569103676  -3.48e-04    1.01e-02      N
+                     2   0.3342176201  -1.95e-04    8.54e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2568678924  -4.25e-05    3.73e-03      N
-                     2   0.3341655762  -5.20e-05    6.50e-03      N
+                     1   0.2568678927  -4.25e-05    3.73e-03      N
+                     2   0.3341655800  -5.20e-05    6.50e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2568518667  -1.60e-05    1.54e-03      N
-                     2   0.3341270552  -3.85e-05    3.93e-03      N
+                     1   0.2568518671  -1.60e-05    1.54e-03      N
+                     2   0.3341270589  -3.85e-05    3.93e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2568487112  -3.16e-06    6.66e-04      N
-                     2   0.3341139860  -1.31e-05    1.85e-03      N
+                     1   0.2568487116  -3.16e-06    6.66e-04      N
+                     2   0.3341139897  -1.31e-05    1.85e-03      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2568481081  -6.03e-07    2.13e-04      N
-                     2   0.3341122245  -1.76e-06    8.92e-04      N
+                     1   0.2568481084  -6.03e-07    2.13e-04      N
+                     2   0.3341122282  -1.76e-06    8.92e-04      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2568489917   8.84e-07    7.21e-05      Y
-                     2   0.3341131534   9.29e-07    3.94e-04      N
+                     1   0.2568489920   8.84e-07    7.21e-05      Y
+                     2   0.3341131571   9.29e-07    3.94e-04      N
 Iter=11   L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2568489988   7.18e-09    7.11e-05      Y
-                     2   0.3341137827   6.29e-07    1.68e-04      N
+                     1   0.2568489992   7.18e-09    7.11e-05      Y
+                     2   0.3341137864   6.29e-07    1.68e-04      N
 Iter=12   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2568490006   1.75e-09    7.12e-05      Y
-                     2   0.3341136893  -9.34e-08    8.17e-05      Y
+                     1   0.2568490009   1.75e-09    7.12e-05      Y
+                     2   0.3341136930  -9.34e-08    8.17e-05      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-EOM CCSD R0 for root 0 =  -0.00300763365
-EOM CCSD R0 for root 1 =  -0.01181206717
+EOM CCSD R0 for root 0 =  -0.00300763378
+EOM CCSD R0 for root 1 =   0.01181206651
 
 Final Energetic Summary for Converged Roots of Irrep A
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      6.989    56371.8   0.2568490006  -150.917014088907
+EOM State 1      6.989    56371.8   0.2568490009  -150.917014087692
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         3 >   0      :        5a >     6a :    0.6760837556
-         3 >   1      :        5a >     7a :   -0.0627193430
-         2 >   0      :        4b >     5b :    0.0421614066
+         3 >   0      :        5a >     6a :    0.6760837560
+         3 >   1      :        5a >     7a :   -0.0627193427
+         2 >   0      :        4b >     5b :    0.0421614061
          1 >   0      :        3b >     5b :   -0.0393688502
-         2 >   0      :        4a >     6a :    0.0330840188
+         2 >   0      :        4a >     6a :    0.0330840179
  RIjAb (libdpd indices)     : (cscf notation)
-        2   1 >   1   0     :     4a     3b >     6b     6a :    0.0461657039
-        1   2 >   0   1     :     3b     4a >     6a     6b :    0.0461657039
-        1   3 >   0   0     :     3a     5a >     6a     6a :    0.0387839602
-        3   1 >   0   0     :     5a     3a >     6a     6a :    0.0387839602
-        2   2 >   1   0     :     4a     4b >     6b     6a :   -0.0277131710
-EOM State 2      9.092    73329.5   0.3341136893  -150.839749400236
+        2   1 >   1   0     :     4a     3b >     6b     6a :    0.0461657036
+        1   2 >   0   1     :     3b     4a >     6a     6b :    0.0461657036
+        1   3 >   0   0     :     3a     5a >     6a     6a :    0.0387839600
+        3   1 >   0   0     :     5a     3a >     6a     6a :    0.0387839600
+        2   2 >   1   0     :     4a     4b >     6b     6a :   -0.0277131706
+EOM State 2      9.092    73329.5   0.3341136930  -150.839749395623
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :        4b >     5b :   -0.5239197397
-         2 >   1      :        4b >     6b :    0.4163608531
-         1 >   0      :        3b >     5b :    0.0822218743
-         1 >   1      :        3b >     6b :   -0.0781958479
-         2 >   2      :        4b >     7b :    0.0486083731
+         2 >   0      :        4b >     5b :    0.5239197418
+         2 >   1      :        4b >     6b :   -0.4163608518
+         1 >   0      :        3b >     5b :   -0.0822218716
+         1 >   1      :        3b >     6b :    0.0781958454
+         2 >   2      :        4b >     7b :   -0.0486083740
  RIjAb (libdpd indices)     : (cscf notation)
-        2   2 >   1   1     :     4a     4a >     6b     6b :   -0.0510618428
-        2   2 >   0   1     :     4a     4a >     5b     6b :    0.0469986877
-        2   2 >   1   0     :     4a     4a >     6b     5b :    0.0469986877
-        2   3 >   1   0     :     4a     5a >     6b     5b :    0.0378991572
-        3   2 >   0   1     :     5a     4a >     5b     6b :    0.0378991572
+        2   2 >   1   1     :     4a     4a >     6b     6b :    0.0510618425
+        2   2 >   0   1     :     4a     4a >     5b     6b :   -0.0469986872
+        2   2 >   1   0     :     4a     4a >     6b     5b :   -0.0469986872
+        2   3 >   1   0     :     4a     5a >     6b     5b :   -0.0378991563
+        3   2 >   0   1     :     5a     4a >     5b     6b :   -0.0378991563
 
 Symmetry of excited state: B
 Symmetry of right eigenvector: B
@@ -624,56 +616,56 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3882488617   3.88e-01    5.94e-01      N
-                     2   0.4553194793   4.55e-01    5.16e-01      N
+                     1   0.3882488645   3.88e-01    5.94e-01      N
+                     2   0.4553194805   4.55e-01    5.16e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2588023069  -1.29e-01    1.02e-01      N
-                     2   0.3396043355  -1.16e-01    8.19e-02      N
+                     1   0.2588023099  -1.29e-01    1.02e-01      N
+                     2   0.3396043367  -1.16e-01    8.19e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2543272412  -4.48e-03    3.53e-02      N
-                     2   0.3360900852  -3.51e-03    3.64e-02      N
+                     1   0.2543272443  -4.48e-03    3.53e-02      N
+                     2   0.3360900864  -3.51e-03    3.64e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2536516214  -6.76e-04    1.11e-02      N
-                     2   0.3353208306  -7.69e-04    1.42e-02      N
+                     1   0.2536516245  -6.76e-04    1.11e-02      N
+                     2   0.3353208318  -7.69e-04    1.42e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535756605  -7.60e-05    5.20e-03      N
-                     2   0.3350746202  -2.46e-04    1.20e-02      N
+                     1   0.2535756637  -7.60e-05    5.20e-03      N
+                     2   0.3350746214  -2.46e-04    1.20e-02      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535459389  -2.97e-05    3.22e-03      N
-                     2   0.3349236965  -1.51e-04    1.15e-02      N
+                     1   0.2535459420  -2.97e-05    3.22e-03      N
+                     2   0.3349236976  -1.51e-04    1.15e-02      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535347464  -1.12e-05    1.60e-03      N
-                     2   0.3347741394  -1.50e-04    9.87e-03      N
+                     1   0.2535347496  -1.12e-05    1.60e-03      N
+                     2   0.3347741406  -1.50e-04    9.87e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535298421  -4.90e-06    6.04e-04      N
-                     2   0.3346778035  -9.63e-05    6.51e-03      N
+                     1   0.2535298452  -4.90e-06    6.04e-04      N
+                     2   0.3346778047  -9.63e-05    6.51e-03      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535293576  -4.84e-07    2.39e-04      N
-                     2   0.3346447577  -3.30e-05    3.02e-03      N
+                     1   0.2535293607  -4.84e-07    2.39e-04      N
+                     2   0.3346447589  -3.30e-05    3.02e-03      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535296363   2.79e-07    1.03e-04      N
-                     2   0.3346486669   3.91e-06    1.59e-03      N
+                     1   0.2535296394   2.79e-07    1.03e-04      N
+                     2   0.3346486680   3.91e-06    1.59e-03      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535297495   1.13e-07    3.84e-05      Y
-                     2   0.3346462567  -2.41e-06    8.15e-04      N
+                     1   0.2535297527   1.13e-07    3.84e-05      Y
+                     2   0.3346462579  -2.41e-06    8.15e-04      N
 Iter=12   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535297611   1.15e-08    2.68e-05      Y
-                     2   0.3346431851  -3.07e-06    4.38e-04      N
+                     1   0.2535297642   1.15e-08    2.68e-05      Y
+                     2   0.3346431862  -3.07e-06    4.38e-04      N
 Iter=13   L=24  
-Sum of complex part of HBar eigenvalues    0.000423840812737,   1.00e-12
+Sum of complex part of HBar eigenvalues    0.000423842411345,   1.00e-12
   Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535297620   9.53e-10    2.45e-05      Y
-                     2   0.3346427453  -4.40e-07    2.18e-04      N
+                     1   0.2535297652   9.53e-10    2.45e-05      Y
+                     2   0.3346427464  -4.40e-07    2.18e-04      N
 Iter=14   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535297620  -7.94e-15    2.45e-05      Y
-                     2   0.3346427453   6.94e-15    2.18e-04      N
+                     1   0.2535297652  -1.04e-14    2.45e-05      Y
+                     2   0.3346427464   2.16e-15    2.18e-04      N
 Iter=15   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535297562  -5.81e-09    2.41e-05      Y
-                     2   0.3346427632   1.80e-08    9.17e-05      Y
+                     1   0.2535297594  -5.81e-09    2.41e-05      Y
+                     2   0.3346427644   1.80e-08    9.17e-05      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-Energy written to CC_INFO:Etot -150.8392203263
+Energy written to CC_INFO:Etot -150.8392203242
 States per irrep written to CC_INFO.
 EOM CCSD R0 for root 0 =   0.00000000000
 EOM CCSD R0 for root 1 =   0.00000000000
@@ -681,67 +673,53 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 3      6.899    55643.3   0.2535297562  -150.920333333272
+EOM State 3      6.899    55643.4   0.2535297594  -150.920333329231
 
 Largest components of excited wave function #3:
  RIA (libdpd indices) : (cscf notation)
-         3 >   0      :        5a >     5b :   -0.5370999792
-         3 >   1      :        5a >     6b :    0.4161236010
-         3 >   2      :        5a >     7b :    0.0504041593
-         2 >   0      :        4a >     5b :   -0.0432076528
-         2 >   1      :        4a >     6b :    0.0408478854
+         3 >   0      :        5a >     5b :   -0.5370999810
+         3 >   1      :        5a >     6b :    0.4161235990
+         3 >   2      :        5a >     7b :    0.0504041602
+         2 >   0      :        4a >     5b :   -0.0432076516
+         2 >   1      :        4a >     6b :    0.0408478844
  RIjAb (libdpd indices)     : (cscf notation)
-        2   1 >   1   0     :     4a     3b >     6b     5b :   -0.0440145644
-        1   2 >   0   1     :     3b     4a >     5b     6b :   -0.0440145644
-        2   1 >   1   1     :     4a     3b >     6b     6b :    0.0381900947
-        1   2 >   1   1     :     3b     4a >     6b     6b :    0.0381900947
-        2   2 >   1   1     :     4a     4b >     6b     6b :   -0.0278614850
-EOM State 4      9.106    73445.6   0.3346427632  -150.839220326266
+        2   1 >   1   0     :     4a     3b >     6b     5b :   -0.0440145641
+        1   2 >   0   1     :     3b     4a >     5b     6b :   -0.0440145641
+        2   1 >   1   1     :     4a     3b >     6b     6b :    0.0381900943
+        1   2 >   1   1     :     3b     4a >     6b     6b :    0.0381900943
+        2   2 >   1   1     :     4a     4b >     6b     6b :   -0.0278614844
+EOM State 4      9.106    73445.6   0.3346427644  -150.839220324206
 
 Largest components of excited wave function #4:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :        4b >     6a :   -0.5730871492
-         3 >   1      :        5a >     6b :   -0.2861444814
-         3 >   0      :        5a >     5b :   -0.1870728413
-         1 >   0      :        3b >     6a :    0.1249235471
-         2 >   1      :        4b >     7a :    0.0562538120
+         2 >   0      :        4b >     6a :    0.5730871545
+         3 >   1      :        5a >     6b :    0.2861444770
+         3 >   0      :        5a >     5b :    0.1870728343
+         1 >   0      :        3b >     6a :   -0.1249235443
+         2 >   1      :        4b >     7a :   -0.0562538120
  RIjAb (libdpd indices)     : (cscf notation)
-        1   2 >   0   0     :     3a     4b >     6a     6a :   -0.0348985008
-        2   1 >   0   0     :     4b     3a >     6a     6a :   -0.0348985008
-        2   2 >   0   1     :     4a     4a >     6a     6b :    0.0301535532
-        2   2 >   1   0     :     4a     4a >     6b     6a :    0.0301535532
-        2   2 >   0   1     :     4b     4b >     6a     6b :   -0.0276825179
+        1   2 >   0   0     :     3a     4b >     6a     6a :    0.0348985009
+        2   1 >   0   0     :     4b     3a >     6a     6a :    0.0348985009
+        2   2 >   0   1     :     4a     4a >     6a     6b :   -0.0301535535
+        2   2 >   1   0     :     4a     4a >     6b     6a :   -0.0301535535
+        2   2 >   0   1     :     4b     4b >     6a     6b :    0.0276825179
 
 	Putting into environment energy for root of R irrep 2 and root 2.
-	Putting into environment CURRENT ENERGY:             -150.8392203263
+	Putting into environment CURRENT ENERGY:             -150.8392203242
 
 	Total # of sigma evaluations: 47
-
-*** tstop() called on psinet at Mon May 15 15:34:50 2017
-Module time:
-	user time   =       0.77 seconds =       0.01 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.77 seconds =       0.03 minutes
-	system time =       0.80 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:50 2017
-
 
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -150.779183872358459
-	Reference energy    (CC_INFO) = -150.779183872358317
-	CCSD energy         (CC_INFO) =   -0.394679217139842
-	Total CCSD energy   (CC_INFO) = -151.173863089498155
+	SCF energy          (wfn)     = -150.779183872130034
+	Reference energy    (CC_INFO) = -150.779183872130091
+	CCSD energy         (CC_INFO) =   -0.394679216471492
+	Total CCSD energy   (CC_INFO) = -151.173863088601593
 
 	Input parameters:
 	-----------------
@@ -754,13 +732,13 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
-	  2   0     1         No       0.2568490006  -0.0030076337
-	  3   0     2         No       0.3341136893  -0.0118120672
-	  4   1     1         No       0.2535297562   0.0000000000
-	  5   1     2         No       0.3346427632   0.0000000000
+	  2   0     1         No       0.2568490009  -0.0030076338
+	  3   0     2         No       0.3341136930   0.0118120665
+	  4   1     1         No       0.2535297594   0.0000000000
+	  5   1     2         No       0.3346427644   0.0000000000
 	Labels for eigenvector 1:
 	LIA 0 -1, Lia 0 -1, LIJAB 0 -1, Lijab 0 -1, LIjAb 0 -1, 2LIjAb - LIjbA 0 -1
 	Labels for eigenvector 2:
@@ -779,40 +757,40 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.394689328362803    0.000e+00
-	   1        -0.387343315323881    8.725e-03
-	   2        -0.386499939899566    2.080e-03
-	   3        -0.386317948466769    6.944e-04
-	   4        -0.386312993213420    2.285e-04
-	   5        -0.386314886727122    9.110e-05
+	   0        -0.394689327699558    0.000e+00
+	   1        -0.387343314762134    8.725e-03
+	   2        -0.386499939344902    2.080e-03
+	   3        -0.386317947916533    6.944e-04
+	   4        -0.386312992662775    2.285e-04
+	   5        -0.386314886176575    9.110e-05
 
 	Largest LIA Amplitudes:
-	          5  14        -0.0082327688
-	          2   7        -0.0070069014
-	          2   4         0.0069956615
-	          6  14        -0.0069317726
+	          5  14        -0.0082327683
+	          2   7        -0.0070069012
+	          2   4         0.0069956614
+	          6  14        -0.0069317721
 	          2   9        -0.0068936824
-	          2   3        -0.0057528670
-	          1   8        -0.0055694647
-	          6  16         0.0053780448
-	          1   3         0.0053582936
-	          5  17         0.0051521370
+	          2   3        -0.0057528669
+	          1   8        -0.0055694646
+	          6  16         0.0053780447
+	          1   3         0.0053582935
+	          5  17         0.0051521367
 
 	Largest LIjAb Amplitudes:
-	  2   2  15  15        -0.0651836334
-	  2   2  14  15         0.0321304290
-	  2   2  15  14         0.0321304290
-	  1   2  15  15         0.0299895523
-	  2   1  15  15         0.0299895523
+	  2   2  15  15        -0.0651836327
+	  2   2  14  15         0.0321304278
+	  2   2  15  14         0.0321304278
+	  1   2  15  15         0.0299895522
+	  2   1  15  15         0.0299895522
 	  1   1  15  15        -0.0298967622
-	  3   3  17  17        -0.0223857160
-	  3   3  15  15        -0.0208901713
-	  1   1   1   1        -0.0208325147
-	  2   2  14  14        -0.0191154516
+	  3   3  17  17        -0.0223857153
+	  3   3  15  15        -0.0208901714
+	  1   1   1   1        -0.0208325146
+	  2   2  14  14        -0.0191154506
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.89177313374
+	Overlap <L|e^T> =        0.89177313450
 	Symmetry of left-hand state: A
 	Symmetry of left-hand eigenvector: A
 	Initial overlap of initial guess <L|R> =    0.9999816056
@@ -822,47 +800,47 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         0.000306122236635    9.110e-05
-	   1        -0.000392059972983    5.148e-02
-	   2        -0.000402796197239    1.320e-02
-	   3        -0.000414436233534    2.780e-03
-	   4        -0.000409594382139    1.309e-03
-	   5        -0.000403683045789    6.251e-04
-	   6        -0.000402421020481    3.342e-04
-	   7        -0.000404094434624    1.427e-04
-	   8        -0.000404386168277    6.007e-05
+	   0         0.000306122337813    9.110e-05
+	   1        -0.000392059897956    5.148e-02
+	   2        -0.000402796125736    1.320e-02
+	   3        -0.000414436162919    2.780e-03
+	   4        -0.000409594311917    1.309e-03
+	   5        -0.000403682975676    6.251e-04
+	   6        -0.000402420950387    3.342e-04
+	   7        -0.000404094364455    1.427e-04
+	   8        -0.000404386098083    6.007e-05
 
-	Initial  <L|R>  =        0.9742430735
+	Initial  <L|R>  =        0.9742430736
 	Normalizing L...
 	L0 * R0 =       -0.0000000000
-	L1 * R1 =        0.9289315277
-	L2 * R2 =        0.0710684723
+	L1 * R1 =        0.9289315282
+	L2 * R2 =        0.0710684718
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =   -0.000415077283338
+	Pseudoenergy or Norm of normalized L =   -0.000415077211259
 
 	Largest LIA Amplitudes:
-	          3   0         0.6694371287
-	          3   1        -0.0598299595
-	          6  14         0.0427964864
+	          3   0         0.6694371291
+	          3   1        -0.0598299592
+	          6  14         0.0427964857
 	          5  14        -0.0409680065
-	          2   0         0.0339087761
-	          5  15        -0.0323994005
-	          6  15         0.0266839617
-	          3   2         0.0191562935
-	          3   5        -0.0155159511
-	          1   0         0.0154280524
+	          2   0         0.0339087752
+	          5  15        -0.0323994000
+	          6  15         0.0266839610
+	          3   2         0.0191562934
+	          3   5        -0.0155159513
+	          1   0         0.0154280519
 
 	Largest LIjAb Amplitudes:
-	  2   5  15   0         0.0565917126
-	  5   2   0  15         0.0565917126
-	  1   3   0   0         0.0414071747
-	  3   1   0   0         0.0414071747
-	  2   6  15   0        -0.0349700251
-	  6   2   0  15        -0.0349700251
-	  1   5  15   0        -0.0312823799
-	  5   1   0  15        -0.0312823799
-	  3   3   0   4        -0.0282415875
-	  3   3   4   0        -0.0282415875
+	  2   5  15   0         0.0565917123
+	  5   2   0  15         0.0565917123
+	  1   3   0   0         0.0414071744
+	  3   1   0   0         0.0414071744
+	  2   6  15   0        -0.0349700246
+	  6   2   0  15        -0.0349700246
+	  1   5  15   0        -0.0312823800
+	  5   1   0  15        -0.0312823800
+	  3   3   0   4        -0.0282415876
+	  3   3   4   0        -0.0282415876
 
 	Iterations converged.
 
@@ -875,48 +853,48 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         0.000362074441195    6.007e-05
-	   1        -0.002780463297453    3.558e-02
-	   2        -0.002713114136486    8.772e-03
-	   3        -0.002791741328469    3.352e-03
-	   4        -0.002782939426774    1.991e-03
-	   5        -0.002764803153316    1.265e-03
-	   6        -0.002764249736296    8.096e-04
-	   7        -0.002763680760567    4.009e-04
-	   8        -0.002764376637713    1.659e-04
-	   9        -0.002764441516993    7.287e-05
+	   0        -0.000362074140726    6.007e-05
+	   1         0.002780463439076    3.558e-02
+	   2         0.002713114272152    8.772e-03
+	   3         0.002791741460138    3.352e-03
+	   4         0.002782939559508    1.991e-03
+	   5         0.002764803286576    1.265e-03
+	   6         0.002764249869335    8.096e-04
+	   7         0.002763680893531    4.009e-04
+	   8         0.002764376770778    1.659e-04
+	   9         0.002764441650095    7.287e-05
 
 	Initial  <L|R>  =        0.9848106991
 	Normalizing L...
-	L0 * R0 =       -0.0000000000
-	L1 * R1 =        0.9287966887
-	L2 * R2 =        0.0712033113
+	L0 * R0 =        0.0000000000
+	L1 * R1 =        0.9287966896
+	L2 * R2 =        0.0712033104
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =   -0.002807079085872
+	Pseudoenergy or Norm of normalized L =    0.002807079221145
 
 	Largest LIA Amplitudes:
-	          6  14        -0.5247537215
-	          6  15         0.4075274400
-	          5  14         0.0833045885
-	          5  15        -0.0777562589
-	          6  16         0.0463658105
-	          6  17         0.0328362939
-	          6  19        -0.0284674940
-	          2   0        -0.0186963479
-	          1   0        -0.0175758944
-	          3   0         0.0167479830
+	          6  14         0.5247537236
+	          6  15        -0.4075274387
+	          5  14        -0.0833045858
+	          5  15         0.0777562564
+	          6  16        -0.0463658113
+	          6  17        -0.0328362944
+	          6  19         0.0284674937
+	          2   0         0.0186963493
+	          1   0         0.0175758949
+	          3   0        -0.0167479833
 
 	Largest LIjAb Amplitudes:
-	  2   2  15  15        -0.0547032947
-	  2   2  14  15         0.0521914678
-	  2   2  15  14         0.0521914678
-	  2   3  15  14         0.0445984833
-	  3   2  14  15         0.0445984833
-	  2   3  15  15        -0.0405980722
-	  3   2  15  15        -0.0405980722
-	  2   2  14  14        -0.0377476140
-	  1   1  15  15         0.0340200654
-	  1   3  15  15         0.0309127366
+	  2   2  15  15         0.0547032945
+	  2   2  14  15        -0.0521914674
+	  2   2  15  14        -0.0521914674
+	  2   3  15  14        -0.0445984823
+	  3   2  14  15        -0.0445984823
+	  2   3  15  15         0.0405980711
+	  3   2  15  15         0.0405980711
+	  2   2  14  14         0.0377476130
+	  1   1  15  15        -0.0340200654
+	  1   3  15  15        -0.0309127361
 
 	Iterations converged.
 
@@ -930,47 +908,47 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    7.287e-05
-	   1         0.981916992615081    3.500e-02
-	   2         0.984667624987075    8.595e-03
-	   3         0.984826101549585    3.006e-03
-	   4         0.985072552211297    1.768e-03
-	   5         0.985364276938065    1.124e-03
-	   6         0.985597038933121    7.321e-04
-	   7         0.985752873582370    3.420e-04
-	   8         0.985807709515666    1.305e-04
-	   9         0.985812447411834    4.997e-05
+	   1         0.981916992432146    3.500e-02
+	   2         0.984667624844179    8.595e-03
+	   3         0.984826101420597    3.006e-03
+	   4         0.985072552088514    1.768e-03
+	   5         0.985364276831351    1.124e-03
+	   6         0.985597038847825    7.321e-04
+	   7         0.985752873507787    3.420e-04
+	   8         0.985807709440838    1.305e-04
+	   9         0.985812447336846    4.997e-05
 
-	Initial  <L|R>  =        0.9848616767
+	Initial  <L|R>  =        0.9848616766
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9388629856
-	L2 * R2 =        0.0611370144
+	L1 * R1 =        0.9388629860
+	L2 * R2 =        0.0611370140
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000965385038309
+	Pseudoenergy or Norm of normalized L =    1.000965385025876
 
 	Largest LIA Amplitudes:
-	          3  14        -0.5381614883
-	          3  15         0.4079749446
-	          3  16         0.0484814254
-	          2  14        -0.0438719981
-	          2  15         0.0405173906
-	          3  17         0.0304281078
-	          3  19        -0.0298057165
-	          6   0        -0.0241516419
-	          3  18         0.0210853335
-	          5   0         0.0187558250
+	          3  14        -0.5381614901
+	          3  15         0.4079749426
+	          3  16         0.0484814263
+	          2  14        -0.0438719969
+	          2  15         0.0405173896
+	          3  17         0.0304281085
+	          3  19        -0.0298057161
+	          6   0        -0.0241516433
+	          3  18         0.0210853325
+	          5   0         0.0187558260
 
 	Largest LIjAb Amplitudes:
-	  2   5  15  14        -0.0516513144
-	  5   2  14  15        -0.0516513144
-	  2   5  15  15         0.0416626981
-	  5   2  15  15         0.0416626981
-	  2   6  15  14         0.0325097498
-	  6   2  14  15         0.0325097498
-	  2   6  15  15        -0.0300565442
-	  6   2  15  15        -0.0300565442
-	  2   5  14  15        -0.0291682395
-	  5   2  15  14        -0.0291682395
+	  2   5  15  14        -0.0516513141
+	  5   2  14  15        -0.0516513141
+	  2   5  15  15         0.0416626976
+	  5   2  15  15         0.0416626976
+	  2   6  15  14         0.0325097492
+	  6   2  14  15         0.0325097492
+	  2   6  15  15        -0.0300565435
+	  6   2  15  15        -0.0300565435
+	  2   5  14  15        -0.0291682386
+	  5   2  15  14        -0.0291682386
 
 	Iterations converged.
 
@@ -984,49 +962,49 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    4.997e-05
-	   1         0.976211588087408    4.248e-02
-	   2         0.979985998265725    1.011e-02
-	   3         0.980087718710463    2.932e-03
-	   4         0.980284264799733    1.394e-03
-	   5         0.980390431502211    6.927e-04
-	   6         0.980435042307265    5.343e-04
-	   7         0.980491961517613    4.330e-04
-	   8         0.980560982055246    3.621e-04
-	   9         0.980641502122382    2.762e-04
-	  10         0.980754380414167    1.982e-04
-	  11         0.980759067339987    9.848e-05
+	   1         0.976211587973123    4.248e-02
+	   2         0.979985998183435    1.011e-02
+	   3         0.980087718625270    2.932e-03
+	   4         0.980284264710606    1.394e-03
+	   5         0.980390431412276    6.927e-04
+	   6         0.980435042218616    5.343e-04
+	   7         0.980491961431606    4.330e-04
+	   8         0.980560981972800    3.621e-04
+	   9         0.980641502043312    2.762e-04
+	  10         0.980754380338436    1.982e-04
+	  11         0.980759067264219    9.848e-05
 
 	Initial  <L|R>  =        0.9796718365
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9371868086
-	L2 * R2 =        0.0628131914
+	L1 * R1 =        0.9371868088
+	L2 * R2 =        0.0628131912
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.001109790808419
+	Pseudoenergy or Norm of normalized L =    1.001109790793320
 
 	Largest LIA Amplitudes:
-	          6   0        -0.5705123020
-	          3  15        -0.2795017567
-	          3  14        -0.1858139975
-	          5   0         0.1258332563
-	          6   1         0.0541463266
-	          2  15        -0.0465744391
-	          3  16         0.0356481840
-	          3  19         0.0312052534
-	          1  14        -0.0301598804
-	          2  14        -0.0250138198
+	          6   0         0.5705123073
+	          3  15         0.2795017523
+	          3  14         0.1858139905
+	          5   0        -0.1258332535
+	          6   1        -0.0541463266
+	          2  15         0.0465744384
+	          3  16        -0.0356481825
+	          3  19        -0.0312052533
+	          1  14         0.0301598806
+	          2  14         0.0250138202
 
 	Largest LIjAb Amplitudes:
-	  1   6   0   0        -0.0370575982
-	  6   1   0   0        -0.0370575982
-	  2   2   0  15         0.0352274318
-	  2   2  15   0         0.0352274318
-	  2   3  15   0         0.0346299353
-	  3   2   0  15         0.0346299353
-	  6   6   0  15        -0.0298415463
-	  6   6  15   0        -0.0298415463
-	  1   2   0  15         0.0261334365
-	  2   1  15   0         0.0261334365
+	  1   6   0   0         0.0370575982
+	  6   1   0   0         0.0370575982
+	  2   2   0  15        -0.0352274321
+	  2   2  15   0        -0.0352274321
+	  2   3  15   0        -0.0346299353
+	  3   2   0  15        -0.0346299353
+	  6   6   0  15         0.0298415461
+	  6   6  15   0         0.0298415461
+	  1   2   0  15        -0.0261334367
+	  2   1  15   0        -0.0261334367
 
 	Iterations converged.
 
@@ -1034,11 +1012,11 @@ Total time:
 
                  1            2            3            4            5
 
-    1    1.0000000   -0.0000000   -0.0000000  -99.0000000  -99.0000000
-    2    0.0000000    1.0000000    0.0000001  -99.0000000  -99.0000000
-    3    0.0000000    0.0000000    1.0000000  -99.0000000  -99.0000000
-    4  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000
-    5  -99.0000000  -99.0000000  -99.0000000   -0.0000001    1.0000000
+    1    1.0000000   -0.0000000    0.0000000  -99.0000000  -99.0000000
+    2    0.0000000    1.0000000   -0.0000001  -99.0000000  -99.0000000
+    3    0.0000000   -0.0000000    1.0000000  -99.0000000  -99.0000000
+    4  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000000
+    5  -99.0000000  -99.0000000  -99.0000000    0.0000001    1.0000000
 
 
 	<L|R> overlap matrix with RHF quantities (-99 => 0 by symmetry)
@@ -1046,7 +1024,7 @@ Total time:
                  1            2            3            4            5
 
     1    1.0000000    0.0000000   -0.0000000  -99.0000000  -99.0000000
-    2    0.0000000    1.0000000   -0.0000000  -99.0000000  -99.0000000
+    2    0.0000000    1.0000000    0.0000000  -99.0000000  -99.0000000
     3    0.0000000   -0.0000000    1.0000000  -99.0000000  -99.0000000
     4  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000
     5  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000000
@@ -1055,45 +1033,31 @@ Total time:
 
 	Projections for excited state, irrep A, root 0:
 	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000088290
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9298607690
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0701303931
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9298607696
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0701303925
 	Sum of above             =    0.9999999911
-	Approx. excitation level =    1.0701215551
+	Approx. excitation level =    1.0701215546
 
 	Projections for excited state, irrep A, root 1:
 	<0|Le^(-T)|0><0|Re^T|0>  =    0.0001615964
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9278172317
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0720211697
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9278172327
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0720211687
 	Sum of above             =    0.9999999978
-	Approx. excitation level =    1.0718595711
+	Approx. excitation level =    1.0718595701
 
 	Projections for excited state, irrep A, root 0:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9381457859
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0618542150
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9381457864
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0618542144
 	Sum of above             =    1.0000000009
-	Approx. excitation level =    1.0618542158
+	Approx. excitation level =    1.0618542153
 
 	Projections for excited state, irrep A, root 1:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9379435074
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0620564970
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9379435076
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0620564968
 	Sum of above             =    1.0000000043
-	Approx. excitation level =    1.0620565013
-
-*** tstop() called on psinet at Mon May 15 15:34:50 2017
-Module time:
-	user time   =       0.33 seconds =       0.01 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       2.10 seconds =       0.04 minutes
-	system time =       0.99 seconds =       0.02 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:50 2017
-
+	Approx. excitation level =    1.0620565011
 
 			**************************
 			*                        *
@@ -1117,323 +1081,93 @@ Total time:
 	Xi connected     = No
 	Compute NO       = No
 
-	Nuclear Rep. energy (wfn)     =   38.253968380680327
-	SCF energy          (wfn)     = -150.779183872358459
-	Reference energy    (file100) = -150.779183872358317
-	CCSD energy         (CC_INFO) =   -0.394679217139842
-	Total CCSD energy   (CC_INFO) = -151.173863089498155
+	Nuclear Rep. energy (wfn)     =   38.253968531042538
+	SCF energy          (wfn)     = -150.779183872130034
+	Reference energy    (file100) = -150.779183872130091
+	CCSD energy         (CC_INFO) =   -0.394679216471492
+	Total CCSD energy   (CC_INFO) = -151.173863088601593
 	Number of States = 5
 
 	Ground?  State     EOM Energy       R0
 	  Yes     0  A    0.0000000000   1.00000000
-	   No     1  A    0.2568490006  -0.00300763
-	   No     2  A    0.3341136893  -0.01181207
-	   No     1  B    0.2535297562   0.00000000
-	   No     2  B    0.3346427632   0.00000000
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.3320
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.1356     Total:     1.1356
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.8865     Total:     2.8865
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -11.6425     YY:   -11.0658     ZZ:    -9.3582
-    XY:    -1.4005     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -0.9537     YY:    -0.3769     ZZ:     1.3306
-    XY:    -1.4005     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.07364  4.07364  0.00000 -0.14728
-       2     O     4.07364  4.07364  0.00000 -0.14728
-       3     H     0.42636  0.42636  0.00000  0.14728
-       4     H     0.42636  0.42636  0.00000  0.14728
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.966
-  HONO-1 :    4  B    1.964
-  HONO-0 :    5  A    1.941
-  LUNO+0 :    5  B    0.056
-  LUNO+1 :    6  A    0.025
-  LUNO+2 :    6  B    0.025
-  LUNO+3 :    7  B    0.018
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 1 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.8513
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.3836     Total:     0.3836
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -0.9750     Total:     0.9750
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -13.6090     YY:   -12.7948     ZZ:   -15.9199
-    XY:     0.1044     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     0.4989     YY:     1.3131     ZZ:    -1.8120
-    XY:     0.1044     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     3.88517  3.88517  0.00000  0.22965
-       2     O     3.88517  3.88517  0.00000  0.22965
-       3     H     0.61483  0.61483  0.00000 -0.22965
-       4     H     0.61483  0.61483  0.00000 -0.22965
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.973
-  HONO-1 :    4  B    1.954
-  HONO-0 :    5  A    1.046
-  LUNO+0 :    6  A    0.977
-  LUNO+1 :    5  B    0.028
-  LUNO+2 :    6  B    0.019
-  LUNO+3 :    7  B    0.005
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 2 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.6741
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.7936     Total:     0.7936
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.0170     Total:     2.0170
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -12.0128     YY:   -13.7400     ZZ:    -9.5378
-    XY:    -1.1099     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -0.2493     YY:    -1.9765     ZZ:     2.2258
-    XY:    -1.1099     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.04123  4.04123  0.00000 -0.08245
-       2     O     4.04123  4.04123  0.00000 -0.08245
-       3     H     0.45877  0.45877  0.00000  0.08245
-       4     H     0.45877  0.45877  0.00000  0.08245
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.961
-  HONO-1 :    5  A    1.949
-  HONO-0 :    4  B    1.050
-  LUNO+0 :    5  B    1.005
-  LUNO+1 :    6  B    0.018
-  LUNO+2 :    6  A    0.008
-  LUNO+3 :    7  B    0.005
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 3 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.6021
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.8656     Total:     0.8656
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.2002     Total:     2.2002
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -11.4406     YY:   -13.7412     ZZ:   -10.3460
-    XY:    -0.6127     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     0.4020     YY:    -1.8986     ZZ:     1.4966
-    XY:    -0.6127     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.02998  4.02998  0.00000 -0.05997
-       2     O     4.02998  4.02998  0.00000 -0.05997
-       3     H     0.47002  0.47002  0.00000  0.05997
-       4     H     0.47002  0.47002  0.00000  0.05997
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.970
-  HONO-1 :    4  B    1.958
-  HONO-0 :    5  A    1.037
-  LUNO+0 :    5  B    1.000
-  LUNO+1 :    6  B    0.017
-  LUNO+2 :    6  A    0.008
-  LUNO+3 :    7  B    0.005
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 4 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4677
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.7945
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.3269     Total:     0.3269
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -0.8308     Total:     0.8308
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -13.9274     YY:   -13.2528     ZZ:   -14.8287
-    XY:    -0.0378     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     0.0756     YY:     0.7502     ZZ:    -0.8258
-    XY:    -0.0378     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     3.90531  3.90531  0.00000  0.18939
-       2     O     3.90531  3.90531  0.00000  0.18939
-       3     H     0.59469  0.59469  0.00000 -0.18939
-       4     H     0.59469  0.59469  0.00000 -0.18939
-
-   Total alpha =  9.00000, Total beta =  9.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    4  A    1.978
-  HONO-1 :    5  A    1.732
-  HONO-0 :    4  B    1.276
-  LUNO+0 :    6  A    0.741
-  LUNO+1 :    5  B    0.260
-  LUNO+2 :    6  B    0.020
-  LUNO+3 :    7  A    0.005
-
+	   No     1  A    0.2568490009  -0.00300763
+	   No     2  A    0.3341136930   0.01181207
+	   No     1  B    0.2535297594   0.00000000
+	   No     2  B    0.3346427644   0.00000000
 Doing transition
 
 	Oscillator Strength for 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.00802795
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.00802796
 	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.00697813
 	Dipole Strength          0.00005602 
 	Oscillator Strength      0.00000959 
-	Einstein A Coefficient   2.03327888e+04 
-	Einstein B Coefficient   6.81576326e+15 
+	Einstein A Coefficient   2.03327968e+04 
+	Einstein B Coefficient   6.81576506e+15 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.00802795
-	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.31729649
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.00802796
+	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.31729650
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.31136481
 	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.00697813
 
 	Rotational Strength (au)                 -0.00235999
-	Rotational Strength (10^-40 esu^2 cm^2)  -1.11260310
+	Rotational Strength (10^-40 esu^2 cm^2)  -1.11260334
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
 	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.01578728
-	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.31729649
+	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.31729650
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.31136481
 	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.01454886
 
 	Rotational Strength (au)                 -0.01856976
-	Rotational Strength (10^-40 esu^2 cm^2)  -8.75459429
+	Rotational Strength (10^-40 esu^2 cm^2)  -8.75459439
 Doing transition
 Doing transition
 
 	Oscillator Strength for 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.18349260
-	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.19376366
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.18349260
+	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.19376367
 	Dipole Strength          0.03555420 
 	Oscillator Strength      0.00791943 
-	Einstein A Coefficient   2.84049046e+07 
-	Einstein B Coefficient   4.32575296e+18 
+	Einstein A Coefficient   2.84049064e+07 
+	Einstein B Coefficient   4.32575255e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.18349260
-	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.21493530
-	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.20717268
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.19376366
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.18349260
+	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.21493530
+	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.20717268
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.19376367
 
 	Rotational Strength (au)                  0.03979079
-	Rotational Strength (10^-40 esu^2 cm^2)  18.75910981
+	Rotational Strength (10^-40 esu^2 cm^2)  18.75910994
 
 	Velocity-Gauge Rotational Strength for 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.10437726
-	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.21493530
-	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.20717268
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.10742394
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.10437726
+	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.21493530
+	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.20717268
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.10742395
 
 	Rotational Strength (au)                  0.06687793
-	Rotational Strength (10^-40 esu^2 cm^2)  31.52916862
+	Rotational Strength (10^-40 esu^2 cm^2)  31.52916868
 Doing transition
 Doing transition
 
 	Oscillator Strength for 1  B
 	                              X    	       Y    	       Z
 	<0|mu_e|n>               0.08328873 	  0.06364968 	  0.00000000
-	<n|mu_e|0>               0.08808891 	  0.06485509 	  0.00000000
+	<n|mu_e|0>               0.08808892 	  0.06485509 	  0.00000000
 	Dipole Strength          0.01146482 
 	Oscillator Strength      0.00193778 
-	Einstein A Coefficient   4.00196854e+06 
-	Einstein B Coefficient   1.39488384e+18 
+	Einstein A Coefficient   4.00196876e+06 
+	Einstein B Coefficient   1.39488368e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1  B
@@ -1441,52 +1175,52 @@ Doing transition
 	<0|mu_e|n>               0.08328873 	  0.06364968 	  0.00000000
 	<n|mu_m|0>              -0.08743728 	  0.03748797 	  0.00000000
 	<0|mu_m|n>*             -0.08299512 	  0.03475549 	  0.00000000
-	<n|mu_e|0>*              0.08808891 	  0.06485509 	  0.00000000
+	<n|mu_e|0>*              0.08808892 	  0.06485509 	  0.00000000
 
 	Rotational Strength (au)                 -0.00497666
-	Rotational Strength (10^-40 esu^2 cm^2)  -2.34621476
+	Rotational Strength (10^-40 esu^2 cm^2)  -2.34621487
 
 	Velocity-Gauge Rotational Strength for 1  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.08802262 	  0.01364048 	  0.00000000
+	<0|mu_e|n>               0.08802263 	  0.01364048 	  0.00000000
 	<n|mu_m|0>              -0.08743728 	  0.03748797 	  0.00000000
 	<0|mu_m|n>*             -0.08299512 	  0.03475549 	  0.00000000
 	<n|mu_e|0>*              0.09026922 	  0.01303789 	  0.00000000
 
 	Rotational Strength (au)                 -0.02805168
-	Rotational Strength (10^-40 esu^2 cm^2)  -13.22478344
+	Rotational Strength (10^-40 esu^2 cm^2)  -13.22478345
 Doing transition
 Doing transition
 
 	Oscillator Strength for 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.17529009 	  0.11742673 	  0.00000000
-	<n|mu_e|0>               0.17665686 	  0.12411470 	  0.00000000
+	<0|mu_e|n>              -0.17529009 	 -0.11742673 	  0.00000000
+	<n|mu_e|0>              -0.17665686 	 -0.12411470 	  0.00000000
 	Dipole Strength          0.04554058 
 	Oscillator Strength      0.01015988 
-	Einstein A Coefficient   3.65563241e+07 
-	Einstein B Coefficient   5.54076071e+18 
+	Einstein A Coefficient   3.65563227e+07 
+	Einstein B Coefficient   5.54075974e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.17529009 	  0.11742673 	  0.00000000
-	<n|mu_m|0>               0.34133130 	  0.14575496 	  0.00000000
-	<0|mu_m|n>*              0.33329068 	  0.14202645 	  0.00000000
-	<n|mu_e|0>*              0.17665686 	  0.12411470 	  0.00000000
+	<0|mu_e|n>              -0.17529009 	 -0.11742673 	  0.00000000
+	<n|mu_m|0>              -0.34133131 	 -0.14575496 	  0.00000000
+	<0|mu_m|n>*             -0.33329069 	 -0.14202644 	  0.00000000
+	<n|mu_e|0>*             -0.17665686 	 -0.12411470 	  0.00000000
 
 	Rotational Strength (au)                  0.07672659
-	Rotational Strength (10^-40 esu^2 cm^2)  36.17225510
+	Rotational Strength (10^-40 esu^2 cm^2)  36.17225490
 
 	Velocity-Gauge Rotational Strength for 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.13163940 	  0.04079478 	  0.00000000
-	<n|mu_m|0>               0.34133130 	  0.14575496 	  0.00000000
-	<0|mu_m|n>*              0.33329068 	  0.14202645 	  0.00000000
-	<n|mu_e|0>*              0.13362943 	  0.04266284 	  0.00000000
+	<0|mu_e|n>              -0.13163939 	 -0.04079479 	  0.00000000
+	<n|mu_m|0>              -0.34133131 	 -0.14575496 	  0.00000000
+	<0|mu_m|n>*             -0.33329069 	 -0.14202644 	  0.00000000
+	<n|mu_e|0>*             -0.13362943 	 -0.04266284 	  0.00000000
 
 	Rotational Strength (au)                  0.15161748
-	Rotational Strength (10^-40 esu^2 cm^2)  71.47908048
+	Rotational Strength (10^-40 esu^2 cm^2)  71.47908013
 Doing transition
 Doing transition
 
@@ -1494,9 +1228,9 @@ Doing transition
 
 	                   Excitation Energy          OS       RS        RS     Einstein A
 	State   (eV)    (cm^-1)    (nm)     (au)              (l,au)   (v,au)     (s^-1)
-	 1  A   6.989   56371.8   177.4   0.256849   0.0000  -0.0024  -0.0186  2.033279E+04
-	 2  A   9.092   73329.5   136.4   0.334114   0.0079   0.0398   0.0669  2.840490E+07
-	 1  B   6.899   55643.3   179.7   0.253530   0.0019  -0.0050  -0.0281  4.001969E+06
+	 1  A   6.989   56371.8   177.4   0.256849   0.0000  -0.0024  -0.0186  2.033280E+04
+	 2  A   9.092   73329.5   136.4   0.334114   0.0079   0.0398   0.0669  2.840491E+07
+	 1  B   6.899   55643.4   179.7   0.253530   0.0019  -0.0050  -0.0281  4.001969E+06
 	 2  B   9.106   73445.6   136.2   0.334643   0.0102   0.0767   0.1516  3.655632E+07
 
 Doing transition
@@ -1526,32 +1260,32 @@ Doing transition
 
 	Oscillator Strength for 1  A to 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.01539035
-	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.02249264
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.01539035
+	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.02249264
 	Dipole Strength          0.00034617 
 	Oscillator Strength      0.00001783 
-	Einstein A Coefficient   3.42020076e+03 
-	Einstein B Coefficient   4.21172116e+16 
+	Einstein A Coefficient   3.42020116e+03 
+	Einstein B Coefficient   4.21172056e+16 
 
 	Length-Gauge Rotational Strength for 1  A to 2  A Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.01539035
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00997871
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.01218772
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.02249264
+	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.01539035
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00997871
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.01218772
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.02249264
 
 	Rotational Strength (au)                 -0.00021385
-	Rotational Strength (10^-40 esu^2 cm^2)  -0.10082048
+	Rotational Strength (10^-40 esu^2 cm^2)  -0.10082049
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00505700
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00997871
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.01218772
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00083996
+	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.00505700
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00997871
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.01218772
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.00083996
 
 	Rotational Strength (au)                 -0.00039280
-	Rotational Strength (10^-40 esu^2 cm^2)  -0.18518424
+	Rotational Strength (10^-40 esu^2 cm^2)  -0.18518426
 
 	*** Computing <1 B|X{pq}}|1 A> (LEFT) Transition Density ***
 
@@ -1569,32 +1303,32 @@ Doing transition
 
 	Oscillator Strength for 1  B to 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.38044178 	 -0.75054660 	  0.00000000
-	<n|mu_e|0>               0.37309013 	 -0.72986015 	  0.00000000
-	Dipole Strength          0.68973313 
+	<0|mu_e|n>               0.38044180 	 -0.75054662 	  0.00000000
+	<n|mu_e|0>               0.37309014 	 -0.72986017 	  0.00000000
+	Dipole Strength          0.68973316 
 	Oscillator Strength      0.00152626 
-	Einstein A Coefficient   5.40279389e+02 
-	Einstein B Coefficient   8.39173785e+19 
+	Einstein A Coefficient   5.40278023e+02 
+	Einstein B Coefficient   8.39173700e+19 
 
 	Length-Gauge Rotational Strength for 1  B to 1  A Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.38044178 	 -0.75054660 	  0.00000000
-	<q|mu_m|p>              -0.05157699 	 -0.03267411 	  0.00000000
-	<p|mu_m|q>*             -0.05536849 	 -0.03275400 	  0.00000000
-	<q|mu_e|p>*              0.37309013 	 -0.72986015 	  0.00000000
+	<p|mu_e|q>               0.38044180 	 -0.75054662 	  0.00000000
+	<q|mu_m|p>              -0.05157700 	 -0.03267411 	  0.00000000
+	<p|mu_m|q>*             -0.05536850 	 -0.03275400 	  0.00000000
+	<q|mu_e|p>*              0.37309014 	 -0.72986017 	  0.00000000
 
 	Rotational Strength (au)                  0.00407490
-	Rotational Strength (10^-40 esu^2 cm^2)   1.92108445
+	Rotational Strength (10^-40 esu^2 cm^2)   1.92108440
 
 	Velocity-Gauge Rotational Strength for 1  B
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.00646845 	 -0.05368008 	  0.00000000
-	<q|mu_m|p>              -0.05157699 	 -0.03267411 	  0.00000000
-	<p|mu_m|q>*             -0.05536849 	 -0.03275400 	  0.00000000
-	<q|mu_e|p>*             -0.01030609 	 -0.06004937 	  0.00000000
+	<p|mu_e|q>              -0.00646845 	 -0.05368007 	  0.00000000
+	<q|mu_m|p>              -0.05157700 	 -0.03267411 	  0.00000000
+	<p|mu_m|q>*             -0.05536850 	 -0.03275400 	  0.00000000
+	<q|mu_e|p>*             -0.01030609 	 -0.06004936 	  0.00000000
 
-	Rotational Strength (au)                  0.69670398
-	Rotational Strength (10^-40 esu^2 cm^2)  328.45658997
+	Rotational Strength (au)                  0.69670461
+	Rotational Strength (10^-40 esu^2 cm^2)  328.45688725
 
 	*** Computing <1 B|X{pq}}|2 A> (LEFT) Transition Density ***
 
@@ -1612,32 +1346,32 @@ Doing transition
 
 	Oscillator Strength for 1  B to 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.07775059 	 -0.48727033 	  0.00000000
-	<n|mu_e|0>               0.07849009 	 -0.48053958 	  0.00000000
+	<0|mu_e|n>              -0.07775059 	  0.48727033 	  0.00000000
+	<n|mu_e|0>              -0.07849009 	  0.48053958 	  0.00000000
 	Dipole Strength          0.24025533 
 	Oscillator Strength      0.01290715 
-	Einstein A Coefficient   2.69301055e+06 
-	Einstein B Coefficient   2.92310128e+19 
+	Einstein A Coefficient   2.69301045e+06 
+	Einstein B Coefficient   2.92310074e+19 
 
 	Length-Gauge Rotational Strength for 1  B to 2  A Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.07775059 	 -0.48727033 	  0.00000000
-	<q|mu_m|p>               0.01648946 	 -0.35534347 	  0.00000000
-	<p|mu_m|q>*              0.03607999 	 -0.35717373 	  0.00000000
-	<q|mu_e|p>*              0.07849009 	 -0.48053958 	  0.00000000
+	<p|mu_e|q>              -0.07775059 	  0.48727033 	  0.00000000
+	<q|mu_m|p>              -0.01648946 	  0.35534348 	  0.00000000
+	<p|mu_m|q>*             -0.03607999 	  0.35717373 	  0.00000000
+	<q|mu_e|p>*             -0.07849009 	  0.48053958 	  0.00000000
 
 	Rotational Strength (au)                  0.17444922
-	Rotational Strength (10^-40 esu^2 cm^2)  82.24295625
+	Rotational Strength (10^-40 esu^2 cm^2)  82.24295565
 
 	Velocity-Gauge Rotational Strength for 1  B
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.01276157 	 -0.05849731 	  0.00000000
-	<q|mu_m|p>               0.01648946 	 -0.35534347 	  0.00000000
-	<p|mu_m|q>*              0.03607999 	 -0.35717373 	  0.00000000
-	<q|mu_e|p>*              0.01852655 	 -0.03168745 	  0.00000000
+	<p|mu_e|q>              -0.01276158 	  0.05849731 	  0.00000000
+	<q|mu_m|p>              -0.01648946 	  0.35534348 	  0.00000000
+	<p|mu_m|q>*             -0.03607999 	  0.35717373 	  0.00000000
+	<q|mu_e|p>*             -0.01852655 	  0.03168745 	  0.00000000
 
 	Rotational Strength (au)                  0.20465266
-	Rotational Strength (10^-40 esu^2 cm^2)  96.48217663
+	Rotational Strength (10^-40 esu^2 cm^2)  96.48217636
 
 	*** Computing <1 A|X{pq}}|2 B> (LEFT) Transition Density ***
 
@@ -1655,32 +1389,32 @@ Doing transition
 
 	Oscillator Strength for 1  A to 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.38497997 	 -0.36360338 	  0.00000000
-	<n|mu_e|0>               0.37997921 	 -0.36215395 	  0.00000000
-	Dipole Strength          0.27796479 
+	<0|mu_e|n>              -0.38497996 	  0.36360336 	  0.00000000
+	<n|mu_e|0>              -0.37997920 	  0.36215392 	  0.00000000
+	Dipole Strength          0.27796476 
 	Oscillator Strength      0.01441595 
-	Einstein A Coefficient   2.80313329e+06 
-	Einstein B Coefficient   3.38189878e+19 
+	Einstein A Coefficient   2.80313304e+06 
+	Einstein B Coefficient   3.38189794e+19 
 
 	Length-Gauge Rotational Strength for 1  A to 2  B Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.38497997 	 -0.36360338 	  0.00000000
-	<q|mu_m|p>               0.01536333 	  0.32343426 	  0.00000000
-	<p|mu_m|q>*              0.01701146 	  0.32547703 	  0.00000000
-	<q|mu_e|p>*              0.37997921 	 -0.36215395 	  0.00000000
+	<p|mu_e|q>              -0.38497996 	  0.36360336 	  0.00000000
+	<q|mu_m|p>              -0.01536333 	 -0.32343426 	  0.00000000
+	<p|mu_m|q>*             -0.01701146 	 -0.32547704 	  0.00000000
+	<q|mu_e|p>*             -0.37997920 	  0.36215392 	  0.00000000
 
 	Rotational Strength (au)                 -0.11154800
-	Rotational Strength (10^-40 esu^2 cm^2)  -52.58858475
+	Rotational Strength (10^-40 esu^2 cm^2)  -52.58858270
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00850035 	 -0.01051942 	  0.00000000
-	<q|mu_m|p>               0.01536333 	  0.32343426 	  0.00000000
-	<p|mu_m|q>*              0.01701146 	  0.32547703 	  0.00000000
-	<q|mu_e|p>*              0.00582108 	 -0.06175903 	  0.00000000
+	<p|mu_e|q>              -0.00850035 	  0.01051941 	  0.00000000
+	<q|mu_m|p>              -0.01536333 	 -0.32343426 	  0.00000000
+	<p|mu_m|q>*             -0.01701146 	 -0.32547704 	  0.00000000
+	<q|mu_e|p>*             -0.00582108 	  0.06175903 	  0.00000000
 
 	Rotational Strength (au)                 -0.14958696
-	Rotational Strength (10^-40 esu^2 cm^2)  -70.52180703
+	Rotational Strength (10^-40 esu^2 cm^2)  -70.52180571
 
 	*** Computing <2 A|X{pq}}|2 B> (LEFT) Transition Density ***
 
@@ -1698,22 +1432,22 @@ Doing transition
 
 	Oscillator Strength for 2  A to 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.31619359 	  0.67422813 	  0.00000000
-	<n|mu_e|0>              -0.30970598 	  0.65504768 	  0.00000000
-	Dipole Strength          0.53957861 
+	<0|mu_e|n>              -0.31619360 	  0.67422815 	  0.00000000
+	<n|mu_e|0>              -0.30970599 	  0.65504770 	  0.00000000
+	Dipole Strength          0.53957865 
 	Oscillator Strength      0.00019032 
-	Einstein A Coefficient   1.71168383e+00 
-	Einstein B Coefficient   6.56486125e+19 
+	Einstein A Coefficient   1.71165913e+00 
+	Einstein B Coefficient   6.56486069e+19 
 
 	Length-Gauge Rotational Strength for 2  A to 2  B Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.31619359 	  0.67422813 	  0.00000000
+	<p|mu_e|q>              -0.31619360 	  0.67422815 	  0.00000000
 	<q|mu_m|p>               0.03059542 	  0.02771109 	  0.00000000
 	<p|mu_m|q>*              0.03021866 	  0.02723917 	  0.00000000
-	<q|mu_e|p>*             -0.30970598 	  0.65504768 	  0.00000000
+	<q|mu_e|p>*             -0.30970599 	  0.65504770 	  0.00000000
 
 	Rotational Strength (au)                  0.00874679
-	Rotational Strength (10^-40 esu^2 cm^2)   4.12361605
+	Rotational Strength (10^-40 esu^2 cm^2)   4.12361576
 
 	Velocity-Gauge Rotational Strength for 2  A
 	                              X    	       Y    	       Z
@@ -1722,8 +1456,8 @@ Doing transition
 	<p|mu_m|q>*              0.03021866 	  0.02723917 	  0.00000000
 	<q|mu_e|p>*              0.00763547 	  0.05046870 	  0.00000000
 
-	Rotational Strength (au)                  2.69516058
-	Rotational Strength (10^-40 esu^2 cm^2)  1270.61604445
+	Rotational Strength (au)                  2.69517365
+	Rotational Strength (10^-40 esu^2 cm^2)  1270.62220198
 
 	*** Computing <1 B|X{pq}}|2 B> (LEFT) Transition Density ***
 
@@ -1741,40 +1475,40 @@ Doing transition
 
 	Oscillator Strength for 1  B to 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.35910767
-	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.35149602
-	Dipole Strength          0.12622491 
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.35910767
+	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.35149602
+	Dipole Strength          0.12622492 
 	Oscillator Strength      0.00682565 
-	Einstein A Coefficient   1.44289998e+06 
-	Einstein B Coefficient   1.53573368e+19 
+	Einstein A Coefficient   1.44289985e+06 
+	Einstein B Coefficient   1.53573347e+19 
 
 	Length-Gauge Rotational Strength for 1  B to 2  B Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.35910767
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00243222
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.00728175
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.35149602
+	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.35910767
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00243222
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00728175
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.35149602
 
 	Rotational Strength (au)                  0.00171647
-	Rotational Strength (10^-40 esu^2 cm^2)   0.80921787
+	Rotational Strength (10^-40 esu^2 cm^2)   0.80921785
 
 	Velocity-Gauge Rotational Strength for 1  B
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.03471717
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00243222
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.00728175
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.01461264
+	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.03471717
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00243222
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00728175
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.01461264
 
 	Rotational Strength (au)                  0.00117642
-	Rotational Strength (10^-40 esu^2 cm^2)   0.55461433
+	Rotational Strength (10^-40 esu^2 cm^2)   0.55461431
 
 	                   Ground State -> Excited State Transitions
 
 	                   Excitation Energy          OS       RS        RS     Einstein A
 	State   (eV)    (cm^-1)    (nm)     (au)              (l,au)   (v,au)     (s^-1)
-	 1  A   6.989   56371.8   177.4   0.256849   0.0000  -0.0024  -0.0186  2.033279E+04
-	 2  A   9.092   73329.5   136.4   0.334114   0.0079   0.0398   0.0669  2.840490E+07
-	 1  B   6.899   55643.3   179.7   0.253530   0.0019  -0.0050  -0.0281  4.001969E+06
+	 1  A   6.989   56371.8   177.4   0.256849   0.0000  -0.0024  -0.0186  2.033280E+04
+	 2  A   9.092   73329.5   136.4   0.334114   0.0079   0.0398   0.0669  2.840491E+07
+	 1  B   6.899   55643.4   179.7   0.253530   0.0019  -0.0050  -0.0281  4.001969E+06
 	 2  B   9.106   73445.6   136.2   0.334643   0.0102   0.0767   0.1516  3.655632E+07
 
 
@@ -1783,21 +1517,14 @@ Doing transition
 	                        Excitation Energy          OS       RS        RS     Einstein A
 	Transition   (eV)    (cm^-1)    (nm)     (au)              (l,au)   (v,au)     (s^-1)
 	  1A->2A   2.102   16957.6   589.7   0.077265   0.0000  -0.0002  -0.0004  3.420201E+03
-	  1B->1A   0.090     728.5 13727.0   0.003319   0.0015   0.0041   0.6967  5.402794E+02
-	  1B->2A   2.193   17686.1   565.4   0.080584   0.0129   0.1744   0.2047  2.693011E+06
+	  1B->1A   0.090     728.5 13727.0   0.003319   0.0015   0.0041   0.6967  5.402780E+02
+	  1B->2A   2.193   17686.1   565.4   0.080584   0.0129   0.1744   0.2047  2.693010E+06
 	  1A->2B   2.117   17073.8   585.7   0.077794   0.0144  -0.1115  -0.1496  2.803133E+06
-	  2A->2B   0.014     116.1 86119.1   0.000529   0.0002   0.0087   2.6952  1.711684E+00
+	  2A->2B   0.014     116.1 86119.5   0.000529   0.0002   0.0087   2.6952  1.711659E+00
 	  1B->2B   2.207   17802.2   561.7   0.081113   0.0068   0.0017   0.0012  1.442900E+06
 
 
-*** tstop() called on psinet at Mon May 15 15:34:51 2017
-Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       2.46 seconds =       0.04 minutes
-	system time =       1.15 seconds =       0.02 minutes
-	total time  =          4 seconds =       0.07 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
+    Psi4 wall time for execution: 0:00:08.82
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc48/output.ref
+++ b/tests/cc48/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:24PM
 
-    Process ID:  12945
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65700
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -129,24 +142,25 @@ D 2 1.00
 ****
 }
 
-property('eom-ccsd', properties=['dipole'])
+properties('eom-ccsd', properties=['dipole'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:47 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:30 2022
 
    => Loading Basis Set <=
 
     Name: SADSSEJPVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 3 entry H          line     4 inputblock sadssejpvtz 
-    atoms 2    entry O          line    53 inputblock sadssejpvtz 
+    atoms 1, 3 entry H          line     5 inputblock sadssejpvtz 
+    atoms 2    entry O          line    54 inputblock sadssejpvtz 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -160,15 +174,15 @@ property('eom-ccsd', properties=['dipole'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           H          0.000000000000     0.756689922073    -0.520321915113     1.007825032070
-           O          0.000000000000     0.000000000000     0.065570021880    15.994914619560
-           H          0.000000000000    -0.756689922073    -0.520321915113     1.007825032070
+         H            0.000000000000     0.756689922073    -0.520321915104     1.007825032230
+         O            0.000000000000     0.000000000000     0.065570021889    15.994914619570
+         H            0.000000000000    -0.756689922073    -0.520321915104     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     27.43416  B =     14.60648  C =      9.53165 [cm^-1]
-  Rotational constants: A = 822455.52035  B = 437891.14152  C = 285751.52976 [MHz]
-  Nuclear repulsion =    9.196933678131742
+  Rotational constants: A = 822455.52651  B = 437891.14479  C = 285751.53189 [MHz]
+  Nuclear repulsion =    9.196933714281490
 
   Charge       = 0
   Multiplicity = 1
@@ -185,30 +199,17 @@ property('eom-ccsd', properties=['dipole'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: SADSSEJPVTZ
     Blend: SADSSEJPVTZ
     Number of shells: 20
-    Number of basis function: 42
+    Number of basis functions: 42
     Number of Cartesian functions: 44
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        19      19       0       0       0       0
-     A2         4       4       0       0       0       0
-     B1         7       7       0       0       0       0
-     B2        12      12       0       0       0       0
-   -------------------------------------------------------
-    Total      42      42       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -227,42 +228,61 @@ property('eom-ccsd', properties=['dipole'])
   Using 816312 doubles for integral storage.
   We computed 22155 shell quartets total.
   Whereas there are 22155 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 6.2247151109E-04.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 5.0705046043E-04.
+  Reciprocal condition number of the overlap matrix is 1.0198352275E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        19      19 
+     A2         4       4 
+     B1         7       7 
+     B2        12      12 
+   -------------------------
+    Total      42      42
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -75.89234661896424   -7.58923e+01   7.11339e-02 
-   @RHF iter   1:   -76.02603641913058   -1.33690e-01   1.06436e-02 
-   @RHF iter   2:   -76.04535794380757   -1.93215e-02   6.05462e-03 DIIS
-   @RHF iter   3:   -76.05277298994213   -7.41505e-03   6.49266e-04 DIIS
-   @RHF iter   4:   -76.05292406908555   -1.51079e-04   1.47815e-04 DIIS
-   @RHF iter   5:   -76.05293845857118   -1.43895e-05   3.59229e-05 DIIS
-   @RHF iter   6:   -76.05293960208137   -1.14351e-06   7.11066e-06 DIIS
-   @RHF iter   7:   -76.05293964538420   -4.33028e-08   9.52367e-07 DIIS
-   @RHF iter   8:   -76.05293964606513   -6.80927e-10   1.23040e-07 DIIS
-   @RHF iter   9:   -76.05293964607596   -1.08287e-11   2.42430e-08 DIIS
-   @RHF iter  10:   -76.05293964607642   -4.68958e-13   4.80927e-09 DIIS
-   @RHF iter  11:   -76.05293964607645   -2.84217e-14   5.26367e-10 DIIS
-   @RHF iter  12:   -76.05293964607645    0.00000e+00   5.54160e-11 DIIS
+   @RHF iter SAD:   -75.47882876160399   -7.54788e+01   0.00000e+00 
+   @RHF iter   1:   -75.96856830496245   -4.89740e-01   1.87099e-02 DIIS/ADIIS
+   @RHF iter   2:   -76.02197351742332   -5.34052e-02   1.23343e-02 DIIS/ADIIS
+   @RHF iter   3:   -76.05242399789803   -3.04505e-02   1.15711e-03 DIIS/ADIIS
+   @RHF iter   4:   -76.05291661968704   -4.92622e-04   1.93587e-04 DIIS/ADIIS
+   @RHF iter   5:   -76.05293783606221   -2.12164e-05   4.50907e-05 DIIS
+   @RHF iter   6:   -76.05293956868346   -1.73262e-06   9.06767e-06 DIIS
+   @RHF iter   7:   -76.05293964432360   -7.56401e-08   1.54203e-06 DIIS
+   @RHF iter   8:   -76.05293964621826   -1.89466e-09   2.31231e-07 DIIS
+   @RHF iter   9:   -76.05293964625771   -3.94493e-11   6.09416e-08 DIIS
+   @RHF iter  10:   -76.05293964626017   -2.45848e-12   9.29533e-09 DIIS
+   @RHF iter  11:   -76.05293964626024   -7.10543e-14   1.40947e-09 DIIS
+   @RHF iter  12:   -76.05293964626017    7.10543e-14   2.07938e-10 DIIS
+   @RHF iter  13:   -76.05293964626020   -2.84217e-14   3.37004e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -289,49 +309,44 @@ property('eom-ccsd', properties=['dipole'])
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.05293964607645
+  @RHF Final Energy:   -76.05293964626020
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1969336781317423
-    One-Electron Energy =                -123.0259164864164774
-    Two-Electron Energy =                  37.7760431622082891
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0529396460764531
+    Nuclear Repulsion Energy =              9.1969337142814904
+    One-Electron Energy =                -123.0259165493680769
+    Two-Electron Energy =                  37.7760431888263923
+    Total Energy =                        -76.0529396462601994
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.9753
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.1950
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.7802     Total:     0.7802
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -1.9832     Total:     1.9832
 
 
-*** tstop() called on psinet at Mon May 15 15:34:47 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:31 2022
 Module time:
-	user time   =       0.50 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.92 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.50 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.92 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -345,19 +360,19 @@ Total time:
       Number of basis functions:        42
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  19    4    7   12 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 103284 non-zero two-electron integrals.
+      Computed 100667 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:47 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:31 2022
 
 
 	Wfn Parameters:
@@ -382,7 +397,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -418,7 +433,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -61.31661947566941
+	Frozen core energy     =    -61.31661948435612
 
 	Size of irrep 0 of <ab|cd> integrals:      0.184 (MW) /      1.472 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.068 (MW) /      0.541 (MB)
@@ -438,34 +453,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.002 (MW) /      0.013 (MB)
 	Total:                                     0.006 (MW) /      0.047 (MB)
 
-	Nuclear Rep. energy          =      9.19693367813174
-	SCF energy                   =    -76.05293964607645
-	One-electron energy          =    -41.52761130034590
-	Two-electron energy          =     17.59435745180714
-	Reference energy             =    -76.05293964607642
+	Nuclear Rep. energy          =      9.19693371428149
+	SCF energy                   =    -76.05293964626020
+	One-electron energy          =    -41.52761134570231
+	Two-electron energy          =     17.59435746951668
+	Reference energy             =    -76.05293964626026
 
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:32 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.21 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.64 seconds =       0.01 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:48 2017
-
+	user time   =       1.13 seconds =       0.02 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.196933678131742
-    SCF energy          (wfn)     =  -76.052939646076453
-    Reference energy    (file100) =  -76.052939646076425
+    Nuclear Rep. energy (wfn)     =    9.196933714281490
+    SCF energy          (wfn)     =  -76.052939646260199
+    Reference energy    (file100) =  -76.052939646260256
 
     Input parameters:
     -----------------
@@ -493,79 +504,67 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2133519389938205
+MP2 correlation energy -0.2133519386414665
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.213351938993820    0.000e+00    0.000000    0.000000    0.000000    0.113745
-     1        -0.216053274079156    3.927e-02    0.010473    0.021942    0.021942    0.119074
-     2        -0.220342953689666    1.309e-02    0.010542    0.022372    0.022372    0.123664
-     3        -0.221700840573433    5.711e-03    0.012356    0.026736    0.026736    0.125926
-     4        -0.221647114013736    1.117e-03    0.012618    0.027509    0.027509    0.126097
-     5        -0.221649066260744    3.817e-04    0.012701    0.027792    0.027792    0.126122
-     6        -0.221653814688659    1.099e-04    0.012731    0.027899    0.027899    0.126117
-     7        -0.221651762801692    3.222e-05    0.012735    0.027919    0.027919    0.126109
-     8        -0.221651271531890    9.508e-06    0.012737    0.027925    0.027925    0.126107
-     9        -0.221651364211471    3.004e-06    0.012737    0.027927    0.027927    0.126107
-    10        -0.221651254619636    1.034e-06    0.012737    0.027927    0.027927    0.126107
-    11        -0.221651259065657    3.709e-07    0.012737    0.027926    0.027926    0.126107
-    12        -0.221651252979993    1.441e-07    0.012737    0.027926    0.027926    0.126107
-    13        -0.221651255229270    4.162e-08    0.012737    0.027926    0.027926    0.126107
+     0        -0.213351938641466    0.000e+00    0.000000    0.000000    0.000000    0.113745
+     1        -0.216053273788571    3.927e-02    0.010473    0.021942    0.021942    0.119074
+     2        -0.220342953363734    1.309e-02    0.010542    0.022372    0.022372    0.123664
+     3        -0.221700840231737    5.711e-03    0.012356    0.026736    0.026736    0.125926
+     4        -0.221647113672522    1.117e-03    0.012618    0.027509    0.027509    0.126097
+     5        -0.221649065919194    3.817e-04    0.012701    0.027792    0.027792    0.126122
+     6        -0.221653814347023    1.099e-04    0.012731    0.027899    0.027899    0.126117
+     7        -0.221651762460090    3.222e-05    0.012735    0.027919    0.027919    0.126109
+     8        -0.221651271190289    9.508e-06    0.012737    0.027925    0.027925    0.126107
+     9        -0.221651363869869    3.004e-06    0.012737    0.027927    0.027927    0.126107
+    10        -0.221651254278037    1.034e-06    0.012737    0.027927    0.027927    0.126107
+    11        -0.221651258724058    3.709e-07    0.012737    0.027926    0.027926    0.126107
+    12        -0.221651252638394    1.441e-07    0.012737    0.027926    0.027926    0.126107
+    13        -0.221651254887671    4.162e-08    0.012737    0.027926    0.027926    0.126107
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2  20         0.0227651796
-              2  21        -0.0144470049
-              1   1        -0.0119899833
-              1   4         0.0074460964
+              2  20         0.0227651795
+              2  21        -0.0144470048
+              1   1        -0.0119899832
+              1   4         0.0074460965
               1   5         0.0067895925
-              3  34         0.0064591245
+              3  34         0.0064591243
               3  35        -0.0053741743
-              2  23         0.0051413307
-              1   0         0.0049479672
-              1   3        -0.0046451680
+              2  23         0.0051413306
+              1   0         0.0049479671
+              1   3        -0.0046451679
 
     Largest TIjAb Amplitudes:
       2   2  23  23        -0.0373026236
-      3   3  30  30        -0.0211945166
-      2   2  20  23        -0.0188824945
-      2   2  23  20        -0.0188824945
+      3   3  30  30        -0.0211945163
+      2   2  20  23        -0.0188824944
+      2   2  23  20        -0.0188824944
       1   1  10  10        -0.0176402710
-      2   3  23  30        -0.0172151336
-      3   2  30  23        -0.0172151336
-      3   3  31  31        -0.0169347306
+      2   3  23  30        -0.0172151335
+      3   2  30  23        -0.0172151335
+      3   3  31  31        -0.0169347307
       1   2  10  23         0.0165268800
       2   1  23  10         0.0165268800
 
-    SCF energy       (wfn)                    =  -76.052939646076453
-    Reference energy (file100)                =  -76.052939646076425
+    SCF energy       (wfn)                    =  -76.052939646260199
+    Reference energy (file100)                =  -76.052939646260256
 
-    Opposite-spin MP2 correlation energy      =   -0.158282584503229
-    Same-spin MP2 correlation energy          =   -0.055069354490591
-    MP2 correlation energy                    =   -0.213351938993820
-      * MP2 total energy                      =  -76.266291585070249
+    Opposite-spin MP2 correlation energy      =   -0.158282584231771
+    Same-spin MP2 correlation energy          =   -0.055069354409695
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.213351938641466
+      * MP2 total energy                      =  -76.266291584901722
 
-    Opposite-spin CCSD correlation energy     =   -0.172840749751025
-    Same-spin CCSD correlation energy         =   -0.048810505476879
-    CCSD correlation energy                   =   -0.221651255229270
-      * CCSD total energy                     =  -76.274590901305700
-
-
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
-Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.76 seconds =       0.01 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:48 2017
+    Opposite-spin CCSD correlation energy     =   -0.172840749440012
+    Same-spin CCSD correlation energy         =   -0.048810505447659
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.221651254887671
+      * CCSD total energy                     =  -76.274590901147931
 
 
 			**************************
@@ -575,28 +574,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.77 seconds =       0.01 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:48 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    9.196933678131742
-	SCF energy          (wfn)     =  -76.052939646076453
-	Reference energy    (file100) =  -76.052939646076425
-	CCSD energy         (file100) =   -0.221651255229270
+	Nuclear Rep. energy (wfn)     =    9.196933714281490
+	SCF energy          (wfn)     =  -76.052939646260199
+	Reference energy    (file100) =  -76.052939646260256
+	CCSD energy         (file100) =   -0.221651254887671
 
 	Input parameters:
 	-----------------
@@ -629,6 +614,14 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total 1995.7218431697
+Fmi   dot Fmi   total    3.3519737287
+Fme   dot Fme   total    0.0001565291
+WMBIJ dot WMBIJ total    0.0000000000
+Wmbij dot Wmbij total    0.0000000000
+WMbIj dot WMbIj total    0.5939386796
+WmBiJ dot WmBiJ total    0.0000000000
 Symmetry of ground state: A1
 Symmetry of excited state: A1
 Symmetry of right eigenvector: A1
@@ -636,98 +629,98 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4809582710   4.81e-01    4.60e-01      N
-                     2   0.5339597844   5.34e-01    4.52e-01      N
+                     1   0.4809582720   4.81e-01    4.60e-01      N
+                     2   0.5339597847   5.34e-01    4.52e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3649450690  -1.16e-01    8.28e-02      N
-                     2   0.4184161634  -1.16e-01    7.45e-02      N
+                     1   0.3649450699  -1.16e-01    8.28e-02      N
+                     2   0.4184161638  -1.16e-01    7.45e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3613742970  -3.57e-03    2.78e-02      N
-                     2   0.4153529583  -3.06e-03    2.22e-02      N
+                     1   0.3613742979  -3.57e-03    2.78e-02      N
+                     2   0.4153529587  -3.06e-03    2.22e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610916763  -2.83e-04    1.03e-02      N
-                     2   0.4152425947  -1.10e-04    9.21e-03      N
+                     1   0.3610916772  -2.83e-04    1.03e-02      N
+                     2   0.4152425951  -1.10e-04    9.21e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610299970  -6.17e-05    3.96e-03      N
-                     2   0.4151992126  -4.34e-05    5.82e-03      N
+                     1   0.3610299979  -6.17e-05    3.96e-03      N
+                     2   0.4151992130  -4.34e-05    5.82e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610051150  -2.49e-05    2.10e-03      N
-                     2   0.4151245143  -7.47e-05    4.28e-03      N
+                     1   0.3610051159  -2.49e-05    2.10e-03      N
+                     2   0.4151245147  -7.47e-05    4.28e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3609991925  -5.92e-06    9.39e-04      N
-                     2   0.4151112540  -1.33e-05    2.24e-03      N
+                     1   0.3609991935  -5.92e-06    9.39e-04      N
+                     2   0.4151112544  -1.33e-05    2.24e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610030634   3.87e-06    3.68e-04      N
-                     2   0.4151153285   4.07e-06    1.16e-03      N
+                     1   0.3610030643   3.87e-06    3.68e-04      N
+                     2   0.4151153289   4.07e-06    1.16e-03      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610024260  -6.37e-07    1.40e-04      N
-                     2   0.4151094136  -5.91e-06    6.95e-04      N
+                     1   0.3610024269  -6.37e-07    1.40e-04      N
+                     2   0.4151094140  -5.91e-06    6.95e-04      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610021295  -2.97e-07    5.09e-05      N
-                     2   0.4151095647   1.51e-07    3.45e-04      N
+                     1   0.3610021304  -2.97e-07    5.09e-05      N
+                     2   0.4151095651   1.51e-07    3.45e-04      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610021916   6.21e-08    1.83e-05      N
-                     2   0.4151104779   9.13e-07    1.53e-04      N
+                     1   0.3610021925   6.21e-08    1.83e-05      N
+                     2   0.4151104783   9.13e-07    1.53e-04      N
 Iter=12   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610022278   3.62e-08    7.52e-06      N
-                     2   0.4151102618  -2.16e-07    6.40e-05      N
+                     1   0.3610022287   3.62e-08    7.52e-06      N
+                     2   0.4151102622  -2.16e-07    6.40e-05      N
 Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610022278   2.29e-14    7.52e-06      N
-                     2   0.4151102618  -7.77e-16    6.40e-05      N
+                     1   0.3610022287  -8.60e-15    7.52e-06      N
+                     2   0.4151102622  -3.39e-15    6.40e-05      N
 Iter=14   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610022303   2.47e-09    4.00e-06      N
-                     2   0.4151101748  -8.69e-08    3.41e-05      N
+                     1   0.3610022312   2.47e-09    4.00e-06      N
+                     2   0.4151101752  -8.69e-08    3.41e-05      N
 Iter=15   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610022378   7.54e-09    1.64e-06      N
-                     2   0.4151100906  -8.42e-08    1.63e-05      N
+                     1   0.3610022387   7.54e-09    1.64e-06      N
+                     2   0.4151100910  -8.42e-08    1.63e-05      N
 Iter=16   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610022382   4.17e-10    5.59e-07      Y
-                     2   0.4151101514   6.09e-08    6.28e-06      N
+                     1   0.3610022391   4.17e-10    5.59e-07      Y
+                     2   0.4151101519   6.09e-08    6.28e-06      N
 Iter=17   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610022371  -1.09e-09    3.42e-07      Y
-                     2   0.4151101441  -7.38e-09    2.20e-06      N
+                     1   0.3610022380  -1.09e-09    3.42e-07      Y
+                     2   0.4151101445  -7.38e-09    2.20e-06      N
 Iter=18   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3610022373   1.53e-10    3.19e-07      Y
-                     2   0.4151101504   6.35e-09    8.39e-07      Y
+                     1   0.3610022382   1.53e-10    3.19e-07      Y
+                     2   0.4151101508   6.35e-09    8.39e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-EOM CCSD R0 for root 0 =  -0.00310174669
-EOM CCSD R0 for root 1 =  -0.02955683253
+EOM CCSD R0 for root 0 =   0.00310174665
+EOM CCSD R0 for root 1 =   0.02955683233
 
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      9.823    79230.8   0.3610022373   -75.913588664035
+EOM State 1      9.823    79230.8   0.3610022382   -75.913588662964
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         1 >   0      :       3a1 >    4a1 :    0.6098694185
-         1 >   2      :       3a1 >    6a1 :    0.2550706023
-         0 >   0      :       1b1 >    2b1 :   -0.1196928700
-         1 >   1      :       3a1 >    5a1 :   -0.0726164942
-         1 >   5      :       3a1 >    9a1 :    0.0691327327
+         1 >   0      :       3a1 >    4a1 :   -0.6098694188
+         1 >   2      :       3a1 >    6a1 :   -0.2550706017
+         0 >   0      :       1b1 >    2b1 :    0.1196928701
+         1 >   1      :       3a1 >    5a1 :    0.0726164947
+         1 >   5      :       3a1 >    9a1 :   -0.0691327327
  RIjAb (libdpd indices)     : (cscf notation)
-        1   1 >   0   5     :    3a1    3a1 >    4a1    9a1 :   -0.0409761560
-        1   1 >   5   0     :    3a1    3a1 >    9a1    4a1 :   -0.0409761560
-        1   1 >   0   1     :    3a1    3a1 >    4a1    5a1 :    0.0403064220
-        1   1 >   1   0     :    3a1    3a1 >    5a1    4a1 :    0.0403064220
-        1   0 >   0   3     :    3a1    1b1 >    4a1    5b1 :   -0.0360697184
-EOM State 2     11.296    91106.1   0.4151101504   -75.859480750891
+        1   1 >   0   5     :    3a1    3a1 >    4a1    9a1 :    0.0409761558
+        1   1 >   5   0     :    3a1    3a1 >    9a1    4a1 :    0.0409761558
+        1   1 >   0   1     :    3a1    3a1 >    4a1    5a1 :   -0.0403064219
+        1   1 >   1   0     :    3a1    3a1 >    5a1    4a1 :   -0.0403064219
+        1   0 >   0   3     :    3a1    1b1 >    4a1    5b1 :    0.0360697185
+EOM State 2     11.296    91106.1   0.4151101508   -75.859480750323
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    2b1 :    0.6482312478
-         1 >   0      :       3a1 >    4a1 :    0.1268535666
-         0 >   1      :       1b1 >    3b1 :   -0.1041858639
-         1 >   1      :       3a1 >    5a1 :    0.1036412540
-         1 >   4      :       3a1 >    8a1 :   -0.0389930917
+         0 >   0      :       1b1 >    2b1 :   -0.6482312480
+         1 >   0      :       3a1 >    4a1 :   -0.1268535666
+         0 >   1      :       1b1 >    3b1 :    0.1041858636
+         1 >   1      :       3a1 >    5a1 :   -0.1036412537
+         1 >   4      :       3a1 >    8a1 :    0.0389930919
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b1 >    2b1    2b1 :   -0.1096961485
-        0   0 >   0   3     :    1b1    1b1 >    2b1    5b1 :   -0.0494666877
-        0   0 >   3   0     :    1b1    1b1 >    5b1    2b1 :   -0.0494666877
-        0   0 >   0   1     :    1b1    1b1 >    2b1    3b1 :    0.0360882475
-        0   0 >   1   0     :    1b1    1b1 >    3b1    2b1 :    0.0360882475
+        0   0 >   0   0     :    1b1    1b1 >    2b1    2b1 :    0.1096961484
+        0   0 >   0   3     :    1b1    1b1 >    2b1    5b1 :    0.0494666877
+        0   0 >   3   0     :    1b1    1b1 >    5b1    2b1 :    0.0494666877
+        0   0 >   0   1     :    1b1    1b1 >    2b1    3b1 :   -0.0360882475
+        0   0 >   1   0     :    1b1    1b1 >    3b1    2b1 :   -0.0360882475
 
 Symmetry of excited state: A2
 Symmetry of right eigenvector: A2
@@ -735,53 +728,53 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4564764679   4.56e-01    4.64e-01      N
-                     2   0.5531517337   5.53e-01    4.73e-01      N
+                     1   0.4564764686   4.56e-01    4.64e-01      N
+                     2   0.5531517348   5.53e-01    4.73e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3395011825  -1.17e-01    7.20e-02      N
-                     2   0.4350492130  -1.18e-01    7.80e-02      N
+                     1   0.3395011833  -1.17e-01    7.20e-02      N
+                     2   0.4350492144  -1.18e-01    7.80e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3366688618  -2.83e-03    2.25e-02      N
-                     2   0.4319920545  -3.06e-03    2.58e-02      N
+                     1   0.3366688626  -2.83e-03    2.25e-02      N
+                     2   0.4319920559  -3.06e-03    2.58e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3365273425  -1.42e-04    7.78e-03      N
-                     2   0.4317522031  -2.40e-04    9.80e-03      N
+                     1   0.3365273434  -1.42e-04    7.78e-03      N
+                     2   0.4317522045  -2.40e-04    9.80e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364822430  -4.51e-05    3.35e-03      N
-                     2   0.4316865561  -6.56e-05    5.99e-03      N
+                     1   0.3364822438  -4.51e-05    3.35e-03      N
+                     2   0.4316865575  -6.56e-05    5.99e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364617410  -2.05e-05    1.75e-03      N
-                     2   0.4315994352  -8.71e-05    6.85e-03      N
+                     1   0.3364617419  -2.05e-05    1.75e-03      N
+                     2   0.4315994366  -8.71e-05    6.85e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364564224  -5.32e-06    5.57e-04      N
-                     2   0.4315544908  -4.49e-05    3.51e-03      N
+                     1   0.3364564232  -5.32e-06    5.57e-04      N
+                     2   0.4315544922  -4.49e-05    3.51e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364572308   8.08e-07    1.80e-04      N
-                     2   0.4315511749  -3.32e-06    1.62e-03      N
+                     1   0.3364572317   8.08e-07    1.80e-04      N
+                     2   0.4315511763  -3.32e-06    1.62e-03      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364569835  -2.47e-07    6.08e-05      N
-                     2   0.4315488180  -2.36e-06    7.38e-04      N
+                     1   0.3364569844  -2.47e-07    6.08e-05      N
+                     2   0.4315488194  -2.36e-06    7.38e-04      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364569764  -7.11e-09    1.69e-05      N
-                     2   0.4315497477   9.30e-07    2.38e-04      N
+                     1   0.3364569773  -7.11e-09    1.69e-05      N
+                     2   0.4315497491   9.30e-07    2.38e-04      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364570074   3.10e-08    4.93e-06      N
-                     2   0.4315505555   8.08e-07    7.15e-05      N
+                     1   0.3364570082   3.10e-08    4.93e-06      N
+                     2   0.4315505568   8.08e-07    7.15e-05      N
 Iter=12   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364570130   5.62e-09    1.47e-06      N
-                     2   0.4315504239  -1.32e-07    2.51e-05      N
+                     1   0.3364570139   5.62e-09    1.47e-06      N
+                     2   0.4315504252  -1.32e-07    2.51e-05      N
 Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364570130  -5.98e-14    1.47e-06      N
-                     2   0.4315504239   4.55e-15    2.51e-05      N
+                     1   0.3364570139  -2.44e-14    1.47e-06      N
+                     2   0.4315504252   2.50e-15    2.51e-05      N
 Iter=14   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364570155   2.51e-09    3.83e-07      Y
-                     2   0.4315503696  -5.42e-08    7.61e-06      N
+                     1   0.3364570164   2.51e-09    3.83e-07      Y
+                     2   0.4315503710  -5.42e-08    7.61e-06      N
 Iter=15   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364570149  -5.91e-10    3.54e-07      Y
-                     2   0.4315503949   2.53e-08    2.26e-06      N
+                     1   0.3364570158  -5.91e-10    3.54e-07      Y
+                     2   0.4315503962   2.53e-08    2.26e-06      N
 Iter=16   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3364570149   3.56e-11    3.54e-07      Y
-                     2   0.4315503914  -3.48e-09    7.25e-07      Y
+                     1   0.3364570158   3.56e-11    3.54e-07      Y
+                     2   0.4315503928  -3.48e-09    7.25e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
@@ -791,36 +784,36 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep A2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 3      9.155    73843.8   0.3364570149   -75.938133886374
+EOM State 3      9.155    73843.8   0.3364570158   -75.938133885345
 
 Largest components of excited wave function #3:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    2b2 :   -0.5934116879
-         0 >   1      :       1b1 >    3b2 :    0.2579805336
-         0 >   2      :       1b1 >    4b2 :   -0.1981001486
-         0 >   4      :       1b1 >    6b2 :   -0.1054556040
-         0 >   6      :       1b1 >    8b2 :   -0.0263671048
+         0 >   0      :       1b1 >    2b2 :   -0.5934116893
+         0 >   1      :       1b1 >    3b2 :    0.2579805325
+         0 >   2      :       1b1 >    4b2 :   -0.1981001468
+         0 >   4      :       1b1 >    6b2 :   -0.1054556029
+         0 >   6      :       1b1 >    8b2 :   -0.0263671046
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b1 >    2b1    2b2 :    0.0488095969
-        0   0 >   0   0     :    1b1    1b1 >    2b2    2b1 :    0.0488095969
-        0   0 >   3   0     :    1b1    1b1 >    5b1    2b2 :    0.0456377956
-        0   0 >   0   3     :    1b1    1b1 >    2b2    5b1 :    0.0456377956
+        0   0 >   0   0     :    1b1    1b1 >    2b1    2b2 :    0.0488095970
+        0   0 >   0   0     :    1b1    1b1 >    2b2    2b1 :    0.0488095970
+        0   0 >   3   0     :    1b1    1b1 >    5b1    2b2 :    0.0456377958
+        0   0 >   0   3     :    1b1    1b1 >    2b2    5b1 :    0.0456377958
         0   0 >   0   4     :    1b1    1b2 >    2b2    6b2 :    0.0357011035
-EOM State 4     11.743    94714.3   0.4315503914   -75.843040509903
+EOM State 4     11.743    94714.4   0.4315503928   -75.843040508395
 
 Largest components of excited wave function #4:
  RIA (libdpd indices) : (cscf notation)
-         0 >   2      :       1b1 >    4b2 :    0.6029324929
-         0 >   0      :       1b1 >    2b2 :   -0.2578027260
-         0 >   4      :       1b1 >    6b2 :    0.1353564779
-         0 >   5      :       1b1 >    7b2 :    0.1150377488
-         0 >   1      :       1b1 >    3b2 :   -0.0686975340
+         0 >   2      :       1b1 >    4b2 :    0.6029324949
+         0 >   0      :       1b1 >    2b2 :   -0.2578027226
+         0 >   4      :       1b1 >    6b2 :    0.1353564768
+         0 >   5      :       1b1 >    7b2 :    0.1150377494
+         0 >   1      :       1b1 >    3b2 :   -0.0686975315
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   2     :    1b1    1b1 >    2b1    4b2 :   -0.0457367861
-        0   0 >   2   0     :    1b1    1b1 >    4b2    2b1 :   -0.0457367861
-        0   0 >   3   2     :    1b1    1b1 >    5b1    4b2 :   -0.0435998817
-        0   0 >   2   3     :    1b1    1b1 >    4b2    5b1 :   -0.0435998817
-        0   0 >   2   4     :    1b1    1b2 >    4b2    6b2 :   -0.0359084318
+        0   0 >   0   2     :    1b1    1b1 >    2b1    4b2 :   -0.0457367862
+        0   0 >   2   0     :    1b1    1b1 >    4b2    2b1 :   -0.0457367862
+        0   0 >   3   2     :    1b1    1b1 >    5b1    4b2 :   -0.0435998818
+        0   0 >   2   3     :    1b1    1b1 >    4b2    5b1 :   -0.0435998818
+        0   0 >   2   4     :    1b1    1b2 >    4b2    6b2 :   -0.0359084317
 
 Symmetry of excited state: B1
 Symmetry of right eigenvector: B1
@@ -828,62 +821,62 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3942791986   3.94e-01    4.71e-01      N
-                     2   0.5040767655   5.04e-01    4.51e-01      N
+                     1   0.3942791993   3.94e-01    4.71e-01      N
+                     2   0.5040767658   5.04e-01    4.51e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2750985990  -1.19e-01    7.75e-02      N
-                     2   0.3903991704  -1.14e-01    6.67e-02      N
+                     1   0.2750985999  -1.19e-01    7.75e-02      N
+                     2   0.3903991708  -1.14e-01    6.67e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2720669119  -3.03e-03    2.37e-02      N
-                     2   0.3879880303  -2.41e-03    1.99e-02      N
+                     1   0.2720669128  -3.03e-03    2.37e-02      N
+                     2   0.3879880308  -2.41e-03    1.99e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719540974  -1.13e-04    7.47e-03      N
-                     2   0.3879041367  -8.39e-05    8.47e-03      N
+                     1   0.2719540983  -1.13e-04    7.47e-03      N
+                     2   0.3879041372  -8.39e-05    8.47e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719485906  -5.51e-06    2.06e-03      N
-                     2   0.3878382859  -6.59e-05    5.41e-03      N
+                     1   0.2719485915  -5.51e-06    2.06e-03      N
+                     2   0.3878382863  -6.59e-05    5.41e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719427875  -5.80e-06    6.75e-04      N
-                     2   0.3877538811  -8.44e-05    4.69e-03      N
+                     1   0.2719427884  -5.80e-06    6.75e-04      N
+                     2   0.3877538816  -8.44e-05    4.69e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719417235  -1.06e-06    3.50e-04      N
-                     2   0.3877369443  -1.69e-05    2.75e-03      N
+                     1   0.2719417244  -1.06e-06    3.50e-04      N
+                     2   0.3877369448  -1.69e-05    2.75e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719414152  -3.08e-07    1.35e-04      N
-                     2   0.3877389669   2.02e-06    1.84e-03      N
+                     1   0.2719414161  -3.08e-07    1.35e-04      N
+                     2   0.3877389673   2.02e-06    1.84e-03      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408945  -5.21e-07    4.14e-05      N
-                     2   0.3877317594  -7.21e-06    9.05e-04      N
+                     1   0.2719408954  -5.21e-07    4.14e-05      N
+                     2   0.3877317599  -7.21e-06    9.05e-04      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408434  -5.11e-08    1.26e-05      N
-                     2   0.3877367909   5.03e-06    5.44e-04      N
+                     1   0.2719408443  -5.11e-08    1.26e-05      N
+                     2   0.3877367913   5.03e-06    5.44e-04      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408806   3.72e-08    3.75e-06      N
-                     2   0.3877357181  -1.07e-06    3.43e-04      N
+                     1   0.2719408815   3.72e-08    3.75e-06      N
+                     2   0.3877357185  -1.07e-06    3.43e-04      N
 Iter=12   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408777  -2.89e-09    1.18e-06      N
-                     2   0.3877337146  -2.00e-06    1.26e-04      N
+                     1   0.2719408787  -2.89e-09    1.18e-06      N
+                     2   0.3877337150  -2.00e-06    1.26e-04      N
 Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408777  -6.72e-15    1.18e-06      N
-                     2   0.3877337146  -5.00e-16    1.26e-04      N
+                     1   0.2719408787  -2.80e-14    1.18e-06      N
+                     2   0.3877337150   1.94e-15    1.26e-04      N
 Iter=14   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408754  -2.39e-09    4.07e-07      Y
-                     2   0.3877338319   1.17e-07    4.13e-05      N
+                     1   0.2719408763  -2.39e-09    4.07e-07      Y
+                     2   0.3877338324   1.17e-07    4.13e-05      N
 Iter=15   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408761   7.45e-10    3.39e-07      Y
-                     2   0.3877337796  -5.23e-08    1.65e-05      N
+                     1   0.2719408770   7.45e-10    3.39e-07      Y
+                     2   0.3877337801  -5.23e-08    1.65e-05      N
 Iter=16   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408749  -1.16e-09    3.20e-07      Y
-                     2   0.3877339253   1.46e-07    8.36e-06      N
+                     1   0.2719408758  -1.16e-09    3.20e-07      Y
+                     2   0.3877339257   1.46e-07    8.36e-06      N
 Iter=17   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408760   1.02e-09    3.15e-07      Y
-                     2   0.3877338533  -7.20e-08    3.91e-06      N
+                     1   0.2719408769   1.02e-09    3.15e-07      Y
+                     2   0.3877338538  -7.20e-08    3.91e-06      N
 Iter=18   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408757  -3.11e-10    3.14e-07      Y
-                     2   0.3877338664   1.31e-08    1.62e-06      N
+                     1   0.2719408766  -3.11e-10    3.14e-07      Y
+                     2   0.3877338669   1.31e-08    1.62e-06      N
 Iter=19   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2719408757   3.51e-11    3.14e-07      Y
-                     2   0.3877338666   2.05e-10    9.34e-07      Y
+                     1   0.2719408766   3.51e-11    3.14e-07      Y
+                     2   0.3877338671   2.05e-10    9.34e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
@@ -893,36 +886,36 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 5      7.400    59684.1   0.2719408757   -76.002650025619
+EOM State 5      7.400    59684.1   0.2719408766   -76.002650024553
 
 Largest components of excited wave function #5:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    4a1 :    0.6131750585
-         0 >   2      :       1b1 >    6a1 :    0.2603270488
-         0 >   1      :       1b1 >    5a1 :   -0.1150292289
-         0 >   5      :       1b1 >    9a1 :    0.0884590132
-         0 >   4      :       1b1 >    8a1 :   -0.0439082247
+         0 >   0      :       1b1 >    4a1 :   -0.6131750590
+         0 >   2      :       1b1 >    6a1 :   -0.2603270479
+         0 >   1      :       1b1 >    5a1 :    0.1150292292
+         0 >   5      :       1b1 >    9a1 :   -0.0884590130
+         0 >   4      :       1b1 >    8a1 :    0.0439082242
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :   -0.0511982193
-        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :   -0.0511982193
-        0   0 >   0   3     :    1b1    1b1 >    4a1    5b1 :   -0.0471722286
-        0   0 >   3   0     :    1b1    1b1 >    5b1    4a1 :   -0.0471722286
-        0   0 >   0   4     :    1b1    1b2 >    4a1    6b2 :   -0.0365775676
-EOM State 6     10.551    85097.7   0.3877338666   -75.886857034681
+        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :    0.0511982193
+        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :    0.0511982193
+        0   0 >   0   3     :    1b1    1b1 >    4a1    5b1 :    0.0471722286
+        0   0 >   3   0     :    1b1    1b1 >    5b1    4a1 :    0.0471722286
+        0   0 >   0   4     :    1b1    1b2 >    4a1    6b2 :    0.0365775674
+EOM State 6     10.551    85097.7   0.3877338671   -75.886857034080
 
 Largest components of excited wave function #6:
  RIA (libdpd indices) : (cscf notation)
-         0 >   1      :       1b1 >    5a1 :   -0.6529977535
-         0 >   0      :       1b1 >    4a1 :   -0.1254075597
-         0 >   5      :       1b1 >    9a1 :    0.1032398979
-         0 >   4      :       1b1 >    8a1 :    0.1005527897
-         0 >   3      :       1b1 >    7a1 :   -0.0794903758
+         0 >   1      :       1b1 >    5a1 :    0.6529977536
+         0 >   0      :       1b1 >    4a1 :    0.1254075596
+         0 >   5      :       1b1 >    9a1 :   -0.1032398975
+         0 >   4      :       1b1 >    8a1 :   -0.1005527904
+         0 >   3      :       1b1 >    7a1 :    0.0794903752
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   1   0     :    1b1    1b1 >    5a1    2b1 :    0.0542251650
-        0   0 >   0   1     :    1b1    1b1 >    2b1    5a1 :    0.0542251650
-        0   0 >   1   3     :    1b1    1b1 >    5a1    5b1 :    0.0493082898
-        0   0 >   3   1     :    1b1    1b1 >    5b1    5a1 :    0.0493082898
-        0   0 >   1   4     :    1b1    1b2 >    5a1    6b2 :    0.0359777541
+        0   0 >   1   0     :    1b1    1b1 >    5a1    2b1 :   -0.0542251650
+        0   0 >   0   1     :    1b1    1b1 >    2b1    5a1 :   -0.0542251650
+        0   0 >   1   3     :    1b1    1b1 >    5a1    5b1 :   -0.0493082899
+        0   0 >   3   1     :    1b1    1b1 >    5b1    5a1 :   -0.0493082899
+        0   0 >   1   4     :    1b1    1b2 >    5a1    6b2 :   -0.0359777540
 
 Symmetry of excited state: B2
 Symmetry of right eigenvector: B2
@@ -930,105 +923,105 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5419328861   5.42e-01    4.50e-01      N
-                     2   0.6074599186   6.07e-01    4.29e-01      N
+                     1   0.5419328871   5.42e-01    4.50e-01      N
+                     2   0.6074599207   6.07e-01    4.29e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4288646967  -1.13e-01    7.85e-02      N
-                     2   0.5114115954  -9.60e-02    6.57e-02      N
+                     1   0.4288646976  -1.13e-01    7.85e-02      N
+                     2   0.5114115973  -9.60e-02    6.57e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4254707013  -3.39e-03    2.70e-02      N
-                     2   0.5095819549  -1.83e-03    1.83e-02      N
+                     1   0.4254707022  -3.39e-03    2.70e-02      N
+                     2   0.5095819567  -1.83e-03    1.83e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4251886326  -2.82e-04    9.72e-03      N
-                     2   0.5094631192  -1.19e-04    8.89e-03      N
+                     1   0.4251886335  -2.82e-04    9.72e-03      N
+                     2   0.5094631211  -1.19e-04    8.89e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4251308823  -5.78e-05    3.28e-03      N
-                     2   0.5093386138  -1.25e-04    1.10e-02      N
+                     1   0.4251308832  -5.78e-05    3.28e-03      N
+                     2   0.5093386156  -1.25e-04    1.10e-02      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250981852  -3.27e-05    1.76e-03      N
-                     2   0.5089063766  -4.32e-04    2.37e-02      N
+                     1   0.4250981861  -3.27e-05    1.76e-03      N
+                     2   0.5089063783  -4.32e-04    2.37e-02      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250923870  -5.80e-06    9.56e-04      N
-                     2   0.5073815116  -1.52e-03    4.05e-02      N
+                     1   0.4250923879  -5.80e-06    9.56e-04      N
+                     2   0.5073815124  -1.52e-03    4.05e-02      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250957580   3.37e-06    3.91e-04      N
+                     1   0.4250957589   3.37e-06    3.91e-04      N
                      2   0.5051185772  -2.26e-03    3.98e-02      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250958929   1.35e-07    1.48e-04      N
+                     1   0.4250958938   1.35e-07    1.48e-04      N
                      2   0.5026812133  -2.44e-03    3.76e-02      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250953576  -5.35e-07    5.60e-05      N
-                     2   0.5012293095  -1.45e-03    2.92e-02      N
+                     1   0.4250953585  -5.35e-07    5.60e-05      N
+                     2   0.5012293097  -1.45e-03    2.92e-02      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956335   2.76e-07    2.46e-05      N
-                     2   0.4997568350  -1.47e-03    2.99e-02      N
+                     1   0.4250956344   2.76e-07    2.46e-05      N
+                     2   0.4997568355  -1.47e-03    2.99e-02      N
 Iter=12   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956951   6.16e-08    8.86e-06      N
-                     2   0.4988127677  -9.44e-04    1.82e-02      N
+                     1   0.4250956960   6.16e-08    8.86e-06      N
+                     2   0.4988127684  -9.44e-04    1.82e-02      N
 Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956951   2.66e-15    8.86e-06      N
-                     2   0.4988127677  -9.99e-16    1.82e-02      N
+                     1   0.4250956960   1.74e-14    8.86e-06      N
+                     2   0.4988127684   1.39e-15    1.82e-02      N
 Iter=14   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956739  -2.13e-08    3.25e-06      N
-                     2   0.4986060396  -2.07e-04    6.83e-03      N
+                     1   0.4250956748  -2.13e-08    3.25e-06      N
+                     2   0.4986060403  -2.07e-04    6.83e-03      N
 Iter=15   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956657  -8.14e-09    1.17e-06      N
-                     2   0.4985691709  -3.69e-05    2.71e-03      N
+                     1   0.4250956666  -8.14e-09    1.17e-06      N
+                     2   0.4985691717  -3.69e-05    2.71e-03      N
 Iter=16   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956666   8.73e-10    4.07e-07      Y
-                     2   0.4985638084  -5.36e-06    1.06e-03      N
+                     1   0.4250956675   8.73e-10    4.07e-07      Y
+                     2   0.4985638091  -5.36e-06    1.06e-03      N
 Iter=17   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956690   2.42e-09    2.83e-07      Y
-                     2   0.4985613505  -2.46e-06    3.47e-04      N
+                     1   0.4250956699   2.42e-09    2.83e-07      Y
+                     2   0.4985613513  -2.46e-06    3.47e-04      N
 Iter=18   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956676  -1.35e-09    2.61e-07      Y
-                     2   0.4985618890   5.38e-07    1.40e-04      N
+                     1   0.4250956685  -1.35e-09    2.61e-07      Y
+                     2   0.4985618897   5.38e-07    1.40e-04      N
 Iter=19   L=13    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956667  -9.25e-10    2.68e-07      Y
-                     2   0.4985614260  -4.63e-07    8.07e-05      N
+                     1   0.4250956676  -9.25e-10    2.68e-07      Y
+                     2   0.4985614267  -4.63e-07    8.07e-05      N
 Iter=20   L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956675   8.22e-10    2.70e-07      Y
-                     2   0.4985615269   1.01e-07    8.56e-05      N
+                     1   0.4250956684   8.22e-10    2.70e-07      Y
+                     2   0.4985615276   1.01e-07    8.56e-05      N
 Iter=21   L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956668  -7.23e-10    2.48e-07      Y
-                     2   0.4985613407  -1.86e-07    6.96e-05      N
+                     1   0.4250956677  -7.23e-10    2.48e-07      Y
+                     2   0.4985613414  -1.86e-07    6.96e-05      N
 Iter=22   L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956666  -1.75e-10    2.41e-07      Y
-                     2   0.4985613857   4.51e-08    5.16e-05      N
+                     1   0.4250956675  -1.75e-10    2.41e-07      Y
+                     2   0.4985613865   4.51e-08    5.16e-05      N
 Iter=23   L=17    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956670   3.11e-10    2.42e-07      Y
-                     2   0.4985612928  -9.29e-08    4.86e-05      N
+                     1   0.4250956679   3.11e-10    2.42e-07      Y
+                     2   0.4985612936  -9.29e-08    4.86e-05      N
 Iter=24   L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956666  -3.44e-10    2.44e-07      Y
-                     2   0.4985610791  -2.14e-07    4.58e-05      N
+                     1   0.4250956675  -3.44e-10    2.44e-07      Y
+                     2   0.4985610799  -2.14e-07    4.58e-05      N
 Iter=25   L=19    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956670   4.26e-10    2.47e-07      Y
-                     2   0.4985611201   4.09e-08    3.44e-05      N
+                     1   0.4250956679   4.26e-10    2.47e-07      Y
+                     2   0.4985611208   4.09e-08    3.44e-05      N
 Iter=26   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956664  -6.81e-10    2.36e-07      Y
-                     2   0.4985609477  -1.72e-07    2.64e-05      N
+                     1   0.4250956673  -6.81e-10    2.36e-07      Y
+                     2   0.4985609484  -1.72e-07    2.64e-05      N
 Iter=27   L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956669   5.73e-10    2.25e-07      Y
-                     2   0.4985609937   4.60e-08    1.64e-05      N
+                     1   0.4250956678   5.73e-10    2.25e-07      Y
+                     2   0.4985609944   4.60e-08    1.64e-05      N
 Iter=28   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956668  -1.11e-10    2.21e-07      Y
-                     2   0.4985609517  -4.19e-08    8.38e-06      N
+                     1   0.4250956677  -1.11e-10    2.21e-07      Y
+                     2   0.4985609525  -4.19e-08    8.38e-06      N
 Iter=29   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956669   3.02e-11    2.21e-07      Y
-                     2   0.4985609552   3.43e-09    3.73e-06      N
+                     1   0.4250956677   3.02e-11    2.21e-07      Y
+                     2   0.4985609559   3.43e-09    3.73e-06      N
 Iter=30   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956669   6.62e-12    2.21e-07      Y
-                     2   0.4985609490  -6.16e-09    1.55e-06      N
+                     1   0.4250956678   6.62e-12    2.21e-07      Y
+                     2   0.4985609498  -6.16e-09    1.55e-06      N
 Iter=31   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956667  -1.53e-10    2.23e-07      Y
-                     2   0.4985609490   1.31e-14    1.55e-06      N
+                     1   0.4250956673  -4.10e-10    2.45e-07      Y
+                     2   0.4985609498  -6.43e-14    1.55e-06      N
 Iter=32   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4250956668   5.75e-11    2.23e-07      Y
-                     2   0.4985609484  -6.46e-10    5.42e-07      Y
+                     1   0.4250956674   8.68e-11    2.46e-07      Y
+                     2   0.4985609491  -6.46e-10    5.42e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-Energy written to CC_INFO:Etot  -75.7760299529
+Energy written to CC_INFO:Etot  -75.7760299520
 States per irrep written to CC_INFO.
 EOM CCSD R0 for root 0 =   0.00000000000
 EOM CCSD R0 for root 1 =   0.00000000000
@@ -1036,67 +1029,53 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 7     11.567    93297.7   0.4250956668   -75.849495234543
+EOM State 7     11.567    93297.7   0.4250956674   -75.849495233717
 
 Largest components of excited wave function #7:
  RIA (libdpd indices) : (cscf notation)
-         1 >   0      :       3a1 >    2b2 :    0.6063175357
-         1 >   1      :       3a1 >    3b2 :   -0.2587074422
-         1 >   2      :       3a1 >    4b2 :    0.1574872853
-         1 >   4      :       3a1 >    6b2 :    0.0895069054
-         0 >   0      :       1b1 >    1a2 :    0.0424699864
+         1 >   0      :       3a1 >    2b2 :   -0.6063176063
+         1 >   1      :       3a1 >    3b2 :    0.2587073716
+         1 >   2      :       3a1 >    4b2 :   -0.1574871495
+         1 >   4      :       3a1 >    6b2 :   -0.0895068601
+         0 >   0      :       1b1 >    1a2 :   -0.0424700142
  RIjAb (libdpd indices)     : (cscf notation)
-        1   1 >   5   0     :    3a1    3a1 >    9a1    2b2 :   -0.0396788102
-        1   1 >   0   5     :    3a1    3a1 >    2b2    9a1 :   -0.0396788102
-        1   0 >   0   0     :    3a1    1b1 >    2b2    2b1 :   -0.0381902785
-        0   1 >   0   0     :    1b1    3a1 >    2b1    2b2 :   -0.0381902785
-        1   1 >   1   0     :    3a1    3a1 >    5a1    2b2 :    0.0371334490
-EOM State 8     13.567   109421.5   0.4985609484   -75.776029952947
+        1   1 >   5   0     :    3a1    3a1 >    9a1    2b2 :    0.0396788153
+        1   1 >   0   5     :    3a1    3a1 >    2b2    9a1 :    0.0396788153
+        1   0 >   0   0     :    3a1    1b1 >    2b2    2b1 :    0.0381902836
+        0   1 >   0   0     :    1b1    3a1 >    2b1    2b2 :    0.0381902836
+        1   1 >   1   0     :    3a1    3a1 >    5a1    2b2 :   -0.0371334543
+EOM State 8     13.567   109421.5   0.4985609491   -75.776029952037
 
 Largest components of excited wave function #8:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    1a2 :   -0.6617073101
-         1 >   2      :       3a1 >    4b2 :   -0.1140297012
-         1 >   0      :       3a1 >    2b2 :    0.0861755010
-         0 >   1      :       1b1 >    2a2 :   -0.0510017221
-         0 >   0      :       1b2 >    4a1 :   -0.0419409977
+         0 >   0      :       1b1 >    1a2 :    0.6617073113
+         1 >   2      :       3a1 >    4b2 :    0.1140296987
+         1 >   0      :       3a1 >    2b2 :   -0.0861754992
+         0 >   1      :       1b1 >    2a2 :    0.0510017221
+         0 >   0      :       1b2 >    4a1 :    0.0419409930
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b1 >    1a2    2b1 :    0.0585451477
-        0   0 >   0   0     :    1b1    1b1 >    2b1    1a2 :    0.0585451477
-        0   0 >   0   3     :    1b1    1b1 >    1a2    5b1 :    0.0562267377
-        0   0 >   3   0     :    1b1    1b1 >    5b1    1a2 :    0.0562267377
-        0   0 >   0   4     :    1b1    1b2 >    1a2    6b2 :    0.0400246617
+        0   0 >   0   0     :    1b1    1b1 >    1a2    2b1 :   -0.0585451477
+        0   0 >   0   0     :    1b1    1b1 >    2b1    1a2 :   -0.0585451477
+        0   0 >   0   3     :    1b1    1b1 >    1a2    5b1 :   -0.0562267378
+        0   0 >   3   0     :    1b1    1b1 >    5b1    1a2 :   -0.0562267378
+        0   0 >   0   4     :    1b1    1b2 >    1a2    6b2 :   -0.0400246616
 
 	Putting into environment energy for root of R irrep 4 and root 2.
-	Putting into environment CURRENT ENERGY:              -75.7760299529
+	Putting into environment CURRENT ENERGY:              -75.7760299520
 
 	Total # of sigma evaluations: 136
-
-*** tstop() called on psinet at Mon May 15 15:34:49 2017
-Module time:
-	user time   =       0.92 seconds =       0.02 minutes
-	system time =       0.53 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.69 seconds =       0.03 minutes
-	system time =       0.88 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:49 2017
-
 
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =    9.196933678131742
+	Nuclear Rep. energy (wfn)     =    9.196933714281490
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     =  -76.052939646076453
-	Reference energy    (CC_INFO) =  -76.052939646076425
-	CCSD energy         (CC_INFO) =   -0.221651255229270
-	Total CCSD energy   (CC_INFO) =  -76.274590901305700
+	SCF energy          (wfn)     =  -76.052939646260199
+	Reference energy    (CC_INFO) =  -76.052939646260256
+	CCSD energy         (CC_INFO) =   -0.221651254887671
+	Total CCSD energy   (CC_INFO) =  -76.274590901147931
 
 	Input parameters:
 	-----------------
@@ -1109,17 +1088,17 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
-	  2   0     1         No       0.3610022373  -0.0031017467
-	  3   0     2         No       0.4151101504  -0.0295568325
-	  4   1     1         No       0.3364570149   0.0000000000
-	  5   1     2         No       0.4315503914   0.0000000000
-	  6   2     1         No       0.2719408757   0.0000000000
-	  7   2     2         No       0.3877338666   0.0000000000
-	  8   3     1         No       0.4250956668   0.0000000000
-	  9   3     2         No       0.4985609484   0.0000000000
+	  2   0     1         No       0.3610022382   0.0031017466
+	  3   0     2         No       0.4151101508   0.0295568323
+	  4   1     1         No       0.3364570158   0.0000000000
+	  5   1     2         No       0.4315503928   0.0000000000
+	  6   2     1         No       0.2719408766   0.0000000000
+	  7   2     2         No       0.3877338671   0.0000000000
+	  8   3     1         No       0.4250956674   0.0000000000
+	  9   3     2         No       0.4985609491   0.0000000000
 	Labels for eigenvector 1:
 	LIA 0 -1, Lia 0 -1, LIJAB 0 -1, Lijab 0 -1, LIjAb 0 -1, 2LIjAb - LIjbA 0 -1
 	Labels for eigenvector 2:
@@ -1146,45 +1125,45 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.221765112782327    0.000e+00
-	   1        -0.218383889288810    2.009e-02
-	   2        -0.217583719800069    3.197e-03
-	   3        -0.217477477574048    1.534e-03
-	   4        -0.217422263947357    4.596e-04
-	   5        -0.217425827510015    9.758e-05
-	   6        -0.217427980150715    2.712e-05
-	   7        -0.217427845555733    6.701e-06
-	   8        -0.217427776913662    1.742e-06
-	   9        -0.217427775669435    4.106e-07
-	  10        -0.217427777405302    9.661e-08
+	   0        -0.221765112442457    0.000e+00
+	   1        -0.218383888971252    2.009e-02
+	   2        -0.217583719487472    3.197e-03
+	   3        -0.217477477262179    1.534e-03
+	   4        -0.217422263636204    4.596e-04
+	   5        -0.217425827198851    9.758e-05
+	   6        -0.217427979839532    2.712e-05
+	   7        -0.217427845244551    6.701e-06
+	   8        -0.217427776602481    1.742e-06
+	   9        -0.217427775358253    4.106e-07
+	  10        -0.217427777094121    9.661e-08
 
 	Largest LIA Amplitudes:
-	          2  20         0.0145518923
-	          2  21        -0.0091632396
-	          1   1        -0.0064742200
-	          3  34         0.0062376916
+	          2  20         0.0145518922
+	          2  21        -0.0091632395
+	          1   1        -0.0064742199
+	          3  34         0.0062376915
 	          3  35        -0.0045660581
 	          0  11        -0.0041272900
-	          1   4         0.0040151408
+	          1   4         0.0040151409
 	          1  10         0.0039444380
-	          1  11        -0.0030684116
+	          1  11        -0.0030684115
 	          1   5         0.0028216410
 
 	Largest LIjAb Amplitudes:
 	  2   2  23  23        -0.0369419004
-	  3   3  30  30        -0.0207570480
-	  2   2  20  23        -0.0184400212
-	  2   2  23  20        -0.0184400212
-	  1   1  10  10        -0.0174220912
-	  2   3  23  30        -0.0169791724
-	  3   2  30  23        -0.0169791724
-	  3   3  31  31        -0.0164372833
+	  3   3  30  30        -0.0207570477
+	  2   2  20  23        -0.0184400211
+	  2   2  23  20        -0.0184400211
+	  1   1  10  10        -0.0174220911
+	  2   3  23  30        -0.0169791723
+	  3   2  30  23        -0.0169791723
+	  3   3  31  31        -0.0164372834
 	  1   2  10  23         0.0163699429
 	  2   1  23  10         0.0163699429
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.93455067608
+	Overlap <L|e^T> =        0.93455067640
 	Symmetry of left-hand state: A1
 	Symmetry of left-hand eigenvector: A1
 	Initial overlap of initial guess <L|R> =    0.9999741333
@@ -1194,120 +1173,120 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.001148296924398    9.661e-08
-	   1        -0.001423933982148    5.221e-02
-	   2        -0.001301176380965    1.779e-02
-	   3        -0.001359235932308    2.481e-03
-	   4        -0.001348860123825    1.669e-03
-	   5        -0.001356345081074    8.641e-04
-	   6        -0.001352696233271    4.685e-04
-	   7        -0.001353856524192    1.916e-04
-	   8        -0.001354600670250    6.387e-05
-	   9        -0.001355215637206    2.766e-05
-	  10        -0.001355478227808    1.183e-05
-	  11        -0.001355600085926    6.348e-06
-	  12        -0.001355659276549    3.116e-06
-	  13        -0.001355676531993    1.497e-06
-	  14        -0.001355695978239    7.645e-07
-	  15        -0.001355710270096    3.963e-07
-	  16        -0.001355717654310    1.963e-07
-	  17        -0.001355718491233    9.179e-08
+	   0         0.001148296868300    9.661e-08
+	   1         0.001423933917894    5.221e-02
+	   2         0.001301176316853    1.779e-02
+	   3         0.001359235867624    2.481e-03
+	   4         0.001348860059407    1.669e-03
+	   5         0.001356345016525    8.641e-04
+	   6         0.001352696168932    4.685e-04
+	   7         0.001353856459859    1.916e-04
+	   8         0.001354600605914    6.387e-05
+	   9         0.001355215572865    2.766e-05
+	  10         0.001355478163465    1.183e-05
+	  11         0.001355600021585    6.348e-06
+	  12         0.001355659212210    3.116e-06
+	  13         0.001355676467654    1.497e-06
+	  14         0.001355695913900    7.645e-07
+	  15         0.001355710205757    3.963e-07
+	  16         0.001355717589971    1.963e-07
+	  17         0.001355718426893    9.179e-08
 
-	Initial  <L|R>  =        0.9756715129
+	Initial  <L|R>  =        0.9756715128
 	Normalizing L...
-	L0 * R0 =       -0.0000000000
-	L1 * R1 =        0.9330684595
-	L2 * R2 =        0.0669315405
+	L0 * R0 =        0.0000000000
+	L1 * R1 =        0.9330684597
+	L2 * R2 =        0.0669315403
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =   -0.001389523495691
+	Pseudoenergy or Norm of normalized L =    0.001389523429801
 
 	Largest LIA Amplitudes:
-	          1   0         0.6058228948
-	          1   2         0.2523180168
-	          2  20        -0.1167100664
-	          1   1        -0.0731697894
-	          1   5         0.0684267048
-	          1   4        -0.0575973799
-	          2  21         0.0376270707
-	          1   6         0.0342786315
-	          1   3        -0.0271343758
-	          0   0        -0.0229993886
+	          1   0        -0.6058228951
+	          1   2        -0.2523180162
+	          2  20         0.1167100665
+	          1   1         0.0731697899
+	          1   5        -0.0684267049
+	          1   4         0.0575973794
+	          2  21        -0.0376270706
+	          1   6        -0.0342786317
+	          1   3         0.0271343757
+	          0   0         0.0229993884
 
 	Largest LIjAb Amplitudes:
-	  1   1   0   5        -0.0447362117
-	  1   1   5   0        -0.0447362117
-	  1   2   0  23        -0.0441249832
-	  2   1  23   0        -0.0441249832
-	  1   3   0  30        -0.0430177767
-	  3   1  30   0        -0.0430177767
-	  1   1   0   1         0.0413087342
-	  1   1   1   0         0.0413087342
-	  1   2   0  20        -0.0370194159
-	  2   1  20   0        -0.0370194159
+	  1   1   0   5         0.0447362115
+	  1   1   5   0         0.0447362115
+	  1   2   0  23         0.0441249834
+	  2   1  23   0         0.0441249834
+	  1   3   0  30         0.0430177765
+	  3   1  30   0         0.0430177765
+	  1   1   0   1        -0.0413087341
+	  1   1   1   0        -0.0413087341
+	  1   2   0  20         0.0370194160
+	  2   1  20   0         0.0370194160
 
 	Iterations converged.
 
 	Symmetry of left-hand state: A1
 	Symmetry of left-hand eigenvector: A1
-	Initial overlap of initial guess <L|R> =    0.9979462825
+	Initial overlap of initial guess <L|R> =    0.9979462826
 	Checking overlap of initial guess <L|R> =    1.0000000000
 
 	          Solving Lambda Equations
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.006705435186846    9.179e-08
-	   1        -0.014503915007960    5.783e-02
-	   2        -0.013447108674323    1.955e-02
-	   3        -0.013608631639733    2.686e-03
-	   4        -0.013597534383298    1.297e-03
-	   5        -0.013593266743815    5.211e-04
-	   6        -0.013585887646355    3.269e-04
-	   7        -0.013580970334515    2.056e-04
-	   8        -0.013580231051703    1.080e-04
-	   9        -0.013579675503096    4.084e-05
-	  10        -0.013579708040923    1.399e-05
-	  11        -0.013579668589715    6.140e-06
-	  12        -0.013579690471201    3.570e-06
-	  13        -0.013579666408198    2.363e-06
-	  14        -0.013579659779202    1.362e-06
-	  15        -0.013579652321869    6.344e-07
-	  16        -0.013579653458484    3.622e-07
-	  17        -0.013579651717256    2.299e-07
-	  18        -0.013579648270980    1.478e-07
-	  19        -0.013579646286973    8.287e-08
+	   0         0.006705435175066    9.179e-08
+	   1         0.014503914923694    5.783e-02
+	   2         0.013447108605799    1.955e-02
+	   3         0.013608631569262    2.686e-03
+	   4         0.013597534313417    1.297e-03
+	   5         0.013593266674163    5.211e-04
+	   6         0.013585887576984    3.269e-04
+	   7         0.013580970265398    2.056e-04
+	   8         0.013580230982684    1.080e-04
+	   9         0.013579675434109    4.084e-05
+	  10         0.013579707971932    1.399e-05
+	  11         0.013579668520724    6.140e-06
+	  12         0.013579690402209    3.570e-06
+	  13         0.013579666339210    2.363e-06
+	  14         0.013579659710219    1.362e-06
+	  15         0.013579652252888    6.344e-07
+	  16         0.013579653389505    3.622e-07
+	  17         0.013579651648278    2.299e-07
+	  18         0.013579648202002    1.478e-07
+	  19         0.013579646217995    8.287e-08
 
-	Initial  <L|R>  =        0.9725662168
+	Initial  <L|R>  =        0.9725662169
 	Normalizing L...
-	L0 * R0 =       -0.0000000000
-	L1 * R1 =        0.9319528705
-	L2 * R2 =        0.0680471295
+	L0 * R0 =        0.0000000000
+	L1 * R1 =        0.9319528707
+	L2 * R2 =        0.0680471293
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =   -0.013962695858278
+	Pseudoenergy or Norm of normalized L =    0.013962695785807
 
 	Largest LIA Amplitudes:
-	          2  20         0.6421154613
-	          1   0         0.1286392255
-	          1   1         0.1060359134
-	          2  21        -0.1030836830
-	          1   4        -0.0407200292
-	          3  27         0.0395259922
-	          3  28        -0.0372602916
-	          1   5        -0.0366007470
-	          3  30        -0.0362088846
-	          3  26        -0.0325041389
+	          2  20        -0.6421154616
+	          1   0        -0.1286392254
+	          1   1        -0.1060359131
+	          2  21         0.1030836827
+	          1   4         0.0407200294
+	          3  27        -0.0395259916
+	          3  28         0.0372602911
+	          1   5         0.0366007467
+	          3  30         0.0362088843
+	          3  26         0.0325041384
 
 	Largest LIjAb Amplitudes:
-	  2   2  20  20        -0.1075805767
-	  2   2  20  23        -0.0546958683
-	  2   2  23  20        -0.0546958683
-	  2   3  20  30        -0.0425394802
-	  3   2  30  20        -0.0425394802
-	  1   2   5  20        -0.0372059974
-	  2   1  20   5        -0.0372059974
-	  2   2  20  21         0.0360384330
-	  2   2  21  20         0.0360384330
-	  2   2  20  22        -0.0345218922
+	  2   2  20  20         0.1075805766
+	  2   2  20  23         0.0546958683
+	  2   2  23  20         0.0546958683
+	  2   3  20  30         0.0425394800
+	  3   2  30  20         0.0425394800
+	  1   2   5  20         0.0372059972
+	  2   1  20   5         0.0372059972
+	  2   2  20  21        -0.0360384332
+	  2   2  21  20        -0.0360384332
+	  2   2  20  22         0.0345218924
 
 	Iterations converged.
 
@@ -1321,52 +1300,52 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    8.287e-08
-	   1         0.961970263403526    5.907e-02
-	   2         0.971584219928316    2.224e-02
-	   3         0.971788423921607    2.501e-03
-	   4         0.972159831981625    1.520e-03
-	   5         0.972400384193376    7.330e-04
-	   6         0.972521990670476    4.091e-04
-	   7         0.972577727591718    1.831e-04
-	   8         0.972595838179289    8.302e-05
-	   9         0.972600312122074    2.441e-05
-	  10         0.972602236630187    7.331e-06
-	  11         0.972602102318337    1.651e-06
-	  12         0.972602307724455    5.103e-07
-	  13         0.972602237714536    2.018e-07
-	  14         0.972602254006090    9.124e-08
+	   1         0.961970263378923    5.907e-02
+	   2         0.971584219911550    2.224e-02
+	   3         0.971788423905618    2.501e-03
+	   4         0.972159831963456    1.520e-03
+	   5         0.972400384174313    7.330e-04
+	   6         0.972521990650988    4.091e-04
+	   7         0.972577727572129    1.831e-04
+	   8         0.972595838159474    8.302e-05
+	   9         0.972600312102086    2.441e-05
+	  10         0.972602236610040    7.331e-06
+	  11         0.972602102298074    1.651e-06
+	  12         0.972602307704079    5.103e-07
+	  13         0.972602237694045    2.018e-07
+	  14         0.972602253985513    9.124e-08
 
 	Initial  <L|R>  =        0.9714981087
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9333265394
-	L2 * R2 =        0.0666734606
+	L1 * R1 =        0.9333265396
+	L2 * R2 =        0.0666734604
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.001136538805478
+	Pseudoenergy or Norm of normalized L =    1.001136538790603
 
 	Largest LIA Amplitudes:
-	          2  26        -0.5888179820
-	          2  27         0.2557106018
-	          2  28        -0.1958130641
-	          2  30        -0.1037674453
-	          2  32        -0.0252911393
-	          2  31        -0.0227107831
-	          2  34         0.0118246849
+	          2  26        -0.5888179834
+	          2  27         0.2557106007
+	          2  28        -0.1958130623
+	          2  30        -0.1037674442
+	          2  32        -0.0252911391
+	          2  31        -0.0227107830
+	          2  34         0.0118246847
 	          2  33         0.0102083325
 	          0  16         0.0066578459
 	          2  35        -0.0046860763
 
 	Largest LIjAb Amplitudes:
-	  2   2  23  26         0.0520533886
-	  2   2  26  23         0.0520533886
-	  2   2  20  26         0.0484127921
-	  2   2  26  20         0.0484127921
-	  2   3  26  30         0.0437961663
-	  3   2  30  26         0.0437961663
-	  1   2   5  26         0.0381097054
-	  2   1  26   5         0.0381097054
-	  2   3  26  27        -0.0318835273
-	  3   2  27  26        -0.0318835273
+	  2   2  23  26         0.0520533887
+	  2   2  26  23         0.0520533887
+	  2   2  20  26         0.0484127922
+	  2   2  26  20         0.0484127922
+	  2   3  26  30         0.0437961661
+	  3   2  30  26         0.0437961661
+	  1   2   5  26         0.0381097053
+	  2   1  26   5         0.0381097053
+	  2   3  26  27        -0.0318835270
+	  3   2  27  26        -0.0318835270
 
 	Iterations converged.
 
@@ -1380,54 +1359,54 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    9.124e-08
-	   1         0.966285823471518    5.430e-02
-	   2         0.975093398138637    2.196e-02
-	   3         0.975334403043973    3.238e-03
-	   4         0.975854625586620    1.830e-03
-	   5         0.976225070227387    8.796e-04
-	   6         0.976374141819945    3.581e-04
-	   7         0.976415091452189    1.338e-04
-	   8         0.976423816950223    7.082e-05
-	   9         0.976431188219431    5.923e-05
-	  10         0.976445867223070    4.740e-05
-	  11         0.976460160308005    2.813e-05
-	  12         0.976465629529037    8.376e-06
-	  13         0.976464919576063    2.800e-06
-	  14         0.976465901478668    1.627e-06
-	  15         0.976465718982244    7.252e-07
-	  16         0.976465792903742    3.532e-07
-	  17         0.976465767949409    1.728e-07
-	  18         0.976465762679558    7.604e-08
+	   1         0.966285823695247    5.430e-02
+	   2         0.975093398272580    2.196e-02
+	   3         0.975334403175617    3.238e-03
+	   4         0.975854625715580    1.830e-03
+	   5         0.976225070355834    8.796e-04
+	   6         0.976374141947068    3.581e-04
+	   7         0.976415091578604    1.338e-04
+	   8         0.976423817076490    7.082e-05
+	   9         0.976431188345617    5.923e-05
+	  10         0.976445867349428    4.740e-05
+	  11         0.976460160434774    2.813e-05
+	  12         0.976465629656012    8.376e-06
+	  13         0.976464919703063    2.800e-06
+	  14         0.976465901605708    1.627e-06
+	  15         0.976465719109315    7.252e-07
+	  16         0.976465793030842    3.532e-07
+	  17         0.976465768076551    1.728e-07
+	  18         0.976465762806719    7.604e-08
 
-	Initial  <L|R>  =        0.9754030288
+	Initial  <L|R>  =        0.9754030289
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9331575553
-	L2 * R2 =        0.0668424447
+	L1 * R1 =        0.9331575556
+	L2 * R2 =        0.0668424444
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.001089533118677
+	Pseudoenergy or Norm of normalized L =    1.001089533100101
 
 	Largest LIA Amplitudes:
-	          2  28         0.5979957877
-	          2  26        -0.2567458550
-	          2  30         0.1338910650
-	          2  31         0.1139273017
-	          2  27        -0.0684216360
-	          2  29         0.0456137292
-	          2  32         0.0376724744
+	          2  28         0.5979957897
+	          2  26        -0.2567458516
+	          2  30         0.1338910639
+	          2  31         0.1139273023
+	          2  27        -0.0684216335
+	          2  29         0.0456137295
+	          2  32         0.0376724746
 	          2  35         0.0104155735
-	          2  34        -0.0080749003
-	          3  20        -0.0063478681
+	          2  34        -0.0080749001
+	          3  20        -0.0063478680
 
 	Largest LIjAb Amplitudes:
-	  2   2  23  28        -0.0491720046
-	  2   2  28  23        -0.0491720046
-	  2   2  20  28        -0.0450620802
-	  2   2  28  20        -0.0450620802
-	  2   3  28  30        -0.0431578615
-	  3   2  30  28        -0.0431578615
-	  1   2   5  28        -0.0372043665
-	  2   1  28   5        -0.0372043665
+	  2   2  23  28        -0.0491720048
+	  2   2  28  23        -0.0491720048
+	  2   2  20  28        -0.0450620803
+	  2   2  28  20        -0.0450620803
+	  2   3  28  30        -0.0431578614
+	  3   2  30  28        -0.0431578614
+	  1   2   5  28        -0.0372043664
+	  2   1  28   5        -0.0372043664
 	  2   3  28  28        -0.0333119562
 	  3   2  28  28        -0.0333119562
 
@@ -1443,53 +1422,53 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    7.604e-08
-	   1         0.968315737774910    5.242e-02
-	   2         0.975526355031357    1.790e-02
-	   3         0.975918603324023    2.642e-03
-	   4         0.976451976924637    1.728e-03
-	   5         0.976810050014052    8.423e-04
-	   6         0.977000629590400    4.458e-04
-	   7         0.977064322193764    1.638e-04
-	   8         0.977074875733116    6.025e-05
-	   9         0.977077134680976    2.009e-05
-	  10         0.977078139637510    8.720e-06
-	  11         0.977077637850715    3.570e-06
-	  12         0.977078077643933    1.470e-06
-	  13         0.977077904640542    6.188e-07
-	  14         0.977077965474764    2.103e-07
-	  15         0.977077958249829    8.841e-08
+	   1         0.968315737792029    5.242e-02
+	   2         0.975526355039528    1.790e-02
+	   3         0.975918603328905    2.642e-03
+	   4         0.976451976924955    1.728e-03
+	   5         0.976810050010980    8.423e-04
+	   6         0.977000629584547    4.458e-04
+	   7         0.977064322186739    1.638e-04
+	   8         0.977074875725788    6.025e-05
+	   9         0.977077134673602    2.009e-05
+	  10         0.977078139630085    8.720e-06
+	  11         0.977077637843276    3.570e-06
+	  12         0.977078077636459    1.470e-06
+	  13         0.977077904633045    6.188e-07
+	  14         0.977077965467245    2.103e-07
+	  15         0.977077958242295    8.841e-08
 
-	Initial  <L|R>  =        0.9759674391
+	Initial  <L|R>  =        0.9759674392
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9325999817
-	L2 * R2 =        0.0674000183
+	L1 * R1 =        0.9325999819
+	L2 * R2 =        0.0674000181
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.001137864910427
+	Pseudoenergy or Norm of normalized L =    1.001137864894316
 
 	Largest LIA Amplitudes:
-	          2   0         0.6084966036
-	          2   2         0.2578495990
-	          2   1        -0.1144768181
-	          2   5         0.0872999897
-	          2   4        -0.0429402082
-	          2   3        -0.0344090634
-	          2   6         0.0324141043
-	          2   7         0.0217866637
-	          2   8         0.0128481462
-	          2  11         0.0083641930
+	          2   0        -0.6084966041
+	          2   2        -0.2578495982
+	          2   1         0.1144768185
+	          2   5        -0.0872999895
+	          2   4         0.0429402077
+	          2   3         0.0344090631
+	          2   6        -0.0324141045
+	          2   7        -0.0217866634
+	          2   8        -0.0128481463
+	          2  11        -0.0083641930
 
 	Largest LIjAb Amplitudes:
-	  2   2   0  23        -0.0533205850
-	  2   2  23   0        -0.0533205850
-	  2   2   0  20        -0.0501991292
-	  2   2  20   0        -0.0501991292
-	  2   3   0  30        -0.0447834325
-	  3   2  30   0        -0.0447834325
-	  1   2   5   0        -0.0386326709
-	  2   1   0   5        -0.0386326709
-	  1   2   1   0         0.0317047738
-	  2   1   0   1         0.0317047738
+	  2   2   0  23         0.0533205851
+	  2   2  23   0         0.0533205851
+	  2   2   0  20         0.0501991292
+	  2   2  20   0         0.0501991292
+	  2   3   0  30         0.0447834322
+	  3   2  30   0         0.0447834322
+	  1   2   5   0         0.0386326707
+	  2   1   0   5         0.0386326707
+	  1   2   1   0        -0.0317047738
+	  2   1   0   1        -0.0317047738
 
 	Iterations converged.
 
@@ -1503,58 +1482,58 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    8.841e-08
-	   1         0.963914420068308    5.649e-02
-	   2         0.972439810679773    1.938e-02
-	   3         0.972720451509450    2.455e-03
-	   4         0.973099256267655    1.422e-03
-	   5         0.973296812363909    6.211e-04
-	   6         0.973390013621778    3.338e-04
-	   7         0.973432173042845    1.585e-04
-	   8         0.973442628177260    9.241e-05
-	   9         0.973450376861850    6.929e-05
-	  10         0.973458645118511    4.964e-05
-	  11         0.973462185760178    3.221e-05
-	  12         0.973466165367528    2.040e-05
-	  13         0.973465245148954    1.094e-05
-	  14         0.973466393866406    5.899e-06
-	  15         0.973465852177502    3.291e-06
-	  16         0.973466109665875    2.249e-06
-	  17         0.973466139915893    9.895e-07
-	  18         0.973466120683044    4.486e-07
-	  19         0.973466134898341    1.708e-07
-	  20         0.973466131438877    8.889e-08
+	   1         0.963914420216219    5.649e-02
+	   2         0.972439810781658    1.938e-02
+	   3         0.972720451610894    2.455e-03
+	   4         0.973099256366761    1.422e-03
+	   5         0.973296812461902    6.211e-04
+	   6         0.973390013718847    3.338e-04
+	   7         0.973432173139305    1.585e-04
+	   8         0.973442628273496    9.241e-05
+	   9         0.973450376957867    6.929e-05
+	  10         0.973458645214103    4.964e-05
+	  11         0.973462185855496    3.221e-05
+	  12         0.973466165462611    2.040e-05
+	  13         0.973465245244053    1.094e-05
+	  14         0.973466393961425    5.899e-06
+	  15         0.973465852272540    3.291e-06
+	  16         0.973466109760883    2.249e-06
+	  17         0.973466140010886    9.895e-07
+	  18         0.973466120778023    4.486e-07
+	  19         0.973466134993308    1.708e-07
+	  20         0.973466131533838    8.889e-08
 
-	Initial  <L|R>  =        0.9723315656
+	Initial  <L|R>  =        0.9723315657
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9351764402
-	L2 * R2 =        0.0648235598
+	L1 * R1 =        0.9351764404
+	L2 * R2 =        0.0648235596
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.001166850817188
+	Pseudoenergy or Norm of normalized L =    1.001166850795986
 
 	Largest LIA Amplitudes:
-	          2   1        -0.6477695971
-	          2   0        -0.1246510506
-	          2   5         0.1024773703
-	          2   4         0.1000227371
-	          2   3        -0.0773904834
-	          2   6        -0.0256268893
-	          2   2        -0.0181748973
-	          2   9         0.0160998248
-	          2   8         0.0159452286
-	          2  10        -0.0143090593
+	          2   1         0.6477695972
+	          2   0         0.1246510505
+	          2   5        -0.1024773699
+	          2   4        -0.1000227378
+	          2   3         0.0773904829
+	          2   6         0.0256268891
+	          2   2         0.0181748980
+	          2   9        -0.0160998249
+	          2   8        -0.0159452285
+	          2  10         0.0143090593
 
 	Largest LIjAb Amplitudes:
-	  2   2   1  23         0.0559021306
-	  2   2  23   1         0.0559021306
-	  2   2   1  20         0.0533637456
-	  2   2  20   1         0.0533637456
-	  2   3   1  30         0.0446245786
-	  3   2  30   1         0.0446245786
-	  1   2   5   1         0.0417085862
-	  2   1   1   5         0.0417085862
-	  1   2   1   1        -0.0377172707
-	  2   1   1   1        -0.0377172707
+	  2   2   1  23        -0.0559021306
+	  2   2  23   1        -0.0559021306
+	  2   2   1  20        -0.0533637455
+	  2   2  20   1        -0.0533637455
+	  2   3   1  30        -0.0446245783
+	  3   2  30   1        -0.0446245783
+	  1   2   5   1        -0.0417085860
+	  2   1   1   5        -0.0417085860
+	  1   2   1   1         0.0377172705
+	  2   1   1   1         0.0377172705
 
 	Iterations converged.
 
@@ -1567,58 +1546,58 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         1.000000000000000    8.889e-08
-	   1         0.961150821150299    6.007e-02
-	   2         0.971115324211837    2.387e-02
-	   3         0.971431555039487    2.403e-03
-	   4         0.971860193813593    1.739e-03
-	   5         0.972270688905126    9.995e-04
-	   6         0.972563625530172    6.059e-04
-	   7         0.972707792160051    2.770e-04
-	   8         0.972748834015806    1.158e-04
-	   9         0.972766273168690    5.718e-05
-	  10         0.972770606373385    3.182e-05
-	  11         0.972773301009319    2.036e-05
-	  12         0.972774706872022    9.439e-06
-	  13         0.972774685107230    3.715e-06
-	  14         0.972774954035669    1.705e-06
-	  15         0.972775033212674    1.220e-06
-	  16         0.972775218674248    7.947e-07
-	  17         0.972775272536617    3.579e-07
-	  18         0.972775280745154    1.506e-07
-	  19         0.972775269952401    7.710e-08
+	   0         0.999999999999999    8.889e-08
+	   1         0.961150803926318    6.007e-02
+	   2         0.971115306428233    2.387e-02
+	   3         0.971431530677343    2.403e-03
+	   4         0.971860163059026    1.739e-03
+	   5         0.972270647599229    9.994e-04
+	   6         0.972563575698338    6.059e-04
+	   7         0.972707739611782    2.770e-04
+	   8         0.972748780650671    1.158e-04
+	   9         0.972766218809609    5.718e-05
+	  10         0.972770551033546    3.182e-05
+	  11         0.972773244351613    2.036e-05
+	  12         0.972774648958377    9.439e-06
+	  13         0.972774626274391    3.715e-06
+	  14         0.972774894506527    1.705e-06
+	  15         0.972774972509946    1.220e-06
+	  16         0.972775156477727    7.947e-07
+	  17         0.972775209096091    3.579e-07
+	  18         0.972775216446830    1.507e-07
+	  19         0.972775205151633    7.717e-08
 
-	Initial  <L|R>  =        0.9717459720
+	Initial  <L|R>  =        0.9717459080
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9340214380
-	L2 * R2 =        0.0659785620
+	L1 * R1 =        0.9340214376
+	L2 * R2 =        0.0659785624
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.001059225312225
+	Pseudoenergy or Norm of normalized L =    1.001059224572180
 
 	Largest LIA Amplitudes:
-	          1  26         0.6015289746
-	          1  27        -0.2561684488
-	          1  28         0.1564800281
-	          1  30         0.0881956148
-	          2  16         0.0415526661
-	          1  32         0.0230552801
-	          0  26        -0.0189400743
-	          2  17         0.0110863856
-	          1  34        -0.0106188933
-	          1  33        -0.0095202835
+	          1  26        -0.6015289748
+	          1  27         0.2561684480
+	          1  28        -0.1564800270
+	          1  30        -0.0881956143
+	          2  16        -0.0415526659
+	          1  32        -0.0230552800
+	          0  26         0.0189400742
+	          2  17        -0.0110863855
+	          1  34         0.0106188932
+	          1  33         0.0095202835
 
 	Largest LIjAb Amplitudes:
-	  1   2  26  23        -0.0443479796
-	  2   1  23  26        -0.0443479796
-	  1   1   5  26        -0.0440100679
-	  1   1  26   5        -0.0440100679
-	  1   3  26  30        -0.0433584351
-	  3   1  30  26        -0.0433584351
-	  1   2  26  20        -0.0407597575
-	  2   1  20  26        -0.0407597575
-	  1   1   1  26         0.0383750500
-	  1   1  26   1         0.0383750500
+	  1   2  26  23         0.0443479797
+	  2   1  23  26         0.0443479797
+	  1   1   5  26         0.0440100676
+	  1   1  26   5         0.0440100676
+	  1   3  26  30         0.0433584350
+	  3   1  30  26         0.0433584350
+	  1   2  26  20         0.0407597576
+	  2   1  20  26         0.0407597576
+	  1   1   1  26        -0.0383750499
+	  1   1  26   1        -0.0383750499
 
 	Iterations converged.
 
@@ -1631,72 +1610,72 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         1.000000000000000    7.710e-08
-	   1         0.965071062599237    5.745e-02
-	   2         0.972433879145104    1.697e-02
-	   3         0.972567938002502    2.413e-03
-	   4         0.972826677211015    1.418e-03
-	   5         0.972961538455947    9.160e-04
-	   6         0.973015553536242    8.001e-04
-	   7         0.973075994534757    7.274e-04
-	   8         0.973163983318519    6.161e-04
-	   9         0.973234404443753    4.253e-04
-	  10         0.973283618613051    3.254e-04
-	  11         0.973324869923009    2.895e-04
-	  12         0.973380916452721    2.535e-04
-	  13         0.973452935272499    2.010e-04
-	  14         0.973514438303295    1.381e-04
-	  15         0.973535932085284    9.487e-05
-	  16         0.973549536711730    6.028e-05
-	  17         0.973552119138022    4.596e-05
-	  18         0.973553589132296    2.972e-05
-	  19         0.973553952368728    2.217e-05
-	  20         0.973556283037381    1.651e-05
-	  21         0.973557571586769    1.007e-05
-	  22         0.973558263293989    6.214e-06
-	  23         0.973559024610499    5.105e-06
-	  24         0.973560106894936    4.512e-06
-	  25         0.973561157933338    3.683e-06
-	  26         0.973562400791176    3.091e-06
-	  27         0.973563738429433    2.651e-06
-	  28         0.973564853307096    1.777e-06
-	  29         0.973564985038400    1.069e-06
-	  30         0.973565033052919    7.037e-07
-	  31         0.973565054412582    4.276e-07
-	  32         0.973565048763963    1.819e-07
-	  33         0.973565049878134    6.046e-08
+	   0         0.999999999999999    7.717e-08
+	   1         0.965071062745727    5.745e-02
+	   2         0.972433879233214    1.697e-02
+	   3         0.972567938077790    2.413e-03
+	   4         0.972826677278473    1.418e-03
+	   5         0.972961538501755    9.160e-04
+	   6         0.973015553562743    8.001e-04
+	   7         0.973075994515394    7.274e-04
+	   8         0.973163983213080    6.161e-04
+	   9         0.973234404261862    4.253e-04
+	  10         0.973283618409796    3.254e-04
+	  11         0.973324869680894    2.895e-04
+	  12         0.973380916195831    2.535e-04
+	  13         0.973452934972903    2.010e-04
+	  14         0.973514437992358    1.381e-04
+	  15         0.973535931782801    9.487e-05
+	  16         0.973549536437782    6.028e-05
+	  17         0.973552118910354    4.596e-05
+	  18         0.973553588948094    2.972e-05
+	  19         0.973553952229634    2.217e-05
+	  20         0.973556282966017    1.651e-05
+	  21         0.973557571576826    1.007e-05
+	  22         0.973558263317580    6.214e-06
+	  23         0.973559024671861    5.105e-06
+	  24         0.973560107019815    4.512e-06
+	  25         0.973561158121934    3.683e-06
+	  26         0.973562401068522    3.091e-06
+	  27         0.973563738830401    2.651e-06
+	  28         0.973564853835530    1.777e-06
+	  29         0.973564985609353    1.069e-06
+	  30         0.973565033677430    7.037e-07
+	  31         0.973565055115077    4.276e-07
+	  32         0.973565049505005    1.819e-07
+	  33         0.973565050638220    6.046e-08
 
-	Initial  <L|R>  =        0.9716996078
+	Initial  <L|R>  =        0.9716996087
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9283563579
-	L2 * R2 =        0.0716436421
+	L1 * R1 =        0.9283563582
+	L2 * R2 =        0.0716436418
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.001919772418332
+	Pseudoenergy or Norm of normalized L =    1.001919772239869
 
 	Largest LIA Amplitudes:
-	          2  16        -0.6524804640
-	          1  28        -0.1171540058
-	          1  26         0.0865899428
-	          3   0        -0.0619134582
-	          2  17        -0.0503089483
-	          3   2        -0.0453508059
-	          2  18         0.0378187741
-	          1  30        -0.0350505597
-	          1  31        -0.0329522908
-	          3   5        -0.0148482574
+	          2  16         0.6524804652
+	          1  28         0.1171540047
+	          1  26        -0.0865899430
+	          3   0         0.0619134504
+	          2  17         0.0503089483
+	          3   2         0.0453508024
+	          2  18        -0.0378187740
+	          1  30         0.0350505592
+	          1  31         0.0329522911
+	          3   5         0.0148482561
 
 	Largest LIjAb Amplitudes:
-	  2   2  16  23         0.0628420790
-	  2   2  23  16         0.0628420790
-	  2   2  16  20         0.0579627499
-	  2   2  20  16         0.0579627499
-	  2   3  16  30         0.0489110135
-	  3   2  30  16         0.0489110135
-	  1   2   5  16         0.0416446410
-	  2   1  16   5         0.0416446410
-	  2   2  16  22         0.0364156797
-	  2   2  22  16         0.0364156797
+	  2   2  16  23        -0.0628420791
+	  2   2  23  16        -0.0628420791
+	  2   2  16  20        -0.0579627500
+	  2   2  20  16        -0.0579627500
+	  2   3  16  30        -0.0489110133
+	  3   2  30  16        -0.0489110133
+	  1   2   5  16        -0.0416446408
+	  2   1  16   5        -0.0416446408
+	  2   2  16  22        -0.0364156799
+	  2   2  22  16        -0.0364156799
 
 	Iterations converged.
 
@@ -1704,7 +1683,7 @@ Total time:
 
                  1            2            3            4            5            6            7            8            9
 
-    1    1.0000000   -0.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
+    1    1.0000000    0.0000000   -0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     2    0.0000000    1.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     3    0.0000000    0.0000000    1.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     4  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
@@ -1719,87 +1698,73 @@ Total time:
 
                  1            2            3            4            5            6            7            8            9
 
-    1    1.0000000    0.0000000   -0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
-    2    0.0000000    1.0000000   -0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
+    1    1.0000000   -0.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
+    2    0.0000000    1.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     3    0.0000000   -0.0000000    1.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     4  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
-    5  -99.0000000  -99.0000000  -99.0000000   -0.0000000    1.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
+    5  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     6  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000  -99.0000000  -99.0000000
     7  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000000  -99.0000000  -99.0000000
-    8  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000
-    9  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000000
+    8  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000000
+    9  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000   -0.0000000    1.0000000
 
 
 
 	Projections for excited state, irrep A1, root 0:
 	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000170243
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9392786529
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0607043228
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9392786530
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0607043227
 	Sum of above             =    1.0000000000
-	Approx. excitation level =    1.0606872985
+	Approx. excitation level =    1.0606872984
 
 	Projections for excited state, irrep A1, root 1:
 	<0|Le^(-T)|0><0|Re^T|0>  =    0.0012043883
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9379823490
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0608132626
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9379823493
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0608132624
 	Sum of above             =    1.0000000000
-	Approx. excitation level =    1.0596088743
+	Approx. excitation level =    1.0596088741
 
 	Projections for excited state, irrep A1, root 0:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9391125360
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0608874640
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9391125362
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0608874637
 	Sum of above             =    1.0000000000
-	Approx. excitation level =    1.0608874639
+	Approx. excitation level =    1.0608874637
 
 	Projections for excited state, irrep A1, root 1:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9386288694
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0613711306
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9386288697
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0613711303
 	Sum of above             =    1.0000000000
-	Approx. excitation level =    1.0613711306
+	Approx. excitation level =    1.0613711303
 
 	Projections for excited state, irrep A1, root 0:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9382319760
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0617680240
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9382319762
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0617680238
 	Sum of above             =    1.0000000000
-	Approx. excitation level =    1.0617680240
+	Approx. excitation level =    1.0617680238
 
 	Projections for excited state, irrep A1, root 1:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9406978981
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0593021019
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9406978984
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0593021016
 	Sum of above             =    1.0000000000
-	Approx. excitation level =    1.0593021018
+	Approx. excitation level =    1.0593021016
 
 	Projections for excited state, irrep A1, root 0:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9405049165
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0594950835
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9405049163
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0594950837
 	Sum of above             =    1.0000000000
-	Approx. excitation level =    1.0594950835
+	Approx. excitation level =    1.0594950837
 
 	Projections for excited state, irrep A1, root 1:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9346385727
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0653614273
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9346385729
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0653614271
 	Sum of above             =    1.0000000000
-	Approx. excitation level =    1.0653614273
-
-*** tstop() called on psinet at Mon May 15 15:34:51 2017
-Module time:
-	user time   =       0.59 seconds =       0.01 minutes
-	system time =       0.62 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-Total time:
-	user time   =       2.28 seconds =       0.04 minutes
-	system time =       1.50 seconds =       0.03 minutes
-	total time  =          4 seconds =       0.07 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:51 2017
-
+	Approx. excitation level =    1.0653614271
 
 			**************************
 			*                        *
@@ -1823,456 +1788,51 @@ Total time:
 	Xi connected     = No
 	Compute NO       = No
 
-	Nuclear Rep. energy (wfn)     =    9.196933678131742
-	SCF energy          (wfn)     =  -76.052939646076453
-	Reference energy    (file100) =  -76.052939646076425
-	CCSD energy         (CC_INFO) =   -0.221651255229270
-	Total CCSD energy   (CC_INFO) =  -76.274590901305700
+	Nuclear Rep. energy (wfn)     =    9.196933714281490
+	SCF energy          (wfn)     =  -76.052939646260199
+	Reference energy    (file100) =  -76.052939646260256
+	CCSD energy         (CC_INFO) =   -0.221651254887671
+	Total CCSD energy   (CC_INFO) =  -76.274590901147931
 	Number of States = 9
 
 	Ground?  State     EOM Energy       R0
 	  Yes     0 A1    0.0000000000   1.00000000
-	   No     1 A1    0.3610022373  -0.00310175
-	   No     2 A1    0.4151101504  -0.02955683
-	   No     1 A2    0.3364570149   0.00000000
-	   No     2 A2    0.4315503914   0.00000000
-	   No     1 B1    0.2719408757   0.00000000
-	   No     2 B1    0.3877338666   0.00000000
-	   No     1 B2    0.4250956668   0.00000000
-	   No     2 B2    0.4985609484   0.00000000
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.2516
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.7236     Total:     0.7236
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -1.8393     Total:     1.8393
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -7.8639     YY:    -4.5376     ZZ:    -6.3260
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -1.6214     YY:     1.7049     ZZ:    -0.0835
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.60972  0.60972  0.00000 -0.21945
-       2     O     3.78055  3.78055  0.00000  0.43889
-       3     H     0.60972  0.60972  0.00000 -0.21945
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B1    1.966
-  HONO-1 :    3 A1    1.962
-  HONO-0 :    1 B2    1.962
-  LUNO+0 :    2 B2    0.028
-  LUNO+1 :    4 A1    0.026
-  LUNO+2 :    2 B1    0.021
-  LUNO+3 :    5 A1    0.013
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 1 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.4984
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.5232     Total:     0.5232
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     1.3298     Total:     1.3298
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -14.2362     YY:   -13.8456     ZZ:   -13.7796
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -0.2824     YY:     0.1082     ZZ:     0.1742
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.73527  0.73527  0.00000 -0.47054
-       2     O     3.52946  3.52946  0.00000  0.94107
-       3     H     0.73527  0.73527  0.00000 -0.47054
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.989
-  HONO-1 :    1 B1    1.959
-  HONO-0 :    3 A1    1.058
-  LUNO+0 :    4 A1    0.936
-  LUNO+1 :    2 B1    0.036
-  LUNO+2 :    2 B2    0.010
-  LUNO+3 :    5 A1    0.005
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 2 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1208
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.0961     Total:     1.0961
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -2.7860     Total:     2.7860
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -23.8597     YY:    -8.7917     ZZ:   -10.9337
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -9.3313     YY:     5.7367     ZZ:     3.5947
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.48700  0.48700  0.00000  0.02600
-       2     O     4.02600  4.02600  0.00000 -0.05200
-       3     H     0.48700  0.48700  0.00000  0.02600
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.981
-  HONO-1 :    3 A1    1.924
-  HONO-0 :    1 B1    1.167
-  LUNO+0 :    2 B1    0.829
-  LUNO+1 :    4 A1    0.070
-  LUNO+2 :    2 B2    0.016
-  LUNO+3 :    5 A1    0.006
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 3 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.5148
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.5395     Total:     0.5395
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     1.3713     Total:     1.3713
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -12.8494     YY:   -28.8838     ZZ:   -14.7502
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     5.9784     YY:   -10.0560     ZZ:     4.0776
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.80729  0.80729  0.00000 -0.61458
-       2     O     3.38542  3.38542  0.00000  1.22917
-       3     H     0.80729  0.80729  0.00000 -0.61458
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    2 A1    1.992
-  HONO-1 :    3 A1    1.992
-  HONO-0 :    1 B1    1.000
-  LUNO+0 :    2 B2    0.995
-  LUNO+1 :    4 A1    0.008
-  LUNO+2 :    3 B2    0.006
-  LUNO+3 :    5 A1    0.003
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 4 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.4622
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.5131     Total:     0.5131
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -1.3041     Total:     1.3041
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -12.1990     YY:   -23.7262     ZZ:   -14.2572
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     4.5285     YY:    -6.9988     ZZ:     2.4703
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.71652  0.71652  0.00000 -0.43304
-       2     O     3.56696  3.56696  0.00000  0.86607
-       3     H     0.71652  0.71652  0.00000 -0.43304
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.991
-  HONO-1 :    3 A1    1.990
-  HONO-0 :    1 B1    1.000
-  LUNO+0 :    2 B2    0.992
-  LUNO+1 :    4 A1    0.010
-  LUNO+2 :    3 B2    0.008
-  LUNO+3 :    5 A1    0.004
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 5 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.6290
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.6538     Total:     0.6538
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     1.6618     Total:     1.6618
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -12.3793     YY:   -13.6539     ZZ:   -15.2575
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     1.3842     YY:     0.1097     ZZ:    -1.4939
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.73789  0.73789  0.00000 -0.47578
-       2     O     3.52422  3.52422  0.00000  0.95156
-       3     H     0.73789  0.73789  0.00000 -0.47578
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    3 A1    1.992
-  HONO-1 :    1 B2    1.990
-  HONO-0 :    1 B1    1.000
-  LUNO+0 :    4 A1    0.993
-  LUNO+1 :    2 B2    0.009
-  LUNO+2 :    5 A1    0.006
-  LUNO+3 :    6 A1    0.004
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 6 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.4533
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -2.4285     Total:     2.4285
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -6.1727     Total:     6.1727
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -13.5313     YY:   -12.5600     ZZ:   -23.8371
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     3.1115     YY:     4.0828     ZZ:    -7.1943
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.60084  0.60084  0.00000 -0.20168
-       2     O     3.79832  3.79832  0.00000  0.40336
-       3     H     0.60084  0.60084  0.00000 -0.20168
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.993
-  HONO-1 :    3 A1    1.992
-  HONO-0 :    1 B1    1.001
-  LUNO+0 :    4 A1    0.996
-  LUNO+1 :    5 A1    0.005
-  LUNO+2 :    2 B2    0.005
-  LUNO+3 :    6 A1    0.003
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 7 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.5785
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.6033     Total:     0.6033
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     1.5334     Total:     1.5334
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -14.5532     YY:   -30.3213     ZZ:   -13.8798
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     5.0316     YY:   -10.7366     ZZ:     5.7050
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.80077  0.80077  0.00000 -0.60155
-       2     O     3.39845  3.39845  0.00000  1.20310
-       3     H     0.80077  0.80077  0.00000 -0.60155
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.991
-  HONO-1 :    1 B1    1.989
-  HONO-0 :    3 A1    1.006
-  LUNO+0 :    2 B2    0.991
-  LUNO+1 :    3 B2    0.007
-  LUNO+2 :    4 A1    0.005
-  LUNO+3 :    1 A2    0.005
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 8 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9753
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.9228
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.0525     Total:     0.0525
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -0.1334     Total:     0.1334
-
-  Quadrupole Moment: (Debye Ang)
-    XX:   -14.6900     YY:   -14.3391     ZZ:    -9.0749
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -1.9887     YY:    -1.6377     ZZ:     3.6264
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     H     0.74991  0.74991  0.00000 -0.49982
-       2     O     3.50018  3.50018  0.00000  0.99964
-       3     H     0.74991  0.74991  0.00000 -0.49982
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.982
-  HONO-1 :    3 A1    1.943
-  HONO-0 :    1 B1    1.058
-  LUNO+0 :    1 A2    0.936
-  LUNO+1 :    2 B2    0.051
-  LUNO+2 :    4 A1    0.014
-  LUNO+3 :    3 B2    0.006
-
+	   No     1 A1    0.3610022382   0.00310175
+	   No     2 A1    0.4151101508   0.02955683
+	   No     1 A2    0.3364570158   0.00000000
+	   No     2 A2    0.4315503928   0.00000000
+	   No     1 B1    0.2719408766   0.00000000
+	   No     2 B1    0.3877338671   0.00000000
+	   No     1 B2    0.4250956674   0.00000000
+	   No     2 B2    0.4985609491   0.00000000
 Doing transition
 
 	Oscillator Strength for 1 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.62325411
-	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.65637508
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.62325411
+	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.65637508
 	Dipole Strength          0.40908847 
 	Oscillator Strength      0.09845457 
-	Einstein A Coefficient   4.12255593e+08 
-	Einstein B Coefficient   4.97723406e+19 
+	Einstein A Coefficient   4.12255582e+08 
+	Einstein B Coefficient   4.97723327e+19 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.62325411
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.62325411
 	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.00000000
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.65637508
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.65637508
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.22987875
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.22987875
 	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.00000000
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.23301866
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.23301866
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2281,30 +1841,30 @@ Doing transition
 
 	Oscillator Strength for 2 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.09333246
-	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.10156376
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.09333246
+	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.10156376
 	Dipole Strength          0.00947919 
 	Oscillator Strength      0.00262327 
-	Einstein A Coefficient   1.45238298e+07 
-	Einstein B Coefficient   1.15329997e+18 
+	Einstein A Coefficient   1.45238295e+07 
+	Einstein B Coefficient   1.15329979e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.09333246
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.09333246
 	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.00000000
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.10156376
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.10156376
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.04352226
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.04352226
 	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.00000000
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.04123809
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.04123809
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2377,30 +1937,30 @@ Doing transition
 
 	Oscillator Strength for 1 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.53249475 	  0.00000000 	  0.00000000
-	<n|mu_e|0>              -0.56607699 	  0.00000000 	  0.00000000
+	<0|mu_e|n>               0.53249475 	  0.00000000 	  0.00000000
+	<n|mu_e|0>               0.56607699 	  0.00000000 	  0.00000000
 	Dipole Strength          0.30143302 
 	Oscillator Strength      0.05464797 
-	Einstein A Coefficient   1.29847604e+08 
-	Einstein B Coefficient   3.66742848e+19 
+	Einstein A Coefficient   1.29847603e+08 
+	Einstein B Coefficient   3.66742794e+19 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.53249475 	  0.00000000 	  0.00000000
-	<n|mu_m|0>               0.00000000 	  0.04449690 	  0.00000000
-	<0|mu_m|n>*              0.00000000 	  0.04354199 	  0.00000000
-	<n|mu_e|0>*             -0.56607699 	  0.00000000 	  0.00000000
+	<0|mu_e|n>               0.53249475 	  0.00000000 	  0.00000000
+	<n|mu_m|0>               0.00000000 	 -0.04449690 	  0.00000000
+	<0|mu_m|n>*              0.00000000 	 -0.04354199 	  0.00000000
+	<n|mu_e|0>*              0.56607699 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.15446305 	  0.00000000 	  0.00000000
-	<n|mu_m|0>               0.00000000 	  0.04449690 	  0.00000000
-	<0|mu_m|n>*              0.00000000 	  0.04354199 	  0.00000000
-	<n|mu_e|0>*             -0.15404627 	  0.00000000 	  0.00000000
+	<0|mu_e|n>               0.15446305 	  0.00000000 	  0.00000000
+	<n|mu_m|0>               0.00000000 	 -0.04449690 	  0.00000000
+	<0|mu_m|n>*              0.00000000 	 -0.04354199 	  0.00000000
+	<n|mu_e|0>*              0.15404627 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2409,30 +1969,30 @@ Doing transition
 
 	Oscillator Strength for 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.16673188 	  0.00000000 	  0.00000000
-	<n|mu_e|0>               0.17511407 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.16673188 	  0.00000000 	  0.00000000
+	<n|mu_e|0>              -0.17511407 	  0.00000000 	  0.00000000
 	Dipole Strength          0.02919710 
 	Oscillator Strength      0.00754714 
-	Einstein A Coefficient   3.64552891e+07 
-	Einstein B Coefficient   3.55230729e+18 
+	Einstein A Coefficient   3.64552879e+07 
+	Einstein B Coefficient   3.55230671e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.16673188 	  0.00000000 	  0.00000000
-	<n|mu_m|0>               0.00000000 	 -0.01123960 	  0.00000000
-	<0|mu_m|n>*              0.00000000 	 -0.00949198 	  0.00000000
-	<n|mu_e|0>*              0.17511407 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.16673188 	  0.00000000 	  0.00000000
+	<n|mu_m|0>               0.00000000 	  0.01123960 	  0.00000000
+	<0|mu_m|n>*              0.00000000 	  0.00949198 	  0.00000000
+	<n|mu_e|0>*             -0.17511407 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.06071430 	  0.00000000 	  0.00000000
-	<n|mu_m|0>               0.00000000 	 -0.01123960 	  0.00000000
-	<0|mu_m|n>*              0.00000000 	 -0.00949198 	  0.00000000
-	<n|mu_e|0>*              0.06383228 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.06071429 	  0.00000000 	  0.00000000
+	<n|mu_m|0>               0.00000000 	  0.01123960 	  0.00000000
+	<0|mu_m|n>*              0.00000000 	  0.00949198 	  0.00000000
+	<n|mu_e|0>*             -0.06383228 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2441,30 +2001,30 @@ Doing transition
 
 	Oscillator Strength for 1 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.24622665 	  0.00000000
-	<n|mu_e|0>               0.00000000 	 -0.26018465 	  0.00000000
-	Dipole Strength          0.06406440 
+	<0|mu_e|n>               0.00000000 	  0.24622659 	  0.00000000
+	<n|mu_e|0>               0.00000000 	  0.26018465 	  0.00000000
+	Dipole Strength          0.06406438 
 	Oscillator Strength      0.01815566 
-	Einstein A Coefficient   1.05413542e+08 
-	Einstein B Coefficient   7.79448744e+18 
+	Einstein A Coefficient   1.05413512e+08 
+	Einstein B Coefficient   7.79448420e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.24622665 	  0.00000000
-	<n|mu_m|0>               0.03024394 	  0.00000000 	  0.00000000
-	<0|mu_m|n>*              0.03107928 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	 -0.26018465 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  0.24622659 	  0.00000000
+	<n|mu_m|0>              -0.03024394 	  0.00000000 	  0.00000000
+	<0|mu_m|n>*             -0.03107924 	  0.00000000 	  0.00000000
+	<n|mu_e|0>*              0.00000000 	  0.26018465 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.09819494 	  0.00000000
-	<n|mu_m|0>               0.03024394 	  0.00000000 	  0.00000000
-	<0|mu_m|n>*              0.03107928 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	 -0.10307171 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  0.09819491 	  0.00000000
+	<n|mu_m|0>              -0.03024394 	  0.00000000 	  0.00000000
+	<0|mu_m|n>*             -0.03107924 	  0.00000000 	  0.00000000
+	<n|mu_e|0>*              0.00000000 	  0.10307171 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2473,30 +2033,30 @@ Doing transition
 
 	Oscillator Strength for 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.43952126 	  0.00000000
-	<n|mu_e|0>               0.00000000 	 -0.43191711 	  0.00000000
-	Dipole Strength          0.18983675 
-	Oscillator Strength      0.06309679 
-	Einstein A Coefficient   5.03912000e+08 
-	Einstein B Coefficient   2.30967629e+19 
+	<0|mu_e|n>               0.00000000 	  0.43952127 	  0.00000000
+	<n|mu_e|0>               0.00000000 	  0.43191712 	  0.00000000
+	Dipole Strength          0.18983676 
+	Oscillator Strength      0.06309680 
+	Einstein A Coefficient   5.03912015e+08 
+	Einstein B Coefficient   2.30967605e+19 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.43952126 	  0.00000000
-	<n|mu_m|0>              -0.02049209 	  0.00000000 	  0.00000000
-	<0|mu_m|n>*             -0.01994602 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	 -0.43191711 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  0.43952127 	  0.00000000
+	<n|mu_m|0>               0.02049209 	  0.00000000 	  0.00000000
+	<0|mu_m|n>*              0.01994602 	  0.00000000 	  0.00000000
+	<n|mu_e|0>*              0.00000000 	  0.43191712 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.22271202 	  0.00000000
-	<n|mu_m|0>              -0.02049209 	  0.00000000 	  0.00000000
-	<0|mu_m|n>*             -0.01994602 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	 -0.20743529 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  0.22271202 	  0.00000000
+	<n|mu_m|0>               0.02049209 	  0.00000000 	  0.00000000
+	<0|mu_m|n>*              0.01994602 	  0.00000000 	  0.00000000
+	<n|mu_e|0>*              0.00000000 	  0.20743530 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2510,7 +2070,7 @@ Doing transition
 	 1 A1   9.823   79230.8   126.2   0.361002   0.0985   0.0000   0.0000  4.122556E+08
 	 2 A1  11.296   91106.1   109.8   0.415110   0.0026   0.0000   0.0000  1.452383E+07
 	 1 A2   9.155   73843.8   135.4   0.336457   0.0000   0.0000   0.0000  0.000000E+00
-	 2 A2  11.743   94714.3   105.6   0.431550   0.0000   0.0000   0.0000  0.000000E+00
+	 2 A2  11.743   94714.4   105.6   0.431550   0.0000   0.0000   0.0000  0.000000E+00
 	 1 B1   7.400   59684.1   167.5   0.271941   0.0546   0.0000   0.0000  1.298476E+08
 	 2 B1  10.551   85097.7   117.5   0.387734   0.0075   0.0000   0.0000  3.645529E+07
 	 1 B2  11.567   93297.7   107.2   0.425096   0.0182   0.0000   0.0000  1.054135E+08
@@ -2547,8 +2107,8 @@ Doing transition
 	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.10631782
 	Dipole Strength          0.01166029 
 	Oscillator Strength      0.00042061 
-	Einstein A Coefficient   3.95650224e+04 
-	Einstein B Coefficient   1.41866630e+18 
+	Einstein A Coefficient   3.95650193e+04 
+	Einstein B Coefficient   1.41866605e+18 
 
 	Length-Gauge Rotational Strength for 1 A1 to 2 A1 Transition
 	                              X    	       Y    	       Z
@@ -2596,8 +2156,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 A2 to 1 A1 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.07432387
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.07662343
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.07432387
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.07662343
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2606,8 +2166,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.07432387
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.07662343
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.07432387
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.07662343
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2639,8 +2199,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 A2 to 2 A1 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.45852318
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.45600240
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.45852318
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.45600240
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2649,8 +2209,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.45852318
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.45600240
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.45852318
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.45600240
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2682,8 +2242,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 A1 to 2 A2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00711234
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.00696095
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00711234
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00696095
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2692,8 +2252,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 A1
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00711234
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.00696095
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00711234
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00696095
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2725,8 +2285,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 2 A1 to 2 A2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.05344309
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.04993655
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.05344309
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.04993654
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2735,8 +2295,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 2 A1
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.05344309
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.04993655
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.05344309
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.04993654
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2758,19 +2318,19 @@ Doing transition
 
 	Oscillator Strength for 1 A2 to 2 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.62926215
-	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.63431000
-	Dipole Strength          0.39914727 
-	Oscillator Strength      0.02530417 
-	Einstein A Coefficient   7.35196789e+06 
-	Einstein B Coefficient   4.85628298e+19 
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.62926216
+	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.63431001
+	Dipole Strength          0.39914729 
+	Oscillator Strength      0.02530418 
+	Einstein A Coefficient   7.35196814e+06 
+	Einstein B Coefficient   4.85628245e+19 
 
 	Length-Gauge Rotational Strength for 1 A2 to 2 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.62926215
+	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.62926216
 	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.63431000
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.63431001
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2805,8 +2365,8 @@ Doing transition
 	<n|mu_e|0>               0.24341811 	  0.00000000 	  0.00000000
 	Dipole Strength          0.06462293 
 	Oscillator Strength      0.00383694 
-	Einstein A Coefficient   9.77854524e+05 
-	Einstein B Coefficient   7.86244185e+18 
+	Einstein A Coefficient   9.77854505e+05 
+	Einstein B Coefficient   7.86244070e+18 
 
 	Length-Gauge Rotational Strength for 1 B1 to 1 A1 Transition
 	                              X    	       Y    	       Z
@@ -2846,10 +2406,10 @@ Doing transition
 	                              X    	       Y    	       Z
 	<0|mu_e|n>              -1.86770950 	  0.00000000 	  0.00000000
 	<n|mu_e|0>              -1.85889679 	  0.00000000 	  0.00000000
-	Dipole Strength          3.47187918 
+	Dipole Strength          3.47187921 
 	Oscillator Strength      0.33137762 
-	Einstein A Coefficient   2.18239679e+08 
-	Einstein B Coefficient   4.22411202e+20 
+	Einstein A Coefficient   2.18239673e+08 
+	Einstein B Coefficient   4.22411142e+20 
 
 	Length-Gauge Rotational Strength for 1 B1 to 2 A1 Transition
 	                              X    	       Y    	       Z
@@ -2887,29 +2447,29 @@ Doing transition
 
 	Oscillator Strength for 1 B1 to 1 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  2.64625594 	  0.00000000
-	<n|mu_e|0>               0.00000000 	  2.63865998 	  0.00000000
-	Dipole Strength          6.98256964 
+	<0|mu_e|n>               0.00000000 	 -2.64625594 	  0.00000000
+	<n|mu_e|0>               0.00000000 	 -2.63865998 	  0.00000000
+	Dipole Strength          6.98256967 
 	Oscillator Strength      0.30032562 
-	Einstein A Coefficient   4.01642833e+07 
-	Einstein B Coefficient   8.49544434e+20 
+	Einstein A Coefficient   4.01642825e+07 
+	Einstein B Coefficient   8.49544310e+20 
 
 	Length-Gauge Rotational Strength for 1 B1 to 1 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  2.64625594 	  0.00000000
-	<q|mu_m|p>               0.14004784 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.14097555 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  2.63865998 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -2.64625594 	  0.00000000
+	<q|mu_m|p>              -0.14004784 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.14097555 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -2.63865998 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.17302131 	  0.00000000
-	<q|mu_m|p>               0.14004784 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.14097555 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.16724325 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.17302131 	  0.00000000
+	<q|mu_m|p>              -0.14004784 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.14097555 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -0.16724325 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2930,29 +2490,29 @@ Doing transition
 
 	Oscillator Strength for 1 B1 to 2 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.49848455 	  0.00000000
-	<n|mu_e|0>               0.00000000 	  0.50013340 	  0.00000000
-	Dipole Strength          0.24930877 
+	<0|mu_e|n>               0.00000000 	 -0.49848454 	  0.00000000
+	<n|mu_e|0>               0.00000000 	 -0.50013338 	  0.00000000
+	Dipole Strength          0.24930876 
 	Oscillator Strength      0.02652803 
-	Einstein A Coefficient   2.17136851e+07 
-	Einstein B Coefficient   3.03325124e+19 
+	Einstein A Coefficient   2.17136836e+07 
+	Einstein B Coefficient   3.03325063e+19 
 
 	Length-Gauge Rotational Strength for 1 B1 to 2 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.49848455 	  0.00000000
-	<q|mu_m|p>               0.06335481 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.06081622 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.50013340 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.49848454 	  0.00000000
+	<q|mu_m|p>              -0.06335481 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.06081622 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -0.50013338 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.08522517 	  0.00000000
-	<q|mu_m|p>               0.06335481 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.06081622 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.07769800 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.08522517 	  0.00000000
+	<q|mu_m|p>              -0.06335481 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.06081622 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -0.07769800 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2977,14 +2537,14 @@ Doing transition
 	<n|mu_e|0>              -0.16885552 	  0.00000000 	  0.00000000
 	Dipole Strength          0.02764536 
 	Oscillator Strength      0.00049267 
-	Einstein A Coefficient   1.13114477e+04 
-	Einstein B Coefficient   3.36351282e+18 
+	Einstein A Coefficient   1.13114468e+04 
+	Einstein B Coefficient   3.36351232e+18 
 
 	Length-Gauge Rotational Strength for 1 A1 to 2 B1 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>              -0.16372199 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.05574163 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	  0.05447937 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.05447938 	  0.00000000
 	<q|mu_e|p>*             -0.16885552 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2994,7 +2554,7 @@ Doing transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>              -0.00287494 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.05574163 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	  0.05447937 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.05447938 	  0.00000000
 	<q|mu_e|p>*             -0.00657462 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3020,8 +2580,8 @@ Doing transition
 	<n|mu_e|0>               0.98565754 	  0.00000000 	  0.00000000
 	Dipole Strength          0.98049829 
 	Oscillator Strength      0.01789493 
-	Einstein A Coefficient   4.30913359e+05 
-	Einstein B Coefficient   1.19293742e+20 
+	Einstein A Coefficient   4.30913346e+05 
+	Einstein B Coefficient   1.19293724e+20 
 
 	Length-Gauge Rotational Strength for 2 B1 to 2 A1 Transition
 	                              X    	       Y    	       Z
@@ -3059,29 +2619,29 @@ Doing transition
 
 	Oscillator Strength for 1 A2 to 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.83243893 	  0.00000000
-	<n|mu_e|0>               0.00000000 	 -0.83830465 	  0.00000000
-	Dipole Strength          0.69783743 
+	<0|mu_e|n>               0.00000000 	  0.83243894 	  0.00000000
+	<n|mu_e|0>               0.00000000 	  0.83830466 	  0.00000000
+	Dipole Strength          0.69783744 
 	Oscillator Strength      0.02385527 
-	Einstein A Coefficient   2.01529187e+06 
-	Einstein B Coefficient   8.49034002e+19 
+	Einstein A Coefficient   2.01529180e+06 
+	Einstein B Coefficient   8.49033889e+19 
 
 	Length-Gauge Rotational Strength for 1 A2 to 2 B1 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.83243893 	  0.00000000
-	<q|mu_m|p>              -0.44715382 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.44667804 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.83830465 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.83243894 	  0.00000000
+	<q|mu_m|p>               0.44715382 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.44667804 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.83830466 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.02052036 	  0.00000000
-	<q|mu_m|p>              -0.44715382 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.44667804 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.01615410 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.02052036 	  0.00000000
+	<q|mu_m|p>               0.44715382 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.44667804 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.01615410 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3102,29 +2662,29 @@ Doing transition
 
 	Oscillator Strength for 2 B1 to 2 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -1.86558459 	  0.00000000
-	<n|mu_e|0>               0.00000000 	 -1.88053817 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  1.86558459 	  0.00000000
+	<n|mu_e|0>               0.00000000 	  1.88053817 	  0.00000000
 	Dipole Strength          3.50830303 
 	Oscillator Strength      0.10248110 
-	Einstein A Coefficient   6.32165108e+06 
-	Einstein B Coefficient   4.26842763e+20 
+	Einstein A Coefficient   6.32165131e+06 
+	Einstein B Coefficient   4.26842697e+20 
 
 	Length-Gauge Rotational Strength for 2 B1 to 2 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -1.86558459 	  0.00000000
-	<q|mu_m|p>              -0.04401709 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.04671030 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -1.88053817 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  1.86558459 	  0.00000000
+	<q|mu_m|p>               0.04401710 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.04671030 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  1.88053817 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 B1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.04625640 	  0.00000000
-	<q|mu_m|p>              -0.04401709 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.04671030 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.04807936 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.04625641 	  0.00000000
+	<q|mu_m|p>               0.04401710 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.04671030 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.04807936 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3145,19 +2705,19 @@ Doing transition
 
 	Oscillator Strength for 1 B1 to 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  1.77050475
-	<n|mu_e|0>               0.00000000 	  0.00000000 	  1.75503336
-	Dipole Strength          3.10729491 
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  1.77050476
+	<n|mu_e|0>               0.00000000 	  0.00000000 	  1.75503337
+	Dipole Strength          3.10729493 
 	Oscillator Strength      0.23986865 
-	Einstein A Coefficient   1.03335352e+08 
-	Einstein B Coefficient   3.78053529e+20 
+	Einstein A Coefficient   1.03335349e+08 
+	Einstein B Coefficient   3.78053475e+20 
 
 	Length-Gauge Rotational Strength for 1 B1 to 2 B1 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	  1.77050475
+	<p|mu_e|q>               0.00000000 	  0.00000000 	  1.77050476
 	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	  1.75503336
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	  1.75503337
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3188,18 +2748,18 @@ Doing transition
 
 	Oscillator Strength for 1 A1 to 1 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -2.69884640 	  0.00000000
+	<0|mu_e|n>               0.00000000 	 -2.69884650 	  0.00000000
 	<n|mu_e|0>               0.00000000 	 -2.68955920 	  0.00000000
-	Dipole Strength          7.25870715 
-	Oscillator Strength      0.31015696 
-	Einstein A Coefficient   4.09373232e+07 
-	Einstein B Coefficient   8.83141104e+20 
+	Dipole Strength          7.25870743 
+	Oscillator Strength      0.31015697 
+	Einstein A Coefficient   4.09373233e+07 
+	Einstein B Coefficient   8.83141005e+20 
 
 	Length-Gauge Rotational Strength for 1 A1 to 1 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -2.69884640 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -2.69884650 	  0.00000000
 	<q|mu_m|p>              -0.12073292 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.12334823 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.12334828 	  0.00000000 	  0.00000000
 	<q|mu_e|p>*              0.00000000 	 -2.68955920 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3207,9 +2767,9 @@ Doing transition
 
 	Velocity-Gauge Rotational Strength for 1 A1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.17715732 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.17715734 	  0.00000000
 	<q|mu_m|p>              -0.12073292 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.12334823 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.12334828 	  0.00000000 	  0.00000000
 	<q|mu_e|p>*              0.00000000 	 -0.17164364 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3231,18 +2791,18 @@ Doing transition
 
 	Oscillator Strength for 2 A1 to 1 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.53742329 	  0.00000000
+	<0|mu_e|n>               0.00000000 	 -0.53742330 	  0.00000000
 	<n|mu_e|0>               0.00000000 	 -0.52352162 	  0.00000000
-	Dipole Strength          0.28135271 
+	Dipole Strength          0.28135272 
 	Oscillator Strength      0.00187297 
-	Einstein A Coefficient   6.00042922e+03 
-	Einstein B Coefficient   3.42311843e+19 
+	Einstein A Coefficient   6.00042972e+03 
+	Einstein B Coefficient   3.42311802e+19 
 
 	Length-Gauge Rotational Strength for 2 A1 to 1 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.53742329 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.53742330 	  0.00000000
 	<q|mu_m|p>               0.02165097 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.02034482 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.02034481 	  0.00000000 	  0.00000000
 	<q|mu_e|p>*              0.00000000 	 -0.52352162 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3250,9 +2810,9 @@ Doing transition
 
 	Velocity-Gauge Rotational Strength for 2 A1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.01738196 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.01738197 	  0.00000000
 	<q|mu_m|p>               0.02165097 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.02034482 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.02034481 	  0.00000000 	  0.00000000
 	<q|mu_e|p>*              0.00000000 	 -0.01193316 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3274,29 +2834,29 @@ Doing transition
 
 	Oscillator Strength for 1 A2 to 1 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.01960660 	  0.00000000 	  0.00000000
-	<n|mu_e|0>               0.02607534 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.01960654 	  0.00000000 	  0.00000000
+	<n|mu_e|0>              -0.02607534 	  0.00000000 	  0.00000000
 	Dipole Strength          0.00051125 
 	Oscillator Strength      0.00003021 
-	Einstein A Coefficient   7.62642929e+03 
-	Einstein B Coefficient   6.22018083e+16 
+	Einstein A Coefficient   7.62640632e+03 
+	Einstein B Coefficient   6.22016135e+16 
 
 	Length-Gauge Rotational Strength for 1 A2 to 1 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.01960660 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.48917994 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	  0.49271237 	  0.00000000
-	<q|mu_e|p>*              0.02607534 	  0.00000000 	  0.00000000
+	<p|mu_e|q>              -0.01960654 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	 -0.48917994 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	 -0.49271237 	  0.00000000
+	<q|mu_e|p>*             -0.02607534 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.01929631 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.48917994 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	  0.49271237 	  0.00000000
-	<q|mu_e|p>*              0.00309487 	  0.00000000 	  0.00000000
+	<p|mu_e|q>              -0.01929630 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	 -0.48917994 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	 -0.49271237 	  0.00000000
+	<q|mu_e|p>*             -0.00309487 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3317,29 +2877,29 @@ Doing transition
 
 	Oscillator Strength for 1 B2 to 2 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.02747101 	  0.00000000 	  0.00000000
-	<n|mu_e|0>              -0.02902483 	  0.00000000 	  0.00000000
+	<0|mu_e|n>               0.02747101 	  0.00000000 	  0.00000000
+	<n|mu_e|0>               0.02902482 	  0.00000000 	  0.00000000
 	Dipole Strength          0.00079734 
 	Oscillator Strength      0.00000343 
-	Einstein A Coefficient   4.59300767e+00 
-	Einstein B Coefficient   9.70097084e+16 
+	Einstein A Coefficient   4.59300665e+00 
+	Einstein B Coefficient   9.70096439e+16 
 
 	Length-Gauge Rotational Strength for 1 B2 to 2 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.02747101 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	 -0.00432309 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	 -0.00374867 	  0.00000000
-	<q|mu_e|p>*             -0.02902483 	  0.00000000 	  0.00000000
+	<p|mu_e|q>               0.02747101 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	  0.00432319 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.00374867 	  0.00000000
+	<q|mu_e|p>*              0.02902482 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.01022984 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	 -0.00432309 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	 -0.00374867 	  0.00000000
-	<q|mu_e|p>*             -0.01164927 	  0.00000000 	  0.00000000
+	<p|mu_e|q>               0.01022984 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	  0.00432319 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.00374867 	  0.00000000
+	<q|mu_e|p>*              0.01164928 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3371,7 +2931,7 @@ Doing transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00948373
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.00977037
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.00977043
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3381,7 +2941,7 @@ Doing transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00948373
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.00977037
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.00977043
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3450,7 +3010,7 @@ Doing transition
 	<n|mu_e|0>               0.00000000 	  0.04232390 	  0.00000000
 	Dipole Strength          0.00148816 
 	Oscillator Strength      0.00013647 
-	Einstein A Coefficient   8.29725590e+04 
+	Einstein A Coefficient   8.29725691e+04 
 	Einstein B Coefficient   1.81059526e+17 
 
 	Length-Gauge Rotational Strength for 1 A1 to 2 B2 Transition
@@ -3493,13 +3053,13 @@ Doing transition
 	<n|mu_e|0>               0.00000000 	 -1.61535951 	  0.00000000
 	Dipole Strength          2.58258263 
 	Oscillator Strength      0.14367905 
-	Einstein A Coefficient   3.21488426e+07 
-	Einstein B Coefficient   3.14213652e+20 
+	Einstein A Coefficient   3.21488421e+07 
+	Einstein B Coefficient   3.14213603e+20 
 
 	Length-Gauge Rotational Strength for 2 A1 to 2 B2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	 -1.59876647 	  0.00000000
-	<q|mu_m|p>               0.00066070 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00066069 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*             -0.00291361 	  0.00000000 	  0.00000000
 	<q|mu_e|p>*              0.00000000 	 -1.61535951 	  0.00000000
 
@@ -3509,7 +3069,7 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 2 A1
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	 -0.09606848 	  0.00000000
-	<q|mu_m|p>               0.00066070 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00066069 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*             -0.00291361 	  0.00000000 	  0.00000000
 	<q|mu_e|p>*              0.00000000 	 -0.09708187 	  0.00000000
 
@@ -3532,29 +3092,29 @@ Doing transition
 
 	Oscillator Strength for 1 A2 to 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               1.48279946 	  0.00000000 	  0.00000000
-	<n|mu_e|0>               1.48467482 	  0.00000000 	  0.00000000
-	Dipole Strength          2.20147502 
+	<0|mu_e|n>              -1.48279946 	  0.00000000 	  0.00000000
+	<n|mu_e|0>              -1.48467482 	  0.00000000 	  0.00000000
+	Dipole Strength          2.20147503 
 	Oscillator Strength      0.23791184 
-	Einstein A Coefficient   2.00869526e+08 
-	Einstein B Coefficient   2.67845642e+20 
+	Einstein A Coefficient   2.00869522e+08 
+	Einstein B Coefficient   2.67845603e+20 
 
 	Length-Gauge Rotational Strength for 1 A2 to 2 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               1.48279946 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	 -0.15158851 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	 -0.15050203 	  0.00000000
-	<q|mu_e|p>*              1.48467482 	  0.00000000 	  0.00000000
+	<p|mu_e|q>              -1.48279946 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	  0.15158851 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.15050202 	  0.00000000
+	<q|mu_e|p>*             -1.48467482 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.10419569 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	 -0.15158851 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	 -0.15050203 	  0.00000000
-	<q|mu_e|p>*              0.11036579 	  0.00000000 	  0.00000000
+	<p|mu_e|q>              -0.10419569 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	  0.15158851 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.15050202 	  0.00000000
+	<q|mu_e|p>*             -0.11036579 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3575,29 +3135,29 @@ Doing transition
 
 	Oscillator Strength for 2 A2 to 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.38740898 	  0.00000000 	  0.00000000
-	<n|mu_e|0>               0.37660632 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.38740897 	  0.00000000 	  0.00000000
+	<n|mu_e|0>              -0.37660632 	  0.00000000 	  0.00000000
 	Dipole Strength          0.14590067 
 	Oscillator Strength      0.00651792 
-	Einstein A Coefficient   9.40386987e+05 
-	Einstein B Coefficient   1.77512163e+19 
+	Einstein A Coefficient   9.40386900e+05 
+	Einstein B Coefficient   1.77512129e+19 
 
 	Length-Gauge Rotational Strength for 2 A2 to 2 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.38740898 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.50682287 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	  0.50528991 	  0.00000000
-	<q|mu_e|p>*              0.37660632 	  0.00000000 	  0.00000000
+	<p|mu_e|q>              -0.38740897 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	 -0.50682287 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	 -0.50528991 	  0.00000000
+	<q|mu_e|p>*             -0.37660632 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 A2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.16018499 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.50682287 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	  0.50528991 	  0.00000000
-	<q|mu_e|p>*             -0.17131227 	  0.00000000 	  0.00000000
+	<p|mu_e|q>               0.16018499 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	 -0.50682287 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	 -0.50528991 	  0.00000000
+	<q|mu_e|p>*              0.17131227 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3628,8 +3188,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 B1 to 2 B2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.20857470
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.19069655
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.20857469
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.19069654
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3638,8 +3198,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.20857470
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.19069655
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.20857469
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.19069654
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3672,7 +3232,7 @@ Doing transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.06436020
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.06427405
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.06427406
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3682,7 +3242,7 @@ Doing transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.06436020
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.06427405
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.06427406
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3705,18 +3265,18 @@ Doing transition
 	Oscillator Strength for 1 B2 to 2 B2
 	                              X    	       Y    	       Z
 	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.06766006
-	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.07562921
+	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.07562920
 	Dipole Strength          0.00511708 
 	Oscillator Strength      0.00025062 
-	Einstein A Coefficient   4.34598281e+04 
-	Einstein B Coefficient   6.22576538e+17 
+	Einstein A Coefficient   4.34598269e+04 
+	Einstein B Coefficient   6.22576439e+17 
 
 	Length-Gauge Rotational Strength for 1 B2 to 2 B2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.06766006
 	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.07562921
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.07562920
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3738,7 +3298,7 @@ Doing transition
 	 1 A1   9.823   79230.8   126.2   0.361002   0.0985   0.0000   0.0000  4.122556E+08
 	 2 A1  11.296   91106.1   109.8   0.415110   0.0026   0.0000   0.0000  1.452383E+07
 	 1 A2   9.155   73843.8   135.4   0.336457   0.0000   0.0000   0.0000  0.000000E+00
-	 2 A2  11.743   94714.3   105.6   0.431550   0.0000   0.0000   0.0000  0.000000E+00
+	 2 A2  11.743   94714.4   105.6   0.431550   0.0000   0.0000   0.0000  0.000000E+00
 	 1 B1   7.400   59684.1   167.5   0.271941   0.0546   0.0000   0.0000  1.298476E+08
 	 2 B1  10.551   85097.7   117.5   0.387734   0.0075   0.0000   0.0000  3.645529E+07
 	 1 B2  11.567   93297.7   107.2   0.425096   0.0182   0.0000   0.0000  1.054135E+08
@@ -3758,35 +3318,409 @@ Doing transition
 	  1B1->1A1   2.423   19546.7   511.6   0.089061   0.0038   0.0000   0.0000  9.778545E+05
 	  1B1->2A1   3.896   31422.0   318.2   0.143169   0.3314   0.0000   0.0000  2.182397E+08
 	  1B1->1A2   1.756   14159.7   706.2   0.064516   0.3003   0.0000   0.0000  4.016428E+07
-	  1B1->2A2   4.343   35030.2   285.5   0.159610   0.0265   0.0000   0.0000  2.171369E+07
+	  1B1->2A2   4.343   35030.2   285.5   0.159610   0.0265   0.0000   0.0000  2.171368E+07
 	  1A1->2B1   0.727    5866.9  1704.5   0.026732   0.0005   0.0000   0.0000  1.131145E+04
-	  2B1->2A1   0.745    6008.4  1664.3   0.027376   0.0179   0.0000   0.0000  4.309134E+05
+	  2B1->2A1   0.745    6008.4  1664.3   0.027376   0.0179   0.0000   0.0000  4.309133E+05
 	  1A2->2B1   1.395   11254.0   888.6   0.051277   0.0239   0.0000   0.0000  2.015292E+06
 	  2B1->2A2   1.192    9616.6  1039.9   0.043817   0.1025   0.0000   0.0000  6.321651E+06
-	  1B1->2B1   3.151   25413.6   393.5   0.115793   0.2399   0.0000   0.0000  1.033354E+08
+	  1B1->2B1   3.151   25413.6   393.5   0.115793   0.2399   0.0000   0.0000  1.033353E+08
 	  1A1->1B2   1.744   14066.9   710.9   0.064093   0.3102   0.0000   0.0000  4.093732E+07
-	  2A1->1B2   0.272    2191.6  4562.9   0.009986   0.0019   0.0000   0.0000  6.000429E+03
-	  1A2->1B2   2.412   19453.9   514.0   0.088639   0.0000   0.0000   0.0000  7.626429E+03
-	  1B2->2A2   0.176    1416.6  7058.9   0.006455   0.0000   0.0000   0.0000  4.593008E+00
+	  2A1->1B2   0.272    2191.6  4562.9   0.009986   0.0019   0.0000   0.0000  6.000430E+03
+	  1A2->1B2   2.412   19453.9   514.0   0.088639   0.0000   0.0000   0.0000  7.626406E+03
+	  1B2->2A2   0.176    1416.6  7058.9   0.006455   0.0000   0.0000   0.0000  4.593007E+00
 	  1B1->1B2   4.168   33613.6   297.5   0.153155   0.0000   0.0000   0.0000  0.000000E+00
 	  2B1->1B2   1.017    8200.0  1219.5   0.037362   0.0000   0.0000   0.0000  0.000000E+00
-	  1A1->2B2   3.743   30190.6   331.2   0.137559   0.0001   0.0000   0.0000  8.297256E+04
+	  1A1->2B2   3.743   30190.6   331.2   0.137559   0.0001   0.0000   0.0000  8.297257E+04
 	  2A1->2B2   2.271   18315.3   546.0   0.083451   0.1437   0.0000   0.0000  3.214884E+07
 	  1A2->2B2   4.411   35577.7   281.1   0.162104   0.2379   0.0000   0.0000  2.008695E+08
-	  2A2->2B2   1.823   14707.1   679.9   0.067011   0.0065   0.0000   0.0000  9.403870E+05
-	  1B1->2B2   6.167   49737.3   201.1   0.226620   0.0000   0.0000   0.0000  0.000000E+00
+	  2A2->2B2   1.823   14707.1   679.9   0.067011   0.0065   0.0000   0.0000  9.403869E+05
+	  1B1->2B2   6.167   49737.4   201.1   0.226620   0.0000   0.0000   0.0000  0.000000E+00
 	  2B1->2B2   3.016   24323.7   411.1   0.110827   0.0000   0.0000   0.0000  0.000000E+00
 	  1B2->2B2   1.999   16123.8   620.2   0.073465   0.0003   0.0000   0.0000  4.345983E+04
 
 
-*** tstop() called on psinet at Mon May 15 15:34:52 2017
-Module time:
-	user time   =       0.78 seconds =       0.01 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       3.06 seconds =       0.05 minutes
-	system time =       1.81 seconds =       0.03 minutes
-	total time  =          5 seconds =       0.08 minutes
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the EOM-CCSD density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.2516
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.7236     Total:     0.7236
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.8393     Total:     1.8393
+
+  Quadrupole Moment: [D A]
+    XX:    -7.8639     YY:    -4.5376     ZZ:    -6.3260
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:    -1.6214     YY:     1.7049     ZZ:    -0.0835
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.60972  0.60972  0.00000 -0.21945
+       2     O     3.78055  3.78055  0.00000  0.43889
+       3     H     0.60972  0.60972  0.00000 -0.21945
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B1    1.966
+  HONO-1 :    3 A1    1.962
+  HONO-0 :    1 B2    1.962
+  LUNO+0 :    2 B2    0.028
+  LUNO+1 :    4 A1    0.026
+  LUNO+2 :    2 B1    0.021
+  LUNO+3 :    5 A1    0.013
+
+
+Properties computed using the CC ROOT 1 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.4984
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.5232     Total:     0.5232
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.3298     Total:     1.3298
+
+  Quadrupole Moment: [D A]
+    XX:   -14.2362     YY:   -13.8456     ZZ:   -13.7796
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:    -0.2824     YY:     0.1082     ZZ:     0.1742
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.73527  0.73527  0.00000 -0.47054
+       2     O     3.52946  3.52946  0.00000  0.94107
+       3     H     0.73527  0.73527  0.00000 -0.47054
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B2    1.989
+  HONO-1 :    1 B1    1.959
+  HONO-0 :    3 A1    1.058
+  LUNO+0 :    4 A1    0.936
+  LUNO+1 :    2 B1    0.036
+  LUNO+2 :    2 B2    0.010
+  LUNO+3 :    5 A1    0.005
+
+
+Properties computed using the CC ROOT 2 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1208
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.0961     Total:     1.0961
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -2.7860     Total:     2.7860
+
+  Quadrupole Moment: [D A]
+    XX:   -23.8597     YY:    -8.7917     ZZ:   -10.9337
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:    -9.3313     YY:     5.7367     ZZ:     3.5947
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.48700  0.48700  0.00000  0.02600
+       2     O     4.02600  4.02600  0.00000 -0.05200
+       3     H     0.48700  0.48700  0.00000  0.02600
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B2    1.981
+  HONO-1 :    3 A1    1.924
+  HONO-0 :    1 B1    1.167
+  LUNO+0 :    2 B1    0.829
+  LUNO+1 :    4 A1    0.070
+  LUNO+2 :    2 B2    0.016
+  LUNO+3 :    5 A1    0.006
+
+
+Properties computed using the CC ROOT 3 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.5148
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.5395     Total:     0.5395
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.3713     Total:     1.3713
+
+  Quadrupole Moment: [D A]
+    XX:   -12.8494     YY:   -28.8838     ZZ:   -14.7502
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:     5.9784     YY:   -10.0560     ZZ:     4.0776
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.80729  0.80729  0.00000 -0.61458
+       2     O     3.38542  3.38542  0.00000  1.22917
+       3     H     0.80729  0.80729  0.00000 -0.61458
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    2 A1    1.992
+  HONO-1 :    3 A1    1.992
+  HONO-0 :    1 B1    1.000
+  LUNO+0 :    2 B2    0.995
+  LUNO+1 :    4 A1    0.008
+  LUNO+2 :    3 B2    0.006
+  LUNO+3 :    5 A1    0.003
+
+
+Properties computed using the CC ROOT 4 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.4622
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.5131     Total:     0.5131
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -1.3041     Total:     1.3041
+
+  Quadrupole Moment: [D A]
+    XX:   -12.1990     YY:   -23.7262     ZZ:   -14.2572
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:     4.5285     YY:    -6.9988     ZZ:     2.4703
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.71652  0.71652  0.00000 -0.43304
+       2     O     3.56696  3.56696  0.00000  0.86607
+       3     H     0.71652  0.71652  0.00000 -0.43304
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B2    1.991
+  HONO-1 :    3 A1    1.990
+  HONO-0 :    1 B1    1.000
+  LUNO+0 :    2 B2    0.992
+  LUNO+1 :    4 A1    0.010
+  LUNO+2 :    3 B2    0.008
+  LUNO+3 :    5 A1    0.004
+
+
+Properties computed using the CC ROOT 5 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.6290
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.6538     Total:     0.6538
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.6618     Total:     1.6618
+
+  Quadrupole Moment: [D A]
+    XX:   -12.3793     YY:   -13.6539     ZZ:   -15.2575
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:     1.3842     YY:     0.1097     ZZ:    -1.4939
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.73789  0.73789  0.00000 -0.47578
+       2     O     3.52422  3.52422  0.00000  0.95156
+       3     H     0.73789  0.73789  0.00000 -0.47578
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    3 A1    1.992
+  HONO-1 :    1 B2    1.990
+  HONO-0 :    1 B1    1.000
+  LUNO+0 :    4 A1    0.993
+  LUNO+1 :    2 B2    0.009
+  LUNO+2 :    5 A1    0.006
+  LUNO+3 :    6 A1    0.004
+
+
+Properties computed using the CC ROOT 6 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -1.4533
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -2.4285     Total:     2.4285
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -6.1727     Total:     6.1727
+
+  Quadrupole Moment: [D A]
+    XX:   -13.5313     YY:   -12.5600     ZZ:   -23.8371
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:     3.1115     YY:     4.0828     ZZ:    -7.1943
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.60084  0.60084  0.00000 -0.20168
+       2     O     3.79832  3.79832  0.00000  0.40336
+       3     H     0.60084  0.60084  0.00000 -0.20168
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B2    1.993
+  HONO-1 :    3 A1    1.992
+  HONO-0 :    1 B1    1.001
+  LUNO+0 :    4 A1    0.996
+  LUNO+1 :    5 A1    0.005
+  LUNO+2 :    2 B2    0.005
+  LUNO+3 :    6 A1    0.003
+
+
+Properties computed using the CC ROOT 7 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     1.5785
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.6033     Total:     0.6033
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.5334     Total:     1.5334
+
+  Quadrupole Moment: [D A]
+    XX:   -14.5532     YY:   -30.3214     ZZ:   -13.8798
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:     5.0316     YY:   -10.7366     ZZ:     5.7050
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.80077  0.80077  0.00000 -0.60155
+       2     O     3.39845  3.39845  0.00000  1.20310
+       3     H     0.80077  0.80077  0.00000 -0.60155
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B2    1.991
+  HONO-1 :    1 B1    1.989
+  HONO-0 :    3 A1    1.006
+  LUNO+0 :    2 B2    0.991
+  LUNO+1 :    3 B2    0.007
+  LUNO+2 :    4 A1    0.005
+  LUNO+3 :    1 A2    0.005
+
+
+Properties computed using the CC ROOT 8 density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.9753
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9228
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0525     Total:     0.0525
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.1334     Total:     0.1334
+
+  Quadrupole Moment: [D A]
+    XX:   -14.6900     YY:   -14.3391     ZZ:    -9.0749
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: [D A]
+    XX:    -1.9887     YY:    -1.6377     ZZ:     3.6264
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     H     0.74991  0.74991  0.00000 -0.49982
+       2     O     3.50018  3.50018  0.00000  0.99964
+       3     H     0.74991  0.74991  0.00000 -0.49982
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B2    1.982
+  HONO-1 :    3 A1    1.943
+  HONO-0 :    1 B1    1.058
+  LUNO+0 :    1 A2    0.936
+  LUNO+1 :    2 B2    0.051
+  LUNO+2 :    4 A1    0.014
+  LUNO+3 :    3 B2    0.006
+
+
+    Psi4 stopped on: Saturday, 12 February 2022 03:24PM
+    Psi4 wall time for execution: 0:00:14.75
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc49/CMakeLists.txt
+++ b/tests/cc49/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc49 "psi;quicktests;cc;autotest;noc1")
+add_regression_test(cc49 "psi;quicktests;cc;noc1")

--- a/tests/cc49/input.dat
+++ b/tests/cc49/input.dat
@@ -100,4 +100,12 @@ D 2 1.00
 ****
 }
 
+scf_ref = -38.277306979617 # TEST
+cc3_ref = -38.387976380737 # TEST
+eom_ref = -38.221966233155 # TEST
+
 energy('eom-cc3')
+compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
+compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
+compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+

--- a/tests/cc49/output.ref
+++ b/tests/cc49/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev51 
+                               Psi4 1.6a1.dev56 
 
-                         Git: Rev {ccdensity_fix} 4732348 dirty
+                         Git: Rev {ccdensity_fix} 027e6dd dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 12 February 2022 03:24PM
+    Psi4 started on: Monday, 14 February 2022 02:00PM
 
-    Process ID: 65688
-    Host:       Jonathons-MacBook-Pro.local
+    Process ID: 11736
+    Host:       dhcp189-242.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -143,21 +143,29 @@ D 2 1.00
 ****
 }
 
+scf_ref = -38.277306979617 # TEST
+cc3_ref = -38.387976380737 # TEST
+eom_ref = -38.221966233155 # TEST
+
 energy('eom-cc3')
+compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
+compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
+compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:24:05 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 14:00:16 2022
 
    => Loading Basis Set <=
 
-    Name: ANONYMOUS4E2328E3
+    Name: ANONYMOUSC1823E4E
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line    22 inputblock anonymous4e2328e3 
-    atoms 2 entry H          line     5 inputblock anonymous4e2328e3 
+    atoms 1 entry C          line    22 inputblock anonymousc1823e4e 
+    atoms 2 entry H          line     5 inputblock anonymousc1823e4e 
 
 
          ---------------------------------------------------------
@@ -205,8 +213,8 @@ Scratch directory: /tmp/
 
   ==> Primary Basis <==
 
-  Basis Set: ANONYMOUS4E2328E3
-    Blend: ANONYMOUS4E2328E3
+  Basis Set: ANONYMOUSC1823E4E
+    Blend: ANONYMOUSC1823E4E
     Number of shells: 15
     Number of basis functions: 33
     Number of Cartesian functions: 35
@@ -265,10 +273,10 @@ Scratch directory: /tmp/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:   -37.45954292475091   -3.74595e+01   0.00000e+00 
-   @UHF iter   1:   -38.26453327391502   -8.04990e-01   5.71337e-03 DIIS/ADIIS
-   @UHF iter   2:   -38.27598667903774   -1.14534e-02   1.57889e-03 DIIS/ADIIS
-   @UHF iter   3:   -38.27709976752695   -1.11309e-03   5.28488e-04 DIIS/ADIIS
-   @UHF iter   4:   -38.27727669693479   -1.76929e-04   1.87711e-04 DIIS/ADIIS
+   @UHF iter   1:   -38.26453327391502   -8.04990e-01   5.71337e-03 ADIIS/DIIS
+   @UHF iter   2:   -38.27598667903774   -1.14534e-02   1.57889e-03 ADIIS/DIIS
+   @UHF iter   3:   -38.27709976752695   -1.11309e-03   5.28488e-04 ADIIS/DIIS
+   @UHF iter   4:   -38.27727669693479   -1.76929e-04   1.87711e-04 ADIIS/DIIS
    @UHF iter   5:   -38.27730302381907   -2.63269e-05   6.21511e-05 DIIS
    @UHF iter   6:   -38.27730628568217   -3.26186e-06   2.36022e-05 DIIS
    @UHF iter   7:   -38.27730687486027   -5.89178e-07   9.31232e-06 DIIS
@@ -370,15 +378,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.5738     Total:     1.5738
 
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:06 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:00:16 2022
 Module time:
-	user time   =       0.79 seconds =       0.01 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.79 seconds =       0.01 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -403,8 +411,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:24:06 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 14:00:17 2022
 
 
 	Wfn Parameters:
@@ -548,15 +556,15 @@ Total time:
 	Two-electron energy          =      4.81061746528307
 	Reference energy             =    -38.27730697961738
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:07 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:00:17 2022
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.96 seconds =       0.02 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -1128,8 +1136,11 @@ Largest components of excited wave function #1:
         1   0 >   1   7     :    3a1    2a1 >    2b1   11a1 :   -0.0080607372
 
 	Total # of sigma evaluations: 79
+    SCF energy............................................................................PASSED
+    CC3 energy............................................................................PASSED
+    EOM-CC3 energy........................................................................PASSED
 
-    Psi4 stopped on: Saturday, 12 February 2022 03:24PM
-    Psi4 wall time for execution: 0:00:24.22
+    Psi4 stopped on: Monday, 14 February 2022 02:00PM
+    Psi4 wall time for execution: 0:00:13.45
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc49/output.ref
+++ b/tests/cc49/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:24PM
 
-    Process ID:  12967
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65688
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -133,21 +146,24 @@ D 2 1.00
 energy('eom-cc3')
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:48 2017
+Scratch directory: /tmp/
+
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:05 2022
 
    => Loading Basis Set <=
 
-    Name: ANONYMOUSAE27F5EE
+    Name: ANONYMOUS4E2328E3
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line    21 inputblock anonymousae27f5ee 
-    atoms 2 entry H          line     4 inputblock anonymousae27f5ee 
+    atoms 1 entry C          line    22 inputblock anonymous4e2328e3 
+    atoms 2 entry H          line     5 inputblock anonymous4e2328e3 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -161,14 +177,14 @@ energy('eom-cc3')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.086760274537    12.000000000000
-           H          0.000000000000     0.000000000000     1.033039725463     1.007825032070
+         C            0.000000000000     0.000000000000    -0.086760274550    12.000000000000
+         H            0.000000000000     0.000000000000     1.033039725450     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A = ************  B =     14.45952  C =     14.45952 [cm^-1]
-  Rotational constants: A = ************  B = 433485.49424  C = 433485.49424 [MHz]
-  Nuclear repulsion =    2.835384221771745
+  Rotational constants: A = ************  B = 433485.49748  C = 433485.49748 [MHz]
+  Nuclear repulsion =    2.835384232916593
 
   Charge       = 0
   Multiplicity = 2
@@ -182,33 +198,20 @@ energy('eom-cc3')
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
-  Basis Set: ANONYMOUSAE27F5EE
-    Blend: ANONYMOUSAE27F5EE
+  Basis Set: ANONYMOUS4E2328E3
+    Blend: ANONYMOUS4E2328E3
     Number of shells: 15
-    Number of basis function: 33
+    Number of basis functions: 33
     Number of Cartesian functions: 35
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        17      17       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         7       7       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      33      33       4       3       3       1
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -227,65 +230,83 @@ energy('eom-cc3')
   Using 315282 doubles for integral storage.
   We computed 7260 shell quartets total.
   Whereas there are 7260 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 1.0499441244E-03.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 1.0499441166E-03.
+  Reciprocal condition number of the overlap matrix is 2.3703254544E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        17      17 
+     A2         2       2 
+     B1         7       7 
+     B2         7       7 
+   -------------------------
+    Total      33      33
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter   1:   -34.70652421946105   -3.47065e+01   4.24647e-01 
-   @UHF iter   2:   -38.23136885398449   -3.52484e+00   1.84971e-02 DIIS
-   @UHF iter   3:   -38.27490535009881   -4.35365e-02   2.99348e-03 DIIS
-   @UHF iter   4:   -38.27698294393200   -2.07759e-03   6.95746e-04 DIIS
-   @UHF iter   5:   -38.27726221700927   -2.79273e-04   2.40501e-04 DIIS
-   @UHF iter   6:   -38.27730248183759   -4.02648e-05   7.00655e-05 DIIS
-   @UHF iter   7:   -38.27730655623873   -4.07440e-06   1.86294e-05 DIIS
-   @UHF iter   8:   -38.27730689142642   -3.35188e-07   8.48185e-06 DIIS
-   @UHF iter   9:   -38.27730697717777   -8.57514e-08   1.56881e-06 DIIS
-   @UHF iter  10:   -38.27730697941664   -2.23887e-09   4.87726e-07 DIIS
-   @UHF iter  11:   -38.27730697961557   -1.98924e-10   1.16907e-07 DIIS
-   @UHF iter  12:   -38.27730697962669   -1.11200e-11   1.97258e-08 DIIS
-   @UHF iter  13:   -38.27730697962704   -3.55271e-13   3.29261e-09 DIIS
+   @UHF iter SAD:   -37.45954292475091   -3.74595e+01   0.00000e+00 
+   @UHF iter   1:   -38.26453327391502   -8.04990e-01   5.71337e-03 DIIS/ADIIS
+   @UHF iter   2:   -38.27598667903774   -1.14534e-02   1.57889e-03 DIIS/ADIIS
+   @UHF iter   3:   -38.27709976752695   -1.11309e-03   5.28488e-04 DIIS/ADIIS
+   @UHF iter   4:   -38.27727669693479   -1.76929e-04   1.87711e-04 DIIS/ADIIS
+   @UHF iter   5:   -38.27730302381907   -2.63269e-05   6.21511e-05 DIIS
+   @UHF iter   6:   -38.27730628568217   -3.26186e-06   2.36022e-05 DIIS
+   @UHF iter   7:   -38.27730687486027   -5.89178e-07   9.31232e-06 DIIS
+   @UHF iter   8:   -38.27730697547304   -1.00613e-07   2.17470e-06 DIIS
+   @UHF iter   9:   -38.27730697939126   -3.91822e-09   5.18737e-07 DIIS
+   @UHF iter  10:   -38.27730697960749   -2.16239e-10   1.08043e-07 DIIS
+   @UHF iter  11:   -38.27730697961708   -9.58522e-12   1.75408e-08 DIIS
+   @UHF iter  12:   -38.27730697961735   -2.70006e-13   3.56930e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   9.241627961E-03
+   @Spin Contamination Metric:   9.241628135E-03
    @S^2 Expected:                7.500000000E-01
-   @S^2 Observed:                7.592416280E-01
+   @S^2 Observed:                7.592416281E-01
    @S   Expected:                5.000000000E-01
    @S   Observed:                5.000000000E-01
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
        1A1   -11.332066     2A1    -0.879880     3A1    -0.473450  
-       1B2    -0.425620  
+       1B1    -0.425620  
 
     Alpha Virtual:                                                        
 
-       1B1     0.019307     4A1     0.035868     2B2     0.101627  
-       5A1     0.103816     2B1     0.130108     6A1     0.174058  
-       7A1     0.184475     3B1     0.188264     3B2     0.189598  
+       1B2     0.019307     4A1     0.035868     2B1     0.101627  
+       5A1     0.103816     2B2     0.130108     6A1     0.174058  
+       7A1     0.184475     3B2     0.188264     3B1     0.189598  
        1A2     0.202131     8A1     0.202634     9A1     0.318457  
-       4B2     0.346682     4B1     0.354375    10A1     0.474340  
-       5B2     0.624324    11A1     0.628900     5B1     0.678886  
-      12A1     0.782234     6B2     1.037449     6B1     1.058241  
+       4B1     0.346682     4B2     0.354375    10A1     0.474340  
+       5B1     0.624324    11A1     0.628900     5B2     0.678886  
+      12A1     0.782234     6B1     1.037449     6B2     1.058241  
       13A1     1.193737     2A2     1.259001    14A1     1.260374  
-      15A1     1.625309     7B2     1.664799     7B1     1.674532  
+      15A1     1.625309     7B1     1.664799     7B2     1.674532  
       16A1     2.345221    17A1    22.363067  
 
     Beta Occupied:                                                        
@@ -294,75 +315,70 @@ energy('eom-cc3')
 
     Beta Virtual:                                                         
 
-       1B1     0.032052     4A1     0.037461     1B2     0.060471  
-       5A1     0.105274     2B1     0.139305     2B2     0.171476  
-       6A1     0.179257     7A1     0.186913     3B1     0.188374  
-       3B2     0.196685     1A2     0.209591     8A1     0.211724  
-       9A1     0.323329     4B1     0.356299     4B2     0.368272  
-      10A1     0.486245    11A1     0.641904     5B1     0.691463  
-       5B2     0.733070    12A1     0.792211     6B1     1.061890  
-       6B2     1.089579    13A1     1.218703     2A2     1.339895  
-      14A1     1.341582    15A1     1.650039     7B1     1.680181  
-       7B2     1.715921    16A1     2.357084    17A1    22.380139  
+       1B2     0.032052     4A1     0.037461     1B1     0.060471  
+       5A1     0.105274     2B2     0.139305     2B1     0.171476  
+       6A1     0.179257     7A1     0.186913     3B2     0.188374  
+       3B1     0.196685     1A2     0.209591     8A1     0.211724  
+       9A1     0.323329     4B2     0.356299     4B1     0.368272  
+      10A1     0.486245    11A1     0.641904     5B2     0.691463  
+       5B1     0.733070    12A1     0.792211     6B2     1.061890  
+       6B1     1.089579    13A1     1.218703     2A2     1.339895  
+      14A1     1.341582    15A1     1.650039     7B2     1.680181  
+       7B1     1.715921    16A1     2.357084    17A1    22.380139  
 
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    0,    0 ]
-    SOCC [     0,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
 
-  Energy converged.
-
-  @UHF Final Energy:   -38.27730697962704
+  @UHF Final Energy:   -38.27730697961735
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              2.8353842217717449
-    One-Electron Energy =                 -56.5869343318169626
-    Two-Electron Energy =                  15.4742431304181736
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -38.2773069796270420
-
+    Nuclear Repulsion Energy =              2.8353842329165926
+    One-Electron Energy =                 -56.5869343457647034
+    Two-Electron Energy =                  15.4742431332307575
+    Total Energy =                        -38.2773069796173502
 
   UHF NO Occupations:
   HONO-2 :    2 A1 1.9995061
   HONO-1 :    3 A1 1.9958651
-  HONO-0 :    1 B2 1.0000000
+  HONO-0 :    1 B1 1.0000000
   LUNO+0 :    4 A1 0.0041349
   LUNO+1 :    5 A1 0.0004939
   LUNO+2 :    6 A1 0.0000006
   LUNO+3 :    7 A1 0.0000000
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9684
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.3492
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.6192     Total:     0.6192
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     1.5738     Total:     1.5738
 
 
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:06 2022
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.79 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.79 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -376,19 +392,19 @@ Total time:
       Number of basis functions:        33
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  17    2    7    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 37814 non-zero two-electron integrals.
+      Computed 34324 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:48 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:24:06 2022
 
 
 	Wfn Parameters:
@@ -406,14 +422,14 @@ Total time:
 	-----	-----	------	------	------	------	------
 	 A1	   17	    1	    2	    0	    14	    0
 	 A2	   2	    0	    0	    0	    2	    0
-	 B1	   7	    0	    0	    0	    7	    0
-	 B2	   7	    0	    0	    1	    6	    0
+	 B1	   7	    0	    0	    1	    6	    0
+	 B2	   7	    0	    0	    0	    7	    0
 	Transforming integrals...
 	IWL integrals will be deleted.
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -473,12 +489,12 @@ Total time:
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -33.30400348951427
+	Frozen core energy     =    -33.30400349325223
 
 	Size of irrep 0 of <AB|CD> integrals:      0.016 (MW) /      0.131 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.005 (MW) /      0.039 (MB)
-	Size of irrep 2 of <AB|CD> integrals:      0.012 (MW) /      0.097 (MB)
-	Size of irrep 3 of <AB|CD> integrals:      0.010 (MW) /      0.077 (MB)
+	Size of irrep 2 of <AB|CD> integrals:      0.010 (MW) /      0.077 (MB)
+	Size of irrep 3 of <AB|CD> integrals:      0.012 (MW) /      0.097 (MB)
 	Total:                                     0.043 (MW) /      0.344 (MB)
 
 	Size of irrep 0 of <ab|cd> integrals:      0.018 (MW) /      0.144 (MB)
@@ -489,14 +505,14 @@ Total time:
 
 	Size of irrep 0 of <Ab|Cd> integrals:      0.085 (MW) /      0.677 (MB)
 	Size of irrep 1 of <Ab|Cd> integrals:      0.022 (MW) /      0.173 (MB)
-	Size of irrep 2 of <Ab|Cd> integrals:      0.049 (MW) /      0.394 (MB)
-	Size of irrep 3 of <Ab|Cd> integrals:      0.044 (MW) /      0.353 (MB)
+	Size of irrep 2 of <Ab|Cd> integrals:      0.044 (MW) /      0.353 (MB)
+	Size of irrep 3 of <Ab|Cd> integrals:      0.049 (MW) /      0.394 (MB)
 	Total:                                     0.200 (MW) /      1.597 (MB)
 
 	Size of irrep 0 of <IA|BC> integrals:      0.010 (MW) /      0.078 (MB)
 	Size of irrep 1 of <IA|BC> integrals:      0.002 (MW) /      0.012 (MB)
-	Size of irrep 2 of <IA|BC> integrals:      0.004 (MW) /      0.028 (MB)
-	Size of irrep 3 of <IA|BC> integrals:      0.005 (MW) /      0.041 (MB)
+	Size of irrep 2 of <IA|BC> integrals:      0.005 (MW) /      0.041 (MB)
+	Size of irrep 3 of <IA|BC> integrals:      0.004 (MW) /      0.028 (MB)
 	Total:                                     0.020 (MW) /      0.159 (MB)
 
 	Size of irrep 0 of <ia|bc> integrals:      0.008 (MW) /      0.067 (MB)
@@ -507,53 +523,49 @@ Total time:
 
 	Size of irrep 0 of <Ia|Bc> integrals:      0.010 (MW) /      0.081 (MB)
 	Size of irrep 1 of <Ia|Bc> integrals:      0.002 (MW) /      0.013 (MB)
-	Size of irrep 2 of <Ia|Bc> integrals:      0.004 (MW) /      0.028 (MB)
-	Size of irrep 3 of <Ia|Bc> integrals:      0.006 (MW) /      0.047 (MB)
+	Size of irrep 2 of <Ia|Bc> integrals:      0.006 (MW) /      0.047 (MB)
+	Size of irrep 3 of <Ia|Bc> integrals:      0.004 (MW) /      0.028 (MB)
 	Total:                                     0.021 (MW) /      0.170 (MB)
 
 	Size of irrep 0 of <iA|bC> integrals:      0.008 (MW) /      0.065 (MB)
 	Size of irrep 1 of <iA|bC> integrals:      0.001 (MW) /      0.005 (MB)
-	Size of irrep 2 of <iA|bC> integrals:      0.003 (MW) /      0.025 (MB)
-	Size of irrep 3 of <iA|bC> integrals:      0.003 (MW) /      0.020 (MB)
+	Size of irrep 2 of <iA|bC> integrals:      0.003 (MW) /      0.020 (MB)
+	Size of irrep 3 of <iA|bC> integrals:      0.003 (MW) /      0.025 (MB)
 	Total:                                     0.014 (MW) /      0.115 (MB)
 
 	Size of irrep 0 of tIjAb amplitudes:       0.001 (MW) /      0.009 (MB)
 	Size of irrep 1 of tIjAb amplitudes:       0.000 (MW) /      0.000 (MB)
-	Size of irrep 2 of tIjAb amplitudes:       0.000 (MW) /      0.000 (MB)
-	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
+	Size of irrep 2 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
+	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.000 (MB)
 	Total:                                     0.002 (MW) /      0.013 (MB)
 
-	Nuclear Rep. energy          =      2.83538422177174
-	SCF energy                   =    -38.27730697962704
-	One-electron energy          =    -12.61930516882379
-	Two-electron (AA) energy     =      1.28902381202298
-	Two-electron (BB) energy     =      0.38514919053510
-	Two-electron (AB) energy     =      3.13644445438111
-	Two-electron energy          =      4.81061745693919
-	Reference energy             =    -38.27730697962713
+	Nuclear Rep. energy          =      2.83538423291659
+	SCF energy                   =    -38.27730697961735
+	One-electron energy          =    -12.61930518456482
+	Two-electron (AA) energy     =      1.28902381507314
+	Two-electron (BB) energy     =      0.38514919089554
+	Two-electron (AB) energy     =      3.13644445931440
+	Two-electron energy          =      4.81061746528307
+	Reference energy             =    -38.27730697961738
 
-*** tstop() called on psinet at Mon May 15 15:34:48 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:07 2022
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.33 seconds =       0.01 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:48 2017
-
+	user time   =       0.96 seconds =       0.02 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    2.835384221771745
-    SCF energy          (wfn)     =  -38.277306979627042
-    Reference energy    (file100) =  -38.277306979627127
+    Nuclear Rep. energy (wfn)     =    2.835384232916593
+    SCF energy          (wfn)     =  -38.277306979617350
+    Reference energy    (file100) =  -38.277306979617379
 
     Input parameters:
     -----------------
@@ -582,114 +594,101 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.0814764555418745
+MP2 correlation energy -0.0814764554506603
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.081476455541875    0.000e+00    0.000000    0.000000    0.000000    0.000000
-     1        -0.100346437879241    5.672e-02    0.008161    0.000000    0.000000    0.000000
-     2        -0.109555884228064    2.715e-02    0.015638    0.000000    0.000000    0.000000
-     3        -0.110501036047185    9.720e-03    0.018561    0.000000    0.000000    0.000000
-     4        -0.110667164979787    3.256e-03    0.018723    0.000000    0.000000    0.000000
-     5        -0.110662429441292    1.394e-03    0.018601    0.000000    0.000000    0.000000
-     6        -0.110660987024067    6.048e-04    0.018487    0.000000    0.000000    0.000000
-     7        -0.110673862425119    1.639e-04    0.018479    0.000000    0.000000    0.000000
-     8        -0.110669652157116    4.988e-05    0.018476    0.000000    0.000000    0.000000
-     9        -0.110669471627574    1.884e-05    0.018477    0.000000    0.000000    0.000000
-    10        -0.110669329303501    7.575e-06    0.018478    0.000000    0.000000    0.000000
-    11        -0.110669493874249    2.779e-06    0.018478    0.000000    0.000000    0.000000
-    12        -0.110669433951639    1.046e-06    0.018478    0.000000    0.000000    0.000000
-    13        -0.110669399394369    3.340e-07    0.018478    0.000000    0.000000    0.000000
-    14        -0.110669399136719    1.268e-07    0.018478    0.000000    0.000000    0.000000
-    15        -0.110669401611305    4.838e-08    0.018478    0.000000    0.000000    0.000000
+     0        -0.081476455450660    0.000e+00    0.000000    0.000000    0.000000    0.000000
+     1        -0.100346437539435    5.672e-02    0.008161    0.000000    0.000000    0.000000
+     2        -0.109555883752014    2.715e-02    0.015638    0.000000    0.000000    0.000000
+     3        -0.110501035613285    9.720e-03    0.018561    0.000000    0.000000    0.000000
+     4        -0.110667164490028    3.256e-03    0.018723    0.000000    0.000000    0.000000
+     5        -0.110662428949275    1.394e-03    0.018601    0.000000    0.000000    0.000000
+     6        -0.110660986530976    6.048e-04    0.018487    0.000000    0.000000    0.000000
+     7        -0.110673861931800    1.639e-04    0.018479    0.000000    0.000000    0.000000
+     8        -0.110669651665970    4.988e-05    0.018476    0.000000    0.000000    0.000000
+     9        -0.110669471136449    1.884e-05    0.018477    0.000000    0.000000    0.000000
+    10        -0.110669328812437    7.575e-06    0.018478    0.000000    0.000000    0.000000
+    11        -0.110669493383145    2.779e-06    0.018478    0.000000    0.000000    0.000000
+    12        -0.110669433460538    1.046e-06    0.018478    0.000000    0.000000    0.000000
+    13        -0.110669398903257    3.340e-07    0.018478    0.000000    0.000000    0.000000
+    14        -0.110669398645605    1.268e-07    0.018478    0.000000    0.000000    0.000000
+    15        -0.110669401120191    4.838e-08    0.018478    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2  23        -0.0157828816
-              1  10         0.0103153833
-              2  25        -0.0100703291
-              0  10         0.0098360812
-              1   4         0.0084650842
-              2  26        -0.0058800163
-              0   4         0.0057794622
-              1   5         0.0046285327
-              0  11         0.0044674314
-              2  24        -0.0037007702
+              2  16        -0.0157828690
+              1  10         0.0103153838
+              2  18        -0.0100703290
+              0  10         0.0098360820
+              1   4         0.0084650867
+              2  19        -0.0058800112
+              0   4         0.0057794636
+              1   5         0.0046285318
+              0  11         0.0044674299
+              2  17        -0.0037007724
 
     Largest Tia Amplitudes:
-              1   2         0.0125268338
-              1   7         0.0107240117
-              0  11         0.0091243135
-              0   6         0.0085589899
-              1   6         0.0082884843
-              0   8        -0.0078387895
-              1   5         0.0077298636
-              0   2         0.0074681216
-              0   7         0.0073546278
-              0   5         0.0065540954
+              1   2         0.0125268742
+              1   7         0.0107240146
+              0  11         0.0091243130
+              0   6         0.0085589765
+              1   6         0.0082885080
+              0   8        -0.0078387770
+              1   5         0.0077298645
+              0   2         0.0074681092
+              0   7         0.0073546359
+              0   5         0.0065540783
 
     Largest TIJAB Amplitudes:
-      2   1  27   8        -0.0170039751
-      2   1  26   7        -0.0168950876
-      2   1  26   8        -0.0131880576
-      2   1  25   8        -0.0126949141
-      2   1  25   5         0.0116821295
-      2   1  27   5         0.0116725485
-      2   0  16  15        -0.0114956908
-      2   0  26   9        -0.0113966858
-      2   1  26   5         0.0113407250
-      2   1  26   1        -0.0111991649
+      2   1  20   8        -0.0170039754
+      2   1  19   7        -0.0168950880
+      2   1  19   8        -0.0131880577
+      2   1  18   8        -0.0126949142
+      2   1  18   5         0.0116821295
+      2   1  20   5         0.0116725487
+      2   0  22  15        -0.0114956909
+      2   0  19   9        -0.0113966859
+      2   1  19   5         0.0113407249
+      2   1  19   1        -0.0111991649
 
     Largest Tijab Amplitudes:
-      1   0  28  24        -0.0098916695
-      1   0  21  16        -0.0089611466
-      1   0  28  23        -0.0078335632
-      1   0  21  17        -0.0074816940
-      1   0  11   8         0.0069531224
-      1   0   7   6        -0.0065143494
-      1   0   6   5        -0.0060795161
+      1   0  21  17        -0.0098916695
+      1   0  28  23        -0.0089611465
+      1   0  21  16        -0.0078335632
+      1   0  28  24        -0.0074816941
+      1   0  11   8         0.0069531223
+      1   0   7   6        -0.0065143497
+      1   0   6   5        -0.0060795159
       1   0   9   7         0.0055672956
       1   0  11   5        -0.0055040374
-      1   0  19  16        -0.0054916512
+      1   0  26  23        -0.0054916517
 
     Largest TIjAb Amplitudes:
-      1   1  16  16        -0.0697656680
-      1   1  16  17        -0.0534779325
-      1   1  17  16        -0.0443432019
-      0   0  16  16        -0.0422728850
-      1   1   8   8        -0.0422027053
-      0   0  16  17        -0.0355368002
-      1   1  17  17        -0.0340105973
-      0   1  16  16        -0.0337951131
-      0   0  17  16        -0.0294540186
-      0   1  16  17        -0.0290773411
+      1   1  22  23        -0.0697656670
+      1   1  22  24        -0.0534779328
+      1   1  23  23        -0.0443432011
+      0   0  22  23        -0.0422728853
+      1   1   8   8        -0.0422027057
+      0   0  22  24        -0.0355368002
+      1   1  23  24        -0.0340105974
+      0   1  22  23        -0.0337951108
+      0   0  23  23        -0.0294540187
+      0   1  22  24        -0.0290773407
 
-    SCF energy       (wfn)                    =  -38.277306979627042
-    Reference energy (file100)                =  -38.277306979627127
+    SCF energy       (wfn)                    =  -38.277306979617350
+    Reference energy (file100)                =  -38.277306979617379
 
-    Opposite-spin MP2 correlation energy      =   -0.069193482636870
-    Same-spin MP2 correlation energy          =   -0.012282972905003
-    MP2 correlation energy                    =   -0.081476455541874
-      * MP2 total energy                      =  -38.358783435169002
-    CC3 correlation energy                    =   -0.110669401611305
-      * CC3 total energy                      =  -38.387976381238431
-
-
-*** tstop() called on psinet at Mon May 15 15:34:50 2017
-Module time:
-	user time   =       1.22 seconds =       0.02 minutes
-	system time =       0.74 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-Total time:
-	user time   =       1.55 seconds =       0.03 minutes
-	system time =       0.86 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:50 2017
+    Opposite-spin MP2 correlation energy      =   -0.069193482559705
+    Same-spin MP2 correlation energy          =   -0.012282972890956
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.081476455450660
+      * MP2 total energy                      =  -38.358783435068041
+    CC3 correlation energy                    =   -0.110669401120191
+      * CC3 total energy                      =  -38.387976380737570
 
 
 			**************************
@@ -700,67 +699,53 @@ Total time:
 
 Dots of (HeT1)c in names "CC3 Wxxx" in CC3_HET1 
 Wamef terms
-	<WAMEF|WAMEF> =    1.5148725370
-	<Wamef|Wamef> =    1.0781495800
-	<WAmEf|WAmEf> =    0.9962446031
-	<WaMeF|WaMeF> =    1.5623092091
+	<WAMEF|WAMEF> =    1.5148725334
+	<Wamef|Wamef> =    1.0781495812
+	<WAmEf|WAmEf> =    0.9962446023
+	<WaMeF|WaMeF> =    1.5623092072
 Wmnie terms
 	<WMNIE (M>N,IE)|WMNIE> =    0.1456067411
-	<Wmnie (m>n,ie)|Wmnie> =    0.0398536973
-	<WMnIe (Mn,Ie)|WMnIe> =    0.1546210376
-	<WmNiE (mN,iE)|WmNiE> =    0.1237859370
+	<Wmnie (m>n,ie)|Wmnie> =    0.0398536974
+	<WMnIe (Mn,Ie)|WMnIe> =    0.1546210380
+	<WmNiE (mN,iE)|WmNiE> =    0.1237859378
 	<WMNIE(M>N,EI)|WMNIE(M>N,EI)> =    0.1456067411
-	<Wmnie(m>n,ei)|Wmnie(m>n,ei)> =    0.0398536973
-	<WMnIe(Mn,eI)|WMnIe(Mn,eI)> =    0.1546210376
-	<WmNiE(mN,Ei)|WmNiE(mN,Ei)> =    0.1237859370
+	<Wmnie(m>n,ei)|Wmnie(m>n,ei)> =    0.0398536974
+	<WMnIe(Mn,eI)|WMnIe(Mn,eI)> =    0.1546210380
+	<WmNiE(mN,Ei)|WmNiE(mN,Ei)> =    0.1237859378
 Doing Wmnij terms.
-	<WMNIJ (M>N,I>J)|WMNIJ> =    2.2118780236
-	<Wmnij (m>n,i>j)|Wmnij> =    0.6008944959
-	<WMnIj (Mn,Ij)|WMnIj> =    1.7132337182
+	<WMNIJ (M>N,I>J)|WMNIJ> =    2.2118780417
+	<Wmnij (m>n,i>j)|Wmnij> =    0.6008944947
+	<WMnIj (Mn,Ij)|WMnIj> =    1.7132337258
 Doing Wmbij terms.
-	<WMBIJ (MB,I>J)|WMBIJ> =    0.1472562810
-	<WMBIJ (I>J,MB)|WMBIJ> =    0.1472562810
-	<Wmbij (mb,i>j)|Wmbij> =    0.0397130853
-	<Wmbij (i>j,mb)|Wmbij> =    0.0397130853
-	<WMbIj (Mb,Ij)|WMbIj> =    0.1558746843
-	<WMbIj (Ij,Mb)|WMbIj> =    0.1558746843
-	<WmBiJ (mB,iJ)|WmBiJ> =    0.1252729444
-	<WmBiJ (iJ,mB)|WmBiJ> =    0.1252729444
+	<WMBIJ (MB,I>J)|WMBIJ> =    0.1472562803
+	<WMBIJ (I>J,MB)|WMBIJ> =    0.1472562803
+	<Wmbij (mb,i>j)|Wmbij> =    0.0397130845
+	<Wmbij (i>j,mb)|Wmbij> =    0.0397130845
+	<WMbIj (Mb,Ij)|WMbIj> =    0.1558746837
+	<WMbIj (Ij,Mb)|WMbIj> =    0.1558746837
+	<WmBiJ (mB,iJ)|WmBiJ> =    0.1252729449
+	<WmBiJ (iJ,mB)|WmBiJ> =    0.1252729449
 Doing Wmbej terms.
-	<WMBEJ (all ME,JB)|WMBEJ> =   10.8219311764
-	<Wmbej|Wmbej> =    7.5544196167
-	<WMbEj|WMbEj> =    0.1943831023
-	<WmBeJ|WmBeJ> =    0.1936252075
-	<WMbeJ|WMbeJ> =   13.8683345459
-	<WmBEj|WmBEj> =    8.5272847304
+	<WMBEJ (all ME,JB)|WMBEJ> =   10.8219312071
+	<Wmbej|Wmbej> =    7.5544196369
+	<WMbEj|WMbEj> =    0.1943831026
+	<WmBeJ|WmBeJ> =    0.1936252076
+	<WMbeJ|WMbeJ> =   13.8683345871
+	<WmBEj|WmBEj> =    8.5272847571
 Doing Wabei terms.
-	<WABEI (IE,B>A) |WABEI> =    1.5310506997
-	<Wabei (ie,b>a)|Wabei> =    1.0834646049
-	<WAbEi (iE,bA)|WAbEi> =    1.0090096112
-	<WAbEi (iE,Ba)|WAbEi> =    1.5797486226
-
-*** tstop() called on psinet at Mon May 15 15:34:51 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.57 seconds =       0.03 minutes
-	system time =       0.90 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:51 2017
-
+	<WABEI (IE,B>A) |WABEI> =    1.5310506930
+	<Wabei (ie,b>a)|Wabei> =    1.0834645866
+	<WAbEi (iE,bA)|WAbEi> =    1.0090096062
+	<WAbEi (iE,Ba)|WAbEi> =    1.5797486167
 
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    2.835384221771745
-	SCF energy          (wfn)     =  -38.277306979627042
-	Reference energy    (file100) =  -38.277306979627127
-	CC3 energy          (file100) =   -0.110669401611305
+	Nuclear Rep. energy (wfn)     =    2.835384232916593
+	SCF energy          (wfn)     =  -38.277306979617350
+	Reference energy    (file100) =  -38.277306979617379
+	CC3 energy          (file100) =   -0.110669401120191
 
 	Input parameters:
 	-----------------
@@ -788,359 +773,363 @@ Total time:
 	Residual vector toleranceSS = 1.0e-06
 	Complex tolerance           = 1.0e-12
 	Root for properties         =     2
-	Sym of state for properties =     B2
+	Sym of state for properties =     B1
 	Guess vectors taken from    = SINGLES
 	Restart EOM CC3             = NO
 	Collapse with last vector   = YES
 	Root following for CC3 turned on.
 
 
-Symmetry of ground state: B2
+
+Fae   dot Fae   total 1048.9031837995
+Fmi   dot Fmi   total    2.2574113079
+WmBeJ and WMbEj dots    0.3605429536
+Symmetry of ground state: B1
 Symmetry of excited state: A1
-Symmetry of right eigenvector: B2
+Symmetry of right eigenvector: B1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1941009288   1.94e-01    3.18e-01      N
-                     2   0.3082954089   3.08e-01    2.73e-01      N
-                     3   0.3710070579   3.71e-01    2.63e-01      N
+                     1   0.1941009401   1.94e-01    3.18e-01      N
+                     2   0.3082954144   3.08e-01    2.73e-01      N
+                     3   0.3710070605   3.71e-01    2.63e-01      N
 Iter=2    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1327440837  -6.14e-02    6.09e-02      N
-                     2   0.2412550846  -6.70e-02    6.16e-02      N
-                     3   0.3089080773  -6.21e-02    5.78e-02      N
+                     1   0.1327440955  -6.14e-02    6.09e-02      N
+                     2   0.2412550911  -6.70e-02    6.16e-02      N
+                     3   0.3089080796  -6.21e-02    5.78e-02      N
 Iter=3    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1290432523  -3.70e-03    3.28e-02      N
-                     2   0.2375003283  -3.75e-03    2.14e-02      N
-                     3   0.3050503167  -3.86e-03    2.28e-02      N
+                     1   0.1290432644  -3.70e-03    3.28e-02      N
+                     2   0.2375003351  -3.75e-03    2.14e-02      N
+                     3   0.3050503197  -3.86e-03    2.28e-02      N
 Iter=4    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1269053099  -2.14e-03    3.31e-02      N
-                     2   0.2369505490  -5.50e-04    1.80e-02      N
-                     3   0.3038564624  -1.19e-03    3.65e-02      N
+                     1   0.1269053223  -2.14e-03    3.31e-02      N
+                     2   0.2369505559  -5.50e-04    1.80e-02      N
+                     3   0.3038564652  -1.19e-03    3.65e-02      N
 Iter=5    L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1248811651  -2.02e-03    2.44e-02      N
-                     2   0.2265956603  -1.04e-02    1.48e-01      N
-                     3   0.2383630339  -6.55e-02    6.42e-02      N
+                     1   0.1248811775  -2.02e-03    2.44e-02      N
+                     2   0.2265956732  -1.04e-02    1.48e-01      N
+                     3   0.2383630420  -6.55e-02    6.42e-02      N
 Iter=6    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1241141155  -7.67e-04    1.29e-02      N
-                     2   0.2038930140  -2.27e-02    7.20e-02      N
-                     3   0.2373471810  -1.02e-03    1.08e-02      N
+                     1   0.1241141277  -7.67e-04    1.29e-02      N
+                     2   0.2038930269  -2.27e-02    7.20e-02      N
+                     3   0.2373471881  -1.02e-03    1.08e-02      N
 Iter=7    L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239245639  -1.90e-04    5.62e-03      N
-                     2   0.1982464816  -5.65e-03    3.47e-02      N
-                     3   0.2372563697  -9.08e-05    5.06e-03      N
+                     1   0.1239245760  -1.90e-04    5.62e-03      N
+                     2   0.1982464941  -5.65e-03    3.47e-02      N
+                     3   0.2372563767  -9.08e-05    5.06e-03      N
 Iter=8    L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239044012  -2.02e-05    1.93e-03      N
-                     2   0.1972490188  -9.97e-04    1.32e-02      N
-                     3   0.2372448334  -1.15e-05    2.07e-03      N
+                     1   0.1239044134  -2.02e-05    1.93e-03      N
+                     2   0.1972490312  -9.97e-04    1.32e-02      N
+                     3   0.2372448405  -1.15e-05    2.07e-03      N
 Iter=9    L=27    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239041492  -2.52e-07    6.84e-04      N
-                     2   0.1970992671  -1.50e-04    5.10e-03      N
-                     3   0.2372435609  -1.27e-06    8.22e-04      N
+                     1   0.1239041613  -2.52e-07    6.84e-04      N
+                     2   0.1970992794  -1.50e-04    5.10e-03      N
+                     3   0.2372435680  -1.27e-06    8.22e-04      N
 Iter=10   L=30    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239048977   7.48e-07    2.37e-04      N
-                     2   0.1970646853  -3.46e-05    2.00e-03      N
-                     3   0.2372438301   2.69e-07    3.45e-04      N
+                     1   0.1239049098   7.48e-07    2.37e-04      N
+                     2   0.1970646976  -3.46e-05    2.00e-03      N
+                     3   0.2372438371   2.69e-07    3.45e-04      N
 Iter=11   L=33    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050631   1.65e-07    8.12e-05      N
-                     2   0.1970639567  -7.29e-07    7.74e-04      N
-                     3   0.2372438636   3.35e-08    1.53e-04      N
+                     1   0.1239050753   1.65e-07    8.12e-05      N
+                     2   0.1970639690  -7.29e-07    7.74e-04      N
+                     3   0.2372438706   3.35e-08    1.53e-04      N
 Iter=12   L=36    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050258  -3.73e-08    2.57e-05      N
-                     2   0.1970651223   1.17e-06    2.74e-04      N
-                     3   0.2372438368  -2.68e-08    5.94e-05      N
+                     1   0.1239050380  -3.73e-08    2.57e-05      N
+                     2   0.1970651347   1.17e-06    2.74e-04      N
+                     3   0.2372438439  -2.68e-08    5.94e-05      N
 Iter=13   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050258   2.36e-15    2.57e-05      N
-                     2   0.1970651223   4.25e-15    2.74e-04      N
-                     3   0.2372438368   6.11e-16    5.94e-05      N
+                     1   0.1239050380  -2.05e-15    2.57e-05      N
+                     2   0.1970651347   3.11e-15    2.74e-04      N
+                     3   0.2372438439  -6.88e-15    5.94e-05      N
 Iter=14   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050251  -7.54e-10    8.00e-06      N
-                     2   0.1970650628  -5.96e-08    9.97e-05      N
-                     3   0.2372438300  -6.85e-09    2.42e-05      N
+                     1   0.1239050372  -7.54e-10    8.00e-06      N
+                     2   0.1970650751  -5.96e-08    9.97e-05      N
+                     3   0.2372438370  -6.85e-09    2.42e-05      N
 Iter=15   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050347   9.62e-09    2.74e-06      N
-                     2   0.1970650364  -2.63e-08    3.92e-05      N
-                     3   0.2372438232  -6.77e-09    1.05e-05      N
+                     1   0.1239050468   9.62e-09    2.74e-06      N
+                     2   0.1970650488  -2.63e-08    3.92e-05      N
+                     3   0.2372438302  -6.77e-09    1.05e-05      N
 Iter=16   L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050370   2.34e-09    1.09e-06      N
-                     2   0.1970650297  -6.71e-09    1.77e-05      N
-                     3   0.2372438377   1.44e-08    5.00e-06      N
+                     1   0.1239050492   2.34e-09    1.09e-06      N
+                     2   0.1970650421  -6.71e-09    1.77e-05      N
+                     3   0.2372438447   1.44e-08    5.00e-06      N
 Iter=17   L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050371   8.33e-11    4.19e-07      Y
-                     2   0.1970650163  -1.34e-08    8.11e-06      N
-                     3   0.2372438380   3.86e-10    2.63e-06      N
+                     1   0.1239050493   8.33e-11    4.19e-07      Y
+                     2   0.1970650287  -1.34e-08    8.11e-06      N
+                     3   0.2372438451   3.86e-10    2.63e-06      N
 Iter=18   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050369  -1.71e-10    1.59e-07      Y
-                     2   0.1970650130  -3.36e-09    3.36e-06      N
-                     3   0.2372438390   9.55e-10    1.16e-06      N
+                     1   0.1239050491  -1.71e-10    1.59e-07      Y
+                     2   0.1970650253  -3.36e-09    3.36e-06      N
+                     3   0.2372438460   9.55e-10    1.16e-06      N
 Iter=19   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050367  -2.88e-10    7.69e-08      Y
-                     2   0.1970650114  -1.53e-09    1.36e-06      N
-                     3   0.2372438397   6.61e-10    4.93e-07      Y
+                     1   0.1239050488  -2.88e-10    7.69e-08      Y
+                     2   0.1970650238  -1.53e-09    1.36e-06      N
+                     3   0.2372438467   6.61e-10    4.93e-07      Y
 Iter=20   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050366  -4.28e-11    6.01e-08      Y
-                     2   0.1970650094  -2.04e-09    5.79e-07      Y
-                     3   0.2372438388  -8.69e-10    2.79e-07      Y
+                     1   0.1239050488  -4.28e-11    6.01e-08      Y
+                     2   0.1970650217  -2.04e-09    5.79e-07      Y
+                     3   0.2372438458  -8.69e-10    2.79e-07      Y
 Completed EOM_CCSD
 Collapsing to only 3 vector(s).
 Copying root 2 to CC3_MISC file.
-Setting initial CC3 eigenvalue to    0.1970650094
+Setting initial CC3 eigenvalue to    0.1970650217
 Iter=1    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.166730
+	 0      0.166730
 	 1      0.976518
-	 2     -0.048593
+	 2      0.048593
 follow_root returning: 1
-                     2   0.1661693621  -3.09e-02    1.97e-02      N
+                     2   0.1661693746  -3.09e-02    1.97e-02      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0     -0.169538
-	 1     -0.975718
+	 1      0.975718
 	 2     -0.049372
-	 3      0.024080
+	 3     -0.024080
 follow_root returning: 1
-                     2   0.1657630111  -4.06e-04    7.54e-03      N
+                     2   0.1657630235  -4.06e-04    7.54e-03      N
 Iter=3    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.170493
+	 0      0.170493
 	 1      0.975289
-	 2      0.049503
+	 2     -0.049503
 	 3      0.029833
-	 4      0.010603
+	 4     -0.010603
 follow_root returning: 1
-                     2   0.1656914597  -7.16e-05    3.94e-03      N
+                     2   0.1656914721  -7.16e-05    3.94e-03      N
 Iter=4    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0      0.170375
-	 1      0.975149
+	 1     -0.975149
 	 2      0.049733
-	 3      0.033262
+	 3     -0.033262
 	 4     -0.004914
-	 5      0.013093
+	 5     -0.013093
 follow_root returning: 1
-                     2   0.1656706363  -2.08e-05    1.50e-03      N
+                     2   0.1656706487  -2.08e-05    1.50e-03      N
 Iter=5    L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.170377
+	 0     -0.170377
 	 1      0.975124
-	 2     -0.049731
+	 2      0.049731
 	 3      0.032644
-	 4      0.013423
+	 4     -0.013423
 	 5      0.003488
-	 6     -0.008274
+	 6      0.008274
 follow_root returning: 1
-                     2   0.1656693600  -1.28e-06    4.86e-04      N
+                     2   0.1656693724  -1.28e-06    4.86e-04      N
 Iter=6    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0     -0.170365
-	 1     -0.975121
+	 1      0.975121
 	 2     -0.049730
-	 3      0.031256
+	 3     -0.031256
 	 4     -0.014894
-	 5      0.002041
+	 5     -0.002041
 	 6      0.009854
-	 7     -0.005669
+	 7      0.005669
 follow_root returning: 1
-                     2   0.1656708162   1.46e-06    1.88e-04      N
+                     2   0.1656708286   1.46e-06    1.88e-04      N
 Iter=7    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.170391
+	 0     -0.170391
 	 1     -0.975121
-	 2     -0.049705
+	 2      0.049705
 	 3      0.029694
-	 4      0.016757
+	 4     -0.016757
 	 5     -0.011161
-	 6     -0.001627
+	 6      0.001627
 	 7     -0.001797
-	 8      0.006920
+	 8     -0.006920
 follow_root returning: 1
-                     2   0.1656712613   4.45e-07    7.12e-05      N
+                     2   0.1656712737   4.45e-07    7.12e-05      N
 Iter=8    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0     -0.170414
-	 1     -0.975121
+	 1      0.975121
 	 2      0.049678
 	 3      0.029185
-	 4      0.016886
-	 5      0.010933
+	 4     -0.016886
+	 5     -0.010933
 	 6      0.004199
-	 7     -0.008013
+	 7      0.008013
 	 8      0.001081
-	 9      0.004976
+	 9     -0.004976
 follow_root returning: 1
-                     2   0.1656713847   1.23e-07    2.92e-05      N
-Collapsing to 4 vector(s).
-Change in CC3 energy from last iterated value   -0.0313936247
-Iter=9    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1656713971   1.23e-07    2.92e-05      N
+Collapsing to 2 vector(s).
+Change in CC3 energy from last iterated value   -0.0313936246
+Iter=9    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.166618
-	 1      0.975860
-	 2     -0.014844
-	 3      0.006472
+	 0      0.166619
+	 1     -0.975860
 follow_root returning: 1
-                     2   0.1660139533   3.43e-04    2.58e-04      N
-Iter=10   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660138139   3.42e-04    2.59e-04      N
+Iter=10   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.166666
-	 1     -0.975869
-	 2     -0.016713
-	 3      0.037149
-	 4     -0.003753
+	 0      0.166658
+	 1      0.975869
+	 2     -0.038953
 follow_root returning: 1
-                     2   0.1660138997  -5.35e-08    9.63e-05      N
-Iter=11   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660138881   7.43e-08    1.02e-04      N
+Iter=11   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.166649
-	 1     -0.975876
-	 2      0.033890
-	 3      0.032282
-	 4     -0.004632
-	 5     -0.007918
+	 0      0.166647
+	 1      0.975875
+	 2      0.044721
+	 3      0.008334
 follow_root returning: 1
-                     2   0.1660139274   2.76e-08    5.36e-05      N
-Iter=12   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660139162   2.80e-08    5.60e-05      N
+Iter=12   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.166670
-	 1     -0.975880
-	 2     -0.048573
-	 3     -0.015156
-	 4      0.001860
-	 5      0.007030
-	 6      0.008009
+	 0     -0.166652
+	 1     -0.975879
+	 2      0.050716
+	 3     -0.000688
+	 4     -0.008693
 follow_root returning: 1
-                     2   0.1660139325   5.10e-09    2.14e-05      N
-Iter=13   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660139751   5.90e-08    2.25e-05      N
+Iter=13   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.166672
-	 1      0.975881
-	 2      0.050289
-	 3     -0.018239
-	 4     -0.004614
-	 5      0.000068
-	 6     -0.000616
-	 7      0.021690
+	 0     -0.166671
+	 1     -0.975881
+	 2      0.054240
+	 3     -0.004001
+	 4      0.003002
+	 5     -0.016914
 follow_root returning: 1
-                     2   0.1660139129  -1.96e-08    5.66e-06      N
-Iter=14   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660139575  -1.77e-08    9.48e-06      N
+Iter=14   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.166512
+	 0     -0.166552
+	 1     -0.975882
+	 2     -0.055969
+	 3     -0.004036
+	 4      0.010660
+	 5      0.014883
+	 6      0.000048
+follow_root returning: 1
+                     2   0.1660139096  -4.79e-08    5.77e-06      N
+Iter=15   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
+Overlaps of Rs with EOM CCSD eigenvector:
+	 0     -0.166517
 	 1      0.975882
-	 2      0.058962
-	 3      0.005475
-	 4      0.018067
-	 5      0.015780
-	 6     -0.004558
-	 7     -0.004840
-	 8     -0.004128
+	 2      0.049409
+	 3      0.024582
+	 4      0.019290
+	 5      0.001319
+	 6      0.002026
+	 7     -0.003740
 follow_root returning: 1
-                     2   0.1660138863  -2.66e-08    6.05e-06      N
-Iter=15   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660138857  -2.38e-08    3.38e-06      N
+Iter=16   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.166475
+	 0      0.166527
+	 1     -0.975883
+	 2      0.045720
+	 3      0.030373
+	 4     -0.018757
+	 5      0.008111
+	 6     -0.003082
+	 7     -0.005327
+	 8     -0.001609
+follow_root returning: 1
+                     2   0.1660138816  -4.15e-09    1.79e-06      N
+Iter=17   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
+Overlaps of Rs with EOM CCSD eigenvector:
+	 0      0.166542
 	 1      0.975883
-	 2      0.050180
-	 3      0.027156
-	 4      0.017645
-	 5     -0.011720
-	 6      0.006778
-	 7     -0.005194
-	 8      0.003509
-	 9     -0.001213
+	 2      0.044547
+	 3      0.031405
+	 4      0.018503
+	 5      0.007550
+	 6      0.008266
+	 7     -0.004665
+	 8      0.003283
+	 9      0.000356
 follow_root returning: 1
-                     2   0.1660138716  -1.48e-08    1.82e-06      N
-Collapsing to 4 vector(s).
-Change in CC3 energy from last iterated value    0.0003424869
-Iter=16   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660138805  -1.08e-09    7.87e-07      Y
+Collapsing to 2 vector(s).
+Change in CC3 energy from last iterated value    0.0003424834
+Iter=18   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.166516
+	 0     -0.166583
 	 1     -0.975875
-	 2     -0.048336
-	 3     -0.009962
 follow_root returning: 1
-                     2   0.1660100982  -3.77e-06    3.41e-06      N
-Iter=17   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660101054  -3.78e-06    3.05e-06      N
+Iter=19   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.166513
-	 1     -0.975875
-	 2     -0.046666
-	 3     -0.029561
-	 4      0.002370
+	 0     -0.166586
+	 1      0.975875
+	 2      0.034417
 follow_root returning: 1
-                     2   0.1660100954  -2.73e-09    1.57e-06      N
-Iter=18   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1660101056   1.93e-10    1.28e-06      N
+Iter=20   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.166510
+	 0      0.166589
 	 1     -0.975875
-	 2      0.046262
-	 3     -0.032048
-	 4      0.004136
-	 5     -0.004917
+	 2     -0.035262
+	 3      0.011354
 follow_root returning: 1
-                     2   0.1660100942  -1.24e-09    7.74e-07      Y
+                     2   0.1660101060   3.85e-10    7.16e-07      Y
 Forcing restart to make sure new sigma vectors give same eigenvalue.
 Collapsing to only 2 vector(s).
-Change in CC3 energy from last iterated value   -0.0000037774
-Setting old CC3 eigenvalue to    0.1660100942
-Iter=19   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
+Change in CC3 energy from last iterated value   -0.0000037745
+Setting old CC3 eigenvalue to    0.1660101060
+Iter=21   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.166510
+	 0     -0.166589
 	 1      0.975875
 follow_root returning: 1
-                     2   0.1660101358   4.16e-08    7.86e-07      Y
+                     2   0.1660101476   4.16e-08    7.25e-07      Y
 Collapsing to only 2 vector(s).
-Copying root 2 to start of EOM_Cxxx files.
+Copying root 2 to start of PSIF_EOM_Cxxx files.
 Change in CC3 energy from last iterated value    0.0000000416
 
 Procedure converged for 1 root(s).
-<R|R> =   1.0000000000000002
+<R|R> =   0.9999999999999999
 EOM CC3 R0 for root 0 =   0.00000000000
 
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      4.517    36435.0   0.1660101358   -38.221966245400
+EOM State 1      4.517    36435.0   0.1660101476   -38.221966233155
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         0 >   2      :       1b2 >    6a1 :   -0.0382027319
-         0 >   1      :       1b2 >    5a1 :   -0.0353416570
-         0 >   0      :       1b2 >    4a1 :   -0.0252978066
-         1 >   0      :       3a1 >    2b2 :   -0.0242731694
-         0 >   6      :       1b2 >   10a1 :   -0.0236335428
+         0 >   2      :       1b1 >    6a1 :    0.0382030601
+         0 >   1      :       1b1 >    5a1 :    0.0353416061
+         0 >   0      :       1b1 >    4a1 :    0.0252982963
+         1 >   0      :       3a1 >    2b1 :    0.0242731232
+         0 >   6      :       1b1 >   10a1 :    0.0236336524
  Ria (libdpd indices) : (cscf notation)
-         1 >   0      :       3a1 >    1b2 :    0.3896733400
-         1 >   1      :       3a1 >    2b2 :    0.3039742608
-         1 >   2      :       3a1 >    3b2 :    0.0932120291
-         1 >   4      :       3a1 >    5b2 :    0.0731098628
-         1 >   3      :       3a1 >    4b2 :    0.0569436043
+         1 >   0      :       3a1 >    1b1 :   -0.3896733590
+         1 >   1      :       3a1 >    2b1 :   -0.3039742462
+         1 >   2      :       3a1 >    3b1 :   -0.0932120528
+         1 >   4      :       3a1 >    5b1 :   -0.0731098759
+         1 >   3      :       3a1 >    4b1 :   -0.0569435854
  RIjAb (libdpd indices)     : (cscf notation)
-        0   1 >   0   0     :    1b2    3a1 >    1b1    1b1 :    0.6395378754
-        0   1 >   0   1     :    1b2    3a1 >    1b1    2b1 :    0.3575591853
-        0   1 >   1   0     :    1b2    3a1 >    2b1    1b1 :    0.3170857139
-        0   1 >   1   1     :    1b2    3a1 >    2b1    2b1 :    0.1511145054
-        0   1 >   4   0     :    1b2    3a1 >    5b1    1b1 :    0.1166013878
+        0   1 >   0   0     :    1b1    3a1 >    1b2    1b2 :   -0.6395377979
+        0   1 >   0   1     :    1b1    3a1 >    1b2    2b2 :   -0.3575592097
+        0   1 >   1   0     :    1b1    3a1 >    2b2    1b2 :   -0.3170857713
+        0   1 >   1   1     :    1b1    3a1 >    2b2    2b2 :   -0.1511145456
+        0   1 >   4   0     :    1b1    3a1 >    5b2    1b2 :   -0.1166013747
  RIJAB (libdpd indices)     : (cscf notation)
-        0   1 >   1   0     :    1b2    3a1 >    2b1    1b1 :    0.0307445836
-        0   1 >   3   0     :    1b2    3a1 >    4b1    1b1 :    0.0211630892
-        0   1 >   5   0     :    1b2    3a1 >    6b1    1b1 :    0.0192656959
-        0   1 >   6   0     :    1b2    3a1 >    7b1    1b1 :   -0.0162363961
-        0   1 >   4   0     :    1b2    3a1 >    5b1    1b1 :    0.0158140200
+        0   1 >   1   0     :    1b1    3a1 >    2b2    1b2 :   -0.0307447420
+        0   1 >   3   0     :    1b1    3a1 >    4b2    1b2 :   -0.0211631255
+        0   1 >   5   0     :    1b1    3a1 >    6b2    1b2 :   -0.0192657333
+        0   1 >   6   0     :    1b1    3a1 >    7b2    1b2 :    0.0162363812
+        0   1 >   4   0     :    1b1    3a1 >    5b2    1b2 :   -0.0158140888
  Rijab (libdpd indices)     : (cscf notation)
-        1   0 >   0   1     :    3a1    2a1 >    1b1    2a2 :    0.0092782148
-        1   0 >   0   8     :    3a1    2a1 >    1b2   12a1 :   -0.0092477652
-        1   0 >   0   5     :    3a1    2a1 >    1b2    9a1 :    0.0088313464
-        1   0 >   0   2     :    3a1    2a1 >    1b2    6a1 :    0.0082159284
-        1   0 >   1   7     :    3a1    2a1 >    2b2   11a1 :    0.0080607441
+        1   0 >   0   1     :    3a1    2a1 >    1b2    2a2 :   -0.0092782013
+        1   0 >   0   8     :    3a1    2a1 >    1b1   12a1 :    0.0092477619
+        1   0 >   0   5     :    3a1    2a1 >    1b1    9a1 :   -0.0088313419
+        1   0 >   0   2     :    3a1    2a1 >    1b1    6a1 :   -0.0082159237
+        1   0 >   1   7     :    3a1    2a1 >    2b1   11a1 :   -0.0080607372
 
-	Total # of sigma evaluations: 81
+	Total # of sigma evaluations: 79
 
-*** tstop() called on psinet at Mon May 15 15:34:57 2017
-Module time:
-	user time   =       4.79 seconds =       0.08 minutes
-	system time =       1.97 seconds =       0.03 minutes
-	total time  =          6 seconds =       0.10 minutes
-Total time:
-	user time   =       6.36 seconds =       0.11 minutes
-	system time =       2.87 seconds =       0.05 minutes
-	total time  =          9 seconds =       0.15 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:24PM
+    Psi4 wall time for execution: 0:00:24.22
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc50/CMakeLists.txt
+++ b/tests/cc50/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc50 "psi;cc;autotest;noc1")
+add_regression_test(cc50 "psi;cc;noc1")

--- a/tests/cc50/input.dat
+++ b/tests/cc50/input.dat
@@ -100,4 +100,12 @@ D 2 1.00
 ****
 }
 
+scf_ref = -38.273017419213 # TEST
+cc3_ref = -38.387945828926 # TEST
+eom_ref = -38.223605162856 # TEST
+
 energy('eom-cc3')
+compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
+compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
+compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+

--- a/tests/cc50/output.ref
+++ b/tests/cc50/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:23PM
 
-    Process ID:  12997
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65665
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -133,21 +146,24 @@ D 2 1.00
 energy('eom-cc3')
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:50 2017
+Scratch directory: /tmp/
+
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:23:06 2022
 
    => Loading Basis Set <=
 
-    Name: ANONYMOUSB715C11D
+    Name: ANONYMOUSAF20C94B
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line    21 inputblock anonymousb715c11d 
-    atoms 2 entry H          line     4 inputblock anonymousb715c11d 
+    atoms 1 entry C          line    22 inputblock anonymousaf20c94b 
+    atoms 2 entry H          line     5 inputblock anonymousaf20c94b 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              ROHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -161,14 +177,14 @@ energy('eom-cc3')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.086760274537    12.000000000000
-           H          0.000000000000     0.000000000000     1.033039725463     1.007825032070
+         C            0.000000000000     0.000000000000    -0.086760274550    12.000000000000
+         H            0.000000000000     0.000000000000     1.033039725450     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A = ************  B =     14.45952  C =     14.45952 [cm^-1]
-  Rotational constants: A = ************  B = 433485.49424  C = 433485.49424 [MHz]
-  Nuclear repulsion =    2.835384221771745
+  Rotational constants: A = ************  B = 433485.49748  C = 433485.49748 [MHz]
+  Nuclear repulsion =    2.835384232916593
 
   Charge       = 0
   Multiplicity = 2
@@ -182,33 +198,20 @@ energy('eom-cc3')
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
-  Basis Set: ANONYMOUSB715C11D
-    Blend: ANONYMOUSB715C11D
+  Basis Set: ANONYMOUSAF20C94B
+    Blend: ANONYMOUSAF20C94B
     Number of shells: 15
-    Number of basis function: 33
+    Number of basis functions: 33
     Number of Cartesian functions: 35
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        17      17       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         7       7       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      33      33       4       3       3       1
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -227,52 +230,58 @@ energy('eom-cc3')
   Using 315282 doubles for integral storage.
   We computed 7260 shell quartets total.
   Whereas there are 7260 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 1.0499441244E-03.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 1.0499441166E-03.
+  Reciprocal condition number of the overlap matrix is 2.3703254544E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        17      17 
+     A2         2       2 
+     B1         7       7 
+     B2         7       7 
+   -------------------------
+    Total      33      33
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     3,    0,    0,    0 ]
-    SOCC [     1,    0,    0,    0 ]
+   @ROHF iter SAD:   -37.45954292475090   -3.74595e+01   0.00000e+00 
+   @ROHF iter   1:   -38.26453327391503   -8.04990e-01   3.46355e-03 DIIS
+   @ROHF iter   2:   -38.27251920193596   -7.98593e-03   8.16960e-04 DIIS
+   @ROHF iter   3:   -38.27295120727584   -4.32005e-04   2.67407e-04 DIIS
+   @ROHF iter   4:   -38.27301142214120   -6.02149e-05   8.29387e-05 DIIS
+   @ROHF iter   5:   -38.27301723373259   -5.81159e-06   1.24737e-05 DIIS
+   @ROHF iter   6:   -38.27301740652690   -1.72794e-07   3.64619e-06 DIIS
+   @ROHF iter   7:   -38.27301741887935   -1.23524e-08   5.48378e-07 DIIS
+   @ROHF iter   8:   -38.27301741919671   -3.17357e-10   1.07000e-07 DIIS
+   @ROHF iter   9:   -38.27301741921254   -1.58380e-11   2.96257e-08 DIIS
+   @ROHF iter  10:   -38.27301741921377   -1.22924e-12   4.84748e-09 DIIS
+  Energy and wave function converged.
 
-   @ROHF iter   1:   -34.70652421946106   -3.47065e+01   3.00344e-01 
-    Occupation by irrep:
-             A1    A2    B1    B2 
-    DOCC [     3,    0,    0,    0 ]
-    SOCC [     0,    0,    1,    0 ]
-
-   @ROHF iter   2:   -37.89253275248417   -3.18601e+00   1.74222e-02 DIIS
-   @ROHF iter   3:   -38.22011998087640   -3.27587e-01   1.04059e-02 DIIS
-   @ROHF iter   4:   -38.26825815596110   -4.81382e-02   2.49318e-03 DIIS
-   @ROHF iter   5:   -38.27245847087201   -4.20031e-03   7.92607e-04 DIIS
-   @ROHF iter   6:   -38.27295171600153   -4.93245e-04   2.37835e-04 DIIS
-   @ROHF iter   7:   -38.27301447395499   -6.27580e-05   5.60954e-05 DIIS
-   @ROHF iter   8:   -38.27301731168701   -2.83773e-06   8.95570e-06 DIIS
-   @ROHF iter   9:   -38.27301741725707   -1.05570e-07   1.72109e-06 DIIS
-   @ROHF iter  10:   -38.27301741915153   -1.89446e-09   2.13965e-07 DIIS
-   @ROHF iter  11:   -38.27301741921222   -6.06946e-11   7.09271e-08 DIIS
-   @ROHF iter  12:   -38.27301741921836   -6.13909e-12   1.38971e-08 DIIS
-   @ROHF iter  13:   -38.27301741921865   -2.84217e-13   1.54575e-09 DIIS
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -300,47 +309,42 @@ energy('eom-cc3')
     DOCC [     3,    0,    0,    0 ]
     SOCC [     0,    0,    1,    0 ]
 
-  Energy converged.
-
-  @ROHF Final Energy:   -38.27301741921865
+  @ROHF Final Energy:   -38.27301741921377
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              2.8353842217717449
-    One-Electron Energy =                 -56.5861448431678298
-    Two-Electron Energy =                  15.4777432021774342
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -38.2730174192186468
+    Nuclear Repulsion Energy =              2.8353842329165926
+    One-Electron Energy =                 -56.5861448813722419
+    Two-Electron Energy =                  15.4777432292418737
+    Total Energy =                        -38.2730174192137724
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9684
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.3522
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.6162     Total:     0.6162
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     1.5663     Total:     1.5663
 
 
-*** tstop() called on psinet at Mon May 15 15:34:50 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:23:06 2022
 Module time:
-	user time   =       0.16 seconds =       0.00 minutes
+	user time   =       0.47 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.16 seconds =       0.00 minutes
+	user time   =       0.47 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
@@ -356,19 +360,19 @@ Total time:
       Number of basis functions:        33
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  17    2    7    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 37814 non-zero two-electron integrals.
+      Computed 34324 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:50 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:23:06 2022
 
 
 	Wfn Parameters:
@@ -393,7 +397,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -453,7 +457,7 @@ Total time:
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -33.30403869882357
+	Frozen core energy     =    -33.30403870244503
 
 	Size of irrep 0 of <AB|CD> integrals:      0.016 (MW) /      0.131 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.005 (MW) /      0.039 (MB)
@@ -503,37 +507,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.000 (MB)
 	Total:                                     0.002 (MW) /      0.013 (MB)
 
-	Nuclear Rep. energy          =      2.83538422177174
-	SCF energy                   =    -38.27301741921865
-	One-electron energy          =    -12.62174489794339
-	Two-electron (AA) energy     =      1.27554861261714
-	Two-electron (BB) energy     =      0.39414780434631
-	Two-electron (AB) energy     =      3.14768553881311
-	Two-electron energy          =      4.81738195577656
-	Reference energy             =    -38.27301741921865
+	Nuclear Rep. energy          =      2.83538423291659
+	SCF energy                   =    -38.27301741921377
+	One-electron energy          =    -12.62174489638321
+	Two-electron (AA) energy     =      1.27554861136019
+	Two-electron (BB) energy     =      0.39414780304581
+	Two-electron (AB) energy     =      3.14768553229182
+	Two-electron energy          =      4.81738194669782
+	Reference energy             =    -38.27301741921383
 
-*** tstop() called on psinet at Mon May 15 15:34:50 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:23:07 2022
 Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.29 seconds =       0.00 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:50 2017
-
+	user time   =       0.64 seconds =       0.01 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    2.835384221771745
-    SCF energy          (wfn)     =  -38.273017419218647
-    Reference energy    (file100) =  -38.273017419218654
+    Nuclear Rep. energy (wfn)     =    2.835384232916593
+    SCF energy          (wfn)     =  -38.273017419213772
+    Reference energy    (file100) =  -38.273017419213829
 
     Input parameters:
     -----------------
@@ -562,114 +562,101 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.0859039849924106
+MP2 correlation energy -0.0859039849629556
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.085947992353272    0.000e+00    0.018491    0.000000    0.000000    0.000000
-     1        -0.105141704838095    5.592e-02    0.022625    0.000000    0.000000    0.000000
-     2        -0.113789612928432    2.599e-02    0.025460    0.000000    0.000000    0.000000
-     3        -0.114766031296706    9.753e-03    0.026300    0.000000    0.000000    0.000000
-     4        -0.114927087707572    3.224e-03    0.026308    0.000000    0.000000    0.000000
-     5        -0.114921880368886    1.362e-03    0.026258    0.000000    0.000000    0.000000
-     6        -0.114921672777205    5.945e-04    0.026219    0.000000    0.000000    0.000000
-     7        -0.114932775936269    1.634e-04    0.026219    0.000000    0.000000    0.000000
-     8        -0.114928594122141    4.794e-05    0.026219    0.000000    0.000000    0.000000
-     9        -0.114928449419162    1.820e-05    0.026219    0.000000    0.000000    0.000000
-    10        -0.114928353748706    7.277e-06    0.026219    0.000000    0.000000    0.000000
-    11        -0.114928501370609    2.643e-06    0.026219    0.000000    0.000000    0.000000
-    12        -0.114928443216912    1.032e-06    0.026219    0.000000    0.000000    0.000000
-    13        -0.114928409628454    3.243e-07    0.026219    0.000000    0.000000    0.000000
-    14        -0.114928408644727    1.210e-07    0.026219    0.000000    0.000000    0.000000
-    15        -0.114928410719721    4.738e-08    0.026219    0.000000    0.000000    0.000000
+     0        -0.085947992324947    0.000e+00    0.018491    0.000000    0.000000    0.000000
+     1        -0.105141704371445    5.592e-02    0.022625    0.000000    0.000000    0.000000
+     2        -0.113789611955339    2.599e-02    0.025460    0.000000    0.000000    0.000000
+     3        -0.114766030288622    9.753e-03    0.026300    0.000000    0.000000    0.000000
+     4        -0.114927086697743    3.224e-03    0.026307    0.000000    0.000000    0.000000
+     5        -0.114921879366162    1.362e-03    0.026258    0.000000    0.000000    0.000000
+     6        -0.114921671771253    5.945e-04    0.026219    0.000000    0.000000    0.000000
+     7        -0.114932774928836    1.634e-04    0.026219    0.000000    0.000000    0.000000
+     8        -0.114928593115508    4.794e-05    0.026219    0.000000    0.000000    0.000000
+     9        -0.114928448412196    1.820e-05    0.026219    0.000000    0.000000    0.000000
+    10        -0.114928352741724    7.277e-06    0.026219    0.000000    0.000000    0.000000
+    11        -0.114928500363622    2.643e-06    0.026219    0.000000    0.000000    0.000000
+    12        -0.114928442209962    1.032e-06    0.026219    0.000000    0.000000    0.000000
+    13        -0.114928408621496    3.243e-07    0.026219    0.000000    0.000000    0.000000
+    14        -0.114928407637764    1.210e-07    0.026219    0.000000    0.000000    0.000000
+    15        -0.114928409712758    4.738e-08    0.026219    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              0   7        -0.0138365039
-              0   6         0.0136077694
-              0  10         0.0125344242
-              0   2        -0.0122250720
-              0  11        -0.0115403616
-              0   8         0.0110085240
-              1   7        -0.0108722976
-              2  16        -0.0106276474
-              1   2        -0.0102244694
-              0   5        -0.0100699143
+              0   7        -0.0138365045
+              0   6         0.0136077649
+              0  10         0.0125344231
+              0   2        -0.0122250643
+              0  11        -0.0115403586
+              0   8         0.0110085222
+              1   7        -0.0108723118
+              2  16        -0.0106276542
+              1   2        -0.0102244533
+              0   5        -0.0100699120
 
     Largest Tia Amplitudes:
-              0  10        -0.0229088869
-              1  10        -0.0202114770
-              1   4        -0.0123599539
-              1   5        -0.0121128851
-              0   4        -0.0099819243
-              1   1         0.0095979917
-              1   3         0.0073446510
-              0   2         0.0068131926
-              1  11         0.0066112449
-              0   7         0.0062197632
+              0  10        -0.0229088865
+              1  10        -0.0202114762
+              1   4        -0.0123599458
+              1   5        -0.0121128741
+              0   4        -0.0099819254
+              1   1         0.0095979852
+              1   3         0.0073446732
+              0   2         0.0068132008
+              1  11         0.0066112474
+              0   7         0.0062197648
 
     Largest TIJAB Amplitudes:
-      2   1  20   8         0.0168560087
-      2   1  19   7        -0.0168302077
-      2   1  19   8        -0.0134268967
-      2   1  18   8         0.0126588301
-      2   1  20   5        -0.0116849243
-      2   1  18   5        -0.0116634297
-      2   0  22  15         0.0115252008
-      2   0  19   9         0.0114482397
-      2   1  19   5         0.0113046229
-      2   1  19   1        -0.0112250041
+      2   1  20   8         0.0168560080
+      2   1  19   7        -0.0168302068
+      2   1  19   8        -0.0134268973
+      2   1  18   8         0.0126588293
+      2   1  20   5        -0.0116849235
+      2   1  18   5        -0.0116634285
+      2   0  22  15         0.0115252005
+      2   0  19   9         0.0114482394
+      2   1  19   5         0.0113046225
+      2   1  19   1        -0.0112250046
 
     Largest Tijab Amplitudes:
-      1   0  21  17         0.0099322266
-      1   0  28  23        -0.0089448831
-      1   0  21  16        -0.0081923545
-      1   0  28  24         0.0075367242
-      1   0  11   8         0.0069145343
-      1   0   7   6         0.0065248124
-      1   0   6   5         0.0060676025
-      1   0   9   7        -0.0055683718
-      1   0   7   2        -0.0055343919
-      1   0  11   5        -0.0054997066
+      1   0  21  17         0.0099322262
+      1   0  28  23        -0.0089448830
+      1   0  21  16        -0.0081923544
+      1   0  28  24         0.0075367240
+      1   0  11   8         0.0069145340
+      1   0   7   6         0.0065248115
+      1   0   6   5         0.0060676022
+      1   0   9   7        -0.0055683711
+      1   0   7   2        -0.0055343912
+      1   0  11   5        -0.0054997061
 
     Largest TIjAb Amplitudes:
-      1   1  22  23         0.0700316767
-      1   1  22  24        -0.0541044260
-      1   1  23  23         0.0438021018
-      0   0  22  23         0.0424475034
-      1   1   8   8        -0.0421575949
-      0   0  22  24        -0.0359945308
-      1   1  23  24        -0.0338612528
-      0   1  22  23         0.0331718894
-      0   0  23  23         0.0290959707
-      0   1  22  24        -0.0287663623
+      1   1  22  23         0.0700316774
+      1   1  22  24        -0.0541044275
+      1   1  23  23         0.0438021033
+      0   0  22  23         0.0424475003
+      1   1   8   8        -0.0421575927
+      0   0  22  24        -0.0359945284
+      1   1  23  24        -0.0338612545
+      0   1  22  23         0.0331718886
+      0   0  23  23         0.0290959690
+      0   1  22  24        -0.0287663610
 
-    SCF energy       (wfn)                    =  -38.273017419218647
-    Reference energy (file100)                =  -38.273017419218654
+    SCF energy       (wfn)                    =  -38.273017419213772
+    Reference energy (file100)                =  -38.273017419213829
 
-    Opposite-spin MP2 correlation energy      =   -0.070701355789079
-    Same-spin MP2 correlation energy          =   -0.012469159199348
-    MP2 correlation energy                    =   -0.085903984992411
-      * MP2 total energy                      =  -38.358921404211067
-    CC3 correlation energy                    =   -0.114928410719721
-      * CC3 total energy                      =  -38.387945829938374
-
-
-*** tstop() called on psinet at Mon May 15 15:34:52 2017
-Module time:
-	user time   =       1.08 seconds =       0.02 minutes
-	system time =       0.73 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-Total time:
-	user time   =       1.37 seconds =       0.02 minutes
-	system time =       0.83 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:52 2017
+    Opposite-spin MP2 correlation energy      =   -0.070701355631077
+    Same-spin MP2 correlation energy          =   -0.012469159273546
+    Singles MP2 correlation energy            =   -0.002733470058333
+    MP2 correlation energy                    =   -0.085903984962956
+      * MP2 total energy                      =  -38.358921404176783
+    CC3 correlation energy                    =   -0.114928409712758
+      * CC3 total energy                      =  -38.387945828926590
 
 
 			**************************
@@ -680,67 +667,53 @@ Total time:
 
 Dots of (HeT1)c in names "CC3 Wxxx" in CC3_HET1 
 Wamef terms
-	<WAMEF|WAMEF> =    1.5252721811
-	<Wamef|Wamef> =    1.0763681029
-	<WAmEf|WAmEf> =    1.0045495441
-	<WaMeF|WaMeF> =    1.5630004960
+	<WAMEF|WAMEF> =    1.5252721942
+	<Wamef|Wamef> =    1.0763681148
+	<WAmEf|WAmEf> =    1.0045495457
+	<WaMeF|WaMeF> =    1.5630005020
 Wmnie terms
-	<WMNIE (M>N,IE)|WMNIE> =    0.1452946835
-	<Wmnie (m>n,ie)|Wmnie> =    0.0401803951
-	<WMnIe (Mn,Ie)|WMnIe> =    0.1540821223
-	<WmNiE (mN,iE)|WmNiE> =    0.1255022295
-	<WMNIE(M>N,EI)|WMNIE(M>N,EI)> =    0.1452946835
-	<Wmnie(m>n,ei)|Wmnie(m>n,ei)> =    0.0401803951
-	<WMnIe(Mn,eI)|WMnIe(Mn,eI)> =    0.1540821223
-	<WmNiE(mN,Ei)|WmNiE(mN,Ei)> =    0.1255022295
+	<WMNIE (M>N,IE)|WMNIE> =    0.1452946843
+	<Wmnie (m>n,ie)|Wmnie> =    0.0401803954
+	<WMnIe (Mn,Ie)|WMnIe> =    0.1540821212
+	<WmNiE (mN,iE)|WmNiE> =    0.1255022288
+	<WMNIE(M>N,EI)|WMNIE(M>N,EI)> =    0.1452946843
+	<Wmnie(m>n,ei)|Wmnie(m>n,ei)> =    0.0401803954
+	<WMnIe(Mn,eI)|WMnIe(Mn,eI)> =    0.1540821212
+	<WmNiE(mN,Ei)|WmNiE(mN,Ei)> =    0.1255022288
 Doing Wmnij terms.
-	<WMNIJ (M>N,I>J)|WMNIJ> =    2.1874482373
-	<Wmnij (m>n,i>j)|Wmnij> =    0.6156871371
-	<WMnIj (Mn,Ij)|WMnIj> =    1.7197505029
+	<WMNIJ (M>N,I>J)|WMNIJ> =    2.1874482333
+	<Wmnij (m>n,i>j)|Wmnij> =    0.6156871333
+	<WMnIj (Mn,Ij)|WMnIj> =    1.7197504997
 Doing Wmbij terms.
-	<WMBIJ (MB,I>J)|WMBIJ> =    0.1455925228
-	<WMBIJ (I>J,MB)|WMBIJ> =    0.1455925228
-	<Wmbij (mb,i>j)|Wmbij> =    0.0406704403
-	<Wmbij (i>j,mb)|Wmbij> =    0.0406704403
-	<WMbIj (Mb,Ij)|WMbIj> =    0.1538336249
-	<WMbIj (Ij,Mb)|WMbIj> =    0.1538336249
-	<WmBiJ (mB,iJ)|WmBiJ> =    0.1266986643
-	<WmBiJ (iJ,mB)|WmBiJ> =    0.1266986643
+	<WMBIJ (MB,I>J)|WMBIJ> =    0.1455925248
+	<WMBIJ (I>J,MB)|WMBIJ> =    0.1455925248
+	<Wmbij (mb,i>j)|Wmbij> =    0.0406704409
+	<Wmbij (i>j,mb)|Wmbij> =    0.0406704409
+	<WMbIj (Mb,Ij)|WMbIj> =    0.1538336233
+	<WMbIj (Ij,Mb)|WMbIj> =    0.1538336233
+	<WmBiJ (mB,iJ)|WmBiJ> =    0.1266986632
+	<WmBiJ (iJ,mB)|WmBiJ> =    0.1266986632
 Doing Wmbej terms.
-	<WMBEJ (all ME,JB)|WMBEJ> =   10.7785218224
-	<Wmbej|Wmbej> =    7.5952148907
-	<WMbEj|WMbEj> =    0.1959156460
-	<WmBeJ|WmBeJ> =    0.1960157827
-	<WMbeJ|WMbeJ> =   13.7856551473
-	<WmBEj|WmBEj> =    8.5812286418
+	<WMBEJ (all ME,JB)|WMBEJ> =   10.7785218081
+	<Wmbej|Wmbej> =    7.5952148808
+	<WMbEj|WMbEj> =    0.1959156451
+	<WmBeJ|WmBeJ> =    0.1960157821
+	<WMbeJ|WMbeJ> =   13.7856551179
+	<WmBEj|WmBEj> =    8.5812286199
 Doing Wabei terms.
-	<WABEI (IE,B>A) |WABEI> =    1.5337406195
-	<Wabei (ie,b>a)|Wabei> =    1.0826307126
-	<WAbEi (iE,bA)|WAbEi> =    1.0108330140
-	<WAbEi (iE,Ba)|WAbEi> =    1.5768527542
-
-*** tstop() called on psinet at Mon May 15 15:34:52 2017
-Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.40 seconds =       0.02 minutes
-	system time =       0.86 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:52 2017
-
+	<WABEI (IE,B>A) |WABEI> =    1.5337406396
+	<Wabei (ie,b>a)|Wabei> =    1.0826307300
+	<WAbEi (iE,bA)|WAbEi> =    1.0108330088
+	<WAbEi (iE,Ba)|WAbEi> =    1.5768527561
 
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    2.835384221771745
-	SCF energy          (wfn)     =  -38.273017419218647
-	Reference energy    (file100) =  -38.273017419218654
-	CC3 energy          (file100) =   -0.114928410719721
+	Nuclear Rep. energy (wfn)     =    2.835384232916593
+	SCF energy          (wfn)     =  -38.273017419213772
+	Reference energy    (file100) =  -38.273017419213829
+	CC3 energy          (file100) =   -0.114928409712758
 
 	Input parameters:
 	-----------------
@@ -775,129 +748,133 @@ Total time:
 	Root following for CC3 turned on.
 
 
+
+Fae   dot Fae   total 1048.8114927116
+Fmi   dot Fmi   total    2.2554173392
+WmBeJ and WMbEj dots    0.3641123413
 Symmetry of ground state: B1
 Symmetry of excited state: A1
 Symmetry of right eigenvector: B1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1890401370   1.89e-01    3.19e-01      N
-                     2   0.3037850417   3.04e-01    2.72e-01      N
-                     3   0.3665087135   3.67e-01    2.63e-01      N
+                     1   0.1890401389   1.89e-01    3.19e-01      N
+                     2   0.3037850337   3.04e-01    2.72e-01      N
+                     3   0.3665087091   3.67e-01    2.63e-01      N
 Iter=2    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1314769411  -5.76e-02    6.09e-02      N
-                     2   0.2404975239  -6.33e-02    6.13e-02      N
-                     3   0.3081878276  -5.83e-02    5.73e-02      N
+                     1   0.1314769431  -5.76e-02    6.09e-02      N
+                     2   0.2404975141  -6.33e-02    6.13e-02      N
+                     3   0.3081878238  -5.83e-02    5.73e-02      N
 Iter=3    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1285858471  -2.89e-03    3.30e-02      N
-                     2   0.2370804027  -3.42e-03    2.14e-02      N
-                     3   0.3046372232  -3.55e-03    2.25e-02      N
+                     1   0.1285858492  -2.89e-03    3.30e-02      N
+                     2   0.2370803927  -3.42e-03    2.14e-02      N
+                     3   0.3046372190  -3.55e-03    2.25e-02      N
 Iter=4    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1265097946  -2.08e-03    3.50e-02      N
-                     2   0.2365253009  -5.55e-04    1.90e-02      N
-                     3   0.3032616583  -1.38e-03    4.33e-02      N
+                     1   0.1265097966  -2.08e-03    3.50e-02      N
+                     2   0.2365252907  -5.55e-04    1.90e-02      N
+                     3   0.3032616543  -1.38e-03    4.33e-02      N
 Iter=5    L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1240764210  -2.43e-03    2.56e-02      N
-                     2   0.2199574854  -1.66e-02    1.46e-01      N
-                     3   0.2373196494  -6.59e-02    4.02e-02      N
+                     1   0.1240764231  -2.43e-03    2.56e-02      N
+                     2   0.2199574837  -1.66e-02    1.46e-01      N
+                     3   0.2373196409  -6.59e-02    4.02e-02      N
 Iter=6    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1231648760  -9.12e-04    1.33e-02      N
-                     2   0.1989862689  -2.10e-02    6.78e-02      N
-                     3   0.2368341863  -4.85e-04    9.01e-03      N
+                     1   0.1231648782  -9.12e-04    1.33e-02      N
+                     2   0.1989862694  -2.10e-02    6.78e-02      N
+                     3   0.2368341769  -4.85e-04    9.01e-03      N
 Iter=7    L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229783583  -1.87e-04    5.85e-03      N
-                     2   0.1939774366  -5.01e-03    3.27e-02      N
-                     3   0.2367801579  -5.40e-05    4.37e-03      N
+                     1   0.1229783605  -1.87e-04    5.85e-03      N
+                     2   0.1939774379  -5.01e-03    3.27e-02      N
+                     3   0.2367801484  -5.40e-05    4.37e-03      N
 Iter=8    L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229371820  -4.12e-05    2.04e-03      N
-                     2   0.1931002806  -8.77e-04    1.27e-02      N
-                     3   0.2367683493  -1.18e-05    1.84e-03      N
+                     1   0.1229371842  -4.12e-05    2.04e-03      N
+                     2   0.1931002820  -8.77e-04    1.27e-02      N
+                     3   0.2367683397  -1.18e-05    1.84e-03      N
 Iter=9    L=27    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229290442  -8.14e-06    7.03e-04      N
-                     2   0.1929730129  -1.27e-04    4.79e-03      N
-                     3   0.2367667453  -1.60e-06    7.25e-04      N
+                     1   0.1229290464  -8.14e-06    7.03e-04      N
+                     2   0.1929730144  -1.27e-04    4.79e-03      N
+                     3   0.2367667358  -1.60e-06    7.25e-04      N
 Iter=10   L=30    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229304922   1.45e-06    2.43e-04      N
-                     2   0.1929410958  -3.19e-05    1.85e-03      N
-                     3   0.2367676495   9.04e-07    3.02e-04      N
+                     1   0.1229304945   1.45e-06    2.43e-04      N
+                     2   0.1929410973  -3.19e-05    1.85e-03      N
+                     3   0.2367676400   9.04e-07    3.02e-04      N
 Iter=11   L=33    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229315022   1.01e-06    8.27e-05      N
-                     2   0.1929388887  -2.21e-06    7.09e-04      N
-                     3   0.2367680892   4.40e-07    1.34e-04      N
+                     1   0.1229315045   1.01e-06    8.27e-05      N
+                     2   0.1929388901  -2.21e-06    7.09e-04      N
+                     3   0.2367680797   4.40e-07    1.34e-04      N
 Iter=12   L=36    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317526   2.50e-07    2.62e-05      N
-                     2   0.1929389960   1.07e-07    2.50e-04      N
-                     3   0.2367681228   3.36e-08    5.16e-05      N
+                     1   0.1229317548   2.50e-07    2.62e-05      N
+                     2   0.1929389974   1.07e-07    2.50e-04      N
+                     3   0.2367681133   3.36e-08    5.16e-05      N
 Iter=13   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317526  -1.77e-14    2.62e-05      N
-                     2   0.1929389960  -1.39e-15    2.50e-04      N
-                     3   0.2367681228   5.33e-15    5.16e-05      N
+                     1   0.1229317548  -1.65e-15    2.62e-05      N
+                     2   0.1929389974  -2.22e-16    2.50e-04      N
+                     3   0.2367681133  -2.47e-15    5.16e-05      N
 Iter=14   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317895   3.69e-08    8.54e-06      N
-                     2   0.1929389361  -5.99e-08    9.41e-05      N
-                     3   0.2367681350   1.21e-08    2.19e-05      N
+                     1   0.1229317917   3.69e-08    8.54e-06      N
+                     2   0.1929389376  -5.99e-08    9.41e-05      N
+                     3   0.2367681254   1.21e-08    2.19e-05      N
 Iter=15   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317848  -4.66e-09    3.04e-06      N
-                     2   0.1929390521   1.16e-07    3.76e-05      N
-                     3   0.2367681301  -4.85e-09    9.56e-06      N
+                     1   0.1229317870  -4.66e-09    3.04e-06      N
+                     2   0.1929390536   1.16e-07    3.76e-05      N
+                     3   0.2367681206  -4.85e-09    9.56e-06      N
 Iter=16   L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317784  -6.45e-09    1.20e-06      N
-                     2   0.1929390861   3.41e-08    1.65e-05      N
-                     3   0.2367681323   2.19e-09    4.42e-06      N
+                     1   0.1229317806  -6.45e-09    1.20e-06      N
+                     2   0.1929390876   3.41e-08    1.65e-05      N
+                     3   0.2367681228   2.19e-09    4.42e-06      N
 Iter=17   L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317766  -1.77e-09    4.52e-07      Y
-                     2   0.1929390763  -9.89e-09    7.29e-06      N
-                     3   0.2367681313  -1.05e-09    2.27e-06      N
+                     1   0.1229317788  -1.77e-09    4.52e-07      Y
+                     2   0.1929390777  -9.89e-09    7.29e-06      N
+                     3   0.2367681217  -1.05e-09    2.27e-06      N
 Iter=18   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317764  -2.39e-10    1.66e-07      Y
-                     2   0.1929390738  -2.49e-09    2.91e-06      N
-                     3   0.2367681330   1.75e-09    1.00e-06      N
+                     1   0.1229317786  -2.39e-10    1.66e-07      Y
+                     2   0.1929390752  -2.49e-09    2.91e-06      N
+                     3   0.2367681235   1.75e-09    1.00e-06      N
 Iter=19   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317762  -2.19e-10    8.21e-08      Y
-                     2   0.1929390712  -2.60e-09    1.16e-06      N
-                     3   0.2367681356   2.62e-09    4.46e-07      Y
+                     1   0.1229317784  -2.19e-10    8.21e-08      Y
+                     2   0.1929390726  -2.60e-09    1.16e-06      N
+                     3   0.2367681261   2.62e-09    4.46e-07      Y
 Iter=20   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1229317761  -1.15e-11    6.67e-08      Y
-                     2   0.1929390684  -2.79e-09    5.11e-07      Y
-                     3   0.2367681358   1.21e-10    2.57e-07      Y
+                     1   0.1229317784  -1.15e-11    6.67e-08      Y
+                     2   0.1929390699  -2.79e-09    5.11e-07      Y
+                     3   0.2367681262   1.21e-10    2.57e-07      Y
 Completed EOM_CCSD
 Collapsing to only 3 vector(s).
 Copying root 2 to CC3_MISC file.
-Setting initial CC3 eigenvalue to    0.1929390684
+Setting initial CC3 eigenvalue to    0.1929390699
 Iter=1    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.164169
+	 0      0.164169
 	 1      0.977373
 	 2     -0.040125
 follow_root returning: 1
-                     2   0.1644941565  -2.84e-02    1.94e-02      N
+                     2   0.1644941584  -2.84e-02    1.94e-02      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0     -0.166833
 	 1     -0.976347
 	 2     -0.040785
-	 3      0.022070
+	 3     -0.022070
 follow_root returning: 1
-                     2   0.1641383615  -3.56e-04    7.07e-03      N
+                     2   0.1641383633  -3.56e-04    7.07e-03      N
 Iter=3    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0      0.167825
 	 1      0.975936
 	 2      0.040894
 	 3      0.027983
-	 4     -0.009792
+	 4      0.009792
 follow_root returning: 1
-                     2   0.1640712657  -6.71e-05    3.68e-03      N
+                     2   0.1640712675  -6.71e-05    3.68e-03      N
 Iter=4    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0      0.167709
 	 1      0.975819
 	 2      0.041090
-	 3     -0.030891
-	 4      0.005678
+	 3      0.030891
+	 4     -0.005678
 	 5     -0.012104
 follow_root returning: 1
-                     2   0.1640534873  -1.78e-05    1.43e-03      N
+                     2   0.1640534891  -1.78e-05    1.43e-03      N
 Iter=5    L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0      0.167711
@@ -906,9 +883,9 @@ Overlaps of Rs with EOM CCSD eigenvector:
 	 3     -0.030297
 	 4     -0.012893
 	 5     -0.003803
-	 6      0.007647
+	 6     -0.007647
 follow_root returning: 1
-                     2   0.1640523373  -1.15e-06    4.66e-04      N
+                     2   0.1640523391  -1.15e-06    4.66e-04      N
 Iter=6    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0     -0.167704
@@ -918,9 +895,9 @@ Overlaps of Rs with EOM CCSD eigenvector:
 	 4     -0.013140
 	 5      0.002501
 	 6      0.009919
-	 7     -0.004938
+	 7      0.004938
 follow_root returning: 1
-                     2   0.1640530999   7.63e-07    1.79e-04      N
+                     2   0.1640531018   7.63e-07    1.79e-04      N
 Iter=7    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0      0.167730
@@ -931,9 +908,9 @@ Overlaps of Rs with EOM CCSD eigenvector:
 	 5     -0.010885
 	 6     -0.000815
 	 7     -0.003103
-	 8      0.006203
+	 8     -0.006203
 follow_root returning: 1
-                     2   0.1640534873   3.87e-07    6.79e-05      N
+                     2   0.1640534892   3.87e-07    6.79e-05      N
 Iter=8    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0     -0.167752
@@ -945,129 +922,136 @@ Overlaps of Rs with EOM CCSD eigenvector:
 	 6      0.003619
 	 7      0.008167
 	 8     -0.000019
-	 9      0.004641
+	 9     -0.004641
 follow_root returning: 1
-                     2   0.1640535999   1.13e-07    2.79e-05      N
-Collapsing to 4 vector(s).
-Change in CC3 energy from last iterated value   -0.0288854685
-Iter=9    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1640536018   1.13e-07    2.79e-05      N
+Collapsing to 2 vector(s).
+Change in CC3 energy from last iterated value   -0.0288854681
+Iter=9    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.164357
-	 1     -0.976460
-	 2     -0.006478
-	 3     -0.002096
+	 0      0.164358
+	 1      0.976460
 follow_root returning: 1
-                     2   0.1643438493   2.90e-04    2.35e-04      N
-Iter=10   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643437492   2.90e-04    2.35e-04      N
+Iter=10   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.164420
+	 0      0.164414
 	 1     -0.976471
-	 2      0.007933
-	 3      0.034588
-	 4      0.003106
+	 2      0.034956
 follow_root returning: 1
-                     2   0.1643434949  -3.54e-07    8.57e-05      N
-Iter=11   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643434793  -2.70e-07    9.07e-05      N
+Iter=11   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.164412
-	 1      0.976476
-	 2     -0.021057
-	 3      0.035325
-	 4     -0.008865
-	 5     -0.003802
+	 0     -0.164408
+	 1     -0.976476
+	 2     -0.040757
+	 3      0.007667
 follow_root returning: 1
-                     2   0.1643436016   1.07e-07    4.78e-05      N
-Iter=12   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643435776   9.83e-08    4.99e-05      N
+Iter=12   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.164426
-	 1     -0.976480
-	 2      0.044173
-	 3      0.010306
-	 4      0.000069
-	 5     -0.009084
-	 6     -0.001085
+	 0     -0.164410
+	 1      0.976479
+	 2     -0.045527
+	 3      0.002591
+	 4      0.007786
 follow_root returning: 1
-                     2   0.1643436070   5.46e-09    1.94e-05      N
-Iter=13   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643436323   5.47e-08    2.01e-05      N
+Iter=13   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.164430
+	 0     -0.164426
+	 1      0.976480
+	 2     -0.048039
+	 3      0.000886
+	 4     -0.002339
+	 5      0.014576
+follow_root returning: 1
+                     2   0.1643436220  -1.03e-08    8.27e-06      N
+Iter=14   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
+Overlaps of Rs with EOM CCSD eigenvector:
+	 0      0.164354
 	 1      0.976481
-	 2      0.045273
-	 3     -0.013878
-	 4     -0.002255
-	 5     -0.003164
-	 6     -0.006416
-	 7     -0.014653
+	 2      0.049734
+	 3      0.003424
+	 4     -0.010713
+	 5     -0.012704
+	 6     -0.000080
 follow_root returning: 1
-                     2   0.1643435988  -8.27e-09    4.94e-06      N
-Iter=14   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643435988  -2.33e-08    4.83e-06      N
+Iter=15   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.164331
-	 1      0.976481
-	 2     -0.050689
-	 3     -0.011591
-	 4      0.015264
-	 5      0.015479
-	 6      0.003142
-	 7     -0.004567
-	 8     -0.003586
+	 0      0.164316
+	 1     -0.976481
+	 2     -0.043395
+	 3     -0.023270
+	 4     -0.017185
+	 5     -0.000277
+	 6     -0.002357
+	 7     -0.002871
 follow_root returning: 1
-                     2   0.1643435888  -1.00e-08    4.86e-06      N
-Iter=15   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643435822  -1.65e-08    2.78e-06      N
+Iter=16   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.164286
+	 0      0.164323
+	 1      0.976482
+	 2      0.038691
+	 3      0.029448
+	 4      0.016326
+	 5     -0.007228
+	 6      0.003449
+	 7     -0.004725
+	 8      0.001784
+follow_root returning: 1
+                     2   0.1643435779  -4.33e-09    1.47e-06      N
+Iter=17   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
+Overlaps of Rs with EOM CCSD eigenvector:
+	 0      0.164333
 	 1     -0.976482
-	 2     -0.043128
-	 3     -0.026799
-	 4      0.015323
-	 5      0.010862
-	 6      0.006013
-	 7      0.005539
-	 8      0.002926
-	 9     -0.001559
+	 2     -0.037966
+	 3     -0.030313
+	 4     -0.016458
+	 5     -0.007706
+	 6     -0.006739
+	 7      0.005179
+	 8      0.002279
+	 9     -0.000300
 follow_root returning: 1
-                     2   0.1643435784  -1.03e-08    1.55e-06      N
-Collapsing to 4 vector(s).
-Change in CC3 energy from last iterated value    0.0002899785
-Iter=16   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643435778  -1.38e-10    6.49e-07      Y
+Collapsing to 2 vector(s).
+Change in CC3 energy from last iterated value    0.0002899760
+Iter=18   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.164320
+	 0     -0.164367
 	 1      0.976475
-	 2     -0.041300
-	 3      0.009738
 follow_root returning: 1
-                     2   0.1643406351  -2.94e-06    2.88e-06      N
-Iter=17   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643406337  -2.94e-06    2.55e-06      N
+Iter=19   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.164308
+	 0      0.164371
 	 1      0.976475
-	 2     -0.039899
-	 3      0.027498
-	 4      0.003015
+	 2     -0.030975
 follow_root returning: 1
-                     2   0.1643406356   5.38e-10    1.31e-06      N
-Iter=18   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     2   0.1643406365   2.85e-09    1.05e-06      N
+Iter=20   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0      0.164305
+	 0     -0.164373
 	 1     -0.976475
-	 2      0.039394
-	 3      0.029781
-	 4     -0.001295
-	 5      0.006255
+	 2     -0.032026
+	 3      0.010518
 follow_root returning: 1
-                     2   0.1643406349  -7.24e-10    6.44e-07      Y
+                     2   0.1643406362  -3.03e-10    5.88e-07      Y
 Forcing restart to make sure new sigma vectors give same eigenvalue.
 Collapsing to only 2 vector(s).
-Change in CC3 energy from last iterated value   -0.0000029435
-Setting old CC3 eigenvalue to    0.1643406349
-Iter=19   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
+Change in CC3 energy from last iterated value   -0.0000029416
+Setting old CC3 eigenvalue to    0.1643406362
+Iter=21   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
-	 0     -0.164305
+	 0      0.164373
 	 1      0.976475
 follow_root returning: 1
-                     2   0.1643406648   2.99e-08    6.53e-07      Y
+                     2   0.1643406661   2.99e-08    5.94e-07      Y
 Collapsing to only 2 vector(s).
-Copying root 2 to start of EOM_Cxxx files.
+Copying root 2 to start of PSIF_EOM_Cxxx files.
 Change in CC3 energy from last iterated value    0.0000000299
 
 Procedure converged for 1 root(s).
@@ -1077,50 +1061,43 @@ EOM CC3 R0 for root 0 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      4.472    36068.6   0.1643406648   -38.223605165170
+EOM State 1      4.472    36068.6   0.1643406661   -38.223605162856
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         0 >   2      :       1b1 >    6a1 :    0.0387771397
-         0 >   1      :       1b1 >    5a1 :    0.0352305709
-         0 >   0      :       1b1 >    4a1 :   -0.0249115026
-         1 >   0      :       3a1 >    2b1 :   -0.0248414366
-         0 >   6      :       1b1 >   10a1 :   -0.0238751467
+         0 >   2      :       1b1 >    6a1 :    0.0387773797
+         0 >   1      :       1b1 >    5a1 :    0.0352305416
+         0 >   0      :       1b1 >    4a1 :   -0.0249118812
+         1 >   0      :       3a1 >    2b1 :   -0.0248413932
+         0 >   6      :       1b1 >   10a1 :   -0.0238752211
  Ria (libdpd indices) : (cscf notation)
-         1 >   0      :       3a1 >    1b1 :    0.4112603313
-         1 >   1      :       3a1 >    2b1 :   -0.3090349801
-         1 >   2      :       3a1 >    3b1 :    0.0755061812
-         1 >   4      :       3a1 >    5b1 :   -0.0732296891
-         1 >   3      :       3a1 >    4b1 :   -0.0540906171
+         1 >   0      :       3a1 >    1b1 :    0.4112603405
+         1 >   1      :       3a1 >    2b1 :   -0.3090349666
+         1 >   2      :       3a1 >    3b1 :    0.0755061903
+         1 >   4      :       3a1 >    5b1 :   -0.0732296999
+         1 >   3      :       3a1 >    4b1 :   -0.0540906088
  RIjAb (libdpd indices)     : (cscf notation)
-        0   1 >   0   0     :    1b1    3a1 >    1b2    1b2 :   -0.6327724926
-        0   1 >   0   1     :    1b1    3a1 >    1b2    2b2 :    0.3571741097
-        0   1 >   1   0     :    1b1    3a1 >    2b2    1b2 :   -0.3076893113
-        0   1 >   1   1     :    1b1    3a1 >    2b2    2b2 :    0.1478050949
-        0   1 >   4   0     :    1b1    3a1 >    5b2    1b2 :    0.1159085713
+        0   1 >   0   0     :    1b1    3a1 >    1b2    1b2 :   -0.6327724181
+        0   1 >   0   1     :    1b1    3a1 >    1b2    2b2 :    0.3571741408
+        0   1 >   1   0     :    1b1    3a1 >    2b2    1b2 :   -0.3076893736
+        0   1 >   1   1     :    1b1    3a1 >    2b2    2b2 :    0.1478051474
+        0   1 >   4   0     :    1b1    3a1 >    5b2    1b2 :    0.1159085659
  RIJAB (libdpd indices)     : (cscf notation)
-        0   1 >   1   0     :    1b1    3a1 >    2b2    1b2 :    0.0303210293
-        0   1 >   3   0     :    1b1    3a1 >    4b2    1b2 :    0.0207260847
-        0   1 >   5   0     :    1b1    3a1 >    6b2    1b2 :    0.0188522172
-        0   1 >   6   0     :    1b1    3a1 >    7b2    1b2 :    0.0159849053
-        0   1 >   4   0     :    1b1    3a1 >    5b2    1b2 :   -0.0158185085
+        0   1 >   1   0     :    1b1    3a1 >    2b2    1b2 :    0.0303211408
+        0   1 >   3   0     :    1b1    3a1 >    4b2    1b2 :    0.0207261179
+        0   1 >   5   0     :    1b1    3a1 >    6b2    1b2 :    0.0188522510
+        0   1 >   6   0     :    1b1    3a1 >    7b2    1b2 :    0.0159848951
+        0   1 >   4   0     :    1b1    3a1 >    5b2    1b2 :   -0.0158185549
  Rijab (libdpd indices)     : (cscf notation)
-        1   0 >   0   8     :    3a1    2a1 >    1b1   12a1 :    0.0099223900
-        1   0 >   0   5     :    3a1    2a1 >    1b1    9a1 :   -0.0092987116
-        1   0 >   0   1     :    3a1    2a1 >    1b2    2a2 :    0.0089193457
-        1   0 >   0   7     :    3a1    2a1 >    1b1   11a1 :   -0.0084170498
-        1   0 >   0   6     :    3a1    2a1 >    1b1   10a1 :    0.0082992966
+        1   0 >   0   8     :    3a1    2a1 >    1b1   12a1 :    0.0099223848
+        1   0 >   0   5     :    3a1    2a1 >    1b1    9a1 :   -0.0092987043
+        1   0 >   0   1     :    3a1    2a1 >    1b2    2a2 :    0.0089193336
+        1   0 >   0   7     :    3a1    2a1 >    1b1   11a1 :   -0.0084170429
+        1   0 >   0   6     :    3a1    2a1 >    1b1   10a1 :    0.0082992876
 
-	Total # of sigma evaluations: 81
+	Total # of sigma evaluations: 79
 
-*** tstop() called on psinet at Mon May 15 15:34:59 2017
-Module time:
-	user time   =       4.68 seconds =       0.08 minutes
-	system time =       2.12 seconds =       0.04 minutes
-	total time  =          7 seconds =       0.12 minutes
-Total time:
-	user time   =       6.08 seconds =       0.10 minutes
-	system time =       2.98 seconds =       0.05 minutes
-	total time  =          9 seconds =       0.15 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:23PM
+    Psi4 wall time for execution: 0:00:23.43
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc50/output.ref
+++ b/tests/cc50/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev51 
+                               Psi4 1.6a1.dev56 
 
-                         Git: Rev {ccdensity_fix} 4732348 dirty
+                         Git: Rev {ccdensity_fix} 027e6dd dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 12 February 2022 03:23PM
+    Psi4 started on: Monday, 14 February 2022 02:01PM
 
-    Process ID: 65665
-    Host:       Jonathons-MacBook-Pro.local
+    Process ID: 12265
+    Host:       dhcp189-242.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -143,21 +143,29 @@ D 2 1.00
 ****
 }
 
+scf_ref = -38.273017419213 # TEST
+cc3_ref = -38.387945828926 # TEST
+eom_ref = -38.223605162856 # TEST
+
 energy('eom-cc3')
+compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
+compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
+compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:23:06 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 14:01:58 2022
 
    => Loading Basis Set <=
 
-    Name: ANONYMOUSAF20C94B
+    Name: ANONYMOUS80518D25
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line    22 inputblock anonymousaf20c94b 
-    atoms 2 entry H          line     5 inputblock anonymousaf20c94b 
+    atoms 1 entry C          line    22 inputblock anonymous80518d25 
+    atoms 2 entry H          line     5 inputblock anonymous80518d25 
 
 
          ---------------------------------------------------------
@@ -205,8 +213,8 @@ Scratch directory: /tmp/
 
   ==> Primary Basis <==
 
-  Basis Set: ANONYMOUSAF20C94B
-    Blend: ANONYMOUSAF20C94B
+  Basis Set: ANONYMOUS80518D25
+    Blend: ANONYMOUS80518D25
     Number of shells: 15
     Number of basis functions: 33
     Number of Cartesian functions: 35
@@ -338,13 +346,13 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.5663     Total:     1.5663
 
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:23:06 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:01:58 2022
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
+	user time   =       0.27 seconds =       0.00 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.47 seconds =       0.01 minutes
+	user time   =       0.27 seconds =       0.00 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
@@ -371,8 +379,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:23:06 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 14:01:58 2022
 
 
 	Wfn Parameters:
@@ -516,15 +524,15 @@ Total time:
 	Two-electron energy          =      4.81738194669782
 	Reference energy             =    -38.27301741921383
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:23:07 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:01:58 2022
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.64 seconds =       0.01 minutes
-	system time =       0.28 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -1096,8 +1104,11 @@ Largest components of excited wave function #1:
         1   0 >   0   6     :    3a1    2a1 >    1b1   10a1 :    0.0082992876
 
 	Total # of sigma evaluations: 79
+    SCF energy............................................................................PASSED
+    CC3 energy............................................................................PASSED
+    EOM-CC3 energy........................................................................PASSED
 
-    Psi4 stopped on: Saturday, 12 February 2022 03:23PM
-    Psi4 wall time for execution: 0:00:23.43
+    Psi4 stopped on: Monday, 14 February 2022 02:02PM
+    Psi4 wall time for execution: 0:00:12.42
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc51/CMakeLists.txt
+++ b/tests/cc51/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc51 "psi;cc;autotest;cart;noc1")
+add_regression_test(cc51 "psi;cc;cart;noc1")

--- a/tests/cc51/input.dat
+++ b/tests/cc51/input.dat
@@ -14,4 +14,12 @@ set {
   roots_per_irrep [0, 0, 1, 0]
 }
 
+scf_ref = -76.0544373134 # TEST
+cc3_ref = -76.3441289194 # TEST
+eom_ref = -76.0519836445 # TEST
+
 energy('eom-cc3')
+compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
+compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
+compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+

--- a/tests/cc51/output.ref
+++ b/tests/cc51/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev51 
+                               Psi4 1.6a1.dev56 
 
-                         Git: Rev {ccdensity_fix} 4732348 dirty
+                         Git: Rev {ccdensity_fix} 027e6dd dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 12 February 2022 03:20PM
+    Psi4 started on: Monday, 14 February 2022 02:04PM
 
-    Process ID: 65610
-    Host:       Jonathons-MacBook-Pro.local
+    Process ID: 12886
+    Host:       dhcp189-242.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -57,13 +57,21 @@ set {
   roots_per_irrep [0, 0, 1, 0]
 }
 
+scf_ref = -76.0544373134 # TEST
+cc3_ref = -76.3441289194 # TEST
+eom_ref = -76.0519836445 # TEST
+
 energy('eom-cc3')
+compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
+compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
+compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:20:42 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 14:04:46 2022
 
    => Loading Basis Set <=
 
@@ -180,10 +188,10 @@ Scratch directory: /tmp/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:   -75.47284908986008   -7.54728e+01   0.00000e+00 
-   @RHF iter   1:   -75.97599997288074   -5.03151e-01   1.43171e-02 ADIIS/DIIS
-   @RHF iter   2:   -76.02797054702684   -5.19706e-02   9.35047e-03 ADIIS/DIIS
-   @RHF iter   3:   -76.05394025202597   -2.59697e-02   7.99318e-04 ADIIS/DIIS
-   @RHF iter   4:   -76.05440637128751   -4.66119e-04   1.77588e-04 ADIIS/DIIS
+   @RHF iter   1:   -75.97599997288074   -5.03151e-01   1.43171e-02 DIIS/ADIIS
+   @RHF iter   2:   -76.02797054702684   -5.19706e-02   9.35047e-03 DIIS/ADIIS
+   @RHF iter   3:   -76.05394025202597   -2.59697e-02   7.99318e-04 DIIS/ADIIS
+   @RHF iter   4:   -76.05440637128751   -4.66119e-04   1.77588e-04 DIIS/ADIIS
    @RHF iter   5:   -76.05443531057378   -2.89393e-05   3.75498e-05 DIIS
    @RHF iter   6:   -76.05443722684294   -1.91627e-06   7.73184e-06 DIIS
    @RHF iter   7:   -76.05443731105581   -8.42129e-08   1.36715e-06 DIIS
@@ -257,15 +265,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -1.9387     Total:     1.9387
 
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:20:44 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:04:47 2022
 Module time:
-	user time   =       1.20 seconds =       0.02 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.75 seconds =       0.01 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.20 seconds =       0.02 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.75 seconds =       0.01 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -290,8 +298,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:20:44 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 14:04:48 2022
 
 
 	Wfn Parameters:
@@ -378,15 +386,15 @@ Total time:
 	Two-electron energy          =     37.74268653457025
 	Reference energy             =    -76.05443731346320
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:20:45 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:04:48 2022
 Module time:
-	user time   =       0.30 seconds =       0.01 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.65 seconds =       0.03 minutes
-	system time =       0.58 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.02 seconds =       0.02 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -651,8 +659,11 @@ Largest components of excited wave function #1:
 	Putting into environment CURRENT ENERGY:              -76.0519836445
 
 	Total # of sigma evaluations: 28
+    SCF energy............................................................................PASSED
+    CC3 energy............................................................................PASSED
+    EOM-CC3 energy........................................................................PASSED
 
-    Psi4 stopped on: Saturday, 12 February 2022 03:21PM
-    Psi4 wall time for execution: 0:00:43.41
+    Psi4 stopped on: Monday, 14 February 2022 02:05PM
+    Psi4 wall time for execution: 0:00:41.97
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc51/output.ref
+++ b/tests/cc51/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:20PM
 
-    Process ID:  13006
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65610
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -47,21 +60,24 @@ set {
 energy('eom-cc3')
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:51 2017
+Scratch directory: /tmp/
+
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:20:42 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1   entry O          line   262 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2-3 entry H          line    23 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -75,15 +91,15 @@ energy('eom-cc3')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000     0.117499201619    15.994914619560
-           H          0.000000000000    -1.515263000000    -0.932398798381     1.007825032070
-           H         -0.000000000000     1.515263000000    -0.932398798381     1.007825032070
+         O            0.000000000000     0.000000000000     0.117499201635    15.994914619570
+         H            0.000000000000    -1.515263000000    -0.932398798365     1.007825032230
+         H           -0.000000000000     1.515263000000    -0.932398798365     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     30.50916  B =     13.00778  C =      9.11958 [cm^-1]
-  Rotational constants: A = 914641.67040  B = 389963.32063  C = 273398.23581 [MHz]
-  Nuclear repulsion =    9.009354229662666
+  Rotational constants: A = 914641.67005  B = 389963.32048  C = 273398.23570 [MHz]
+  Nuclear repulsion =    9.009354229662664
 
   Charge       = 0
   Multiplicity = 1
@@ -100,30 +116,17 @@ energy('eom-cc3')
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVTZ
     Blend: CC-PVTZ
     Number of shells: 22
-    Number of basis function: 58
+    Number of basis functions: 58
     Number of Cartesian functions: 65
     Spherical Harmonics?: true
     Max angular momentum: 3
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        23      23       0       0       0       0
-     A2         7       7       0       0       0       0
-     B1        11      11       0       0       0       0
-     B2        17      17       0       0       0       0
-   -------------------------------------------------------
-    Total      58      58       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -142,40 +145,58 @@ energy('eom-cc3')
   Using 2929232 doubles for integral storage.
   We computed 32131 shell quartets total.
   Whereas there are 32131 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.5859987910E-03.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.3349122967E-03.
+  Reciprocal condition number of the overlap matrix is 5.4219835068E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        23      23 
+     A2         7       7 
+     B1        11      11 
+     B2        17      17 
+   -------------------------
+    Total      58      58
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -75.86919676257928   -7.58692e+01   5.17182e-02 
-   @RHF iter   1:   -76.02591340294912   -1.56717e-01   8.57685e-03 
-   @RHF iter   2:   -76.04674656394026   -2.08332e-02   5.00109e-03 DIIS
-   @RHF iter   3:   -76.05422394303842   -7.47738e-03   5.16520e-04 DIIS
-   @RHF iter   4:   -76.05441084767729   -1.86905e-04   1.51928e-04 DIIS
-   @RHF iter   5:   -76.05443501762272   -2.41699e-05   3.80845e-05 DIIS
-   @RHF iter   6:   -76.05443722182255   -2.20420e-06   7.69698e-06 DIIS
-   @RHF iter   7:   -76.05443731244634   -9.06238e-08   9.32880e-07 DIIS
-   @RHF iter   8:   -76.05443731345918   -1.01284e-09   7.13034e-08 DIIS
-   @RHF iter   9:   -76.05443731346293   -3.75167e-12   1.10084e-08 DIIS
-   @RHF iter  10:   -76.05443731346303   -9.94760e-14   2.22551e-09 DIIS
+   @RHF iter SAD:   -75.47284908986008   -7.54728e+01   0.00000e+00 
+   @RHF iter   1:   -75.97599997288074   -5.03151e-01   1.43171e-02 ADIIS/DIIS
+   @RHF iter   2:   -76.02797054702684   -5.19706e-02   9.35047e-03 ADIIS/DIIS
+   @RHF iter   3:   -76.05394025202597   -2.59697e-02   7.99318e-04 ADIIS/DIIS
+   @RHF iter   4:   -76.05440637128751   -4.66119e-04   1.77588e-04 ADIIS/DIIS
+   @RHF iter   5:   -76.05443531057378   -2.89393e-05   3.75498e-05 DIIS
+   @RHF iter   6:   -76.05443722684294   -1.91627e-06   7.73184e-06 DIIS
+   @RHF iter   7:   -76.05443731105581   -8.42129e-08   1.36715e-06 DIIS
+   @RHF iter   8:   -76.05443731339022   -2.33442e-09   2.33822e-07 DIIS
+   @RHF iter   9:   -76.05443731345912   -6.88942e-11   5.98627e-08 DIIS
+   @RHF iter  10:   -76.05443731346327   -4.14957e-12   6.63712e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -207,49 +228,44 @@ energy('eom-cc3')
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.05443731346303
+  @RHF Final Energy:   -76.05443731346327
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.0093542296626659
-    One-Electron Energy =                -122.8064782102997441
-    Two-Electron Energy =                  37.7426866671740484
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0544373134630405
+    Nuclear Repulsion Energy =              9.0093542296626641
+    One-Electron Energy =                -122.8064784832630352
+    Two-Electron Energy =                  37.7426869401371050
+    Total Energy =                        -76.0544373134632679
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.9248
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.1620
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.7628     Total:     0.7628
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -1.9387     Total:     1.9387
 
 
-*** tstop() called on psinet at Mon May 15 15:34:52 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:20:44 2022
 Module time:
-	user time   =       0.65 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.20 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.65 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.20 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -263,19 +279,19 @@ Total time:
       Number of basis functions:        58
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  23    7   11   17 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 362089 non-zero two-electron integrals.
+      Computed 350015 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:52 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:20:44 2022
 
 
 	Wfn Parameters:
@@ -300,7 +316,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -356,34 +372,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.005 (MW) /      0.037 (MB)
 	Total:                                     0.018 (MW) /      0.148 (MB)
 
-	Nuclear Rep. energy          =      9.00935422966267
-	SCF energy                   =    -76.05443731346303
-	One-electron energy          =   -122.80647806829835
-	Two-electron energy          =     37.74268652517269
-	Reference energy             =    -76.05443731346300
+	Nuclear Rep. energy          =      9.00935422966266
+	SCF energy                   =    -76.05443731346327
+	One-electron energy          =   -122.80647807769611
+	Two-electron energy          =     37.74268653457025
+	Reference energy             =    -76.05443731346320
 
-*** tstop() called on psinet at Mon May 15 15:34:52 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:20:45 2022
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.00 seconds =       0.02 minutes
-	system time =       0.19 seconds =       0.00 minutes
+	user time   =       0.30 seconds =       0.01 minutes
+	system time =       0.42 seconds =       0.01 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:52 2017
-
+Total time:
+	user time   =       1.65 seconds =       0.03 minutes
+	system time =       0.58 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.009354229662666
-    SCF energy          (wfn)     =  -76.054437313463026
-    Reference energy    (file100) =  -76.054437313462998
+    Nuclear Rep. energy (wfn)     =    9.009354229662664
+    SCF energy          (wfn)     =  -76.054437313463268
+    Reference energy    (file100) =  -76.054437313463197
 
     Input parameters:
     -----------------
@@ -412,74 +424,61 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2758350535710778
+MP2 correlation energy -0.2758350525611515
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.275835053571077    0.000e+00    0.000000    0.000000    0.000000    0.117056
-     1        -0.284194342295744    2.916e-02    0.004406    0.008041    0.008041    0.125326
-     2        -0.289394065784020    1.031e-02    0.005096    0.009416    0.009416    0.130919
-     3        -0.289651484844096    2.694e-03    0.005531    0.010486    0.010486    0.132163
-     4        -0.289681269022568    7.302e-04    0.005595    0.010758    0.010758    0.132420
-     5        -0.289694266393482    2.079e-04    0.005617    0.010893    0.010893    0.132436
-     6        -0.289692050184867    7.001e-05    0.005624    0.010944    0.010944    0.132427
-     7        -0.289692055658294    2.234e-05    0.005628    0.010968    0.010968    0.132426
-     8        -0.289691638733677    4.124e-06    0.005629    0.010970    0.010970    0.132425
-     9        -0.289691586089557    1.121e-06    0.005629    0.010971    0.010971    0.132425
-    10        -0.289691608492813    2.606e-07    0.005629    0.010971    0.010971    0.132425
-    11        -0.289691607071927    6.247e-08    0.005629    0.010971    0.010971    0.132425
+     0        -0.275835052561152    0.000e+00    0.000000    0.000000    0.000000    0.117056
+     1        -0.284194341448798    2.916e-02    0.004406    0.008041    0.008041    0.125326
+     2        -0.289394064728986    1.031e-02    0.005096    0.009416    0.009416    0.130919
+     3        -0.289651483708352    2.694e-03    0.005531    0.010486    0.010486    0.132163
+     4        -0.289681267891566    7.302e-04    0.005595    0.010758    0.010758    0.132420
+     5        -0.289694265258202    2.079e-04    0.005617    0.010893    0.010893    0.132436
+     6        -0.289692049051451    7.001e-05    0.005624    0.010944    0.010944    0.132427
+     7        -0.289692054525358    2.234e-05    0.005628    0.010968    0.010968    0.132426
+     8        -0.289691637601027    4.124e-06    0.005629    0.010970    0.010970    0.132425
+     9        -0.289691584956895    1.121e-06    0.005629    0.010971    0.010971    0.132425
+    10        -0.289691607360151    2.606e-07    0.005629    0.010971    0.010971    0.132425
+    11        -0.289691605939266    6.247e-08    0.005629    0.010971    0.010971    0.132425
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              3  27        -0.0068849973
-              2   0        -0.0063232782
-              4  41         0.0053297330
-              3  28        -0.0043934645
-              2   3         0.0041740308
-              2   5        -0.0040037993
-              1   2         0.0038552445
-              2   2        -0.0037971301
-              4  46         0.0036633872
-              2  11         0.0035898243
+              3  27        -0.0068849789
+              2   0        -0.0063232732
+              4  41         0.0053297307
+              3  28        -0.0043934604
+              2   3         0.0041740277
+              2   5        -0.0040037986
+              1   2         0.0038552443
+              2   2        -0.0037971322
+              4  46         0.0036633867
+              2  11         0.0035898240
 
     Largest TIjAb Amplitudes:
-      3   3  27  27        -0.0499894564
-      2   2   2   2        -0.0326014544
-      4   4   1   1        -0.0291682375
-      2   3   2  27        -0.0283326678
-      3   2  27   2        -0.0283326678
-      4   4  38  38        -0.0281223939
-      2   2  38  38        -0.0235715578
-      3   4  27  39        -0.0232682921
-      4   3  39  27        -0.0232682921
+      3   3  27  27        -0.0499894539
+      2   2   2   2        -0.0326014552
+      4   4   1   1        -0.0291682394
+      2   3   2  27        -0.0283326675
+      3   2  27   2        -0.0283326675
+      4   4  38  38        -0.0281223947
+      2   2  38  38        -0.0235715576
+      3   4  27  39        -0.0232682915
+      4   3  39  27        -0.0232682915
       4   4  39  39        -0.0232373445
 
-    SCF energy       (wfn)                    =  -76.054437313463026
-    Reference energy (file100)                =  -76.054437313462998
+    SCF energy       (wfn)                    =  -76.054437313463268
+    Reference energy (file100)                =  -76.054437313463197
 
-    Opposite-spin MP2 correlation energy      =   -0.209130957063002
-    Same-spin MP2 correlation energy          =   -0.066704096508075
-    MP2 correlation energy                    =   -0.275835053571078
-      * MP2 total energy                      =  -76.330272367034070
-    CC3 correlation energy                    =   -0.289691607071927
-      * CC3 total energy                      =  -76.344128920534928
-
-
-*** tstop() called on psinet at Mon May 15 15:34:57 2017
-Module time:
-	user time   =       3.30 seconds =       0.06 minutes
-	system time =       0.95 seconds =       0.02 minutes
-	total time  =          5 seconds =       0.08 minutes
-Total time:
-	user time   =       4.30 seconds =       0.07 minutes
-	system time =       1.14 seconds =       0.02 minutes
-	total time  =          6 seconds =       0.10 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:57 2017
+    Opposite-spin MP2 correlation energy      =   -0.209130956357103
+    Same-spin MP2 correlation energy          =   -0.066704096204049
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.275835052561152
+      * MP2 total energy                      =  -76.330272366024346
+    CC3 correlation energy                    =   -0.289691605939266
+      * CC3 total energy                      =  -76.344128919402465
 
 
 			**************************
@@ -489,37 +488,23 @@ Total time:
 			**************************
 
 Dots of (HeT1)c in names "CC3 Wxxx" in CC3_HET1 
-<WAmEf (Am,Ef) | WAmEf (Am,Ef)> =   11.4550009954
-<WMnIe (Mn,Ie) | WMnIe (Mn,Ie)> =    3.5330094137
-<WMnIj (Mn,Ij) | WMnIj (Mn,Ij)> =   38.6161220090
-<WMbIj (Ij,Mb) | WMbIj (Ij,Mb)> =    3.5598235794
-<WMbIj (Mb,Ij) | WMbIj (Mb,Ij)> =    3.5598235794
-<WMbEj (ME,jb) | WMbEj (ME,jb)> =    1.7094466761
-<WMbeJ (Me,Jb) | WMbeJ (Me,Jb)> =  113.7063701750
-<WAbEi (Ie,bA) | WAbEi (Ie,bA)> =   11.5303140743
-
-*** tstop() called on psinet at Mon May 15 15:34:57 2017
-Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       4.33 seconds =       0.07 minutes
-	system time =       1.18 seconds =       0.02 minutes
-	total time  =          6 seconds =       0.10 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:57 2017
-
+<WAmEf (Am,Ef) | WAmEf (Am,Ef)> =   11.4550009907
+<WMnIe (Mn,Ie) | WMnIe (Mn,Ie)> =    3.5330094158
+<WMnIj (Mn,Ij) | WMnIj (Mn,Ij)> =   38.6161220348
+<WMbIj (Ij,Mb) | WMbIj (Ij,Mb)> =    3.5598235797
+<WMbIj (Mb,Ij) | WMbIj (Mb,Ij)> =    3.5598235797
+<WMbEj (ME,jb) | WMbEj (ME,jb)> =    1.7094466770
+<WMbeJ (Me,Jb) | WMbeJ (Me,Jb)> =  113.7063702279
+<WAbEi (Ie,bA) | WAbEi (Ie,bA)> =   11.5303140636
 
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    9.009354229662666
-	SCF energy          (wfn)     =  -76.054437313463026
-	Reference energy    (file100) =  -76.054437313462998
-	CC3 energy          (file100) =   -0.289691607071927
+	Nuclear Rep. energy (wfn)     =    9.009354229662664
+	SCF energy          (wfn)     =  -76.054437313463268
+	Reference energy    (file100) =  -76.054437313463197
+	CC3 energy          (file100) =   -0.289691605939266
 
 	Input parameters:
 	-----------------
@@ -553,6 +538,14 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total 1160.8867669857
+Fmi   dot Fmi   total  426.0220490632
+Fme   dot Fme   total    0.0000221163
+WMBIJ dot WMBIJ total    0.0000000000
+Wmbij dot Wmbij total    0.0000000000
+WMbIj dot WMbIj total    2.9350923768
+WmBiJ dot WmBiJ total    0.0000000000
 Symmetry of ground state: A1
 Symmetry of excited state: B1
 Symmetry of right eigenvector: B1
@@ -560,113 +553,106 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=1     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4167468680   4.17e-01    5.57e-01      N
+                     1   0.4167468892   4.17e-01    5.57e-01      N
 Iter=2    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2982708163  -1.18e-01    8.87e-02      N
+                     1   0.2982708329  -1.18e-01    8.87e-02      N
 Iter=3    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2959659054  -2.30e-03    2.40e-02      N
+                     1   0.2959659218  -2.30e-03    2.40e-02      N
 Iter=4    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958576020  -1.08e-04    7.63e-03      N
+                     1   0.2958576184  -1.08e-04    7.63e-03      N
 Iter=5    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958527923  -4.81e-06    1.85e-03      N
+                     1   0.2958528087  -4.81e-06    1.85e-03      N
 Iter=6    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958533161   5.24e-07    6.71e-04      N
+                     1   0.2958533324   5.24e-07    6.71e-04      N
 Iter=7    L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958537796   4.64e-07    2.57e-04      N
+                     1   0.2958537959   4.64e-07    2.57e-04      N
 Iter=8    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958543006   5.21e-07    6.99e-05      N
+                     1   0.2958543170   5.21e-07    6.99e-05      N
 Iter=9    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958540107  -2.90e-07    1.98e-05      N
+                     1   0.2958540271  -2.90e-07    1.98e-05      N
 Iter=10   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958540870   7.63e-08    5.71e-06      N
+                     1   0.2958541034   7.63e-08    5.71e-06      N
 Iter=11   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958540919   4.97e-09    1.36e-06      N
+                     1   0.2958541083   4.97e-09    1.36e-06      N
 Iter=12   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958540945   2.52e-09    3.56e-07      Y
+                     1   0.2958541109   2.52e-09    3.56e-07      Y
 Iter=13   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958540945   1.29e-13    3.56e-07      Y
+                     1   0.2958541109   3.01e-13    3.56e-07      Y
 Completed EOM_CCSD
 Collapsing to only 1 vector(s).
 Copying root 1 to CC3_MISC file.
-Setting initial CC3 eigenvalue to    0.2958540945
+Setting initial CC3 eigenvalue to    0.2958541109
 Iter=1    L=1     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2934866845  -2.37e-03    4.89e-02      N
+                     1   0.2934867010  -2.37e-03    4.89e-02      N
 Iter=2    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921146019  -1.37e-03    1.39e-02      N
+                     1   0.2921146183  -1.37e-03    1.39e-02      N
 Iter=3    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921684749   5.39e-05    3.64e-03      N
+                     1   0.2921684914   5.39e-05    3.64e-03      N
 Iter=4    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921507853  -1.77e-05    1.14e-03      N
+                     1   0.2921508018  -1.77e-05    1.14e-03      N
 Iter=5    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921471299  -3.66e-06    3.19e-04      N
+                     1   0.2921471464  -3.66e-06    3.19e-04      N
 Iter=6    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921485000   1.37e-06    8.65e-05      N
+                     1   0.2921485164   1.37e-06    8.65e-05      N
 Iter=7    L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921486607   1.61e-07    2.92e-05      N
+                     1   0.2921486771   1.61e-07    2.92e-05      N
 Iter=8    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921486168  -4.39e-08    7.44e-06      N
+                     1   0.2921486332  -4.39e-08    7.44e-06      N
 Iter=9    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921486277   1.10e-08    2.13e-06      N
+                     1   0.2921486442   1.10e-08    2.13e-06      N
 Iter=10   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921486311   3.41e-09    7.50e-07      Y
-Collapsing to 2 vector(s).
-Change in CC3 energy from last iterated value   -0.0037054633
-Iter=11   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921457717  -2.86e-06    5.74e-05      N
-Iter=12   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921454284  -3.43e-07    1.85e-05      N
-Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921452358  -1.93e-07    4.78e-06      N
-Iter=14   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921452588   2.30e-08    1.49e-06      N
-Iter=15   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921452615   2.71e-09    4.55e-07      Y
+                     1   0.2921486476   3.41e-09    7.50e-07      Y
+Collapsing to 1 vector(s).
+Change in CC3 energy from last iterated value   -0.0037054632
+Iter=11   L=1     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     1   0.2921457870  -2.86e-06    5.74e-05      N
+Iter=12   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     1   0.2921454445  -3.42e-07    1.85e-05      N
+Iter=13   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     1   0.2921452519  -1.93e-07    4.79e-06      N
+Iter=14   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     1   0.2921452751   2.32e-08    1.50e-06      N
+Iter=15   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
+                     1   0.2921452780   2.87e-09    4.62e-07      Y
 Forcing restart to make sure new sigma vectors give same eigenvalue.
 Collapsing to only 1 vector(s).
-Change in CC3 energy from last iterated value   -0.0000033696
-Setting old CC3 eigenvalue to    0.2921452615
+Change in CC3 energy from last iterated value   -0.0000033697
+Setting old CC3 eigenvalue to    0.2921452780
 Iter=16   L=1     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921452584  -3.06e-09    4.60e-07      Y
+                     1   0.2921452749  -3.06e-09    4.67e-07      Y
 Collapsing to only 1 vector(s).
 Change in CC3 energy from last iterated value   -0.0000000031
 
 Procedure converged for 1 root(s).
-Energy written to CC_INFO:Etot  -76.0519836621
+Energy written to CC_INFO:Etot  -76.0519836445
 States per irrep written to CC_INFO.
 EOM CC3 R0 for root 0 =   0.00000000000
 
 Final Energetic Summary for Converged Roots of Irrep B1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      7.950    64118.5   0.2921452584   -76.051983662088
+EOM State 1      7.950    64118.5   0.2921452749   -76.051983644489
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    4a1 :    0.6714703701
-         0 >   1      :       1b1 >    5a1 :   -0.0981472158
-         0 >   2      :       1b1 >    6a1 :    0.0587842837
-         0 >   3      :       1b1 >    7a1 :   -0.0247616593
-         0 >   4      :       1b1 >    8a1 :   -0.0246210996
+         0 >   0      :       1b1 >    4a1 :   -0.6714703757
+         0 >   1      :       1b1 >    5a1 :    0.0981471713
+         0 >   2      :       1b1 >    6a1 :   -0.0587842764
+         0 >   3      :       1b1 >    7a1 :    0.0247616622
+         0 >   4      :       1b1 >    8a1 :    0.0246211037
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :    0.0759932240
-        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :    0.0759932240
-        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :    0.0548457579
-        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :    0.0548457579
-        2   0 >   2   0     :    3a1    1b1 >    6a1    4a1 :    0.0513307087
+        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :   -0.0759932273
+        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :   -0.0759932273
+        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :   -0.0548457621
+        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :   -0.0548457621
+        2   0 >   2   0     :    3a1    1b1 >    6a1    4a1 :   -0.0513307135
 
 	Putting into environment energy for root of R irrep 3 and root 1.
-	Putting into environment CURRENT ENERGY:              -76.0519836621
+	Putting into environment CURRENT ENERGY:              -76.0519836445
 
-	Total # of sigma evaluations: 29
+	Total # of sigma evaluations: 28
 
-*** tstop() called on psinet at Mon May 15 15:35:13 2017
-Module time:
-	user time   =      13.55 seconds =       0.23 minutes
-	system time =       2.55 seconds =       0.04 minutes
-	total time  =         16 seconds =       0.27 minutes
-Total time:
-	user time   =      17.88 seconds =       0.30 minutes
-	system time =       3.73 seconds =       0.06 minutes
-	total time  =         22 seconds =       0.37 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:21PM
+    Psi4 wall time for execution: 0:00:43.41
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc52/output.ref
+++ b/tests/cc52/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:19PM
 
-    Process ID:  13007
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65567
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -45,27 +58,25 @@ set {
   basis cc-pVDZ
 }
 
-property('ccsd',properties=['roa_tensor'])
+properties('ccsd',properties=['roa_tensor'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:51 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:19:29 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 3-4 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1-2 entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3-4 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -79,15 +90,15 @@ property('ccsd',properties=['roa_tensor'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O         -0.054730547952    -1.312218696095    -0.093235962587    15.994914619560
-           O          0.054730547952     1.312218696095    -0.093235962587    15.994914619560
-           H          0.662345455220    -1.720870706405     1.479722385924     1.007825032070
-           H         -0.662345455220     1.720870706405     1.479722385924     1.007825032070
+         O           -0.054730547952    -1.312218696095    -0.093235962601    15.994914619570
+         O            0.054730547952     1.312218696095    -0.093235962601    15.994914619570
+         H            0.662345455220    -1.720870706405     1.479722385910     1.007825032230
+         H           -0.662345455220     1.720870706405     1.479722385910     1.007825032230
 
   Running in c2 symmetry.
 
   Rotational constants: A =     10.61423  B =      0.97044  C =      0.91566 [cm^-1]
-  Rotational constants: A = 318206.62322  B =  29093.20183  C =  27450.82863 [MHz]
+  Rotational constants: A = 318206.62310  B =  29093.20182  C =  27450.82862 [MHz]
   Nuclear repulsion =   38.253971301898780
 
   Charge       = 0
@@ -105,28 +116,17 @@ property('ccsd',properties=['roa_tensor'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 18
-    Number of basis function: 38
+    Number of basis functions: 38
     Number of Cartesian functions: 40
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         19      19       0       0       0       0
-     B         19      19       0       0       0       0
-   -------------------------------------------------------
-    Total      38      38       9       9       9       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -145,45 +145,60 @@ property('ccsd',properties=['roa_tensor'])
   Using 549822 doubles for integral storage.
   We computed 14706 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.1870573093E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.0969229145E-02.
+  Reciprocal condition number of the overlap matrix is 8.7476035903E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+     B         19      19 
+   -------------------------
+    Total      38      38
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -150.83343525113654   -1.50833e+02   7.63461e-02 
-   @RHF iter   1:  -150.75353795846758    7.98973e-02   8.82719e-03 
-   @RHF iter   2:  -150.77679010769094   -2.32521e-02   2.18427e-03 DIIS
-   @RHF iter   3:  -150.77866919255425   -1.87908e-03   7.99699e-04 DIIS
-   @RHF iter   4:  -150.77908235686454   -4.13164e-04   3.09600e-04 DIIS
-   @RHF iter   5:  -150.77917088073266   -8.85239e-05   9.47403e-05 DIIS
-   @RHF iter   6:  -150.77918351965570   -1.26389e-05   1.61826e-05 DIIS
-   @RHF iter   7:  -150.77918384960782   -3.29952e-07   3.84188e-06 DIIS
-   @RHF iter   8:  -150.77918386693418   -1.73264e-08   8.22654e-07 DIIS
-   @RHF iter   9:  -150.77918386782613   -8.91959e-10   2.40060e-07 DIIS
-   @RHF iter  10:  -150.77918386791740   -9.12621e-11   5.87388e-08 DIIS
-   @RHF iter  11:  -150.77918386792231   -4.91696e-12   9.67949e-09 DIIS
-   @RHF iter  12:  -150.77918386792228    2.84217e-14   2.28250e-09 DIIS
-   @RHF iter  13:  -150.77918386792237   -8.52651e-14   4.76361e-10 DIIS
-   @RHF iter  14:  -150.77918386792223    1.42109e-13   1.50217e-10 DIIS
-   @RHF iter  15:  -150.77918386792234   -1.13687e-13   2.45399e-11 DIIS
+   @RHF iter SAD:  -150.13109175655745   -1.50131e+02   0.00000e+00 
+   @RHF iter   1:  -150.72994418203805   -5.98852e-01   1.20798e-02 ADIIS/DIIS
+   @RHF iter   2:  -150.77474437176173   -4.48002e-02   3.93712e-03 ADIIS/DIIS
+   @RHF iter   3:  -150.77872861849664   -3.98425e-03   9.99210e-04 ADIIS/DIIS
+   @RHF iter   4:  -150.77914038720894   -4.11769e-04   2.79341e-04 ADIIS/DIIS
+   @RHF iter   5:  -150.77918120416425   -4.08170e-05   4.89524e-05 DIIS
+   @RHF iter   6:  -150.77918362205793   -2.41789e-06   1.25560e-05 DIIS
+   @RHF iter   7:  -150.77918384507149   -2.23014e-07   3.89299e-06 DIIS
+   @RHF iter   8:  -150.77918386710951   -2.20380e-08   8.16054e-07 DIIS
+   @RHF iter   9:  -150.77918386789929   -7.89782e-10   1.49865e-07 DIIS
+   @RHF iter  10:  -150.77918386792138   -2.20837e-11   3.10868e-08 DIIS
+   @RHF iter  11:  -150.77918386792260   -1.22213e-12   6.61625e-09 DIIS
+   @RHF iter  12:  -150.77918386792251    8.52651e-14   1.38474e-09 DIIS
+   @RHF iter  13:  -150.77918386792257   -5.68434e-14   3.05202e-10 DIIS
+   @RHF iter  14:  -150.77918386792260   -2.84217e-14   6.31847e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -208,48 +223,43 @@ property('ccsd',properties=['roa_tensor'])
               A     B 
     DOCC [     5,    4 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -150.77918386792234
+  @RHF Final Energy:  -150.77918386792260
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             38.2539713018987797
-    One-Electron Energy =                -284.0698976825351565
-    Two-Electron Energy =                  95.0367425127140280
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -150.7791838679223417
+    One-Electron Energy =                -284.0698976786380854
+    Two-Electron Energy =                  95.0367425088167010
+    Total Energy =                       -150.7791838679225975
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.2602
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.2074     Total:     1.2074
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on psinet at Mon May 15 15:34:52 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:19:30 2022
 Module time:
-	user time   =       0.61 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.15 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.61 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       1.15 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -264,19 +274,19 @@ Total time:
       Number of basis functions:        38
 
       Number of irreps:                  2
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  19   19 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 135343 non-zero two-electron integrals.
+      Computed 117739 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:52 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:19:30 2022
 
 
 	Wfn Parameters:
@@ -299,7 +309,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -350,24 +360,20 @@ Total time:
 	Total:                                     0.034 (MW) /      0.272 (MB)
 
 	Nuclear Rep. energy          =     38.25397130189878
-	SCF energy                   =   -150.77918386792234
-	One-electron energy          =   -284.06989768056661
-	Two-electron energy          =     95.03674251074538
-	Reference energy             =   -150.77918386792243
+	SCF energy                   =   -150.77918386792260
+	One-electron energy          =   -284.06989768243102
+	Two-electron energy          =     95.03674251260959
+	Reference energy             =   -150.77918386792265
 
-*** tstop() called on psinet at Mon May 15 15:34:52 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:19:31 2022
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.82 seconds =       0.01 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.24 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:52 2017
-
+Total time:
+	user time   =       1.42 seconds =       0.02 minutes
+	system time =       0.39 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -375,8 +381,8 @@ Total time:
             **************************
 
     Nuclear Rep. energy (wfn)     =   38.253971301898780
-    SCF energy          (wfn)     = -150.779183867922342
-    Reference energy    (file100) = -150.779183867922427
+    SCF energy          (wfn)     = -150.779183867922598
+    Reference energy    (file100) = -150.779183867922654
 
     Input parameters:
     -----------------
@@ -404,39 +410,39 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3846819202176234
+MP2 correlation energy -0.3846819202183502
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.384681920217623    0.000e+00    0.000000    0.000000    0.000000    0.143443
-     1        -0.388195063372415    4.161e-02    0.005536    0.014944    0.014944    0.146546
-     2        -0.397131368987842    1.579e-02    0.006295    0.016701    0.016701    0.156214
-     3        -0.398540157742984    5.272e-03    0.007094    0.018500    0.018500    0.160058
-     4        -0.398592388306193    1.389e-03    0.007211    0.018629    0.018629    0.160897
-     5        -0.398626159810397    5.016e-04    0.007271    0.018667    0.018667    0.161087
-     6        -0.398618320807045    1.894e-04    0.007295    0.018670    0.018670    0.161082
-     7        -0.398614908700885    5.957e-05    0.007301    0.018667    0.018667    0.161072
-     8        -0.398614877267304    2.091e-05    0.007303    0.018667    0.018667    0.161070
-     9        -0.398614537478538    7.866e-06    0.007303    0.018666    0.018666    0.161069
-    10        -0.398614816168221    3.334e-06    0.007303    0.018666    0.018666    0.161069
-    11        -0.398614791737047    1.107e-06    0.007304    0.018666    0.018666    0.161069
-    12        -0.398614829307719    3.663e-07    0.007304    0.018666    0.018666    0.161069
-    13        -0.398614827840053    1.109e-07    0.007304    0.018666    0.018666    0.161069
-    14        -0.398614828149518    3.779e-08    0.007304    0.018666    0.018666    0.161069
+     0        -0.384681920218350    0.000e+00    0.000000    0.000000    0.000000    0.143443
+     1        -0.388195063375176    4.161e-02    0.005536    0.014944    0.014944    0.146546
+     2        -0.397131368993452    1.579e-02    0.006295    0.016701    0.016701    0.156214
+     3        -0.398540157751685    5.272e-03    0.007094    0.018500    0.018500    0.160058
+     4        -0.398592388314298    1.389e-03    0.007211    0.018629    0.018629    0.160897
+     5        -0.398626159818644    5.016e-04    0.007271    0.018667    0.018667    0.161087
+     6        -0.398618320814936    1.894e-04    0.007295    0.018670    0.018670    0.161082
+     7        -0.398614908708726    5.957e-05    0.007301    0.018667    0.018667    0.161072
+     8        -0.398614877275146    2.091e-05    0.007303    0.018667    0.018667    0.161070
+     9        -0.398614537486384    7.866e-06    0.007303    0.018666    0.018666    0.161069
+    10        -0.398614816176060    3.334e-06    0.007303    0.018666    0.018666    0.161069
+    11        -0.398614791744887    1.107e-06    0.007304    0.018666    0.018666    0.161069
+    12        -0.398614829315558    3.663e-07    0.007304    0.018666    0.018666    0.161069
+    13        -0.398614827847895    1.109e-07    0.007304    0.018666    0.018666    0.161069
+    14        -0.398614828157357    3.779e-08    0.007304    0.018666    0.018666    0.161069
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              7  14        -0.0101502101
-              8  14        -0.0087340592
+              7  14        -0.0101502103
+              8  14        -0.0087340595
               3   7        -0.0082767744
               3   9        -0.0079615875
               3   4         0.0077314694
               2   8        -0.0067261148
               2   0        -0.0066430741
-              7  17         0.0064676898
+              7  17         0.0064676899
               2   3         0.0061934100
               8  16         0.0060750570
 
@@ -452,32 +458,20 @@ MP2 correlation energy -0.3846819202176234
       2   2   1   1        -0.0213000213
       3   3  14  14        -0.0200219571
 
-    SCF energy       (wfn)                    = -150.779183867922342
-    Reference energy (file100)                = -150.779183867922427
+    SCF energy       (wfn)                    = -150.779183867922598
+    Reference energy (file100)                = -150.779183867922654
 
-    Opposite-spin MP2 correlation energy      =   -0.285626227170513
-    Same-spin MP2 correlation energy          =   -0.099055693047110
-    MP2 correlation energy                    =   -0.384681920217623
-      * MP2 total energy                      = -151.163865788140043
+    Opposite-spin MP2 correlation energy      =   -0.285626227171874
+    Same-spin MP2 correlation energy          =   -0.099055693046476
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.384681920218350
+      * MP2 total energy                      = -151.163865788141010
 
-    Opposite-spin CCSD correlation energy     =   -0.311603037116158
-    Same-spin CCSD correlation energy         =   -0.087011791036590
-    CCSD correlation energy                   =   -0.398614828149518
-      * CCSD total energy                     = -151.177798696071932
-
-
-*** tstop() called on psinet at Mon May 15 15:34:53 2017
-Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.18 seconds =       0.02 minutes
-	system time =       0.48 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:53 2017
+    Opposite-spin CCSD correlation energy     =   -0.311603037120795
+    Same-spin CCSD correlation energy         =   -0.087011791036562
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.398614828157357
+      * CCSD total energy                     = -151.177798696080004
 
 
 			**************************
@@ -487,20 +481,6 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:53 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.20 seconds =       0.02 minutes
-	system time =       0.51 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:53 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
@@ -508,10 +488,10 @@ Total time:
 
 	Nuclear Rep. energy (wfn)     =   38.253971301898780
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -150.779183867922342
-	Reference energy    (CC_INFO) = -150.779183867922427
-	CCSD energy         (CC_INFO) =   -0.398614828149518
-	Total CCSD energy   (CC_INFO) = -151.177798696071932
+	SCF energy          (wfn)     = -150.779183867922598
+	Reference energy    (CC_INFO) = -150.779183867922654
+	CCSD energy         (CC_INFO) =   -0.398614828157357
+	Total CCSD energy   (CC_INFO) = -151.177798696080004
 
 	Input parameters:
 	-----------------
@@ -524,7 +504,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -537,26 +517,26 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.398624699623161    0.000e+00
-	   1        -0.391214048569795    8.462e-03
-	   2        -0.390364515552455    2.118e-03
-	   3        -0.390185508068063    7.366e-04
-	   4        -0.390186454460750    2.599e-04
-	   5        -0.390188067867247    1.092e-04
-	   6        -0.390187382517926    3.731e-05
-	   7        -0.390187977594359    1.258e-05
-	   8        -0.390188017894507    4.692e-06
-	   9        -0.390187964801878    1.968e-06
-	  10        -0.390187962251415    6.939e-07
-	  11        -0.390187961564797    2.239e-07
-	  12        -0.390187964869423    7.240e-08
+	   0        -0.398624699627845    0.000e+00
+	   1        -0.391214048570689    8.462e-03
+	   2        -0.390364515553340    2.118e-03
+	   3        -0.390185508068917    7.366e-04
+	   4        -0.390186454461606    2.599e-04
+	   5        -0.390188067868143    1.092e-04
+	   6        -0.390187382518825    3.731e-05
+	   7        -0.390187977595261    1.258e-05
+	   8        -0.390188017895408    4.692e-06
+	   9        -0.390187964802781    1.968e-06
+	  10        -0.390187962252321    6.939e-07
+	  11        -0.390187961565701    2.239e-07
+	  12        -0.390187964870325    7.240e-08
 
 	Largest LIA Amplitudes:
-	          7  14        -0.0081022818
+	          7  14        -0.0081022820
 	          3   7        -0.0070235768
-	          3   4         0.0069916602
+	          3   4         0.0069916601
 	          3   9        -0.0068965989
-	          8  14        -0.0068236615
+	          8  14        -0.0068236617
 	          3   3        -0.0057527613
 	          2   8        -0.0055687935
 	          2   3         0.0053706171
@@ -567,8 +547,8 @@ Total time:
 	  3   3  15  15        -0.0651028563
 	  3   3  14  15         0.0320888191
 	  3   3  15  14         0.0320888191
-	  2   3  15  15         0.0299752805
-	  3   2  15  15         0.0299752805
+	  2   3  15  15         0.0299752804
+	  3   2  15  15         0.0299752804
 	  2   2  15  15        -0.0298862579
 	  4   4  17  17        -0.0223692554
 	  4   4  15  15        -0.0208228065
@@ -577,21 +557,7 @@ Total time:
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.89181921412
-
-*** tstop() called on psinet at Mon May 15 15:34:53 2017
-Module time:
-	user time   =       0.14 seconds =       0.00 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.34 seconds =       0.02 minutes
-	system time =       0.62 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:53 2017
-
+	Overlap <L|e^T> =        0.89181921409
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -618,4936 +584,985 @@ Total time:
 	Irrep RX         =    B
 	Irrep RY         =    B
 	Irrep RZ         =    A
-	Gauge            =    LENGTH
+	Gauge            =    VELOCITY
 	Applied field  0 =    0.077 E_h (589.00 nm, 2.105 eV, 16977.93 cm-1)
 	Analyze X2 Amps  =    No
 	Local CC         =    No
 
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.008726358253324  0.004099789370796 -0.008330479294140 -0.051357761393593  0.030906784149030 -0.019128343817679  0.004489543486253 -0.004635107317701  0.004635328366960
-    1  (  1)  0.027048402565333  0.015352698194109 -0.027966810828923 -0.165495847619996  0.113032378954357 -0.059172921563583  0.054022069625682  0.034114622002470  0.002886104670801
-    2  (  2)  0.197986819375265  0.163526050346022 -0.274966370917799  0.062421303214726  0.155967385768679  0.185920865566873  0.363704252195049  0.011868287507021  0.094068340161851
-    3  (  3)  0.001994764352967 -0.040665396609448 -0.057882197632570  0.076919849484572  0.080668844960328  0.050712060789419 -0.045932844767313  0.241652623780467  0.100470930712698
-    4  (  4) -0.134618177447064 -0.169475265434671 -0.112338311475877 -0.029804538774238  0.003944400702454  0.058729577634632 -0.233881473947597 -0.145241250552739  0.577534952252569
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.015264708398609  0.000380839620875  0.000958406208127  0.000022771221818  0.007771119331940 -0.004180693865458
-    1  (  1) -0.036861149574356  0.060248607922654 -0.005564051978491 -0.004146759903694  0.016591701782065 -0.007733798483021
-    2  (  2) -0.035918767544593 -0.084747648129592 -0.145084305566167 -0.032998091307020 -0.051841362485402  0.022806683673173
-    3  (  3) -0.084717188897695  0.396671962274355 -0.041908756327673 -0.023248483109410 -0.041530857306626  0.002269989755115
-    4  (  4)  0.038883162178730 -0.071756266385489  0.163991683627981 -0.069947362602168 -0.143620946254033 -0.040929672235998
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.006642198224872 -0.017864517410705 -0.002436455117640  0.034327697321106  0.044296142107527 -0.004524598483767 -0.007642041469558  0.002038938474699 -0.017547409291226
-    1  (  6)  0.052809064594288 -0.081154571387218  0.006856489971971  0.153404046471364  0.196852316929167 -0.080976227071713  0.074658872735033  0.007719527504526 -0.043614905942800
-    2  (  7)  0.345238807209103  0.019785748737115 -0.050847201503871 -0.077921963643687  0.068975113172113 -0.351671681449397  0.386754786184204 -0.290601492514340  0.053302937912910
-    3  (  8)  0.016264186371442 -0.328366407178677 -0.028951150608889 -0.018921397483150 -0.077573752184046 -0.021800325659185  0.192628944675434  0.357488576270743 -0.081608450226918
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5) -0.002800892899341  0.001588044547621 -0.002043530443472 -0.002989801891975  0.009924697077259
-    1  (  6)  0.002259901952667 -0.008421833483970 -0.029392105663941  0.031370000803135  0.013404149148181
-    2  (  7)  0.208575434351967  0.067711741287105 -0.203628160296894 -0.030033358884083  0.027351415718804
-    3  (  8) -0.187162855515783 -0.097599571742167 -0.071289744582036 -0.047614083662496 -0.125833426449637
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.054640928604079  0.005210601329773  0.051616911789990 -0.021289306638363
-    1  (  1)  0.002918130971429 -0.083685930032084 -0.629038391350598  0.187773679543592
-    2  (  2)  0.007590553200849 -0.172618831857560 -0.014249434463544 -0.090476293197145
-    3  (  3) -0.001656007900849  0.012405930617653  0.140259881389899 -0.033090225966566
-    4  (  4) -0.060549418115409  0.617360626468562 -0.177011250977925 -0.059209090638140
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5)  0.054640627456712  0.002969769138836  0.007701916943750 -0.001647694192880 -0.060488917840894
-    1  (  6)  0.005063584133923 -0.083990281035735 -0.171918098878149  0.012481144251307  0.618887559195101
-    2  (  7)  0.051989862635947 -0.628248874097967 -0.014468225422280  0.141950072237577 -0.177061951774040
-    3  (  8) -0.021491599575181  0.185984085003910 -0.088114580327343 -0.035355592596440 -0.057157867183425
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.828706146034386 -0.451242109852709 -0.217484138501230  0.586282287351547 -0.198652063850505 -0.103905752222109 -0.006640989619586 -0.001834560031245 -0.094019453805335
-    1  (  1) -0.134100700080040 -0.143648267876425 -0.612001094401369  0.241016548337875 -0.051447992063061 -0.174324624000297  0.232758066319163  0.145665329684001 -0.128122484666347
-    2  (  2)  0.012063242030172 -0.029491585921282  0.163573153509056 -0.247029613708601 -0.158755826864665 -0.232663100280139 -0.114949348720011 -0.088611713985977 -0.022640568468258
-    3  (  3) -0.387196287625114 -0.007619888810882 -0.010215945023127 -0.204815573940664  0.014943114055119  0.002429418787150 -0.270124928364800  0.245261455960510  0.504578168045275
-    4  (  4) -0.460892786703299 -0.083409861133685 -0.199941848514522 -0.175473221892135 -0.163725104209158  0.040242844508077 -0.067820817652324 -0.310800434323545  0.577770697777668
-    5  (  5) -0.141671388309899  0.052085424887701 -0.250889199898616 -0.425020293953164  0.233838976722190 -0.158342892875998  0.178720592805468  0.245883965544865 -0.083556345867639
-    6  (  6) -0.130216026417529 -0.059016496111328  0.175413504158991  0.193340854958521  0.081296144751237  0.027169219273725 -0.479006492875890  0.042683275801603 -0.241452076216105
-    7  (  7) -0.128547311284246 -0.164218887003252  0.072921092938496 -0.418221968357328  0.302481302349542 -0.324000436351745 -0.075457449047149 -0.283015193488097  0.036411772565860
-    8  (  8) -0.062136138821468 -0.089655855116764  0.258683432372161  0.013238066621816  0.089006716298679  0.141926238487964  0.145723637909448 -0.025158497993198  0.043087738853390
-    9  (  9)  0.009157820730330  0.060303970748008  0.008728789531235 -0.116944655283660  0.076880496829354 -0.036379961660859  0.025483815995756  0.084185902888697 -0.015373912850922
-   10  ( 10)  0.047801707847592 -0.149112775043073  0.075802889752490 -0.048946990543248 -0.067508818044676 -0.106234902064945  0.028517357036704 -0.172546945128713  0.080205622482774
-   11  ( 11) -0.167487243201529 -0.138909034367258  0.283705985411626  0.091574934848991 -0.067077361755332 -0.025283449194756 -0.222327980731763 -0.000487496834220 -0.057943753196592
-   12  ( 12) -0.037232826569727  0.362746944725965  0.118756614826307  0.060033266562179  0.015288836065774 -0.066371534338223  0.063047295845484 -0.118285916405811 -0.151867403217362
-   13  ( 13)  0.015285003281902 -0.071147280667215  0.097867241882436 -0.110090394044023  0.125072443482472 -0.056834448354770 -0.036030597903336 -0.003982741201085 -0.062348593829030
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.129551238177096 -0.009488456158753 -0.145865286204104 -0.063534582075814 -0.014263018255126  0.066213919173090
-    1  (  1)  0.281752071049832  0.090568985194257  0.289770608164313  0.012153910923956 -0.002973145726343 -0.002348497409112
-    2  (  2) -0.119859956565822 -0.017639167739410 -0.056884775212415 -0.114244082569373 -0.081967897124079  0.047554375904432
-    3  (  3)  0.046052437580045 -0.068238293863321 -0.078833485689447  0.147717911146477  0.178531582040062  0.041892849005174
-    4  (  4)  0.224633883396051  0.054732485212034 -0.049353614808463 -0.010496061614547  0.270818815860100  0.056282361048398
-    5  (  5) -0.031022260628429 -0.167865237629900  0.089183099627055  0.032869671397236 -0.093572690466920 -0.005456840308638
-    6  (  6)  0.000982133418989 -0.078801662265047 -0.231661085764917  0.077972890170051 -0.062232529975331 -0.004237613677504
-    7  (  7) -0.058899229378581  0.114393506277186 -0.121935937848221 -0.061774412530829  0.018066748886740  0.046892838199463
-    8  (  8) -0.513409737347451 -0.085342661995497  0.027485932540569  0.006687260362005  0.194553247064750 -0.182125456067964
-    9  (  9) -0.072026053071414  0.003186222518884  0.005510353122010  0.002695440956634  0.031995071427630  0.027434782359825
-   10  ( 10) -0.012940293864882  0.102600682351947  0.011650957701747  0.003161631735307  0.051176877208360  0.036262211648487
-   11  ( 11) -0.072389469580127 -0.058864264067381 -0.028127934262967 -0.005944143158315 -0.000119588476469 -0.005493093990009
-   12  ( 12) -0.054636171447082 -0.008288858918728 -0.024567957728312 -0.016528672388406 -0.046478535392181 -0.050873413900705
-   13  ( 13)  0.233742268237557  0.059061359722307 -0.024587714125957  0.004543189871606 -0.015684499425205  0.012075186778911
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.826711156195337 -0.135935151565258  0.011489969073388 -0.387391839727672 -0.461365581651292 -0.145467712201618 -0.125019996952858 -0.128340561685360 -0.063848573844888
-    1  ( 15) -0.452838227194430 -0.142306798766955 -0.028877531672345 -0.006301533154291 -0.083456581821052  0.052281129604496 -0.060350144393154 -0.164374695812529 -0.091100547176124
-    2  ( 16) -0.216310054009477 -0.610399898516470  0.164685213415757 -0.011222973076338 -0.198700993790197 -0.249895223410389  0.173163780734669  0.071385572741419  0.260545733486437
-    3  ( 17)  0.584295572109460  0.240131435592180 -0.247503497789340 -0.203669352864468 -0.175657823643113 -0.423099271752240  0.191635180366038 -0.415445845313167  0.012400800769501
-    4  ( 18) -0.199044562720114 -0.050377818277258 -0.159053276836240  0.015283930627252 -0.162357231214840  0.232428029782015  0.082723129382115  0.299784734961446  0.088347612836073
-    5  ( 19) -0.104273592770362 -0.175241490750589 -0.233618474932292  0.003345089862021  0.039541365820652 -0.159215770988207  0.028729316829135 -0.323092862210534  0.140740607225090
-    6  ( 20) -0.009429335018838  0.234933790685113 -0.114394007036927 -0.268468302596859 -0.069018401858714  0.178510702843373 -0.480182866961241 -0.075908236499367  0.143022251545674
-    7  ( 21) -0.002869882965177  0.147319499520357 -0.089022570902071  0.243061937922923 -0.308864448701183  0.246225508993362  0.042994447165724 -0.286146292781464 -0.024663726337053
-    8  ( 22) -0.094478736507172 -0.129734933216468 -0.024605609602966  0.506958586831599  0.578503509565487 -0.083637076410159 -0.240370604361310  0.036575630460933  0.043366918121103
-    9  ( 23) -0.127470997074015  0.279778736469960 -0.119965615903303  0.046832895086933  0.224615257627647 -0.032676002796073  0.003107097546044 -0.057480331380710 -0.513622568025337
-   10  ( 24) -0.010112145856398  0.091493161331689 -0.018678003435740 -0.071591866273240  0.058564372003588 -0.167585681613965 -0.077209541817243  0.110207052994212 -0.083925491648311
-   11  ( 25) -0.144415523585391  0.288922618884642 -0.057020341791240 -0.078931919343244 -0.049197799442361  0.089025981977188 -0.231280478987433 -0.121730292595615  0.028617522205192
-   12  ( 26) -0.063358105777822  0.012361945563287 -0.113921025259528  0.147470462823697 -0.010508084965815  0.032944118863399  0.077679822784259 -0.061767269758067  0.006770104986395
-   13  ( 27) -0.013993837072694 -0.002562110452836 -0.081334933917155  0.177742267998911  0.270579570421532 -0.093515516405201 -0.062573025821331  0.017990546310044  0.194659673293224
-   14  ( 28)  0.066065251106744 -0.002210340499780  0.047580995754206  0.041754873475777  0.056032464253567 -0.005463311356664 -0.004248346332330  0.046944812393441 -0.182305805960673
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.009979379572814  0.047798747321919 -0.170240230765171 -0.037928069435865  0.014469797880662
-    1  ( 15)  0.061027751185507 -0.148840702791378 -0.138630226960344  0.363021177441020 -0.070821263422492
-    2  ( 16)  0.008874729207977  0.075935276016761  0.284548525764052  0.119188802798918  0.098634707511262
-    3  ( 17) -0.119117086503999 -0.049600984032187  0.092587202914304  0.060255249862003 -0.110664730215096
-    4  ( 18)  0.077873158500033 -0.066964465409446 -0.067808229278391  0.015339476585213  0.125520595140883
-    5  ( 19) -0.036383539416228 -0.106251119170760 -0.025901213572670 -0.066582645600730 -0.057304048193053
-    6  ( 20)  0.027022056662628  0.029104260975181 -0.222331916070169  0.063168479037920 -0.035714694607018
-    7  ( 21)  0.082539033408343 -0.172537331705974 -0.000670422490370 -0.118275081356325 -0.003845416382836
-    8  ( 22) -0.015061455884277  0.080414315259920 -0.057451946757190 -0.151720063978593 -0.062257934041710
-    9  ( 23) -0.071494160600195 -0.013120644645817 -0.073373282570407 -0.054798986026219  0.233373314199454
-   10  ( 24) -0.000027666792880  0.102292357079099 -0.059322109099378 -0.008317847549247  0.059028052494592
-   11  ( 25)  0.005764684616375  0.011614577578045 -0.028065246881801 -0.024579519350874 -0.024526886305124
-   12  ( 26)  0.002692917534545  0.003133257383266 -0.005931148158517 -0.016507347414869  0.004578243786138
-   13  ( 27)  0.031988181666996  0.051121346364317 -0.000222760070979 -0.046532939793729 -0.015678091975120
-   14  ( 28)  0.027397882083938  0.036259576902543 -0.005558241600308 -0.050917515214298  0.012016026604405
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.008738714188262  0.004039194397261 -0.008127980070865 -0.050655606898753  0.030439544744837 -0.018707903279643  0.004460301652062 -0.004487162776284  0.004640583122401
-    1  (  1)  0.025464105793567  0.023322251028318 -0.022318311579118 -0.168981942365647  0.107958094829728 -0.060967664324034  0.050899742777678  0.027099711163650  0.006144058982229
-    2  (  2)  0.191072298160517  0.147214807884978 -0.245314939461247  0.051214709951103  0.145788096508092  0.177073439248461  0.335655286205939  0.014742215764281  0.084887786428846
-    3  (  3) -0.003186278006520 -0.027262310295902 -0.053200037794675  0.087160188200802  0.072587962677224  0.049786512042849 -0.037066848030461  0.221100046597742  0.094067986413720
-    4  (  4) -0.148066244304402 -0.143793459059393 -0.095636804238921 -0.040634965287268  0.006984168978332  0.053393224298865 -0.215351187382742 -0.136718664045745  0.551492376609727
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.014883248103234  0.000447524480570  0.000953402346197  0.000015028916964  0.007616606179432 -0.004045766207387
-    1  (  1) -0.030007366287879  0.050763977322566 -0.002877267596603 -0.003524485582812  0.015219426860028 -0.007305493198944
-    2  (  2) -0.023553545181112 -0.073804286498201 -0.128816859439703 -0.028660158132981 -0.047825385053869  0.021696397029188
-    3  (  3) -0.073207463864785  0.364255662603108 -0.036747232817153 -0.019228531486396 -0.037102604043679  0.000179257038479
-    4  (  4)  0.040426426340129 -0.065213161657927  0.146105992269011 -0.062375299545412 -0.126872343354634 -0.038208213322541
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.006539105564376 -0.017707323111357 -0.002499007493135  0.033748669654763  0.043426168613627 -0.004376517576248 -0.007331691779182  0.002175835593629 -0.017125007623034
-    1  (  6)  0.049476498396240 -0.071428033492344  0.010982221416816  0.154099892546157  0.199342311510189 -0.070559836005122  0.064227747325895  0.009736411806781 -0.037806955842619
-    2  (  7)  0.343113105238399  0.025590887445013 -0.051500206680835 -0.074207698718739  0.055613629832995 -0.335551360314332  0.361717174711126 -0.278367381019521  0.053439300213695
-    3  (  8)  0.008981567803547 -0.297283767239541 -0.029279921669206 -0.011824918559736 -0.070221583593260 -0.014561568621694  0.183332584603252  0.338826200673234 -0.064061984920529
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5) -0.002655135611054  0.001569518715490 -0.001987600984138 -0.002932201164091  0.009687073865030
-    1  (  6)  0.003017180197358 -0.006878355915454 -0.023867242245617  0.027359958180905  0.011597430265208
-    2  (  7)  0.191101237606457  0.061794620704227 -0.180138129116816 -0.027170833808731  0.022115595947187
-    3  (  8) -0.170766304250859 -0.089149012850623 -0.060688270949031 -0.041495171428001 -0.115637989109118
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.019521006165281 -0.055311188970005 -0.010706738443583 -0.032331179853756 -0.020999963919199  0.046831932628285 -0.007924283366416  0.010861182431020 -0.005026855082536
-    1  (  1) -0.033754065271540  0.007555323601594 -0.012636543474800 -0.059168088022016 -0.007696122167807  0.117635607585961 -0.032183938476143  0.074301266031173  0.005019432868473
-    2  (  2) -0.423755901473008  0.394319953583624  0.072147795319661 -0.012389584147675  0.176348209775790  0.099930460951952 -0.086701711601797  0.210493559894712 -0.033589875704030
-    3  (  3)  0.731556308731298 -0.976828874482841  0.033351755384687  0.123378267443698  0.157072568357327 -0.117469395519379  0.019850788477436  0.009097965090148  0.052535977761936
-    4  (  4) -0.047142005374305  0.198059776273808 -0.117104111550433  0.059612491656410 -0.051541011220576  0.120490619961906  0.186894254778088 -0.315632222294417 -0.008321570634058
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003262690356194 -0.000921635855382  0.000034364479618  0.000830273666301  0.001668851552789  0.011974216240854
-    1  (  1)  0.004809888663567 -0.006374186820277  0.001349974273730 -0.006100973447119  0.011138135467635  0.022680638608240
-    2  (  2)  0.028102393751442  0.000289728193602  0.008262914874638 -0.124989508593931  0.066219550071583  0.018649107035260
-    3  (  3)  0.064127670119822 -0.065272254484780 -0.003581214913271 -0.076462594745773 -0.021447979734985 -0.132206769185044
-    4  (  4)  0.084986178663625 -0.498497660067068 -0.040822624142053 -0.043076717241011  0.013585580967101  0.027785124769563
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.008340446213445  0.001319543713287  0.002585312986801 -0.036574951751463  0.035584760184465  0.014212251125619  0.008333090140714 -0.020105467085781  0.018182658670262
-    1  (  6)  0.016730545191635 -0.000493195311453  0.017302877905216 -0.256616108678247  0.185493081539624 -0.020593293392496 -0.009463626383465 -0.002961963262001  0.026859262466342
-    2  (  7) -0.075519334277090  0.118875834952039  0.079935744901980 -0.178710155118301 -0.108180717969282 -0.177149200959755 -0.083450893895434  0.113241571854644  0.031859915842082
-    3  (  8) -0.130570303260619  0.286100763360337  0.219485954048373 -0.104893538873990  0.173427375354673 -0.413346163755587 -0.212933837522820  0.179033004883616  0.025997503548255
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5) -0.022178092937579 -0.006192777331479  0.000265547702251 -0.001796630581332 -0.005838309357701
-    1  (  6)  0.021490603426123 -0.022287911746425  0.002597642056197 -0.020805619372963 -0.017185300683315
-    2  (  7) -0.023718657960482  0.015749632524175  0.008406848859514 -0.192275121572811  0.036883303440684
-    3  (  8)  0.028766610087134 -0.272291127261861 -0.017419736923766  0.092820042031070  0.043867783302541
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.312071983578507 -0.011814876857950  0.001749854763442  0.004860639055962
-    1  (  1)  0.012607230082849  1.239345828125903 -0.063577833893335 -0.037142890606408
-    2  (  2) -0.024758209244809  0.637221232191289  0.563297780481640  1.010299718642921
-    3  (  3)  0.052130684447186 -1.018425228708053  0.319422169856126  0.762006603805681
-    4  (  4) -0.006181596445579  0.045227882767329 -1.211417782056943  0.547652752607847
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5)  1.312073329340832  0.012916671336045 -0.025327794269357  0.053171357300251 -0.006379162140484
-    1  (  6) -0.012204346486938  1.240079163662107  0.636087106947960 -1.017453481268297  0.045095378978851
-    2  (  7)  0.002283790492478 -0.063116414325747  0.559667151426996  0.326872235147613 -1.214495041331997
-    3  (  8)  0.005391564300466 -0.036008776543251  1.005416456141600  0.769683801437904  0.546253171656459
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.840016539608651  0.879753468452699  0.280415731570084  0.209447514149777 -0.115989496283759 -0.005848981184439 -0.092528751282017  0.016865841544358 -0.000555643555622
-    1  (  1)  0.406957372636473 -0.250361017718524  1.752820583779622  0.218267703062559 -0.014945333567651  0.085168821063673 -0.020237564672152  0.502759408379448  0.012614437172938
-    2  (  2) -0.011941792295457 -0.087293012666816 -0.224334308464796 -0.261121254288044 -0.841757183547563 -0.627836026290384  0.172053710890284  0.617241445078585  0.119309904822696
-    3  (  3)  0.811175226999415 -0.188292949321421  0.222402236987636 -0.118808337714817  0.529561197149942 -1.235458031177234  0.515403991569446 -0.727582947600793 -0.017311936329445
-    4  (  4) -0.382867370754787  0.342146135514685  0.036039554210222 -1.515965889553083  0.125472034154194  0.736745138882596  0.136009550644029  0.102467599608712  0.013412178693964
-    5  (  5) -0.056654365649433  0.399240631274606 -0.011418861518996 -0.698109204208624 -1.282946166494922  0.508746828096109 -0.451446643358377 -0.904110049342953  0.596673954736893
-    6  (  6) -0.005522502604356  0.206035158805044 -0.144483368870027 -0.121244362194411 -0.485302242833422  0.548549626073424  1.475358435950266 -0.106844110516643 -0.027446830473777
-    7  (  7)  0.133570215574571  0.328958458733595  0.162331426230781  0.054204675906593  0.478145844867824  0.570684634855355 -0.024901924913465  0.585192241991829  0.835814613688614
-    8  (  8)  0.031087442161182 -0.063500744070072 -0.272771207726926 -0.132861451881092 -0.103452299165205  0.119423299933467 -0.197404336020949  0.153618581888351 -0.347695539805157
-    9  (  9) -0.117645924792058  0.675672354085764  0.057145948312353  0.137497063432611 -0.007399284421135 -0.153449953993442 -0.039660015788702 -0.125410855887841 -0.348925440159647
-   10  ( 10) -0.183221924795553 -0.105455417529214  0.367791276871039 -0.008056257356940  0.178868934040902 -0.183121802513848 -0.020135569677962  0.515209166549771 -0.117080023257153
-   11  ( 11) -0.007464196331880  0.021033043073410 -0.001690254114910 -0.009511493213125 -0.028294720649660 -0.022246323268653  0.137499291012681 -0.039432763611338 -0.108598726797226
-   12  ( 12) -0.123944868649327 -0.111730063484439  0.047510016501505  0.255974986542992  0.005124525325680  0.148074762637129  0.114007095319636 -0.069663819016891  0.028473521942296
-   13  ( 13) -0.017141665481432  0.000597794755207 -0.092098297312466 -0.096823673318897 -0.041569429048225  0.197812754792637 -0.008676808477930  0.009877471432288 -0.053725238314554
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.015272189168424  0.055884768539045  0.022595917470325 -0.097739095389748  0.101307913638561  0.083139600282190
-    1  (  1) -0.170077092311119 -0.306275302846949 -0.015342747127271  0.140907625323906 -0.086768622273736 -0.004431165103266
-    2  (  2)  0.122267788619369 -0.173862456143997 -0.008834053126769 -0.258488090806208  0.008602277416252 -0.030801568843762
-    3  (  3)  0.115158711903404  0.000175672912050 -0.007958576188365 -0.065252519934628 -0.027276626325445  0.039310526043171
-    4  (  4)  0.041447381123119 -0.223427131166786  0.042072110146949 -0.028071743572502  0.027227765908070 -0.074902348865513
-    5  (  5) -0.019058447644624  0.170850397406824 -0.086742980133007  0.110178642267263  0.041910331302803 -0.107083340437408
-    6  (  6)  0.021256128257336  0.392229702029744  0.124665976454248  0.015545953081771  0.011542806511744 -0.015720528942715
-    7  (  7)  0.300617336083830  0.028516008672802  0.099451398565332 -0.057626854824784  0.020679502273617  0.041205067751965
-    8  (  8)  1.560902586180894  0.259171315930325 -0.164601621596176 -0.034972297622026 -0.150378069698849 -0.038202202289355
-    9  (  9)  0.094514617795907 -0.031270661372965 -0.062263685480237 -0.058840025270249  0.760182124797917  0.950335816577509
-   10  ( 10) -0.066834169589386  0.207009281624996 -0.021103713759929  1.235346852225813 -0.166059838728010  0.166192619645048
-   11  ( 11)  0.166613198202047 -0.057716191456314  1.335141155252760  0.048926469642815 -0.084810155942877  0.094069039382148
-   12  ( 12)  0.208439592407666 -1.201609834698812 -0.134583337794606  0.366858431203607 -0.092230835527544  0.010845969009094
-   13  ( 13) -0.191515265145491 -0.044443624544712  0.113534850826653  0.222934973071322  0.996667030569391 -0.918946127940319
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.838280644477338  0.411749409174955 -0.011245234094850  0.801190478556523 -0.375290789094279 -0.060205424083126 -0.006501167621028  0.129532275739011  0.036205199088877
-    1  ( 15)  0.881547713655820 -0.253476259192829 -0.085409214242930 -0.179675479112556  0.333528737889923  0.397874058388083  0.204744440154325  0.337404547376050 -0.068236667307226
-    2  ( 16)  0.280692634571588  1.751456537066117 -0.225740951023896  0.222727976019996  0.035667476486175 -0.008414165620519 -0.143291432626295  0.160653469895074 -0.273482724393967
-    3  ( 17)  0.209621820016790  0.218340608992592 -0.261722304538244 -0.119298704640737 -1.513363271201510 -0.698056808788139 -0.120911096831614  0.053174581758334 -0.132396798533522
-    4  ( 18) -0.117747454013746 -0.014296174337710 -0.842589107669591  0.528472799150322  0.125624897537886 -1.282501726363068 -0.485017022947313  0.477094930079181 -0.104194864390587
-    5  ( 19) -0.007044649144414  0.085834122092601 -0.626602602777561 -1.234604202394205  0.736228892085545  0.506584309099678  0.547679430826503  0.572570459557118  0.118654558713704
-    6  ( 20) -0.091286832209729 -0.021685067563440  0.171007526618887  0.515578709103199  0.135940786888869 -0.450672841124454  1.476397129902319 -0.025199130908638 -0.196552847100905
-    7  ( 21)  0.014615654265313  0.504143573825401  0.617830135418354 -0.727392291135203  0.101524375136093 -0.903543088194501 -0.107570659310641  0.584681158909250  0.151735811529355
-    8  ( 22) -0.000241453256584  0.012132142876842  0.118812360800492 -0.017957890934814  0.014213389909554  0.597612125089046 -0.026933571648999  0.834881086954240 -0.347394760041507
-    9  ( 23) -0.016266053110368 -0.168714015152345  0.122969309513146  0.113296295327446  0.042933145158516 -0.021312384755420  0.020475859582173  0.301307848192248  1.561266657466521
-   10  ( 24)  0.055165531229391 -0.304174792419748 -0.172047704399792 -0.001658247990654 -0.223925945933408  0.170794176393984  0.390519314933783  0.028524827382189  0.258484259000343
-   11  ( 25)  0.022516060504305 -0.015267978279714 -0.008788965795068 -0.007966965679884  0.041913364969496 -0.086578208119411  0.124614409340383  0.099374043509409 -0.164728194335593
-   12  ( 26) -0.096630537120399  0.140627523104698 -0.257995589308713 -0.065718152741261 -0.028202808988491  0.110258552517716  0.015357146207524 -0.057303010475208 -0.034362310026668
-   13  ( 27)  0.100848088361249 -0.086659417483530  0.008641513610077 -0.026546859017740  0.026660166393590  0.041683336083082  0.011441910657526  0.021040368708156 -0.150877463075199
-   14  ( 28)  0.083365224797539 -0.004662989899931 -0.030269035739860  0.040383400960418 -0.076012521819708 -0.107569111967635 -0.016046582728723  0.042417148908367 -0.038629830529648
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124736975708158 -0.186411776743034 -0.007554894642479 -0.125045482362293 -0.016560912827519
-    1  ( 15)  0.684937568019553 -0.103746255611685  0.021156368207705 -0.111849274618068  0.000603940837217
-    2  ( 16)  0.056865928627337  0.369384831426575 -0.001636838466353  0.047380751995444 -0.092508463817391
-    3  ( 17)  0.136933570746214 -0.009057416181716 -0.009590529636152  0.257433664523196 -0.097054069284064
-    4  ( 18) -0.008313788441199  0.179603173666670 -0.028243750586218  0.004112887482634 -0.041625527546987
-    5  ( 19) -0.152105865098285 -0.183914536442156 -0.022267058403363  0.148020189566822  0.198105351022900
-    6  ( 20) -0.039829638471541 -0.019552662543845  0.137602498789214  0.113713529573672 -0.008789200997015
-    7  ( 21) -0.125501834594654  0.515707561656430 -0.039509690533859 -0.069986683110118  0.009910809935426
-    8  ( 22) -0.349422704533081 -0.116838521157927 -0.108584856627687  0.028578306598228 -0.053879476555945
-    9  ( 23)  0.094340149488803 -0.067969414470118  0.166597333139477  0.208168406200233 -0.191317009755880
-   10  ( 24) -0.031516412594543  0.206893750616708 -0.057842704170583 -1.201945661815303 -0.044330664157653
-   11  ( 25) -0.062291188792870 -0.020995145760044  1.335136172955022 -0.134637121847955  0.113529460902908
-   12  ( 26) -0.058655437808125  1.235298002492330  0.048926806561180  0.366850302415595  0.222951214247617
-   13  ( 27)  0.760530637421970 -0.165994791782963 -0.084811494320818 -0.092272520144448  0.996709935525076
-   14  ( 28)  0.951451912746980  0.166208011331488  0.094073608057127  0.010839457269152 -0.918866007921684
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.019099970347343 -0.054200428981669 -0.010520950257794 -0.031946786023760 -0.020789948382165  0.046048192837971 -0.007769544283036  0.010726358280579 -0.004737284482511
-    1  (  1) -0.062357973394911  0.006102716190631 -0.007171436790893 -0.068204106383514 -0.016585383202659  0.122954333957858 -0.029137422311448  0.069540782433786  0.016612677854354
-    2  (  2) -0.403784221261672  0.324450217719893  0.076440353288707 -0.003195328333497  0.185926074649307  0.105855195394340 -0.081039639793703  0.184312198455384 -0.032860202529844
-    3  (  3)  0.661680759344399 -0.861306152603537  0.035411665154572  0.124528897034066  0.167552319952712 -0.112319302658493  0.015940441414302  0.001217383610459  0.035477914526862
-    4  (  4) -0.034449500309985  0.179808342457340 -0.111540854299158  0.024072097805195 -0.030238931122872  0.104800201827573  0.173762892431977 -0.303169138868400 -0.006501123235744
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.003314687329091 -0.000896551034830  0.000033558582264  0.000794374677250  0.001644256971405  0.011633570068621
-    1  (  1)  0.009325118439895 -0.006336349835898  0.001275960183554 -0.004140951590704  0.009680905112470  0.018932694158521
-    2  (  2)  0.023719150040951 -0.000738967719204  0.007569060114466 -0.110533602415497  0.058917756400987  0.020774154154267
-    3  (  3)  0.056355549266372 -0.059247843497842 -0.002846444129993 -0.070552027045529 -0.021764128059453 -0.125666637171124
-    4  (  4)  0.082841249558895 -0.459275247936066 -0.034497539865451 -0.040593000530447  0.013715827198936  0.025921402447776
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.008125794682267  0.001276249636263  0.002806266113454 -0.035252411242348  0.034410257839062  0.014002174894653  0.008101111284788 -0.019050099843062  0.017725035187010
-    1  (  6) -0.017654043276675  0.003167944262643  0.014342495194670 -0.266776981041182  0.199715641374170  0.004878393976865  0.001145655833319 -0.004944436864167  0.030889189327673
-    2  (  7) -0.088079106687675  0.114882791154415  0.063160374273819 -0.188024451751884 -0.135737709352592 -0.170124712301873 -0.072241326644284  0.102256821435413  0.024879708599730
-    3  (  8) -0.139233727927992  0.270559406074782  0.173436713877051 -0.086006232424740  0.170235177581669 -0.397032110835526 -0.208263233769902  0.170212218459687  0.014874905593169
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5) -0.021580521896634 -0.006055119274041  0.000252171213578 -0.001778382625147 -0.005627763904708
-    1  (  6)  0.007355906511153 -0.019404404398890  0.002112099508557 -0.017902001326765 -0.015562547315969
-    2  (  7) -0.015992253053020  0.016886516071243  0.006249441168084 -0.170619149916496  0.032130783380492
-    3  (  8)  0.030737556983705 -0.242789556213817 -0.014796175459534  0.086288360752946  0.038591432029459
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016796518156450 -0.024684593045813  0.052100982254469 -0.008325488861209 -0.006219441028095  0.005301394715715  0.000551561287803 -0.006588272705655 -0.036006859369018
-    1  (  1)  0.055004136989890 -0.064555164589185  0.195953358880290 -0.041248559952056 -0.011229675252995 -0.030149486699975 -0.052245049968209 -0.006640134402823 -0.060816046357794
-    2  (  2)  0.618380671087664 -0.527850834448018 -0.215416551440811 -0.157035303379525 -0.069798484859426  0.063297355909930 -0.224803839283465 -0.036770111759382 -0.093292419816030
-    3  (  3)  0.089963765281913  0.016694159627680 -0.049894373546596 -0.224500365718289  0.100545561053062 -0.339809122650522 -0.300486432165757  0.103978668557985  0.003854595424659
-    4  (  4) -0.017912508215489  0.240051537968708  0.016875923860512 -0.019658133296819  0.000950535375128  0.139486143224495 -0.307526372036989 -0.245045454550295  0.038982170942781
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.002154834242698 -0.005543396803274 -0.002277100884889 -0.002175922896050  0.020132467962373
-    1  (  1)  0.004110247805773 -0.053483310290609  0.001461397054189 -0.009996127328147  0.040844897807206
-    2  (  2)  0.010356133969881  0.045196519949836  0.123149449772057 -0.009608801282581 -0.092775083998984
-    3  (  3)  0.068261693123193 -0.266621586059825  0.090983471277348 -0.007824989919295 -0.015479691146983
-    4  (  4)  0.102991624862593  0.095940858234946  0.235195863928789  0.030438277845211  0.100331918666020
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5)  0.014799909061593  0.010553936782505 -0.033829100199687 -0.001269237592455 -0.033645272802155 -0.021824963606521  0.004369805125316  0.014950382203236  0.015526069045780
-    1  (  6)  0.110154739420111  0.055002386146006 -0.190701649304707 -0.008587144439846 -0.137456621056027 -0.102685176355914 -0.038575709259110  0.049077772225267  0.038775529727110
-    2  (  7)  0.266426065720336  0.201904424455229 -0.404472718271240  0.112355611598838  0.244543347617279  0.203488245975836  0.093346126249958  0.046662190607840  0.162564525561425
-    3  (  8)  0.310200492167619  0.275860835986490 -0.334362480547667  0.111323266813215  0.107269544906807 -0.015396528656859 -0.485347855891879 -0.115211765458900 -0.189399357373984
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5) -0.035663810081786 -0.008140062733320  0.003307906131469  0.001197387663019  0.016919962811790 -0.011091968883075
-    1  (  6) -0.089155447498508 -0.010182808652268  0.015536227858557  0.027148077612804  0.019304528745904 -0.012170544777103
-    2  (  7) -0.076359125641658  0.072719915293599 -0.105706049002103 -0.076791094381570 -0.095250603999340  0.044053074847775
-    3  (  8) -0.023401542320878 -0.060789749402432  0.233844043042904 -0.060200627565189 -0.022972219371194  0.078966379018947
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     5
-	   Irrep: 1 row =     4	col =     4
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  0)  0.093040439536572  0.006883832168587  0.044349903674439  0.024184673728570  0.010619326000930
-    1  (  1)  0.006737409626207 -0.134476575430850 -0.662147168748391 -0.267933347768737 -0.078921686095923
-    2  (  2)  0.044312365343188 -0.664732743208614 -0.209245886171141  0.147512394239481  0.068882111957148
-    3  (  3)  0.024445011658610 -0.267156978888942  0.148428625650258  0.187324113043417  0.001809525749512
-    4  (  4)  0.010711658101998 -0.077773439467326  0.066598278216547  0.004060574085153  0.013912977363208
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.093040812704647  0.010355128152229  0.014585271883669  0.052101513158615
-    1  (  6)  0.010098501371772 -0.274846300766149 -0.278230917959964 -0.671644086417202
-    2  (  7)  0.014499676556256 -0.278525551401332 -0.012068158915018 -0.010562415676214
-    3  (  8)  0.052124122910609 -0.670478058911760 -0.009627607142891  0.097763126732394
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959678155538980 -0.408101491214063 -0.490372311759102  0.038742122810453 -0.077959104605300 -0.487340087540545 -0.107420610970357 -0.396110728068779 -0.237560877798824
-    1  (  1) -0.405273522537742 -1.324247451168747  0.174907022304499  0.249084801953490 -0.197881827602852 -0.317617545843934 -0.251163922650930 -0.030179101652225  0.632878654899624
-    2  (  2) -0.488733161639064  0.174538939027552  0.686791689554804  0.342695531685382 -0.009976771546676  0.483628059926314  0.287667942774822  0.302838598723376 -0.272072273040255
-    3  (  3)  0.037678582365270  0.250808349059262  0.345042183715650 -0.288918857481701  0.242063981506071 -0.302243247956577 -0.510959969860135  0.184733903080464 -0.217020096997004
-    4  (  4) -0.076474587009002 -0.199552047603210 -0.011326364866863  0.242357020763511 -0.131822054288625  0.385843215375445 -0.241515454680397 -0.375184603473883  0.062580850623181
-    5  (  5) -0.485851929718097 -0.318976250301899  0.484044322085048 -0.298906365351502  0.382613974458461 -0.557148293802458  0.333193927484660  0.111817236916922  0.019840268115496
-    6  (  6) -0.104965972984117 -0.251903192083727  0.289640373307082 -0.510970695647538 -0.243415583312445  0.333475478757662 -0.859912620153685 -0.040220545664775  0.015980570043176
-    7  (  7) -0.396754872501798 -0.028569642970538  0.303623938973664  0.181374950955466 -0.373312622339830  0.109078036064913 -0.042395161510191 -0.424448388350181 -0.165358444103851
-    8  (  8) -0.232582075657829  0.628639207035361 -0.273411305797432 -0.217895348393060  0.062015615338663  0.020853222567396  0.015644250305069 -0.165521554892621 -1.139940231757149
-    9  (  9)  0.005613026623683  0.056038847504695  0.162941948364533 -0.082448579057758  0.072872713438688 -0.108706057750015 -0.023486980245706  0.044748629553023 -0.147249839147741
-   10  ( 10) -0.006825753996711  0.054330625174688 -0.040600459289215  0.341773335142725 -0.179762468019758  0.323459898735361  0.128247809507689 -0.274645895767087 -0.052523179564083
-   11  ( 11)  0.095363168422481 -0.102110731037112  0.068440221249872 -0.163728565012588 -0.155635974392383  0.243236759471133 -0.456651581538985 -0.005318538066323 -0.049821609330003
-   12  ( 12) -0.031684198302062  0.049379171777146 -0.071598204249869  0.132088838854510 -0.108611791389140  0.096656376288631  0.079498071414236 -0.086713119228540 -0.054538981695138
-   13  ( 13) -0.055052088990008  0.125838721460397 -0.045965127568992 -0.019981443486908 -0.072418251872370 -0.032557607491985 -0.014098948539510 -0.073500123212979  0.566227707872874
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807055954803 -0.007349560547306  0.096090210995538 -0.031847220536043 -0.055762343356614
-    1  (  1)  0.055013930617197  0.054714027538139 -0.101497827834384  0.049505507832132  0.126445948907677
-    2  (  2)  0.163060865569910 -0.041369580216838  0.069584979716894 -0.071596735131772 -0.045869015905501
-    3  (  3) -0.081108015764366  0.339431492389606 -0.164732616757883  0.131959707125059 -0.019695894387602
-    4  (  4)  0.071391836436492 -0.177483697337661 -0.155863465031852 -0.108539945941810 -0.072778714718060
-    5  (  5) -0.105602245382245  0.324540838628283  0.243448104901399  0.096679723936886 -0.032476071903887
-    6  (  6) -0.022597408891723  0.128544508498159 -0.457502934072308  0.079428438645028 -0.014294748162537
-    7  (  7)  0.043846653586753 -0.277397992584845 -0.005216642533355 -0.086813532812450 -0.073536670734562
-    8  (  8) -0.147650125553786 -0.051825295863361 -0.049479660483167 -0.054623180883232  0.565537444216626
-    9  (  9)  0.072041211973719  0.045487933933136  0.010268881336321  0.009607614271066  0.026535743404897
-   10  ( 10)  0.047954198166250 -0.139046226141143 -0.006986156794561 -0.101926928298850 -0.021981984041468
-   11  ( 11)  0.010233046554828 -0.006894969642876 -0.093445756711608 -0.006456213628444  0.037416583338516
-   12  ( 12)  0.009698803720534 -0.101908692095225 -0.006445564947776  0.055515584672607  0.004587506975718
-   13  ( 13)  0.026517774925525 -0.022107422255419  0.037498472740235  0.004566324288604 -0.064482720503433
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532121740251372 -0.788085893788107 -0.217603131818698  0.182539967978995  0.602236043610333 -0.200120087912369  0.029444285669184 -0.008605095326859 -0.142335353957114
-    1  ( 15) -0.793282621455022 -0.320017528069242 -0.162610728946909  0.058737218053218  0.020902506471437 -0.223398291687142  0.107401673519300 -0.353937376792643 -0.096067759979202
-    2  ( 16) -0.212759476996556 -0.165318270212151 -1.296151478596657  0.042126449869970  0.273651941080466 -0.438869203377379 -0.121824412649609  0.097175442570440 -0.140941186550869
-    3  ( 17)  0.179954880120570  0.058840502409980  0.044126141588593  0.293103913820441  0.349346070587604  0.303429750321539  0.077093345289226  0.005877969516463  0.014043346853729
-    4  ( 18)  0.599464052798745  0.022232621038034  0.273956879467586  0.351249953189962  0.210827296015343  0.044583492026591 -0.439001124466305 -0.490999583382665 -0.399377312800566
-    5  ( 19) -0.200415193166410 -0.221454031684581 -0.440130233545449  0.305750704102692  0.044861293601065 -0.117461802710973 -0.191543198726986 -0.319737132858222 -0.359372267290625
-    6  ( 20)  0.032162042641391  0.105939534185909 -0.123875705708069  0.078981922601714 -0.440630863197322 -0.189870927178213 -1.110683844987227  0.246908880887798  0.255270735640994
-    7  ( 21) -0.008285955423528 -0.354490618261744  0.096610776337144  0.006344018251589 -0.491267638906147 -0.319007555266299  0.247398627809012 -1.005042496360271  0.329309047032999
-    8  ( 22) -0.142956373400391 -0.097017990054122 -0.141102064852077  0.015167547287076 -0.401325286099402 -0.359428470055654  0.255243395364296  0.329093038265683  0.052124314989423
-    9  ( 23) -0.219992223135260 -0.250002494357102  0.576453745382011  0.098961038079451 -0.020558259411669  0.097520564952485 -0.059903591236483  0.014730830826408  0.155043406171131
-   10  ( 24) -0.078950842282313  0.108192974588866  0.027256719920767  0.046488247022766  0.091309317204861  0.113370441218381 -0.170232341234565  0.302098437505070 -0.032846701337118
-   11  ( 25)  0.043327368920802  0.032363952950934 -0.179596967558333  0.107314731322016 -0.187556827175706 -0.097228397429410 -0.510756367288586 -0.080036476206955  0.081234951141581
-   12  ( 26) -0.068201021543243  0.217294299321812  0.162617933330394  0.182155522535814 -0.078641713660581 -0.138388367525664  0.046101976903326 -0.318339173129021 -0.094298474892480
-   13  ( 27)  0.012951678979883 -0.163153522763377  0.064958952093448  0.076424604369489 -0.116360203393674 -0.057049776701144  0.002569816029803  0.275506313029663 -0.101256314986208
-   14  ( 28)  0.072510783557042  0.116062864225355 -0.039412265271734 -0.060057300037980 -0.063412982184515 -0.039929346804056 -0.007406002256896  0.061653925330301  0.127195708506786
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223477411018950 -0.079382092199477  0.044405876096731 -0.069431344021685  0.011741951342713  0.073537474381983
-    1  ( 15) -0.252078539786821  0.107741515735708  0.032079184967221  0.217694985552139 -0.162983145775431  0.115656082983714
-    2  ( 16)  0.579845214226217  0.028378277843429 -0.180831251410613  0.163170287068100  0.065406321504410 -0.039943977007537
-    3  ( 17)  0.098336981013973  0.045583962953317  0.108737934246579  0.182608495905146  0.076967952355432 -0.060238035075337
-    4  ( 18) -0.021655536506867  0.091328256246422 -0.188516919147371 -0.078660950073341 -0.116895024500355 -0.063657672277112
-    5  ( 19)  0.097173245411524  0.112970556070869 -0.096626215256070 -0.138713116461386 -0.057497847550096 -0.039672758164800
-    6  ( 20) -0.058058256497948 -0.170134518380977 -0.511530143099129  0.046149343186038  0.002602376428286 -0.007423125108159
-    7  ( 21)  0.014906176867529  0.302176604086977 -0.080525473721937 -0.318411929730376  0.275449015770937  0.061693835883636
-    8  ( 22)  0.155161704952536 -0.033183337025881  0.080999970058022 -0.094077909752701 -0.101047603227782  0.127072498046474
-    9  ( 23) -1.153503005767297 -0.223848903771637  0.084925642410683 -0.000156040974629  0.401129411733861 -0.346052633941368
-   10  ( 24) -0.223987158177205 -0.015012375119840 -0.013161680177939  0.067285733183973 -0.009874833878360 -0.084312156783672
-   11  ( 25)  0.084246106951679 -0.012978302546649 -0.099616038589144  0.005045908621884 -0.012239519066641  0.023063968015233
-   12  ( 26)  0.000204330581661  0.067424456852217  0.005011146178068  0.014688018065117 -0.012600679620463 -0.022022412661756
-   13  ( 27)  0.401486356038018 -0.009674031259633 -0.012248632103385 -0.012689383006113 -0.008213187132806  0.091177159326338
-   14  ( 28) -0.346416681769813 -0.084403068294800  0.023147285879115 -0.022062581881564  0.091087972953239  0.040127268579997
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.016537936861949 -0.024241922388593  0.051201768802404 -0.008322833960590 -0.006017494989066  0.005428740737672  0.000568250580578 -0.006150795675417 -0.035135595176184
-    1  (  1)  0.056326887338365 -0.054579833033550  0.202068439942577 -0.031068756578896 -0.011725287705163 -0.013046651503248 -0.042335288233490 -0.000688387643387 -0.052313679280302
-    2  (  2)  0.580148995945398 -0.459943587856779 -0.203259661043762 -0.146372180867085 -0.059058345536409  0.052145096815196 -0.210467981306920 -0.032271635615917 -0.063238799881584
-    3  (  3)  0.093322501636621  0.013379808386711 -0.072571510463262 -0.188886866268837  0.080216103750382 -0.320478414806242 -0.281759931921308  0.095690125232350  0.009981144666503
-    4  (  4) -0.010962354238104  0.212761704234353  0.010035071199247 -0.008865784299369  0.020318709621357  0.122346083557563 -0.286499721446839 -0.227683899528049  0.024604637421951
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.001987988383625 -0.005438080390036 -0.002229714982382 -0.002132335016216  0.019626939139985
-    1  (  1)  0.004776478692708 -0.045613293917544  0.000327284020475 -0.008899398072627  0.037239498717223
-    2  (  2)  0.012619828860439  0.038688250260721  0.110069870553538 -0.008171016922275 -0.088375830773748
-    3  (  3)  0.059812855709606 -0.242170801311687  0.080653581740597 -0.004749465445585 -0.010574164740826
-    4  (  4)  0.093170518807436  0.087595785514659  0.210553441090662  0.029300195949229  0.092614450849574
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5)  0.014822074124680  0.010207669121242 -0.033350155056769 -0.001307733807806 -0.033081626230795 -0.021091589632192  0.004217511869089  0.014606538347173  0.015414361987771
-    1  (  6)  0.095519356708354  0.063741657381197 -0.166255985625807 -0.019051929039505 -0.150087133539163 -0.101276609851160 -0.031455413000742  0.053511482220944  0.042972231654537
-    2  (  7)  0.255851471012538  0.182047821607422 -0.358011207661796  0.117954537787342  0.215810969930988  0.198253579704871  0.082269438642449  0.046105537607070  0.145102930234725
-    3  (  8)  0.310185582931469  0.238348070413016 -0.293800958364503  0.096264526550363  0.113972447821148 -0.010344179631658 -0.450994570484378 -0.111847826897367 -0.191892259052759
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5) -0.034677751819065 -0.007932160683329  0.003227095632223  0.001173710946733  0.016573240696415 -0.010731741557610
-    1  (  6) -0.073867211030248 -0.008651318954981  0.012683664553962  0.023684620946345  0.017802288617299 -0.009307505930558
-    2  (  7) -0.053426110389916  0.073021874922902 -0.094937653058510 -0.066924927327665 -0.087586036904454  0.040165294203525
-    3  (  8) -0.005408461911796 -0.054901561047120  0.206210199007396 -0.056448347500372 -0.025437450993951  0.074189939620793
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.169079147013067  0.181398472271101 -0.418346537516512  0.010479590676640 -0.433274055754517 -0.333974741215202  0.069746020881106  0.194340009035054  0.223641697824386
-    1  (  1)  0.016009276689030  0.076567446932798 -0.125166337039093  0.007592453612462 -0.098480410050875 -0.089737908381391 -0.045486472738146  0.143199887927110  0.062916365543690
-    2  (  2) -0.038605132226418  0.325735563708610 -0.218009814858074  0.077381145892201  0.123187590884398  0.048889336335591 -0.262562783859021  0.048309454387723 -0.024346554904250
-    3  (  3) -0.014979345531200  0.182689417416161 -0.081658171125982  0.065474061220856  0.193719558728945  0.090995702617436 -0.143671181956007  0.007595234796482 -0.060244504649077
-    4  (  4) -0.067326880829078 -0.014019514528751  0.166079096202343 -0.050483681333365 -0.175920263326446 -0.180597768068034 -0.198820916076870 -0.109379569710197 -0.213777238598869
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.509745833838701 -0.114656609203285  0.048629220633750  0.010405234436097  0.246884756649403 -0.174503049803694
-    1  (  1) -0.159507006357648 -0.056302070388232  0.034397385257058 -0.068360305204010  0.100741705433253 -0.049850192065006
-    2  (  2) -0.121516040086149 -0.004562730012851  0.189568353516518  0.051932897550589 -0.189148835217686  0.205130688490104
-    3  (  3)  0.013365010155837 -0.072899199914719  0.147744895629826 -0.343128825881135  0.052918455467163  0.086660617340563
-    4  (  4)  0.064044315985741 -0.072658430245154  0.366494578686027  0.156516693310286  0.183833641545764 -0.043558656630646
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.222253545892244 -0.308754480278884  0.684888401384565 -0.077094923901758 -0.114132498246181  0.066899096811017  0.002565146162785 -0.065013418078775 -0.530087407435393
-    1  (  6)  0.095334276679193 -0.133297826228700  0.233197346278755 -0.109601967204616 -0.034275480758760 -0.001203333963837 -0.083638018427257 -0.006960569040888 -0.188458864487261
-    2  (  7)  0.132031061747719 -0.218523067630196 -0.122630993985032 -0.145558520241812  0.033193720251677 -0.142560381166407 -0.001867788081308  0.178023293664542 -0.083084361136401
-    3  (  8)  0.307498004496819 -0.248791244048898 -0.171772368494742 -0.290615228523969  0.046349400199126 -0.102375085874076 -0.404689074901353 -0.035662710613182 -0.067098781839471
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5) -0.009919929749940 -0.070754419675403 -0.033057132824845 -0.029936683588897  0.302173230741933
-    1  (  6) -0.011309858279613  0.047826417485879  0.011715232447735 -0.012088004910524  0.055738135466992
-    2  (  7) -0.060288713658253 -0.100230259139583 -0.175888837964231 -0.033113629525454 -0.296260914045054
-    3  (  8)  0.156436486115695 -0.054087340712273  0.405606823449570 -0.026699936395146 -0.143365750641886
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000032603418837  0.126124356870090  0.170554254128647  0.621713480371517
-    1  (  1) -0.063391990530330  0.021021973667360 -0.035141514385331 -0.107429862625930
-    2  (  2) -0.544499875281630  0.300008667648211 -0.100039136771104 -0.265278637596522
-    3  (  3) -0.250324690465962  0.260056134456994  0.124414801683600  0.440136140630983
-    4  (  4) -0.136414480343098  0.064431360418323 -0.021015287492156 -0.051343774737237
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5)  0.000019327025352  0.065093211127625  0.544782466708479  0.245382364722837  0.134937357643702
-    1  (  6) -0.123031148662641 -0.019474806029226 -0.300926234869739 -0.262383133461068 -0.064721107261509
-    2  (  7) -0.168930413345025  0.034874779439887  0.099232631257934 -0.125516014095032  0.023646961316768
-    3  (  8) -0.622345214333519  0.106268567242580  0.261765947213873 -0.441767814164735  0.052476472563320
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.143168742050969  0.065593092719620 -0.058357223814998  0.095233744064776 -0.054991990252275 -0.158738663239417  0.005861644512419 -0.046171301568673  0.009241470545286
-    1  (  1)  0.090546554003407  0.201829179559043 -0.091139660909400 -0.093658466030896  0.161060795901430  0.077753943704190 -0.543239332695236  0.814462205940737 -0.067298988063212
-    2  (  2) -0.021728082981507  0.356853707760702 -0.273297343085382  0.263661367453919  0.358975826989998 -0.204621891372348 -0.313142134375876  0.064377163119988 -0.200411159416666
-    3  (  3) -0.101092642386777 -0.248351561644884  0.325472253383733 -0.022461569908437  0.220395643002352  0.053342935824144  0.023680160861624  0.049360779001958 -0.000464252060147
-    4  (  4)  0.053504276998688  0.177332374278721 -0.223488999246937 -0.043202317426006 -0.200403874496849 -0.109676936134016 -0.130968685942067  0.223685121938792  0.051883473042391
-    5  (  5)  0.218652321770515 -0.312539731115342  0.301937592016120 -0.119144864786212 -0.273807562569020 -0.291329095765088  0.214350574455061  0.196966818811601  0.071530668658618
-    6  (  6)  0.085275599488616 -0.152038903160436  0.395824749485933 -0.020600022744657 -0.230254876491235 -0.119190020655303  0.196964194480387  0.232999347129610 -0.074131260226173
-    7  (  7)  0.047705443252103  0.280546373408872 -0.366470889708310  0.110969029401947 -0.088365350080466  0.149809323623181  0.036903907285247 -0.394126097469672 -0.043470630949031
-    8  (  8)  0.213434636208738  0.108264999729057 -0.634417157620428 -0.069187858002595 -0.037899789726715 -0.161396484647500  0.081572968058128 -0.216972039968308  0.039198046889909
-    9  (  9) -0.053322372799114  0.090836400230606  0.086595499357010 -0.028326926095153  0.134566066437039 -0.073537213795396 -0.007049259902868 -0.447872012493398 -0.046316327587981
-   10  ( 10)  0.217341204893281 -0.434346962083385 -0.408839180880640 -0.321260492764443 -0.034272175446499  0.320142409512337 -0.023798683867179  0.279256094128980  0.028678082826067
-   11  ( 11) -0.043839598607802 -0.078964641572311  0.267355581977089 -0.331608561699507  0.435766960294310  0.066306924416866  0.247976787569883 -0.002758180414468 -0.128221736037864
-   12  ( 12)  0.056965688274708 -0.011499629769275 -0.132082161790900 -0.097919309901065 -0.064498574997948  0.001828531017010 -0.216798363947827  0.142474052325396 -0.129433978300506
-   13  ( 13)  0.037736233652834  0.226173453877373 -0.091059172339369 -0.252258976670285 -0.015520139516800 -0.284734500126441  0.105582624775749 -0.004840642243881  0.367726601468554
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222351700796231 -0.016051014603450  0.082411788344132  0.002090829543127 -0.060332287300641  0.093379423932350
-    1  (  1)  0.558696663631320 -0.124839828449119 -0.159093196566891  0.170657712172229  0.081500451405233 -0.084538068524715
-    2  (  2) -0.171547101260385 -0.032355031252886  0.410357578755376 -0.223619460950125 -0.075332226894427  0.314396046680626
-    3  (  3) -0.113943755316531 -0.023262630947533 -0.282031318687168  0.174392564657866 -0.284646066238925 -0.036137544982085
-    4  (  4)  0.007270912134622 -0.039474507242411 -0.327411282761334 -0.428749102590040 -0.081932338953496  0.119337549539454
-    5  (  5) -0.007124770871955 -0.054853461684570  0.118747764774226  0.018464599829059 -0.153416652566852 -0.075577494357491
-    6  (  6) -0.092349921440075 -0.334618605800085 -0.214792660948048 -0.112965638408468 -0.018250213734362 -0.100586056001693
-    7  (  7)  0.152021384124484  0.104998322455761 -0.079320526127899  0.028605808968327 -0.093251815005480  0.234533113346203
-    8  (  8) -0.034304143528697  0.223813766962522  0.061239992371489 -0.498104576719364  0.749088367409234 -0.381133927713764
-    9  (  9) -0.119289648143127  0.308069531198503  0.075394971169272  0.759043062697070 -0.290009195725773  0.156443196633644
-   10  ( 10)  0.438322970066134  0.163961241971126 -0.419972225637626  0.045406760285923 -0.044943204755759 -0.568952239499600
-   11  ( 11) -0.012786276184910  0.354874474517313  0.016716751019783  0.314729629014795 -0.109367125733961 -0.038956514405505
-   12  ( 12)  0.278790389094552 -0.047235199403271  0.203285043476247  0.096947952714326  0.275888785771950 -0.187110182878589
-   13  ( 13) -0.588336834741451  0.141774978422199  0.127446795642639 -0.417479745467518  0.223574211999999  0.209731578694231
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.139202374272621 -0.095177641569675  0.018773909554975  0.097441952386086 -0.052881778233791 -0.221098968415819 -0.088678880810398 -0.046152832918285 -0.215108327569156
-    1  ( 15) -0.062945487192671 -0.202399962667017 -0.354690347352157  0.248169855248633 -0.178112035030668  0.312759612055100  0.152465077862104 -0.279550518176369 -0.106786563882068
-    2  ( 16)  0.053747901607914  0.094055462729839  0.275452788140149 -0.323607865915763  0.223365974526806 -0.300652023916840 -0.393867617385155  0.365397282883089  0.633006843106556
-    3  ( 17) -0.094002363012655  0.093421728368421 -0.262348870274066  0.022315744436414  0.042732961100197  0.119651095539310  0.019208709619051 -0.111738898683176  0.069298150001950
-    4  ( 18)  0.056373744495590 -0.163033205250659 -0.357789849982426 -0.219752154386331  0.199609932463510  0.273164341776646  0.231164134722957  0.090622648154173  0.037758220090686
-    5  ( 19)  0.160595804065382 -0.080035650166188  0.203841516073520 -0.053966491195577  0.109684055455432  0.290491436031534  0.118088683716894 -0.148835930426789  0.161333320462923
-    6  ( 20) -0.008655895544046  0.543677859447897  0.312247361260707 -0.021746144643383  0.131150127368204 -0.214268497298583 -0.195294294028571 -0.037322598271958 -0.082710341175990
-    7  ( 21)  0.047044000148847 -0.814755045611703 -0.065202059732802 -0.048607853740734 -0.224058525580443 -0.197250760154244 -0.232147678456731  0.394910024115792  0.217741693866694
-    8  ( 22) -0.009438322952131  0.067105129183881  0.200111373517365  0.001546802997496 -0.051921461755131 -0.071400999009348  0.075219081936387  0.043282136981162 -0.038956055715065
-    9  ( 23)  0.222690431794590 -0.560436921351761  0.171874955212197  0.112182377152414 -0.007071284207137  0.006427896378768  0.090201256315770 -0.151794514368373  0.032052056842716
-   10  ( 24)  0.015965707326541  0.124165042149601  0.031933550526408  0.022576537585984  0.040255135623963  0.054700257408159  0.334875806524789 -0.105283502146394 -0.223919488004079
-   11  ( 25) -0.081167640673829  0.159983011732312 -0.408649974214824  0.280674694561068  0.326885126511498 -0.118534226661232  0.213699274668233  0.079763309363181 -0.060690310069395
-   12  ( 26) -0.003657920398281 -0.169345800545151  0.223179507594994 -0.177432493477436  0.431822644586944 -0.017469946131729  0.113428863232752 -0.031984070329444  0.498986991132235
-   13  ( 27)  0.059466371837119 -0.080543553642064  0.075187799272484  0.285726158437972  0.080575068896982  0.153138088483086  0.017504315580652  0.094018000472634 -0.750489816823238
-   14  ( 28) -0.091779364641270  0.083757100689969 -0.314063329930966  0.035360766104356 -0.119047215679504  0.075525935404181  0.100523702542950 -0.234167736555125  0.382416402775017
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054180568174087 -0.218758432536746  0.045617833544743 -0.057539775261661 -0.041968766977599
-    1  ( 15) -0.090582635286264  0.434585538609120  0.078290573102774  0.011551815535752 -0.225206285929556
-    2  ( 16) -0.087805337077496  0.409609254316999 -0.269432869300411  0.132294575357470  0.092781259667513
-    3  ( 17)  0.029497163039810  0.321887635448263  0.333951917483107  0.098004347098165  0.253999249955738
-    4  ( 18) -0.133860313754778  0.034109453432679 -0.437353037936869  0.064342088723588  0.014911719082035
-    5  ( 19)  0.074763336207957 -0.320521161823854 -0.065101664451371 -0.002026005130085  0.283685137533505
-    6  ( 20)  0.006545865730575  0.024114900293167 -0.248934112787968  0.216846340655195 -0.105410458820591
-    7  ( 21)  0.447836131833085 -0.279310069582177  0.002049813773497 -0.142438428094426  0.004546144226345
-    8  ( 22)  0.046136686751539 -0.028286865341649  0.127990987917726  0.129509607296348 -0.367102200851883
-    9  ( 23)  0.119914751772745 -0.438597311614088  0.013925046534151 -0.279070419042896  0.587111860916756
-   10  ( 24) -0.308678492665754 -0.164180912654775 -0.355114774474331  0.047147124734095 -0.142335590283680
-   11  ( 25) -0.075357196311108  0.419786064000589 -0.016982355834687 -0.203268419894548 -0.127372410738112
-   12  ( 26) -0.762258414223746 -0.045740824623019 -0.314843572140565 -0.096925863993462  0.417498766326933
-   13  ( 27)  0.290828580624809  0.045085064630915  0.109302729868749 -0.275851789428657 -0.223795262166736
-   14  ( 28) -0.156282170808113  0.568695990355867  0.039099936467268  0.187067180190658 -0.209842904780090
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.177176189319106 -0.180745793486905  0.423966619701935 -0.011581551404741  0.435227736673098  0.332709997157265 -0.068635087820603 -0.194270603508529 -0.223291438362236
-    1  (  1) -0.008029890996168 -0.071159352891358  0.119616475449642 -0.008384702537145  0.089986137914585  0.086564609736733  0.049250356893305 -0.145842215930710 -0.062347034381301
-    2  (  2)  0.045518518818118 -0.343839163535337  0.233472741242365 -0.080368579839727 -0.126856225273009 -0.050346450796604  0.272797593505565 -0.041981263678006  0.011707811055133
-    3  (  3)  0.007469493431466 -0.183213548317289  0.088762887991898 -0.062931810249318 -0.191997293752100 -0.097209516755103  0.155086433180615 -0.027940706556696  0.056922226205762
-    4  (  4)  0.077210986504954  0.016819701247264 -0.185033281633968  0.049422880081936  0.189109252440732  0.186779489198708  0.210881285540922  0.117042610951531  0.222226069367720
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.507946526774708  0.114570217649703 -0.048527245841715 -0.010203674621089 -0.247705919078547  0.174877034117309
-    1  (  1)  0.163586225647048  0.058410702959740 -0.036675256440181  0.075406267920947 -0.102476735587228  0.049143594232354
-    2  (  2)  0.131726728459177  0.004508445722954 -0.197654988901926 -0.066111573872410  0.203202352604923 -0.214036125650491
-    3  (  3) -0.021759317124854  0.083238776914552 -0.152336827943842  0.374381558468693 -0.063066050023990 -0.084939819929268
-    4  (  4) -0.069143922701874  0.077043776247882 -0.380503989867731 -0.165903594058003 -0.189537425628195  0.045315939845075
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.227899181285790  0.310912498894659 -0.689219478239478  0.079478153793595  0.114665208382697 -0.066874135145553 -0.001767106336999  0.064286635593960  0.528833011123776
-    1  (  6) -0.085932045206305  0.139425745641633 -0.214132623058670  0.106466023697561  0.037133087530216 -0.003208228270672  0.084039871476020  0.008112165516730  0.198641379371657
-    2  (  7) -0.140865167755975  0.238964691084419  0.123719313544378  0.150178910156346 -0.036552827587667  0.145788047396894 -0.003054599487236 -0.190610288385272  0.091268008839967
-    3  (  8) -0.314003646861887  0.266801948817500  0.167544658270699  0.306344841393429 -0.048058476242923  0.091573571786136  0.424170238232336  0.025710444562560  0.069058517523444
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.009761505709912  0.071611041965292  0.033187890464826  0.030058911489328 -0.303252590138004
-    1  (  6)  0.012970687354604 -0.054215080678130 -0.013408998303624  0.012376394063089 -0.052601499533993
-    2  (  7)  0.065224427887993  0.099017080029867  0.181261938377539  0.033115377888204  0.307260857218546
-    3  (  8) -0.162148451935080  0.052469354166273 -0.420462509284504  0.024749294887708  0.151001983092948
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.000094586245827 -0.001739034216159  0.010537869552908 -0.047334972317920  0.047731439209250 -0.005684365059231  0.002004970769717 -0.013002399512935 -0.004362281903148
-    1  (  1) -0.002961766394137 -0.004522349261464  0.004971921732979 -0.008281714530426 -0.002230363604714 -0.014875582549511 -0.067042000917223 -0.013799171377680  0.003919897579650
-    2  (  2) -0.001156412963293 -0.011364234143839 -0.009216206726470  0.026466547461677 -0.045020900704996 -0.024548395511813 -0.151471994533512 -0.022837481284214  0.020115226329263
-    3  (  3)  0.011852349375574  0.003988646850217 -0.013577384689322  0.005526397380180 -0.001842046319486  0.004979014314656  0.016339528158709  0.010418265583646  0.006987140577564
-    4  (  4)  0.053414892823166  0.048153350433577 -0.085702787700908  0.002590796143814  0.032944657079404  0.019536461914947  0.058299722542085 -0.003474393981100  0.035804248206919
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.005742496352089  0.004961968677187 -0.000867750492921 -0.000423220824064 -0.002281350853377  0.002319078012885
-    1  (  1) -0.000158469276644  0.005351239914036  0.000795321285338  0.002864683008960 -0.001069113574892  0.000329369855655
-    2  (  2) -0.008857571112387 -0.013536716587928 -0.030733225492944 -0.004374372006235  0.001058560017428 -0.003465102183553
-    3  (  3) -0.011600439755925  0.024957479123119 -0.006847707754520  0.007864292440218 -0.004416464065001 -0.003633652759043
-    4  (  4) -0.033694384788133 -0.004962932699877  0.009297525951248 -0.012733703500189 -0.018367081934284 -0.009679397059252
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.003045623738158 -0.003223303867390 -0.030817819346573  0.037045300325429  0.045442950096415 -0.007571150688185 -0.007566775075852  0.005588481369027  0.003651001867964
-    1  (  6)  0.004099418610937 -0.004975274176733 -0.011544459812740 -0.010294229250284 -0.015031160006114  0.051218487667392 -0.101906256296975 -0.009904945529844  0.005253312938090
-    2  (  7) -0.030335391006009  0.051022890381624  0.010476800488702 -0.022518293205800 -0.032764950392901  0.046697791867379 -0.082351516945318 -0.029648976257074  0.032167076936008
-    3  (  8)  0.044658129227156 -0.062597356732527 -0.000792791453374 -0.033784835620008 -0.053456373167225  0.070727519139336 -0.103493505632204  0.004470770048209 -0.021985036653810
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5) -0.001480974473112  0.004808173156554 -0.000537012459275 -0.002113989621550 -0.002047536201115
-    1  (  6)  0.001406578559496 -0.001390228208264 -0.004138454793102  0.000537337753817 -0.000303816821287
-    2  (  7)  0.018025108332468  0.007054019298238 -0.018234650266675 -0.000615735445240  0.005903954759545
-    3  (  8) -0.015821389930880 -0.004485038750012 -0.033862855604013 -0.005131802362361 -0.004339290288994
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000001449238259 -0.000678316267211  0.036387013015476 -0.044165966800408
-    1  (  1)  0.000814667967299  0.001352515705922  0.045321830954914 -0.038349341793270
-    2  (  2)  0.015502636931662  0.023469494614593  0.379996723739930 -0.218264143072345
-    3  (  3)  0.013628579969907  0.020644856937936  0.203890445404530 -0.063633237712543
-    4  (  4)  0.057281075456987  0.097258539285045  0.216440994273141  0.416992135205754
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5) -0.000001236340623 -0.000844654959821 -0.015387325728454 -0.013448305856449 -0.057069742160392
-    1  (  6)  0.000671443618202 -0.001379778933016 -0.023464050046926 -0.020715419540811 -0.097609214874198
-    2  (  7) -0.036865842405657 -0.045128807455787 -0.379409175136556 -0.203871625155191 -0.217739325178581
-    3  (  8)  0.044448744496422  0.038059525477200  0.217450238194944  0.062961627736516 -0.417728912438826
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.065654735008108  0.041947596327668  0.013161199168533 -0.111347678755871  0.110023740318908  0.028611010363429  0.087382345014260 -0.000508462096037  0.012737899474334
-    1  (  1) -0.002767746541470 -0.010697717051867  0.013506220021757  0.073915296604893 -0.218001416614763 -0.148131871022263 -0.817268502509706 -0.116805979922717  0.086849043444928
-    2  (  2)  0.048963621348430  0.019287708607099  0.016788280782980 -0.373428608200955  0.152149392753608 -0.191763183105895 -0.187319092582735 -0.050811648582791  0.023575112696311
-    3  (  3) -0.095762834263892 -0.056431729424626  0.178579681981428  0.038136357828172  0.140424938057787  0.089806149182954 -0.125801298670935 -0.116636879752083 -0.084795042899147
-    4  (  4) -0.100604286311178 -0.067706025938121  0.243618193961101  0.044366280428374  0.181211603026352  0.115080151607553 -0.179519058512823 -0.083926718748696 -0.086977297577403
-    5  (  5)  0.065265671644906  0.066327743019948 -0.367151009089566  0.044017259434143  0.156512208948530  0.073862917481627 -0.054143364445078 -0.093320733204408  0.170259938231209
-    6  (  6) -0.072248633599947 -0.071960000241620  0.684414897034704 -0.206865946506378 -0.380155073024861 -0.217464187923408  0.101287724653335  0.035777873700140 -0.341068954568277
-    7  (  7)  0.019742165644621  0.004654695913907  0.113798440024880 -0.000565529496792  0.010619803498230  0.072865384546327  0.376900870832898  0.139303623390988 -0.056085243769597
-    8  (  8)  0.000680094833114  0.001599154367371 -0.037525715342391  0.088616153955606 -0.068221855491928  0.039176398110699  0.208508596289410  0.056090509029161 -0.046056992364179
-    9  (  9) -0.002777645983491 -0.007429062082265 -0.024943481241087  0.022917119544815 -0.035703520332323 -0.020318143538961 -0.128836192485179  0.002260232930744 -0.005711636818947
-   10  ( 10) -0.005703995475187  0.023273790317780  0.027225231172569  0.026560091638037 -0.035400448225392 -0.015156814544557 -0.030152251932565 -0.170108826646880 -0.002596342796932
-   11  ( 11) -0.003384396390287 -0.002280174982981  0.118256290646368  0.004806020897038 -0.008748567786521  0.061729684148256  0.016174365364760 -0.021868062171602  0.291086856664191
-   12  ( 12)  0.020556143591060 -0.013540147573963  0.000211121149248 -0.008542300507699  0.013892871033950  0.041889373563059  0.006010019596642  0.135825905700256  0.000315224141913
-   13  ( 13)  0.004670555023840  0.000926561289656  0.016865377218670 -0.001909514550959 -0.008533193721317 -0.002601173416076 -0.067131182151494 -0.024630652702465 -0.002093308136502
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006448538326546 -0.007804286654557  0.001728462971935  0.009631296803397  0.002170488409239 -0.006916574569899
-    1  (  1) -0.039841926431094 -0.031613947455229 -0.126270875290483  0.005440111027698  0.010222827907129 -0.010738179450812
-    2  (  2) -0.049401198576892  0.028053807136363  0.027408978164445  0.001009242763448 -0.006677350800637 -0.009978793374560
-    3  (  3)  0.070461023388028 -0.083098730910732  0.035907242226525 -0.018802920956394  0.017169790328324  0.011284969259854
-    4  (  4)  0.035774581056077  0.067898310104354 -0.022184152779517  0.018305692607931  0.010769002732021  0.005255691542637
-    5  (  5)  0.149333021464651 -0.107123749279080 -0.046254018736456 -0.009064635064199  0.006568763780996  0.015962058047808
-    6  (  6) -0.264128410974010 -0.189717497993806  0.013846515708785 -0.034468727519864  0.018622848646936 -0.039126031881052
-    7  (  7) -0.078788486645653  0.137080811211666 -0.129024824415654  0.020540287905800 -0.010701749641589 -0.006364102239056
-    8  (  8)  0.066828033976249  0.061150264268413  0.661663701924733  0.064427601490291 -0.022787129232047 -0.001755163119735
-    9  (  9)  0.058361499120098  0.002765573216636  0.292978668220555 -0.024531949919018  0.033842058784980 -0.017477748330907
-   10  ( 10)  0.025537285280604 -0.402776973579754  0.195006698620815  0.143818174533728 -0.044952564489986  0.042833811279285
-   11  ( 11) -0.612581240841896 -0.030682190159458  0.052907135351065 -0.397594452860863 -0.644994636219877  0.225177389580867
-   12  ( 12)  0.078361600716649 -0.147641318569098  0.139660052106199 -0.415352895613913  0.111207710564659 -0.045767890147728
-   13  ( 13)  0.007556092974866 -0.007033999869554  0.662815062198416  0.034075784956457 -0.058439367352623  0.002858040197037
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.065637755065296  0.002922147800215 -0.048671929226138  0.095125218272003  0.099723510384958 -0.064120169702230  0.070291835315882 -0.020001124961592 -0.000648211315578
-    1  ( 15) -0.042163964947943  0.010964528434227 -0.019190852116048  0.056424446694003  0.067775298013055 -0.066345972766125  0.071820352073591 -0.004697838980096 -0.001720052135460
-    2  ( 16) -0.013293234442870 -0.013552616835989 -0.017151141683736 -0.178064685884642 -0.243210819205006  0.366658155299651 -0.683572979587335 -0.113726231443006  0.037674714506423
-    3  ( 17)  0.111834066297571 -0.074488566075957  0.373405604015245 -0.038275795575228 -0.044268719891376 -0.043920774238880  0.206762135944084  0.000719712475052 -0.088713007894149
-    4  ( 18) -0.110610680532425  0.218553221231058 -0.152104326157335 -0.140305969875780 -0.181385048024784 -0.156380031467975  0.379725260140945 -0.010777712393018  0.068072026056361
-    5  ( 19) -0.028752302296866  0.148103525280228  0.191867478523695 -0.089886445678393 -0.115405895081911 -0.073530973630370  0.216895482105819 -0.072888841616772 -0.039414401003105
-    6  ( 20) -0.088850241354773  0.817864851326399  0.187539096014714  0.126557765665900  0.179187648392432  0.053967687035441 -0.101345461779185 -0.376808417579726 -0.209641178673511
-    7  ( 21)  0.000237007967331  0.116953554114382  0.050876563599610  0.116849514388006  0.083854529763923  0.093202283171221 -0.035655664861976 -0.139240246932033 -0.056215237122519
-    8  ( 22) -0.012631614747874 -0.086750070473424 -0.023465016121868  0.084651439922309  0.087073871250464 -0.170290795114530  0.341033647036818  0.056079524884524  0.046129894380799
-    9  ( 23) -0.006387258080938  0.039628230453701  0.049240369744356 -0.070606950701540 -0.036097322010346 -0.148730552434340  0.263190621956396  0.078651755284235 -0.066792980839994
-   10  ( 24)  0.007794022168576  0.031646533198791 -0.027998592231561  0.083306318414635 -0.068241222884855  0.107186318196201  0.189423229550161 -0.136892100121890 -0.061228415636292
-   11  ( 25) -0.001991556117374  0.126407066966917 -0.027445453708537 -0.035776931996673  0.022144073093222  0.046221166077784 -0.013824310435878  0.129003604478449 -0.661853480191135
-   12  ( 26) -0.009600001381321 -0.005495023036659 -0.001033843833566  0.018933720846780 -0.018384184656961  0.009023079515234  0.034487318996206 -0.020439451427378 -0.064455522190826
-   13  ( 27) -0.002162652889855 -0.010273373773252  0.006629751598900 -0.017146243746684 -0.010737091256527 -0.006596576890623 -0.018510833168568  0.010689123006489  0.022830313481384
-   14  ( 28)  0.006906519508983  0.010703298470916  0.009943758355024 -0.011262502029653 -0.005260769217762 -0.015967223931621  0.039174936770116  0.006358557612866  0.001746796831110
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.002837541625479  0.005729995405909  0.002886518732238 -0.020605597892472 -0.004641188066032
-    1  ( 15)  0.007437048654888 -0.023276858901465  0.002356564609691  0.013557218145514 -0.000920022592980
-    2  ( 16)  0.025051840291799 -0.027193054194177 -0.117992112524578 -0.000179363116265 -0.016865629814803
-    3  ( 17) -0.023119646954968 -0.026651954594642 -0.004797412115556  0.008529729543576  0.001864254829128
-    4  ( 18)  0.035882182969490  0.035473966824270  0.008734659729202 -0.013878374004773  0.008565471497804
-    5  ( 19)  0.020360728363539  0.015171578403734 -0.061893166186221 -0.041911320086821  0.002602292601012
-    6  ( 20)  0.129299086068177  0.030292751382697 -0.016131997141108 -0.006006544744005  0.067163025039189
-    7  ( 21) -0.002077772697434  0.170151043409813  0.021893310204112 -0.135824150659838  0.024649382850585
-    8  ( 22)  0.005657966549308  0.002564604629079 -0.291029976300794 -0.000304129767732  0.002095216593482
-    9  ( 23) -0.058382786939725 -0.025529985547566  0.612383083539007 -0.078382664400516 -0.007563097139095
-   10  ( 24) -0.002481602054434  0.402824416561843  0.030641142278648  0.147639477009355  0.007047503750138
-   11  ( 25) -0.292947582813084 -0.194977107587304 -0.052900457813842 -0.139655219584998 -0.662817050200718
-   12  ( 26)  0.024630679059925 -0.143803617200920  0.397605905120325  0.415353689227297 -0.034075915591583
-   13  ( 27) -0.033850912401595  0.044956212946434  0.644990528852317 -0.111210544073818  0.058439348225225
-   14  ( 28)  0.017470255422903 -0.042829071311909 -0.225189839155519  0.045765192297719 -0.002860289599065
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.000082472399485  0.001685231176796 -0.010755773525388  0.047851717401665 -0.048146819273485  0.005778305812536 -0.002186428407135  0.012926921192549  0.004368364269075
-    1  (  1)  0.003220446784849  0.004738636604093 -0.005203623953188  0.008888194042355  0.002288606689271  0.015840258607316  0.070307447815582  0.014526857103437 -0.004025200443461
-    2  (  2)  0.000042865955623  0.012225756716588  0.007261122888631 -0.023892647415290  0.043398248169209  0.025204087353238  0.154395827172648  0.022995799169003 -0.019572129394279
-    3  (  3) -0.012592260526611 -0.003257441214905  0.012596956453141 -0.005674588565405  0.002140019515693 -0.004967236803689 -0.013568818625003 -0.009521055757566 -0.006284449533271
-    4  (  4) -0.059292235157972 -0.046128803984366  0.084656929226350 -0.003079990219286 -0.032543882069924 -0.021965559038436 -0.062290418066479  0.002788049090113 -0.031737368724626
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.005684037207820 -0.005039602793450  0.000945725061671  0.000425951737672  0.002277778912713 -0.002317519936550
-    1  (  1)  0.000191501808207 -0.005615106236174 -0.000663390126010 -0.002975225050682  0.001105781730417 -0.000339070552009
-    2  (  2)  0.008635332517955  0.014191287532215  0.036089824283730  0.005156223258275 -0.001596897527108  0.003548958630526
-    3  (  3)  0.011309890019207 -0.025010408644042  0.008100841134420 -0.008221606197850  0.004567545117431  0.003602034133643
-    4  (  4)  0.031941089920318  0.005014599851329 -0.011202388687432  0.013321967999428  0.018949090937004  0.009629290338373
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.003125233656564  0.003399455999144  0.031148741955022 -0.037381076738134 -0.045638651622127  0.007662804831572  0.007349573449525 -0.005611310740733 -0.003664917328648
-    1  (  6) -0.004239191785748  0.005425853767687  0.012492096709600  0.009631640513977  0.014641915170010 -0.052628124238989  0.104836411205794  0.010149090123868 -0.005577978579558
-    2  (  7)  0.032249780945436 -0.047831723366508 -0.011228580328865  0.021149918738029  0.032870923541039 -0.049288992677552  0.085080122313267  0.029157301245289 -0.030452694267850
-    3  (  8) -0.047028350491069  0.061446566566321  0.003294033338017  0.033510810591702  0.054311398746913 -0.073088847241071  0.108790202560997 -0.002661112810634  0.019632264686795
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.001457812391480 -0.004843826108852  0.000616649231345  0.002107188882039  0.002069763501018
-    1  (  6) -0.001542410811557  0.001336446699507  0.005164909835080 -0.000321011671623  0.000311756266696
-    2  (  7) -0.017960207879172 -0.006001515410680  0.022177717492308 -0.000230841789591 -0.006008101007254
-    3  (  8)  0.014825188397798  0.004501578726465  0.038679782557990  0.004764087686308  0.004599594990344
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.087812486802714  0.227185881204308  0.033695530666594 -0.478017916502669 -0.574663197793692  0.064626389159099  0.111307888755798 -0.039881613474602  0.259357506752495
-    1  (  1) -0.022503443769316  0.058098624598860  0.000062737918384 -0.132304975924250 -0.206845232883897  0.090151376053575 -0.021623075719394 -0.039361678247531  0.081041759051801
-    2  (  2) -0.058445994221533  0.108172157762627  0.020491572140790  0.029038343086670 -0.075256235298781  0.197244174432849 -0.268904784689931 -0.104165947953548  0.067340387823683
-    3  (  3) -0.015395524077221  0.065975045803857  0.020693287808150  0.145278133913277  0.156811996241071  0.026190402384534 -0.072791620047589 -0.106379128630683  0.008110006774417
-    4  (  4)  0.209889658675087  0.051262188320910 -0.016792501067509 -0.095510068644020  0.095336439261671 -0.289116373116523  0.245753854267222 -0.379261942918032  0.084194499540513
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.026329060677561 -0.025808752955184  0.031327528625543  0.046690857000306 -0.148308927158050
-    1  (  1)  0.009235920741953 -0.024147623936324  0.039515998985496  0.082736567474275 -0.047511961836932
-    2  (  2)  0.028213252690267  0.067760879803439  0.238885756342533 -0.125969167249307  0.177609450790050
-    3  (  3)  0.077606280867099 -0.045313516945509  0.093141201786142  0.365274001930932  0.093447139644196
-    4  (  4)  0.414915524340511  0.159852629117801 -0.273568256443621 -0.034618663880565  0.200919735657569
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5) -0.100097042064109 -0.081572276694192  0.096987973401318  0.663339574002089 -0.420147890655544  0.277783810889268 -0.064637315926862  0.070466235403012 -0.070257725486540
-    1  (  6) -0.016102698458229 -0.069778494124348  0.053388838781434  0.227200874402225 -0.199230150396393  0.049687570998643 -0.168877481796607 -0.014461212744262 -0.006078038840458
-    2  (  7)  0.058029520985814 -0.323045677762244  0.030451382839222 -0.087822452562579 -0.049669591787373 -0.052839271896380 -0.277652100807769 -0.149775013154872  0.305937144304185
-    3  (  8) -0.084055246767285  0.046073361564883  0.190725816125328 -0.087557928956100 -0.137785486093215 -0.205465565690345 -0.198777613886308 -0.118276971790536 -0.298899295836575
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.218570828330775 -0.002459809908623 -0.012856145681193  0.000021824790697 -0.113054815969725  0.069738880637081
-    1  (  6)  0.065173966437703  0.083163104973586  0.059838817731124  0.009394320556862 -0.030439480905892  0.004211863644554
-    2  (  7)  0.056299348264054 -0.068872050619792  0.330916473514167 -0.053769726019105 -0.184435953275485 -0.103868529931394
-    3  (  8)  0.066328835526796 -0.124449731804258  0.113043712188522  0.144452781296566  0.299204298913047 -0.043729266175510
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     5
-	   Irrep: 1 row =     4	col =     4
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  0)  0.000004573398161 -0.026286921007013 -0.102140891739196  0.046329210496983  0.729390567548561
-    1  (  1)  0.025713594330025 -0.000257493963458  0.008292820651928  0.017063129342656 -0.120829528247487
-    2  (  2)  0.100328894362796 -0.008488274458083  0.000453486802032  0.070579792758556 -0.263656732394771
-    3  (  3) -0.045991765483214 -0.016576004580395 -0.069995620780228  0.000663293929053  0.516192116287051
-    4  (  4) -0.731630680372910  0.119898957246876  0.260394403495538 -0.515781832284347  0.000889122841553
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.000000233652363 -0.064564285041516 -0.616105149487094  0.260390668506121
-    1  (  6)  0.062839473886914 -0.000444869313415  0.381925918949370 -0.143836397980783
-    2  (  7)  0.621984815196279 -0.379451666136779 -0.000474943168189  0.057946188304698
-    3  (  8) -0.264102417786712  0.142711834506710 -0.057683662296849  0.001429338231608
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000907955469773  0.057469185422175  0.021763852977055 -0.110173024043768 -0.041201460747158  0.038867594921468 -0.013631034243177  0.027732793365817  0.095898777358609
-    1  (  1) -0.055346863269661 -0.000117397021226 -0.161081748599380  0.114723957474251 -0.226132876592379  0.429585342377155 -0.364791648688510 -0.339772079862666 -0.220539658945858
-    2  (  2) -0.020991641046944  0.161271433223917  0.000050685334098  0.056776200217074  0.009044014133991  0.218250624524151 -0.249343498568951 -0.218110128138336  0.109319147419263
-    3  (  3)  0.109915677298642 -0.115821457323195 -0.056019036251094  0.000733462930927  0.462847670362492  0.122610728429171  0.103870362151314  0.116256811511125  0.000235264198743
-    4  (  4)  0.040148332688022  0.225919341325781 -0.007774686784298 -0.462782646228266 -0.000741776518072  0.292876641149551 -0.009422958660044 -0.051871653386108 -0.039841372684353
-    5  (  5) -0.036323208125674 -0.431174165520025 -0.219019937969006 -0.122662494624249 -0.292740404743441 -0.000270242671647  0.380080578538411  0.122527668576026  0.042269981844046
-    6  (  6)  0.010516440934539  0.366108347757634  0.249485131281357 -0.103528510366960  0.008569286781080 -0.379122670006848 -0.000624830510989  0.110535367048428 -0.061996730290172
-    7  (  7) -0.028781772116013  0.339082292903162  0.216804267770263 -0.114009058372185  0.053199921835397 -0.122164619547920 -0.109911089305582 -0.000201005708325 -0.084720810347527
-    8  (  8) -0.095803905327850  0.221313012959504 -0.109107703119537 -0.000853061874275  0.038572704846279 -0.040543435561974  0.059772638543626  0.084702259478363  0.000398228836127
-    9  (  9)  0.014691667187958 -0.105292570343760 -0.107275838133277  0.218834816088194  0.309692871922803 -0.105243205577181 -0.129645166169486  0.117998834741075  0.042504917170727
-   10  ( 10) -0.029203870468029  0.107748796905021 -0.099755509494998  0.053531025979861  0.138316456824170  0.190112587233628 -0.089998700048056 -0.050364754033155 -0.205939040674301
-   11  ( 11) -0.155171838187128  0.443695654470558 -0.328777376012082 -0.218797371784095 -0.215174674557682  0.086664093392768 -0.081418220508178 -0.042687160450597  0.076994354407445
-   12  ( 12)  0.047145160367930  0.056368730619817 -0.091887374001802  0.290642148185853 -0.241903957589790 -0.247340653422069  0.042832976953373  0.092376972414730 -0.274156931627591
-   13  ( 13) -0.050391965898587  0.050333352324666 -0.290239980689431  0.162047784246261  0.213771322704111 -0.103684767873762 -0.033887030706559 -0.045587927208000  0.299795917187637
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015152137307395  0.029090729505159  0.157684936500365 -0.046161542678081  0.051363105029612
-    1  (  1)  0.106897196217704 -0.107201102435279 -0.445385718438941 -0.057067785198253 -0.050052518334036
-    2  (  2)  0.108854165260085  0.100194375517978  0.328544186390936  0.092696505312142  0.291518890939844
-    3  (  3) -0.218863893287095 -0.054794851259918  0.218938432987514 -0.287403740652911 -0.163302332974643
-    4  (  4) -0.309034872968878 -0.137544963853166  0.215099581748332  0.238286123100997 -0.213544968889557
-    5  (  5)  0.105670967587971 -0.189853214810089 -0.086869490259104  0.246369920975845  0.103885372481427
-    6  (  6)  0.128168532603125  0.089875733171815  0.081956625213594 -0.043636943354897  0.033214897715844
-    7  (  7) -0.118055343081714  0.049681264688510  0.043690935847564 -0.088890000697565  0.045590550639158
-    8  (  8) -0.043186782282413  0.206227590933231 -0.075246025161497  0.272589996873107 -0.299124983726597
-    9  (  9) -0.000078385332361  0.416516334936076  0.033604820343445 -1.079154966452740  0.144880662209521
-   10  ( 10) -0.417423659534060 -0.000158734809049 -0.288841615674402 -0.322138826783892 -0.291543232279926
-   11  ( 11) -0.033231980297474  0.288689770834225  0.000097756434677  0.357467030590011 -0.110233460697010
-   12  ( 12)  1.082591724249888  0.322580189787378 -0.357467662511204 -0.000002506014296 -0.002430685027476
-   13  ( 13) -0.144962273119514  0.291352173494917  0.110200949743104  0.002467419229282  0.000069717512569
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000157847868290  0.016215825751449  0.024921140835205 -0.061983131961857 -0.021488523719638  0.118636842442394 -0.004655357150719 -0.089073046050162  0.035341743401839
-    1  ( 15) -0.019053182436356  0.000070169967981  0.073750458708140 -0.220490357770091  0.117197217087347 -0.070067667295608 -0.194628222644904  0.297272902676479 -0.000293976323977
-    2  ( 16) -0.022582832837764 -0.073727619849646 -0.001107847074438 -0.015450445254245 -0.086512268412040 -0.104891342903803 -0.398746578386172 -0.436629051698872  0.174929886371767
-    3  ( 17)  0.059789121193802  0.223561162265227  0.017246884213665  0.001133413477177  0.251269351960067 -0.316046055900051  0.194798853929635  0.070662293795111 -0.376486192709736
-    4  ( 18)  0.020057750204430 -0.119048744706178  0.086804996984604 -0.251600027452705 -0.000367087018011  0.043049167161065  0.031725417674779  0.166603526743631  0.162562866352690
-    5  ( 19) -0.121121989980594  0.070389389412088  0.107110436996367  0.315426861814928 -0.043156406137713 -0.000869379131471  0.084802565522683  0.176704066299640 -0.191684108270085
-    6  ( 20)  0.000235440759562  0.194647772440619  0.399809021490062 -0.193925182227417 -0.032502800135540 -0.085527959530692  0.000317898540611  0.483152129979633 -0.288296772864155
-    7  ( 21)  0.086715820819702 -0.297225893875278  0.437407006325733 -0.070318446772769 -0.166613176598092 -0.177266472787051 -0.482842334868818 -0.000016918979194  0.098143930537984
-    8  ( 22) -0.034831350836153  0.000872627608987 -0.174095892709366  0.374201949238123 -0.160687471280960  0.191573703451277  0.289458084753142 -0.097035452987332 -0.000013740238338
-    9  ( 23) -0.146118515580350  0.053502339654622  0.324227151480280  0.062879262377670  0.055255843282985  0.064120285426383  0.153000151235781  0.139466633420354 -0.103712199912250
-   10  ( 24)  0.228945744119783 -0.607905104064675 -0.190622145647686 -0.232969653682917 -0.097299564671426  0.308157084769049 -0.021742266672299  0.163622560408140  0.316403584487308
-   11  ( 25) -0.113574561081893 -0.174427526201227  0.418996588560739  0.308337890204768 -0.075444305281087  0.339087016260170 -0.159464081752923 -0.028413159978625 -0.098872332026849
-   12  ( 26) -0.037423041327835 -0.021648771086278  0.117301902633040 -0.051910253781133  0.180460975810878  0.010738685992300  0.081522476682207 -0.155892729451823  0.070548639310764
-   13  ( 27)  0.017278226707665 -0.067257600974327  0.031226328151039 -0.363801361341849  0.387214773801119  0.012092634242527  0.015811686451139  0.054980449112106 -0.199341286273110
-   14  ( 28)  0.034098877274819  0.073619948740194 -0.020485593124333 -0.085857788764361  0.016813215913708 -0.112843948958225 -0.014111719587198  0.178008154299853  0.110352523624475
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147089036077913 -0.230609246333956  0.117988169590393  0.038149068395854 -0.016533997268475 -0.035539218704947
-    1  ( 15) -0.054543847501128  0.607931931871522  0.173885522614505  0.021417520123414  0.066622101243279 -0.073367218834160
-    2  ( 16) -0.323560135302739  0.191870807778304 -0.420420434136358 -0.118053590585123 -0.032670802184181  0.021056727281085
-    3  ( 17) -0.062629597315317  0.233299844808483 -0.309977543312231  0.052769685030093  0.365461347094339  0.086199175003951
-    4  ( 18) -0.056447422230211  0.097271671471775  0.076718205841652 -0.181009141023511 -0.388597209783852 -0.017027546198961
-    5  ( 19) -0.064625561658584 -0.308871002861823 -0.338019230856820 -0.010261814723335 -0.011433268868982  0.112355672161098
-    6  ( 20) -0.155386502136174  0.021348579055017  0.159407999745103 -0.081841042748257 -0.016549191473790  0.014157952683401
-    7  ( 21) -0.140540096961588 -0.163951619155724  0.028637880230024  0.155665388085339 -0.055624540700681 -0.178156006121949
-    8  ( 22)  0.103301881326260 -0.315447035672016  0.098512677196952 -0.070639282292011  0.199218391104609 -0.110198697628348
-    9  ( 23)  0.000663622883023 -0.100173520438882 -0.098204705212881  0.175395219081789 -0.218098160139060  0.228144978515468
-   10  ( 24)  0.099942092134404 -0.000097468800859  0.318473220070567 -0.225313093930981 -0.500004371994231 -0.463865695451562
-   11  ( 25)  0.099842118029420 -0.317761930545871 -0.000010523168953  0.325598172610521 -0.211905221625396 -0.064803699959669
-   12  ( 26) -0.174938990446214  0.225293131455683 -0.325706928587658 -0.000017996650401 -0.212072595691568  0.098012137478043
-   13  ( 27)  0.218632649333873  0.499554553991155  0.211866619547631  0.212028430474401  0.000008186017705 -0.140826029388741
-   14  ( 28) -0.228628738648224  0.463532597742934  0.064881129531643 -0.097950992094232  0.140879017093708 -0.000044241358907
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.090077743026585 -0.231039150143160 -0.035901155034428  0.481309880145456  0.577015812892151 -0.065493297263049 -0.109555018957673  0.040603254337130 -0.258464518895278
-    1  (  1)  0.019495186393093 -0.054320580816236  0.001045736787244  0.125508921505938  0.201846826508412 -0.093650850655654  0.025107322700080  0.040286353452445 -0.082871989440490
-    2  (  2)  0.062215540941165 -0.120396336103156 -0.021743992129717 -0.030463697336240  0.074900934911718 -0.202626976611110  0.283667442951541  0.110634443439646 -0.075608806251107
-    3  (  3)  0.020163928258686 -0.073789795481527 -0.021156706374422 -0.146008461264537 -0.150840822798868 -0.033519029414616  0.073778852718729  0.114734511054422 -0.006819656222072
-    4  (  4) -0.203040453592295 -0.062001347868375  0.011512293647419  0.096768363837510 -0.111807150026723  0.294391558964001 -0.263747857598306  0.381852842949882 -0.093844039126354
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.025993782100173  0.025999585079478 -0.031172097435929 -0.047041016408549  0.148712388894479
-    1  (  1) -0.009949948380770  0.025509667540199 -0.042843352121632 -0.089630217336913  0.047316601811719
-    2  (  2) -0.029963791233496 -0.072057651603260 -0.251082472301341  0.142797702824446 -0.185511481024750
-    3  (  3) -0.083129601747289  0.054851933187026 -0.095052156702046 -0.402625231275539 -0.093237580628574
-    4  (  4) -0.432717579385058 -0.171349899855996  0.283686718567670  0.039467885900519 -0.208554131467473
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5)  0.104614863306895  0.081909309664589 -0.097158251467365 -0.670160714387605  0.424820194069004 -0.278664534578716  0.065626044006430 -0.069546432842010  0.070000054325300
-    1  (  6)  0.010085625022161  0.069917915491100 -0.056941601077432 -0.210912516923027  0.193068723612150 -0.043449407478297  0.178527100593784  0.011181245670583  0.006301249278673
-    2  (  7) -0.063931508371222  0.335394578331372 -0.025043518081311  0.077579408335948  0.050355760225038  0.056838358642999  0.295412430798026  0.157711561653239 -0.309543375529247
-    3  (  8)  0.095558904649282 -0.044385291331450 -0.213125203767356  0.091469789652533  0.149404677133607  0.211821253458640  0.210445033324566  0.121082629036070  0.309925077983326
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5) -0.218346355468078  0.003902993442248  0.013122127072821 -0.000019181154163  0.113545011116700 -0.070000462264808
-    1  (  6) -0.067825713099569 -0.093018679870754 -0.065864077971857 -0.010196560530307  0.030000649698597 -0.002861076795818
-    2  (  7) -0.052960836246031  0.070309519011265 -0.343853923778325  0.057147372465282  0.187370347352601  0.107071443547134
-    3  (  8) -0.073661134979508  0.126624026209396 -0.117774893248785 -0.149927731022440 -0.310100412138852  0.046254145606780
-
-	DPD File2: Q_XX_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_XX_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008537980225406  0.000945129898893  0.007861735497576 -0.052182167001425  0.040296326576182  0.021342115682946  0.008589565219662 -0.023920501121483  0.020368605444251
-    1  (  1)  0.018153183499795  0.263067425438602  0.054389562430026 -0.192797377640586  0.331682218327527 -0.243952632834839  0.461269403091705 -0.298922731992746  0.099896278321566
-    2  (  2) -0.473326829875092  0.354711999777870 -0.045090199768973 -0.314963130314597  0.484581423303539 -0.627500427087376  0.228125650843963  0.368881833483696 -0.157854461147027
-    3  (  3)  0.142130794677702  0.342688800193651 -0.029357693905734  0.498931542705872 -0.368478571746859 -0.414527072528585 -0.252954775496281 -0.015279178704786  0.080181432500952
-    4  (  4)  0.045064243451358 -0.170905256844858 -0.120227782295818 -0.283209584153808 -0.322449437149278  0.038350986239344  0.323826512195772 -0.059016014348560  0.119767984014863
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.039288387606598 -0.012530946118356  0.010540240190623 -0.002008690297392 -0.012278044193192
-    1  (  1)  0.160692242004841  0.062252071716309 -0.137783791826936 -0.026578859783182  0.028742980427099
-    2  (  2)  0.161243886788011 -0.100211501517742  0.348376475476578 -0.082136549374097  0.022118891398939
-    3  (  3) -0.498438465752397 -0.305508098523993  0.089925319692057  0.062246802948415  0.022206361260900
-    4  (  4)  0.210891793961552 -0.284752766396421  0.047831529612126  0.616417457719904  0.071971027828774
-
-	File 101 DPD File2: Q_XX_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5)  0.027305626588484 -0.073741629810772 -0.017438002297891 -0.036456768415579 -0.033126212194457  0.060695094244282 -0.013083425973683  0.014649828771994 -0.001284333146953
-    1  (  6) -0.626563284648171  0.695676242750969  0.258061610829489 -0.298319223780268 -0.059409101916708  0.338135237453913  0.449964588735144  0.381885811904641 -0.481449878716824
-    2  (  7)  0.022970848447705 -0.199764367909729  0.423421514589056 -0.711550427884322  0.518045051934556 -0.315628326776047 -0.140450214486087  0.325716187060650  0.078259909247222
-    3  (  8) -0.309133686518377 -0.362143907714078  0.173255356379258  0.423143469435391  0.561190260248246  0.356391367499218  0.368571371342619  0.295334312114285 -0.032978376388635
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.002378747928322 -0.003511549169582  0.010631991574133 -0.002571292762870 -0.008839697137822  0.010242893937049
-    1  (  6) -0.085960437111493  0.044988313044920 -0.097396817537321  0.025649938865655  0.105833477571782  0.118775709578814
-    2  (  7) -0.209770979569160  0.272487579187359  0.152822097753159 -0.158113339267141 -0.173350458633040 -0.021709048101947
-    3  (  8)  0.118042089893306 -0.322012321265633  0.372175054367104 -0.239170671204544  0.081902669734810 -0.085405605717041
-
-	DPD File2: Q_XXBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     5
-	   Irrep: 1 row =     4	col =     4
-
-	File 101 DPD File2: Q_XXBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  0)  0.862071640662304  0.016351318979468 -0.029889496804943  0.070985652246304 -0.000705964121241
-    1  (  1)  0.015903497186238  0.588670457746305  0.460377441287237 -0.652676730327246  0.015443613752749
-    2  (  2) -0.029099359817576  0.465994930161498  1.308107068634168 -0.032168959292088  0.117270905199363
-    3  (  3)  0.069605337915699 -0.661683785184383 -0.032912244968924  1.560877733159385 -0.066248477371675
-    4  (  4) -0.000423395325819  0.014963658899577  0.116745724878824 -0.066754188762823  0.344483497692680
-
-	File 101 DPD File2: Q_XXBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.862138468665977 -0.015307132554464 -0.002113597466984  0.013023727701940
-    1  (  6) -0.015802137891222  1.384815532974117  0.008171112126307  0.093008560897416
-    2  (  7) -0.001446022183218  0.005254330147633  0.137305671181348  0.575269234895980
-    3  (  8)  0.013719239984068  0.082279018714029  0.570449669770554  1.383911865696573
-
-	DPD File2: Q_XXBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Q_XXBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  2.551603268786990  0.138373615916206 -0.102387973622845  0.436940648659153 -0.528353143394874  0.710602660080805 -0.626278799336929  0.717811414838044  0.293908609997899
-    1  (  1)  0.133912346767623  2.226791890796868 -0.088555637224519  0.086652657895287  0.071712529641298 -0.382328651104983  0.113672404294203  0.579521875189545 -0.725774338528130
-    2  (  2) -0.102457347476787 -0.087777965784388  1.376875648639232 -0.101174035950797 -0.087160100540626  0.196865948929846 -0.070553172650201 -0.192580636802412  0.299112555320116
-    3  (  3)  0.441275529555936  0.089428350722570 -0.101677904582988  1.326604842432615 -1.155538414491226 -0.229347448192267  0.371938210259229 -0.698309622253325  0.146066795377661
-    4  (  4) -0.535141141932053  0.070626048874319 -0.084755240940798 -1.156531231419824  0.734978297712902  0.263166069058665  0.616947459677552  0.592961860525285  0.106278818787805
-    5  (  5)  0.716859788120336 -0.385214862465396  0.198213709858067 -0.231449878347558  0.261927831510659  2.090287142908488  0.598193097430313 -0.552821032757369  0.022011352897618
-    6  (  6) -0.629134866296866  0.111839648897009 -0.069191764308103  0.374546434442846  0.617482182682076  0.598208936767595  1.539355217822228  0.099237276477238 -0.168711257674387
-    7  (  7)  0.718664778535713  0.583668568077409 -0.193510313365971 -0.690885246168080  0.588064035168548 -0.556471105587091  0.097007055629018  0.576810532909079  0.231575880305157
-    8  (  8)  0.290834774972227 -0.724324019008662  0.298944601921667  0.141665345753778  0.112637760479256  0.018748278540186 -0.165906874997330  0.232868533891722  2.082639485930188
-    9  (  9)  0.383107359889946 -0.206646454535165 -0.050636327971112  0.066128129093323 -0.066676189635563  0.092772447668203 -0.062429816494630 -0.029493468334010  0.028429171627375
-   10  ( 10) -0.170788916679879  0.403364692321961 -0.072227459289461 -0.295402799108950  0.008765725538453 -0.359593397281363 -0.149764864437266  0.118082712611894 -0.051088533998503
-   11  ( 11) -0.417742309424716  0.106687068186627 -0.137906825885992  0.076992131159771  0.223589422235805 -0.146409082537757  0.269795281666904 -0.087427619579112 -0.114780641722244
-   12  ( 12) -0.088159764847759  0.263889577991843  0.017488872539242 -0.051142093636976  0.268295320112179 -0.231719550072020 -0.261524550096350  0.093630535853078  0.006083814929246
-   13  ( 13)  0.151965092346797  0.116943586275175 -0.223831556418652 -0.266802823305441  0.284617396116393  0.104999893818870  0.042652366367552 -0.038481391386399 -0.504305721310015
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.380233191837108 -0.172438426767148 -0.415785990178637 -0.089652690476348  0.152217065850224
-    1  (  1) -0.207151154323514  0.403086331804238  0.105934048111937  0.266302251395745  0.117134967250445
-    2  (  2) -0.052211565372529 -0.074511564055808 -0.136649371934671  0.019396638206300 -0.223561665134605
-    3  (  3)  0.056610911799992 -0.296181635385706  0.074835792531053 -0.052342958071918 -0.267151593587368
-    4  (  4) -0.059207805506185  0.011048608061851  0.224493410407725  0.267630141261824  0.284642926719082
-    5  (  5)  0.095759627207745 -0.359666909017988 -0.146052324814945 -0.231268772922716  0.105096448094441
-    6  (  6) -0.059154508490596 -0.148080114751640  0.269739064655617 -0.263530259574515  0.042609363191198
-    7  (  7) -0.032353147932772  0.116890139442811 -0.087734356031546  0.093337617929303 -0.038510162602378
-    8  (  8)  0.029560900815491 -0.050869498913223 -0.112813153581568  0.004554478343553 -0.504246839866476
-    9  (  9)  0.890737392724025 -0.207170673147941  0.192511946971887 -0.106432947933787 -0.262091046327284
-   10  ( 10) -0.206021226456380  1.359104505964990 -0.001152039376712  0.247107802772041 -0.137336718575902
-   11  ( 11)  0.192973214421692 -0.000686262088567  0.806016490117703 -0.082987442711885 -0.119652109600334
-   12  ( 12) -0.106128086256931  0.247181861481605 -0.082868729918214  0.724280895968825 -0.009738853210270
-   13  ( 13) -0.262293715468066 -0.137457091409736 -0.119522669986563 -0.009690283912076  1.224524587358329
-
-	File 101 DPD File2: Q_XXBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  3.366926728761273  0.491874729741744  0.781751499188203  0.951721676586564 -0.182628250376605 -0.373561011333374 -0.462279091638608 -0.245907200160699  0.713980602886853
-    1  ( 15)  0.495310291510535  1.673597128538777 -0.161229534069568 -0.190996923233554 -0.590538560955254  0.879277872925077 -0.447085318537077 -0.137576661730209  0.206803222100994
-    2  ( 16)  0.776144458601573 -0.156795897201246  2.310851996679876  0.572862821050738  0.080493988594292  0.323827190936847  0.535865063694421  0.541258959929166  0.514821707746238
-    3  ( 17)  0.952265394078580 -0.187283704286177  0.573032903989022  0.233458119889621  1.226180445127863 -1.224564270000527 -0.331138590452448 -0.019586140804942  0.093999706191795
-    4  ( 18) -0.193400112526412 -0.586613428441392  0.087188330453609  1.223585542671669  2.234174244405610  0.016425679794966  0.098424568398033  0.300604695786031 -0.182572438527233
-    5  ( 19) -0.374516939845101  0.876658632700525  0.325751533155300 -1.228429245752109  0.020762917673826  2.172967668577391 -0.159826739396163 -0.045667590885273  0.082138678845310
-    6  ( 20) -0.463694311338142 -0.447018415851752  0.536497175935173 -0.335891700467338  0.097696913872482 -0.161632274190593  1.636668897076275 -0.297415950830715  0.253058733775514
-    7  ( 21) -0.250862707578750 -0.138285357466418  0.542948181134904 -0.020693295300588  0.299085565986468 -0.048441025616268 -0.298073610126351  2.080482574877543  0.313979854517648
-    8  ( 22)  0.712891490632112  0.210619414158720  0.515616936354643  0.096063576322321 -0.183464554399298  0.082547597436773  0.253603438623844  0.313171098494729  0.140558276378028
-    9  ( 23)  0.365610697432413  0.118383834966450 -0.622755809520523 -0.229006739814224  0.109319311355230 -0.128309540872704 -0.089231400699044  0.170934586608886 -0.367813845316576
-   10  ( 24)  0.170873285921951  0.195083423440389 -0.224604122481311 -0.245572144919623 -0.063269320429308  0.015224692827416  0.181718119484666 -0.448045011027307 -0.057741304586738
-   11  ( 25) -0.296394730144587  0.023897919078048  0.336244207104588 -0.203810046302098  0.230699398314582  0.116682331087604  0.328489261387761 -0.065623709703088 -0.099252948502409
-   12  ( 26) -0.075521791921352 -0.095798718734628  0.366588729560989  0.070630519370038  0.363379357956175  0.092108895224621 -0.056904804457970  0.293853789026258  0.035377472506056
-   13  ( 27)  0.486176303529741  0.311308348099977  0.174863925728164  0.070311865294577  0.225334731062507 -0.024665731200327  0.009759203773807 -0.158710995212818  0.036853654089670
-   14  ( 28)  0.178083931908320  0.319379973245610  0.132594130567177  0.442940682813295  0.170538282947834 -0.450226163983505  0.120764257726433  0.166627404609428 -0.020030873293632
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.368056702384515  0.171273319750709 -0.291866681002457 -0.079111891266501  0.484592447824440  0.176817853151615
-    1  ( 15)  0.117468115884197  0.195641012922332  0.022479216624437 -0.095181488125573  0.312549954811163  0.320746887347747
-    2  ( 16) -0.626111704273546 -0.224207924088795  0.333434346049701  0.368508959202610  0.175101386915920  0.133480440000644
-    3  ( 17) -0.226078339204334 -0.246620990803017 -0.203872685797858  0.071125079743613  0.071927946398006  0.442994658005568
-    4  ( 18)  0.104414175970987 -0.062349034671336  0.230327802997268  0.363555840548047  0.224326311149464  0.170542488528361
-    5  ( 19) -0.130038269544335  0.014853338449470  0.118586643014374  0.090886758464512 -0.024316748302199 -0.450434999320654
-    6  ( 20) -0.092397898111309  0.182470257344789  0.327905220351615 -0.056461336887458  0.009976184051191  0.121199507746336
-    7  ( 21)  0.166998612563240 -0.448266618240638 -0.065674436904914  0.293944370206516 -0.158942172620265  0.166678328353852
-    8  ( 22) -0.366104021505585 -0.057412657115354 -0.100288730109722  0.036102926936412  0.036676884635963 -0.020024890744667
-    9  ( 23)  1.948491674673338  0.157094693731002 -0.303153158152460 -0.156394830887543 -0.433620164607490  0.242964381043701
-   10  ( 24)  0.156987415168906  0.849294461005729  0.021739684925417 -0.064546516598580 -0.071477364087860  0.010241716742233
-   11  ( 25) -0.304796579349191  0.021597065328245  0.814687582067318 -0.008061138708508  0.075287336463091  0.164908920175640
-   12  ( 26) -0.155073129580215 -0.064183668135549 -0.008235466791762  1.349747279982772 -0.159360207300293  0.027699292570878
-   13  ( 27) -0.433821305869840 -0.071226555847791  0.075585716816530 -0.159522589610244  0.959640915013408 -0.013532256894016
-   14  ( 28)  0.242989229919748  0.010112581909544  0.165162788934687  0.027499760348936 -0.013473801211782  1.500775099732085
-
-	DPD File2: Q_XXBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_XXBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.008095985617132  0.001144916131710  0.007801443313003 -0.049973287152022  0.038248284725339  0.020537474915089  0.008520295998499 -0.022481570507269  0.019772116776673
-    1  (  1)  0.012627946961003  0.241476072793311  0.052539307599774 -0.215487895375100  0.342295504085441 -0.235893948157475  0.460723976353569 -0.312436580335061  0.091437483830340
-    2  (  2) -0.437633666002439  0.316611504404080 -0.049541927153222 -0.283770842599671  0.453892998291014 -0.600908575893051  0.232874242338074  0.340445854799682 -0.169023680445678
-    3  (  3)  0.139576932568691  0.302741921422550 -0.032818514988077  0.457818032045688 -0.347986923711440 -0.398291863011123 -0.242675668807138 -0.004699723430208  0.056851134261509
-    4  (  4)  0.037619727580174 -0.146467942650952 -0.117137370640647 -0.312115642334262 -0.362376061169628  0.042444956380982  0.320153029046517 -0.063315305275822  0.133396417351100
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.037180745850955 -0.011927919919221  0.009965044093423 -0.001925148171752 -0.011856723103085
-    1  (  1)  0.155999922131283  0.065270377036377 -0.130367453208222 -0.023563423165234  0.029870187347127
-    2  (  2)  0.128274056553395 -0.072945663824518  0.349167449469952 -0.071259482437377  0.023531078494476
-    3  (  3) -0.444194202421035 -0.278899752958341  0.093812748754399  0.062196662634993  0.017629105271386
-    4  (  4)  0.201120401065327 -0.264758960164971  0.049281922750043  0.569520824426228  0.070190776173194
-
-	File 101 DPD File2: Q_XXBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5)  0.026250767785996 -0.070929014514990 -0.016637285673699 -0.035088064010709 -0.032336457700526  0.058815662205881 -0.012412986629436  0.014288588660807 -0.001501411076130
-    1  (  6) -0.581253253057800  0.616998661042978  0.224937073337130 -0.302158415871365 -0.072492088009743  0.340764590845209  0.441678001362741  0.366178192063000 -0.476271654908417
-    2  (  7)  0.025005337440019 -0.165980640613250  0.384950379792931 -0.731661324031012  0.524490865797278 -0.323781198113420 -0.118580199671952  0.291290322397482  0.082052149882477
-    3  (  8) -0.304806474714221 -0.337760174179585  0.141673370323803  0.434112862386083  0.528797842572521  0.343467884925719  0.361584469265998  0.286736619223146 -0.036000233515442
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.002641754178934 -0.003290233760030  0.010000776665241 -0.002419089462872 -0.008521533180523  0.009904824793092
-    1  (  6) -0.092746682284479  0.040823847594246 -0.091775448292948  0.031294472161901  0.098786292819334  0.105521045070018
-    2  (  7) -0.218406423523069  0.221962850962713  0.148904240272370 -0.145135255368976 -0.176391466510292 -0.017613694987959
-    3  (  8)  0.096606967379314 -0.293118353959171  0.376977860611602 -0.203845280873998  0.076416218742444 -0.080342897031977
-
-	DPD File2: Q_XY_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_XY_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011821750136002  0.034920377802408  0.004373287116608 -0.063478703767714 -0.088508811043050  0.008279142796402  0.014533243859546 -0.002931376270166  0.032063319338865
-    1  (  1) -0.058084945151698  0.155197634202789  0.009892487965527 -0.370414517012903 -0.392189517274892  0.078323583678554 -0.109339523368557  0.014601967701400  0.077022618195978
-    2  (  2) -0.448854428000334  0.664032245000025  0.150824533781984 -0.375781517433172 -0.162736648955162  0.269444917876422 -0.806736114967985 -0.262074271113220  0.090066356620591
-    3  (  3)  0.096479139471951  0.143837078875552  0.045405148198401  0.726890386208399  0.684282965954435  0.279357255718365 -0.268218178883463 -0.357589926092787 -0.063055049212253
-    4  (  4)  0.619095249806184  0.431090282610677  0.005814563305988  0.332452217098153 -0.323171537851572 -0.904062277795992  0.514520683047270 -0.441692344482735  0.106817644990003
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.008395863185235 -0.005427093979213  0.003319230409600  0.020521864068729 -0.020470889496103
-    1  (  1) -0.007534899851642  0.057097895695776  0.028135034011334 -0.081268723143297 -0.027241320511134
-    2  (  2)  0.015587813491695  0.278164165277413  0.237503052303318 -0.133735857060223  0.143162845927911
-    3  (  3)  0.214787706169657 -0.177009120882796  0.109984143377335  0.667812329696960  0.008690242330614
-    4  (  4)  0.680201128726043  0.383309935453627 -0.211284974180620 -0.122597513519248  0.223886959918798
-
-	File 101 DPD File2: Q_XY_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5) -0.018649542295605 -0.003393502433887  0.016330325888174  0.103747296576944 -0.059452896822485  0.034123016651687 -0.006329969957214  0.004868983720923 -0.008566580089655
-    1  (  6) -0.246533569878076 -0.196946899107381  0.268387989324035  0.319395132337255 -0.177116789265185 -0.003138579199018 -0.580348533940645  0.465999340039675  0.035897405036977
-    2  (  7) -0.799776632370963 -0.260157252520399 -0.022471016148273 -0.257336653529044 -0.200791740189502  0.046842730256590 -0.812340094584406 -0.318492141621719  0.943599417014982
-    3  (  8) -0.232175110022354 -0.157150958208711  0.727595504819014 -0.135996137687985 -0.206580604970328 -0.428195022188453 -0.439976025488407  0.083640779292888 -0.742856679441037
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.031216419365180 -0.013971349351201 -0.004262406832120  0.000760816187301 -0.016715772336892  0.009269091450497
-    1  (  6) -0.049699779993075  0.567795236222441  0.062408176194476  0.065499178916875 -0.046441905793097 -0.008180473956682
-    2  (  7)  0.118981324525083 -0.344091213688336  0.329885627451601 -0.034021220498308 -0.189675924788236 -0.139607445330608
-    3  (  8) -0.037425882832473 -0.455294903466920  0.011675173852149  0.261304402084969  0.176817183455944  0.047509622257974
-
-	DPD File2: Q_XYBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     5
-	   Irrep: 1 row =     4	col =     4
-
-	File 101 DPD File2: Q_XYBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  0) -0.107532646482401 -0.006879426121500 -0.013478847002998 -0.000835856952178  0.120538949889821
-    1  (  1) -0.006747543287833  0.103347687289162  0.306676748777048 -0.039309525102271 -1.183636515057436
-    2  (  2) -0.013308521453760  0.310467519644645  0.347868277607343 -0.162291591317299 -0.281806345471740
-    3  (  3) -0.000726361817151 -0.037850571785387 -0.164846492333610 -0.031791306549565  0.934090541009703
-    4  (  4)  0.120611673314161 -1.186539486736817 -0.272824580659796  0.925246393531016 -0.381390714915063
-
-	File 101 DPD File2: Q_XYBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.107543915697695 -0.009415542554102 -0.100968777571447  0.040934108671349
-    1  (  6) -0.009089500365894  0.300834609421041  1.346232006797483 -0.288997656088466
-    2  (  7) -0.101737329457760  1.342020602962315 -0.398241138940265  0.004280148736201
-    3  (  8)  0.041290975058613 -0.288548812248536  0.003727140624681  0.327782420281849
-
-	DPD File2: Q_XYBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Q_XYBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.813750413758495  0.109985799873369 -0.143488049241605  1.216587546250076  1.281764422507476  0.321957124294994  0.105004758792961  0.487003758562780  0.366032977796950
-    1  (  1)  0.108021479984142  1.463087492595190 -0.290743062858307  0.228413496228139  1.004316797626047  0.469817338946096 -0.902352641931337  0.104124918979583 -0.729812894814948
-    2  (  2) -0.143026588417880 -0.288271658560211 -0.242452642229147 -0.268949880957647 -0.240349654586663 -0.351379734914996  0.283924978000848  0.190326793169903  0.342785486357039
-    3  (  3)  1.219765238938621  0.223786143769442 -0.273713014783725  1.455166998782561 -0.092895980593925 -0.690364292256644  0.444507824320564 -0.714737633024210 -0.008527005829673
-    4  (  4)  1.279519627022222  1.007769803695180 -0.242642514066964 -0.103978300664900 -1.199450015309966 -1.582948020152280  0.163635207829128 -0.239867789381186 -0.252590906146866
-    5  (  5)  0.317352746700509  0.475005519780292 -0.349940471662133 -0.694788938159441 -1.582844098630188  0.347906821908358  0.323563142546539  0.050226375637116  0.136471115660009
-    6  (  6)  0.110640903950314 -0.907585021445523  0.284120643830033  0.440541883720300  0.163403942844783  0.324996918110290  1.554097895391422  0.129081012234393 -0.106181932616833
-    7  (  7)  0.489683037198067  0.104418659483413  0.193363243203420 -0.710620878237899 -0.236162223604936  0.053688847870123  0.125210563691095  0.288310572145820  0.111767723724790
-    8  (  8)  0.361414413712510 -0.726499493591081  0.343725775246178 -0.012408601371440 -0.255852643574980  0.138584679436232 -0.111588048108118  0.112054450790787  1.430569901101805
-    9  (  9) -0.010439531544148  0.059739038066642  0.043958750275361  0.118802167956639  0.009574728623266  0.072772072504685 -0.149956676975692 -0.030617034280259  0.204206633187713
-   10  ( 10)  0.052878755158483  0.028095201914259 -0.007691341892937 -0.307127210898965  0.394247091563872 -0.304453667729728 -0.331031109253237  0.277390234036183 -0.098006418354853
-   11  ( 11)  0.328223834553693 -0.738841561776248  0.162317684158659  0.241352123399368  0.227991690464766 -0.140844204064726  0.597142978148276  0.189496664316217  0.215058960786182
-   12  ( 12) -0.502536544592491 -0.032683175586596  0.244337201296158 -0.181694837426119  0.176456527719082 -0.040151600187301 -0.192178270066787  0.180151999944041  0.133650410302886
-   13  ( 13)  0.018403679270597 -0.102873319258936  0.118024378089826 -0.376031459863534 -0.147150549578467  0.092432550758889  0.136116680532256  0.034977917475014 -0.657265788129075
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.011813054587628  0.053325652774689  0.330897574818396 -0.501145197587058  0.018838294532632
-    1  (  1)  0.063216826664931  0.030199438853762 -0.740244336134121 -0.034461749029343 -0.102332709898743
-    2  (  2)  0.046757937323071 -0.006924972909831  0.162336809634591  0.246452550141395  0.118922612358998
-    3  (  3)  0.111633858502470 -0.311758091095193  0.241440340327530 -0.176457746116205 -0.378019583340833
-    4  (  4)  0.002099190243593  0.395946051006036  0.227774950286666  0.171239456245325 -0.146872505953969
-    5  (  5)  0.070177437430315 -0.303695793078047 -0.141401368052929 -0.041606393009273  0.092775812939932
-    6  (  6) -0.151647426006927 -0.332064748709746  0.597775313532771 -0.193472699236974  0.135638742930386
-    7  (  7) -0.028574310422876  0.274839004340268  0.190319637220479  0.185855295920754  0.034536574668385
-    8  (  8)  0.203798693509887 -0.096005100260287  0.216711347569874  0.131216204119416 -0.656596808211851
-    9  (  9) -0.067877527133344 -0.037394400179997  0.001237790876622 -0.228454969678907 -0.012690550864382
-   10  ( 10) -0.034701105872209  0.001990914574463 -0.259519960179195  0.116541389496059 -0.207695057666406
-   11  ( 11)  0.000529750770377 -0.259508478417478  0.144769482331176 -0.253537495219966  0.018205735096527
-   12  ( 12) -0.234244598389483  0.115982179322626 -0.253619758535615  0.006093701660384  0.182261090721229
-   13  ( 13) -0.011868304995110 -0.207492891665530  0.018292807598929  0.182455637236639  0.257011226933879
-
-	File 101 DPD File2: Q_XYBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  3.129957716780603  1.709487426238976  1.008372449275402 -1.276765968277357 -0.065446307723680  0.742021832051918  0.436332599611655 -0.667055197719947  0.142659410690324
-    1  ( 15)  1.714334301166813  0.700526286404250  0.648407039146880 -0.082187902917956 -0.083925296715317  0.412626654600965  0.022155756924809  0.476428125836557  0.067616090221052
-    2  ( 16)  1.004889143369286  0.650316640783399  1.998153280399342 -0.507870830167831 -0.039112960902049  0.768415113506394 -0.691125590794351 -0.226431506013134  0.263857602369259
-    3  ( 17) -1.269421985001052 -0.083373095695230 -0.506983578378752 -1.263098642948249 -0.374471320057592  0.074978132794915 -0.297260722017830 -0.452170040968050  1.050173052431991
-    4  ( 18) -0.064747836599454 -0.085201382625694 -0.041627664590248 -0.374535705588497 -0.046703869002225 -0.700762349492484 -0.091567339314563  0.418157505097632 -0.785741366289708
-    5  ( 19)  0.743036750652246  0.410673884351049  0.768466137402025  0.075428816032864 -0.703035805441588  0.314123367939291 -0.195779628330961  0.668388148829413  0.586022121530341
-    6  ( 20)  0.448861595045559  0.022268432968839 -0.695996747604689 -0.299039357299196 -0.087643067600830 -0.191851548627364  1.730420545431552 -0.327097691187574 -0.195052046580288
-    7  ( 21) -0.665176492733851  0.474697179147161 -0.229070812537720 -0.456509653450532  0.418746501000567  0.669426422647124 -0.326704272416130  0.747881016377404  0.362406882908971
-    8  ( 22)  0.140550731155041  0.067145133214418  0.261067562517139  1.059403828293538 -0.791123605948274  0.587521801265389 -0.196441175786152  0.361546615668658  0.026521472400518
-    9  ( 23)  0.183960752400236  0.090648149401017 -0.951941189763357  0.248345722083149 -0.393024730585672 -0.277795637307642 -0.115801327759540  0.079790484226362 -0.328104044469749
-   10  ( 24) -0.096999004318018  0.626557370844378 -0.255720242863489  0.074089211117426 -0.322650588726138 -0.120274438102632  0.135763949857182 -0.407749321761093  0.308366563042107
-   11  ( 25)  0.407205371370843  0.400523898216947 -0.571544522265930 -0.193909113341939  0.083886868417408  0.091312559974794  0.631988580744505  0.013108395391089  0.082668659590215
-   12  ( 26) -0.129228709580998  0.099727214866939 -0.100060970484827 -0.015941685134031 -0.082302613975460  0.197457522516659 -0.272267273975511  0.325467300120502  0.083219190361926
-   13  ( 27)  0.028075996591360  0.033288139884456 -0.031657050748594  0.482400837770596 -0.517095863243159  0.127743215834403 -0.003902066405070 -0.059749603348758  0.133994178327020
-   14  ( 28) -0.273136601610741 -0.188601639941912 -0.187478867630393  0.009614280452030  0.021419895096816  0.019676076647385 -0.065299916825948 -0.089158000768035 -0.159014829774556
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.189067512684415 -0.102496789105839  0.410654707878315 -0.127342842175287  0.027788275096733 -0.274054514827827
-    1  ( 15)  0.092569039491299  0.630719742486575  0.400222010471337  0.099354786357621  0.032882750235495 -0.188589543062389
-    2  ( 16) -0.956030203265825 -0.251017350759149 -0.571942090019317 -0.101339895760847 -0.032232343593004 -0.187540849558250
-    3  ( 17)  0.247408208848905  0.077226334022248 -0.195762209231719 -0.014892221719137  0.484418697183312  0.010980560423775
-    4  ( 18) -0.390471916376519 -0.321072752160193  0.085241250919945 -0.082929586905556 -0.518446707359415  0.020725560487627
-    5  ( 19) -0.276085584806377 -0.122753716334935  0.091777975463841  0.198255613256156  0.128106130978898  0.019757919607764
-    6  ( 20) -0.109281747348802  0.138819455362619  0.631931707244074 -0.272906281184370 -0.004567396890772 -0.065539107895275
-    7  ( 21)  0.078860388222395 -0.407912307197262  0.013588050423304  0.324886983199182 -0.059578662331878 -0.088992520282932
-    8  ( 22) -0.328236887526537  0.308891754287031  0.081908251614941  0.082991173001543  0.133719894258456 -0.158776023572950
-    9  ( 23)  1.436856164461350  0.249384784994306  0.022347111245506 -0.129893936938419 -0.461604447719581  0.449006747580467
-   10  ( 24)  0.250262739479672  0.086227917872089  0.311749984502828 -0.162248434523399 -0.107591001482132  0.176012643265562
-   11  ( 25)  0.021123977610386  0.311105118560602  0.233973360713413 -0.204980222609714  0.110871402540350 -0.068117274246059
-   12  ( 26) -0.131121910435957 -0.162016158931924 -0.204892256710919 -0.182518292975433 -0.120649253364666 -0.006834723735918
-   13  ( 27) -0.461492836526352 -0.108023084228299  0.111025723101441 -0.120661429567117  0.118222866627246 -0.150273583122085
-   14  ( 28)  0.449307854753117  0.175579254045662 -0.068051883155874 -0.006789591489122 -0.150168327953186 -0.086537045939434
-
-	DPD File2: Q_XYBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_XYBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011805695024598  0.034992763432279  0.004462140920506 -0.063122437892726 -0.087474771158541  0.008042335300982  0.014057938043334 -0.003177831649274  0.031711169970175
-    1  (  1) -0.055573939542751  0.140907388342312  0.003316984012425 -0.384478151119584 -0.412891175872713  0.060973940461778 -0.094719077377273  0.007458385756948  0.068069991420835
-    2  (  2) -0.419627260626533  0.608023942970289  0.149649898013477 -0.363118959013547 -0.162752689730023  0.257196398088489 -0.774518584928342 -0.258611606965876  0.061139442895175
-    3  (  3)  0.091826375533470  0.136780329022874  0.053389557143553  0.688017533265971  0.680722301222751  0.269185675862565 -0.269218717929093 -0.345510091695087 -0.070727464771127
-    4  (  4)  0.629512509887410  0.417048321341404  0.009617059149628  0.327729529134849 -0.360503272937336 -0.887467140390734  0.487659347625856 -0.427756151618870  0.098689721444246
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.007994539761143 -0.005235119382381  0.003279699281102  0.019777797082027 -0.020138505418272
-    1  (  1) -0.009018238247018  0.057958409547357  0.020659668663920 -0.077367526316125 -0.023640442259231
-    2  (  2)  0.011058300095965  0.266287526342250  0.211065950734315 -0.122740386780814  0.139079547031469
-    3  (  3)  0.203710004993493 -0.168007259833028  0.099516257475658  0.635126811682311  0.003780258900248
-    4  (  4)  0.651607465920600  0.364865266495963 -0.186050400788225 -0.120894760297612  0.207720673538239
-
-	File 101 DPD File2: Q_XYBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5) -0.018776122478509 -0.003516932988588  0.016185966790962  0.103005437910031 -0.058996387642607  0.033677439848222 -0.006555907757992  0.004943429938180 -0.008673234381993
-    1  (  6) -0.229317165793185 -0.203922295837344  0.236381389548029  0.343030484184692 -0.168220233454749  0.002070028793707 -0.550849665474538  0.454373901655846  0.029204576778314
-    2  (  7) -0.826581307225571 -0.248141299803835 -0.040580104021485 -0.274688873396250 -0.186997257812666  0.044512235649138 -0.777087624287131 -0.307827377137018  0.935360296008197
-    3  (  8) -0.212075384780701 -0.152493170809657  0.663898605839720 -0.114689839738095 -0.197309003805366 -0.422628192956036 -0.431880030359280  0.089589322707163 -0.717782630036867
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.030713573040164 -0.013233627688701 -0.004171830214503  0.000741328194514 -0.016529617755578  0.009072661642018
-    1  (  6) -0.059376876162672  0.545097710028939  0.052607325244023  0.066593744532753 -0.043416822148381 -0.009796861309280
-    2  (  7)  0.112007837970219 -0.329264981368721  0.296245980281503 -0.027825000648174 -0.168338803590710 -0.134330947676505
-    3  (  8) -0.068078591846890 -0.441198549977012  0.001173592644729  0.248239875217764  0.161760460928194  0.044802607448477
-
-	DPD File2: Q_XZ_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Q_XZ_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.004074879064756 -0.002532012046020  0.005554129052739  0.006560368948777 -0.002779926643572  0.002335656135966 -0.003395532472587 -0.001327548191671 -0.005265442640044
-    1  (  1)  0.200872614880490  0.145096481863003 -0.381705941305716  0.084050059564267  0.280827470698156  0.249332273590050  0.350130827104574  0.139753873158578  0.237707533718911
-    2  (  2)  0.454779931346540  0.284344346911741 -0.400796369507145 -0.391949355367063  0.298875363575278 -0.015873865692240  0.282090607400328  0.102045399349015  0.015518336693105
-    3  (  3) -0.068064441685710 -0.019874250939596  0.056124240432189 -0.235507520391358  0.120471483525898 -0.164841848750856 -0.160135553406143  0.158216498854868 -0.028358662007540
-    4  (  4) -0.171021104899262 -0.071184540170143  0.095610097777485  0.030939020482397  0.430951106225423  0.157370892130066 -0.397313061920960 -0.331853174015563  0.030552444997461
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.008280919117306 -0.001598825931089  0.008779579561246  0.004875551160851  0.005784200167522 -0.002119562479832
-    1  (  1) -0.038741258393760  0.085374379527266 -0.120801322502726 -0.009476083364151 -0.060610355284795  0.002892549569692
-    2  (  2)  0.351946791784957  0.027190638110694  0.217298406525411  0.110576853967177  0.117893349244747 -0.058880912343960
-    3  (  3)  0.036738679751102 -0.177625128003096  0.007110800682711  0.152932034409694  0.002269948947637  0.012590827368318
-    4  (  4) -0.011826651539788  0.053686376236646 -0.298275298603196  0.079882264337261  0.076903328378595 -0.019877525965890
-
-	File 101 DPD File2: Q_XZ_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.003418157316825  0.006248938465190 -0.003328653777979 -0.003795259538711 -0.005276387673124  0.001173750834571 -0.001422449403200 -0.002552073671433  0.008156049235358
-    1  (  6)  0.251364284589577 -0.496483365344414 -0.084754627400406  0.002233956751806  0.039729725347428 -0.245011238305347  0.476774577064519  0.321231366304764  0.004899068206628
-    2  (  7)  0.394873169246260 -0.107912444706184  0.569108548099488  0.130150036840399  0.165282113454427 -0.127070996031771  0.380790473078487  0.081309247667860  0.080778036617404
-    3  (  8)  0.232115096088585 -0.378773964710906 -0.188281955191172  0.292225544726507  0.391556281817038 -0.132429872578643 -0.081151662702157  0.130807982509805  0.324841536785196
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.003374573930473  0.002911937750971  0.009944171268417  0.002359222638062  0.006867137555593
-    1  (  6) -0.117108993328076 -0.078240062578820 -0.098736185820815 -0.032808874459956 -0.061607689244828
-    2  (  7) -0.026668505986174  0.119154464955432  0.388664508389551  0.020572973313306  0.012978611330797
-    3  (  8)  0.038689812718219  0.105270060899416  0.073045872658081 -0.017431584097677  0.153808781794468
-
-	DPD File2: Q_XZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: Q_XZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.007626044531834 -0.000976692612680 -0.007523282451906 -0.000697082806565
-    1  (  1) -0.000552220721842 -0.112308878501127 -0.103758878809839 -0.090319795590276
-    2  (  2) -0.003718739619501 -0.210497216850041 -0.694030530837677 -0.062972903566088
-    3  (  3) -0.001754344190881  0.012543863071645 -0.259943782087902  0.108395146957537
-    4  (  4)  0.007085681647499  0.103950763276849  0.141490816275654  0.580299008132658
-
-	File 101 DPD File2: Q_XZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5) -0.007626018340644 -0.000568107249963 -0.003753586184003 -0.001733792997507  0.007085233004913
-    1  (  6) -0.000938558594265 -0.113296044387823 -0.212099371772606  0.009419688652325  0.109713723609279
-    2  (  7) -0.007556926916031 -0.100229621336926 -0.687537266640526 -0.262131427764931  0.142289528541732
-    3  (  8) -0.000685378129623 -0.089225894752005 -0.061764096024840  0.105280680308524  0.583369661933430
-
-	DPD File2: Q_XZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Q_XZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -2.454716641543829 -1.483291650737991 -0.297365449983833  0.288420830932892 -0.217169391426612 -1.314460663988032 -0.280935220002927 -0.150847926702959 -0.431561450914452
-    1  (  1) -0.289981477221043 -0.154687683497078 -1.595727531172475  0.252187813748134  0.091624823876394 -0.615983534114679  0.448772537854966  0.256054494670598 -0.551554078696446
-    2  (  2)  0.240585271838033  0.077776263889878  0.232873408525797  1.033948982484620 -0.434806916340617  0.666999157332637  0.070720348290813 -0.241203413120274 -0.024573905221141
-    3  (  3) -0.131129359926950  0.021123045712403  0.135361130173095  0.218278873638143  0.788850796519149  0.492749776151576 -0.589289625463523  0.303380766183610  0.078276380710024
-    4  (  4) -0.385489496570785 -0.286654590877551 -0.148805837686689  0.231498708509063  0.631896861875863  0.131016326978424 -0.368297145262522 -0.840329432166826 -0.132848554153440
-    5  (  5) -0.398358207247369 -0.078977779507927 -0.828843923997183  0.149102811790732  0.424208629689331 -0.073628643455092  0.435823717865851  0.876073631002118 -0.230145216817784
-    6  (  6) -0.858949407780290 -0.427546968971227  0.139584468407109  0.272555602174351 -0.415262992797832 -0.166161760167003 -0.634710781492896  0.391022684161517  0.433280950744833
-    7  (  7) -0.714505827107073 -0.546785105438817 -0.082461618607383  0.065582740463543  0.061302419954485 -0.252199346131435  0.225838102589624 -0.532054842479612  0.399234811270711
-    8  (  8) -0.437597547452730 -0.166665887512917  0.884608856563974 -0.071847633999938  0.196115035101740  0.307984567617406  0.001033625488148 -0.248319156280341  0.263982116001698
-    9  (  9) -0.014050933460234  0.061521312474205  0.075986820943266 -0.003857016433969  0.049801809421784  0.054355969567726 -0.059001955258276  0.153413578849718 -0.126161876404776
-   10  ( 10)  0.109888463355253 -0.067177947715743  0.192322050888198  0.117953228015266 -0.119447610772357  0.017474941004481  0.014801179973552 -0.607437395442374 -0.030444707038302
-   11  ( 11) -0.390137487408324 -0.068051147417832  0.235872078452404  0.192264956588343 -0.187736075175352  0.064050457859643 -0.418327196887149 -0.048773366162726 -0.022435230187346
-   12  ( 12)  0.044297300522110 -0.074514001326939  0.118901139253501 -0.038102822286343 -0.180234539078099 -0.073653096009808  0.138887294279128 -0.091677465636449  0.028306780848160
-   13  ( 13) -0.218173262148351  0.031923214338008 -0.279273699043729 -0.296240798967995 -0.102538865324455 -0.347223174184031 -0.023258788555149  0.009371356192758 -0.133080599480495
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.506851617468524 -0.123312272924514 -0.319772171966197 -0.330388320949798 -0.260626910659361  0.296009143703883
-    1  (  1)  0.838664437092735  0.084048936391461  0.130519364241547 -0.058295160971861 -0.352689050307543  0.312676279191508
-    2  (  2) -0.424245733068130  0.094688985686263  0.032487769067423 -0.049840972257505  0.242182498481101 -0.258169771444316
-    3  (  3) -0.275925763607251 -0.158614048273031 -0.265637253281501  0.340924751759094  0.103748650636041 -0.182386846592538
-    4  (  4)  0.223341603531457  0.179610861622819 -0.208592953192156 -0.000066608245217  0.152150208910578 -0.043032133632034
-    5  (  5)  0.120534430442526 -0.000894933086435  0.224347489110960  0.161892180430137 -0.149801264964330  0.022483324180902
-    6  (  6) -0.049702807038789 -0.094404161160978 -0.313154542891932  0.051994095399954  0.001446348599381  0.092258679821771
-    7  (  7) -0.093785029728044  0.099189067484616 -0.172621773264165 -0.134289925799854  0.108520033167713  0.086461363864754
-    8  (  8) -1.471727910650786 -0.225056626317030 -0.045495207069456  0.027374532922661  0.530816356461179 -0.379457060782898
-    9  (  9) -0.084302204259948 -0.164047597069931  0.183683931444347  0.134877669766643  0.175065955053181 -0.089844560973618
-   10  ( 10) -0.155190058293153  0.408092440143445  0.002189167477560 -0.137730806305859  0.142300169778525 -0.008670154843836
-   11  ( 11) -0.304366562428170 -0.030234911866092 -0.185923164163158 -0.001349513433959  0.116012076536723  0.097952480510914
-   12  ( 12) -0.048670113620180  0.046580019682191  0.031004719176933 -0.396841200902567  0.122309338710921  0.023769852585632
-   13  ( 13)  0.607487233542026  0.051711095812138 -0.148321593153569 -0.095411947673119 -0.393676374240309  0.517180676529953
-
-	File 101 DPD File2: Q_XZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -2.452560829529818 -0.293354071897449  0.245385857181672 -0.125053748515534 -0.381838977398162 -0.401081183690855 -0.856344113897366 -0.711884204329561 -0.437567965483089
-    1  ( 15) -1.486104581846278 -0.154668985215266  0.077511478771224  0.021577231958456 -0.288356126021600 -0.079419773997215 -0.426515586859729 -0.545957025574733 -0.169727827849989
-    2  ( 16) -0.294739387603737 -1.595186950823466  0.231399556640055  0.131614824615275 -0.150904499049520 -0.828304358444007  0.140732512477017 -0.082637124209643  0.885773640790047
-    3  ( 17)  0.290505394921826  0.248809242927937  1.030950835030146  0.217191583521550  0.231534995778155  0.148626076406430  0.271218815852754  0.067613959906656 -0.069398389144441
-    4  ( 18) -0.218574875374942  0.089929643038917 -0.433511734043207  0.790672747250865  0.632440411329192  0.423247498511693 -0.411014571989387  0.061503045419557  0.194208577505009
-    5  ( 19) -1.313139066022934 -0.618501880736554  0.668264255004994  0.494952717089704  0.132327630535153 -0.074530924194515 -0.165747377154518 -0.250754279898054  0.308984392043030
-    6  ( 20) -0.284840831313155  0.451084284369336  0.073654454622948 -0.589328641378573 -0.370146833097925  0.436177279845969 -0.635726236400236  0.225861918840592 -0.002796365684946
-    7  ( 21) -0.153406552440280  0.258737024846266 -0.239543680202371  0.301388262902417 -0.839297750493704  0.877048090993896  0.390547303501850 -0.534511922505813 -0.249506968699475
-    8  ( 22) -0.433023177955431 -0.552041560188894 -0.024610946211831  0.077540459065873 -0.133043605192608 -0.230135268587080  0.433860427553137  0.399213472626220  0.263051365789356
-    9  ( 23) -0.506097311366858  0.835659578918269 -0.424309329702488 -0.272346434902667  0.224460742197186  0.118442872636669 -0.047211793817979 -0.091411572686524 -1.472411058128675
-   10  ( 24) -0.122180623441180  0.082863357186810  0.096372604097650 -0.157071941740121  0.178825366620054 -0.001685071902513 -0.093619910975294  0.100950420829548 -0.225462843127604
-   11  ( 25) -0.321261067620524  0.132341000738389  0.032838322020350 -0.265192027668083 -0.209807521747567  0.224452572282716 -0.314102262452642 -0.172558715274771 -0.047304292984641
-   12  ( 26) -0.331546035951652 -0.058111348051298 -0.050833986561178  0.340911441539955  0.000591591532536  0.162003589164510  0.052587064393920 -0.135174644956458  0.027032832494077
-   13  ( 27) -0.261060917177365 -0.352376550070747  0.241916719039106  0.104964216378030  0.151625424942235 -0.149854940930181  0.001241015089295  0.108719061992146  0.530269930665440
-   14  ( 28)  0.296300031393760  0.312875902647857 -0.257962435363950 -0.182754239066371 -0.042541534327470  0.022683659369914  0.091951675635884  0.086046872751557 -0.378910189123763
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.012617142161543  0.112381937099773 -0.385678694480240  0.044313173234011 -0.216660768512443
-    1  ( 15)  0.061796510634243 -0.067623922832911 -0.069117536392848 -0.074634681675038  0.031361417046503
-    2  ( 16)  0.074447168672154  0.190942409095979  0.234315741832266  0.118962128398907 -0.280518188732768
-    3  ( 17) -0.003288843324492  0.116920849397596  0.189661996599567 -0.038461560655366 -0.295964996404074
-    4  ( 18)  0.049604036264734 -0.119187871951736 -0.186500489894393 -0.180266209333192 -0.102978100807436
-    5  ( 19)  0.055725013880946  0.018117749866710  0.065102666786058 -0.073763029401625 -0.346488157241662
-    6  ( 20) -0.057980923808565  0.014725907136023 -0.418520133472894  0.138855376272011 -0.023445230708336
-    7  ( 21)  0.151854452198540 -0.607496786648753 -0.048401854208936 -0.091594885129488  0.009276924761595
-    8  ( 22) -0.126332096204745 -0.030983531106088 -0.023285034738236  0.028168990126250 -0.133338055120191
-    9  ( 23) -0.083903372341094 -0.154335937186597 -0.303319212494159 -0.048771154619623  0.607856230085617
-   10  ( 24) -0.162683328561470  0.408409390352239 -0.029532633430699  0.046553684421432  0.051796699656394
-   11  ( 25)  0.183950177695694  0.002391933980502 -0.185972258495596  0.031084777064328 -0.148416502157047
-   12  ( 26)  0.134084714357723 -0.137741629989910 -0.001420766193977 -0.396831432436955 -0.095516559350284
-   13  ( 27)  0.175688538790618  0.142622729596870  0.116301196333008  0.122366764083138 -0.393621171360157
-   14  ( 28) -0.090052478464024 -0.008620237604519  0.098140479362490  0.023790246180176  0.517298405990531
-
-	DPD File2: Q_XZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Q_XZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.003983666373255 -0.002353651762198  0.004933125300278  0.006596583433943 -0.002614342451578  0.002132465276882 -0.003012460159181 -0.001223503888639 -0.004889405336778
-    1  (  1)  0.201135115953463  0.151243841512351 -0.361188406461476  0.086379753849444  0.272163801945699  0.254818614317866  0.343703766885252  0.135577053527702  0.235786250904787
-    2  (  2)  0.452572939228447  0.278785922462906 -0.374242715559236 -0.396366655229040  0.292813190258060 -0.007420868883830  0.272380281383336  0.103622653171364  0.017354041500184
-    3  (  3) -0.069740114395509  0.007405040619443  0.056329917896026 -0.233066765932548  0.124667443957726 -0.172262566204308 -0.154483019725586  0.146218574276066 -0.031583387013550
-    4  (  4) -0.168082571354239 -0.075988239857436  0.101748208313577  0.016912196027717  0.443856147553522  0.157430638670053 -0.393257769588503 -0.327875483419098  0.022936217603338
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.007433715209833 -0.001517004948877  0.008313297481149  0.004622925166720  0.005645729583552 -0.002184169597483
-    1  (  1) -0.027034222192758  0.086360154536757 -0.114516476994660 -0.007663777387575 -0.059358678322294  0.001518325593955
-    2  (  2)  0.359056453197877  0.025612871962698  0.218616726319955  0.114621110907337  0.109502038643106 -0.053404466724778
-    3  (  3)  0.042602428732743 -0.175888460232533  0.009074453373936  0.147337744685697  0.001411164554109  0.014592876078209
-    4  (  4) -0.014339565652089  0.055496156658258 -0.293976988949184  0.080888392155942  0.079771717087352 -0.021301553357757
-
-	File 101 DPD File2: Q_XZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.003282620714986  0.005664679288576 -0.003086801053658 -0.003693900321914 -0.005269678743379  0.000901429296691 -0.001207795993955 -0.002428895511753  0.007313018280004
-    1  (  6)  0.242884322257858 -0.467994494371817 -0.085351931974429 -0.001715416703069  0.036628787206898 -0.231958392242055  0.468975363391203  0.320327479678977  0.014982833176508
-    2  (  7)  0.406386591023012 -0.098118290682955  0.573010232103244  0.128863028033736  0.157969534456746 -0.112693292775534  0.382941933554739  0.089969969691354  0.083484054987097
-    3  (  8)  0.235827881949739 -0.359662723414843 -0.201444668593835  0.299888433005399  0.398610453476842 -0.127653404035872 -0.079106949632752  0.130504803359457  0.334294361718793
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.003111745735179  0.002692426538595  0.009341842103298  0.002205650137423  0.006741804159924
-    1  (  6) -0.113746363257686 -0.075448189826302 -0.091899492069418 -0.030884246031957 -0.063462033193843
-    2  (  7) -0.027283869583893  0.118675903648485  0.389547196457847  0.022072577958594  0.006382251197348
-    3  (  8)  0.041971346710981  0.106102252104320  0.079894506673964 -0.017109706677562  0.145721778440645
-
-	DPD File2: Q_YX_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_YX_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011821750136002  0.034920377802408  0.004373287116608 -0.063478703767714 -0.088508811043050  0.008279142796402  0.014533243859546 -0.002931376270166  0.032063319338865
-    1  (  1) -0.058084945151698  0.155197634202789  0.009892487965527 -0.370414517012903 -0.392189517274892  0.078323583678554 -0.109339523368557  0.014601967701400  0.077022618195978
-    2  (  2) -0.448854428000334  0.664032245000025  0.150824533781984 -0.375781517433172 -0.162736648955162  0.269444917876422 -0.806736114967985 -0.262074271113220  0.090066356620591
-    3  (  3)  0.096479139471951  0.143837078875552  0.045405148198401  0.726890386208399  0.684282965954435  0.279357255718365 -0.268218178883463 -0.357589926092787 -0.063055049212253
-    4  (  4)  0.619095249806184  0.431090282610677  0.005814563305988  0.332452217098153 -0.323171537851572 -0.904062277795992  0.514520683047270 -0.441692344482735  0.106817644990003
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.008395863185235 -0.005427093979213  0.003319230409600  0.020521864068729 -0.020470889496103
-    1  (  1) -0.007534899851642  0.057097895695776  0.028135034011334 -0.081268723143297 -0.027241320511134
-    2  (  2)  0.015587813491695  0.278164165277413  0.237503052303318 -0.133735857060223  0.143162845927911
-    3  (  3)  0.214787706169657 -0.177009120882796  0.109984143377335  0.667812329696960  0.008690242330614
-    4  (  4)  0.680201128726043  0.383309935453627 -0.211284974180620 -0.122597513519248  0.223886959918798
-
-	File 101 DPD File2: Q_YX_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5) -0.018649542295605 -0.003393502433887  0.016330325888174  0.103747296576944 -0.059452896822485  0.034123016651687 -0.006329969957214  0.004868983720923 -0.008566580089655
-    1  (  6) -0.246533569878076 -0.196946899107381  0.268387989324035  0.319395132337255 -0.177116789265185 -0.003138579199018 -0.580348533940645  0.465999340039675  0.035897405036977
-    2  (  7) -0.799776632370963 -0.260157252520399 -0.022471016148273 -0.257336653529044 -0.200791740189502  0.046842730256590 -0.812340094584406 -0.318492141621719  0.943599417014982
-    3  (  8) -0.232175110022354 -0.157150958208711  0.727595504819014 -0.135996137687985 -0.206580604970328 -0.428195022188453 -0.439976025488407  0.083640779292888 -0.742856679441037
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.031216419365180 -0.013971349351201 -0.004262406832120  0.000760816187301 -0.016715772336892  0.009269091450497
-    1  (  6) -0.049699779993075  0.567795236222441  0.062408176194476  0.065499178916875 -0.046441905793097 -0.008180473956682
-    2  (  7)  0.118981324525083 -0.344091213688336  0.329885627451601 -0.034021220498308 -0.189675924788236 -0.139607445330608
-    3  (  8) -0.037425882832473 -0.455294903466920  0.011675173852149  0.261304402084969  0.176817183455944  0.047509622257974
-
-	DPD File2: Q_YXBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     5
-	   Irrep: 1 row =     4	col =     4
-
-	File 101 DPD File2: Q_YXBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  0) -0.107532646482401 -0.006879426121500 -0.013478847002998 -0.000835856952178  0.120538949889821
-    1  (  1) -0.006747543287833  0.103347687289162  0.306676748777048 -0.039309525102271 -1.183636515057436
-    2  (  2) -0.013308521453760  0.310467519644645  0.347868277607343 -0.162291591317299 -0.281806345471740
-    3  (  3) -0.000726361817151 -0.037850571785387 -0.164846492333610 -0.031791306549565  0.934090541009703
-    4  (  4)  0.120611673314161 -1.186539486736817 -0.272824580659796  0.925246393531016 -0.381390714915063
-
-	File 101 DPD File2: Q_YXBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.107543915697695 -0.009415542554102 -0.100968777571447  0.040934108671349
-    1  (  6) -0.009089500365894  0.300834609421041  1.346232006797483 -0.288997656088466
-    2  (  7) -0.101737329457760  1.342020602962315 -0.398241138940265  0.004280148736201
-    3  (  8)  0.041290975058613 -0.288548812248536  0.003727140624681  0.327782420281849
-
-	DPD File2: Q_YXBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Q_YXBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  1.813750413758495  0.109985799873369 -0.143488049241605  1.216587546250076  1.281764422507476  0.321957124294994  0.105004758792961  0.487003758562780  0.366032977796950
-    1  (  1)  0.108021479984142  1.463087492595190 -0.290743062858307  0.228413496228139  1.004316797626047  0.469817338946096 -0.902352641931337  0.104124918979583 -0.729812894814948
-    2  (  2) -0.143026588417880 -0.288271658560211 -0.242452642229147 -0.268949880957647 -0.240349654586663 -0.351379734914996  0.283924978000848  0.190326793169903  0.342785486357039
-    3  (  3)  1.219765238938621  0.223786143769442 -0.273713014783725  1.455166998782561 -0.092895980593925 -0.690364292256644  0.444507824320564 -0.714737633024210 -0.008527005829673
-    4  (  4)  1.279519627022222  1.007769803695180 -0.242642514066964 -0.103978300664900 -1.199450015309966 -1.582948020152280  0.163635207829128 -0.239867789381186 -0.252590906146866
-    5  (  5)  0.317352746700509  0.475005519780292 -0.349940471662133 -0.694788938159441 -1.582844098630188  0.347906821908358  0.323563142546539  0.050226375637116  0.136471115660009
-    6  (  6)  0.110640903950314 -0.907585021445523  0.284120643830033  0.440541883720300  0.163403942844783  0.324996918110290  1.554097895391422  0.129081012234393 -0.106181932616833
-    7  (  7)  0.489683037198067  0.104418659483413  0.193363243203420 -0.710620878237899 -0.236162223604936  0.053688847870123  0.125210563691095  0.288310572145820  0.111767723724790
-    8  (  8)  0.361414413712510 -0.726499493591081  0.343725775246178 -0.012408601371440 -0.255852643574980  0.138584679436232 -0.111588048108118  0.112054450790787  1.430569901101805
-    9  (  9) -0.010439531544148  0.059739038066642  0.043958750275361  0.118802167956639  0.009574728623266  0.072772072504685 -0.149956676975692 -0.030617034280259  0.204206633187713
-   10  ( 10)  0.052878755158483  0.028095201914259 -0.007691341892937 -0.307127210898965  0.394247091563872 -0.304453667729728 -0.331031109253237  0.277390234036183 -0.098006418354853
-   11  ( 11)  0.328223834553693 -0.738841561776248  0.162317684158659  0.241352123399368  0.227991690464766 -0.140844204064726  0.597142978148276  0.189496664316217  0.215058960786182
-   12  ( 12) -0.502536544592491 -0.032683175586596  0.244337201296158 -0.181694837426119  0.176456527719082 -0.040151600187301 -0.192178270066787  0.180151999944041  0.133650410302886
-   13  ( 13)  0.018403679270597 -0.102873319258936  0.118024378089826 -0.376031459863534 -0.147150549578467  0.092432550758889  0.136116680532256  0.034977917475014 -0.657265788129075
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.011813054587628  0.053325652774689  0.330897574818396 -0.501145197587058  0.018838294532632
-    1  (  1)  0.063216826664931  0.030199438853762 -0.740244336134121 -0.034461749029343 -0.102332709898743
-    2  (  2)  0.046757937323071 -0.006924972909831  0.162336809634591  0.246452550141395  0.118922612358998
-    3  (  3)  0.111633858502470 -0.311758091095193  0.241440340327530 -0.176457746116205 -0.378019583340833
-    4  (  4)  0.002099190243593  0.395946051006036  0.227774950286666  0.171239456245325 -0.146872505953969
-    5  (  5)  0.070177437430315 -0.303695793078047 -0.141401368052929 -0.041606393009273  0.092775812939932
-    6  (  6) -0.151647426006927 -0.332064748709746  0.597775313532771 -0.193472699236974  0.135638742930386
-    7  (  7) -0.028574310422876  0.274839004340268  0.190319637220479  0.185855295920754  0.034536574668385
-    8  (  8)  0.203798693509887 -0.096005100260287  0.216711347569874  0.131216204119416 -0.656596808211851
-    9  (  9) -0.067877527133344 -0.037394400179997  0.001237790876622 -0.228454969678907 -0.012690550864382
-   10  ( 10) -0.034701105872209  0.001990914574463 -0.259519960179195  0.116541389496059 -0.207695057666406
-   11  ( 11)  0.000529750770377 -0.259508478417478  0.144769482331176 -0.253537495219966  0.018205735096527
-   12  ( 12) -0.234244598389483  0.115982179322626 -0.253619758535615  0.006093701660384  0.182261090721229
-   13  ( 13) -0.011868304995110 -0.207492891665530  0.018292807598929  0.182455637236639  0.257011226933879
-
-	File 101 DPD File2: Q_YXBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  3.129957716780603  1.709487426238976  1.008372449275402 -1.276765968277357 -0.065446307723680  0.742021832051918  0.436332599611655 -0.667055197719947  0.142659410690324
-    1  ( 15)  1.714334301166813  0.700526286404250  0.648407039146880 -0.082187902917956 -0.083925296715317  0.412626654600965  0.022155756924809  0.476428125836557  0.067616090221052
-    2  ( 16)  1.004889143369286  0.650316640783399  1.998153280399342 -0.507870830167831 -0.039112960902049  0.768415113506394 -0.691125590794351 -0.226431506013134  0.263857602369259
-    3  ( 17) -1.269421985001052 -0.083373095695230 -0.506983578378752 -1.263098642948249 -0.374471320057592  0.074978132794915 -0.297260722017830 -0.452170040968050  1.050173052431991
-    4  ( 18) -0.064747836599454 -0.085201382625694 -0.041627664590248 -0.374535705588497 -0.046703869002225 -0.700762349492484 -0.091567339314563  0.418157505097632 -0.785741366289708
-    5  ( 19)  0.743036750652246  0.410673884351049  0.768466137402025  0.075428816032864 -0.703035805441588  0.314123367939291 -0.195779628330961  0.668388148829413  0.586022121530341
-    6  ( 20)  0.448861595045559  0.022268432968839 -0.695996747604689 -0.299039357299196 -0.087643067600830 -0.191851548627364  1.730420545431552 -0.327097691187574 -0.195052046580288
-    7  ( 21) -0.665176492733851  0.474697179147161 -0.229070812537720 -0.456509653450532  0.418746501000567  0.669426422647124 -0.326704272416130  0.747881016377404  0.362406882908971
-    8  ( 22)  0.140550731155041  0.067145133214418  0.261067562517139  1.059403828293538 -0.791123605948274  0.587521801265389 -0.196441175786152  0.361546615668658  0.026521472400518
-    9  ( 23)  0.183960752400236  0.090648149401017 -0.951941189763357  0.248345722083149 -0.393024730585672 -0.277795637307642 -0.115801327759540  0.079790484226362 -0.328104044469749
-   10  ( 24) -0.096999004318018  0.626557370844378 -0.255720242863489  0.074089211117426 -0.322650588726138 -0.120274438102632  0.135763949857182 -0.407749321761093  0.308366563042107
-   11  ( 25)  0.407205371370843  0.400523898216947 -0.571544522265930 -0.193909113341939  0.083886868417408  0.091312559974794  0.631988580744505  0.013108395391089  0.082668659590215
-   12  ( 26) -0.129228709580998  0.099727214866939 -0.100060970484827 -0.015941685134031 -0.082302613975460  0.197457522516659 -0.272267273975511  0.325467300120502  0.083219190361926
-   13  ( 27)  0.028075996591360  0.033288139884456 -0.031657050748594  0.482400837770596 -0.517095863243159  0.127743215834403 -0.003902066405070 -0.059749603348758  0.133994178327020
-   14  ( 28) -0.273136601610741 -0.188601639941912 -0.187478867630393  0.009614280452030  0.021419895096816  0.019676076647385 -0.065299916825948 -0.089158000768035 -0.159014829774556
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.189067512684415 -0.102496789105839  0.410654707878315 -0.127342842175287  0.027788275096733 -0.274054514827827
-    1  ( 15)  0.092569039491299  0.630719742486575  0.400222010471337  0.099354786357621  0.032882750235495 -0.188589543062389
-    2  ( 16) -0.956030203265825 -0.251017350759149 -0.571942090019317 -0.101339895760847 -0.032232343593004 -0.187540849558250
-    3  ( 17)  0.247408208848905  0.077226334022248 -0.195762209231719 -0.014892221719137  0.484418697183312  0.010980560423775
-    4  ( 18) -0.390471916376519 -0.321072752160193  0.085241250919945 -0.082929586905556 -0.518446707359415  0.020725560487627
-    5  ( 19) -0.276085584806377 -0.122753716334935  0.091777975463841  0.198255613256156  0.128106130978898  0.019757919607764
-    6  ( 20) -0.109281747348802  0.138819455362619  0.631931707244074 -0.272906281184370 -0.004567396890772 -0.065539107895275
-    7  ( 21)  0.078860388222395 -0.407912307197262  0.013588050423304  0.324886983199182 -0.059578662331878 -0.088992520282932
-    8  ( 22) -0.328236887526537  0.308891754287031  0.081908251614941  0.082991173001543  0.133719894258456 -0.158776023572950
-    9  ( 23)  1.436856164461350  0.249384784994306  0.022347111245506 -0.129893936938419 -0.461604447719581  0.449006747580467
-   10  ( 24)  0.250262739479672  0.086227917872089  0.311749984502828 -0.162248434523399 -0.107591001482132  0.176012643265562
-   11  ( 25)  0.021123977610386  0.311105118560602  0.233973360713413 -0.204980222609714  0.110871402540350 -0.068117274246059
-   12  ( 26) -0.131121910435957 -0.162016158931924 -0.204892256710919 -0.182518292975433 -0.120649253364666 -0.006834723735918
-   13  ( 27) -0.461492836526352 -0.108023084228299  0.111025723101441 -0.120661429567117  0.118222866627246 -0.150273583122085
-   14  ( 28)  0.449307854753117  0.175579254045662 -0.068051883155874 -0.006789591489122 -0.150168327953186 -0.086537045939434
-
-	DPD File2: Q_YXBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_YXBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.011805695024598  0.034992763432279  0.004462140920506 -0.063122437892726 -0.087474771158541  0.008042335300982  0.014057938043334 -0.003177831649274  0.031711169970175
-    1  (  1) -0.055573939542751  0.140907388342312  0.003316984012425 -0.384478151119584 -0.412891175872713  0.060973940461778 -0.094719077377273  0.007458385756948  0.068069991420835
-    2  (  2) -0.419627260626533  0.608023942970289  0.149649898013477 -0.363118959013547 -0.162752689730023  0.257196398088489 -0.774518584928342 -0.258611606965876  0.061139442895175
-    3  (  3)  0.091826375533470  0.136780329022874  0.053389557143553  0.688017533265971  0.680722301222751  0.269185675862565 -0.269218717929093 -0.345510091695087 -0.070727464771127
-    4  (  4)  0.629512509887410  0.417048321341404  0.009617059149628  0.327729529134849 -0.360503272937336 -0.887467140390734  0.487659347625856 -0.427756151618870  0.098689721444246
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.007994539761143 -0.005235119382381  0.003279699281102  0.019777797082027 -0.020138505418272
-    1  (  1) -0.009018238247018  0.057958409547357  0.020659668663920 -0.077367526316125 -0.023640442259231
-    2  (  2)  0.011058300095965  0.266287526342250  0.211065950734315 -0.122740386780814  0.139079547031469
-    3  (  3)  0.203710004993493 -0.168007259833028  0.099516257475658  0.635126811682311  0.003780258900248
-    4  (  4)  0.651607465920600  0.364865266495963 -0.186050400788225 -0.120894760297612  0.207720673538239
-
-	File 101 DPD File2: Q_YXBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5) -0.018776122478509 -0.003516932988588  0.016185966790962  0.103005437910031 -0.058996387642607  0.033677439848222 -0.006555907757992  0.004943429938180 -0.008673234381993
-    1  (  6) -0.229317165793185 -0.203922295837344  0.236381389548029  0.343030484184692 -0.168220233454749  0.002070028793707 -0.550849665474538  0.454373901655846  0.029204576778314
-    2  (  7) -0.826581307225571 -0.248141299803835 -0.040580104021485 -0.274688873396250 -0.186997257812666  0.044512235649138 -0.777087624287131 -0.307827377137018  0.935360296008197
-    3  (  8) -0.212075384780701 -0.152493170809657  0.663898605839720 -0.114689839738095 -0.197309003805366 -0.422628192956036 -0.431880030359280  0.089589322707163 -0.717782630036867
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.030713573040164 -0.013233627688701 -0.004171830214503  0.000741328194514 -0.016529617755578  0.009072661642018
-    1  (  6) -0.059376876162672  0.545097710028939  0.052607325244023  0.066593744532753 -0.043416822148381 -0.009796861309280
-    2  (  7)  0.112007837970219 -0.329264981368721  0.296245980281503 -0.027825000648174 -0.168338803590710 -0.134330947676505
-    3  (  8) -0.068078591846890 -0.441198549977012  0.001173592644729  0.248239875217764  0.161760460928194  0.044802607448477
-
-	DPD File2: Q_YY_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_YY_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.024342991115419 -0.008607682482030 -0.002992224403845  0.095010412958861 -0.090092066992013 -0.037486895782279 -0.022021317207469  0.050932640338130 -0.054276748631694
-    1  (  1) -0.411513990262250  0.205737457358234  0.095726614874774  0.699825294860008 -0.469657594572958  0.158821830454924  0.021819014597903  0.167714041015168 -0.086531794992601
-    2  (  2) -0.092448335809038 -0.049865821518381 -0.734570624144577  0.895524961570072 -0.582242528935047  0.625771983630518  0.359097438172271 -0.796349956745338 -0.213186923404472
-    3  (  3) -0.234060951886580 -0.855119407521468 -0.606152414997006 -0.925015138472668  0.674856279519340  1.001303634316535  0.526202043125510  0.046026900078905 -0.132025419872514
-    4  (  4) -0.016294665961218  0.035981296968647 -0.055548667965538 -0.118652841714683 -0.201196212144661 -0.278929152878848 -0.155799235053581  0.225623053253456  0.154996159003484
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.071976366566545  0.016792050594289 -0.000219829771762  0.002464846175761  0.012721394913520
-    1  (  1) -0.102983739084702 -0.004699724964549 -0.004332719843401  0.020811177702821  0.030605256267747
-    2  (  2) -0.413185556954419  0.165299773641034  0.018318216003677  0.050151311064429 -0.130358995956216
-    3  (  3)  1.009528183134310  0.191587811242284  0.067520544036446 -0.178534179017655 -0.006080809518212
-    4  (  4) -0.315253021540833  0.576990940198330  0.092618070735429 -0.967180406885694  0.109322615307993
-
-	File 101 DPD File2: Q_YY_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5) -0.050400368537009  0.150685614199456  0.023708908742616  0.081456491968675  0.053234173997325 -0.123644521275091  0.020607835855770 -0.027104738891277  0.011731299037022
-    1  (  6)  0.889772516805186 -1.625705586070814  0.364257431385706  0.339194152798652  0.021851328762718 -0.742834529765978  0.304369037789611 -0.465304421121129  0.430098959772153
-    2  (  7) -0.183247409989584  0.321912684279330 -0.136435127850254  0.412922399867810 -0.555638698890679  0.368523984415832  0.432240845227411 -1.048100212634306 -0.122850884478564
-    3  (  8) -0.047579336112279  0.388446635445945  0.081597821420509 -0.350513223379033 -0.425870140035406 -0.062511191718611  0.107346139743776 -0.906452719402225 -0.086511067723903
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5) -0.015364183113451  0.002511616309117  0.000766111000104 -0.002247436005763  0.004821408782443 -0.016136808286519
-    1  (  6)  0.052394880360824 -0.014619736017344 -0.015820169663871  0.045225774352768 -0.123802695745983 -0.240548199044004
-    2  (  7) -0.091848553724297 -0.662866226382579 -0.114441468066110  0.058372799913313  0.006174536776649  0.139883282912119
-    3  (  8) -0.444872596836423  0.778351434117421  0.067547928599141  0.539970600352882 -0.181649436569160  0.193440947374150
-
-	DPD File2: Q_YYBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     5
-	   Irrep: 1 row =     4	col =     4
-
-	File 101 DPD File2: Q_YYBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  0) -1.715635190158419 -0.032032720626089  0.068920885907506 -0.135211793814630  0.014372241292624
-    1  (  1) -0.031155261780234 -1.025562151095813 -0.628798289770944  1.304496272904645 -0.112415632104800
-    2  (  2)  0.067322584018886 -0.640387287098309 -1.256372881039952  0.542738490590014  0.047612576812745
-    3  (  3) -0.132386916070937  1.315015251397801  0.534146918090512 -2.821587358460932  0.240869892501381
-    4  (  4)  0.013817908395229 -0.114250084735797  0.043596100926008  0.236639374233555 -1.688037421931371
-
-	File 101 DPD File2: Q_YYBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -1.715770712591689  0.031586383919203 -0.000898596593793 -0.009661379541521
-    1  (  6)  0.032527827437308 -2.486752259782782  0.159819223290397  0.183267985547784
-    2  (  7) -0.002306120342154  0.164757272944922 -1.162464390461208 -0.264854656407098
-    3  (  8) -0.011026109130055  0.191160056945235 -0.260816534449447 -1.676020580816317
-
-	DPD File2: Q_YYBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Q_YYBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.090253560856093  0.266686501991155 -0.244272543288825 -1.578258855063394  1.084779471402821  0.512130072543987  0.269518931256341  0.227277930774676  0.218158852802390
-    1  (  1)  0.269798748086241 -1.539998255431672 -0.066927733458632 -0.400394592790731  0.434110152110065  1.401338892071336  0.854962567774486 -0.470020047660668 -0.232842278258429
-    2  (  2) -0.237514875123605 -0.072957150649504 -0.081991476298800  0.104179080640775 -0.019964196967611 -0.288242674430015 -0.120120702657437  0.246041382596050 -0.075132252871599
-    3  (  3) -1.585909182142435 -0.405180217252999  0.109941809618558 -2.789256835527734  0.781841377264032  0.913343645778787  0.434647037834560  0.920498305222641  0.444985422307237
-    4  (  4)  1.090835196405407  0.441285563787874 -0.020688727234358  0.782495640693726 -2.552839965673415 -1.140627057160361 -0.371288029748747 -0.498617973892776 -0.272723592418581
-    5  (  5)  0.503779682645996  1.407242470946861 -0.290934804129972  0.911731626179636 -1.136199001721370 -2.838911349545838 -0.831144811176630  0.543223634193898 -0.213028929621077
-    6  (  6)  0.265498345065672  0.859113911118993 -0.120815590133534  0.435697826339939 -0.369505920913540 -0.831496066903583 -1.656617824284741  0.122784582477642 -0.086892102658376
-    7  (  7)  0.229118830041592 -0.478725938784188  0.243310942544375  0.908598725544431 -0.489238405849829  0.552029214060157  0.128004231308334 -0.864149414509097 -0.190940515690714
-    8  (  8)  0.220279643295963 -0.232245945554877 -0.078412938582176  0.454228655152188 -0.279014014024783 -0.211013139311077 -0.085318547504674 -0.195317517125828 -1.421957046054468
-    9  (  9) -0.714587976360447  0.197204733260132  0.198819358765054  0.093272612304538 -0.030280881440897  0.084299030171759 -0.003837983300814  0.131236328872752  0.125195759725260
-   10  ( 10)  0.349654536858523 -0.976487941772500  0.495445415509198  0.025664109947426  0.200131656128388  0.355466519668399  0.126424306520979  0.063662886956018  0.225436104022133
-   11  ( 11) -0.043661189197500  0.053574284884635  0.069536653680628  0.021831118006896  0.045935427519458 -0.081658768974649  0.060492193982502  0.010207840421600 -0.026475422673424
-   12  ( 12)  0.371684311372758 -0.564018997504298  0.121207955301356  0.075710778756154 -0.032615236827858  0.154201951087728  0.161884437839777  0.026240358070066  0.131774106025837
-   13  ( 13)  0.317153296278915  0.431785975787431 -0.455423198191838  0.348106889137524 -0.287135757432154 -0.161983100260472 -0.162117104407489  0.184790462723215 -0.125288346075121
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.711519671707625  0.350738241322204 -0.043425762121925  0.373161970972252  0.316139721953365
-    1  (  1)  0.200904331688709 -0.974479990748127  0.053796576636260 -0.567653798982668  0.432777252358173
-    2  (  2)  0.203784455205672  0.497529011383680  0.070115637251214  0.117747638264786 -0.455121286794564
-    3  (  3)  0.111903218017369  0.025041205936844  0.021717993688018  0.077480845714629  0.349008656637805
-    4  (  4) -0.046188318540260  0.198430488821062  0.045477352407028 -0.031113254871222 -0.287937081409918
-    5  (  5)  0.074948941475865  0.355643464025440 -0.081851134920141  0.153697068109474 -0.162248286238473
-    6  (  6) -0.008833944209604  0.124472318401256  0.060007492319879  0.165006471238111 -0.162630796259319
-    7  (  7)  0.137947857544831  0.063113905833555  0.010667817909466  0.026173313889871  0.184976326907946
-    8  (  8)  0.121062340856801  0.225313862106642 -0.026564239708378  0.133747698363760 -0.126243501483280
-    9  (  9) -1.923298279412031  0.083687094584206 -0.041092602404345  0.065910319193699  0.152965484744789
-   10  ( 10)  0.084697121235281 -1.864087033289797 -0.003127551810500  0.000426855908109  0.108606264359420
-   11  ( 11) -0.041321039884016 -0.003278319766503 -1.205330278424836  0.040139563125266 -0.032839266621538
-   12  ( 12)  0.065898232410324  0.000348341651181  0.039861427008242 -1.950272737395795  0.026584460926211
-   13  ( 13)  0.153017263180705  0.108587696634766 -0.032775491975687  0.026449226308266 -1.241866799748394
-
-	File 101 DPD File2: Q_YYBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -3.943186119351278  0.611543768141941 -1.688670293735843 -1.496505264308787 -0.450076985025435  1.850687460317133 -0.386274567708075  0.120259793297098 -0.942689528213069
-    1  ( 15)  0.609021845382251 -2.390081819972881  0.185785449194411  0.688233410386016  0.821025406672035 -1.113477827623548  0.026425274942537  0.560513430498864 -0.065375924164264
-    2  ( 16) -1.685285958270808  0.177492565853163 -2.215381588775731 -0.896040165247049 -0.601909265055630  0.507123645459364  0.122266890292288 -1.322944471008213 -0.522298474260220
-    3  ( 17) -1.493766859294783  0.680347623777159 -0.895645070612193 -2.195831359497479 -1.422756206295168  1.961075789165218  0.115230890898387 -0.603695101364626 -0.252997193329400
-    4  ( 18) -0.439262926804637  0.815754532030626 -0.605780227523777 -1.421931877150413 -2.649954870142273  1.028217951889226  0.032717294668620 -0.588905792221379 -0.075697158399478
-    5  ( 19)  1.847044439133869 -1.108080802472890  0.509353297764380  1.965509303598441  1.025760634226664 -3.368953427361358  0.390091434115630 -0.006356970339985 -0.162354408026315
-    6  ( 20) -0.391487746276352  0.025045061216092  0.123084452739915  0.117735093741242  0.031308141618161  0.389104782517851 -1.332818405259512  0.185514052636596  0.137967404225986
-    7  ( 21)  0.137903999361762  0.560210342678297 -1.330544776046839 -0.605756700222429 -0.585940299153347  0.000074502468146  0.183985956972016 -1.933776807103359 -0.230152279216468
-    8  ( 22) -0.938849003981979 -0.071351764553985 -0.523387731564958 -0.254448751334891 -0.075003713995343 -0.163507271487724  0.137526158845337 -0.227769888951778 -1.167093707744542
-    9  ( 23)  0.306844117492406  0.247899723475974 -0.067381225294871  0.073558644827160 -0.187219938478138 -0.282901124098406  0.107263521422496 -0.079721480818646  0.126431799084493
-   10  ( 24) -0.048293120181733 -0.327297425330403  0.475995895739725  0.342072430659284  0.165280822416435 -0.083443115261233  0.031111545592174 -0.049669302723587  0.076694819734381
-   11  ( 25) -0.119162442533473 -0.079355756933079 -0.022830680408169  0.088971488605106 -0.040858024404385  0.080819379541046  0.111132511721692 -0.024342855338426 -0.033011594956378
-   12  ( 26)  0.254381217055556  0.411232056749145 -0.847063307059588 -0.226080135824625 -0.211665221401425  0.058455047569747  0.022862992692310 -0.181202339023124 -0.091263110505200
-   13  ( 27) -0.622829184370111 -0.778279147300184  0.087596751772574 -0.149904047094486 -0.181250611547582  0.155173856733511  0.086549803822355 -0.010425311676662  0.035206165125124
-   14  ( 28) -0.602907760930320 -0.636630299068525 -0.657480547619927 -0.987818051045771 -0.664683646424703  0.600197150408945 -0.021024908286539 -0.241308429991800 -0.139073256567832
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.299378510056002 -0.048464484768822 -0.119575732455166  0.259470683932760 -0.623427847750207 -0.599169357175934
-    1  ( 15)  0.252972646145452 -0.327959870817153 -0.079611304197115  0.410502606108128 -0.780116947674937 -0.639576112377174
-    2  ( 16) -0.065645972981995  0.472845946770190 -0.022887448862502 -0.850462719071786  0.088794433668405 -0.659299983347687
-    3  ( 17)  0.071979861421674  0.347566270869496  0.089725275995759 -0.224873104335581 -0.150634163996671 -0.988671053045993
-    4  ( 18) -0.183112660445829  0.161853864390905 -0.041598743305605 -0.212763102027718 -0.180762489003477 -0.664835723845377
-    5  ( 19) -0.282718255445060 -0.082022605607409  0.080654986727402  0.060722461359680  0.153677444677097  0.600615307444439
-    6  ( 20)  0.105389927060317  0.028037361295427  0.110971087219198  0.021654361576742  0.087054495871807 -0.021382752384988
-    7  ( 21) -0.070767752302361 -0.049014223758044 -0.024842776527344 -0.182057935757829 -0.009936156500609 -0.240872391823716
-    8  ( 22)  0.126361292923088  0.076476887820341 -0.032913922905545 -0.092149255295883  0.035714327387115 -0.139608937339268
-    9  ( 23) -1.395802543261593  0.023947796409329  0.037546628981133  0.231479809978131  0.017492180239634  0.131665608723804
-   10  ( 24)  0.022590932712563 -1.911194172338057 -0.086136161074572  0.043088235083797  0.006191299454329  0.111138223861769
-   11  ( 25)  0.037817865173482 -0.086296189745106 -1.222232238573918  0.005079720018963  0.002780176419931 -0.050638098186175
-   12  ( 26)  0.229050475743344  0.042784084702301  0.005280917410968 -1.917436263487832  0.106911427626117 -0.254306598770826
-   13  ( 27)  0.018514283856998  0.006181698752959  0.002670917714217  0.106982137805423 -1.557381204648767 -0.577629564281199
-   14  ( 28)  0.131141177438018  0.111183536858070 -0.050611973015083 -0.253996365838148 -0.577942223543412 -2.479043504186053
-
-	DPD File2: Q_YYBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_YYBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.023242718663093 -0.007906919254678 -0.003206064741951  0.090699783691768 -0.085825493554922 -0.036010130786866 -0.021048108413619  0.047964352597932 -0.051656992001052
-    1  (  1) -0.398683122387043  0.209925067035988  0.110355295047494  0.730935620819049 -0.500168625629568  0.130175390846453  0.004957111498220  0.185067698871481 -0.091329430236487
-    2  (  2) -0.132168099574871 -0.030598973300039 -0.714569185588914  0.826686857818894 -0.538256523929386  0.568272934244429  0.331263180485331 -0.756642402126797 -0.201927808667937
-    3  (  3) -0.250981739344651 -0.765314414413508 -0.591263596488687 -0.874707217358118  0.652817272493166  0.955252741449322  0.502950743280582  0.027644577125072 -0.091886363611070
-    4  (  4) -0.010353073957434  0.019199981664699 -0.061495098835704 -0.081006638873616 -0.155601020490311 -0.278247945506226 -0.155013810236580  0.223369006252483  0.142922323222932
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.068296456786718  0.016125211178139 -0.000208262773754  0.002414625293017  0.012043611746170
-    1  (  1) -0.099032707648360 -0.011201377176078 -0.004093861348962  0.014658593455382  0.026144254956098
-    2  (  2) -0.349017390936615  0.104508649329556  0.017813638151547  0.024379762352311 -0.117461103121769
-    3  (  3)  0.897606671942110  0.147036233356725  0.061764584638100 -0.170893095928749  0.007978569979247
-    4  (  4) -0.287749229102280  0.536127382188217  0.084144867934349 -0.876704980779795  0.103527647375058
-
-	File 101 DPD File2: Q_YYBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5) -0.048492388152524  0.144902399352759  0.023098275699028  0.078727961355930  0.051643294702111 -0.119445334935864  0.019942689395655 -0.026235110724910  0.011451999773627
-    1  (  6)  0.825273380063140 -1.465066508575364  0.374492471806678  0.362079562733551  0.050520826752396 -0.764123495352586  0.293295607135848 -0.435875381562883  0.425577281558969
-    2  (  7) -0.178337311375639  0.261277969517545 -0.101486629859307  0.423851616255530 -0.543672619712151  0.368369883492112  0.397452427103591 -0.981520399524720 -0.122319892442723
-    3  (  8) -0.048302416726224  0.336779735074636  0.111101516406423 -0.352596629978989 -0.377713767646648 -0.040858476521755  0.104304068444894 -0.877628643131400 -0.087132452042740
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5) -0.014616614375935  0.002433681854537  0.000712389726924 -0.002138799354259  0.004540595477650 -0.015398837775762
-    1  (  6)  0.045624483381462 -0.010590494228575 -0.012770221175887  0.029994116623241 -0.106477071015473 -0.216923041948159
-    2  (  7) -0.092611458596085 -0.570790847853499 -0.099304152425560  0.033385923446846  0.019804190738350  0.124579664797882
-    3  (  8) -0.416080282004841  0.716373278050540  0.060395161517046  0.469591249251713 -0.160308902907616  0.176158861918289
-
-	DPD File2: Q_YZ_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Q_YZ_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.029552868724211 -0.012090786984276  0.068482939759800  0.006587872357708  0.067252594152802  0.036842394187700 -0.007117570009899 -0.032320686376030 -0.029089112307392
-    1  (  1) -0.213653767690103 -0.028153888862101  0.314079796683866  0.017068466152245  0.375888522199907  0.257053852917044  0.011921528866969  0.059385104504110 -0.060994806711073
-    2  (  2) -1.415860929430990 -0.658487925410427  1.067008798150550 -0.337507446167742  0.063918717814757  0.111624530781545  0.601654980676806  0.703470688724419  0.100498607118445
-    3  (  3)  0.036224770061911  0.142036374749427  0.166080800401930 -0.398756400592409 -1.154779674457841 -0.323290423120714  0.625779247465735 -0.310843980143136  0.194430913262496
-    4  (  4)  0.216167941594352  0.125954715766933 -0.597080876886763  0.091488826716116  0.354481843623787  0.386559164252613  0.737580263602502 -0.004323673156499  0.431570165801849
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.067344578071882  0.018002028513115 -0.006736420918309  0.011057399869179 -0.039042734588826  0.022316741635117
-    1  (  1)  0.154593832425177 -0.031056774704003 -0.017509680342204 -0.043192844861057 -0.051029596599146  0.017695344972824
-    2  (  2)  0.120858991371896 -0.202629045997310 -0.210252380955293  0.084415928651666  0.075143744631989 -0.181030920230081
-    3  (  3) -0.182098393102296  0.273397420336855 -0.169656403658152  0.500932931390355 -0.174093852893344 -0.034076041924340
-    4  (  4)  0.052123951285458  0.347412092720287 -0.334461423425518 -0.267600772918557 -0.067727490664997 -0.025021459769394
-
-	File 101 DPD File2: Q_YZ_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.032226976198718  0.045661938218276 -0.103780707516731  0.022738706155801  0.006114547541344 -0.008715007772506 -0.000406250936894  0.012835570776838  0.066817571454234
-    1  (  6) -0.469774435546931  0.750778092218380 -0.082468553040984 -0.313520475438351  0.381209949393646 -0.716831585179108 -0.232630851604267  0.363203673620615  0.168544634889542
-    2  (  7) -0.701123420984566  0.955807783218331  0.315239120103576 -0.074002978230075  0.218484137356380  0.236997767457141 -0.356119865511778 -0.492683755022539  0.029487097950503
-    3  (  8) -1.231033497453453  0.751067214448950  0.377977797626086 -0.236463685484809  0.545910595188220 -0.018542864675254  1.000115092742505 -0.005765755176850 -0.109291556700302
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.005148323529480  0.024059905128524  0.005047832013405  0.006419449288222 -0.043076812447681
-    1  (  6)  0.026688401889087 -0.224875695979734 -0.018204008587849  0.085412454766648 -0.018596286023125
-    2  (  7)  0.054314414878613  0.438950921897505  0.224278092321833  0.148272224357174  0.186808794914827
-    3  (  8) -0.426297609422135  0.453452046862797 -0.402777523724423  0.089035917412808  0.012668721974473
-
-	DPD File2: Q_YZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: Q_YZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.183113492974552 -0.019155249920488 -0.029414410031321 -0.104332044589643
-    1  (  1) -0.014986838026268  0.456208739737301  0.496096237769932  1.260223229970932
-    2  (  2) -0.083552336449296  1.603811510672729  0.296932918157193  0.506439147201208
-    3  (  3) -0.054629743368394  0.482393973093855 -0.431705217833494 -1.072915958338034
-    4  (  4) -0.019855532415157  0.074855839337550 -0.054813180657032 -0.128101573033608
-
-	File 101 DPD File2: Q_YZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5) -0.183114920519781 -0.015323279665094 -0.083550871538948 -0.054287056546782 -0.019635673621509
-    1  (  6) -0.018583856504190  0.459926178818044  1.603723039016419  0.483945733467738  0.072675317603419
-    2  (  7) -0.029304394392622  0.501501570704140  0.288553978608740 -0.426398677957415 -0.057207620590045
-    3  (  8) -0.104419344410532  1.266843771351296  0.491593164713869 -1.059879379279394 -0.128974149716998
-
-	DPD File2: Q_YZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Q_YZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  5.360951233046640  2.692798200640125  1.220104874187389 -0.357660273909617 -2.070077113802377  0.902589467326102 -0.363953318737363  0.307391101819755  0.481218709838381
-    1  (  1)  0.877247782108379  0.766209717481105  3.765536366292496 -0.232141689647508 -0.868330404065230  1.397550226616591  0.198954770331920  0.789470574082564  0.343838333365764
-    2  (  2)  0.364050013320412 -0.032191992008470 -0.379948892671640  0.903658291699696  1.378774377873059  0.052962827326198 -0.619972693658452 -0.119533831724703 -1.111532226202491
-    3  (  3)  0.864153577358945  0.115407451736855 -0.593820450452942  0.082415227574979 -0.896322200318177 -0.206568188385829  1.031914705393776 -1.516375358321331 -0.037564960493691
-    4  (  4) -0.187356147069814  0.204900244645625  0.505213932526079  0.366572057098164  1.259568976247780  1.217870862267439  0.630646031828998  0.886121074119630  0.292713468615236
-    5  (  5)  2.307244443497588  0.146952177623651  0.823126103453695  0.815781933963058  0.283474030249305  0.119316476301075 -1.556938474910068 -1.918799531882256  0.200794358317896
-    6  (  6)  0.999929817150612 -0.009879459677370  0.532894247670965 -0.119316902560033  1.185029416130923  0.365478190089731  2.390912867658629 -0.651667483205356 -0.433383408007920
-    7  (  7)  0.601394286089563  1.099657963273472  0.563425281618900 -0.591301544328125  0.252100174276413  1.261046957456791  0.118292395101533  1.117218126442026  0.169205181814331
-    8  (  8)  0.571403760791916  0.616597898552471 -1.857086938821677 -0.253108661744386 -0.166765536432630 -0.583354574407550 -0.209900488709868  0.010230926163718 -0.436478429708121
-    9  (  9)  0.209747299861770  0.038108419514222 -0.064537214176209 -0.007275943563652 -0.185703840121506 -0.141415304618201 -0.048928168952213 -0.144641032490529 -0.007113952535538
-   10  ( 10) -0.528917371193515 -0.405481935690602 -0.127287504633020 -0.186945059578633  0.351138728761902  0.556593402472593 -0.260559175767430  1.273226681393493 -0.139887516226760
-   11  ( 11) -0.046333044169863 -0.130145741301105  0.246982397492458 -0.245073892054749  0.413512266355639  0.093777790023920  1.313818702926236  0.204836400875976 -0.274511526614319
-   12  ( 12) -0.310127818709089  0.038293243379654 -0.132269091260197 -0.216358262562713  0.103017277322460  0.195528693138779 -0.097003003799161  0.628396859230412 -0.000835754733914
-   13  ( 13)  0.137253902359117  0.329242072065084  0.058655541997836 -0.187659849170682  0.133211284576206  0.224953542396808  0.080970111421629  0.032052228677688  0.444388375606088
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.578426138362048  0.071143247029465 -0.200641446668603 -0.394425009590772  0.091103550454678 -0.308998982593138
-    1  (  1) -1.883033737487733 -0.331990463074909  0.377210418761052 -0.001853600774245 -0.292916270677594 -0.078756267610642
-    2  (  2)  0.454544036870719  0.127944564815060 -0.260470007540829  0.311908668285056 -0.346176272137431 -0.112577837112077
-    3  (  3)  0.524546935261907  0.774579123649812  0.319497757558062 -0.597922896459268  0.123968012912054  0.075764061045705
-    4  (  4)  0.081830355405225 -0.089332716576273  0.464669505348895  0.522820306788420  0.208352633066704 -0.149018029577851
-    5  (  5) -0.087898620649583  0.372688904622524 -0.667131349021728 -0.333530032746713  0.387061380003103 -0.157085288313622
-    6  (  6)  0.351550280184077  0.201786561762424  1.154374714468388 -0.191249055431593  0.052879268342601  0.060266216491085
-    7  (  7)  0.241046667679705 -0.346723327516737  0.138221944436218  0.525994526828183 -0.131107511017704 -0.082870474604600
-    8  (  8)  3.197601115795361  0.634062286554303 -0.352759559329291 -0.172901070625571 -0.985124548987110  0.995624657058980
-    9  (  9)  0.382805543090693  0.172265373302413 -0.111470290531661 -0.367072489885716 -0.068385914917459 -0.074411606767888
-   10  ( 10) -0.083172271767999 -0.353536915838163  0.330710864812354  0.037706373264966 -0.356898862008954 -0.058964088026598
-   11  ( 11)  0.183552926494685  0.327247809312295  0.364560763821055  0.096049891497978 -0.159009797538618  0.083303877914261
-   12  ( 12) -0.079816813859873  0.072587983653898 -0.071322160174810 -0.003907017234655 -0.266450558063296  0.054886931715625
-   13  ( 13) -1.495679627370525 -0.108859512825657  0.126296843375062  0.041442735094546  0.417893799160475 -0.269622266251739
-
-	File 101 DPD File2: Q_YZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  5.353505141165546  0.890688859557432  0.370986991492220  0.853423503631065 -0.175579535476913  2.310024166184490  1.006204075207132  0.594737573040884  0.580912757243584
-    1  ( 15)  2.699239529253951  0.764443250041726 -0.033891490675767  0.110545474137795  0.207971565761542  0.144896702873739 -0.011665154649099  1.099560303882922  0.622352626705053
-    2  ( 16)  1.217983749973932  3.764925493121569 -0.382606170318571 -0.590096731144521  0.500877090215735  0.821277057629923  0.525498183844259  0.564162067732067 -1.863924914608564
-    3  ( 17) -0.354378865275301 -0.235517234537521  0.904059819746174  0.081778776047408  0.366152127151403  0.811195163293337 -0.115460016783434 -0.584082592819068 -0.251614634578761
-    4  ( 18) -2.068328882054058 -0.868493189733572  1.383062082889841 -0.889004990074110  1.252079532403483  0.280363659094828  1.179107716558007  0.260223380378208 -0.169071425930085
-    5  ( 19)  0.896860010886759  1.399700044153152  0.055611982090691 -0.204054666569984  1.218046417960395  0.118995521046613  0.368895192443561  1.262795992609439 -0.585037262838195
-    6  ( 20) -0.366637507848360  0.197259762996753 -0.625793698825295  1.034813181912127  0.632152731683643 -1.556944750011882  2.391591655950920  0.115182881667896 -0.211264316589643
-    7  ( 21)  0.304826000780040  0.789394296489110 -0.119156637586011 -1.509731643923624  0.880539480584384 -1.918887457585959 -0.654178779681708  1.119814351020919  0.004695271666279
-    8  ( 22)  0.482673161434467  0.341764670705712 -1.114860194148782 -0.036661800416755  0.293226328632846  0.198937250412172 -0.433178052673118  0.170008110377442 -0.435678840938016
-    9  ( 23)  0.568809995257824 -1.874744812516267  0.457495936532682  0.523861440209940  0.084814462127761 -0.090388820008976  0.353391274922666  0.242340258320801  3.196555172716930
-   10  ( 24)  0.070335835358122 -0.330650173154532  0.126776784766783  0.772543265810599 -0.085884670580227  0.373009134942036  0.202786679587987 -0.349382742604520  0.636682150412552
-   11  ( 25) -0.198633655276233  0.377502815878866 -0.258791029874716  0.318244103545271  0.463863792456558 -0.666810847217600  1.152788198213469  0.138659403225890 -0.352130337593852
-   12  ( 26) -0.396901806546964  0.000395285484119  0.310508766643833 -0.601280056476283  0.526252062566165 -0.332539317400707 -0.191083130251521  0.521826702050678 -0.172519578082087
-   13  ( 27)  0.091351513735343 -0.293128213798388 -0.345330574903456  0.125609568290854  0.206375849513224  0.387475344491849  0.052511328809426 -0.130081029254173 -0.986253343969630
-   14  ( 28) -0.308104497916485 -0.079095998516156 -0.111812378605463  0.074847508726824 -0.148580287539640 -0.156369183783182  0.060723799046636 -0.083364531892640  0.996547838811843
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.202668000464361 -0.522005316857815 -0.047438780537185 -0.307836616438326  0.139276639627676
-    1  ( 15)  0.036301645667224 -0.408693148732606 -0.129466422170618  0.038156420592379  0.328909687255469
-    2  ( 16) -0.061411263263283 -0.130911966368035  0.248587665898269 -0.132943428674306  0.058094285835748
-    3  ( 17) -0.006444941345020 -0.189328821232246 -0.247663855883141 -0.216841465123872 -0.188758126911417
-    4  ( 18) -0.174882495068945  0.352059542473143  0.415457742715615  0.103379942414574  0.134308245258646
-    5  ( 19) -0.139662167305942  0.559445806987568  0.092833979039118  0.195985083464074  0.225502233166089
-    6  ( 20) -0.050036885646758 -0.261079528741436  1.314976093463703 -0.097097007122576  0.080738973098351
-    7  ( 21) -0.139571528354083  1.274371934387910  0.205626509359679  0.628369271820743  0.032328517281743
-    8  ( 22) -0.007083324404061 -0.141460741245176 -0.274184199497861 -0.000997758723955  0.443965607091155
-    9  ( 23)  0.383064190737188 -0.080702339917536  0.182521216411565 -0.078746180366527 -1.495050228794565
-   10  ( 24)  0.170090225393199 -0.353075382711013  0.327690489245921  0.072940960473288 -0.108603449735698
-   11  ( 25) -0.111060583178837  0.330445456105407  0.364666825850954 -0.071352356473691  0.126399272365111
-   12  ( 26) -0.371089628890737  0.037216243105304  0.095990843882462 -0.003846246071552  0.041271278631872
-   13  ( 27) -0.066908426584578 -0.356205971328699 -0.158985300207994 -0.266453168087701  0.418014608875444
-   14  ( 28) -0.074914522268607 -0.058696973494151  0.083202963234434  0.054875862837609 -0.269527522173395
-
-	DPD File2: Q_YZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Q_YZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.029788620507893 -0.011938329127465  0.068273509474652  0.006608163500201  0.066809621565168  0.036248735989190 -0.007037628394506 -0.031617432097739 -0.029157043626897
-    1  (  1) -0.207811299205550 -0.072668392092003  0.275181722630279  0.031799375814548  0.412015868705937  0.264039641738986  0.002732818131385  0.048610613827444 -0.073466897200643
-    2  (  2) -1.409212746391881 -0.615283779048791  0.973116698528813 -0.317311423592346  0.066232813236537  0.090615092187427  0.589649919279850  0.666093653624415  0.122910191660261
-    3  (  3)  0.018931059416101  0.095495887908358  0.148007879674709 -0.407897274323649 -1.138069396579467 -0.290766885239806  0.602248159921183 -0.270975491959150  0.204899880433037
-    4  (  4)  0.192338141542218  0.121289777758424 -0.564798574419255  0.120372528792873  0.302925085448342  0.375066280689552  0.701144482076972 -0.013931949716402  0.417689073827744
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.066335748617021  0.017592894427430 -0.006633003641402  0.010518228542818 -0.038447224768607  0.021783813505935
-    1  (  1)  0.133121100586288 -0.034708776594714 -0.013148203407377 -0.037106561215713 -0.046839856184517  0.015841779346747
-    2  (  2)  0.073954369688987 -0.199911599534852 -0.187710702021101  0.087631365070933  0.075967192792968 -0.180035954611313
-    3  (  3) -0.190488658603295  0.257026169801377 -0.153541847940925  0.476220664878281 -0.164289641341438 -0.025116032681626
-    4  (  4)  0.079770210612789  0.335365137191353 -0.306987596230603 -0.257032293506196 -0.061214777318568 -0.022845423906988
-
-	File 101 DPD File2: Q_YZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.032151491375372  0.045516746488014 -0.102781737835612  0.022481221627501  0.006175010696377 -0.009274495720830 -0.000544447375209  0.012153632639189  0.066169443302312
-    1  (  6) -0.449720792780689  0.686798680183923 -0.124569019631082 -0.303964393794838  0.355423933103665 -0.720237081425067 -0.239810719167573  0.341042714384499  0.140689721101496
-    2  (  7) -0.702789387361410  0.875521189944887  0.305785020861818 -0.074047880881526  0.238445552160892  0.207042784808629 -0.350025587205443 -0.482374288594554 -0.013112484954988
-    3  (  8) -1.224567499181353  0.687299596482771  0.391346208534734 -0.285596817553042  0.532028212183931 -0.015314824081747  0.958505046307769 -0.004571205051097 -0.147828673371976
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.004832334700531  0.023216249232221  0.005002981530126  0.006310667249010 -0.042396337097595
-    1  (  6)  0.014241313650309 -0.208202651299433 -0.016534816565328  0.088005078276853 -0.009840669973197
-    2  (  7)  0.044204167225996  0.422787697609623  0.204490198883489  0.143279060616817  0.179780316729728
-    3  (  8) -0.420374780271730  0.436793419502513 -0.369111713277317  0.088297039397212  0.022457686151177
-
-	DPD File2: Q_ZX_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Q_ZX_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.004074879064756 -0.002532012046020  0.005554129052739  0.006560368948777 -0.002779926643572  0.002335656135966 -0.003395532472587 -0.001327548191671 -0.005265442640044
-    1  (  1)  0.200872614880490  0.145096481863003 -0.381705941305716  0.084050059564267  0.280827470698156  0.249332273590050  0.350130827104574  0.139753873158578  0.237707533718911
-    2  (  2)  0.454779931346540  0.284344346911741 -0.400796369507145 -0.391949355367063  0.298875363575278 -0.015873865692240  0.282090607400328  0.102045399349015  0.015518336693105
-    3  (  3) -0.068064441685710 -0.019874250939596  0.056124240432189 -0.235507520391358  0.120471483525898 -0.164841848750856 -0.160135553406143  0.158216498854868 -0.028358662007540
-    4  (  4) -0.171021104899262 -0.071184540170143  0.095610097777485  0.030939020482397  0.430951106225423  0.157370892130066 -0.397313061920960 -0.331853174015563  0.030552444997461
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.008280919117306 -0.001598825931089  0.008779579561246  0.004875551160851  0.005784200167522 -0.002119562479832
-    1  (  1) -0.038741258393760  0.085374379527266 -0.120801322502726 -0.009476083364151 -0.060610355284795  0.002892549569692
-    2  (  2)  0.351946791784957  0.027190638110694  0.217298406525411  0.110576853967177  0.117893349244747 -0.058880912343960
-    3  (  3)  0.036738679751102 -0.177625128003096  0.007110800682711  0.152932034409694  0.002269948947637  0.012590827368318
-    4  (  4) -0.011826651539788  0.053686376236646 -0.298275298603196  0.079882264337261  0.076903328378595 -0.019877525965890
-
-	File 101 DPD File2: Q_ZX_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.003418157316825  0.006248938465190 -0.003328653777979 -0.003795259538711 -0.005276387673124  0.001173750834571 -0.001422449403200 -0.002552073671433  0.008156049235358
-    1  (  6)  0.251364284589577 -0.496483365344414 -0.084754627400406  0.002233956751806  0.039729725347428 -0.245011238305347  0.476774577064519  0.321231366304764  0.004899068206628
-    2  (  7)  0.394873169246260 -0.107912444706184  0.569108548099488  0.130150036840399  0.165282113454427 -0.127070996031771  0.380790473078487  0.081309247667860  0.080778036617404
-    3  (  8)  0.232115096088585 -0.378773964710906 -0.188281955191172  0.292225544726507  0.391556281817038 -0.132429872578643 -0.081151662702157  0.130807982509805  0.324841536785196
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.003374573930473  0.002911937750971  0.009944171268417  0.002359222638062  0.006867137555593
-    1  (  6) -0.117108993328076 -0.078240062578820 -0.098736185820815 -0.032808874459956 -0.061607689244828
-    2  (  7) -0.026668505986174  0.119154464955432  0.388664508389551  0.020572973313306  0.012978611330797
-    3  (  8)  0.038689812718219  0.105270060899416  0.073045872658081 -0.017431584097677  0.153808781794468
-
-	DPD File2: Q_ZXBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: Q_ZXBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.007626044531834 -0.000976692612680 -0.007523282451906 -0.000697082806565
-    1  (  1) -0.000552220721842 -0.112308878501127 -0.103758878809839 -0.090319795590276
-    2  (  2) -0.003718739619501 -0.210497216850041 -0.694030530837677 -0.062972903566088
-    3  (  3) -0.001754344190881  0.012543863071645 -0.259943782087902  0.108395146957537
-    4  (  4)  0.007085681647499  0.103950763276849  0.141490816275654  0.580299008132658
-
-	File 101 DPD File2: Q_ZXBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5) -0.007626018340644 -0.000568107249963 -0.003753586184003 -0.001733792997507  0.007085233004913
-    1  (  6) -0.000938558594265 -0.113296044387823 -0.212099371772606  0.009419688652325  0.109713723609279
-    2  (  7) -0.007556926916031 -0.100229621336926 -0.687537266640526 -0.262131427764931  0.142289528541732
-    3  (  8) -0.000685378129623 -0.089225894752005 -0.061764096024840  0.105280680308524  0.583369661933430
-
-	DPD File2: Q_ZXBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Q_ZXBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -2.454716641543829 -1.483291650737991 -0.297365449983833  0.288420830932892 -0.217169391426612 -1.314460663988032 -0.280935220002927 -0.150847926702959 -0.431561450914452
-    1  (  1) -0.289981477221043 -0.154687683497078 -1.595727531172475  0.252187813748134  0.091624823876394 -0.615983534114679  0.448772537854966  0.256054494670598 -0.551554078696446
-    2  (  2)  0.240585271838033  0.077776263889878  0.232873408525797  1.033948982484620 -0.434806916340617  0.666999157332637  0.070720348290813 -0.241203413120274 -0.024573905221141
-    3  (  3) -0.131129359926950  0.021123045712403  0.135361130173095  0.218278873638143  0.788850796519149  0.492749776151576 -0.589289625463523  0.303380766183610  0.078276380710024
-    4  (  4) -0.385489496570785 -0.286654590877551 -0.148805837686689  0.231498708509063  0.631896861875863  0.131016326978424 -0.368297145262522 -0.840329432166826 -0.132848554153440
-    5  (  5) -0.398358207247369 -0.078977779507927 -0.828843923997183  0.149102811790732  0.424208629689331 -0.073628643455092  0.435823717865851  0.876073631002118 -0.230145216817784
-    6  (  6) -0.858949407780290 -0.427546968971227  0.139584468407109  0.272555602174351 -0.415262992797832 -0.166161760167003 -0.634710781492896  0.391022684161517  0.433280950744833
-    7  (  7) -0.714505827107073 -0.546785105438817 -0.082461618607383  0.065582740463543  0.061302419954485 -0.252199346131435  0.225838102589624 -0.532054842479612  0.399234811270711
-    8  (  8) -0.437597547452730 -0.166665887512917  0.884608856563974 -0.071847633999938  0.196115035101740  0.307984567617406  0.001033625488148 -0.248319156280341  0.263982116001698
-    9  (  9) -0.014050933460234  0.061521312474205  0.075986820943266 -0.003857016433969  0.049801809421784  0.054355969567726 -0.059001955258276  0.153413578849718 -0.126161876404776
-   10  ( 10)  0.109888463355253 -0.067177947715743  0.192322050888198  0.117953228015266 -0.119447610772357  0.017474941004481  0.014801179973552 -0.607437395442374 -0.030444707038302
-   11  ( 11) -0.390137487408324 -0.068051147417832  0.235872078452404  0.192264956588343 -0.187736075175352  0.064050457859643 -0.418327196887149 -0.048773366162726 -0.022435230187346
-   12  ( 12)  0.044297300522110 -0.074514001326939  0.118901139253501 -0.038102822286343 -0.180234539078099 -0.073653096009808  0.138887294279128 -0.091677465636449  0.028306780848160
-   13  ( 13) -0.218173262148351  0.031923214338008 -0.279273699043729 -0.296240798967995 -0.102538865324455 -0.347223174184031 -0.023258788555149  0.009371356192758 -0.133080599480495
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.506851617468524 -0.123312272924514 -0.319772171966197 -0.330388320949798 -0.260626910659361  0.296009143703883
-    1  (  1)  0.838664437092735  0.084048936391461  0.130519364241547 -0.058295160971861 -0.352689050307543  0.312676279191508
-    2  (  2) -0.424245733068130  0.094688985686263  0.032487769067423 -0.049840972257505  0.242182498481101 -0.258169771444316
-    3  (  3) -0.275925763607251 -0.158614048273031 -0.265637253281501  0.340924751759094  0.103748650636041 -0.182386846592538
-    4  (  4)  0.223341603531457  0.179610861622819 -0.208592953192156 -0.000066608245217  0.152150208910578 -0.043032133632034
-    5  (  5)  0.120534430442526 -0.000894933086435  0.224347489110960  0.161892180430137 -0.149801264964330  0.022483324180902
-    6  (  6) -0.049702807038789 -0.094404161160978 -0.313154542891932  0.051994095399954  0.001446348599381  0.092258679821771
-    7  (  7) -0.093785029728044  0.099189067484616 -0.172621773264165 -0.134289925799854  0.108520033167713  0.086461363864754
-    8  (  8) -1.471727910650786 -0.225056626317030 -0.045495207069456  0.027374532922661  0.530816356461179 -0.379457060782898
-    9  (  9) -0.084302204259948 -0.164047597069931  0.183683931444347  0.134877669766643  0.175065955053181 -0.089844560973618
-   10  ( 10) -0.155190058293153  0.408092440143445  0.002189167477560 -0.137730806305859  0.142300169778525 -0.008670154843836
-   11  ( 11) -0.304366562428170 -0.030234911866092 -0.185923164163158 -0.001349513433959  0.116012076536723  0.097952480510914
-   12  ( 12) -0.048670113620180  0.046580019682191  0.031004719176933 -0.396841200902567  0.122309338710921  0.023769852585632
-   13  ( 13)  0.607487233542026  0.051711095812138 -0.148321593153569 -0.095411947673119 -0.393676374240309  0.517180676529953
-
-	File 101 DPD File2: Q_ZXBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -2.452560829529818 -0.293354071897449  0.245385857181672 -0.125053748515534 -0.381838977398162 -0.401081183690855 -0.856344113897366 -0.711884204329561 -0.437567965483089
-    1  ( 15) -1.486104581846278 -0.154668985215266  0.077511478771224  0.021577231958456 -0.288356126021600 -0.079419773997215 -0.426515586859729 -0.545957025574733 -0.169727827849989
-    2  ( 16) -0.294739387603737 -1.595186950823466  0.231399556640055  0.131614824615275 -0.150904499049520 -0.828304358444007  0.140732512477017 -0.082637124209643  0.885773640790047
-    3  ( 17)  0.290505394921826  0.248809242927937  1.030950835030146  0.217191583521550  0.231534995778155  0.148626076406430  0.271218815852754  0.067613959906656 -0.069398389144441
-    4  ( 18) -0.218574875374942  0.089929643038917 -0.433511734043207  0.790672747250865  0.632440411329192  0.423247498511693 -0.411014571989387  0.061503045419557  0.194208577505009
-    5  ( 19) -1.313139066022934 -0.618501880736554  0.668264255004994  0.494952717089704  0.132327630535153 -0.074530924194515 -0.165747377154518 -0.250754279898054  0.308984392043030
-    6  ( 20) -0.284840831313155  0.451084284369336  0.073654454622948 -0.589328641378573 -0.370146833097925  0.436177279845969 -0.635726236400236  0.225861918840592 -0.002796365684946
-    7  ( 21) -0.153406552440280  0.258737024846266 -0.239543680202371  0.301388262902417 -0.839297750493704  0.877048090993896  0.390547303501850 -0.534511922505813 -0.249506968699475
-    8  ( 22) -0.433023177955431 -0.552041560188894 -0.024610946211831  0.077540459065873 -0.133043605192608 -0.230135268587080  0.433860427553137  0.399213472626220  0.263051365789356
-    9  ( 23) -0.506097311366858  0.835659578918269 -0.424309329702488 -0.272346434902667  0.224460742197186  0.118442872636669 -0.047211793817979 -0.091411572686524 -1.472411058128675
-   10  ( 24) -0.122180623441180  0.082863357186810  0.096372604097650 -0.157071941740121  0.178825366620054 -0.001685071902513 -0.093619910975294  0.100950420829548 -0.225462843127604
-   11  ( 25) -0.321261067620524  0.132341000738389  0.032838322020350 -0.265192027668083 -0.209807521747567  0.224452572282716 -0.314102262452642 -0.172558715274771 -0.047304292984641
-   12  ( 26) -0.331546035951652 -0.058111348051298 -0.050833986561178  0.340911441539955  0.000591591532536  0.162003589164510  0.052587064393920 -0.135174644956458  0.027032832494077
-   13  ( 27) -0.261060917177365 -0.352376550070747  0.241916719039106  0.104964216378030  0.151625424942235 -0.149854940930181  0.001241015089295  0.108719061992146  0.530269930665440
-   14  ( 28)  0.296300031393760  0.312875902647857 -0.257962435363950 -0.182754239066371 -0.042541534327470  0.022683659369914  0.091951675635884  0.086046872751557 -0.378910189123763
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.012617142161543  0.112381937099773 -0.385678694480240  0.044313173234011 -0.216660768512443
-    1  ( 15)  0.061796510634243 -0.067623922832911 -0.069117536392848 -0.074634681675038  0.031361417046503
-    2  ( 16)  0.074447168672154  0.190942409095979  0.234315741832266  0.118962128398907 -0.280518188732768
-    3  ( 17) -0.003288843324492  0.116920849397596  0.189661996599567 -0.038461560655366 -0.295964996404074
-    4  ( 18)  0.049604036264734 -0.119187871951736 -0.186500489894393 -0.180266209333192 -0.102978100807436
-    5  ( 19)  0.055725013880946  0.018117749866710  0.065102666786058 -0.073763029401625 -0.346488157241662
-    6  ( 20) -0.057980923808565  0.014725907136023 -0.418520133472894  0.138855376272011 -0.023445230708336
-    7  ( 21)  0.151854452198540 -0.607496786648753 -0.048401854208936 -0.091594885129488  0.009276924761595
-    8  ( 22) -0.126332096204745 -0.030983531106088 -0.023285034738236  0.028168990126250 -0.133338055120191
-    9  ( 23) -0.083903372341094 -0.154335937186597 -0.303319212494159 -0.048771154619623  0.607856230085617
-   10  ( 24) -0.162683328561470  0.408409390352239 -0.029532633430699  0.046553684421432  0.051796699656394
-   11  ( 25)  0.183950177695694  0.002391933980502 -0.185972258495596  0.031084777064328 -0.148416502157047
-   12  ( 26)  0.134084714357723 -0.137741629989910 -0.001420766193977 -0.396831432436955 -0.095516559350284
-   13  ( 27)  0.175688538790618  0.142622729596870  0.116301196333008  0.122366764083138 -0.393621171360157
-   14  ( 28) -0.090052478464024 -0.008620237604519  0.098140479362490  0.023790246180176  0.517298405990531
-
-	DPD File2: Q_ZXBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Q_ZXBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.003983666373255 -0.002353651762198  0.004933125300278  0.006596583433943 -0.002614342451578  0.002132465276882 -0.003012460159181 -0.001223503888639 -0.004889405336778
-    1  (  1)  0.201135115953463  0.151243841512351 -0.361188406461476  0.086379753849444  0.272163801945699  0.254818614317866  0.343703766885252  0.135577053527702  0.235786250904787
-    2  (  2)  0.452572939228447  0.278785922462906 -0.374242715559236 -0.396366655229040  0.292813190258060 -0.007420868883830  0.272380281383336  0.103622653171364  0.017354041500184
-    3  (  3) -0.069740114395509  0.007405040619443  0.056329917896026 -0.233066765932548  0.124667443957726 -0.172262566204308 -0.154483019725586  0.146218574276066 -0.031583387013550
-    4  (  4) -0.168082571354239 -0.075988239857436  0.101748208313577  0.016912196027717  0.443856147553522  0.157430638670053 -0.393257769588503 -0.327875483419098  0.022936217603338
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.007433715209833 -0.001517004948877  0.008313297481149  0.004622925166720  0.005645729583552 -0.002184169597483
-    1  (  1) -0.027034222192758  0.086360154536757 -0.114516476994660 -0.007663777387575 -0.059358678322294  0.001518325593955
-    2  (  2)  0.359056453197877  0.025612871962698  0.218616726319955  0.114621110907337  0.109502038643106 -0.053404466724778
-    3  (  3)  0.042602428732743 -0.175888460232533  0.009074453373936  0.147337744685697  0.001411164554109  0.014592876078209
-    4  (  4) -0.014339565652089  0.055496156658258 -0.293976988949184  0.080888392155942  0.079771717087352 -0.021301553357757
-
-	File 101 DPD File2: Q_ZXBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.003282620714986  0.005664679288576 -0.003086801053658 -0.003693900321914 -0.005269678743379  0.000901429296691 -0.001207795993955 -0.002428895511753  0.007313018280004
-    1  (  6)  0.242884322257858 -0.467994494371817 -0.085351931974429 -0.001715416703069  0.036628787206898 -0.231958392242055  0.468975363391203  0.320327479678977  0.014982833176508
-    2  (  7)  0.406386591023012 -0.098118290682955  0.573010232103244  0.128863028033736  0.157969534456746 -0.112693292775534  0.382941933554739  0.089969969691354  0.083484054987097
-    3  (  8)  0.235827881949739 -0.359662723414843 -0.201444668593835  0.299888433005399  0.398610453476842 -0.127653404035872 -0.079106949632752  0.130504803359457  0.334294361718793
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.003111745735179  0.002692426538595  0.009341842103298  0.002205650137423  0.006741804159924
-    1  (  6) -0.113746363257686 -0.075448189826302 -0.091899492069418 -0.030884246031957 -0.063462033193843
-    2  (  7) -0.027283869583893  0.118675903648485  0.389547196457847  0.022072577958594  0.006382251197348
-    3  (  8)  0.041971346710981  0.106102252104320  0.079894506673964 -0.017109706677562  0.145721778440645
-
-	DPD File2: Q_ZY_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Q_ZY_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.029552868724211 -0.012090786984276  0.068482939759800  0.006587872357708  0.067252594152802  0.036842394187700 -0.007117570009899 -0.032320686376030 -0.029089112307392
-    1  (  1) -0.213653767690103 -0.028153888862101  0.314079796683866  0.017068466152245  0.375888522199907  0.257053852917044  0.011921528866969  0.059385104504110 -0.060994806711073
-    2  (  2) -1.415860929430990 -0.658487925410427  1.067008798150550 -0.337507446167742  0.063918717814757  0.111624530781545  0.601654980676806  0.703470688724419  0.100498607118445
-    3  (  3)  0.036224770061911  0.142036374749427  0.166080800401930 -0.398756400592409 -1.154779674457841 -0.323290423120714  0.625779247465735 -0.310843980143136  0.194430913262496
-    4  (  4)  0.216167941594352  0.125954715766933 -0.597080876886763  0.091488826716116  0.354481843623787  0.386559164252613  0.737580263602502 -0.004323673156499  0.431570165801849
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.067344578071882  0.018002028513115 -0.006736420918309  0.011057399869179 -0.039042734588826  0.022316741635117
-    1  (  1)  0.154593832425177 -0.031056774704003 -0.017509680342204 -0.043192844861057 -0.051029596599146  0.017695344972824
-    2  (  2)  0.120858991371896 -0.202629045997310 -0.210252380955293  0.084415928651666  0.075143744631989 -0.181030920230081
-    3  (  3) -0.182098393102296  0.273397420336855 -0.169656403658152  0.500932931390355 -0.174093852893344 -0.034076041924340
-    4  (  4)  0.052123951285458  0.347412092720287 -0.334461423425518 -0.267600772918557 -0.067727490664997 -0.025021459769394
-
-	File 101 DPD File2: Q_ZY_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.032226976198718  0.045661938218276 -0.103780707516731  0.022738706155801  0.006114547541344 -0.008715007772506 -0.000406250936894  0.012835570776838  0.066817571454234
-    1  (  6) -0.469774435546931  0.750778092218380 -0.082468553040984 -0.313520475438351  0.381209949393646 -0.716831585179108 -0.232630851604267  0.363203673620615  0.168544634889542
-    2  (  7) -0.701123420984566  0.955807783218331  0.315239120103576 -0.074002978230075  0.218484137356380  0.236997767457141 -0.356119865511778 -0.492683755022539  0.029487097950503
-    3  (  8) -1.231033497453453  0.751067214448950  0.377977797626086 -0.236463685484809  0.545910595188220 -0.018542864675254  1.000115092742505 -0.005765755176850 -0.109291556700302
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.005148323529480  0.024059905128524  0.005047832013405  0.006419449288222 -0.043076812447681
-    1  (  6)  0.026688401889087 -0.224875695979734 -0.018204008587849  0.085412454766648 -0.018596286023125
-    2  (  7)  0.054314414878613  0.438950921897505  0.224278092321833  0.148272224357174  0.186808794914827
-    3  (  8) -0.426297609422135  0.453452046862797 -0.402777523724423  0.089035917412808  0.012668721974473
-
-	DPD File2: Q_ZYBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: Q_ZYBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.183113492974552 -0.019155249920488 -0.029414410031321 -0.104332044589643
-    1  (  1) -0.014986838026268  0.456208739737301  0.496096237769932  1.260223229970932
-    2  (  2) -0.083552336449296  1.603811510672729  0.296932918157193  0.506439147201208
-    3  (  3) -0.054629743368394  0.482393973093855 -0.431705217833494 -1.072915958338034
-    4  (  4) -0.019855532415157  0.074855839337550 -0.054813180657032 -0.128101573033608
-
-	File 101 DPD File2: Q_ZYBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5) -0.183114920519781 -0.015323279665094 -0.083550871538948 -0.054287056546782 -0.019635673621509
-    1  (  6) -0.018583856504190  0.459926178818044  1.603723039016419  0.483945733467738  0.072675317603419
-    2  (  7) -0.029304394392622  0.501501570704140  0.288553978608740 -0.426398677957415 -0.057207620590045
-    3  (  8) -0.104419344410532  1.266843771351296  0.491593164713869 -1.059879379279394 -0.128974149716998
-
-	DPD File2: Q_ZYBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Q_ZYBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  5.360951233046640  2.692798200640125  1.220104874187389 -0.357660273909617 -2.070077113802377  0.902589467326102 -0.363953318737363  0.307391101819755  0.481218709838381
-    1  (  1)  0.877247782108379  0.766209717481105  3.765536366292496 -0.232141689647508 -0.868330404065230  1.397550226616591  0.198954770331920  0.789470574082564  0.343838333365764
-    2  (  2)  0.364050013320412 -0.032191992008470 -0.379948892671640  0.903658291699696  1.378774377873059  0.052962827326198 -0.619972693658452 -0.119533831724703 -1.111532226202491
-    3  (  3)  0.864153577358945  0.115407451736855 -0.593820450452942  0.082415227574979 -0.896322200318177 -0.206568188385829  1.031914705393776 -1.516375358321331 -0.037564960493691
-    4  (  4) -0.187356147069814  0.204900244645625  0.505213932526079  0.366572057098164  1.259568976247780  1.217870862267439  0.630646031828998  0.886121074119630  0.292713468615236
-    5  (  5)  2.307244443497588  0.146952177623651  0.823126103453695  0.815781933963058  0.283474030249305  0.119316476301075 -1.556938474910068 -1.918799531882256  0.200794358317896
-    6  (  6)  0.999929817150612 -0.009879459677370  0.532894247670965 -0.119316902560033  1.185029416130923  0.365478190089731  2.390912867658629 -0.651667483205356 -0.433383408007920
-    7  (  7)  0.601394286089563  1.099657963273472  0.563425281618900 -0.591301544328125  0.252100174276413  1.261046957456791  0.118292395101533  1.117218126442026  0.169205181814331
-    8  (  8)  0.571403760791916  0.616597898552471 -1.857086938821677 -0.253108661744386 -0.166765536432630 -0.583354574407550 -0.209900488709868  0.010230926163718 -0.436478429708121
-    9  (  9)  0.209747299861770  0.038108419514222 -0.064537214176209 -0.007275943563652 -0.185703840121506 -0.141415304618201 -0.048928168952213 -0.144641032490529 -0.007113952535538
-   10  ( 10) -0.528917371193515 -0.405481935690602 -0.127287504633020 -0.186945059578633  0.351138728761902  0.556593402472593 -0.260559175767430  1.273226681393493 -0.139887516226760
-   11  ( 11) -0.046333044169863 -0.130145741301105  0.246982397492458 -0.245073892054749  0.413512266355639  0.093777790023920  1.313818702926236  0.204836400875976 -0.274511526614319
-   12  ( 12) -0.310127818709089  0.038293243379654 -0.132269091260197 -0.216358262562713  0.103017277322460  0.195528693138779 -0.097003003799161  0.628396859230412 -0.000835754733914
-   13  ( 13)  0.137253902359117  0.329242072065084  0.058655541997836 -0.187659849170682  0.133211284576206  0.224953542396808  0.080970111421629  0.032052228677688  0.444388375606088
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.578426138362048  0.071143247029465 -0.200641446668603 -0.394425009590772  0.091103550454678 -0.308998982593138
-    1  (  1) -1.883033737487733 -0.331990463074909  0.377210418761052 -0.001853600774245 -0.292916270677594 -0.078756267610642
-    2  (  2)  0.454544036870719  0.127944564815060 -0.260470007540829  0.311908668285056 -0.346176272137431 -0.112577837112077
-    3  (  3)  0.524546935261907  0.774579123649812  0.319497757558062 -0.597922896459268  0.123968012912054  0.075764061045705
-    4  (  4)  0.081830355405225 -0.089332716576273  0.464669505348895  0.522820306788420  0.208352633066704 -0.149018029577851
-    5  (  5) -0.087898620649583  0.372688904622524 -0.667131349021728 -0.333530032746713  0.387061380003103 -0.157085288313622
-    6  (  6)  0.351550280184077  0.201786561762424  1.154374714468388 -0.191249055431593  0.052879268342601  0.060266216491085
-    7  (  7)  0.241046667679705 -0.346723327516737  0.138221944436218  0.525994526828183 -0.131107511017704 -0.082870474604600
-    8  (  8)  3.197601115795361  0.634062286554303 -0.352759559329291 -0.172901070625571 -0.985124548987110  0.995624657058980
-    9  (  9)  0.382805543090693  0.172265373302413 -0.111470290531661 -0.367072489885716 -0.068385914917459 -0.074411606767888
-   10  ( 10) -0.083172271767999 -0.353536915838163  0.330710864812354  0.037706373264966 -0.356898862008954 -0.058964088026598
-   11  ( 11)  0.183552926494685  0.327247809312295  0.364560763821055  0.096049891497978 -0.159009797538618  0.083303877914261
-   12  ( 12) -0.079816813859873  0.072587983653898 -0.071322160174810 -0.003907017234655 -0.266450558063296  0.054886931715625
-   13  ( 13) -1.495679627370525 -0.108859512825657  0.126296843375062  0.041442735094546  0.417893799160475 -0.269622266251739
-
-	File 101 DPD File2: Q_ZYBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  5.353505141165546  0.890688859557432  0.370986991492220  0.853423503631065 -0.175579535476913  2.310024166184490  1.006204075207132  0.594737573040884  0.580912757243584
-    1  ( 15)  2.699239529253951  0.764443250041726 -0.033891490675767  0.110545474137795  0.207971565761542  0.144896702873739 -0.011665154649099  1.099560303882922  0.622352626705053
-    2  ( 16)  1.217983749973932  3.764925493121569 -0.382606170318571 -0.590096731144521  0.500877090215735  0.821277057629923  0.525498183844259  0.564162067732067 -1.863924914608564
-    3  ( 17) -0.354378865275301 -0.235517234537521  0.904059819746174  0.081778776047408  0.366152127151403  0.811195163293337 -0.115460016783434 -0.584082592819068 -0.251614634578761
-    4  ( 18) -2.068328882054058 -0.868493189733572  1.383062082889841 -0.889004990074110  1.252079532403483  0.280363659094828  1.179107716558007  0.260223380378208 -0.169071425930085
-    5  ( 19)  0.896860010886759  1.399700044153152  0.055611982090691 -0.204054666569984  1.218046417960395  0.118995521046613  0.368895192443561  1.262795992609439 -0.585037262838195
-    6  ( 20) -0.366637507848360  0.197259762996753 -0.625793698825295  1.034813181912127  0.632152731683643 -1.556944750011882  2.391591655950920  0.115182881667896 -0.211264316589643
-    7  ( 21)  0.304826000780040  0.789394296489110 -0.119156637586011 -1.509731643923624  0.880539480584384 -1.918887457585959 -0.654178779681708  1.119814351020919  0.004695271666279
-    8  ( 22)  0.482673161434467  0.341764670705712 -1.114860194148782 -0.036661800416755  0.293226328632846  0.198937250412172 -0.433178052673118  0.170008110377442 -0.435678840938016
-    9  ( 23)  0.568809995257824 -1.874744812516267  0.457495936532682  0.523861440209940  0.084814462127761 -0.090388820008976  0.353391274922666  0.242340258320801  3.196555172716930
-   10  ( 24)  0.070335835358122 -0.330650173154532  0.126776784766783  0.772543265810599 -0.085884670580227  0.373009134942036  0.202786679587987 -0.349382742604520  0.636682150412552
-   11  ( 25) -0.198633655276233  0.377502815878866 -0.258791029874716  0.318244103545271  0.463863792456558 -0.666810847217600  1.152788198213469  0.138659403225890 -0.352130337593852
-   12  ( 26) -0.396901806546964  0.000395285484119  0.310508766643833 -0.601280056476283  0.526252062566165 -0.332539317400707 -0.191083130251521  0.521826702050678 -0.172519578082087
-   13  ( 27)  0.091351513735343 -0.293128213798388 -0.345330574903456  0.125609568290854  0.206375849513224  0.387475344491849  0.052511328809426 -0.130081029254173 -0.986253343969630
-   14  ( 28) -0.308104497916485 -0.079095998516156 -0.111812378605463  0.074847508726824 -0.148580287539640 -0.156369183783182  0.060723799046636 -0.083364531892640  0.996547838811843
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.202668000464361 -0.522005316857815 -0.047438780537185 -0.307836616438326  0.139276639627676
-    1  ( 15)  0.036301645667224 -0.408693148732606 -0.129466422170618  0.038156420592379  0.328909687255469
-    2  ( 16) -0.061411263263283 -0.130911966368035  0.248587665898269 -0.132943428674306  0.058094285835748
-    3  ( 17) -0.006444941345020 -0.189328821232246 -0.247663855883141 -0.216841465123872 -0.188758126911417
-    4  ( 18) -0.174882495068945  0.352059542473143  0.415457742715615  0.103379942414574  0.134308245258646
-    5  ( 19) -0.139662167305942  0.559445806987568  0.092833979039118  0.195985083464074  0.225502233166089
-    6  ( 20) -0.050036885646758 -0.261079528741436  1.314976093463703 -0.097097007122576  0.080738973098351
-    7  ( 21) -0.139571528354083  1.274371934387910  0.205626509359679  0.628369271820743  0.032328517281743
-    8  ( 22) -0.007083324404061 -0.141460741245176 -0.274184199497861 -0.000997758723955  0.443965607091155
-    9  ( 23)  0.383064190737188 -0.080702339917536  0.182521216411565 -0.078746180366527 -1.495050228794565
-   10  ( 24)  0.170090225393199 -0.353075382711013  0.327690489245921  0.072940960473288 -0.108603449735698
-   11  ( 25) -0.111060583178837  0.330445456105407  0.364666825850954 -0.071352356473691  0.126399272365111
-   12  ( 26) -0.371089628890737  0.037216243105304  0.095990843882462 -0.003846246071552  0.041271278631872
-   13  ( 27) -0.066908426584578 -0.356205971328699 -0.158985300207994 -0.266453168087701  0.418014608875444
-   14  ( 28) -0.074914522268607 -0.058696973494151  0.083202963234434  0.054875862837609 -0.269527522173395
-
-	DPD File2: Q_ZYBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: Q_ZYBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.029788620507893 -0.011938329127465  0.068273509474652  0.006608163500201  0.066809621565168  0.036248735989190 -0.007037628394506 -0.031617432097739 -0.029157043626897
-    1  (  1) -0.207811299205550 -0.072668392092003  0.275181722630279  0.031799375814548  0.412015868705937  0.264039641738986  0.002732818131385  0.048610613827444 -0.073466897200643
-    2  (  2) -1.409212746391881 -0.615283779048791  0.973116698528813 -0.317311423592346  0.066232813236537  0.090615092187427  0.589649919279850  0.666093653624415  0.122910191660261
-    3  (  3)  0.018931059416101  0.095495887908358  0.148007879674709 -0.407897274323649 -1.138069396579467 -0.290766885239806  0.602248159921183 -0.270975491959150  0.204899880433037
-    4  (  4)  0.192338141542218  0.121289777758424 -0.564798574419255  0.120372528792873  0.302925085448342  0.375066280689552  0.701144482076972 -0.013931949716402  0.417689073827744
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.066335748617021  0.017592894427430 -0.006633003641402  0.010518228542818 -0.038447224768607  0.021783813505935
-    1  (  1)  0.133121100586288 -0.034708776594714 -0.013148203407377 -0.037106561215713 -0.046839856184517  0.015841779346747
-    2  (  2)  0.073954369688987 -0.199911599534852 -0.187710702021101  0.087631365070933  0.075967192792968 -0.180035954611313
-    3  (  3) -0.190488658603295  0.257026169801377 -0.153541847940925  0.476220664878281 -0.164289641341438 -0.025116032681626
-    4  (  4)  0.079770210612789  0.335365137191353 -0.306987596230603 -0.257032293506196 -0.061214777318568 -0.022845423906988
-
-	File 101 DPD File2: Q_ZYBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.032151491375372  0.045516746488014 -0.102781737835612  0.022481221627501  0.006175010696377 -0.009274495720830 -0.000544447375209  0.012153632639189  0.066169443302312
-    1  (  6) -0.449720792780689  0.686798680183923 -0.124569019631082 -0.303964393794838  0.355423933103665 -0.720237081425067 -0.239810719167573  0.341042714384499  0.140689721101496
-    2  (  7) -0.702789387361410  0.875521189944887  0.305785020861818 -0.074047880881526  0.238445552160892  0.207042784808629 -0.350025587205443 -0.482374288594554 -0.013112484954988
-    3  (  8) -1.224567499181353  0.687299596482771  0.391346208534734 -0.285596817553042  0.532028212183931 -0.015314824081747  0.958505046307769 -0.004571205051097 -0.147828673371976
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.004832334700531  0.023216249232221  0.005002981530126  0.006310667249010 -0.042396337097595
-    1  (  6)  0.014241313650309 -0.208202651299433 -0.016534816565328  0.088005078276853 -0.009840669973197
-    2  (  7)  0.044204167225996  0.422787697609623  0.204490198883489  0.143279060616817  0.179780316729728
-    3  (  8) -0.420374780271730  0.436793419502513 -0.369111713277317  0.088297039397212  0.022457686151177
-
-	DPD File2: Q_ZZ_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_ZZ_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015805010890013  0.007662552583137 -0.004869511093731 -0.042828245957435  0.049795740415831  0.016144780099332  0.013431751987806 -0.027012139216648  0.033908143187443
-    1  (  1)  0.393360806762455 -0.468804882796836 -0.150116177304800 -0.507027917219422  0.137975376245431  0.085130802379916 -0.483088417689608  0.131208690977580 -0.013364483328965
-    2  (  2)  0.565775165684129 -0.304846178259490  0.779660823913550 -0.580561831255475  0.097661105631508  0.001728443456858 -0.587223089016234  0.427468123261642  0.371041384551499
-    3  (  3)  0.091930157208878  0.512430607327817  0.635510108902741  0.426083595766797 -0.306377707772481 -0.586776561787950 -0.273247267629228 -0.030747721374120  0.051843987371562
-    4  (  4) -0.028769577490140  0.134923959876210  0.175776450261355  0.401862425868490  0.523645649293939  0.240578166639504 -0.168027277142192 -0.166607038904895 -0.274764143018347
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.032687978959947 -0.004261104475933 -0.010320410418861 -0.000456155878369 -0.000443350720327
-    1  (  1) -0.057708502920139 -0.057552346751761  0.142116511670337  0.005767682080360 -0.059348236694845
-    2  (  2)  0.251941670166408 -0.065088272123292 -0.366694691480255  0.031985238309668  0.108240104557277
-    3  (  3) -0.511089717381913  0.113920287281710 -0.157445863728503  0.116287376069240 -0.016125551742689
-    4  (  4)  0.104361227579280 -0.292238173801909 -0.140449600347555  0.350762949165790 -0.181293643136767
-
-	File 101 DPD File2: Q_ZZ_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5)  0.023094741948525 -0.076943984388683 -0.006270906444725 -0.044999723553096 -0.020107961802868  0.062949427030808 -0.007524409882087  0.012454910119283 -0.010446965890069
-    1  (  6) -0.263209232157014  0.930029343319844 -0.622319042215194 -0.040874929018383  0.037557773153990  0.404699292312064 -0.754333626524755  0.083418609216488  0.051350918944674
-    2  (  7)  0.160276561541878 -0.122148316369601 -0.286986386738803  0.298628028016512  0.037593646956123 -0.052895657639785 -0.291790630741324  0.722384025573655  0.044590975231341
-    3  (  8)  0.356713022630655 -0.026302727731867 -0.254853177799768 -0.072630246056358 -0.135320120212841 -0.293880175780608 -0.475917511086395  0.611118407287940  0.119489444112537
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.012985435185129  0.000999932860465 -0.011398102574237  0.004818728768634  0.004018288355379  0.005893914349470
-    1  (  6)  0.033565556750669 -0.030368577027576  0.113216987201192 -0.070875713218422  0.017969218174201  0.121772489465190
-    2  (  7)  0.301619533293457  0.390378647195220 -0.038380629687049  0.099740539353828  0.167175921856391 -0.118174234810172
-    3  (  8)  0.326830506943116 -0.456339112851789 -0.439722982966245 -0.300799929148339  0.099746766834350 -0.108035341657110
-
-	DPD File2: Q_ZZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     5
-	   Irrep: 1 row =     4	col =     4
-
-	File 101 DPD File2: Q_ZZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  0)  0.853563549496115  0.015681401646620 -0.039031389102563  0.064226141568326 -0.013666277171383
-    1  (  1)  0.015251764593996  0.436891693349508  0.168420848483707 -0.651819542577400  0.096972018352051
-    2  (  2) -0.038223224201309  0.174392356936811 -0.051734187594216 -0.510569531297925 -0.164883482012108
-    3  (  3)  0.062781578155238 -0.653331466213418 -0.501234673121588  1.260709625301546 -0.174621415129705
-    4  (  4) -0.013394513069410  0.099286425836220 -0.160341825804832 -0.169885185470731  1.343553924238690
-
-	File 101 DPD File2: Q_ZZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.853632243925712 -0.016279251364738  0.003012194060777 -0.003362348160419
-    1  (  6) -0.016725689546086  1.101936726808663 -0.167990335416704 -0.276276546445200
-    2  (  7)  0.003752142525371 -0.170011603092554  1.025158719279859 -0.310414578488882
-    3  (  8) -0.002693130854012 -0.273439075659264 -0.309633135321107  0.292108715119745
-
-	DPD File2: Q_ZZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Q_ZZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -2.641856829643082 -0.405060117907360  0.346660516911670  1.141318206404241 -0.556426328007946 -1.222732732624787  0.356759868080590 -0.945089345612717 -0.512067462800290
-    1  (  1) -0.403711094853864 -0.686793635365198  0.155483370683149  0.313741934895442 -0.505822681751364 -1.019010240966351 -0.968634972068689 -0.109501827528875  0.958616616786558
-    2  (  2)  0.339972222600392  0.160735116433891 -1.294884172340434 -0.003005044689978  0.107124297508237  0.091376725500167  0.190673875307638 -0.053460745793638 -0.223980302448516
-    3  (  3)  1.144633652586498  0.315751866530427 -0.008263905035571  1.462651993095119  0.373697037227193 -0.683996197586520 -0.806585248093790 -0.222188682969317 -0.591052217684897
-    4  (  4) -0.555694054473354 -0.511911612662193  0.105443968175155  0.374035590726097  1.817861667960512  0.877460988101697 -0.245659429928804 -0.094343886632507  0.166444773630775
-    5  (  5) -1.220639470766330 -1.022027608481463  0.092721094271904 -0.680281747832080  0.874271170210712  0.748624206637355  0.232951713746319  0.009597398563475  0.191017576723458
-    6  (  6)  0.363636521231196 -0.970953560016001  0.190007354441637 -0.810244260782785 -0.247976261768535  0.233287130135988  0.117262606462514 -0.222021858954878  0.255603360332763
-    7  (  7) -0.947783608577302 -0.104942629293219 -0.049800629178403 -0.217713479376353 -0.098825629318717  0.004441891526938 -0.225011286937350  0.287338881600021 -0.040635364614443
-    8  (  8) -0.511114418268192  0.956569964563537 -0.220531663339489 -0.595894000905966  0.166376253545526  0.192264860770888  0.251225422502002 -0.037551016765897 -0.660682439875718
-    9  (  9)  0.331480616470501  0.009441721275033 -0.148183030793943 -0.159400741397861  0.096957071076460 -0.177071477839961  0.066267799795444 -0.101742860538742 -0.153624931352634
-   10  ( 10) -0.178865620178644  0.573123249450538 -0.423217956219736  0.269738689161524 -0.208897381666842  0.004126877612964  0.023340557916286 -0.181745599567912 -0.174347570023630
-   11  ( 11)  0.461403498622215 -0.160261353071262  0.068370172205364 -0.098823249166667 -0.269524849755263  0.228067851512405 -0.330287475649405  0.077219779157512  0.141256064395668
-   12  ( 12) -0.283524546524998  0.300129419512455 -0.138696827840597 -0.024568685119178 -0.235680083284321  0.077517598984291  0.099640112256573 -0.119870893923145 -0.137857920955083
-   13  ( 13) -0.469118388625709 -0.548729562062602  0.679254754610490 -0.081304065832083  0.002518361315762  0.056983206441607  0.119464738039939 -0.146309071336814  0.629594067385135
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.331286479870516 -0.178299814555056  0.459211752300562 -0.283509280495904 -0.468356787803585
-    1  (  1)  0.006246822634805  0.571393658943888 -0.159730624748198  0.301351547586922 -0.549912219608613
-    2  (  2) -0.151572889833143 -0.423017447327870  0.066533734683458 -0.137144276471085  0.678682951929170
-    3  (  3) -0.168514129817360  0.271140429448862 -0.096553786219071 -0.025137887642710 -0.081857063050439
-    4  (  4)  0.105396124046444 -0.209479096882914 -0.269970762814754 -0.236516886390601  0.003294154690839
-    5  (  5) -0.170708568683610  0.004023444992547  0.227903459735085  0.077571704813243  0.057151838144038
-    6  (  6)  0.067988452700199  0.023607796350385 -0.329746556975495  0.098523788336403  0.120021433068123
-    7  (  7) -0.105594709612058 -0.180004045276367  0.077066538122078 -0.119510931819174 -0.146466164305568
-    8  (  8) -0.150623241672292 -0.174444363193418  0.139377393289946 -0.138302176707312  0.630490341349754
-    9  (  9)  1.032560886688005  0.123483578563735 -0.151419344567541  0.040522628740088  0.109125561582496
-   10  ( 10)  0.121324105221099  0.504982527324808  0.004279591187211 -0.247534658680150  0.028730454216480
-   11  ( 11) -0.151652174537675  0.003964581855070  0.399313788307133  0.042847879586619  0.152491376221872
-   12  ( 12)  0.040229853846607 -0.247530203132786  0.043007302909972  1.225991841426971 -0.016845607715942
-   13  ( 13)  0.109276452287361  0.028869394774969  0.152298161962250 -0.016758942396192  0.017342212390064
-
-	File 101 DPD File2: Q_ZZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.576259390590003 -1.103418497883686  0.906918794547638  0.544783587722223  0.632705235402040 -1.477126448983762  0.848553659346683  0.125647406863601  0.228708925326222
-    1  ( 15) -1.104332136892787  0.716484691434106 -0.024555915124844 -0.497236487152463 -0.230486845716782  0.234199954698472  0.420660043594540 -0.422936768768656 -0.141427297936729
-    2  ( 16)  0.909141499669234 -0.020696668651917 -0.095470407904147  0.323177344196312  0.521415276461338 -0.830950836396210 -0.658131953986708  0.781685511079047  0.007476766513987
-    3  ( 17)  0.541501465216203 -0.493063919490985  0.322612166623171  1.962373239607858  0.196575761167305 -0.736511519164693  0.215907699554063  0.623281242169568  0.158997487137606
-    4  ( 18)  0.632663039331048 -0.229141103589237  0.518591897070169  0.198346334478745  0.415780625736661 -1.044643631684195 -0.131141863066652  0.288301096435349  0.258269596926712
-    5  ( 19) -1.472527499288766  0.231422169772367 -0.835104830919680 -0.737080057846334 -1.046523551900493  1.195985758783965 -0.230264694719466  0.052024561225259  0.080215729181008
-    6  ( 20)  0.855182057614495  0.421973354635660 -0.659581628675088  0.218156606726095 -0.129005055490642 -0.227472508327257 -0.303850491816763  0.111901898194119 -0.391026138001500
-    7  ( 21)  0.112958708216987 -0.421924985211880  0.787596594911935  0.626449995523018  0.286854733166881  0.048366523148120  0.114087653154335 -0.146705767774184 -0.083827575301180
-    8  ( 22)  0.225957513349869 -0.139267649604740  0.007770795210319  0.158385175012573  0.258468268394644  0.080959674050946 -0.391129597469178 -0.085401209542950  1.026535431366531
-    9  ( 23) -0.672454814924820 -0.366283558442426  0.690137034815393  0.155448094987065  0.077900627122909  0.411210664971109 -0.018032120723452 -0.091213105790239  0.241382046232083
-   10  ( 24) -0.122580165740218  0.132214001890015 -0.251391773258414 -0.096500285739661 -0.102011501987128  0.068218422433817 -0.212829665076840  0.497714313750895 -0.018953515147643
-   11  ( 25)  0.415557172678060  0.055457837855031 -0.313413526696419  0.114838557696991 -0.189841373910197 -0.197501710628650 -0.439621773109452  0.089966565041514  0.132264543458788
-   12  ( 26) -0.178859425134204 -0.315433338014519  0.480474577498600  0.155449616454588 -0.151714136554750 -0.150563942794371  0.034041811765661 -0.112651450003132  0.055885637999148
-   13  ( 27)  0.136652880840373  0.466970799200203 -0.262460677500734  0.079592181799911 -0.044084119514923 -0.130508125533189 -0.096309007596160  0.169136306889481 -0.072059819214781
-   14  ( 28)  0.424823829022000  0.317250325822912  0.524886417052750  0.544877368232479  0.494145363476872 -0.149970986425442 -0.099739349439893  0.074681025382372  0.159104129861470
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.667435212440517 -0.122808834981887  0.411442413457623 -0.180358792666258  0.138835399925770  0.422351504024319
-    1  ( 15) -0.370440762029650  0.132318857894821  0.057132087572679 -0.315321117982554  0.467566992863774  0.318829225029424
-    2  ( 16)  0.691757677255539 -0.248638022681395 -0.310546897187199  0.481953759869177 -0.263895820584321  0.525819543347041
-    3  ( 17)  0.154098477782660 -0.100945280066479  0.114147409802098  0.153748024591967  0.078706217598665  0.545676395040428
-    4  ( 18)  0.078698484474843 -0.099504829719569 -0.188729059691663 -0.150792738520330 -0.043563822145987  0.494293235317020
-    5  ( 19)  0.412756524989396  0.067169267157939 -0.199241629741775 -0.151609219824191 -0.129360696374898 -0.150180308123786
-    6  ( 20) -0.012992028949008 -0.210507618640215 -0.438876307570813  0.034806975310717 -0.097030679922998 -0.099816755361348
-    7  ( 21) -0.096230860260879  0.497280841998682  0.090517213432258 -0.111886434448687  0.168878329120874  0.074194063469865
-    8  ( 22)  0.239742728582499 -0.019064230704987  0.133202653015265  0.056046328359474 -0.072391212023069  0.159633828083939
-    9  ( 23) -0.552689131411744 -0.181042490140331  0.265606529171326 -0.075084979090588  0.416127984367856 -0.374629989767504
-   10  ( 24) -0.179578347881469  1.061899711332329  0.064396476149156  0.021458281514783  0.065286064633530 -0.121379940604002
-   11  ( 25)  0.266978714175710  0.064699124416861  0.407544656506600  0.002981418689545 -0.078067512883021 -0.114270821989465
-   12  ( 26) -0.073977346163128  0.021399583433247  0.002954549380794  0.567688983505060  0.052448779674176  0.226607306199950
-   13  ( 27)  0.415307022012844  0.065044857094832 -0.078256634530747  0.052540451804823  0.597740289635366  0.591161821175219
-   14  ( 28) -0.374130407357765 -0.121296118767614 -0.114550815919605  0.226496605489212  0.591416024755197  0.978268404453969
-
-	DPD File2: Q_ZZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: Q_ZZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.015146733045961  0.006762003122969 -0.004595378571052 -0.040726496539746  0.047577208829584  0.015472655871777  0.012527812415120 -0.025482782090663  0.031884875224379
-    1  (  1)  0.386055175426041 -0.451401139829299 -0.162894602647268 -0.515447725443949  0.157873121544128  0.105718557311023 -0.465681087851789  0.127368881463582 -0.000108053593854
-    2  (  2)  0.569801765577310 -0.286012531104041  0.764111112742137 -0.542916015219223  0.084363525638372  0.032635641648621 -0.564137422823406  0.416196547327115  0.370951489113615
-    3  (  3)  0.111404806775960  0.462572492990957  0.624082111476765  0.416889185312431 -0.304830348781726 -0.556960878438200 -0.260275074473444 -0.022944853694865  0.035035229349562
-    4  (  4) -0.027266653622739  0.127267960986253  0.178632469476350  0.393122281207878  0.517977081659939  0.235802989125245 -0.165139218809937 -0.160053700976661 -0.276318740574032
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.031115710935762 -0.004197291258918 -0.009756781319670 -0.000489477121266 -0.000186888643085
-    1  (  1) -0.056967214482923 -0.054068999860299  0.134461314557184  0.008904829709852 -0.056014442303224
-    2  (  2)  0.220743334383219 -0.031562985505038 -0.366981087621499  0.046879720085066  0.093930024627293
-    3  (  3) -0.453412469521075  0.131863519601616 -0.155577333392499  0.108696433293756 -0.025607675250635
-    4  (  4)  0.086628828036953 -0.271368422023246 -0.133426790684392  0.307184156353567 -0.173718423548252
-
-	File 101 DPD File2: Q_ZZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5)  0.022241620366528 -0.073973384837769 -0.006460990025330 -0.043639897345221 -0.019306837001585  0.060629672729983 -0.007529702766219  0.011946522064103 -0.009950588697497
-    1  (  6) -0.244020127005340  0.848067847532386 -0.599429545143807 -0.059921146862186  0.021971261257347  0.423358904507377 -0.734973608498589  0.069697189499884  0.050694373349450
-    2  (  7)  0.153331973935619 -0.095297328904295 -0.283463749933624  0.307809707775482  0.019181753914873 -0.044588685378692 -0.278872227431640  0.690230077127238  0.040267742560245
-    3  (  8)  0.353108891440444  0.000980439104948 -0.252774886730227 -0.081516232407094 -0.151084074925874 -0.302609408403965 -0.465888537710892  0.590892023908255  0.123132685558181
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.011974860197001  0.000856551905493 -0.010713166392164  0.004557888817131  0.003980937702872  0.005494012982669
-    1  (  6)  0.047122198903018 -0.030233353365671  0.104545669468835 -0.061288588785142  0.007690778196140  0.111401996878142
-    2  (  7)  0.311017882119154  0.348827996890786 -0.049600087846811  0.111749331922130  0.156587275771940 -0.106965969809923
-    3  (  8)  0.319473314625526 -0.423254924091369 -0.437373022128648 -0.265745968377715  0.083892684165171 -0.095815964886312
+	Computing P_X-Perturbed Wave Function (0.000 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         8.791849505480
+	   1         9.874826203575    2.079e-01
+	   2        10.415122648198    1.004e-01
+	   3        10.434344977555    3.529e-02
+	   4        10.441342562141    1.361e-02
+	   5        10.442871941875    5.151e-03
+	   6        10.443282191957    2.216e-03
+	   7        10.443461544673    9.411e-04
+	   8        10.443396791129    3.834e-04
+	   9        10.443410427151    1.235e-04
+	  10        10.443417458181    4.765e-05
+	  11        10.443410372840    1.289e-05
+	  12        10.443404691606    3.554e-06
+	  13        10.443403491039    8.645e-07
+	  14        10.443403391653    3.217e-07
+	  15        10.443403375807    1.324e-07
+	-----------------------------------------
+	Converged P_X-Perturbed Wfn to 5.683e-08
+
+	Computing L_X-Perturbed Wave Function (0.000 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         4.886661193644
+	   1         6.056741276424    3.035e-01
+	   2         7.155869457435    1.783e-01
+	   3         7.200400055753    4.476e-02
+	   4         7.231758703162    1.895e-02
+	   5         7.233814775343    6.466e-03
+	   6         7.234478515688    3.100e-03
+	   7         7.235145006256    1.290e-03
+	   8         7.235054395382    5.109e-04
+	   9         7.235048179821    1.584e-04
+	  10         7.235049145576    5.400e-05
+	  11         7.235061983163    1.702e-05
+	  12         7.235063878329    6.080e-06
+	  13         7.235062645981    2.029e-06
+	  14         7.235062217033    7.304e-07
+	  15         7.235062029299    2.737e-07
+	  16         7.235061929719    1.061e-07
+	-----------------------------------------
+	Converged L_X-Perturbed Wfn to 4.463e-08
+
+	Computing P_Y-Perturbed Wave Function (0.000 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         9.142006738662
+	   1        10.624821273094    2.763e-01
+	   2        11.570599760470    1.363e-01
+	   3        11.606723108902    3.199e-02
+	   4        11.615453593556    1.430e-02
+	   5        11.617276086274    3.644e-03
+	   6        11.617146399254    1.215e-03
+	   7        11.617330671579    3.699e-04
+	   8        11.617324722217    1.475e-04
+	   9        11.617299748660    7.453e-05
+	  10        11.617306054457    3.554e-05
+	  11        11.617312362817    1.275e-05
+	  12        11.617315055975    3.776e-06
+	  13        11.617313282606    1.308e-06
+	  14        11.617312708341    5.317e-07
+	  15        11.617312512623    1.794e-07
+	-----------------------------------------
+	Converged P_Y-Perturbed Wfn to 6.034e-08
+
+	Computing L_Y-Perturbed Wave Function (0.000 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         0.250096256322
+	   1         0.332522411605    8.410e-02
+	   2         0.417303491137    5.141e-02
+	   3         0.423284199690    1.414e-02
+	   4         0.425106258625    3.705e-03
+	   5         0.424977847406    1.123e-03
+	   6         0.424958663236    4.533e-04
+	   7         0.424998418546    2.392e-04
+	   8         0.424985241882    9.820e-05
+	   9         0.424989207896    2.255e-05
+	  10         0.424989689818    8.188e-06
+	  11         0.424989142717    2.336e-06
+	  12         0.424988579794    8.196e-07
+	  13         0.424988534419    1.946e-07
+	-----------------------------------------
+	Converged L_Y-Perturbed Wfn to 8.886e-08
+
+	Computing P_Z-Perturbed Wave Function (0.000 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         9.517222057223
+	   1        10.765478514721    2.474e-01
+	   2        11.512737139486    1.157e-01
+	   3        11.522021410445    2.789e-02
+	   4        11.525146414925    1.213e-02
+	   5        11.526724013900    3.629e-03
+	   6        11.526779277380    1.364e-03
+	   7        11.526909415111    5.798e-04
+	   8        11.526912921185    2.172e-04
+	   9        11.526894658061    6.328e-05
+	  10        11.526898204928    2.000e-05
+	  11        11.526900096085    7.487e-06
+	  12        11.526901189838    2.578e-06
+	  13        11.526900501516    9.421e-07
+	  14        11.526900187105    3.588e-07
+	  15        11.526900070291    1.346e-07
+	-----------------------------------------
+	Converged P_Z-Perturbed Wfn to 5.270e-08
+
+	Computing L_Z-Perturbed Wave Function (0.000 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         4.304406331452
+	   1         5.241871759909    2.659e-01
+	   2         6.106793600100    1.693e-01
+	   3         6.202781583265    5.866e-02
+	   4         6.243845399800    1.952e-02
+	   5         6.242578238472    5.856e-03
+	   6         6.243082316481    2.214e-03
+	   7         6.243406666011    7.231e-04
+	   8         6.243252262562    2.718e-04
+	   9         6.243257299798    7.101e-05
+	  10         6.243255341307    2.410e-05
+	  11         6.243255564219    8.644e-06
+	  12         6.243251498040    3.747e-06
+	  13         6.243250285749    1.491e-06
+	  14         6.243250638461    6.113e-07
+	  15         6.243250956089    2.005e-07
+	-----------------------------------------
+	Converged L_Z-Perturbed Wfn to 6.787e-08
+
+	Computing <<P;L>>_(0.000) tensor.
+
+    CCSD Optical Rotation Tensor (Velocity Gauge): <<P;L>>_(0.000)
+  -------------------------------------------------------------------------
+   Evaluated at omega = 0.00 E_h (Inf nm, 0.0 eV, 0.0 cm-1)
+  -------------------------------------------------------------------------
+
+                   0                     1                     2        
+
+    0      0.432503170311545    -0.331857323590442     0.000000000000000
+    1     -0.197475949240893     0.012520076490456     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.461313899176918
 
 	Computing Mu_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.701674417963
-	   1         4.466205832906    2.236e-01
-	   2         5.049571107511    1.154e-01
-	   3         5.053949959837    2.409e-02
-	   4         5.060916947183    8.650e-03
-	   5         5.061406712892    2.467e-03
-	   6         5.061350641220    6.677e-04
-	   7         5.061433107750    2.664e-04
-	   8         5.061399274665    9.121e-05
-	   9         5.061393033093    3.528e-05
-	  10         5.061393373684    1.598e-05
-	  11         5.061394695920    5.030e-06
-	  12         5.061394406407    1.099e-06
-	  13         5.061394082955    2.781e-07
+	   0         3.701674414840
+	   1         4.466205828363    2.236e-01
+	   2         5.049571100631    1.154e-01
+	   3         5.053949952864    2.409e-02
+	   4         5.060916940123    8.650e-03
+	   5         5.061406705824    2.467e-03
+	   6         5.061350634153    6.677e-04
+	   7         5.061433100683    2.664e-04
+	   8         5.061399267598    9.121e-05
+	   9         5.061393026026    3.528e-05
+	  10         5.061393366617    1.598e-05
+	  11         5.061394688853    5.030e-06
+	  12         5.061394399341    1.099e-06
+	  13         5.061394075888    2.781e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 8.430e-08
 
 	Computing Mu_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.057304191347
-	   1         5.012402626934    2.952e-01
-	   2         5.976255357450    1.793e-01
-	   3         6.016957777061    5.182e-02
-	   4         6.052490175914    2.334e-02
-	   5         6.056619454093    9.340e-03
-	   6         6.056529717280    3.809e-03
-	   7         6.057267945767    2.041e-03
-	   8         6.056907793685    9.820e-04
-	   9         6.056897433440    4.959e-04
-	  10         6.056914639642    2.015e-04
-	  11         6.056907029907    5.193e-05
-	  12         6.056890366961    1.778e-05
-	  13         6.056884357203    6.839e-06
-	  14         6.056886030139    3.161e-06
-	  15         6.056887934473    1.286e-06
-	  16         6.056888567684    4.585e-07
-	  17         6.056888562721    1.879e-07
+	   0         4.057304192998
+	   1         5.012402629694    2.952e-01
+	   2         5.976255362878    1.793e-01
+	   3         6.016957782964    5.182e-02
+	   4         6.052490182165    2.334e-02
+	   5         6.056619460404    9.340e-03
+	   6         6.056529723595    3.809e-03
+	   7         6.057267952095    2.041e-03
+	   8         6.056907800008    9.820e-04
+	   9         6.056897439764    4.959e-04
+	  10         6.056914645966    2.015e-04
+	  11         6.056907036231    5.193e-05
+	  12         6.056890373285    1.778e-05
+	  13         6.056884363526    6.839e-06
+	  14         6.056886036462    3.161e-06
+	  15         6.056887940796    1.286e-06
+	  16         6.056888574007    4.585e-07
+	  17         6.056888569045    1.879e-07
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 7.837e-08
+
+	Computing P_X-Perturbed Wave Function (-0.077 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         8.542533679148
+	   1         9.550751397802    1.875e-01
+	   2        10.009737592295    8.303e-02
+	   3        10.018791160245    2.522e-02
+	   4        10.021334243299    8.859e-03
+	   5        10.021974376503    2.951e-03
+	   6        10.022125412051    1.125e-03
+	   7        10.022197437756    4.316e-04
+	   8        10.022170506694    1.588e-04
+	   9        10.022172915166    4.375e-05
+	  10        10.022174706991    1.539e-05
+	  11        10.022172826891    4.311e-06
+	  12        10.022171304749    1.149e-06
+	  13        10.022170966092    2.487e-07
+	-----------------------------------------
+	Converged P_X-Perturbed Wfn to 7.666e-08
 
 	Computing L_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.110362143499
-	   1         6.423602594420    3.511e-01
-	   2         7.859984430655    2.242e-01
-	   3         7.962369801100    6.663e-02
-	   4         8.029317228456    3.132e-02
-	   5         8.035548646564    1.253e-02
-	   6         8.038141068154    6.778e-03
-	   7         8.040224051907    3.244e-03
-	   8         8.040092692404    1.565e-03
-	   9         8.040156573903    5.668e-04
-	  10         8.040180184523    2.142e-04
-	  11         8.040228500430    7.462e-05
-	  12         8.040226704395    3.193e-05
-	  13         8.040218575610    1.122e-05
-	  14         8.040217076303    4.322e-06
-	  15         8.040216412615    1.822e-06
-	  16         8.040215680440    8.604e-07
-	  17         8.040214905678    4.036e-07
-	  18         8.040214519631    2.000e-07
-	  19         8.040214400361    1.159e-07
+	   0         5.110362146499
+	   1         6.423602599474    3.511e-01
+	   2         7.859984440971    2.242e-01
+	   3         7.962369812602    6.663e-02
+	   4         8.029317240672    3.132e-02
+	   5         8.035548658882    1.253e-02
+	   6         8.038141080526    6.778e-03
+	   7         8.040224064317    3.244e-03
+	   8         8.040092704816    1.565e-03
+	   9         8.040156586316    5.668e-04
+	  10         8.040180196937    2.142e-04
+	  11         8.040228512845    7.462e-05
+	  12         8.040226716810    3.193e-05
+	  13         8.040218588025    1.122e-05
+	  14         8.040217088718    4.322e-06
+	  15         8.040216425030    1.822e-06
+	  16         8.040215692854    8.604e-07
+	  17         8.040214918092    4.036e-07
+	  18         8.040214532046    2.000e-07
+	  19         8.040214412775    1.159e-07
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.802e-08
 
 	Computing Mu_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.682092024785
-	   1         9.710746052410    4.035e-01
-	   2        11.687269525500    2.141e-01
-	   3        11.708468848568    3.640e-02
-	   4        11.735154350293    1.727e-02
-	   5        11.738659817021    4.385e-03
-	   6        11.738204578563    1.371e-03
-	   7        11.738457109599    5.970e-04
-	   8        11.738481926120    2.545e-04
-	   9        11.738418022830    8.250e-05
-	  10        11.738426708486    2.167e-05
-	  11        11.738443132454    7.221e-06
-	  12        11.738451564068    1.655e-06
-	  13        11.738451761311    4.698e-07
-	  14        11.738451303820    2.137e-07
+	   0         7.682092018455
+	   1         9.710746042530    4.035e-01
+	   2        11.687269509496    2.141e-01
+	   3        11.708468832450    3.640e-02
+	   4        11.735154334001    1.727e-02
+	   5        11.738659800710    4.385e-03
+	   6        11.738204562256    1.371e-03
+	   7        11.738457093291    5.970e-04
+	   8        11.738481909811    2.545e-04
+	   9        11.738418006523    8.250e-05
+	  10        11.738426692178    2.167e-05
+	  11        11.738443116145    7.221e-06
+	  12        11.738451547760    1.655e-06
+	  13        11.738451745003    4.698e-07
+	  14        11.738451287512    2.137e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 7.056e-08
 
 	Computing Mu_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.734078820583
-	   1        11.372481989815    5.267e-01
-	   2        14.625138932075    3.172e-01
-	   3        14.707458926758    6.768e-02
-	   4        14.802431810071    3.812e-02
-	   5        14.817274275322    1.312e-02
-	   6        14.816185855312    5.533e-03
-	   7        14.817784760410    3.298e-03
-	   8        14.818252314725    1.701e-03
-	   9        14.817811858669    5.900e-04
-	  10        14.817864320592    2.121e-04
-	  11        14.818061341062    1.007e-04
-	  12        14.818194078306    3.557e-05
-	  13        14.818182672631    1.287e-05
-	  14        14.818158334853    6.183e-06
-	  15        14.818145305681    2.934e-06
-	  16        14.818143433027    1.121e-06
-	  17        14.818143606277    3.282e-07
-	  18        14.818143531906    2.019e-07
-	  19        14.818143474983    1.097e-07
+	   0         8.734078829064
+	   1        11.372482003376    5.267e-01
+	   2        14.625138958204    3.172e-01
+	   3        14.707458953928    6.768e-02
+	   4        14.802431838347    3.812e-02
+	   5        14.817274303863    1.312e-02
+	   6        14.816185883861    5.533e-03
+	   7        14.817784789015    3.298e-03
+	   8        14.818252343345    1.701e-03
+	   9        14.817811887283    5.900e-04
+	  10        14.817864349207    2.121e-04
+	  11        14.818061369682    1.007e-04
+	  12        14.818194106929    3.557e-05
+	  13        14.818182701254    1.287e-05
+	  14        14.818158363475    6.183e-06
+	  15        14.818145334303    2.934e-06
+	  16        14.818143461649    1.121e-06
+	  17        14.818143634898    3.282e-07
+	  18        14.818143560527    2.019e-07
+	  19        14.818143503605    1.097e-07
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 3.717e-08
+
+	Computing P_Y-Perturbed Wave Function (-0.077 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         8.812990810177
+	   1        10.171843310504    2.477e-01
+	   2        10.959725460670    1.141e-01
+	   3        10.982059732526    2.422e-02
+	   4        10.985800380525    1.012e-02
+	   5        10.986781491825    2.298e-03
+	   6        10.986692082107    7.035e-04
+	   7        10.986788770182    2.025e-04
+	   8        10.986787200891    6.323e-05
+	   9        10.986776253061    2.684e-05
+	  10        10.986778054415    1.224e-05
+	  11        10.986780472331    4.666e-06
+	  12        10.986781545715    1.140e-06
+	  13        10.986781064112    3.064e-07
+	  14        10.986780901581    1.160e-07
+	-----------------------------------------
+	Converged P_Y-Perturbed Wfn to 3.880e-08
 
 	Computing L_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.262633836200
-	   1         0.354933360306    9.748e-02
-	   2         0.466629572834    6.516e-02
-	   3         0.480858940373    2.190e-02
-	   4         0.485088714570    6.615e-03
-	   5         0.484933490997    2.522e-03
-	   6         0.484906035190    1.298e-03
-	   7         0.485092236784    7.672e-04
-	   8         0.485041900018    2.958e-04
-	   9         0.485057705146    7.779e-05
-	  10         0.485058819867    3.420e-05
-	  11         0.485055937681    1.000e-05
-	  12         0.485053054967    3.974e-06
-	  13         0.485052834856    1.263e-06
-	  14         0.485053254224    6.830e-07
-	  15         0.485053444940    2.280e-07
+	   0         0.262633836313
+	   1         0.354933360531    9.748e-02
+	   2         0.466629573419    6.516e-02
+	   3         0.480858941128    2.190e-02
+	   4         0.485088715376    6.615e-03
+	   5         0.484933491805    2.522e-03
+	   6         0.484906036000    1.298e-03
+	   7         0.485092237600    7.672e-04
+	   8         0.485041900833    2.958e-04
+	   9         0.485057705961    7.779e-05
+	  10         0.485058820682    3.420e-05
+	  11         0.485055938496    1.000e-05
+	  12         0.485053055782    3.974e-06
+	  13         0.485052835670    1.263e-06
+	  14         0.485053255039    6.830e-07
+	  15         0.485053445755    2.280e-07
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 9.226e-08
 
 	Computing Mu_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.589388162755
-	   1         6.873021156775    3.048e-01
-	   2         7.928921864565    1.503e-01
-	   3         7.927317335128    2.453e-02
-	   4         7.934899150731    1.048e-02
-	   5         7.936156288676    2.537e-03
-	   6         7.936046898122    8.182e-04
-	   7         7.936116726445    3.326e-04
-	   8         7.936106189055    1.061e-04
-	   9         7.936086112075    3.219e-05
-	  10         7.936088123538    1.024e-05
-	  11         7.936092042954    3.844e-06
-	  12         7.936094248651    1.071e-06
-	  13         7.936094273613    3.684e-07
-	  14         7.936094054533    1.329e-07
+	   0         5.589388158319
+	   1         6.873021150307    3.048e-01
+	   2         7.928921854879    1.503e-01
+	   3         7.927317325416    2.453e-02
+	   4         7.934899140943    1.048e-02
+	   5         7.936156278878    2.537e-03
+	   6         7.936046888324    8.182e-04
+	   7         7.936116716647    3.326e-04
+	   8         7.936106179257    1.061e-04
+	   9         7.936086102277    3.219e-05
+	  10         7.936088113740    1.024e-05
+	  11         7.936092033157    3.844e-06
+	  12         7.936094238853    1.071e-06
+	  13         7.936094263816    3.684e-07
+	  14         7.936094044735    1.329e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 4.235e-08
 
 	Computing Mu_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.253187525243
-	   1         7.896306822418    3.986e-01
-	   2         9.620732683149    2.265e-01
-	   3         9.638587567733    4.898e-02
-	   4         9.675383129738    2.494e-02
-	   5         9.681366170429    8.203e-03
-	   6         9.681090347500    3.258e-03
-	   7         9.681530080070    1.667e-03
-	   8         9.681501474282    6.286e-04
-	   9         9.681394323743    2.154e-04
-	  10         9.681413574300    7.645e-05
-	  11         9.681445284218    3.380e-05
-	  12         9.681467079395    1.322e-05
-	  13         9.681465045471    6.061e-06
-	  14         9.681459706615    2.930e-06
-	  15         9.681456779214    1.402e-06
-	  16         9.681456564718    6.184e-07
-	  17         9.681456789516    2.702e-07
-	  18         9.681456918071    1.198e-07
+	   0         6.253187530003
+	   1         7.896306830198    3.986e-01
+	   2         9.620732697411    2.265e-01
+	   3         9.638587582337    4.898e-02
+	   4         9.675383144770    2.494e-02
+	   5         9.681366185540    8.203e-03
+	   6         9.681090362612    3.258e-03
+	   7         9.681530095191    1.667e-03
+	   8         9.681501489403    6.286e-04
+	   9         9.681394338864    2.154e-04
+	  10         9.681413589421    7.645e-05
+	  11         9.681445299340    3.380e-05
+	  12         9.681467094517    1.322e-05
+	  13         9.681465060593    6.061e-06
+	  14         9.681459721737    2.930e-06
+	  15         9.681456794336    1.402e-06
+	  16         9.681456579840    6.184e-07
+	  17         9.681456804638    2.702e-07
+	  18         9.681456933193    1.198e-07
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 5.009e-08
+
+	Computing P_Z-Perturbed Wave Function (-0.077 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         9.200464708753
+	   1        10.346822417381    2.220e-01
+	   2        10.971763481054    9.650e-02
+	   3        10.975740590281    2.048e-02
+	   4        10.976064814529    8.272e-03
+	   5        10.976882446422    2.213e-03
+	   6        10.976885036975    7.474e-04
+	   7        10.976946619863    2.889e-04
+	   8        10.976950755843    9.823e-05
+	   9        10.976941834739    2.666e-05
+	  10        10.976943088139    7.829e-06
+	  11        10.976943865067    2.818e-06
+	  12        10.976944409489    8.775e-07
+	  13        10.976944226646    2.902e-07
+	  14        10.976944135759    1.006e-07
+	-----------------------------------------
+	Converged P_Z-Perturbed Wfn to 3.307e-08
 
 	Computing L_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.475329530155
-	   1         5.518347530304    3.096e-01
-	   2         6.646665888415    2.165e-01
-	   3         6.872592327798    9.221e-02
-	   4         6.973440652828    3.626e-02
-	   5         6.974394657093    1.325e-02
-	   6         6.977028827682    5.757e-03
-	   7         6.978147303266    2.088e-03
-	   8         6.977545310695    8.810e-04
-	   9         6.977573007408    3.001e-04
-	  10         6.977566275288    1.472e-04
-	  11         6.977556445557    6.560e-05
-	  12         6.977514803332    2.900e-05
-	  13         6.977508491791    9.720e-06
-	  14         6.977513185465    3.322e-06
-	  15         6.977515482384    1.148e-06
-	  16         6.977516245897    4.351e-07
-	  17         6.977516314130    1.364e-07
+	   0         4.475329532579
+	   1         5.518347534253    3.096e-01
+	   2         6.646665896319    2.165e-01
+	   3         6.872592338423    9.221e-02
+	   4         6.973440664749    3.626e-02
+	   5         6.974394669107    1.325e-02
+	   6         6.977028839759    5.757e-03
+	   7         6.978147315365    2.088e-03
+	   8         6.977545322784    8.810e-04
+	   9         6.977573019497    3.001e-04
+	  10         6.977566287377    1.472e-04
+	  11         6.977556457646    6.560e-05
+	  12         6.977514815420    2.900e-05
+	  13         6.977508503879    9.720e-06
+	  14         6.977513197553    3.322e-06
+	  15         6.977515494472    1.148e-06
+	  16         6.977516257985    4.351e-07
+	  17         6.977516326218    1.364e-07
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 4.957e-08
 
 	Computing Q_XX-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        16.113420534082
-	   1        20.114071871695    4.956e-01
-	   2        23.075627091741    2.496e-01
-	   3        23.146615489265    6.283e-02
-	   4        23.204621346692    3.027e-02
-	   5        23.208820473014    8.041e-03
-	   6        23.211099920698    2.922e-03
-	   7        23.211848123681    1.133e-03
-	   8        23.211709642647    5.570e-04
-	   9        23.211698245783    2.572e-04
-	  10        23.211766671885    1.104e-04
-	  11        23.211794503403    4.498e-05
-	  12        23.211783660677    2.050e-05
-	  13        23.211769647570    7.681e-06
-	  14        23.211766276859    2.453e-06
-	  15        23.211764891161    8.895e-07
-	  16        23.211764233558    3.878e-07
-	  17        23.211763934824    1.725e-07
+	   0        16.113420541740
+	   1        20.114071883931    4.956e-01
+	   2        23.075627111083    2.496e-01
+	   3        23.146615509196    6.283e-02
+	   4        23.204621367090    3.027e-02
+	   5        23.208820493449    8.041e-03
+	   6        23.211099941147    2.922e-03
+	   7        23.211848144131    1.133e-03
+	   8        23.211709663099    5.570e-04
+	   9        23.211698266234    2.572e-04
+	  10        23.211766692336    1.104e-04
+	  11        23.211794523855    4.498e-05
+	  12        23.211783681129    2.050e-05
+	  13        23.211769668022    7.681e-06
+	  14        23.211766297311    2.453e-06
+	  15        23.211764911613    8.895e-07
+	  16        23.211764254010    3.878e-07
+	  17        23.211763955276    1.725e-07
 	-----------------------------------------
 	Converged Q_XX-Perturbed Wfn to 7.664e-08
 
 	Computing Q_XY-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        25.909125380724
-	   1        33.801467186518    9.058e-01
-	   2        42.618147734343    6.017e-01
-	   3        43.569474551116    2.433e-01
-	   4        44.423510707444    1.229e-01
-	   5        44.526346965062    4.054e-02
-	   6        44.539175799252    1.251e-02
-	   7        44.546738209391    5.188e-03
-	   8        44.543945482883    2.054e-03
-	   9        44.543718049519    6.275e-04
-	  10        44.543938753251    2.478e-04
-	  11        44.544029085396    9.200e-05
-	  12        44.543997021115    4.219e-05
-	  13        44.543965052016    1.985e-05
-	  14        44.543970239672    8.095e-06
-	  15        44.543976168533    3.044e-06
-	  16        44.543977011406    1.205e-06
-	  17        44.543975413886    5.193e-07
-	  18        44.543973282181    2.666e-07
-	  19        44.543972315952    1.022e-07
+	   0        25.909125393510
+	   1        33.801467209683    9.058e-01
+	   2        42.618147783876    6.017e-01
+	   3        43.569474612153    2.433e-01
+	   4        44.423510779129    1.229e-01
+	   5        44.526347038765    4.054e-02
+	   6        44.539175873249    1.251e-02
+	   7        44.546738283510    5.188e-03
+	   8        44.543945556961    2.054e-03
+	   9        44.543718123594    6.275e-04
+	  10        44.543938827333    2.478e-04
+	  11        44.544029159478    9.200e-05
+	  12        44.543997095195    4.219e-05
+	  13        44.543965126096    1.985e-05
+	  14        44.543970313752    8.095e-06
+	  15        44.543976242613    3.044e-06
+	  16        44.543977085487    1.205e-06
+	  17        44.543975487967    5.193e-07
+	  18        44.543973356262    2.666e-07
+	  19        44.543972390033    1.022e-07
 	-----------------------------------------
 	Converged Q_XY-Perturbed Wfn to 3.057e-08
 
 	Computing Q_XZ-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.001440295242
-	   1        13.147461790026    5.019e-01
-	   2        15.905455862965    2.785e-01
-	   3        15.998802766667    7.948e-02
-	   4        16.066409701254    3.638e-02
-	   5        16.076392689609    1.680e-02
-	   6        16.082322991441    8.487e-03
-	   7        16.084709872846    4.114e-03
-	   8        16.083721718832    1.750e-03
-	   9        16.083914952864    6.700e-04
-	  10        16.084117226185    2.779e-04
-	  11        16.084113121940    7.428e-05
-	  12        16.084056879787    2.454e-05
-	  13        16.084040212669    7.212e-06
-	  14        16.084040287529    2.696e-06
-	  15        16.084041343605    1.115e-06
-	  16        16.084041594205    5.795e-07
-	  17        16.084041189703    2.834e-07
-	  18        16.084040916924    1.195e-07
+	   0        10.001440299797
+	   1        13.147461798254    5.019e-01
+	   2        15.905455878328    2.785e-01
+	   3        15.998802782958    7.948e-02
+	   4        16.066409718080    3.638e-02
+	   5        16.076392706535    1.680e-02
+	   6        16.082323008431    8.487e-03
+	   7        16.084709889869    4.114e-03
+	   8        16.083721735847    1.750e-03
+	   9        16.083914969884    6.700e-04
+	  10        16.084117243209    2.779e-04
+	  11        16.084113138964    7.428e-05
+	  12        16.084056896809    2.454e-05
+	  13        16.084040229691    7.212e-06
+	  14        16.084040304551    2.696e-06
+	  15        16.084041360627    1.115e-06
+	  16        16.084041611227    5.795e-07
+	  17        16.084041206725    2.834e-07
+	  18        16.084040933947    1.195e-07
 	-----------------------------------------
 	Converged Q_XZ-Perturbed Wfn to 5.632e-08
 
 	Computing Q_YX-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        25.909125380724
-	   1        33.801467186518    9.058e-01
-	   2        42.618147734343    6.017e-01
-	   3        43.569474551116    2.433e-01
-	   4        44.423510707444    1.229e-01
-	   5        44.526346965062    4.054e-02
-	   6        44.539175799252    1.251e-02
-	   7        44.546738209391    5.188e-03
-	   8        44.543945482883    2.054e-03
-	   9        44.543718049519    6.275e-04
-	  10        44.543938753251    2.478e-04
-	  11        44.544029085396    9.200e-05
-	  12        44.543997021115    4.219e-05
-	  13        44.543965052016    1.985e-05
-	  14        44.543970239672    8.095e-06
-	  15        44.543976168533    3.044e-06
-	  16        44.543977011406    1.205e-06
-	  17        44.543975413886    5.193e-07
-	  18        44.543973282181    2.666e-07
-	  19        44.543972315952    1.022e-07
+	   0        25.909125393510
+	   1        33.801467209683    9.058e-01
+	   2        42.618147783876    6.017e-01
+	   3        43.569474612153    2.433e-01
+	   4        44.423510779129    1.229e-01
+	   5        44.526347038765    4.054e-02
+	   6        44.539175873249    1.251e-02
+	   7        44.546738283510    5.188e-03
+	   8        44.543945556961    2.054e-03
+	   9        44.543718123594    6.275e-04
+	  10        44.543938827333    2.478e-04
+	  11        44.544029159478    9.200e-05
+	  12        44.543997095195    4.219e-05
+	  13        44.543965126096    1.985e-05
+	  14        44.543970313752    8.095e-06
+	  15        44.543976242613    3.044e-06
+	  16        44.543977085487    1.205e-06
+	  17        44.543975487967    5.193e-07
+	  18        44.543973356262    2.666e-07
+	  19        44.543972390033    1.022e-07
 	-----------------------------------------
 	Converged Q_YX-Perturbed Wfn to 3.057e-08
 
 	Computing Q_YY-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        34.532788462805
-	   1        41.818157073430    6.285e-01
-	   2        46.955934120647    3.213e-01
-	   3        47.250760030915    1.122e-01
-	   4        47.426212728647    5.464e-02
-	   5        47.443730446327    1.916e-02
-	   6        47.449264680671    7.378e-03
-	   7        47.451134792535    3.197e-03
-	   8        47.450859336433    1.341e-03
-	   9        47.450986072218    4.346e-04
-	  10        47.451146806039    1.696e-04
-	  11        47.451126223272    5.746e-05
-	  12        47.451069955507    2.431e-05
-	  13        47.451038347970    9.303e-06
-	  14        47.451028851187    4.822e-06
-	  15        47.451024829240    2.584e-06
-	  16        47.451022984862    1.171e-06
-	  17        47.451022032127    4.532e-07
-	  18        47.451021972823    1.497e-07
+	   0        34.532788476992
+	   1        41.818157094437    6.285e-01
+	   2        46.955934151323    3.213e-01
+	   3        47.250760063520    1.122e-01
+	   4        47.426212762795    5.464e-02
+	   5        47.443730480746    1.916e-02
+	   6        47.449264715192    7.378e-03
+	   7        47.451134827084    3.197e-03
+	   8        47.450859370983    1.341e-03
+	   9        47.450986106770    4.346e-04
+	  10        47.451146840594    1.696e-04
+	  11        47.451126257826    5.746e-05
+	  12        47.451069990060    2.431e-05
+	  13        47.451038382522    9.303e-06
+	  14        47.451028885739    4.822e-06
+	  15        47.451024863792    2.584e-06
+	  16        47.451023019414    1.171e-06
+	  17        47.451022066679    4.532e-07
+	  18        47.451022007375    1.497e-07
 	-----------------------------------------
 	Converged Q_YY-Perturbed Wfn to 6.644e-08
 
 	Computing Q_YZ-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        45.008235367799
-	   1        60.535096976231    1.325e+00
-	   2        79.387272017609    8.233e-01
-	   3        80.000780783187    2.063e-01
-	   4        80.749251122251    1.067e-01
-	   5        80.841812091878    2.893e-02
-	   6        80.854829308074    1.062e-02
-	   7        80.862014145010    4.431e-03
-	   8        80.860634064562    1.698e-03
-	   9        80.859569296133    8.978e-04
-	  10        80.858985039821    5.400e-04
-	  11        80.859786733008    2.521e-04
-	  12        80.860293509603    9.340e-05
-	  13        80.860261605771    3.973e-05
-	  14        80.860133638612    1.968e-05
-	  15        80.860064723923    7.481e-06
-	  16        80.860052620070    2.844e-06
-	  17        80.860050530190    1.000e-06
-	  18        80.860051300144    4.107e-07
-	  19        80.860050798321    1.782e-07
+	   0        45.008235401582
+	   1        60.535097037772    1.325e+00
+	   2        79.387272154844    8.233e-01
+	   3        80.000780929526    2.063e-01
+	   4        80.749251277178    1.067e-01
+	   5        80.841812248009    2.893e-02
+	   6        80.854829464398    1.062e-02
+	   7        80.862014301418    4.431e-03
+	   8        80.860634220955    1.698e-03
+	   9        80.859569452516    8.978e-04
+	  10        80.858985196194    5.400e-04
+	  11        80.859786889388    2.521e-04
+	  12        80.860293665993    9.340e-05
+	  13        80.860261762160    3.973e-05
+	  14        80.860133794997    1.968e-05
+	  15        80.860064880306    7.481e-06
+	  16        80.860052776452    2.844e-06
+	  17        80.860050686573    1.000e-06
+	  18        80.860051456526    4.107e-07
+	  19        80.860050954703    1.782e-07
 	-----------------------------------------
 	Converged Q_YZ-Perturbed Wfn to 7.735e-08
 
 	Computing Q_ZX-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        10.001440295242
-	   1        13.147461790026    5.019e-01
-	   2        15.905455862965    2.785e-01
-	   3        15.998802766667    7.948e-02
-	   4        16.066409701254    3.638e-02
-	   5        16.076392689609    1.680e-02
-	   6        16.082322991441    8.487e-03
-	   7        16.084709872846    4.114e-03
-	   8        16.083721718832    1.750e-03
-	   9        16.083914952864    6.700e-04
-	  10        16.084117226185    2.779e-04
-	  11        16.084113121940    7.428e-05
-	  12        16.084056879787    2.454e-05
-	  13        16.084040212669    7.212e-06
-	  14        16.084040287529    2.696e-06
-	  15        16.084041343605    1.115e-06
-	  16        16.084041594205    5.795e-07
-	  17        16.084041189703    2.834e-07
-	  18        16.084040916924    1.195e-07
+	   0        10.001440299797
+	   1        13.147461798254    5.019e-01
+	   2        15.905455878328    2.785e-01
+	   3        15.998802782958    7.948e-02
+	   4        16.066409718080    3.638e-02
+	   5        16.076392706535    1.680e-02
+	   6        16.082323008431    8.487e-03
+	   7        16.084709889869    4.114e-03
+	   8        16.083721735847    1.750e-03
+	   9        16.083914969884    6.700e-04
+	  10        16.084117243209    2.779e-04
+	  11        16.084113138964    7.428e-05
+	  12        16.084056896809    2.454e-05
+	  13        16.084040229691    7.212e-06
+	  14        16.084040304551    2.696e-06
+	  15        16.084041360627    1.115e-06
+	  16        16.084041611227    5.795e-07
+	  17        16.084041206725    2.834e-07
+	  18        16.084040933947    1.195e-07
 	-----------------------------------------
 	Converged Q_ZX-Perturbed Wfn to 5.632e-08
 
 	Computing Q_ZY-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        45.008235367799
-	   1        60.535096976231    1.325e+00
-	   2        79.387272017609    8.233e-01
-	   3        80.000780783187    2.063e-01
-	   4        80.749251122251    1.067e-01
-	   5        80.841812091878    2.893e-02
-	   6        80.854829308074    1.062e-02
-	   7        80.862014145010    4.431e-03
-	   8        80.860634064562    1.698e-03
-	   9        80.859569296133    8.978e-04
-	  10        80.858985039821    5.400e-04
-	  11        80.859786733008    2.521e-04
-	  12        80.860293509603    9.340e-05
-	  13        80.860261605771    3.973e-05
-	  14        80.860133638612    1.968e-05
-	  15        80.860064723923    7.481e-06
-	  16        80.860052620070    2.844e-06
-	  17        80.860050530190    1.000e-06
-	  18        80.860051300144    4.107e-07
-	  19        80.860050798321    1.782e-07
+	   0        45.008235401582
+	   1        60.535097037772    1.325e+00
+	   2        79.387272154844    8.233e-01
+	   3        80.000780929526    2.063e-01
+	   4        80.749251277178    1.067e-01
+	   5        80.841812248009    2.893e-02
+	   6        80.854829464398    1.062e-02
+	   7        80.862014301418    4.431e-03
+	   8        80.860634220955    1.698e-03
+	   9        80.859569452516    8.978e-04
+	  10        80.858985196194    5.400e-04
+	  11        80.859786889388    2.521e-04
+	  12        80.860293665993    9.340e-05
+	  13        80.860261762160    3.973e-05
+	  14        80.860133794997    1.968e-05
+	  15        80.860064880306    7.481e-06
+	  16        80.860052776452    2.844e-06
+	  17        80.860050686573    1.000e-06
+	  18        80.860051456526    4.107e-07
+	  19        80.860050954703    1.782e-07
 	-----------------------------------------
 	Converged Q_ZY-Perturbed Wfn to 7.735e-08
 
 	Computing Q_ZZ-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        19.662089360807
-	   1        24.761074407733    5.727e-01
-	   2        28.618488906591    3.024e-01
-	   3        28.791739429359    9.773e-02
-	   4        28.891647988955    4.119e-02
-	   5        28.906909717825    1.670e-02
-	   6        28.914051129501    6.364e-03
-	   7        28.915865402995    2.569e-03
-	   8        28.915344040122    1.052e-03
-	   9        28.915350961057    3.233e-04
-	  10        28.915419421664    1.329e-04
-	  11        28.915398727338    4.553e-05
-	  12        28.915357546981    1.775e-05
-	  13        28.915344895422    5.278e-06
-	  14        28.915343355540    2.120e-06
-	  15        28.915342521026    1.088e-06
-	  16        28.915341429244    5.939e-07
-	  17        28.915340422043    2.783e-07
-	  18        28.915340250961    1.135e-07
+	   0        19.662089368212
+	   1        24.761074420000    5.727e-01
+	   2        28.618488926976    3.024e-01
+	   3        28.791739451230    9.773e-02
+	   4        28.891648011647    4.119e-02
+	   5        28.906909740720    1.670e-02
+	   6        28.914051152480    6.364e-03
+	   7        28.915865426002    2.569e-03
+	   8        28.915344063123    1.052e-03
+	   9        28.915350984059    3.233e-04
+	  10        28.915419444667    1.329e-04
+	  11        28.915398750341    4.553e-05
+	  12        28.915357569983    1.775e-05
+	  13        28.915344918424    5.278e-06
+	  14        28.915343378542    2.120e-06
+	  15        28.915342544028    1.088e-06
+	  16        28.915341452245    5.939e-07
+	  17        28.915340445045    2.783e-07
+	  18        28.915340273962    1.135e-07
 	-----------------------------------------
 	Converged Q_ZZ-Perturbed Wfn to 5.266e-08
 
 	Computing 1/2 <<Mu;Mu>>_(0.077) tensor.
-	Computing 1/2 <<Mu;L>>_(0.077) tensor.
+	Computing 1/2 <<P;L>>_(0.077) tensor.
 	Computing 1/2 <<Mu;Q>>_(0.077) tensor.
 
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.169079147013067 -0.181398472271101  0.418346537516512 -0.010479590676640  0.433274055754517  0.333974741215202 -0.069746020881106 -0.194340009035054 -0.223641697824386
-    1  (  1) -0.016009276689030 -0.076567446932798  0.125166337039093 -0.007592453612462  0.098480410050875  0.089737908381391  0.045486472738146 -0.143199887927110 -0.062916365543690
-    2  (  2)  0.038605132226418 -0.325735563708610  0.218009814858074 -0.077381145892201 -0.123187590884398 -0.048889336335591  0.262562783859021 -0.048309454387723  0.024346554904250
-    3  (  3)  0.014979345531200 -0.182689417416161  0.081658171125982 -0.065474061220856 -0.193719558728945 -0.090995702617436  0.143671181956007 -0.007595234796482  0.060244504649077
-    4  (  4)  0.067326880829078  0.014019514528751 -0.166079096202343  0.050483681333365  0.175920263326446  0.180597768068034  0.198820916076870  0.109379569710197  0.213777238598869
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.509745833838701  0.114656609203285 -0.048629220633750 -0.010405234436097 -0.246884756649403  0.174503049803694
-    1  (  1)  0.159507006357648  0.056302070388232 -0.034397385257058  0.068360305204010 -0.100741705433253  0.049850192065006
-    2  (  2)  0.121516040086149  0.004562730012851 -0.189568353516518 -0.051932897550589  0.189148835217686 -0.205130688490104
-    3  (  3) -0.013365010155837  0.072899199914719 -0.147744895629826  0.343128825881135 -0.052918455467163 -0.086660617340563
-    4  (  4) -0.064044315985741  0.072658430245154 -0.366494578686027 -0.156516693310286 -0.183833641545764  0.043558656630646
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.222253545892244  0.308754480278884 -0.684888401384565  0.077094923901758  0.114132498246181 -0.066899096811017 -0.002565146162785  0.065013418078775  0.530087407435393
-    1  (  6) -0.095334276679193  0.133297826228700 -0.233197346278755  0.109601967204616  0.034275480758760  0.001203333963837  0.083638018427257  0.006960569040888  0.188458864487261
-    2  (  7) -0.132031061747719  0.218523067630196  0.122630993985032  0.145558520241812 -0.033193720251677  0.142560381166407  0.001867788081308 -0.178023293664542  0.083084361136401
-    3  (  8) -0.307498004496819  0.248791244048898  0.171772368494742  0.290615228523969 -0.046349400199126  0.102375085874076  0.404689074901353  0.035662710613182  0.067098781839471
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.009919929749940  0.070754419675403  0.033057132824845  0.029936683588897 -0.302173230741933
-    1  (  6)  0.011309858279613 -0.047826417485879 -0.011715232447735  0.012088004910524 -0.055738135466992
-    2  (  7)  0.060288713658253  0.100230259139583  0.175888837964231  0.033113629525454  0.296260914045054
-    3  (  8) -0.156436486115695  0.054087340712273 -0.405606823449570  0.026699936395146  0.143365750641886
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000032603418837 -0.126124356870090 -0.170554254128647 -0.621713480371517
-    1  (  1)  0.063391990530330 -0.021021973667360  0.035141514385331  0.107429862625930
-    2  (  2)  0.544499875281630 -0.300008667648211  0.100039136771104  0.265278637596522
-    3  (  3)  0.250324690465962 -0.260056134456994 -0.124414801683600 -0.440136140630983
-    4  (  4)  0.136414480343098 -0.064431360418323  0.021015287492156  0.051343774737237
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5) -0.000019327025352 -0.065093211127625 -0.544782466708479 -0.245382364722837 -0.134937357643702
-    1  (  6)  0.123031148662641  0.019474806029226  0.300926234869739  0.262383133461068  0.064721107261509
-    2  (  7)  0.168930413345025 -0.034874779439887 -0.099232631257934  0.125516014095032 -0.023646961316768
-    3  (  8)  0.622345214333519 -0.106268567242580 -0.261765947213873  0.441767814164735 -0.052476472563320
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.143168742050969 -0.065593092719620  0.058357223814998 -0.095233744064776  0.054991990252275  0.158738663239417 -0.005861644512419  0.046171301568673 -0.009241470545286
-    1  (  1) -0.090546554003407 -0.201829179559043  0.091139660909400  0.093658466030896 -0.161060795901430 -0.077753943704190  0.543239332695236 -0.814462205940737  0.067298988063212
-    2  (  2)  0.021728082981507 -0.356853707760702  0.273297343085382 -0.263661367453919 -0.358975826989998  0.204621891372348  0.313142134375876 -0.064377163119988  0.200411159416666
-    3  (  3)  0.101092642386777  0.248351561644884 -0.325472253383733  0.022461569908437 -0.220395643002352 -0.053342935824144 -0.023680160861624 -0.049360779001958  0.000464252060147
-    4  (  4) -0.053504276998688 -0.177332374278721  0.223488999246937  0.043202317426006  0.200403874496849  0.109676936134016  0.130968685942067 -0.223685121938792 -0.051883473042391
-    5  (  5) -0.218652321770515  0.312539731115342 -0.301937592016120  0.119144864786212  0.273807562569020  0.291329095765088 -0.214350574455061 -0.196966818811601 -0.071530668658618
-    6  (  6) -0.085275599488616  0.152038903160436 -0.395824749485933  0.020600022744657  0.230254876491235  0.119190020655303 -0.196964194480387 -0.232999347129610  0.074131260226173
-    7  (  7) -0.047705443252103 -0.280546373408872  0.366470889708310 -0.110969029401947  0.088365350080466 -0.149809323623181 -0.036903907285247  0.394126097469672  0.043470630949031
-    8  (  8) -0.213434636208738 -0.108264999729057  0.634417157620428  0.069187858002595  0.037899789726715  0.161396484647500 -0.081572968058128  0.216972039968308 -0.039198046889909
-    9  (  9)  0.053322372799114 -0.090836400230606 -0.086595499357010  0.028326926095153 -0.134566066437039  0.073537213795396  0.007049259902868  0.447872012493398  0.046316327587981
-   10  ( 10) -0.217341204893281  0.434346962083385  0.408839180880640  0.321260492764443  0.034272175446499 -0.320142409512337  0.023798683867179 -0.279256094128980 -0.028678082826067
-   11  ( 11)  0.043839598607802  0.078964641572311 -0.267355581977089  0.331608561699507 -0.435766960294310 -0.066306924416866 -0.247976787569883  0.002758180414468  0.128221736037864
-   12  ( 12) -0.056965688274708  0.011499629769275  0.132082161790900  0.097919309901065  0.064498574997948 -0.001828531017010  0.216798363947827 -0.142474052325396  0.129433978300506
-   13  ( 13) -0.037736233652834 -0.226173453877373  0.091059172339369  0.252258976670285  0.015520139516800  0.284734500126441 -0.105582624775749  0.004840642243881 -0.367726601468554
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222351700796231  0.016051014603450 -0.082411788344132 -0.002090829543127  0.060332287300641 -0.093379423932350
-    1  (  1) -0.558696663631320  0.124839828449119  0.159093196566891 -0.170657712172229 -0.081500451405233  0.084538068524715
-    2  (  2)  0.171547101260385  0.032355031252886 -0.410357578755376  0.223619460950125  0.075332226894427 -0.314396046680626
-    3  (  3)  0.113943755316531  0.023262630947533  0.282031318687168 -0.174392564657866  0.284646066238925  0.036137544982085
-    4  (  4) -0.007270912134622  0.039474507242411  0.327411282761334  0.428749102590040  0.081932338953496 -0.119337549539454
-    5  (  5)  0.007124770871955  0.054853461684570 -0.118747764774226 -0.018464599829059  0.153416652566852  0.075577494357491
-    6  (  6)  0.092349921440075  0.334618605800085  0.214792660948048  0.112965638408468  0.018250213734362  0.100586056001693
-    7  (  7) -0.152021384124484 -0.104998322455761  0.079320526127899 -0.028605808968327  0.093251815005480 -0.234533113346203
-    8  (  8)  0.034304143528697 -0.223813766962522 -0.061239992371489  0.498104576719364 -0.749088367409234  0.381133927713764
-    9  (  9)  0.119289648143127 -0.308069531198503 -0.075394971169272 -0.759043062697070  0.290009195725773 -0.156443196633644
-   10  ( 10) -0.438322970066134 -0.163961241971126  0.419972225637626 -0.045406760285923  0.044943204755759  0.568952239499600
-   11  ( 11)  0.012786276184910 -0.354874474517313 -0.016716751019783 -0.314729629014795  0.109367125733961  0.038956514405505
-   12  ( 12) -0.278790389094552  0.047235199403271 -0.203285043476247 -0.096947952714326 -0.275888785771950  0.187110182878589
-   13  ( 13)  0.588336834741451 -0.141774978422199 -0.127446795642639  0.417479745467518 -0.223574211999999 -0.209731578694231
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.139202374272621  0.095177641569675 -0.018773909554975 -0.097441952386086  0.052881778233791  0.221098968415819  0.088678880810398  0.046152832918285  0.215108327569156
-    1  ( 15)  0.062945487192671  0.202399962667017  0.354690347352157 -0.248169855248633  0.178112035030668 -0.312759612055100 -0.152465077862104  0.279550518176369  0.106786563882068
-    2  ( 16) -0.053747901607914 -0.094055462729839 -0.275452788140149  0.323607865915763 -0.223365974526806  0.300652023916840  0.393867617385155 -0.365397282883089 -0.633006843106556
-    3  ( 17)  0.094002363012655 -0.093421728368421  0.262348870274066 -0.022315744436414 -0.042732961100197 -0.119651095539310 -0.019208709619051  0.111738898683176 -0.069298150001950
-    4  ( 18) -0.056373744495590  0.163033205250659  0.357789849982426  0.219752154386331 -0.199609932463510 -0.273164341776646 -0.231164134722957 -0.090622648154173 -0.037758220090686
-    5  ( 19) -0.160595804065382  0.080035650166188 -0.203841516073520  0.053966491195577 -0.109684055455432 -0.290491436031534 -0.118088683716894  0.148835930426789 -0.161333320462923
-    6  ( 20)  0.008655895544046 -0.543677859447897 -0.312247361260707  0.021746144643383 -0.131150127368204  0.214268497298583  0.195294294028571  0.037322598271958  0.082710341175990
-    7  ( 21) -0.047044000148847  0.814755045611703  0.065202059732802  0.048607853740734  0.224058525580443  0.197250760154244  0.232147678456731 -0.394910024115792 -0.217741693866694
-    8  ( 22)  0.009438322952131 -0.067105129183881 -0.200111373517365 -0.001546802997496  0.051921461755131  0.071400999009348 -0.075219081936387 -0.043282136981162  0.038956055715065
-    9  ( 23) -0.222690431794590  0.560436921351761 -0.171874955212197 -0.112182377152414  0.007071284207137 -0.006427896378768 -0.090201256315770  0.151794514368373 -0.032052056842716
-   10  ( 24) -0.015965707326541 -0.124165042149601 -0.031933550526408 -0.022576537585984 -0.040255135623963 -0.054700257408159 -0.334875806524789  0.105283502146394  0.223919488004079
-   11  ( 25)  0.081167640673829 -0.159983011732312  0.408649974214824 -0.280674694561068 -0.326885126511498  0.118534226661232 -0.213699274668233 -0.079763309363181  0.060690310069395
-   12  ( 26)  0.003657920398281  0.169345800545151 -0.223179507594994  0.177432493477436 -0.431822644586944  0.017469946131729 -0.113428863232752  0.031984070329444 -0.498986991132235
-   13  ( 27) -0.059466371837119  0.080543553642064 -0.075187799272484 -0.285726158437972 -0.080575068896982 -0.153138088483086 -0.017504315580652 -0.094018000472634  0.750489816823238
-   14  ( 28)  0.091779364641270 -0.083757100689969  0.314063329930966 -0.035360766104356  0.119047215679504 -0.075525935404181 -0.100523702542950  0.234167736555125 -0.382416402775017
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054180568174087  0.218758432536746 -0.045617833544743  0.057539775261661  0.041968766977599
-    1  ( 15)  0.090582635286264 -0.434585538609120 -0.078290573102774 -0.011551815535752  0.225206285929556
-    2  ( 16)  0.087805337077496 -0.409609254316999  0.269432869300411 -0.132294575357470 -0.092781259667513
-    3  ( 17) -0.029497163039810 -0.321887635448263 -0.333951917483107 -0.098004347098165 -0.253999249955738
-    4  ( 18)  0.133860313754778 -0.034109453432679  0.437353037936869 -0.064342088723588 -0.014911719082035
-    5  ( 19) -0.074763336207957  0.320521161823854  0.065101664451371  0.002026005130085 -0.283685137533505
-    6  ( 20) -0.006545865730575 -0.024114900293167  0.248934112787968 -0.216846340655195  0.105410458820591
-    7  ( 21) -0.447836131833085  0.279310069582177 -0.002049813773497  0.142438428094426 -0.004546144226345
-    8  ( 22) -0.046136686751539  0.028286865341649 -0.127990987917726 -0.129509607296348  0.367102200851883
-    9  ( 23) -0.119914751772745  0.438597311614088 -0.013925046534151  0.279070419042896 -0.587111860916756
-   10  ( 24)  0.308678492665754  0.164180912654775  0.355114774474331 -0.047147124734095  0.142335590283680
-   11  ( 25)  0.075357196311108 -0.419786064000589  0.016982355834687  0.203268419894548  0.127372410738112
-   12  ( 26)  0.762258414223746  0.045740824623019  0.314843572140565  0.096925863993462 -0.417498766326933
-   13  ( 27) -0.290828580624809 -0.045085064630915 -0.109302729868749  0.275851789428657  0.223795262166736
-   14  ( 28)  0.156282170808113 -0.568695990355867 -0.039099936467268 -0.187067180190658  0.209842904780090
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.177176189319106  0.180745793486905 -0.423966619701935  0.011581551404741 -0.435227736673098 -0.332709997157265  0.068635087820603  0.194270603508529  0.223291438362236
-    1  (  1)  0.008029890996168  0.071159352891358 -0.119616475449642  0.008384702537145 -0.089986137914585 -0.086564609736733 -0.049250356893305  0.145842215930710  0.062347034381301
-    2  (  2) -0.045518518818118  0.343839163535337 -0.233472741242365  0.080368579839727  0.126856225273009  0.050346450796604 -0.272797593505565  0.041981263678006 -0.011707811055133
-    3  (  3) -0.007469493431466  0.183213548317289 -0.088762887991898  0.062931810249318  0.191997293752100  0.097209516755103 -0.155086433180615  0.027940706556696 -0.056922226205762
-    4  (  4) -0.077210986504954 -0.016819701247264  0.185033281633968 -0.049422880081936 -0.189109252440732 -0.186779489198708 -0.210881285540922 -0.117042610951531 -0.222226069367720
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.507946526774708 -0.114570217649703  0.048527245841715  0.010203674621089  0.247705919078547 -0.174877034117309
-    1  (  1) -0.163586225647048 -0.058410702959740  0.036675256440181 -0.075406267920947  0.102476735587228 -0.049143594232354
-    2  (  2) -0.131726728459177 -0.004508445722954  0.197654988901926  0.066111573872410 -0.203202352604923  0.214036125650491
-    3  (  3)  0.021759317124854 -0.083238776914552  0.152336827943842 -0.374381558468693  0.063066050023990  0.084939819929268
-    4  (  4)  0.069143922701874 -0.077043776247882  0.380503989867731  0.165903594058003  0.189537425628195 -0.045315939845075
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.227899181285790 -0.310912498894659  0.689219478239478 -0.079478153793595 -0.114665208382697  0.066874135145553  0.001767106336999 -0.064286635593960 -0.528833011123776
-    1  (  6)  0.085932045206305 -0.139425745641633  0.214132623058670 -0.106466023697561 -0.037133087530216  0.003208228270672 -0.084039871476020 -0.008112165516730 -0.198641379371657
-    2  (  7)  0.140865167755975 -0.238964691084419 -0.123719313544378 -0.150178910156346  0.036552827587667 -0.145788047396894  0.003054599487236  0.190610288385272 -0.091268008839967
-    3  (  8)  0.314003646861887 -0.266801948817500 -0.167544658270699 -0.306344841393429  0.048058476242923 -0.091573571786136 -0.424170238232336 -0.025710444562560 -0.069058517523444
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5) -0.009761505709912 -0.071611041965292 -0.033187890464826 -0.030058911489328  0.303252590138004
-    1  (  6) -0.012970687354604  0.054215080678130  0.013408998303624 -0.012376394063089  0.052601499533993
-    2  (  7) -0.065224427887993 -0.099017080029867 -0.181261938377539 -0.033115377888204 -0.307260857218546
-    3  (  8)  0.162148451935080 -0.052469354166273  0.420462509284504 -0.024749294887708 -0.151001983092948
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.000094586245827  0.001739034216159 -0.010537869552908  0.047334972317920 -0.047731439209250  0.005684365059231 -0.002004970769717  0.013002399512935  0.004362281903148
-    1  (  1)  0.002961766394137  0.004522349261464 -0.004971921732979  0.008281714530426  0.002230363604714  0.014875582549511  0.067042000917223  0.013799171377680 -0.003919897579650
-    2  (  2)  0.001156412963293  0.011364234143839  0.009216206726470 -0.026466547461677  0.045020900704996  0.024548395511813  0.151471994533512  0.022837481284214 -0.020115226329263
-    3  (  3) -0.011852349375574 -0.003988646850217  0.013577384689322 -0.005526397380180  0.001842046319486 -0.004979014314656 -0.016339528158709 -0.010418265583646 -0.006987140577564
-    4  (  4) -0.053414892823166 -0.048153350433577  0.085702787700908 -0.002590796143814 -0.032944657079404 -0.019536461914947 -0.058299722542085  0.003474393981100 -0.035804248206919
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.005742496352089 -0.004961968677187  0.000867750492921  0.000423220824064  0.002281350853377 -0.002319078012885
-    1  (  1)  0.000158469276644 -0.005351239914036 -0.000795321285338 -0.002864683008960  0.001069113574892 -0.000329369855655
-    2  (  2)  0.008857571112387  0.013536716587928  0.030733225492944  0.004374372006235 -0.001058560017428  0.003465102183553
-    3  (  3)  0.011600439755925 -0.024957479123119  0.006847707754520 -0.007864292440218  0.004416464065001  0.003633652759043
-    4  (  4)  0.033694384788133  0.004962932699877 -0.009297525951248  0.012733703500189  0.018367081934284  0.009679397059252
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5)  0.003045623738158  0.003223303867390  0.030817819346573 -0.037045300325429 -0.045442950096415  0.007571150688185  0.007566775075852 -0.005588481369027 -0.003651001867964
-    1  (  6) -0.004099418610937  0.004975274176733  0.011544459812740  0.010294229250284  0.015031160006114 -0.051218487667392  0.101906256296975  0.009904945529844 -0.005253312938090
-    2  (  7)  0.030335391006009 -0.051022890381624 -0.010476800488702  0.022518293205800  0.032764950392901 -0.046697791867379  0.082351516945318  0.029648976257074 -0.032167076936008
-    3  (  8) -0.044658129227156  0.062597356732527  0.000792791453374  0.033784835620008  0.053456373167225 -0.070727519139336  0.103493505632204 -0.004470770048209  0.021985036653810
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5)  0.001480974473112 -0.004808173156554  0.000537012459275  0.002113989621550  0.002047536201115
-    1  (  6) -0.001406578559496  0.001390228208264  0.004138454793102 -0.000537337753817  0.000303816821287
-    2  (  7) -0.018025108332468 -0.007054019298238  0.018234650266675  0.000615735445240 -0.005903954759545
-    3  (  8)  0.015821389930880  0.004485038750012  0.033862855604013  0.005131802362361  0.004339290288994
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     4
-	   Irrep: 1 row =     4	col =     5
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000001449238259  0.000678316267211 -0.036387013015476  0.044165966800408
-    1  (  1) -0.000814667967299 -0.001352515705922 -0.045321830954914  0.038349341793270
-    2  (  2) -0.015502636931662 -0.023469494614593 -0.379996723739930  0.218264143072345
-    3  (  3) -0.013628579969907 -0.020644856937936 -0.203890445404530  0.063633237712543
-    4  (  4) -0.057281075456987 -0.097258539285045 -0.216440994273141 -0.416992135205754
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  5)  0.000001236340623  0.000844654959821  0.015387325728454  0.013448305856449  0.057069742160392
-    1  (  6) -0.000671443618202  0.001379778933016  0.023464050046926  0.020715419540811  0.097609214874198
-    2  (  7)  0.036865842405657  0.045128807455787  0.379409175136556  0.203871625155191  0.217739325178581
-    3  (  8) -0.044448744496422 -0.038059525477200 -0.217450238194944 -0.062961627736516  0.417728912438826
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.065654735008108 -0.041947596327668 -0.013161199168533  0.111347678755871 -0.110023740318908 -0.028611010363429 -0.087382345014260  0.000508462096037 -0.012737899474334
-    1  (  1)  0.002767746541470  0.010697717051867 -0.013506220021757 -0.073915296604893  0.218001416614763  0.148131871022263  0.817268502509706  0.116805979922717 -0.086849043444928
-    2  (  2) -0.048963621348430 -0.019287708607099 -0.016788280782980  0.373428608200955 -0.152149392753608  0.191763183105895  0.187319092582735  0.050811648582791 -0.023575112696311
-    3  (  3)  0.095762834263892  0.056431729424626 -0.178579681981428 -0.038136357828172 -0.140424938057787 -0.089806149182954  0.125801298670935  0.116636879752083  0.084795042899147
-    4  (  4)  0.100604286311178  0.067706025938121 -0.243618193961101 -0.044366280428374 -0.181211603026352 -0.115080151607553  0.179519058512823  0.083926718748696  0.086977297577403
-    5  (  5) -0.065265671644906 -0.066327743019948  0.367151009089566 -0.044017259434143 -0.156512208948530 -0.073862917481627  0.054143364445078  0.093320733204408 -0.170259938231209
-    6  (  6)  0.072248633599947  0.071960000241620 -0.684414897034704  0.206865946506378  0.380155073024861  0.217464187923408 -0.101287724653335 -0.035777873700140  0.341068954568277
-    7  (  7) -0.019742165644621 -0.004654695913907 -0.113798440024880  0.000565529496792 -0.010619803498230 -0.072865384546327 -0.376900870832898 -0.139303623390988  0.056085243769597
-    8  (  8) -0.000680094833114 -0.001599154367371  0.037525715342391 -0.088616153955606  0.068221855491928 -0.039176398110699 -0.208508596289410 -0.056090509029161  0.046056992364179
-    9  (  9)  0.002777645983491  0.007429062082265  0.024943481241087 -0.022917119544815  0.035703520332323  0.020318143538961  0.128836192485179 -0.002260232930744  0.005711636818947
-   10  ( 10)  0.005703995475187 -0.023273790317780 -0.027225231172569 -0.026560091638037  0.035400448225392  0.015156814544557  0.030152251932565  0.170108826646880  0.002596342796932
-   11  ( 11)  0.003384396390287  0.002280174982981 -0.118256290646368 -0.004806020897038  0.008748567786521 -0.061729684148256 -0.016174365364760  0.021868062171602 -0.291086856664191
-   12  ( 12) -0.020556143591060  0.013540147573963 -0.000211121149248  0.008542300507699 -0.013892871033950 -0.041889373563059 -0.006010019596642 -0.135825905700256 -0.000315224141913
-   13  ( 13) -0.004670555023840 -0.000926561289656 -0.016865377218670  0.001909514550959  0.008533193721317  0.002601173416076  0.067131182151494  0.024630652702465  0.002093308136502
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006448538326546  0.007804286654557 -0.001728462971935 -0.009631296803397 -0.002170488409239  0.006916574569899
-    1  (  1)  0.039841926431094  0.031613947455229  0.126270875290483 -0.005440111027698 -0.010222827907129  0.010738179450812
-    2  (  2)  0.049401198576892 -0.028053807136363 -0.027408978164445 -0.001009242763448  0.006677350800637  0.009978793374560
-    3  (  3) -0.070461023388028  0.083098730910732 -0.035907242226525  0.018802920956394 -0.017169790328324 -0.011284969259854
-    4  (  4) -0.035774581056077 -0.067898310104354  0.022184152779517 -0.018305692607931 -0.010769002732021 -0.005255691542637
-    5  (  5) -0.149333021464651  0.107123749279080  0.046254018736456  0.009064635064199 -0.006568763780996 -0.015962058047808
-    6  (  6)  0.264128410974010  0.189717497993806 -0.013846515708785  0.034468727519864 -0.018622848646936  0.039126031881052
-    7  (  7)  0.078788486645653 -0.137080811211666  0.129024824415654 -0.020540287905800  0.010701749641589  0.006364102239056
-    8  (  8) -0.066828033976249 -0.061150264268413 -0.661663701924733 -0.064427601490291  0.022787129232047  0.001755163119735
-    9  (  9) -0.058361499120098 -0.002765573216636 -0.292978668220555  0.024531949919018 -0.033842058784980  0.017477748330907
-   10  ( 10) -0.025537285280604  0.402776973579754 -0.195006698620815 -0.143818174533728  0.044952564489986 -0.042833811279285
-   11  ( 11)  0.612581240841896  0.030682190159458 -0.052907135351065  0.397594452860863  0.644994636219877 -0.225177389580867
-   12  ( 12) -0.078361600716649  0.147641318569098 -0.139660052106199  0.415352895613913 -0.111207710564659  0.045767890147728
-   13  ( 13) -0.007556092974866  0.007033999869554 -0.662815062198416 -0.034075784956457  0.058439367352623 -0.002858040197037
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.065637755065296 -0.002922147800215  0.048671929226138 -0.095125218272003 -0.099723510384958  0.064120169702230 -0.070291835315882  0.020001124961592  0.000648211315578
-    1  ( 15)  0.042163964947943 -0.010964528434227  0.019190852116048 -0.056424446694003 -0.067775298013055  0.066345972766125 -0.071820352073591  0.004697838980096  0.001720052135460
-    2  ( 16)  0.013293234442870  0.013552616835989  0.017151141683736  0.178064685884642  0.243210819205006 -0.366658155299651  0.683572979587335  0.113726231443006 -0.037674714506423
-    3  ( 17) -0.111834066297571  0.074488566075957 -0.373405604015245  0.038275795575228  0.044268719891376  0.043920774238880 -0.206762135944084 -0.000719712475052  0.088713007894149
-    4  ( 18)  0.110610680532425 -0.218553221231058  0.152104326157335  0.140305969875780  0.181385048024784  0.156380031467975 -0.379725260140945  0.010777712393018 -0.068072026056361
-    5  ( 19)  0.028752302296866 -0.148103525280228 -0.191867478523695  0.089886445678393  0.115405895081911  0.073530973630370 -0.216895482105819  0.072888841616772  0.039414401003105
-    6  ( 20)  0.088850241354773 -0.817864851326399 -0.187539096014714 -0.126557765665900 -0.179187648392432 -0.053967687035441  0.101345461779185  0.376808417579726  0.209641178673511
-    7  ( 21) -0.000237007967331 -0.116953554114382 -0.050876563599610 -0.116849514388006 -0.083854529763923 -0.093202283171221  0.035655664861976  0.139240246932033  0.056215237122519
-    8  ( 22)  0.012631614747874  0.086750070473424  0.023465016121868 -0.084651439922309 -0.087073871250464  0.170290795114530 -0.341033647036818 -0.056079524884524 -0.046129894380799
-    9  ( 23)  0.006387258080938 -0.039628230453701 -0.049240369744356  0.070606950701540  0.036097322010346  0.148730552434340 -0.263190621956396 -0.078651755284235  0.066792980839994
-   10  ( 24) -0.007794022168576 -0.031646533198791  0.027998592231561 -0.083306318414635  0.068241222884855 -0.107186318196201 -0.189423229550161  0.136892100121890  0.061228415636292
-   11  ( 25)  0.001991556117374 -0.126407066966917  0.027445453708537  0.035776931996673 -0.022144073093222 -0.046221166077784  0.013824310435878 -0.129003604478449  0.661853480191135
-   12  ( 26)  0.009600001381321  0.005495023036659  0.001033843833566 -0.018933720846780  0.018384184656961 -0.009023079515234 -0.034487318996206  0.020439451427378  0.064455522190826
-   13  ( 27)  0.002162652889855  0.010273373773252 -0.006629751598900  0.017146243746684  0.010737091256527  0.006596576890623  0.018510833168568 -0.010689123006489 -0.022830313481384
-   14  ( 28) -0.006906519508983 -0.010703298470916 -0.009943758355024  0.011262502029653  0.005260769217762  0.015967223931621 -0.039174936770116 -0.006358557612866 -0.001746796831110
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.002837541625479 -0.005729995405909 -0.002886518732238  0.020605597892472  0.004641188066032
-    1  ( 15) -0.007437048654888  0.023276858901465 -0.002356564609691 -0.013557218145514  0.000920022592980
-    2  ( 16) -0.025051840291799  0.027193054194177  0.117992112524578  0.000179363116265  0.016865629814803
-    3  ( 17)  0.023119646954968  0.026651954594642  0.004797412115556 -0.008529729543576 -0.001864254829128
-    4  ( 18) -0.035882182969490 -0.035473966824270 -0.008734659729202  0.013878374004773 -0.008565471497804
-    5  ( 19) -0.020360728363539 -0.015171578403734  0.061893166186221  0.041911320086821 -0.002602292601012
-    6  ( 20) -0.129299086068177 -0.030292751382697  0.016131997141108  0.006006544744005 -0.067163025039189
-    7  ( 21)  0.002077772697434 -0.170151043409813 -0.021893310204112  0.135824150659838 -0.024649382850585
-    8  ( 22) -0.005657966549308 -0.002564604629079  0.291029976300794  0.000304129767732 -0.002095216593482
-    9  ( 23)  0.058382786939725  0.025529985547566 -0.612383083539007  0.078382664400516  0.007563097139095
-   10  ( 24)  0.002481602054434 -0.402824416561843 -0.030641142278648 -0.147639477009355 -0.007047503750138
-   11  ( 25)  0.292947582813084  0.194977107587304  0.052900457813842  0.139655219584998  0.662817050200718
-   12  ( 26) -0.024630679059925  0.143803617200920 -0.397605905120325 -0.415353689227297  0.034075915591583
-   13  ( 27)  0.033850912401595 -0.044956212946434 -0.644990528852317  0.111210544073818 -0.058439348225225
-   14  ( 28) -0.017470255422903  0.042829071311909  0.225189839155519 -0.045765192297719  0.002860289599065
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    15
-	   Irrep: 1 row =     4	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.000082472399485 -0.001685231176796  0.010755773525388 -0.047851717401665  0.048146819273485 -0.005778305812536  0.002186428407135 -0.012926921192549 -0.004368364269075
-    1  (  1) -0.003220446784849 -0.004738636604093  0.005203623953188 -0.008888194042355 -0.002288606689271 -0.015840258607316 -0.070307447815582 -0.014526857103437  0.004025200443461
-    2  (  2) -0.000042865955623 -0.012225756716588 -0.007261122888631  0.023892647415290 -0.043398248169209 -0.025204087353238 -0.154395827172648 -0.022995799169003  0.019572129394279
-    3  (  3)  0.012592260526611  0.003257441214905 -0.012596956453141  0.005674588565405 -0.002140019515693  0.004967236803689  0.013568818625003  0.009521055757566  0.006284449533271
-    4  (  4)  0.059292235157972  0.046128803984366 -0.084656929226350  0.003079990219286  0.032543882069924  0.021965559038436  0.062290418066479 -0.002788049090113  0.031737368724626
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.005684037207820  0.005039602793450 -0.000945725061671 -0.000425951737672 -0.002277778912713  0.002317519936550
-    1  (  1) -0.000191501808207  0.005615106236174  0.000663390126010  0.002975225050682 -0.001105781730417  0.000339070552009
-    2  (  2) -0.008635332517955 -0.014191287532215 -0.036089824283730 -0.005156223258275  0.001596897527108 -0.003548958630526
-    3  (  3) -0.011309890019207  0.025010408644042 -0.008100841134420  0.008221606197850 -0.004567545117431 -0.003602034133643
-    4  (  4) -0.031941089920318 -0.005014599851329  0.011202388687432 -0.013321967999428 -0.018949090937004 -0.009629290338373
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.003125233656564 -0.003399455999144 -0.031148741955022  0.037381076738134  0.045638651622127 -0.007662804831572 -0.007349573449525  0.005611310740733  0.003664917328648
-    1  (  6)  0.004239191785748 -0.005425853767687 -0.012492096709600 -0.009631640513977 -0.014641915170010  0.052628124238989 -0.104836411205794 -0.010149090123868  0.005577978579558
-    2  (  7) -0.032249780945436  0.047831723366508  0.011228580328865 -0.021149918738029 -0.032870923541039  0.049288992677552 -0.085080122313267 -0.029157301245289  0.030452694267850
-    3  (  8)  0.047028350491069 -0.061446566566321 -0.003294033338017 -0.033510810591702 -0.054311398746913  0.073088847241071 -0.108790202560997  0.002661112810634 -0.019632264686795
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  5) -0.001457812391480  0.004843826108852 -0.000616649231345 -0.002107188882039 -0.002069763501018
-    1  (  6)  0.001542410811557 -0.001336446699507 -0.005164909835080  0.000321011671623 -0.000311756266696
-    2  (  7)  0.017960207879172  0.006001515410680 -0.022177717492308  0.000230841789591  0.006008101007254
-    3  (  8) -0.014825188397798 -0.004501578726465 -0.038679782557990 -0.004764087686308 -0.004599594990344
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.087812486802714 -0.227185881204308 -0.033695530666594  0.478017916502669  0.574663197793692 -0.064626389159099 -0.111307888755798  0.039881613474602 -0.259357506752495
-    1  (  1)  0.022503443769316 -0.058098624598860 -0.000062737918384  0.132304975924250  0.206845232883897 -0.090151376053575  0.021623075719394  0.039361678247531 -0.081041759051801
-    2  (  2)  0.058445994221533 -0.108172157762627 -0.020491572140790 -0.029038343086670  0.075256235298781 -0.197244174432849  0.268904784689931  0.104165947953548 -0.067340387823683
-    3  (  3)  0.015395524077221 -0.065975045803857 -0.020693287808150 -0.145278133913277 -0.156811996241071 -0.026190402384534  0.072791620047589  0.106379128630683 -0.008110006774417
-    4  (  4) -0.209889658675087 -0.051262188320910  0.016792501067509  0.095510068644020 -0.095336439261671  0.289116373116523 -0.245753854267222  0.379261942918032 -0.084194499540513
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.026329060677561  0.025808752955184 -0.031327528625543 -0.046690857000306  0.148308927158050
-    1  (  1) -0.009235920741953  0.024147623936324 -0.039515998985496 -0.082736567474275  0.047511961836932
-    2  (  2) -0.028213252690267 -0.067760879803439 -0.238885756342533  0.125969167249307 -0.177609450790050
-    3  (  3) -0.077606280867099  0.045313516945509 -0.093141201786142 -0.365274001930932 -0.093447139644196
-    4  (  4) -0.414915524340511 -0.159852629117801  0.273568256443621  0.034618663880565 -0.200919735657569
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5)  0.100097042064109  0.081572276694192 -0.096987973401318 -0.663339574002089  0.420147890655544 -0.277783810889268  0.064637315926862 -0.070466235403012  0.070257725486540
-    1  (  6)  0.016102698458229  0.069778494124348 -0.053388838781434 -0.227200874402225  0.199230150396393 -0.049687570998643  0.168877481796607  0.014461212744262  0.006078038840458
-    2  (  7) -0.058029520985814  0.323045677762244 -0.030451382839222  0.087822452562579  0.049669591787373  0.052839271896380  0.277652100807769  0.149775013154872 -0.305937144304185
-    3  (  8)  0.084055246767285 -0.046073361564883 -0.190725816125328  0.087557928956100  0.137785486093215  0.205465565690345  0.198777613886308  0.118276971790536  0.298899295836575
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5) -0.218570828330775  0.002459809908623  0.012856145681193 -0.000021824790697  0.113054815969725 -0.069738880637081
-    1  (  6) -0.065173966437703 -0.083163104973586 -0.059838817731124 -0.009394320556862  0.030439480905892 -0.004211863644554
-    2  (  7) -0.056299348264054  0.068872050619792 -0.330916473514167  0.053769726019105  0.184435953275485  0.103868529931394
-    3  (  8) -0.066328835526796  0.124449731804258 -0.113043712188522 -0.144452781296566 -0.299204298913047  0.043729266175510
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =     5
-	   Irrep: 1 row =     4	col =     4
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4     
-                      (  0)              (  1)              (  2)              (  3)              (  4)    
-
-    0  (  0) -0.000004573398161  0.026286921007013  0.102140891739196 -0.046329210496983 -0.729390567548561
-    1  (  1) -0.025713594330025  0.000257493963458 -0.008292820651928 -0.017063129342656  0.120829528247487
-    2  (  2) -0.100328894362796  0.008488274458083 -0.000453486802032 -0.070579792758556  0.263656732394771
-    3  (  3)  0.045991765483214  0.016576004580395  0.069995620780228 -0.000663293929053 -0.516192116287051
-    4  (  4)  0.731630680372910 -0.119898957246876 -0.260394403495538  0.515781832284347 -0.000889122841553
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  5)              (  6)              (  7)              (  8)    
-
-    0  (  5) -0.000000233652363  0.064564285041516  0.616105149487094 -0.260390668506121
-    1  (  6) -0.062839473886914  0.000444869313415 -0.381925918949370  0.143836397980783
-    2  (  7) -0.621984815196279  0.379451666136779  0.000474943168189 -0.057946188304698
-    3  (  8)  0.264102417786712 -0.142711834506710  0.057683662296849 -0.001429338231608
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000907955469773 -0.057469185422175 -0.021763852977055  0.110173024043768  0.041201460747158 -0.038867594921468  0.013631034243177 -0.027732793365817 -0.095898777358609
-    1  (  1)  0.055346863269661  0.000117397021226  0.161081748599380 -0.114723957474251  0.226132876592379 -0.429585342377155  0.364791648688510  0.339772079862666  0.220539658945858
-    2  (  2)  0.020991641046944 -0.161271433223917 -0.000050685334098 -0.056776200217074 -0.009044014133991 -0.218250624524151  0.249343498568951  0.218110128138336 -0.109319147419263
-    3  (  3) -0.109915677298642  0.115821457323195  0.056019036251094 -0.000733462930927 -0.462847670362492 -0.122610728429171 -0.103870362151314 -0.116256811511125 -0.000235264198743
-    4  (  4) -0.040148332688022 -0.225919341325781  0.007774686784298  0.462782646228266  0.000741776518072 -0.292876641149551  0.009422958660044  0.051871653386108  0.039841372684353
-    5  (  5)  0.036323208125674  0.431174165520025  0.219019937969006  0.122662494624249  0.292740404743441  0.000270242671647 -0.380080578538411 -0.122527668576026 -0.042269981844046
-    6  (  6) -0.010516440934539 -0.366108347757634 -0.249485131281357  0.103528510366960 -0.008569286781080  0.379122670006848  0.000624830510989 -0.110535367048428  0.061996730290172
-    7  (  7)  0.028781772116013 -0.339082292903162 -0.216804267770263  0.114009058372185 -0.053199921835397  0.122164619547920  0.109911089305582  0.000201005708325  0.084720810347527
-    8  (  8)  0.095803905327850 -0.221313012959504  0.109107703119537  0.000853061874275 -0.038572704846279  0.040543435561974 -0.059772638543626 -0.084702259478363 -0.000398228836127
-    9  (  9) -0.014691667187958  0.105292570343760  0.107275838133277 -0.218834816088194 -0.309692871922803  0.105243205577181  0.129645166169486 -0.117998834741075 -0.042504917170727
-   10  ( 10)  0.029203870468029 -0.107748796905021  0.099755509494998 -0.053531025979861 -0.138316456824170 -0.190112587233628  0.089998700048056  0.050364754033155  0.205939040674301
-   11  ( 11)  0.155171838187128 -0.443695654470558  0.328777376012082  0.218797371784095  0.215174674557682 -0.086664093392768  0.081418220508178  0.042687160450597 -0.076994354407445
-   12  ( 12) -0.047145160367930 -0.056368730619817  0.091887374001802 -0.290642148185853  0.241903957589790  0.247340653422069 -0.042832976953373 -0.092376972414730  0.274156931627591
-   13  ( 13)  0.050391965898587 -0.050333352324666  0.290239980689431 -0.162047784246261 -0.213771322704111  0.103684767873762  0.033887030706559  0.045587927208000 -0.299795917187637
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015152137307395 -0.029090729505159 -0.157684936500365  0.046161542678081 -0.051363105029612
-    1  (  1) -0.106897196217704  0.107201102435279  0.445385718438941  0.057067785198253  0.050052518334036
-    2  (  2) -0.108854165260085 -0.100194375517978 -0.328544186390936 -0.092696505312142 -0.291518890939844
-    3  (  3)  0.218863893287095  0.054794851259918 -0.218938432987514  0.287403740652911  0.163302332974643
-    4  (  4)  0.309034872968878  0.137544963853166 -0.215099581748332 -0.238286123100997  0.213544968889557
-    5  (  5) -0.105670967587971  0.189853214810089  0.086869490259104 -0.246369920975845 -0.103885372481427
-    6  (  6) -0.128168532603125 -0.089875733171815 -0.081956625213594  0.043636943354897 -0.033214897715844
-    7  (  7)  0.118055343081714 -0.049681264688510 -0.043690935847564  0.088890000697565 -0.045590550639158
-    8  (  8)  0.043186782282413 -0.206227590933231  0.075246025161497 -0.272589996873107  0.299124983726597
-    9  (  9)  0.000078385332361 -0.416516334936076 -0.033604820343445  1.079154966452740 -0.144880662209521
-   10  ( 10)  0.417423659534060  0.000158734809049  0.288841615674402  0.322138826783892  0.291543232279926
-   11  ( 11)  0.033231980297474 -0.288689770834225 -0.000097756434677 -0.357467030590011  0.110233460697010
-   12  ( 12) -1.082591724249888 -0.322580189787378  0.357467662511204  0.000002506014296  0.002430685027476
-   13  ( 13)  0.144962273119514 -0.291352173494917 -0.110200949743104 -0.002467419229282 -0.000069717512569
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000157847868290 -0.016215825751449 -0.024921140835205  0.061983131961857  0.021488523719638 -0.118636842442394  0.004655357150719  0.089073046050162 -0.035341743401839
-    1  ( 15)  0.019053182436356 -0.000070169967981 -0.073750458708140  0.220490357770091 -0.117197217087347  0.070067667295608  0.194628222644904 -0.297272902676479  0.000293976323977
-    2  ( 16)  0.022582832837764  0.073727619849646  0.001107847074438  0.015450445254245  0.086512268412040  0.104891342903803  0.398746578386172  0.436629051698872 -0.174929886371767
-    3  ( 17) -0.059789121193802 -0.223561162265227 -0.017246884213665 -0.001133413477177 -0.251269351960067  0.316046055900051 -0.194798853929635 -0.070662293795111  0.376486192709736
-    4  ( 18) -0.020057750204430  0.119048744706178 -0.086804996984604  0.251600027452705  0.000367087018011 -0.043049167161065 -0.031725417674779 -0.166603526743631 -0.162562866352690
-    5  ( 19)  0.121121989980594 -0.070389389412088 -0.107110436996367 -0.315426861814928  0.043156406137713  0.000869379131471 -0.084802565522683 -0.176704066299640  0.191684108270085
-    6  ( 20) -0.000235440759562 -0.194647772440619 -0.399809021490062  0.193925182227417  0.032502800135540  0.085527959530692 -0.000317898540611 -0.483152129979633  0.288296772864155
-    7  ( 21) -0.086715820819702  0.297225893875278 -0.437407006325733  0.070318446772769  0.166613176598092  0.177266472787051  0.482842334868818  0.000016918979194 -0.098143930537984
-    8  ( 22)  0.034831350836153 -0.000872627608987  0.174095892709366 -0.374201949238123  0.160687471280960 -0.191573703451277 -0.289458084753142  0.097035452987332  0.000013740238338
-    9  ( 23)  0.146118515580350 -0.053502339654622 -0.324227151480280 -0.062879262377670 -0.055255843282985 -0.064120285426383 -0.153000151235781 -0.139466633420354  0.103712199912250
-   10  ( 24) -0.228945744119783  0.607905104064675  0.190622145647686  0.232969653682917  0.097299564671426 -0.308157084769049  0.021742266672299 -0.163622560408140 -0.316403584487308
-   11  ( 25)  0.113574561081893  0.174427526201227 -0.418996588560739 -0.308337890204768  0.075444305281087 -0.339087016260170  0.159464081752923  0.028413159978625  0.098872332026849
-   12  ( 26)  0.037423041327835  0.021648771086278 -0.117301902633040  0.051910253781133 -0.180460975810878 -0.010738685992300 -0.081522476682207  0.155892729451823 -0.070548639310764
-   13  ( 27) -0.017278226707665  0.067257600974327 -0.031226328151039  0.363801361341849 -0.387214773801119 -0.012092634242527 -0.015811686451139 -0.054980449112106  0.199341286273110
-   14  ( 28) -0.034098877274819 -0.073619948740194  0.020485593124333  0.085857788764361 -0.016813215913708  0.112843948958225  0.014111719587198 -0.178008154299853 -0.110352523624475
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147089036077913  0.230609246333956 -0.117988169590393 -0.038149068395854  0.016533997268475  0.035539218704947
-    1  ( 15)  0.054543847501128 -0.607931931871522 -0.173885522614505 -0.021417520123414 -0.066622101243279  0.073367218834160
-    2  ( 16)  0.323560135302739 -0.191870807778304  0.420420434136358  0.118053590585123  0.032670802184181 -0.021056727281085
-    3  ( 17)  0.062629597315317 -0.233299844808483  0.309977543312231 -0.052769685030093 -0.365461347094339 -0.086199175003951
-    4  ( 18)  0.056447422230211 -0.097271671471775 -0.076718205841652  0.181009141023511  0.388597209783852  0.017027546198961
-    5  ( 19)  0.064625561658584  0.308871002861823  0.338019230856820  0.010261814723335  0.011433268868982 -0.112355672161098
-    6  ( 20)  0.155386502136174 -0.021348579055017 -0.159407999745103  0.081841042748257  0.016549191473790 -0.014157952683401
-    7  ( 21)  0.140540096961588  0.163951619155724 -0.028637880230024 -0.155665388085339  0.055624540700681  0.178156006121949
-    8  ( 22) -0.103301881326260  0.315447035672016 -0.098512677196952  0.070639282292011 -0.199218391104609  0.110198697628348
-    9  ( 23) -0.000663622883023  0.100173520438882  0.098204705212881 -0.175395219081789  0.218098160139060 -0.228144978515468
-   10  ( 24) -0.099942092134404  0.000097468800859 -0.318473220070567  0.225313093930981  0.500004371994231  0.463865695451562
-   11  ( 25) -0.099842118029420  0.317761930545871  0.000010523168953 -0.325598172610521  0.211905221625396  0.064803699959669
-   12  ( 26)  0.174938990446214 -0.225293131455683  0.325706928587658  0.000017996650401  0.212072595691568 -0.098012137478043
-   13  ( 27) -0.218632649333873 -0.499554553991155 -0.211866619547631 -0.212028430474401 -0.000008186017705  0.140826029388741
-   14  ( 28)  0.228628738648224 -0.463532597742934 -0.064881129531643  0.097950992094232 -0.140879017093708  0.000044241358907
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     5	col =    14
-	   Irrep: 1 row =     4	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.090077743026585  0.231039150143160  0.035901155034428 -0.481309880145456 -0.577015812892151  0.065493297263049  0.109555018957673 -0.040603254337130  0.258464518895278
-    1  (  1) -0.019495186393093  0.054320580816236 -0.001045736787244 -0.125508921505938 -0.201846826508412  0.093650850655654 -0.025107322700080 -0.040286353452445  0.082871989440490
-    2  (  2) -0.062215540941165  0.120396336103156  0.021743992129717  0.030463697336240 -0.074900934911718  0.202626976611110 -0.283667442951541 -0.110634443439646  0.075608806251107
-    3  (  3) -0.020163928258686  0.073789795481527  0.021156706374422  0.146008461264537  0.150840822798868  0.033519029414616 -0.073778852718729 -0.114734511054422  0.006819656222072
-    4  (  4)  0.203040453592295  0.062001347868375 -0.011512293647419 -0.096768363837510  0.111807150026723 -0.294391558964001  0.263747857598306 -0.381852842949882  0.093844039126354
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.025993782100173 -0.025999585079478  0.031172097435929  0.047041016408549 -0.148712388894479
-    1  (  1)  0.009949948380770 -0.025509667540199  0.042843352121632  0.089630217336913 -0.047316601811719
-    2  (  2)  0.029963791233496  0.072057651603260  0.251082472301341 -0.142797702824446  0.185511481024750
-    3  (  3)  0.083129601747289 -0.054851933187026  0.095052156702046  0.402625231275539  0.093237580628574
-    4  (  4)  0.432717579385058  0.171349899855996 -0.283686718567670 -0.039467885900519  0.208554131467473
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  5) -0.104614863306895 -0.081909309664589  0.097158251467365  0.670160714387605 -0.424820194069004  0.278664534578716 -0.065626044006430  0.069546432842010 -0.070000054325300
-    1  (  6) -0.010085625022161 -0.069917915491100  0.056941601077432  0.210912516923027 -0.193068723612150  0.043449407478297 -0.178527100593784 -0.011181245670583 -0.006301249278673
-    2  (  7)  0.063931508371222 -0.335394578331372  0.025043518081311 -0.077579408335948 -0.050355760225038 -0.056838358642999 -0.295412430798026 -0.157711561653239  0.309543375529247
-    3  (  8) -0.095558904649282  0.044385291331450  0.213125203767356 -0.091469789652533 -0.149404677133607 -0.211821253458640 -0.210445033324566 -0.121082629036070 -0.309925077983326
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  5)  0.218346355468078 -0.003902993442248 -0.013122127072821  0.000019181154163 -0.113545011116700  0.070000462264808
-    1  (  6)  0.067825713099569  0.093018679870754  0.065864077971857  0.010196560530307 -0.030000649698597  0.002861076795818
-    2  (  7)  0.052960836246031 -0.070309519011265  0.343853923778325 -0.057147372465282 -0.187370347352601 -0.107071443547134
-    3  (  8)  0.073661134979508 -0.126624026209396  0.117774893248785  0.149927731022440  0.310100412138852 -0.046254145606780
+	Computing P*_X-Perturbed Wave Function (0.077 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         9.060667107213
+	   1        10.230094331833    2.336e-01
+	   2        10.878623310666    1.246e-01
+	   3        10.920755475451    5.172e-02
+	   4        10.940073592800    2.266e-02
+	   5        10.944573462611    1.007e-02
+	   6        10.946062995316    5.009e-03
+	   7        10.946724959637    2.433e-03
+	   8        10.946587522118    1.129e-03
+	   9        10.946678480221    4.413e-04
+	  10        10.946714665293    1.827e-04
+	  11        10.946683114809    4.749e-05
+	  12        10.946657639330    1.451e-05
+	  13        10.946652290833    4.569e-06
+	  14        10.946652161370    2.193e-06
+	  15        10.946652311423    9.841e-07
+	  16        10.946652170321    4.231e-07
+	  17        10.946651978847    1.867e-07
+	  18        10.946651882362    1.012e-07
+	-----------------------------------------
+	Converged P*_X-Perturbed Wfn to 4.472e-08
 
 	Computing L*_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.688113428622
-	   1         5.741498311354    2.665e-01
-	   2         6.609560316268    1.453e-01
-	   3         6.630463299655    3.197e-02
-	   4         6.646768475800    1.241e-02
-	   5         6.647630147101    3.715e-03
-	   6         6.647850482439    1.592e-03
-	   7         6.648121962751    6.038e-04
-	   8         6.648081073408    2.075e-04
-	   9         6.648073487392    5.707e-05
-	  10         6.648073001126    1.759e-05
-	  11         6.648077370550    5.089e-06
-	  12         6.648078340134    1.449e-06
-	  13         6.648078087027    4.425e-07
-	  14         6.648077950643    1.615e-07
+	   0         4.688113425770
+	   1         5.741498306932    2.665e-01
+	   2         6.609560308995    1.453e-01
+	   3         6.630463292169    3.197e-02
+	   4         6.646768468168    1.241e-02
+	   5         6.647630139460    3.715e-03
+	   6         6.647850474795    1.592e-03
+	   7         6.648121955104    6.038e-04
+	   8         6.648081065761    2.075e-04
+	   9         6.648073479746    5.707e-05
+	  10         6.648072993479    1.759e-05
+	  11         6.648077362903    5.089e-06
+	  12         6.648078332487    1.449e-06
+	  13         6.648078079380    4.425e-07
+	  14         6.648077942996    1.615e-07
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 5.768e-08
+
+	Computing P*_Y-Perturbed Wave Function (0.077 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         9.507619434276
+	   1        11.138227594445    3.116e-01
+	   2        12.296565595750    1.658e-01
+	   3        12.358209815784    4.377e-02
+	   4        12.378046484514    2.114e-02
+	   5        12.381846695815    6.242e-03
+	   6        12.381701897066    2.293e-03
+	   7        12.382093991071    7.879e-04
+	   8        12.382073474260    4.104e-04
+	   9        12.382007729879    2.356e-04
+	  10        12.382035954041    1.188e-04
+	  11        12.382058128515    4.754e-05
+	  12        12.382066916021    2.007e-05
+	  13        12.382056860811    7.631e-06
+	  14        12.382053858651    2.828e-06
+	  15        12.382052923373    1.052e-06
+	  16        12.382052862014    4.232e-07
+	  17        12.382052650276    1.827e-07
+	-----------------------------------------
+	Converged P*_Y-Perturbed Wfn to 6.758e-08
 
 	Computing L*_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.238988351791
-	   1         0.313357017162    7.380e-02
-	   2         0.379958534676    4.166e-02
-	   3         0.382751712719    9.776e-03
-	   4         0.383652093665    2.304e-03
-	   5         0.383571357599    5.862e-04
-	   6         0.383562021794    1.868e-04
-	   7         0.383573372581    8.272e-05
-	   8         0.383569452795    3.591e-05
-	   9         0.383570743838    8.691e-06
-	  10         0.383570961612    2.649e-06
-	  11         0.383570827805    7.177e-07
-	  12         0.383570673574    2.328e-07
+	   0         0.238988351583
+	   1         0.313357016823    7.380e-02
+	   2         0.379958534082    4.166e-02
+	   3         0.382751712094    9.776e-03
+	   4         0.383652093031    2.304e-03
+	   5         0.383571356966    5.862e-04
+	   6         0.383562021161    1.868e-04
+	   7         0.383573371948    8.272e-05
+	   8         0.383569452162    3.591e-05
+	   9         0.383570743205    8.691e-06
+	  10         0.383570960979    2.649e-06
+	  11         0.383570827173    7.177e-07
+	  12         0.383570672941    2.328e-07
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 4.632e-08
+
+	Computing P*_Z-Perturbed Wave Function (0.077 E_h).
+	Iter   Pseudopolarizability       RMS 
+	----   --------------------   -----------
+	   0         9.864920677955
+	   1        11.233855850930    2.789e-01
+	   2        12.146354177879    1.415e-01
+	   3        12.167457193356    3.954e-02
+	   4        12.177946730928    1.875e-02
+	   5        12.181408634620    6.469e-03
+	   6        12.181692879173    2.767e-03
+	   7        12.182028146949    1.329e-03
+	   8        12.182037386487    5.669e-04
+	   9        12.182000771466    1.860e-04
+	  10        12.182016630476    6.954e-05
+	  11        12.182023239907    3.243e-05
+	  12        12.182025135065    1.576e-05
+	  13        12.182020072269    7.115e-06
+	  14        12.182018296516    3.126e-06
+	  15        12.182017778567    1.369e-06
+	  16        12.182017707230    5.555e-07
+	  17        12.182017562070    2.154e-07
+	-----------------------------------------
+	Converged P*_Z-Perturbed Wfn to 9.868e-08
 
 	Computing L*_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.150959808489
-	   1         5.002082687546    2.326e-01
-	   2         5.684029553731    1.364e-01
-	   3         5.730062791808    4.045e-02
-	   4         5.750019839179    1.196e-02
-	   5         5.749109122479    3.146e-03
-	   6         5.749287452679    1.051e-03
-	   7         5.749426387564    3.241e-04
-	   8         5.749379266935    1.156e-04
-	   9         5.749383318015    3.001e-05
-	  10         5.749383600309    9.479e-06
-	  11         5.749384330234    3.047e-06
-	  12         5.749383626324    1.191e-06
-	  13         5.749383528651    4.017e-07
-	  14         5.749383689716    1.511e-07
+	   0         4.150959806417
+	   1         5.002082684326    2.326e-01
+	   2         5.684029548231    1.364e-01
+	   3         5.730062785856    4.045e-02
+	   4         5.750019833031    1.196e-02
+	   5         5.749109116339    3.146e-03
+	   6         5.749287446537    1.051e-03
+	   7         5.749426381420    3.241e-04
+	   8         5.749379260792    1.156e-04
+	   9         5.749383311871    3.001e-05
+	  10         5.749383594166    9.479e-06
+	  11         5.749384324091    3.047e-06
+	  12         5.749383620181    1.191e-06
+	  13         5.749383522508    4.017e-07
+	  14         5.749383683573    1.511e-07
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 4.933e-08
 
 	Computing Q_XX-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        14.805312489026
-	   1        18.148639935840    4.034e-01
-	   2        20.228012764774    1.777e-01
-	   3        20.248814382193    3.433e-02
-	   4        20.265866417772    1.459e-02
-	   5        20.266754475724    3.378e-03
-	   6        20.267427867973    1.063e-03
-	   7        20.267656930144    3.577e-04
-	   8        20.267606669625    1.198e-04
-	   9        20.267598891344    3.861e-05
-	  10        20.267606630598    1.277e-05
-	  11        20.267611154159    4.577e-06
-	  12        20.267611273778    1.579e-06
-	  13        20.267610349370    5.593e-07
-	  14        20.267610081444    1.788e-07
+	   0        14.805312478725
+	   1        18.148639921062    4.034e-01
+	   2        20.228012744816    1.777e-01
+	   3        20.248814362069    3.433e-02
+	   4        20.265866397499    1.459e-02
+	   5        20.266754455442    3.378e-03
+	   6        20.267427847686    1.063e-03
+	   7        20.267656909856    3.577e-04
+	   8        20.267606649337    1.198e-04
+	   9        20.267598871056    3.861e-05
+	  10        20.267606610310    1.277e-05
+	  11        20.267611133871    4.577e-06
+	  12        20.267611253489    1.579e-06
+	  13        20.267610329082    5.593e-07
+	  14        20.267610061156    1.788e-07
 	-----------------------------------------
 	Converged Q_XX-Perturbed Wfn to 4.619e-08
 
 	Computing Q_XY-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        23.448099889616
-	   1        29.712317103197    6.721e-01
-	   2        34.917120453991    3.700e-01
-	   3        35.035803823627    9.803e-02
-	   4        35.172513815946    3.905e-02
-	   5        35.180440097397    1.004e-02
-	   6        35.181436767845    2.444e-03
-	   7        35.182468220712    7.788e-04
-	   8        35.182176230658    2.604e-04
-	   9        35.182134204730    7.397e-05
-	  10        35.182141794809    2.517e-05
-	  11        35.182158794488    8.021e-06
-	  12        35.182160478409    1.833e-06
-	  13        35.182159241887    4.627e-07
-	  14        35.182158720183    1.591e-07
+	   0        23.448099869244
+	   1        29.712317071386    6.721e-01
+	   2        34.917120401053    3.700e-01
+	   3        35.035803768673    9.803e-02
+	   4        35.172513759212    3.905e-02
+	   5        35.180440040529    1.004e-02
+	   6        35.181436710965    2.444e-03
+	   7        35.182468163819    7.788e-04
+	   8        35.182176173770    2.604e-04
+	   9        35.182134147843    7.397e-05
+	  10        35.182141737922    2.517e-05
+	  11        35.182158737600    8.021e-06
+	  12        35.182160421521    1.833e-06
+	  13        35.182159184999    4.627e-07
+	  14        35.182158663295    1.591e-07
 	-----------------------------------------
 	Converged Q_XY-Perturbed Wfn to 6.553e-08
 
 	Computing Q_XZ-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.101914608196
-	   1        11.665920043825    3.919e-01
-	   2        13.454458827309    1.855e-01
-	   3        13.466343705000    3.656e-02
-	   4        13.479504123216    1.348e-02
-	   5        13.480126750021    4.525e-03
-	   6        13.480885460174    1.735e-03
-	   7        13.481202712218    6.953e-04
-	   8        13.481033582540    2.341e-04
-	   9        13.481039044820    6.618e-05
-	  10        13.481050373173    2.469e-05
-	  11        13.481052943246    6.947e-06
-	  12        13.481050074965    1.813e-06
-	  13        13.481049058829    4.471e-07
-	  14        13.481048981773    1.417e-07
+	   0         9.101914600591
+	   1        11.665920032049    3.919e-01
+	   2        13.454458809654    1.855e-01
+	   3        13.466343687108    3.656e-02
+	   4        13.479504105131    1.348e-02
+	   5        13.480126731913    4.525e-03
+	   6        13.480885442053    1.735e-03
+	   7        13.481202694093    6.953e-04
+	   8        13.481033564418    2.341e-04
+	   9        13.481039026697    6.618e-05
+	  10        13.481050355050    2.469e-05
+	  11        13.481052925123    6.947e-06
+	  12        13.481050056843    1.813e-06
+	  13        13.481049040706    4.471e-07
+	  14        13.481048963650    1.417e-07
 	-----------------------------------------
 	Converged Q_XZ-Perturbed Wfn to 4.434e-08
 
 	Computing Q_YX-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        23.448099889616
-	   1        29.712317103197    6.721e-01
-	   2        34.917120453991    3.700e-01
-	   3        35.035803823627    9.803e-02
-	   4        35.172513815946    3.905e-02
-	   5        35.180440097397    1.004e-02
-	   6        35.181436767845    2.444e-03
-	   7        35.182468220712    7.788e-04
-	   8        35.182176230658    2.604e-04
-	   9        35.182134204730    7.397e-05
-	  10        35.182141794809    2.517e-05
-	  11        35.182158794488    8.021e-06
-	  12        35.182160478409    1.833e-06
-	  13        35.182159241887    4.627e-07
-	  14        35.182158720183    1.591e-07
+	   0        23.448099869244
+	   1        29.712317071386    6.721e-01
+	   2        34.917120401053    3.700e-01
+	   3        35.035803768673    9.803e-02
+	   4        35.172513759212    3.905e-02
+	   5        35.180440040529    1.004e-02
+	   6        35.181436710965    2.444e-03
+	   7        35.182468163819    7.788e-04
+	   8        35.182176173770    2.604e-04
+	   9        35.182134147843    7.397e-05
+	  10        35.182141737922    2.517e-05
+	  11        35.182158737600    8.021e-06
+	  12        35.182160421521    1.833e-06
+	  13        35.182159184999    4.627e-07
+	  14        35.182158663295    1.591e-07
 	-----------------------------------------
 	Converged Q_YX-Perturbed Wfn to 6.553e-08
 
 	Computing Q_YY-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        31.974515737951
-	   1        38.164010251841    5.239e-01
-	   2        41.924440437018    2.362e-01
-	   3        42.036040316296    6.239e-02
-	   4        42.087565639641    2.567e-02
-	   5        42.090719560016    7.023e-03
-	   6        42.091569331464    2.110e-03
-	   7        42.091876756466    7.057e-04
-	   8        42.091765851021    2.524e-04
-	   9        42.091771456349    7.936e-05
-	  10        42.091796913398    2.532e-05
-	  11        42.091793318992    6.574e-06
-	  12        42.091787223385    2.119e-06
-	  13        42.091784225317    6.605e-07
-	  14        42.091783520886    2.328e-07
+	   0        31.974515716990
+	   1        38.164010222735    5.239e-01
+	   2        41.924440398910    2.362e-01
+	   3        42.036040277453    6.239e-02
+	   4        42.087565600366    2.567e-02
+	   5        42.090719520716    7.023e-03
+	   6        42.091569292157    2.110e-03
+	   7        42.091876717155    7.057e-04
+	   8        42.091765811711    2.524e-04
+	   9        42.091771417039    7.936e-05
+	  10        42.091796874088    2.532e-05
+	  11        42.091793279681    6.574e-06
+	  12        42.091787184075    2.119e-06
+	  13        42.091784186006    6.605e-07
+	  14        42.091783481576    2.328e-07
 	-----------------------------------------
 	Converged Q_YY-Perturbed Wfn to 8.729e-08
 
 	Computing Q_YZ-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        39.954772779892
-	   1        51.957752337265    9.905e-01
-	   2        62.902860177639    5.252e-01
-	   3        62.947363013333    9.308e-02
-	   4        63.100669657903    4.106e-02
-	   5        63.116806596927    8.563e-03
-	   6        63.118498944289    2.530e-03
-	   7        63.119866005297    8.132e-04
-	   8        63.119722998148    2.197e-04
-	   9        63.119592721856    6.781e-05
-	  10        63.119569563025    3.132e-05
-	  11        63.119606027947    1.574e-05
-	  12        63.119628485164    4.587e-06
-	  13        63.119627275183    1.382e-06
-	  14        63.119624661617    5.588e-07
-	  15        63.119623139422    1.875e-07
+	   0        39.954772744042
+	   1        51.957752280097    9.905e-01
+	   2        62.902860081869    5.252e-01
+	   3        62.947362916394    9.308e-02
+	   4        63.100669559336    4.106e-02
+	   5        63.116806498177    8.563e-03
+	   6        63.118498845517    2.530e-03
+	   7        63.119865906510    8.132e-04
+	   8        63.119722899365    2.197e-04
+	   9        63.119592623075    6.781e-05
+	  10        63.119569464246    3.132e-05
+	  11        63.119605929166    1.574e-05
+	  12        63.119628386382    4.587e-06
+	  13        63.119627176401    1.382e-06
+	  14        63.119624562835    5.588e-07
+	  15        63.119623040640    1.875e-07
 	-----------------------------------------
 	Converged Q_YZ-Perturbed Wfn to 5.966e-08
 
 	Computing Q_ZX-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.101914608196
-	   1        11.665920043825    3.919e-01
-	   2        13.454458827309    1.855e-01
-	   3        13.466343705000    3.656e-02
-	   4        13.479504123216    1.348e-02
-	   5        13.480126750021    4.525e-03
-	   6        13.480885460174    1.735e-03
-	   7        13.481202712218    6.953e-04
-	   8        13.481033582540    2.341e-04
-	   9        13.481039044820    6.618e-05
-	  10        13.481050373173    2.469e-05
-	  11        13.481052943246    6.947e-06
-	  12        13.481050074965    1.813e-06
-	  13        13.481049058829    4.471e-07
-	  14        13.481048981773    1.417e-07
+	   0         9.101914600591
+	   1        11.665920032049    3.919e-01
+	   2        13.454458809654    1.855e-01
+	   3        13.466343687108    3.656e-02
+	   4        13.479504105131    1.348e-02
+	   5        13.480126731913    4.525e-03
+	   6        13.480885442053    1.735e-03
+	   7        13.481202694093    6.953e-04
+	   8        13.481033564418    2.341e-04
+	   9        13.481039026697    6.618e-05
+	  10        13.481050355050    2.469e-05
+	  11        13.481052925123    6.947e-06
+	  12        13.481050056843    1.813e-06
+	  13        13.481049040706    4.471e-07
+	  14        13.481048963650    1.417e-07
 	-----------------------------------------
 	Converged Q_ZX-Perturbed Wfn to 4.434e-08
 
 	Computing Q_ZY-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        39.954772779892
-	   1        51.957752337265    9.905e-01
-	   2        62.902860177639    5.252e-01
-	   3        62.947363013333    9.308e-02
-	   4        63.100669657903    4.106e-02
-	   5        63.116806596927    8.563e-03
-	   6        63.118498944289    2.530e-03
-	   7        63.119866005297    8.132e-04
-	   8        63.119722998148    2.197e-04
-	   9        63.119592721856    6.781e-05
-	  10        63.119569563025    3.132e-05
-	  11        63.119606027947    1.574e-05
-	  12        63.119628485164    4.587e-06
-	  13        63.119627275183    1.382e-06
-	  14        63.119624661617    5.588e-07
-	  15        63.119623139422    1.875e-07
+	   0        39.954772744042
+	   1        51.957752280097    9.905e-01
+	   2        62.902860081869    5.252e-01
+	   3        62.947362916394    9.308e-02
+	   4        63.100669559336    4.106e-02
+	   5        63.116806498177    8.563e-03
+	   6        63.118498845517    2.530e-03
+	   7        63.119865906510    8.132e-04
+	   8        63.119722899365    2.197e-04
+	   9        63.119592623075    6.781e-05
+	  10        63.119569464246    3.132e-05
+	  11        63.119605929166    1.574e-05
+	  12        63.119628386382    4.587e-06
+	  13        63.119627176401    1.382e-06
+	  14        63.119624562835    5.588e-07
+	  15        63.119623040640    1.875e-07
 	-----------------------------------------
 	Converged Q_ZY-Perturbed Wfn to 5.966e-08
 
 	Computing Q_ZZ-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0        18.104195785315
-	   1        22.365315082761    4.613e-01
-	   2        25.033890417193    2.101e-01
-	   3        25.076482314140    4.921e-02
-	   4        25.100811912511    1.753e-02
-	   5        25.103376058860    5.652e-03
-	   6        25.104642724506    1.684e-03
-	   7        25.104978343723    5.592e-04
-	   8        25.104854426480    2.026e-04
-	   9        25.104846119315    5.719e-05
-	  10        25.104856085086    2.013e-05
-	  11        25.104855319106    5.788e-06
-	  12        25.104851623424    1.835e-06
-	  13        25.104850233945    4.810e-07
-	  14        25.104850025901    1.585e-07
+	   0        18.104195771598
+	   1        22.365315062639    4.613e-01
+	   2        25.033890389349    2.101e-01
+	   3        25.076482285854    4.921e-02
+	   4        25.100811883944    1.753e-02
+	   5        25.103376030263    5.652e-03
+	   6        25.104642695893    1.684e-03
+	   7        25.104978315107    5.592e-04
+	   8        25.104854397865    2.026e-04
+	   9        25.104846090701    5.719e-05
+	  10        25.104856056471    2.013e-05
+	  11        25.104855290491    5.788e-06
+	  12        25.104851594810    1.835e-06
+	  13        25.104850205330    4.810e-07
+	  14        25.104849997286    1.585e-07
 	-----------------------------------------
 	Converged Q_ZZ-Perturbed Wfn to 6.258e-08
 
-	Computing 1/2 <<Mu;L*>>_(0.077) tensor.
+	Computing 1/2 <<P*;L*>>_(0.077) tensor.
 	Computing <<Mu;Q>>_(-0.077) tensor.
 
                  CCSD Dipole Polarizability [(e^2 a0^2)/E_h]:
@@ -5557,20 +1572,31 @@ Total time:
 
                    0                     1                     2        
 
-    0      5.442456939024460    -0.829631301969881     0.000000000000000
-    1     -0.829631301969881    12.750805632709747     0.000000000000000
-    2      0.000000000000000     0.000000000000000     8.574680086683259
+    0      5.442456938699039    -0.829631300710540     0.000000000000000
+    1     -0.829631300710540    12.750805638017125     0.000000000000000
+    2      0.000000000000000     0.000000000000000     8.574680089100873
 
-           CCSD Optical Rotation Tensor (Length Gauge):
+         CCSD Optical Rotation Tensor (Velocity Gauge):
   -------------------------------------------------------------------------
    Evaluated at omega = 0.077357 E_h (589.00 nm, 2.105 eV, 16977.93 cm-1)
   -------------------------------------------------------------------------
 
                    0                     1                     2        
 
-    0      0.141270618728712    -0.070694644057443     0.000000000000000
-    1     -0.272119688532902     0.001283822415178     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.126887899998584
+    0      0.444271559563171    -0.343249618294797     0.000000000000000
+    1     -0.220426046552221     0.013132320723532     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.470902367218709
+
+        CCSD Optical Rotation Tensor (Modified Velocity Gauge):
+  -------------------------------------------------------------------------
+   Evaluated at omega = 0.077357 E_h (589.00 nm, 2.105 eV, 16977.93 cm-1)
+  -------------------------------------------------------------------------
+
+                   0                     1                     2        
+
+    0      0.011768389251626    -0.011392294704355     0.000000000000000
+    1     -0.022950097311328     0.000612244233077     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.009588468041791
 
     CCSD Electric-Dipole/Quadrupole Polarizability [(e^2 a0^2)/E_h]:
   -------------------------------------------------------------------------
@@ -5579,30 +1605,23 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.000000000000000     0.000000000000000     3.900095510001937
-    1      0.000000000000000     0.000000000000000    -5.834071940968372
-    2      3.900095510001937    -5.834071940968372     0.000000000000000
+    0      0.000000000000000     0.000000000000000     3.900095508706231
+    1      0.000000000000000     0.000000000000000    -5.834071939276820
+    2      3.900095508706231    -5.834071939276820     0.000000000000000
 
                    0                     1                     2        
 
-    0      0.000000000000000     0.000000000000000    -2.378762400542874
-    1      0.000000000000000     0.000000000000000     6.852406905358083
-    2     -2.378762400542874     6.852406905358083     0.000000000000000
+    0      0.000000000000000     0.000000000000000    -2.378762400760358
+    1      0.000000000000000     0.000000000000000     6.852406904104008
+    2     -2.378762400760358     6.852406904104008     0.000000000000000
 
                    0                     1                     2        
 
-    0     -4.548246647409733    -5.301116090947991     0.000000000000000
-    1     -5.301116090947991    -1.354243751474929     0.000000000000000
-    2      0.000000000000000     0.000000000000000     5.902490424326464
+    0     -4.548246648393270    -5.301116089249589     0.000000000000000
+    1     -5.301116089249589    -1.354243751850194     0.000000000000000
+    2      0.000000000000000     0.000000000000000     5.902490425685267
 
-*** tstop() called on psinet at Mon May 15 15:35:14 2017
-Module time:
-	user time   =       8.85 seconds =       0.15 minutes
-	system time =       7.71 seconds =       0.13 minutes
-	total time  =         21 seconds =       0.35 minutes
-Total time:
-	user time   =      10.19 seconds =       0.17 minutes
-	system time =       8.33 seconds =       0.14 minutes
-	total time  =         23 seconds =       0.38 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:20PM
+    Psi4 wall time for execution: 0:00:59.74
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc55/output.ref
+++ b/tests/cc55/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev51 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} 4732348 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Saturday, 12 February 2022 03:25PM
 
-    Process ID:  13051
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 65760
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -47,27 +60,25 @@ set {
   roots_per_irrep [2, 2, 2, 2]
 }
 
-property('eom-ccsd', properties=['oscillator_strength'])
+properties('eom-ccsd', properties=['oscillator_strength'])
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:53 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:36 2022
 
    => Loading Basis Set <=
 
     Name: 6-31G
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   112 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31g.gbs 
-    atoms 2-3 entry H          line    21 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31g.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1   entry O          line   117 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2-3 entry H          line    26 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -81,15 +92,15 @@ property('eom-ccsd', properties=['oscillator_strength'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.068516219310    15.994914619560
-           H          0.000000000000    -0.790689573744     0.543701060724     1.007825032070
-           H          0.000000000000     0.790689573744     0.543701060724     1.007825032070
+         O            0.000000000000     0.000000000000    -0.068516219320    15.994914619570
+         H            0.000000000000    -0.790689573744     0.543701060715     1.007825032230
+         H            0.000000000000     0.790689573744     0.543701060715     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.12555  B =     13.37733  C =      8.72955 [cm^-1]
-  Rotational constants: A = 753245.06586  B = 401042.16407  C = 261705.25278 [MHz]
-  Nuclear repulsion =    8.801465529972067
+  Rotational constants: A = 753245.07149  B = 401042.16706  C = 261705.25473 [MHz]
+  Nuclear repulsion =    8.801465564567374
 
   Charge       = 0
   Multiplicity = 1
@@ -106,30 +117,17 @@ property('eom-ccsd', properties=['oscillator_strength'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: 6-31G
     Blend: 6-31G
     Number of shells: 9
-    Number of basis function: 13
+    Number of basis functions: 13
     Number of Cartesian functions: 13
     Spherical Harmonics?: false
     Max angular momentum: 1
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1         7       7       0       0       0       0
-     A2         0       0       0       0       0       0
-     B1         2       2       0       0       0       0
-     B2         4       4       0       0       0       0
-   -------------------------------------------------------
-    Total      13      13       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -148,42 +146,60 @@ property('eom-ccsd', properties=['oscillator_strength'])
   Using 8372 doubles for integral storage.
   We computed 1035 shell quartets total.
   Whereas there are 1035 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 7.3923789377E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 6.8932338569E-02.
+  Reciprocal condition number of the overlap matrix is 2.3411885555E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1         7       7 
+     A2         0       0 
+     B1         2       2 
+     B2         4       4 
+   -------------------------
+    Total      13      13
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -75.93597265956066   -7.59360e+01   1.84698e-01 
-   @RHF iter   1:   -75.94103378692986   -5.06113e-03   3.28265e-02 
-   @RHF iter   2:   -75.97085378111443   -2.98200e-02   1.83707e-02 DIIS
-   @RHF iter   3:   -75.97940248360368   -8.54870e-03   2.93541e-03 DIIS
-   @RHF iter   4:   -75.98009248037137   -6.89997e-04   7.92448e-04 DIIS
-   @RHF iter   5:   -75.98015679391645   -6.43135e-05   9.28728e-05 DIIS
-   @RHF iter   6:   -75.98015787076486   -1.07685e-06   2.25046e-05 DIIS
-   @RHF iter   7:   -75.98015792106840   -5.03035e-08   2.05175e-06 DIIS
-   @RHF iter   8:   -75.98015792130234   -2.33939e-10   2.25515e-07 DIIS
-   @RHF iter   9:   -75.98015792130749   -5.15854e-12   3.67709e-08 DIIS
-   @RHF iter  10:   -75.98015792130758   -8.52651e-14   1.69431e-09 DIIS
-   @RHF iter  11:   -75.98015792130751    7.10543e-14   1.75527e-10 DIIS
-   @RHF iter  12:   -75.98015792130759   -8.52651e-14   2.14919e-11 DIIS
+   @RHF iter SAD:   -75.45943592521854   -7.54594e+01   0.00000e+00 
+   @RHF iter   1:   -75.90436458408752   -4.44929e-01   4.85074e-02 DIIS/ADIIS
+   @RHF iter   2:   -75.95858768446710   -5.42231e-02   2.97684e-02 DIIS/ADIIS
+   @RHF iter   3:   -75.97907117898052   -2.04835e-02   5.69754e-03 DIIS/ADIIS
+   @RHF iter   4:   -75.98014026978690   -1.06909e-03   5.91516e-04 DIIS/ADIIS
+   @RHF iter   5:   -75.98015752007261   -1.72503e-05   6.60012e-05 DIIS
+   @RHF iter   6:   -75.98015790504668   -3.84974e-07   1.26150e-05 DIIS
+   @RHF iter   7:   -75.98015792108538   -1.60387e-08   2.75882e-06 DIIS
+   @RHF iter   8:   -75.98015792192051   -8.35129e-10   4.43577e-07 DIIS
+   @RHF iter   9:   -75.98015792193421   -1.36993e-11   4.79680e-08 DIIS
+   @RHF iter  10:   -75.98015792193436   -1.56319e-13   4.63906e-09 DIIS
+   @RHF iter  11:   -75.98015792193442   -5.68434e-14   4.24617e-10 DIIS
+   @RHF iter  12:   -75.98015792193442    0.00000e+00   2.82945e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -200,49 +216,44 @@ property('eom-ccsd', properties=['oscillator_strength'])
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -75.98015792130759
+  @RHF Final Energy:   -75.98015792193442
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              8.8014655299720665
-    One-Electron Energy =                -122.2750963023189996
-    Two-Electron Energy =                  37.4934728510393427
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -75.9801579213075939
+    Nuclear Repulsion Energy =              8.8014655645673745
+    One-Electron Energy =                -122.2750963644174078
+    Two-Electron Energy =                  37.4934728779156075
+    Total Energy =                        -75.9801579219344205
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.0191
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.0213
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.0404     Total:     1.0404
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.6444     Total:     2.6444
 
 
-*** tstop() called on psinet at Mon May 15 15:34:53 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:37 2022
 Module time:
-	user time   =       0.35 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.70 seconds =       0.01 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.35 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.70 seconds =       0.01 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -256,7 +267,7 @@ Total time:
       Number of basis functions:        13
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [   7    0    2    4 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
@@ -267,8 +278,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:54 2017
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Feb 12 15:25:37 2022
 
 
 	Wfn Parameters:
@@ -293,7 +304,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -349,34 +360,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.000 (MW) /      0.001 (MB)
 	Total:                                     0.000 (MW) /      0.004 (MB)
 
-	Nuclear Rep. energy          =      8.80146552997207
-	SCF energy                   =    -75.98015792130759
-	One-electron energy          =   -122.27509630206946
-	Two-electron energy          =     37.49347285078982
-	Reference energy             =    -75.98015792130758
+	Nuclear Rep. energy          =      8.80146556456737
+	SCF energy                   =    -75.98015792193442
+	One-electron energy          =   -122.27509636458441
+	Two-electron energy          =     37.49347287808265
+	Reference energy             =    -75.98015792193438
 
-*** tstop() called on psinet at Mon May 15 15:34:54 2017
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:38 2022
 Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:54 2017
-
+Total time:
+	user time   =       0.73 seconds =       0.01 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    8.801465529972067
-    SCF energy          (wfn)     =  -75.980157921307594
-    Reference energy    (file100) =  -75.980157921307580
+    Nuclear Rep. energy (wfn)     =    8.801465564567374
+    SCF energy          (wfn)     =  -75.980157921934421
+    Reference energy    (file100) =  -75.980157921934378
 
     Input parameters:
     -----------------
@@ -404,78 +411,66 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.1327273372127091
+MP2 correlation energy -0.1327273368495928
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.132727337212709    0.000e+00    0.000000    0.000000    0.000000    0.104105
-     1        -0.134589930263448    2.973e-02    0.004967    0.010084    0.010084    0.113786
-     2        -0.138786973414894    1.159e-02    0.006104    0.012740    0.012740    0.121780
-     3        -0.139364365109242    2.945e-03    0.006640    0.014402    0.014402    0.123671
-     4        -0.139399028802832    7.447e-04    0.006696    0.014765    0.014765    0.123922
-     5        -0.139413091414788    2.308e-04    0.006738    0.014976    0.014976    0.123962
-     6        -0.139407602387260    6.670e-05    0.006752    0.015042    0.015042    0.123940
-     7        -0.139407071650058    1.450e-05    0.006755    0.015058    0.015058    0.123936
-     8        -0.139406988622050    2.993e-06    0.006756    0.015061    0.015061    0.123936
-     9        -0.139406913830282    7.226e-07    0.006756    0.015061    0.015061    0.123936
-    10        -0.139406927391255    1.250e-07    0.006756    0.015061    0.015061    0.123936
-    11        -0.139406925402181    2.562e-08    0.006756    0.015061    0.015061    0.123936
-    12        -0.139406925328868    3.830e-09    0.006756    0.015061    0.015061    0.123936
+     0        -0.132727336849593    0.000e+00    0.000000    0.000000    0.000000    0.104105
+     1        -0.134589929939242    2.973e-02    0.004967    0.010084    0.010084    0.113786
+     2        -0.138786973046120    1.159e-02    0.006104    0.012740    0.012740    0.121780
+     3        -0.139364364730533    2.945e-03    0.006640    0.014402    0.014402    0.123671
+     4        -0.139399028423602    7.447e-04    0.006696    0.014765    0.014765    0.123922
+     5        -0.139413091035228    2.308e-04    0.006738    0.014976    0.014976    0.123962
+     6        -0.139407602007902    6.670e-05    0.006752    0.015042    0.015042    0.123940
+     7        -0.139407071270693    1.450e-05    0.006755    0.015058    0.015058    0.123936
+     8        -0.139406988242693    2.993e-06    0.006756    0.015061    0.015061    0.123936
+     9        -0.139406913450926    7.226e-07    0.006756    0.015061    0.015061    0.123936
+    10        -0.139406927011899    1.250e-07    0.006756    0.015061    0.015061    0.123936
+    11        -0.139406925022825    2.562e-08    0.006756    0.015061    0.015061    0.123936
+    12        -0.139406924949512    3.830e-09    0.006756    0.015061    0.015061    0.123936
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2   0         0.0128556725
-              4   7         0.0100625368
+              2   0         0.0128556723
+              4   7         0.0100625367
               4   5        -0.0076287191
-              2   3        -0.0065077226
-              3   4        -0.0062342991
+              2   3        -0.0065077225
+              3   4        -0.0062342990
               1   2        -0.0052561486
-              1   0        -0.0032974098
+              1   0        -0.0032974099
               4   6        -0.0027747751
               1   3         0.0013849932
-              2   2         0.0011500411
+              2   2         0.0011500410
 
     Largest TIjAb Amplitudes:
       3   3   4   4        -0.0533061677
-      4   4   5   5        -0.0477436528
-      2   2   2   2        -0.0398839207
+      4   4   5   5        -0.0477436522
+      2   2   2   2        -0.0398839206
       2   3   2   4        -0.0309510654
       3   2   4   2        -0.0309510654
-      4   4   6   6        -0.0284556953
-      2   2   0   0        -0.0266999235
-      2   4   0   5         0.0264819013
-      4   2   5   0         0.0264819013
+      4   4   6   6        -0.0284556952
+      2   2   0   0        -0.0266999230
+      2   4   0   5         0.0264819008
+      4   2   5   0         0.0264819008
       3   4   4   7        -0.0260449094
 
-    SCF energy       (wfn)                    =  -75.980157921307594
-    Reference energy (file100)                =  -75.980157921307580
+    SCF energy       (wfn)                    =  -75.980157921934421
+    Reference energy (file100)                =  -75.980157921934378
 
-    Opposite-spin MP2 correlation energy      =   -0.101705451821769
-    Same-spin MP2 correlation energy          =   -0.031021885390940
-    MP2 correlation energy                    =   -0.132727337212709
-      * MP2 total energy                      =  -76.112885258520294
+    Opposite-spin MP2 correlation energy      =   -0.101705451538622
+    Same-spin MP2 correlation energy          =   -0.031021885310971
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.132727336849593
+      * MP2 total energy                      =  -76.112885258783976
 
-    Opposite-spin CCSD correlation energy     =   -0.114888689224048
-    Same-spin CCSD correlation energy         =   -0.024518236104511
-    CCSD correlation energy                   =   -0.139406925328868
-      * CCSD total energy                     =  -76.119564846636450
-
-
-*** tstop() called on psinet at Mon May 15 15:34:54 2017
-Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:54 2017
+    Opposite-spin CCSD correlation energy     =   -0.114888688875932
+    Same-spin CCSD correlation energy         =   -0.024518236073580
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.139406924949512
+      * CCSD total energy                     =  -76.119564846883890
 
 
 			**************************
@@ -485,28 +480,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:54 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:54 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    8.801465529972067
-	SCF energy          (wfn)     =  -75.980157921307594
-	Reference energy    (file100) =  -75.980157921307580
-	CCSD energy         (file100) =   -0.139406925328868
+	Nuclear Rep. energy (wfn)     =    8.801465564567374
+	SCF energy          (wfn)     =  -75.980157921934421
+	Reference energy    (file100) =  -75.980157921934378
+	CCSD energy         (file100) =   -0.139406924949512
 
 	Input parameters:
 	-----------------
@@ -539,6 +520,14 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total   10.3144564090
+Fmi   dot Fmi   total  426.4809344372
+Fme   dot Fme   total    0.0000305513
+WMBIJ dot WMBIJ total    0.0000000000
+Wmbij dot Wmbij total    0.0000000000
+WMbIj dot WMbIj total    1.2339607178
+WmBiJ dot WmBiJ total    0.0000000000
 Symmetry of ground state: A1
 Symmetry of excited state: A1
 Symmetry of right eigenvector: A1
@@ -546,71 +535,71 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4746717252   4.75e-01    3.76e-01      N
-                     2   0.7389170717   7.39e-01    3.23e-01      N
+                     1   0.4746717265   4.75e-01    3.76e-01      N
+                     2   0.7389170742   7.39e-01    3.23e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3913403971  -8.33e-02    7.76e-02      N
-                     2   0.6780163805  -6.09e-02    6.45e-02      N
+                     1   0.3913403983  -8.33e-02    7.76e-02      N
+                     2   0.6780163829  -6.09e-02    6.45e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3881072150  -3.23e-03    2.66e-02      N
-                     2   0.6754967288  -2.52e-03    2.82e-02      N
+                     1   0.3881072162  -3.23e-03    2.66e-02      N
+                     2   0.6754967312  -2.52e-03    2.82e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3879197124  -1.88e-04    6.31e-03      N
-                     2   0.6751801732  -3.17e-04    9.92e-03      N
+                     1   0.3879197137  -1.88e-04    6.31e-03      N
+                     2   0.6751801756  -3.17e-04    9.92e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3879053558  -1.44e-05    1.64e-03      N
-                     2   0.6750765341  -1.04e-04    4.14e-03      N
+                     1   0.3879053570  -1.44e-05    1.64e-03      N
+                     2   0.6750765366  -1.04e-04    4.14e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3879108842   5.53e-06    5.93e-04      N
-                     2   0.6750815396   5.01e-06    2.11e-03      N
+                     1   0.3879108854   5.53e-06    5.93e-04      N
+                     2   0.6750815420   5.01e-06    2.11e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3879118457   9.62e-07    1.85e-04      N
-                     2   0.6750845645   3.02e-06    8.48e-04      N
+                     1   0.3879118470   9.62e-07    1.85e-04      N
+                     2   0.6750845669   3.02e-06    8.48e-04      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3879112811  -5.65e-07    4.91e-05      Y
-                     2   0.6750823631  -2.20e-06    2.88e-04      N
+                     1   0.3879112824  -5.65e-07    4.91e-05      Y
+                     2   0.6750823655  -2.20e-06    2.88e-04      N
 Iter=9    L=17    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3879112360  -4.52e-08    4.36e-05      Y
-                     2   0.6750818697  -4.93e-07    8.97e-05      Y
+                     1   0.3879112372  -4.52e-08    4.36e-05      Y
+                     2   0.6750818722  -4.93e-07    8.97e-05      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-EOM CCSD R0 for root 0 =  -0.02065387987
-EOM CCSD R0 for root 1 =  -0.01903802475
+EOM CCSD R0 for root 0 =   0.02065387946
+EOM CCSD R0 for root 1 =   0.01903802449
 
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1     10.556    85136.7   0.3879112360   -75.731653610676
+EOM State 1     10.556    85136.7   0.3879112372   -75.731653609639
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    4a1 :    0.6807538092
-         0 >   0      :       1b2 >    2b2 :    0.0740421039
-         2 >   1      :       3a1 >    5a1 :    0.0345654630
-         1 >   0      :       2a1 >    4a1 :    0.0336386762
-         0 >   0      :       1b1 >    2b1 :    0.0304429540
+         2 >   0      :       3a1 >    4a1 :   -0.6807538095
+         0 >   0      :       1b2 >    2b2 :   -0.0740421025
+         2 >   1      :       3a1 >    5a1 :   -0.0345654628
+         1 >   0      :       2a1 >    4a1 :   -0.0336386757
+         0 >   0      :       1b1 >    2b1 :   -0.0304429540
  RIjAb (libdpd indices)     : (cscf notation)
-        2   2 >   0   0     :    3a1    3a1 >    4a1    4a1 :   -0.1110147873
-        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :    0.0666262968
-        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :    0.0666262968
-        2   2 >   0   0     :    3a1    3a1 >    2b2    2b2 :   -0.0476626228
-        2   2 >   0   2     :    3a1    3a1 >    4a1    6a1 :    0.0417426765
-EOM State 2     18.370   148163.3   0.6750818697   -75.444482976914
+        2   2 >   0   0     :    3a1    3a1 >    4a1    4a1 :    0.1110147861
+        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :   -0.0666262966
+        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :   -0.0666262966
+        2   2 >   0   0     :    3a1    3a1 >    2b2    2b2 :    0.0476626222
+        2   2 >   0   2     :    3a1    3a1 >    4a1    6a1 :   -0.0417426767
+EOM State 2     18.370   148163.3   0.6750818722   -75.444482974730
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    2b2 :   -0.6764665616
-         0 >   0      :       1b1 >    2b1 :    0.0926656455
-         2 >   0      :       3a1 >    4a1 :    0.0652548916
-         2 >   2      :       3a1 >    6a1 :    0.0621558890
-         2 >   1      :       3a1 >    5a1 :   -0.0430899125
+         0 >   0      :       1b2 >    2b2 :    0.6764665619
+         0 >   0      :       1b1 >    2b1 :   -0.0926656455
+         2 >   0      :       3a1 >    4a1 :   -0.0652548903
+         2 >   2      :       3a1 >    6a1 :   -0.0621558889
+         2 >   1      :       3a1 >    5a1 :    0.0430899126
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b2    1b2 >    2b2    2b2 :   -0.0960816030
-        0   0 >   0   0     :    1b2    1b2 >    4a1    4a1 :   -0.0840818784
-        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :    0.0457258019
-        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :    0.0457258019
-        0   0 >   0   0     :    1b1    1b1 >    2b2    2b2 :   -0.0411112317
+        0   0 >   0   0     :    1b2    1b2 >    2b2    2b2 :    0.0960816031
+        0   0 >   0   0     :    1b2    1b2 >    4a1    4a1 :    0.0840818773
+        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :   -0.0457258013
+        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :   -0.0457258013
+        0   0 >   0   0     :    1b1    1b1 >    2b2    2b2 :    0.0411112313
 
 Symmetry of excited state: A2
 Symmetry of right eigenvector: A2
@@ -618,50 +607,50 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4508366460   4.51e-01    3.59e-01      N
-                     2   1.1670795803   1.17e+00    4.37e-01      N
+                     1   0.4508366479   4.51e-01    3.59e-01      N
+                     2   1.1670795808   1.17e+00    4.37e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3744760444  -7.64e-02    7.18e-02      N
-                     2   1.0422879738  -1.25e-01    7.57e-02      N
+                     1   0.3744760463  -7.64e-02    7.18e-02      N
+                     2   1.0422879754  -1.25e-01    7.57e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3713460695  -3.13e-03    2.06e-02      N
-                     2   1.0395864819  -2.70e-03    3.18e-02      N
+                     1   0.3713460715  -3.13e-03    2.06e-02      N
+                     2   1.0395864835  -2.70e-03    3.18e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712128742  -1.33e-04    5.48e-03      N
-                     2   1.0380541844  -1.53e-03    6.38e-02      N
+                     1   0.3712128762  -1.33e-04    5.48e-03      N
+                     2   1.0380541862  -1.53e-03    6.38e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712071784  -5.70e-06    1.57e-03      N
-                     2   1.0351829841  -2.87e-03    6.09e-02      N
+                     1   0.3712071804  -5.70e-06    1.57e-03      N
+                     2   1.0351829865  -2.87e-03    6.09e-02      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712107695   3.59e-06    4.77e-04      N
-                     2   1.0321963260  -2.99e-03    4.82e-02      N
+                     1   0.3712107714   3.59e-06    4.77e-04      N
+                     2   1.0321963289  -2.99e-03    4.82e-02      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712109098   1.40e-07    1.50e-04      N
-                     2   1.0301757605  -2.02e-03    7.13e-02      N
+                     1   0.3712109118   1.40e-07    1.50e-04      N
+                     2   1.0301757637  -2.02e-03    7.13e-02      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712108063  -1.04e-07    2.94e-05      Y
-                     2   0.9913127345  -3.89e-02    3.27e-01      N
+                     1   0.3712108082  -1.04e-07    2.94e-05      Y
+                     2   0.9913127428  -3.89e-02    3.27e-01      N
 Iter=9    L=17    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712108094   3.14e-09    2.44e-05      Y
-                     2   0.9624650596  -2.88e-02    9.58e-02      N
+                     1   0.3712108114   3.14e-09    2.44e-05      Y
+                     2   0.9624650652  -2.88e-02    9.58e-02      N
 Iter=10   L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712108110   1.56e-09    2.38e-05      Y
-                     2   0.9606676322  -1.80e-03    2.44e-02      N
+                     1   0.3712108129   1.56e-09    2.38e-05      Y
+                     2   0.9606676377  -1.80e-03    2.44e-02      N
 Iter=11   L=19    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712108048  -6.20e-09    2.15e-05      Y
-                     2   0.9605186574  -1.49e-04    9.00e-03      N
+                     1   0.3712108067  -6.20e-09    2.15e-05      Y
+                     2   0.9605186628  -1.49e-04    9.00e-03      N
 Iter=12   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712108078   2.98e-09    2.12e-05      Y
-                     2   0.9605061360  -1.25e-05    4.61e-03      N
+                     1   0.3712108097   2.98e-09    2.12e-05      Y
+                     2   0.9605061414  -1.25e-05    4.61e-03      N
 Iter=13   L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712108051  -2.68e-09    2.06e-05      Y
-                     2   0.9605057408  -3.95e-07    1.54e-03      N
+                     1   0.3712108070  -2.68e-09    2.06e-05      Y
+                     2   0.9605057463  -3.95e-07    1.54e-03      N
 Iter=14   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712108025  -2.58e-09    2.09e-05      Y
-                     2   0.9605057732   3.24e-08    2.20e-04      N
+                     1   0.3712108045  -2.58e-09    2.09e-05      Y
+                     2   0.9605057787   3.24e-08    2.20e-04      N
 Iter=15   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3712108026   1.49e-10    2.02e-05      Y
-                     2   0.9605057243  -4.89e-08    4.62e-05      Y
+                     1   0.3712108046   1.49e-10    2.02e-05      Y
+                     2   0.9605057297  -4.89e-08    4.62e-05      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
@@ -671,34 +660,34 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep A2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 3     10.101    81471.3   0.3712108026   -75.748354043991
+EOM State 3     10.101    81471.4   0.3712108046   -75.748354042274
 
 Largest components of excited wave function #3:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    2b2 :   -0.6849789380
-         0 >   1      :       1b1 >    3b2 :   -0.0583418535
-         0 >   2      :       1b1 >    4b2 :   -0.0568631314
+         0 >   0      :       1b1 >    2b2 :   -0.6849789382
+         0 >   1      :       1b1 >    3b2 :   -0.0583418529
+         0 >   2      :       1b1 >    4b2 :   -0.0568631318
          0 >   0      :       1b2 >    2b1 :    0.0034723299
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :   -0.0811048073
-        0   0 >   0   0     :    1b2    1b1 >    2b2    2b2 :   -0.0811048073
-        2   0 >   0   0     :    3a1    1b1 >    4a1    2b2 :    0.0528081505
-        0   2 >   0   0     :    1b1    3a1 >    2b2    4a1 :    0.0528081505
-        0   0 >   0   0     :    1b1    1b1 >    2b1    2b2 :   -0.0451350958
-EOM State 4     26.137   210806.6   0.9605057243   -75.159059122367
+        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :   -0.0811048068
+        0   0 >   0   0     :    1b2    1b1 >    2b2    2b2 :   -0.0811048068
+        2   0 >   0   0     :    3a1    1b1 >    4a1    2b2 :    0.0528081500
+        0   2 >   0   0     :    1b1    3a1 >    2b2    4a1 :    0.0528081500
+        0   0 >   0   0     :    1b1    1b1 >    2b1    2b2 :   -0.0451350960
+EOM State 4     26.137   210806.6   0.9605057297   -75.159059117138
 
 Largest components of excited wave function #4:
  RIA (libdpd indices) : (cscf notation)
-         0 >   2      :       1b1 >    4b2 :    0.0135859788
-         0 >   0      :       1b1 >    2b2 :    0.0099970319
+         0 >   2      :       1b1 >    4b2 :    0.0135859795
+         0 >   0      :       1b1 >    2b2 :    0.0099970318
          0 >   0      :       1b2 >    2b1 :    0.0066574500
-         0 >   1      :       1b1 >    3b2 :    0.0018688543
+         0 >   1      :       1b1 >    3b2 :    0.0018688547
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b2 >    4a1    4a1 :   -0.3853402176
-        0   0 >   0   0     :    1b2    1b1 >    4a1    4a1 :   -0.3853402176
-        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :    0.2395024726
-        0   0 >   0   0     :    1b2    1b1 >    2b2    2b2 :    0.2395024726
-        2   0 >   0   0     :    3a1    1b1 >    4a1    2b2 :    0.2247644688
+        0   0 >   0   0     :    1b2    1b1 >    4a1    4a1 :   -0.3853402136
+        0   0 >   0   0     :    1b1    1b2 >    4a1    4a1 :   -0.3853402136
+        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :    0.2395024701
+        0   0 >   0   0     :    1b2    1b1 >    2b2    2b2 :    0.2395024701
+        2   0 >   0   0     :    3a1    1b1 >    4a1    2b2 :    0.2247644706
 
 Symmetry of excited state: B1
 Symmetry of right eigenvector: B1
@@ -706,44 +695,44 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3792569996   3.79e-01    3.75e-01      N
-                     2   1.1714738056   1.17e+00    2.70e-01      N
+                     1   0.3792570011   3.79e-01    3.75e-01      N
+                     2   1.1714738073   1.17e+00    2.70e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2935619944  -8.57e-02    7.00e-02      N
-                     2   1.1182743254  -5.32e-02    8.23e-02      N
+                     1   0.2935619960  -8.57e-02    7.00e-02      N
+                     2   1.1182743292  -5.32e-02    8.23e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2912091468  -2.35e-03    2.00e-02      N
-                     2   1.1011058127  -1.72e-02    1.06e-01      N
+                     1   0.2912091485  -2.35e-03    2.00e-02      N
+                     2   1.1011058171  -1.72e-02    1.06e-01      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911452799  -6.39e-05    5.36e-03      N
-                     2   1.0812701132  -1.98e-02    9.93e-02      N
+                     1   0.2911452815  -6.39e-05    5.36e-03      N
+                     2   1.0812701177  -1.98e-02    9.93e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911428780  -2.40e-06    1.11e-03      N
-                     2   0.9980954841  -8.32e-02    2.96e-01      N
+                     1   0.2911428796  -2.40e-06    1.11e-03      N
+                     2   0.9980954910  -8.32e-02    2.96e-01      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911457852   2.91e-06    2.91e-04      N
-                     2   0.9502588696  -4.78e-02    1.26e-01      N
+                     1   0.2911457868   2.91e-06    2.91e-04      N
+                     2   0.9502588751  -4.78e-02    1.26e-01      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911466698   8.85e-07    6.71e-05      Y
-                     2   0.9429823130  -7.28e-03    6.66e-02      N
+                     1   0.2911466714   8.85e-07    6.71e-05      Y
+                     2   0.9429823183  -7.28e-03    6.66e-02      N
 Iter=8    L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911467518   8.20e-08    5.83e-05      Y
-                     2   0.9421612830  -8.21e-04    2.05e-02      N
+                     1   0.2911467535   8.20e-08    5.83e-05      Y
+                     2   0.9421612883  -8.21e-04    2.05e-02      N
 Iter=9    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911467772   2.54e-08    5.40e-05      Y
-                     2   0.9420718546  -8.94e-05    6.19e-03      N
+                     1   0.2911467788   2.54e-08    5.40e-05      Y
+                     2   0.9420718599  -8.94e-05    6.19e-03      N
 Iter=10   L=17    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911467758  -1.38e-09    5.48e-05      Y
-                     2   0.9420612174  -1.06e-05    2.19e-03      N
+                     1   0.2911467775  -1.38e-09    5.48e-05      Y
+                     2   0.9420612227  -1.06e-05    2.19e-03      N
 Iter=11   L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911467682  -7.62e-09    5.09e-05      Y
-                     2   0.9420595385  -1.68e-06    8.18e-04      N
+                     1   0.2911467698  -7.62e-09    5.09e-05      Y
+                     2   0.9420595438  -1.68e-06    8.18e-04      N
 Iter=12   L=19    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911467725   4.25e-09    4.92e-05      Y
-                     2   0.9420594290  -1.09e-07    2.24e-04      N
+                     1   0.2911467741   4.25e-09    4.92e-05      Y
+                     2   0.9420594343  -1.09e-07    2.24e-04      N
 Iter=13   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2911467624  -1.01e-08    4.67e-05      Y
-                     2   0.9420596012   1.72e-07    6.16e-05      Y
+                     1   0.2911467640  -1.01e-08    4.67e-05      Y
+                     2   0.9420596065   1.72e-07    6.16e-05      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
@@ -753,36 +742,36 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 5      7.923    63899.3   0.2911467624   -75.828418084239
+EOM State 5      7.923    63899.3   0.2911467640   -75.828418082855
 
 Largest components of excited wave function #5:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    4a1 :   -0.6865963670
-         0 >   1      :       1b1 >    5a1 :   -0.0500431673
-         0 >   3      :       1b1 >    7a1 :   -0.0209986929
-         0 >   2      :       1b1 >    6a1 :    0.0152070956
-         2 >   0      :       3a1 >    2b1 :   -0.0029793610
+         0 >   0      :       1b1 >    4a1 :    0.6865963672
+         0 >   1      :       1b1 >    5a1 :    0.0500431670
+         0 >   3      :       1b1 >    7a1 :    0.0209986929
+         0 >   2      :       1b1 >    6a1 :   -0.0152070954
+         2 >   0      :       3a1 >    2b1 :    0.0029793610
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :   -0.0736849876
-        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :   -0.0736849876
-        2   0 >   0   0     :    3a1    1b1 >    4a1    4a1 :    0.0549784244
-        0   2 >   0   0     :    1b1    3a1 >    4a1    4a1 :    0.0549784244
-        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :   -0.0494409187
-EOM State 6     25.635   206758.2   0.9420596012   -75.177505245411
+        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :    0.0736849872
+        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :    0.0736849872
+        2   0 >   0   0     :    3a1    1b1 >    4a1    4a1 :   -0.0549784237
+        0   2 >   0   0     :    1b1    3a1 >    4a1    4a1 :   -0.0549784237
+        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :    0.0494409189
+EOM State 6     25.635   206758.2   0.9420596065   -75.177505240374
 
 Largest components of excited wave function #6:
  RIA (libdpd indices) : (cscf notation)
-         0 >   1      :       1b1 >    5a1 :    0.0427940122
-         0 >   0      :       1b1 >    4a1 :    0.0339702289
-         0 >   3      :       1b1 >    7a1 :    0.0217404912
-         2 >   0      :       3a1 >    2b1 :   -0.0157823203
-         0 >   2      :       1b1 >    6a1 :   -0.0109343975
+         0 >   1      :       1b1 >    5a1 :   -0.0427940128
+         0 >   0      :       1b1 >    4a1 :   -0.0339702285
+         0 >   3      :       1b1 >    7a1 :   -0.0217404912
+         2 >   0      :       3a1 >    2b1 :    0.0157823205
+         0 >   2      :       1b1 >    6a1 :    0.0109343973
  RIjAb (libdpd indices)     : (cscf notation)
-        2   0 >   0   0     :    3a1    1b1 >    4a1    4a1 :    0.5475640384
-        0   2 >   0   0     :    1b1    3a1 >    4a1    4a1 :    0.5475640384
-        2   0 >   0   0     :    3a1    1b1 >    2b2    2b2 :   -0.2726001764
-        0   2 >   0   0     :    1b1    3a1 >    2b2    2b2 :   -0.2726001764
-        0   0 >   0   0     :    1b1    1b2 >    2b2    4a1 :   -0.1353914903
+        0   2 >   0   0     :    1b1    3a1 >    4a1    4a1 :   -0.5475640395
+        2   0 >   0   0     :    3a1    1b1 >    4a1    4a1 :   -0.5475640395
+        2   0 >   0   0     :    3a1    1b1 >    2b2    2b2 :    0.2726001761
+        0   2 >   0   0     :    1b1    3a1 >    2b2    2b2 :    0.2726001761
+        0   0 >   0   0     :    1b1    1b2 >    2b2    4a1 :    0.1353914891
 
 Symmetry of excited state: B2
 Symmetry of right eigenvector: B2
@@ -790,33 +779,33 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5510364550   5.51e-01    3.54e-01      N
-                     2   0.6033431140   6.03e-01    3.22e-01      N
+                     1   0.5510364568   5.51e-01    3.54e-01      N
+                     2   0.6033431164   6.03e-01    3.22e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4764436495  -7.46e-02    7.80e-02      N
-                     2   0.5451364519  -5.82e-02    6.11e-02      N
+                     1   0.4764436513  -7.46e-02    7.80e-02      N
+                     2   0.5451364542  -5.82e-02    6.11e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4730474643  -3.40e-03    2.75e-02      N
-                     2   0.5430983130  -2.04e-03    2.39e-02      N
+                     1   0.4730474661  -3.40e-03    2.75e-02      N
+                     2   0.5430983154  -2.04e-03    2.39e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4727765793  -2.71e-04    6.87e-03      N
-                     2   0.5429226871  -1.76e-04    6.20e-03      N
+                     1   0.4727765811  -2.71e-04    6.87e-03      N
+                     2   0.5429226895  -1.76e-04    6.20e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4727548990  -2.17e-05    1.54e-03      N
-                     2   0.5428659224  -5.68e-05    1.77e-03      N
+                     1   0.4727549008  -2.17e-05    1.54e-03      N
+                     2   0.5428659248  -5.68e-05    1.77e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4727587050   3.81e-06    3.99e-04      N
-                     2   0.5428634010  -2.52e-06    5.91e-04      N
+                     1   0.4727587068   3.81e-06    3.99e-04      N
+                     2   0.5428634034  -2.52e-06    5.91e-04      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4727594627   7.58e-07    8.20e-05      Y
-                     2   0.5428633855  -1.55e-08    1.79e-04      N
+                     1   0.4727594645   7.58e-07    8.20e-05      Y
+                     2   0.5428633879  -1.55e-08    1.79e-04      N
 Iter=8    L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4727594369  -2.58e-08    7.03e-05      Y
-                     2   0.5428630852  -3.00e-07    4.21e-05      Y
+                     1   0.4727594387  -2.58e-08    7.03e-05      Y
+                     2   0.5428630875  -3.00e-07    4.21e-05      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-Energy written to CC_INFO:Etot  -75.5767017614
+Energy written to CC_INFO:Etot  -75.5767017593
 States per irrep written to CC_INFO.
 EOM CCSD R0 for root 0 =   0.00000000000
 EOM CCSD R0 for root 1 =   0.00000000000
@@ -824,67 +813,53 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 7     12.864   103758.7   0.4727594369   -75.646805409699
+EOM State 7     12.864   103758.7   0.4727594387   -75.646805408168
 
 Largest components of excited wave function #7:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    2b2 :    0.6747478487
-         0 >   0      :       1b2 >    4a1 :    0.1214381587
-         2 >   2      :       3a1 >    4b2 :    0.0505297165
-         2 >   1      :       3a1 >    3b2 :    0.0306437095
-         0 >   1      :       1b2 >    5a1 :    0.0299665376
+         2 >   0      :       3a1 >    2b2 :    0.6747478496
+         0 >   0      :       1b2 >    4a1 :    0.1214381550
+         2 >   2      :       3a1 >    4b2 :    0.0505297168
+         2 >   1      :       3a1 >    3b2 :    0.0306437089
+         0 >   1      :       1b2 >    5a1 :    0.0299665372
  RIjAb (libdpd indices)     : (cscf notation)
-        2   2 >   0   0     :    3a1    3a1 >    4a1    2b2 :   -0.0896598781
-        2   2 >   0   0     :    3a1    3a1 >    2b2    4a1 :   -0.0896598781
-        2   0 >   0   0     :    3a1    1b2 >    2b2    2b2 :    0.0650382955
-        0   2 >   0   0     :    1b2    3a1 >    2b2    2b2 :    0.0650382955
-        2   2 >   1   0     :    3a1    3a1 >    5a1    2b2 :   -0.0343890032
-EOM State 8     14.772   119144.7   0.5428630852   -75.576701761442
+        2   2 >   0   0     :    3a1    3a1 >    4a1    2b2 :   -0.0896598772
+        2   2 >   0   0     :    3a1    3a1 >    2b2    4a1 :   -0.0896598772
+        2   0 >   0   0     :    3a1    1b2 >    2b2    2b2 :    0.0650382958
+        0   2 >   0   0     :    1b2    3a1 >    2b2    2b2 :    0.0650382958
+        2   2 >   1   0     :    3a1    3a1 >    5a1    2b2 :   -0.0343890033
+EOM State 8     14.772   119144.7   0.5428630875   -75.576701759343
 
 Largest components of excited wave function #8:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    4a1 :   -0.6811978576
-         2 >   0      :       3a1 >    2b2 :    0.1214053288
-         0 >   1      :       1b2 >    5a1 :   -0.0259004045
-         2 >   1      :       3a1 >    3b2 :   -0.0224718863
-         0 >   2      :       1b2 >    6a1 :    0.0217936520
+         0 >   0      :       1b2 >    4a1 :    0.6811978584
+         2 >   0      :       3a1 >    2b2 :   -0.1214053251
+         0 >   1      :       1b2 >    5a1 :    0.0259004048
+         2 >   1      :       3a1 >    3b2 :    0.0224718863
+         0 >   2      :       1b2 >    6a1 :   -0.0217936518
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b2    1b2 >    4a1    2b2 :   -0.0869477162
-        0   0 >   0   0     :    1b2    1b2 >    2b2    4a1 :   -0.0869477162
-        2   0 >   0   0     :    3a1    1b2 >    2b2    2b2 :    0.0445814507
-        0   2 >   0   0     :    1b2    3a1 >    2b2    2b2 :    0.0445814507
-        2   0 >   0   0     :    3a1    1b2 >    4a1    4a1 :    0.0255595962
+        0   0 >   0   0     :    1b2    1b2 >    4a1    2b2 :    0.0869477158
+        0   0 >   0   0     :    1b2    1b2 >    2b2    4a1 :    0.0869477158
+        2   0 >   0   0     :    3a1    1b2 >    2b2    2b2 :   -0.0445814499
+        0   2 >   0   0     :    1b2    3a1 >    2b2    2b2 :   -0.0445814499
+        2   0 >   0   0     :    3a1    1b2 >    4a1    4a1 :   -0.0255595959
 
 	Putting into environment energy for root of R irrep 4 and root 2.
-	Putting into environment CURRENT ENERGY:              -75.5767017614
+	Putting into environment CURRENT ENERGY:              -75.5767017593
 
 	Total # of sigma evaluations: 75
-
-*** tstop() called on psinet at Mon May 15 15:34:54 2017
-Module time:
-	user time   =       0.17 seconds =       0.00 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.65 seconds =       0.01 minutes
-	system time =       0.41 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:54 2017
-
 
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =    8.801465529972067
+	Nuclear Rep. energy (wfn)     =    8.801465564567374
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     =  -75.980157921307594
-	Reference energy    (CC_INFO) =  -75.980157921307580
-	CCSD energy         (CC_INFO) =   -0.139406925328868
-	Total CCSD energy   (CC_INFO) =  -76.119564846636450
+	SCF energy          (wfn)     =  -75.980157921934421
+	Reference energy    (CC_INFO) =  -75.980157921934378
+	CCSD energy         (CC_INFO) =   -0.139406924949512
+	Total CCSD energy   (CC_INFO) =  -76.119564846883890
 
 	Input parameters:
 	-----------------
@@ -897,17 +872,17 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
-	  2   0     1         No       0.3879112360  -0.0206538799
-	  3   0     2         No       0.6750818697  -0.0190380247
-	  4   1     1         No       0.3712108026   0.0000000000
-	  5   1     2         No       0.9605057243   0.0000000000
-	  6   2     1         No       0.2911467624   0.0000000000
-	  7   2     2         No       0.9420596012   0.0000000000
-	  8   3     1         No       0.4727594369   0.0000000000
-	  9   3     2         No       0.5428630852   0.0000000000
+	  2   0     1         No       0.3879112372   0.0206538795
+	  3   0     2         No       0.6750818722   0.0190380245
+	  4   1     1         No       0.3712108046   0.0000000000
+	  5   1     2         No       0.9605057297   0.0000000000
+	  6   2     1         No       0.2911467640   0.0000000000
+	  7   2     2         No       0.9420596065   0.0000000000
+	  8   3     1         No       0.4727594387   0.0000000000
+	  9   3     2         No       0.5428630875   0.0000000000
 	Labels for eigenvector 1:
 	LIA 0 -1, Lia 0 -1, LIJAB 0 -1, Lijab 0 -1, LIjAb 0 -1, 2LIjAb - LIjbA 0 -1
 	Labels for eigenvector 2:
@@ -934,39 +909,39 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.139431958323451    0.000e+00
-	   1        -0.139281602102358    7.659e-03
-	   2        -0.139034244456245    1.051e-03
-	   3        -0.138979698616850    2.770e-04
-	   4        -0.138967952300339    6.777e-05
+	   0        -0.139431957944070    0.000e+00
+	   1        -0.139281601738476    7.659e-03
+	   2        -0.139034244094760    1.051e-03
+	   3        -0.138979698256134    2.770e-04
+	   4        -0.138967951939841    6.777e-05
 
 	Largest LIA Amplitudes:
-	          2   0         0.0093920700
-	          4   7         0.0090026774
-	          2   3        -0.0058062067
+	          2   0         0.0093920699
+	          4   7         0.0090026773
+	          2   3        -0.0058062066
 	          4   5        -0.0048468120
-	          1   2        -0.0043570327
-	          3   4        -0.0042950820
+	          1   2        -0.0043570326
+	          3   4        -0.0042950819
 	          4   6        -0.0032496656
-	          1   0        -0.0022448908
-	          2   2         0.0019612044
+	          1   0        -0.0022448909
+	          2   2         0.0019612043
 	          1   3         0.0016242620
 
 	Largest LIjAb Amplitudes:
 	  3   3   4   4        -0.0535744558
-	  4   4   5   5        -0.0469484716
-	  2   2   2   2        -0.0396884593
-	  2   3   2   4        -0.0310720920
-	  3   2   4   2        -0.0310720920
+	  4   4   5   5        -0.0469484710
+	  2   2   2   2        -0.0396884592
+	  2   3   2   4        -0.0310720919
+	  3   2   4   2        -0.0310720919
 	  4   4   6   6        -0.0278758115
-	  3   4   4   7        -0.0260306505
-	  4   3   7   4        -0.0260306505
-	  2   2   0   0        -0.0260019857
-	  2   4   0   5         0.0258554222
+	  3   4   4   7        -0.0260306506
+	  4   3   7   4        -0.0260306506
+	  2   2   0   0        -0.0260019852
+	  2   4   0   5         0.0258554218
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.95214891635
+	Overlap <L|e^T> =        0.95214891671
 	Symmetry of left-hand state: A1
 	Symmetry of left-hand eigenvector: A1
 	Initial overlap of initial guess <L|R> =    0.9990574191
@@ -976,45 +951,45 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.005968024803881    6.777e-05
-	   1        -0.008453505660137    3.230e-02
-	   2        -0.008243451836543    6.941e-03
-	   3        -0.008352615152913    2.167e-03
-	   4        -0.008356706806179    6.567e-04
-	   5        -0.008348308810931    1.612e-04
-	   6        -0.008344798364391    5.418e-05
+	   0         0.005968024725406    6.777e-05
+	   1         0.008453505550163    3.230e-02
+	   2         0.008243451728631    6.941e-03
+	   3         0.008352615043616    2.167e-03
+	   4         0.008356706696986    6.567e-04
+	   5         0.008348308702027    1.612e-04
+	   6         0.008344798255570    5.418e-05
 
-	Initial  <L|R>  =        0.9851587422
+	Initial  <L|R>  =        0.9851587421
 	Normalizing L...
-	L0 * R0 =       -0.0000000000
-	L1 * R1 =        0.9431006182
-	L2 * R2 =        0.0568993818
+	L0 * R0 =        0.0000000000
+	L1 * R1 =        0.9431006185
+	L2 * R2 =        0.0568993815
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =   -0.008470511407471
+	Pseudoenergy or Norm of normalized L =    0.008470511298017
 
 	Largest LIA Amplitudes:
-	          2   0         0.6779350616
-	          4   5         0.0740803037
-	          2   1         0.0323710616
-	          1   0         0.0322183765
-	          3   4         0.0285866747
-	          2   3         0.0203081327
-	          4   6         0.0193853307
-	          4   7         0.0179147072
-	          2   2         0.0114216499
-	          1   1         0.0093466937
+	          2   0        -0.6779350619
+	          4   5        -0.0740803023
+	          2   1        -0.0323710615
+	          1   0        -0.0322183760
+	          3   4        -0.0285866747
+	          2   3        -0.0203081328
+	          4   6        -0.0193853303
+	          4   7        -0.0179147072
+	          2   2        -0.0114216500
+	          1   1        -0.0093466936
 
 	Largest LIjAb Amplitudes:
-	  2   2   0   0        -0.1130238249
-	  2   4   0   5         0.0747452296
-	  4   2   5   0         0.0747452296
-	  2   2   0   2         0.0463024304
-	  2   2   2   0         0.0463024304
-	  2   2   5   5        -0.0457199447
-	  2   3   0   4         0.0387712200
-	  3   2   4   0         0.0387712200
-	  2   4   5   0         0.0352031815
-	  4   2   0   5         0.0352031815
+	  2   2   0   0         0.1130238238
+	  2   4   0   5        -0.0747452294
+	  4   2   5   0        -0.0747452294
+	  2   2   0   2        -0.0463024305
+	  2   2   2   0        -0.0463024305
+	  2   2   5   5         0.0457199442
+	  2   3   0   4        -0.0387712203
+	  3   2   4   0        -0.0387712203
+	  2   4   5   0        -0.0352031813
+	  4   2   0   5        -0.0352031813
 
 	Iterations converged.
 
@@ -1027,47 +1002,47 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.012146948173091    5.418e-05
-	   1        -0.015140718723841    2.496e-02
-	   2        -0.014892998628318    6.616e-03
-	   3        -0.015083176584764    2.873e-03
-	   4        -0.015102206307762    1.482e-03
-	   5        -0.015100980702500    6.365e-04
-	   6        -0.015090627544694    3.083e-04
-	   7        -0.015095188681258    1.042e-04
-	   8        -0.015097874271609    3.826e-05
+	   0         0.012146948080257    5.418e-05
+	   1         0.015140718639147    2.496e-02
+	   2         0.014892998542579    6.616e-03
+	   3         0.015083176497641    2.873e-03
+	   4         0.015102206221701    1.482e-03
+	   5         0.015100980617473    6.365e-04
+	   6         0.015090627460081    3.083e-04
+	   7         0.015095188596466    1.042e-04
+	   8         0.015097874186716    3.826e-05
 
-	Initial  <L|R>  =        0.9918651397
+	Initial  <L|R>  =        0.9918651396
 	Normalizing L...
-	L0 * R0 =       -0.0000000000
-	L1 * R1 =        0.9535016205
-	L2 * R2 =        0.0464983795
+	L0 * R0 =        0.0000000000
+	L1 * R1 =        0.9535016209
+	L2 * R2 =        0.0464983791
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =   -0.015221700679803
+	Pseudoenergy or Norm of normalized L =    0.015221700596457
 
 	Largest LIA Amplitudes:
-	          4   5        -0.6762960262
-	          3   4         0.0885255787
-	          2   0         0.0649610493
-	          2   2         0.0588761099
-	          2   1        -0.0423695944
-	          1   3         0.0201499707
-	          1   0         0.0182450725
-	          1   1         0.0132470955
-	          4   7        -0.0123503778
-	          4   6        -0.0085492779
+	          4   5         0.6762960264
+	          3   4        -0.0885255788
+	          2   0        -0.0649610481
+	          2   2        -0.0588761098
+	          2   1         0.0423695944
+	          1   3        -0.0201499706
+	          1   0        -0.0182450719
+	          1   1        -0.0132470954
+	          4   7         0.0123503780
+	          4   6         0.0085492778
 
 	Largest LIjAb Amplitudes:
-	  4   4   5   5        -0.1015995309
-	  4   4   0   0        -0.0803368883
-	  2   4   0   5         0.0487976327
-	  4   2   5   0         0.0487976327
-	  3   3   5   5        -0.0363107751
-	  4   4   7   7         0.0338712714
-	  4   4   0   1        -0.0299742990
-	  4   4   1   0        -0.0299742990
-	  2   4   5   0         0.0281865113
-	  4   2   0   5         0.0281865113
+	  4   4   5   5         0.1015995311
+	  4   4   0   0         0.0803368873
+	  2   4   0   5        -0.0487976322
+	  4   2   5   0        -0.0487976322
+	  3   3   5   5         0.0363107747
+	  4   4   7   7        -0.0338712714
+	  4   4   0   1         0.0299742987
+	  4   4   1   0         0.0299742987
+	  2   4   5   0        -0.0281865109
+	  4   2   0   5        -0.0281865109
 
 	Iterations converged.
 
@@ -1080,39 +1055,39 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         1.000000000000000    3.826e-05
-	   1         0.984903477505621    2.939e-02
-	   2         0.986958121198562    6.930e-03
-	   3         0.987630616633284    2.608e-03
-	   4         0.987838803633134    5.947e-04
-	   5         0.987868614919817    1.368e-04
-	   6         0.987869467160513    2.616e-05
+	   0         0.999999999999999    3.826e-05
+	   1         0.984903477428668    2.939e-02
+	   2         0.986958121120370    6.930e-03
+	   3         0.987630616546215    2.608e-03
+	   4         0.987838803543172    5.947e-04
+	   5         0.987868614829002    1.368e-04
+	   6         0.987869467069609    2.616e-05
 
 	Initial  <L|R>  =        0.9871836151
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9474518726
-	L2 * R2 =        0.0525481274
+	L1 * R1 =        0.9474518730
+	L2 * R2 =        0.0525481270
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000694756282289
+	Pseudoenergy or Norm of normalized L =    1.000694756276521
 
 	Largest LIA Amplitudes:
-	          3   5        -0.6822165536
-	          3   6        -0.0566106555
-	          3   7        -0.0546496360
-	          4   4         0.0033539160
+	          3   5        -0.6822165538
+	          3   6        -0.0566106549
+	          3   7        -0.0546496363
+	          4   4         0.0033539159
 
 	Largest LIjAb Amplitudes:
-	  3   4   5   5        -0.0861557379
-	  4   3   5   5        -0.0861557379
-	  2   3   0   5         0.0567038860
-	  3   2   5   0         0.0567038860
-	  3   3   4   5        -0.0500297675
-	  3   3   5   4        -0.0500297675
+	  3   4   5   5        -0.0861557374
+	  4   3   5   5        -0.0861557374
+	  2   3   0   5         0.0567038853
+	  3   2   5   0         0.0567038853
+	  3   3   4   5        -0.0500297678
+	  3   3   5   4        -0.0500297678
 	  1   3   0   5        -0.0368287903
 	  3   1   5   0        -0.0368287903
-	  3   4   0   0        -0.0326879824
-	  4   3   0   0        -0.0326879824
+	  3   4   0   0        -0.0326879821
+	  4   3   0   0        -0.0326879821
 
 	Iterations converged.
 
@@ -1125,43 +1100,43 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         1.000000000000000    2.616e-05
-	   1         1.000630797983129    8.666e-03
-	   2         1.000580395879972    3.541e-03
-	   3         1.000943156465975    2.509e-03
-	   4         1.001077980248641    1.788e-03
-	   5         1.001347726932554    1.567e-03
-	   6         1.001738831385941    1.153e-03
-	   7         1.002072361246845    6.397e-04
-	   8         1.002195803720824    2.928e-04
-	   9         1.002101880442391    1.702e-04
-	  10         1.002090661411808    9.398e-05
+	   0         1.000000000002408    2.616e-05
+	   1         1.000630797995499    8.666e-03
+	   2         1.000580395898951    3.541e-03
+	   3         1.000943156481059    2.509e-03
+	   4         1.001077980250231    1.788e-03
+	   5         1.001347726844824    1.567e-03
+	   6         1.001738830818800    1.153e-03
+	   7         1.002072359185520    6.397e-04
+	   8         1.002195798728384    2.928e-04
+	   9         1.002101869410782    1.702e-04
+	  10         1.002090646674744    9.398e-05
 
-	Initial  <L|R>  =        1.0016662977
+	Initial  <L|R>  =        1.0016662849
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.0003457155
-	L2 * R2 =        0.9996542845
+	L1 * R1 =        0.0003457156
+	L2 * R2 =        0.9996542844
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000423657724952
+	Pseudoenergy or Norm of normalized L =    1.000423655875527
 
 	Largest LIA Amplitudes:
-	          3   6        -0.0097822570
-	          3   5         0.0088828872
-	          4   4         0.0056352608
-	          3   7         0.0047711252
+	          3   6        -0.0097822301
+	          3   5         0.0088828804
+	          4   4         0.0056352597
+	          3   7         0.0047711303
 
 	Largest LIjAb Amplitudes:
-	  3   4   0   0        -0.3940420230
-	  4   3   0   0        -0.3940420052
-	  3   4   5   5         0.2391036966
-	  4   3   5   5         0.2391036964
-	  2   3   0   5         0.2263336665
+	  4   3   0   0        -0.3940419880
+	  3   4   0   0        -0.3940419762
+	  3   4   5   5         0.2391037009
+	  4   3   5   5         0.2391037008
+	  2   3   0   5         0.2263336652
 	  3   2   5   0         0.2263336574
-	  3   2   0   5        -0.1635006964
-	  2   3   5   0        -0.1635006873
-	  3   4   1   0        -0.0911894778
-	  4   3   0   1        -0.0911894776
+	  3   2   0   5        -0.1635007151
+	  2   3   5   0        -0.1635007110
+	  4   3   0   1        -0.0911894702
+	  3   4   1   0        -0.0911894701
 
 	Iterations converged.
 
@@ -1175,40 +1150,40 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    9.398e-05
-	   1         0.981564598069772    3.389e-02
-	   2         0.983684103435774    6.831e-03
-	   3         0.984169181428484    2.436e-03
-	   4         0.984339651250455    4.929e-04
-	   5         0.984354430838076    9.684e-05
+	   1         0.981564598013546    3.389e-02
+	   2         0.983684103378851    6.831e-03
+	   3         0.984169181366402    2.436e-03
+	   4         0.984339651186795    4.929e-04
+	   5         0.984354430774039    9.684e-05
 
-	Initial  <L|R>  =        0.9835057724
+	Initial  <L|R>  =        0.9835057723
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9436223831
-	L2 * R2 =        0.0563776169
+	L1 * R1 =        0.9436223835
+	L2 * R2 =        0.0563776165
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000862891200358
+	Pseudoenergy or Norm of normalized L =    1.000862891193088
 
 	Largest LIA Amplitudes:
-	          3   0        -0.6827422763
-	          3   1        -0.0476672148
-	          3   3        -0.0202512040
-	          3   2         0.0145786220
-	          2   4        -0.0031303155
-	          1   4        -0.0010329878
-	          0   4        -0.0003565169
+	          3   0         0.6827422764
+	          3   1         0.0476672146
+	          3   3         0.0202512041
+	          3   2        -0.0145786218
+	          2   4         0.0031303155
+	          1   4         0.0010329878
+	          0   4         0.0003565169
 
 	Largest LIjAb Amplitudes:
-	  3   4   0   5        -0.0833050585
-	  4   3   5   0        -0.0833050585
-	  2   3   0   0         0.0581637808
-	  3   2   0   0         0.0581637808
-	  3   3   0   4        -0.0546335294
-	  3   3   4   0        -0.0546335294
-	  1   3   0   0        -0.0500452098
-	  3   1   0   0        -0.0500452098
-	  3   4   5   0        -0.0422126833
-	  4   3   0   5        -0.0422126833
+	  3   4   0   5         0.0833050580
+	  4   3   5   0         0.0833050580
+	  2   3   0   0        -0.0581637801
+	  3   2   0   0        -0.0581637801
+	  3   3   0   4         0.0546335297
+	  3   3   4   0         0.0546335297
+	  1   3   0   0         0.0500452098
+	  3   1   0   0         0.0500452098
+	  3   4   5   0         0.0422126828
+	  4   3   0   5         0.0422126828
 
 	Iterations converged.
 
@@ -1221,44 +1196,44 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         0.999999999999986    9.684e-05
-	   1         1.000376904692918    5.709e-03
-	   2         1.000293324589945    3.112e-03
-	   3         1.000186243921243    2.020e-03
-	   4         0.999960629644416    1.122e-03
-	   5         0.999760270539700    6.150e-04
-	   6         0.999633753122336    3.321e-04
-	   7         0.999612946301177    1.335e-04
-	   8         0.999611874904655    5.774e-05
+	   0         0.999999999999980    9.684e-05
+	   1         1.000376904665608    5.709e-03
+	   2         1.000293324561488    3.112e-03
+	   3         1.000186243886989    2.020e-03
+	   4         0.999960629598764    1.122e-03
+	   5         0.999760270463562    6.150e-04
+	   6         0.999633752953809    3.321e-04
+	   7         0.999612945934075    1.335e-04
+	   8         0.999611874353618    5.774e-05
 
-	Initial  <L|R>  =        0.9993565720
+	Initial  <L|R>  =        0.9993565714
 	Normalizing L...
 	L0 * R0 =        0.0000000000
 	L1 * R1 =        0.0068018673
 	L2 * R2 =        0.9931981327
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000255467285056
+	Pseudoenergy or Norm of normalized L =    1.000255467285222
 
 	Largest LIA Amplitudes:
-	          3   0         0.0360262127
-	          3   1         0.0342668591
-	          3   3         0.0207857934
-	          2   4        -0.0113453675
-	          3   2        -0.0072340811
-	          1   4        -0.0006829432
-	          0   4         0.0000424644
+	          3   0        -0.0360262123
+	          3   1        -0.0342668596
+	          3   3        -0.0207857934
+	          2   4         0.0113453677
+	          3   2         0.0072340808
+	          1   4         0.0006829432
+	          0   4        -0.0000424644
 
 	Largest LIjAb Amplitudes:
-	  2   3   0   0         0.5460647205
-	  3   2   0   0         0.5460647192
-	  3   2   5   5        -0.2688165840
-	  2   3   5   5        -0.2688165840
-	  3   4   5   0        -0.1406137198
-	  4   3   0   5        -0.1406137198
-	  2   3   0   1         0.1152578393
-	  3   2   1   0         0.1152578393
-	  1   3   0   0        -0.1024701115
-	  3   1   0   0        -0.1024701115
+	  3   2   0   0        -0.5460647210
+	  2   3   0   0        -0.5460647207
+	  3   2   5   5         0.2688165839
+	  2   3   5   5         0.2688165839
+	  4   3   0   5         0.1406137187
+	  3   4   5   0         0.1406137186
+	  3   2   1   0        -0.1152578395
+	  2   3   0   1        -0.1152578395
+	  3   1   0   0         0.1024701116
+	  1   3   0   0         0.1024701116
 
 	Iterations converged.
 
@@ -1272,44 +1247,44 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    5.774e-05
-	   1         0.985909237775600    2.715e-02
-	   2         0.987971382901814    6.661e-03
-	   3         0.988583992238198    2.256e-03
-	   4         0.988840089429147    6.308e-04
-	   5         0.988879611903883    1.473e-04
-	   6         0.988880842691616    4.004e-05
+	   1         0.985909237642096    2.715e-02
+	   2         0.987971382773970    6.661e-03
+	   3         0.988583992102091    2.256e-03
+	   4         0.988840089289927    6.308e-04
+	   5         0.988879611763713    1.473e-04
+	   6         0.988880842551342    4.004e-05
 
-	Initial  <L|R>  =        0.9883187411
+	Initial  <L|R>  =        0.9883187409
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9459174012
-	L2 * R2 =        0.0540825988
+	L1 * R1 =        0.9459174016
+	L2 * R2 =        0.0540825984
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000568745300586
+	Pseudoenergy or Norm of normalized L =    1.000568745299122
 
 	Largest LIA Amplitudes:
-	          2   5         0.6728471370
-	          4   0         0.1207307388
-	          2   7         0.0481347498
-	          2   6         0.0296104616
-	          4   1         0.0294307328
-	          1   5         0.0079490539
+	          2   5         0.6728471378
+	          4   0         0.1207307351
+	          2   7         0.0481347501
+	          2   6         0.0296104610
+	          4   1         0.0294307325
+	          1   5         0.0079490536
 	          1   6         0.0031434816
-	          4   2        -0.0016094965
+	          4   2        -0.0016094963
 	          0   7         0.0007552543
-	          1   7         0.0005973577
+	          1   7         0.0005973578
 
 	Largest LIjAb Amplitudes:
-	  2   2   0   5        -0.0879867968
-	  2   2   5   0        -0.0879867968
-	  2   4   5   5         0.0678006257
-	  4   2   5   5         0.0678006257
-	  2   2   2   5         0.0375733912
-	  2   2   5   2         0.0375733912
-	  2   2   1   5        -0.0363876051
-	  2   2   5   1        -0.0363876051
-	  2   3   5   4         0.0339913697
-	  3   2   4   5         0.0339913697
+	  2   2   0   5        -0.0879867959
+	  2   2   5   0        -0.0879867959
+	  2   4   5   5         0.0678006260
+	  4   2   5   5         0.0678006260
+	  2   2   2   5         0.0375733913
+	  2   2   5   2         0.0375733913
+	  2   2   1   5        -0.0363876053
+	  2   2   5   1        -0.0363876053
+	  2   3   5   4         0.0339913701
+	  3   2   4   5         0.0339913701
 
 	Iterations converged.
 
@@ -1323,44 +1298,44 @@ Total time:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    4.004e-05
-	   1         0.989791875612111    2.237e-02
-	   2         0.990722225468884    5.033e-03
-	   3         0.990972491039656    1.862e-03
-	   4         0.991070138873063    5.241e-04
-	   5         0.991056614020944    1.438e-04
-	   6         0.991052171507760    5.100e-05
+	   1         0.989791875493417    2.237e-02
+	   2         0.990722225344509    5.033e-03
+	   3         0.990972490909789    1.862e-03
+	   4         0.991070138741945    5.241e-04
+	   5         0.991056613890715    1.438e-04
+	   6         0.991052171377709    5.100e-05
 
-	Initial  <L|R>  =        0.9905823451
+	Initial  <L|R>  =        0.9905823449
 	Normalizing L...
 	L0 * R0 =        0.0000000000
-	L1 * R1 =        0.9605148865
-	L2 * R2 =        0.0394851135
+	L1 * R1 =        0.9605148867
+	L2 * R2 =        0.0394851133
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000474293173242
+	Pseudoenergy or Norm of normalized L =    1.000474293169116
 
 	Largest LIA Amplitudes:
-	          4   0        -0.6797730355
-	          2   5         0.1222604392
-	          4   1        -0.0238070189
-	          2   6        -0.0218272846
-	          4   2         0.0201102492
-	          4   3        -0.0194468019
-	          1   5        -0.0151108122
-	          1   6         0.0114512046
-	          2   7         0.0058484226
-	          1   7         0.0021355386
+	          4   0         0.6797730362
+	          2   5        -0.1222604354
+	          4   1         0.0238070192
+	          2   6         0.0218272846
+	          4   2        -0.0201102491
+	          4   3         0.0194468019
+	          1   5         0.0151108125
+	          1   6        -0.0114512046
+	          2   7        -0.0058484223
+	          1   7        -0.0021355386
 
 	Largest LIjAb Amplitudes:
-	  4   4   0   5        -0.0886933299
-	  4   4   5   0        -0.0886933299
-	  2   4   5   5         0.0438234148
-	  4   2   5   5         0.0438234148
-	  3   4   4   0        -0.0306094351
-	  4   3   0   4        -0.0306094351
-	  2   4   2   0        -0.0296439998
-	  4   2   0   2        -0.0296439998
-	  4   4   0   7        -0.0270673379
-	  4   4   7   0        -0.0270673379
+	  4   4   0   5         0.0886933296
+	  4   4   5   0         0.0886933296
+	  2   4   5   5        -0.0438234139
+	  4   2   5   5        -0.0438234139
+	  3   4   4   0         0.0306094355
+	  4   3   0   4         0.0306094355
+	  2   4   2   0         0.0296440000
+	  4   2   0   2         0.0296440000
+	  4   4   0   7         0.0270673381
+	  4   4   7   0         0.0270673381
 
 	Iterations converged.
 
@@ -1368,102 +1343,88 @@ Total time:
 
                  1            2            3            4            5            6            7            8            9
 
-    1    1.0000000   -0.0000000   -0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
+    1    1.0000000    0.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     2    0.0000000    1.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     3    0.0000000   -0.0000001    1.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     4  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000001  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     5  -99.0000000  -99.0000000  -99.0000000   -0.0000012    1.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     6  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000003  -99.0000000  -99.0000000
     7  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    0.0000005    1.0000000  -99.0000000  -99.0000000
-    8  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000
-    9  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000000
+    8  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000000
+    9  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000   -0.0000000    1.0000000
 
 
 	<L|R> overlap matrix with RHF quantities (-99 => 0 by symmetry)
 
                  1            2            3            4            5            6            7            8            9
 
-    1    1.0000000    0.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
+    1    1.0000000   -0.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     2    0.0000000    1.0000000   -0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
     3    0.0000000   -0.0000000    1.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
-    4  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
-    5  -99.0000000  -99.0000000  -99.0000000   -0.0000000    1.0000031  -99.0000000  -99.0000000  -99.0000000  -99.0000000
-    6  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000001   -0.0000000  -99.0000000  -99.0000000
+    4  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000
+    5  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000031  -99.0000000  -99.0000000  -99.0000000  -99.0000000
+    6  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000001    0.0000000  -99.0000000  -99.0000000
     7  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000   -0.0000000    1.0000011  -99.0000000  -99.0000000
     8  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000
-    9  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000000
+    9  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000  -99.0000000   -0.0000000    1.0000000
 
 
 
 	Projections for excited state, irrep A1, root 0:
 	<0|Le^(-T)|0><0|Re^T|0>  =    0.0005202670
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9457838666
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0536958674
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9457838669
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0536958671
 	Sum of above             =    1.0000000010
-	Approx. excitation level =    1.0531756014
+	Approx. excitation level =    1.0531756012
 
 	Projections for excited state, irrep A1, root 1:
 	<0|Le^(-T)|0><0|Re^T|0>  =    0.0004512389
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9558804005
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0436683526
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9558804008
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0436683522
 	Sum of above             =    0.9999999920
-	Approx. excitation level =    1.0432171057
+	Approx. excitation level =    1.0432171053
 
 	Projections for excited state, irrep A1, root 0:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9494983526
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0505016499
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9494983530
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0505016495
 	Sum of above             =    1.0000000025
-	Approx. excitation level =    1.0505016524
+	Approx. excitation level =    1.0505016520
 
 	Projections for excited state, irrep A1, root 1:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.0001791350
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.9998239515
-	Sum of above             =    1.0000030865
-	Approx. excitation level =    1.9998270380
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.0001791351
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.9998239526
+	Sum of above             =    1.0000030877
+	Approx. excitation level =    1.9998270403
 
 	Projections for excited state, irrep A1, root 0:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9457661628
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0542338888
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9457661631
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0542338885
 	Sum of above             =    1.0000000516
-	Approx. excitation level =    1.0542339405
+	Approx. excitation level =    1.0542339401
 
 	Projections for excited state, irrep A1, root 1:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.0062701143
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.0062701144
 	<0|Le^(-T)|D><D|Re^T|0>  =    0.9937309833
 	Sum of above             =    1.0000010976
 	Approx. excitation level =    1.9937320809
 
 	Projections for excited state, irrep A1, root 0:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9481853840
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0518146154
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9481853843
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0518146151
 	Sum of above             =    0.9999999994
-	Approx. excitation level =    1.0518146148
+	Approx. excitation level =    1.0518146145
 
 	Projections for excited state, irrep A1, root 1:
-	<0|Le^(-T)|0><0|Re^T|0>  =   -0.0000000000
-	<0|Le^(-T)|S><S|Re^T|0>  =    0.9619655031
-	<0|Le^(-T)|D><D|Re^T|0>  =    0.0380345013
+	<0|Le^(-T)|0><0|Re^T|0>  =    0.0000000000
+	<0|Le^(-T)|S><S|Re^T|0>  =    0.9619655033
+	<0|Le^(-T)|D><D|Re^T|0>  =    0.0380345011
 	Sum of above             =    1.0000000044
-	Approx. excitation level =    1.0380345056
-
-*** tstop() called on psinet at Mon May 15 15:34:54 2017
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.72 seconds =       0.01 minutes
-	system time =       0.50 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:54 2017
-
+	Approx. excitation level =    1.0380345054
 
 			**************************
 			*                        *
@@ -1487,456 +1448,51 @@ Total time:
 	Xi connected     = No
 	Compute NO       = No
 
-	Nuclear Rep. energy (wfn)     =    8.801465529972067
-	SCF energy          (wfn)     =  -75.980157921307594
-	Reference energy    (file100) =  -75.980157921307580
-	CCSD energy         (CC_INFO) =   -0.139406925328868
-	Total CCSD energy   (CC_INFO) =  -76.119564846636450
+	Nuclear Rep. energy (wfn)     =    8.801465564567374
+	SCF energy          (wfn)     =  -75.980157921934421
+	Reference energy    (file100) =  -75.980157921934378
+	CCSD energy         (CC_INFO) =   -0.139406924949512
+	Total CCSD energy   (CC_INFO) =  -76.119564846883890
 	Number of States = 9
 
 	Ground?  State     EOM Energy       R0
 	  Yes     0 A1    0.0000000000   1.00000000
-	   No     1 A1    0.3879112360  -0.02065388
-	   No     2 A1    0.6750818697  -0.01903802
-	   No     1 A2    0.3712108026   0.00000000
-	   No     2 A2    0.9605057243   0.00000000
-	   No     1 B1    0.2911467624   0.00000000
-	   No     2 B1    0.9420596012   0.00000000
-	   No     1 B2    0.4727594369   0.00000000
-	   No     2 B2    0.5428630852   0.00000000
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.0325
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.9866     Total:     0.9866
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.5076     Total:     2.5076
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -7.3753     YY:    -4.3197     ZZ:    -5.9901
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -1.4803     YY:     1.5754     ZZ:    -0.0951
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.36352  4.36352  0.00000 -0.72705
-       2     H     0.31824  0.31824  0.00000  0.36352
-       3     H     0.31824  0.31824  0.00000  0.36352
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B1    1.981
-  HONO-1 :    3 A1    1.970
-  HONO-0 :    1 B2    1.966
-  LUNO+0 :    2 B2    0.030
-  LUNO+1 :    4 A1    0.029
-  LUNO+2 :    2 B1    0.018
-  LUNO+3 :    5 A1    0.012
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 1 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.1789
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1598     Total:     0.1598
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -0.4061     Total:     0.4061
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -8.4226     YY:    -8.6025     ZZ:    -7.9129
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -0.1100     YY:    -0.2898     ZZ:     0.3998
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.04709  4.04709  0.00000 -0.09417
-       2     H     0.47646  0.47646  0.00000  0.04709
-       3     H     0.47646  0.47646  0.00000  0.04709
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    2 A1    1.995
-  HONO-1 :    1 B2    1.973
-  HONO-0 :    3 A1    1.139
-  LUNO+0 :    4 A1    0.852
-  LUNO+1 :    2 B2    0.030
-  LUNO+2 :    5 A1    0.006
-  LUNO+3 :    2 B1    0.004
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 2 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.6707
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.3484     Total:     0.3484
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.8855     Total:     0.8855
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -8.2766     YY:    -8.8130     ZZ:    -8.5078
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     0.2559     YY:    -0.2805     ZZ:     0.0246
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.24546  4.24546  0.00000 -0.49092
-       2     H     0.37727  0.37727  0.00000  0.24546
-       3     H     0.37727  0.37727  0.00000  0.24546
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B1    1.977
-  HONO-1 :    3 A1    1.969
-  HONO-0 :    1 B2    1.137
-  LUNO+0 :    2 B2    0.847
-  LUNO+1 :    4 A1    0.034
-  LUNO+2 :    2 B1    0.018
-  LUNO+3 :    5 A1    0.013
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 3 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.9947
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0243     Total:     0.0243
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0618     Total:     0.0618
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -6.9182     YY:   -10.1270     ZZ:    -8.5723
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     1.6210     YY:    -1.5879     ZZ:    -0.0331
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.07221  4.07221  0.00000 -0.14442
-       2     H     0.46389  0.46389  0.00000  0.07221
-       3     H     0.46389  0.46389  0.00000  0.07221
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.992
-  HONO-1 :    3 A1    1.989
-  HONO-0 :    1 B1    0.999
-  LUNO+0 :    2 B2    0.992
-  LUNO+1 :    4 A1    0.018
-  LUNO+2 :    3 B2    0.006
-  LUNO+3 :    2 B1    0.002
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 4 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -2.1529
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.1338     Total:     1.1338
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -2.8819     Total:     2.8819
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -8.3078     YY:   -13.4310     ZZ:   -11.2182
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     2.6779     YY:    -2.4454     ZZ:    -0.2325
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     3.64501  3.64501  0.00000  0.70999
-       2     H     0.67750  0.67750  0.00000 -0.35499
-       3     H     0.67750  0.67750  0.00000 -0.35499
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.526
-  HONO-1 :    3 A1    1.477
-  HONO-0 :    4 A1    1.198
-  LUNO+0 :    1 B1    1.000
-  LUNO+1 :    2 B2    0.791
-  LUNO+2 :    5 A1    0.004
-  LUNO+3 :    2 B1    0.002
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 5 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.0799
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.0609     Total:     0.0609
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -0.1547     Total:     0.1547
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -7.2898     YY:    -8.8721     ZZ:    -9.2106
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     1.1677     YY:    -0.4146     ZZ:    -0.7531
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     3.99880  3.99880  0.00000  0.00239
-       2     H     0.50060  0.50060  0.00000 -0.00120
-       3     H     0.50060  0.50060  0.00000 -0.00120
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    3 A1    1.994
-  HONO-1 :    1 B2    1.987
-  HONO-0 :    1 B1    0.999
-  LUNO+0 :    4 A1    0.994
-  LUNO+1 :    2 B2    0.016
-  LUNO+2 :    5 A1    0.005
-  LUNO+3 :    6 A1    0.002
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 6 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -2.2544
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.2354     Total:     1.2354
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -3.1400     Total:     3.1400
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -8.4197     YY:   -13.5000     ZZ:   -11.0800
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     2.5803     YY:    -2.5001     ZZ:    -0.0801
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     3.59810  3.59810  0.00000  0.80380
-       2     H     0.70095  0.70095  0.00000 -0.40190
-       3     H     0.70095  0.70095  0.00000 -0.40190
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B2    1.866
-  HONO-1 :    3 A1    1.512
-  HONO-0 :    4 A1    1.135
-  LUNO+0 :    1 B1    1.002
-  LUNO+1 :    2 B2    0.474
-  LUNO+2 :    5 A1    0.009
-  LUNO+3 :    2 B1    0.002
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 7 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -1.1600
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1409     Total:     0.1409
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:    -0.3582     Total:     0.3582
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -8.1468     YY:   -10.0140     ZZ:    -7.4213
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:     0.3806     YY:    -1.4867     ZZ:     1.1061
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.12655  4.12655  0.00000 -0.25311
-       2     H     0.43672  0.43672  0.00000  0.12655
-       3     H     0.43672  0.43672  0.00000  0.12655
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    2 A1    1.995
-  HONO-1 :    1 B2    1.955
-  HONO-0 :    3 A1    1.030
-  LUNO+0 :    2 B2    0.961
-  LUNO+1 :    4 A1    0.047
-  LUNO+2 :    3 B2    0.007
-  LUNO+3 :    2 B1    0.002
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC ROOT 8 density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0191
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.8091
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.2100     Total:     0.2100
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.5338     Total:     0.5338
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -8.5741     YY:    -7.4993     ZZ:    -9.1153
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -0.1779     YY:     0.8969     ZZ:    -0.7190
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.11680  4.11680  0.00000 -0.23360
-       2     H     0.44160  0.44160  0.00000  0.11680
-       3     H     0.44160  0.44160  0.00000  0.11680
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    2 A1    1.994
-  HONO-1 :    3 A1    1.957
-  HONO-0 :    1 B2    1.036
-  LUNO+0 :    4 A1    0.960
-  LUNO+1 :    2 B2    0.041
-  LUNO+2 :    5 A1    0.006
-  LUNO+3 :    3 B2    0.004
-
+	   No     1 A1    0.3879112372   0.02065388
+	   No     2 A1    0.6750818722   0.01903802
+	   No     1 A2    0.3712108046   0.00000000
+	   No     2 A2    0.9605057297   0.00000000
+	   No     1 B1    0.2911467640   0.00000000
+	   No     2 B1    0.9420596065   0.00000000
+	   No     1 B2    0.4727594387   0.00000000
+	   No     2 B2    0.5428630875   0.00000000
 Doing transition
 
 	Oscillator Strength for 1 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.66570300
-	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.68343339
-	Dipole Strength          0.45496366 
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.66570299
+	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.68343339
+	Dipole Strength          0.45496365 
 	Oscillator Strength      0.11765701 
-	Einstein A Coefficient   5.68844308e+08 
-	Einstein B Coefficient   5.53538112e+19 
+	Einstein A Coefficient   5.68844298e+08 
+	Einstein B Coefficient   5.53538025e+19 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.66570300
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.66570299
 	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.00000000
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.68343339
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.68343339
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.31781642
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.31781642
 	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.00000000
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.32248795
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.32248795
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -1945,30 +1501,30 @@ Doing transition
 
 	Oscillator Strength for 2 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.77759836
-	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.79624641
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.77759836
+	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.79624640
 	Dipole Strength          0.61915990 
 	Oscillator Strength      0.27865575 
-	Einstein A Coefficient   4.08029715e+09 
-	Einstein B Coefficient   7.53309852e+19 
+	Einstein A Coefficient   4.08029704e+09 
+	Einstein B Coefficient   7.53309728e+19 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.77759836
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.77759836
 	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.00000000
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.79624641
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.79624640
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.46054373
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.46054373
 	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.00000000
 	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.46929531
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.46929531
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2041,30 +1597,30 @@ Doing transition
 
 	Oscillator Strength for 1 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.22673078 	  0.00000000 	  0.00000000
-	<n|mu_e|0>               0.23178447 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.22673078 	  0.00000000 	  0.00000000
+	<n|mu_e|0>              -0.23178447 	  0.00000000 	  0.00000000
 	Dipole Strength          0.05255267 
 	Oscillator Strength      0.01020036 
-	Einstein A Coefficient   2.77811570e+07 
-	Einstein B Coefficient   6.39389681e+18 
+	Einstein A Coefficient   2.77811574e+07 
+	Einstein B Coefficient   6.39389598e+18 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.22673078 	  0.00000000 	  0.00000000
-	<n|mu_m|0>               0.00000000 	  0.13977761 	  0.00000000
-	<0|mu_m|n>*              0.00000000 	  0.13553081 	  0.00000000
-	<n|mu_e|0>*              0.23178447 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.22673078 	  0.00000000 	  0.00000000
+	<n|mu_m|0>               0.00000000 	 -0.13977760 	  0.00000000
+	<0|mu_m|n>*              0.00000000 	 -0.13553081 	  0.00000000
+	<n|mu_e|0>*             -0.23178447 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.13423419 	  0.00000000 	  0.00000000
-	<n|mu_m|0>               0.00000000 	  0.13977761 	  0.00000000
-	<0|mu_m|n>*              0.00000000 	  0.13553081 	  0.00000000
-	<n|mu_e|0>*              0.13713590 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.13423419 	  0.00000000 	  0.00000000
+	<n|mu_m|0>               0.00000000 	 -0.13977760 	  0.00000000
+	<0|mu_m|n>*              0.00000000 	 -0.13553081 	  0.00000000
+	<n|mu_e|0>*             -0.13713591 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2073,30 +1629,30 @@ Doing transition
 
 	Oscillator Strength for 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.01280737 	  0.00000000 	  0.00000000
-	<n|mu_e|0>              -0.01738137 	  0.00000000 	  0.00000000
+	<0|mu_e|n>               0.01280737 	  0.00000000 	  0.00000000
+	<n|mu_e|0>               0.01738137 	  0.00000000 	  0.00000000
 	Dipole Strength          0.00022261 
 	Oscillator Strength      0.00013981 
-	Einstein A Coefficient   3.98656386e+06 
-	Einstein B Coefficient   2.70841227e+16 
+	Einstein A Coefficient   3.98656351e+06 
+	Einstein B Coefficient   2.70841165e+16 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.01280737 	  0.00000000 	  0.00000000
-	<n|mu_m|0>               0.00000000 	 -0.00840834 	  0.00000000
-	<0|mu_m|n>*              0.00000000 	 -0.01065898 	  0.00000000
-	<n|mu_e|0>*             -0.01738137 	  0.00000000 	  0.00000000
+	<0|mu_e|n>               0.01280737 	  0.00000000 	  0.00000000
+	<n|mu_m|0>               0.00000000 	  0.00840834 	  0.00000000
+	<0|mu_m|n>*              0.00000000 	  0.01065898 	  0.00000000
+	<n|mu_e|0>*              0.01738137 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00056893 	  0.00000000 	  0.00000000
-	<n|mu_m|0>               0.00000000 	 -0.00840834 	  0.00000000
-	<0|mu_m|n>*              0.00000000 	 -0.01065898 	  0.00000000
-	<n|mu_e|0>*             -0.00207821 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.00056893 	  0.00000000 	  0.00000000
+	<n|mu_m|0>               0.00000000 	  0.00840834 	  0.00000000
+	<0|mu_m|n>*              0.00000000 	  0.01065898 	  0.00000000
+	<n|mu_e|0>*              0.00207820 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2109,8 +1665,8 @@ Doing transition
 	<n|mu_e|0>               0.00000000 	  0.60384466 	  0.00000000
 	Dipole Strength          0.35158757 
 	Oscillator Strength      0.11081089 
-	Einstein A Coefficient   7.95744721e+08 
-	Einstein B Coefficient   4.27764100e+19 
+	Einstein A Coefficient   7.95744713e+08 
+	Einstein B Coefficient   4.27764037e+19 
 Doing transition
 
 	Length-Gauge Rotational Strength for 1 B2
@@ -2137,30 +1693,30 @@ Doing transition
 
 	Oscillator Strength for 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  1.13139823 	  0.00000000
-	<n|mu_e|0>               0.00000000 	  1.16685360 	  0.00000000
-	Dipole Strength          1.32017609 
-	Oscillator Strength      0.47778325 
-	Einstein A Coefficient   4.52399828e+09 
-	Einstein B Coefficient   1.60621134e+20 
+	<0|mu_e|n>               0.00000000 	 -1.13139822 	  0.00000000
+	<n|mu_e|0>               0.00000000 	 -1.16685359 	  0.00000000
+	Dipole Strength          1.32017607 
+	Oscillator Strength      0.47778324 
+	Einstein A Coefficient   4.52399815e+09 
+	Einstein B Coefficient   1.60621107e+20 
 Doing transition
 
 	Length-Gauge Rotational Strength for 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  1.13139823 	  0.00000000
-	<n|mu_m|0>              -0.07236260 	  0.00000000 	  0.00000000
-	<0|mu_m|n>*             -0.06918800 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  1.16685360 	  0.00000000
+	<0|mu_e|n>               0.00000000 	 -1.13139822 	  0.00000000
+	<n|mu_m|0>               0.07236260 	  0.00000000 	  0.00000000
+	<0|mu_m|n>*              0.06918800 	  0.00000000 	  0.00000000
+	<n|mu_e|0>*              0.00000000 	 -1.16685359 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.56464938 	  0.00000000
-	<n|mu_m|0>              -0.07236260 	  0.00000000 	  0.00000000
-	<0|mu_m|n>*             -0.06918800 	  0.00000000 	  0.00000000
-	<n|mu_e|0>*              0.00000000 	  0.57884175 	  0.00000000
+	<0|mu_e|n>               0.00000000 	 -0.56464938 	  0.00000000
+	<n|mu_m|0>               0.07236260 	  0.00000000 	  0.00000000
+	<0|mu_m|n>*              0.06918800 	  0.00000000 	  0.00000000
+	<n|mu_e|0>*              0.00000000 	 -0.57884174 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2173,7 +1729,7 @@ Doing transition
 	State   (eV)    (cm^-1)    (nm)     (au)              (l,au)   (v,au)     (s^-1)
 	 1 A1  10.556   85136.7   117.5   0.387911   0.1177   0.0000   0.0000  5.688443E+08
 	 2 A1  18.370  148163.3    67.5   0.675082   0.2787   0.0000   0.0000  4.080297E+09
-	 1 A2  10.101   81471.3   122.7   0.371211   0.0000   0.0000   0.0000  0.000000E+00
+	 1 A2  10.101   81471.4   122.7   0.371211   0.0000   0.0000   0.0000  0.000000E+00
 	 2 A2  26.137  210806.6    47.4   0.960506   0.0000   0.0000   0.0000  0.000000E+00
 	 1 B1   7.923   63899.3   156.5   0.291147   0.0102   0.0000   0.0000  2.778116E+07
 	 2 B1  25.635  206758.2    48.4   0.942060   0.0001   0.0000   0.0000  3.986564E+06
@@ -2211,8 +1767,8 @@ Doing transition
 	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.05129600
 	Dipole Strength          0.00301590 
 	Oscillator Strength      0.00057739 
-	Einstein A Coefficient   1.52987979e+06 
-	Einstein B Coefficient   3.66934390e+17 
+	Einstein A Coefficient   1.52987978e+06 
+	Einstein B Coefficient   3.66934337e+17 
 
 	Length-Gauge Rotational Strength for 1 A1 to 2 A1 Transition
 	                              X    	       Y    	       Z
@@ -2260,8 +1816,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 A2 to 1 A1 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.04578453
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.04629517
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.04578453
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.04629517
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2270,8 +1826,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.04578453
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.04629517
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.04578453
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.04629517
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2303,8 +1859,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 A2 to 2 A1 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.47999752
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.48612691
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.47999752
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.48612691
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2313,8 +1869,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.47999752
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.48612691
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.47999752
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.48612691
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2346,8 +1902,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 A1 to 2 A2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.12940468
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.12352525
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.12940469
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.12352525
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2356,8 +1912,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 A1
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.12940468
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.12352525
+	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.12940469
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.12352525
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2389,8 +1945,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 2 A1 to 2 A2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.07684490
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.07093301
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.07684490
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.07093301
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2399,8 +1955,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 2 A1
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.07684490
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.07093301
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.07684490
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.07093301
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -2422,16 +1978,16 @@ Doing transition
 
 	Oscillator Strength for 1 A2 to 2 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.25076667
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.25076668
 	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.26771602
 	Dipole Strength          0.06713426 
 	Oscillator Strength      0.02637458 
-	Einstein A Coefficient   2.94280791e+08 
-	Einstein B Coefficient   8.16798644e+18 
+	Einstein A Coefficient   2.94280787e+08 
+	Einstein B Coefficient   8.16798514e+18 
 
 	Length-Gauge Rotational Strength for 1 A2 to 2 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.25076667
+	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.25076668
 	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00000000
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.26771602
@@ -2469,8 +2025,8 @@ Doing transition
 	<n|mu_e|0>               0.17220289 	  0.00000000 	  0.00000000
 	Dipole Strength          0.02843930 
 	Oscillator Strength      0.00183461 
-	Einstein A Coefficient   5.51932964e+05 
-	Einstein B Coefficient   3.46010842e+18 
+	Einstein A Coefficient   5.51932950e+05 
+	Einstein B Coefficient   3.46010792e+18 
 
 	Length-Gauge Rotational Strength for 1 B1 to 1 A1 Transition
 	                              X    	       Y    	       Z
@@ -2509,18 +2065,18 @@ Doing transition
 	Oscillator Strength for 1 B1 to 2 A1
 	                              X    	       Y    	       Z
 	<0|mu_e|n>              -0.05615869 	  0.00000000 	  0.00000000
-	<n|mu_e|0>              -0.05073908 	  0.00000000 	  0.00000000
+	<n|mu_e|0>              -0.05073909 	  0.00000000 	  0.00000000
 	Dipole Strength          0.00284944 
 	Oscillator Strength      0.00072933 
-	Einstein A Coefficient   3.45424128e+06 
-	Einstein B Coefficient   3.46681270e+17 
+	Einstein A Coefficient   3.45424140e+06 
+	Einstein B Coefficient   3.46681236e+17 
 
 	Length-Gauge Rotational Strength for 1 B1 to 2 A1 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>              -0.05615869 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	 -0.05236758 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	 -0.05104876 	  0.00000000
-	<q|mu_e|p>*             -0.05073908 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*             -0.05073909 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2551,29 +2107,29 @@ Doing transition
 
 	Oscillator Strength for 1 B1 to 1 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  1.59437685 	  0.00000000
-	<n|mu_e|0>               0.00000000 	  1.58700110 	  0.00000000
-	Dipole Strength          2.53027781 
+	<0|mu_e|n>               0.00000000 	 -1.59437685 	  0.00000000
+	<n|mu_e|0>               0.00000000 	 -1.58700111 	  0.00000000
+	Dipole Strength          2.53027783 
 	Oscillator Strength      0.13505618 
-	Einstein A Coefficient   2.78163632e+07 
-	Einstein B Coefficient   3.07849910e+20 
+	Einstein A Coefficient   2.78163630e+07 
+	Einstein B Coefficient   3.07849865e+20 
 
 	Length-Gauge Rotational Strength for 1 B1 to 1 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  1.59437685 	  0.00000000
-	<q|mu_m|p>              -0.10749901 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.11012965 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  1.58700110 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -1.59437685 	  0.00000000
+	<q|mu_m|p>               0.10749901 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.11012965 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -1.58700111 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.14039048 	  0.00000000
-	<q|mu_m|p>              -0.10749901 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.11012965 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.16993929 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.14039048 	  0.00000000
+	<q|mu_m|p>               0.10749901 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.11012965 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -0.16993929 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2594,29 +2150,29 @@ Doing transition
 
 	Oscillator Strength for 1 B1 to 2 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.03948724 	  0.00000000
-	<n|mu_e|0>               0.00000000 	  0.01264796 	  0.00000000
-	Dipole Strength          0.00049943 
+	<0|mu_e|n>               0.00000000 	 -0.03948724 	  0.00000000
+	<n|mu_e|0>               0.00000000 	 -0.01264805 	  0.00000000
+	Dipole Strength          0.00049944 
 	Oscillator Strength      0.00022287 
-	Einstein A Coefficient   3.20829288e+06 
-	Einstein B Coefficient   6.07642229e+16 
+	Einstein A Coefficient   3.20831735e+06 
+	Einstein B Coefficient   6.07646777e+16 
 
 	Length-Gauge Rotational Strength for 1 B1 to 2 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.03948724 	  0.00000000
-	<q|mu_m|p>               0.15598289 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.14620366 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.01264796 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.03948724 	  0.00000000
+	<q|mu_m|p>              -0.15598289 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.14620366 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -0.01264805 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00033386 	  0.00000000
-	<q|mu_m|p>               0.15598289 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.14620366 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.00771645 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.00033387 	  0.00000000
+	<q|mu_m|p>              -0.15598289 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.14620366 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.00771640 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2637,16 +2193,16 @@ Doing transition
 
 	Oscillator Strength for 1 A1 to 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.10641453 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.10641454 	  0.00000000 	  0.00000000
 	<n|mu_e|0>              -0.10367695 	  0.00000000 	  0.00000000
 	Dipole Strength          0.01103273 
 	Oscillator Strength      0.00407585 
-	Einstein A Coefficient   4.02143414e+07 
-	Einstein B Coefficient   1.34231357e+18 
+	Einstein A Coefficient   4.02143425e+07 
+	Einstein B Coefficient   1.34231340e+18 
 
 	Length-Gauge Rotational Strength for 1 A1 to 2 B1 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.10641453 	  0.00000000 	  0.00000000
+	<p|mu_e|q>              -0.10641454 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	 -0.07146906 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	 -0.06731277 	  0.00000000
 	<q|mu_e|p>*             -0.10367695 	  0.00000000 	  0.00000000
@@ -2684,8 +2240,8 @@ Doing transition
 	<n|mu_e|0>               0.02476202 	  0.00000000 	  0.00000000
 	Dipole Strength          0.00055721 
 	Oscillator Strength      0.00009918 
-	Einstein A Coefficient   2.27124829e+05 
-	Einstein B Coefficient   6.77939105e+16 
+	Einstein A Coefficient   2.27124828e+05 
+	Einstein B Coefficient   6.77938995e+16 
 
 	Length-Gauge Rotational Strength for 2 A1 to 2 B1 Transition
 	                              X    	       Y    	       Z
@@ -2723,29 +2279,29 @@ Doing transition
 
 	Oscillator Strength for 1 A2 to 2 B1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.06412963 	  0.00000000
-	<n|mu_e|0>               0.00000000 	 -0.09104943 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  0.06412963 	  0.00000000
+	<n|mu_e|0>               0.00000000 	  0.09104942 	  0.00000000
 	Dipole Strength          0.00583897 
 	Oscillator Strength      0.00222211 
-	Einstein A Coefficient   2.32658460e+07 
-	Einstein B Coefficient   7.10406233e+17 
+	Einstein A Coefficient   2.32658437e+07 
+	Einstein B Coefficient   7.10406060e+17 
 
 	Length-Gauge Rotational Strength for 1 A2 to 2 B1 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.06412963 	  0.00000000
-	<q|mu_m|p>               0.10139813 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.08911340 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.09104943 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.06412963 	  0.00000000
+	<q|mu_m|p>              -0.10139812 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.08911340 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.09104942 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.05895211 	  0.00000000
-	<q|mu_m|p>               0.10139813 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*              0.08911340 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.06625451 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.05895211 	  0.00000000
+	<q|mu_m|p>              -0.10139812 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*             -0.08911340 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.06625451 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2766,29 +2322,29 @@ Doing transition
 
 	Oscillator Strength for 2 B1 to 2 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.26497909 	  0.00000000
-	<n|mu_e|0>               0.00000000 	 -0.25620179 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  0.26497908 	  0.00000000
+	<n|mu_e|0>               0.00000000 	  0.25620181 	  0.00000000
 	Dipole Strength          0.06788812 
 	Oscillator Strength      0.00083485 
-	Einstein A Coefficient   9.12701351e+03 
-	Einstein B Coefficient   8.25970579e+18 
+	Einstein A Coefficient   9.12701408e+03 
+	Einstein B Coefficient   8.25970500e+18 
 
 	Length-Gauge Rotational Strength for 2 B1 to 2 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.26497909 	  0.00000000
-	<q|mu_m|p>              -0.18354335 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.16974777 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.25620179 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.26497908 	  0.00000000
+	<q|mu_m|p>               0.18354333 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.16974777 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.25620181 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 B1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.00032211 	  0.00000000
-	<q|mu_m|p>              -0.18354335 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.16974777 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.01108403 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.00032211 	  0.00000000
+	<q|mu_m|p>               0.18354333 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.16974777 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -0.01108402 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2810,18 +2366,18 @@ Doing transition
 	Oscillator Strength for 1 B1 to 2 B1
 	                              X    	       Y    	       Z
 	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.18209904
-	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.18385728
+	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.18385729
 	Dipole Strength          0.03348024 
 	Oscillator Strength      0.01452848 
-	Einstein A Coefficient   1.97777394e+08 
-	Einstein B Coefficient   4.07342126e+18 
+	Einstein A Coefficient   1.97777397e+08 
+	Einstein B Coefficient   4.07342072e+18 
 
 	Length-Gauge Rotational Strength for 1 B1 to 2 B1 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.18209904
 	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.18385728
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.18385729
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2852,29 +2408,29 @@ Doing transition
 
 	Oscillator Strength for 1 A1 to 1 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  1.61710064 	  0.00000000
-	<n|mu_e|0>               0.00000000 	  1.60454110 	  0.00000000
-	Dipole Strength          2.59470445 
+	<0|mu_e|n>               0.00000000 	 -1.61710064 	  0.00000000
+	<n|mu_e|0>               0.00000000 	 -1.60454111 	  0.00000000
+	Dipole Strength          2.59470446 
 	Oscillator Strength      0.14677067 
 	Einstein A Coefficient   3.39496613e+07 
-	Einstein B Coefficient   3.15688469e+20 
+	Einstein B Coefficient   3.15688423e+20 
 
 	Length-Gauge Rotational Strength for 1 A1 to 1 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  1.61710064 	  0.00000000
-	<q|mu_m|p>              -0.07050233 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.07406798 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  1.60454110 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -1.61710064 	  0.00000000
+	<q|mu_m|p>               0.07050234 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.07406798 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -1.60454111 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 A1
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.13878314 	  0.00000000
-	<q|mu_m|p>              -0.07050233 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.07406798 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.16012384 	  0.00000000
+	<p|mu_e|q>               0.00000000 	 -0.13878314 	  0.00000000
+	<q|mu_m|p>               0.07050234 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.07406798 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	 -0.16012384 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2895,29 +2451,29 @@ Doing transition
 
 	Oscillator Strength for 1 B2 to 2 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	 -0.30006657 	  0.00000000
-	<n|mu_e|0>               0.00000000 	 -0.27981946 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  0.30006656 	  0.00000000
+	<n|mu_e|0>               0.00000000 	  0.27981945 	  0.00000000
 	Dipole Strength          0.08396446 
 	Oscillator Strength      0.01132526 
-	Einstein A Coefficient   1.48952319e+07 
-	Einstein B Coefficient   1.02156579e+19 
+	Einstein A Coefficient   1.48952309e+07 
+	Einstein B Coefficient   1.02156558e+19 
 
 	Length-Gauge Rotational Strength for 1 B2 to 2 A1 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.30006657 	  0.00000000
-	<q|mu_m|p>              -0.40831576 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.41266431 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.27981946 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.30006656 	  0.00000000
+	<q|mu_m|p>               0.40831577 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.41266431 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.27981945 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	 -0.11107540 	  0.00000000
-	<q|mu_m|p>              -0.40831576 	  0.00000000 	  0.00000000
-	<p|mu_m|q>*             -0.41266431 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	 -0.08425156 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.11107540 	  0.00000000
+	<q|mu_m|p>               0.40831577 	  0.00000000 	  0.00000000
+	<p|mu_m|q>*              0.41266431 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  0.08425156 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -2942,8 +2498,8 @@ Doing transition
 	<n|mu_e|0>               0.17834465 	  0.00000000 	  0.00000000
 	Dipole Strength          0.03116048 
 	Oscillator Strength      0.00210954 
-	Einstein A Coefficient   6.98949859e+05 
-	Einstein B Coefficient   3.79118475e+18 
+	Einstein A Coefficient   6.98949847e+05 
+	Einstein B Coefficient   3.79118423e+18 
 
 	Length-Gauge Rotational Strength for 1 A2 to 1 B2 Transition
 	                              X    	       Y    	       Z
@@ -2982,18 +2538,18 @@ Doing transition
 	Oscillator Strength for 1 B2 to 2 A2
 	                              X    	       Y    	       Z
 	<0|mu_e|n>               0.11167651 	  0.00000000 	  0.00000000
-	<n|mu_e|0>               0.11146066 	  0.00000000 	  0.00000000
+	<n|mu_e|0>               0.11146067 	  0.00000000 	  0.00000000
 	Dipole Strength          0.01244754 
 	Oscillator Strength      0.00404749 
-	Einstein A Coefficient   3.09374836e+07 
-	Einstein B Coefficient   1.51444762e+18 
+	Einstein A Coefficient   3.09374861e+07 
+	Einstein B Coefficient   1.51444752e+18 
 
 	Length-Gauge Rotational Strength for 1 B2 to 2 A2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.11167651 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.09657690 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	  0.08949805 	  0.00000000
-	<q|mu_e|p>*              0.11146066 	  0.00000000 	  0.00000000
+	<q|mu_e|p>*              0.11146067 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3034,8 +2590,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 B1 to 1 B2 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.08580167
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.08518578
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.08580167
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.08518578
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3044,8 +2600,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 B1
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.08580167
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.08518578
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.08580167
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.08518578
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3077,8 +2633,8 @@ Doing transition
 	Length-Gauge Rotational Strength for 1 B2 to 2 B1 Transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.07901584
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.07461978
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.07901584
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.07461978
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3087,8 +2643,8 @@ Doing transition
 	Velocity-Gauge Rotational Strength for 1 B2
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.07901584
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.07461978
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.07901584
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.07461978
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3110,16 +2666,16 @@ Doing transition
 
 	Oscillator Strength for 1 A1 to 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.03557487 	  0.00000000
+	<0|mu_e|n>               0.00000000 	  0.03557486 	  0.00000000
 	<n|mu_e|0>               0.00000000 	  0.03661946 	  0.00000000
 	Dipole Strength          0.00130273 
 	Oscillator Strength      0.00013457 
-	Einstein A Coefficient   1.03816208e+05 
-	Einstein B Coefficient   1.58498830e+17 
+	Einstein A Coefficient   1.03816191e+05 
+	Einstein B Coefficient   1.58498780e+17 
 
 	Length-Gauge Rotational Strength for 1 A1 to 2 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.03557487 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  0.03557486 	  0.00000000
 	<q|mu_m|p>              -0.46155033 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*             -0.46681939 	  0.00000000 	  0.00000000
 	<q|mu_e|p>*              0.00000000 	  0.03661946 	  0.00000000
@@ -3153,19 +2709,19 @@ Doing transition
 
 	Oscillator Strength for 2 B2 to 2 A1
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  1.47253361 	  0.00000000
-	<n|mu_e|0>               0.00000000 	  1.48315434 	  0.00000000
-	Dipole Strength          2.18399462 
+	<0|mu_e|n>               0.00000000 	  1.47253362 	  0.00000000
+	<n|mu_e|0>               0.00000000 	  1.48315435 	  0.00000000
+	Dipole Strength          2.18399464 
 	Oscillator Strength      0.19251008 
-	Einstein A Coefficient   1.08131115e+08 
-	Einstein B Coefficient   2.65718864e+20 
+	Einstein A Coefficient   1.08131114e+08 
+	Einstein B Coefficient   2.65718827e+20 
 
 	Length-Gauge Rotational Strength for 2 B2 to 2 A1 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  1.47253361 	  0.00000000
+	<p|mu_e|q>               0.00000000 	  1.47253362 	  0.00000000
 	<q|mu_m|p>              -0.13938131 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*             -0.14129465 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  1.48315434 	  0.00000000
+	<q|mu_e|p>*              0.00000000 	  1.48315435 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3196,29 +2752,29 @@ Doing transition
 
 	Oscillator Strength for 1 A2 to 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00659689 	  0.00000000 	  0.00000000
-	<n|mu_e|0>               0.00898049 	  0.00000000 	  0.00000000
+	<0|mu_e|n>              -0.00659689 	  0.00000000 	  0.00000000
+	<n|mu_e|0>              -0.00898049 	  0.00000000 	  0.00000000
 	Dipole Strength          0.00005924 
 	Oscillator Strength      0.00000678 
-	Einstein A Coefficient   6.41812021e+03 
-	Einstein B Coefficient   7.20792547e+15 
+	Einstein A Coefficient   6.41811830e+03 
+	Einstein B Coefficient   7.20792236e+15 
 
 	Length-Gauge Rotational Strength for 1 A2 to 2 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00659689 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	 -0.07993498 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	 -0.08255915 	  0.00000000
-	<q|mu_e|p>*              0.00898049 	  0.00000000 	  0.00000000
+	<p|mu_e|q>              -0.00659689 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	  0.07993498 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.08255915 	  0.00000000
+	<q|mu_e|p>*             -0.00898049 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 A2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00548397 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	 -0.07993498 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	 -0.08255915 	  0.00000000
-	<q|mu_e|p>*              0.00507495 	  0.00000000 	  0.00000000
+	<p|mu_e|q>              -0.00548397 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	  0.07993498 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.08255915 	  0.00000000
+	<q|mu_e|p>*             -0.00507495 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3239,29 +2795,29 @@ Doing transition
 
 	Oscillator Strength for 2 B2 to 2 A2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.06344721 	  0.00000000 	  0.00000000
-	<n|mu_e|0>              -0.06421093 	  0.00000000 	  0.00000000
+	<0|mu_e|n>               0.06344721 	  0.00000000 	  0.00000000
+	<n|mu_e|0>               0.06421093 	  0.00000000 	  0.00000000
 	Dipole Strength          0.00407400 
 	Oscillator Strength      0.00113432 
-	Einstein A Coefficient   6.35705042e+06 
-	Einstein B Coefficient   4.95669676e+17 
+	Einstein A Coefficient   6.35705000e+06 
+	Einstein B Coefficient   4.95669569e+17 
 
 	Length-Gauge Rotational Strength for 2 B2 to 2 A2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.06344721 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	 -0.05483804 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	 -0.05339271 	  0.00000000
-	<q|mu_e|p>*             -0.06421093 	  0.00000000 	  0.00000000
+	<p|mu_e|q>               0.06344721 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	  0.05483803 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.05339271 	  0.00000000
+	<q|mu_e|p>*              0.06421093 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 2 B2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.02325230 	  0.00000000 	  0.00000000
-	<q|mu_m|p>               0.00000000 	 -0.05483804 	  0.00000000
-	<p|mu_m|q>*              0.00000000 	 -0.05339271 	  0.00000000
-	<q|mu_e|p>*             -0.02583125 	  0.00000000 	  0.00000000
+	<p|mu_e|q>               0.02325230 	  0.00000000 	  0.00000000
+	<q|mu_m|p>               0.00000000 	  0.05483803 	  0.00000000
+	<p|mu_m|q>*              0.00000000 	  0.05339271 	  0.00000000
+	<q|mu_e|p>*              0.02583125 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3336,7 +2892,7 @@ Doing transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.08625715
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.08644782
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.08644781
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3346,7 +2902,7 @@ Doing transition
 	                              X    	       Y    	       Z
 	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00000000
 	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.08625715
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.08644782
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.08644781
 	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00000000
 
 	Rotational Strength (au)                  0.00000000
@@ -3368,29 +2924,29 @@ Doing transition
 
 	Oscillator Strength for 1 B2 to 2 B2
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.04333516
-	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.04554797
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.04333516
+	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.04554796
 	Dipole Strength          0.00197383 
 	Oscillator Strength      0.00009225 
-	Einstein A Coefficient   1.45663536e+04 
-	Einstein B Coefficient   2.40148665e+17 
+	Einstein A Coefficient   1.45663529e+04 
+	Einstein B Coefficient   2.40148617e+17 
 
 	Length-Gauge Rotational Strength for 1 B2 to 2 B2 Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.04333516
+	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.04333516
 	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.04554797
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.04554796
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
 
 	Velocity-Gauge Rotational Strength for 1 B2
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00581876
+	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.00581876
 	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00000000
 	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.00000000
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00129671
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.00129671
 
 	Rotational Strength (au)                  0.00000000
 	Rotational Strength (10^-40 esu^2 cm^2)   0.00000000
@@ -3401,7 +2957,7 @@ Doing transition
 	State   (eV)    (cm^-1)    (nm)     (au)              (l,au)   (v,au)     (s^-1)
 	 1 A1  10.556   85136.7   117.5   0.387911   0.1177   0.0000   0.0000  5.688443E+08
 	 2 A1  18.370  148163.3    67.5   0.675082   0.2787   0.0000   0.0000  4.080297E+09
-	 1 A2  10.101   81471.3   122.7   0.371211   0.0000   0.0000   0.0000  0.000000E+00
+	 1 A2  10.101   81471.4   122.7   0.371211   0.0000   0.0000   0.0000  0.000000E+00
 	 2 A2  26.137  210806.6    47.4   0.960506   0.0000   0.0000   0.0000  0.000000E+00
 	 1 B1   7.923   63899.3   156.5   0.291147   0.0102   0.0000   0.0000  2.778116E+07
 	 2 B1  25.635  206758.2    48.4   0.942060   0.0001   0.0000   0.0000  3.986564E+06
@@ -3416,41 +2972,34 @@ Doing transition
 	  1A1->2A1   7.814   63026.7   158.7   0.287171   0.0006   0.0000   0.0000  1.529880E+06
 	  1A2->1A1   0.454    3665.3  2728.3   0.016700   0.0000   0.0000   0.0000  0.000000E+00
 	  1A2->2A1   8.269   66692.0   149.9   0.303871   0.0000   0.0000   0.0000  0.000000E+00
-	  1A1->2A2  15.581  125669.9    79.6   0.572594   0.0000   0.0000   0.0000  0.000000E+00
+	  1A1->2A2  15.581  125670.0    79.6   0.572594   0.0000   0.0000   0.0000  0.000000E+00
 	  2A1->2A2   7.767   62643.3   159.6   0.285424   0.0000   0.0000   0.0000  0.000000E+00
 	  1A2->2A2  16.036  129335.3    77.3   0.589295   0.0264   0.0000   0.0000  2.942808E+08
-	  1B1->1A1   2.633   21237.3   470.9   0.096764   0.0018   0.0000   0.0000  5.519330E+05
+	  1B1->1A1   2.633   21237.3   470.9   0.096764   0.0018   0.0000   0.0000  5.519329E+05
 	  1B1->2A1  10.447   84264.0   118.7   0.383935   0.0007   0.0000   0.0000  3.454241E+06
 	  1B1->1A2   2.179   17572.0   569.1   0.080064   0.1351   0.0000   0.0000  2.781636E+07
-	  1B1->2A2  18.214  146907.3    68.1   0.669359   0.0002   0.0000   0.0000  3.208293E+06
+	  1B1->2A2  18.214  146907.3    68.1   0.669359   0.0002   0.0000   0.0000  3.208317E+06
 	  1A1->2B1  15.079  121621.5    82.2   0.554148   0.0041   0.0000   0.0000  4.021434E+07
 	  2A1->2B1   7.265   58594.8   170.7   0.266978   0.0001   0.0000   0.0000  2.271248E+05
-	  1A2->2B1  15.534  125286.8    79.8   0.570849   0.0022   0.0000   0.0000  2.326585E+07
+	  1A2->2B1  15.534  125286.8    79.8   0.570849   0.0022   0.0000   0.0000  2.326584E+07
 	  2B1->2A2   0.502    4048.5  2470.1   0.018446   0.0008   0.0000   0.0000  9.127014E+03
-	  1B1->2B1  17.712  142858.8    70.0   0.650913   0.0145   0.0000   0.0000  1.977774E+08
+	  1B1->2B1  17.712  142858.9    70.0   0.650913   0.0145   0.0000   0.0000  1.977774E+08
 	  1A1->1B2   2.309   18622.0   537.0   0.084848   0.1468   0.0000   0.0000  3.394966E+07
 	  1B2->2A1   5.505   44404.6   225.2   0.202322   0.0113   0.0000   0.0000  1.489523E+07
-	  1A2->1B2   2.763   22287.3   448.7   0.101549   0.0021   0.0000   0.0000  6.989499E+05
-	  1B2->2A2  13.272  107047.9    93.4   0.487746   0.0040   0.0000   0.0000  3.093748E+07
+	  1A2->1B2   2.763   22287.3   448.7   0.101549   0.0021   0.0000   0.0000  6.989498E+05
+	  1B2->2A2  13.272  107047.9    93.4   0.487746   0.0040   0.0000   0.0000  3.093749E+07
 	  1B1->1B2   4.942   39859.4   250.9   0.181613   0.0000   0.0000   0.0000  0.000000E+00
 	  1B2->2B1  12.770  102999.5    97.1   0.469300   0.0000   0.0000   0.0000  0.000000E+00
 	  1A1->2B2   4.216   34008.0   294.0   0.154952   0.0001   0.0000   0.0000  1.038162E+05
 	  2B2->2A1   3.598   29018.7   344.6   0.132219   0.1925   0.0000   0.0000  1.081311E+08
-	  1A2->2B2   4.671   37673.3   265.4   0.171652   0.0000   0.0000   0.0000  6.418120E+03
+	  1A2->2B2   4.671   37673.3   265.4   0.171652   0.0000   0.0000   0.0000  6.418118E+03
 	  2B2->2A2  11.365   91662.0   109.1   0.417643   0.0011   0.0000   0.0000  6.357050E+06
 	  1B1->2B2   6.850   55245.3   181.0   0.251716   0.0000   0.0000   0.0000  0.000000E+00
 	  2B2->2B1  10.863   87613.5   114.1   0.399197   0.0000   0.0000   0.0000  0.000000E+00
 	  1B2->2B2   1.908   15386.0   649.9   0.070104   0.0001   0.0000   0.0000  1.456635E+04
 
 
-*** tstop() called on psinet at Mon May 15 15:34:55 2017
-Module time:
-	user time   =       0.46 seconds =       0.01 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.18 seconds =       0.02 minutes
-	system time =       0.72 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
+    Psi4 wall time for execution: 0:00:06.37
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc8/CMakeLists.txt
+++ b/tests/cc8/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc8 "psi;quicktests;cc;autotest;noc1")
+add_regression_test(cc8 "psi;quicktests;cc;noc1")

--- a/tests/cc8/input.dat
+++ b/tests/cc8/input.dat
@@ -21,3 +21,15 @@ set {
 }
 
 energy('ccsd(t)')
+
+refnuc  =  18.91527050905531  # TEST
+refscf  = -92.21277694979756  # TEST
+refccsd = -92.47683016412106  # TEST
+e_total = -92.48929141166354  # TEST
+
+compare_values(refnuc, CN.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(refscf, variable("SCF total energy"), 7, "SCF energy") #TEST
+compare_values(refccsd, variable("CCSD total energy"), 7, "CCSD energy") #TEST
+compare_values(e_total, variable("CCSD(T) total energy"), 7, "CCSD(T) energy") #TEST
+compare_values(e_total, variable("Current energy"), 7, "CCSD(T) energy") #TEST
+

--- a/tests/cc8/output.ref
+++ b/tests/cc8/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev52 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} ecc1908 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 February 2022 12:24PM
 
-    Process ID:  13133
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 4660
+    Host:       dhcp189-242.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -51,23 +64,38 @@ set {
 }
 
 energy('ccsd(t)')
+
+refnuc  =  18.91527050905531  # TEST
+refscf  = -92.21277694979756  # TEST
+refccsd = -92.47683016412106  # TEST
+e_total = -92.48929141166354  # TEST
+
+compare_values(refnuc, CN.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(refscf, variable("SCF total energy"), 7, "SCF energy") #TEST
+compare_values(refccsd, variable("CCSD total energy"), 7, "CCSD energy") #TEST
+compare_values(e_total, variable("CCSD(T) total energy"), 7, "CCSD(T) energy") #TEST
+compare_values(e_total, variable("Current energy"), 7, "CCSD(T) energy") #TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:56 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:24:44 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line   130 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2 entry N          line   160 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1 entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry N          line   168 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -81,14 +109,14 @@ energy('ccsd(t)')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.632756417668    12.000000000000
-           N          0.000000000000     0.000000000000     0.542243582332    14.003074004780
+         C            0.000000000000     0.000000000000    -0.632756417661    12.000000000000
+         N            0.000000000000     0.000000000000     0.542243582339    14.003074004430
 
   Running in c2v symmetry.
 
   Rotational constants: A = ************  B =      1.88947  C =      1.88947 [cm^-1]
-  Rotational constants: A = ************  B =  56644.99264  C =  56644.99264 [MHz]
-  Nuclear repulsion =   18.915270434706379
+  Rotational constants: A = ************  B =  56644.99308  C =  56644.99308 [MHz]
+  Nuclear repulsion =   18.915270509055315
 
   Charge       = 0
   Multiplicity = 2
@@ -102,33 +130,20 @@ energy('ccsd(t)')
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 28
+    Number of basis functions: 28
     Number of Cartesian functions: 30
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        14      14       5       4       4       1
-     A2         2       2       0       0       0       0
-     B1         6       6       1       1       1       0
-     B2         6       6       1       1       1       0
-   -------------------------------------------------------
-    Total      28      28       7       6       6       1
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -147,86 +162,102 @@ energy('ccsd(t)')
   Using 165242 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 1.0795200227E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 1.0795200130E-02.
+  Reciprocal condition number of the overlap matrix is 3.4696262257E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         6       6 
+     B2         6       6 
+   -------------------------
+    Total      28      28
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter   1:   -91.19134628324666   -9.11913e+01   1.20557e-01 
-   @UHF iter   2:   -91.11800770331497    7.33386e-02   8.80228e-02 DIIS
-   @UHF iter   3:   -92.04213245265299   -9.24125e-01   3.40651e-02 DIIS
-   @UHF iter   4:   -92.19008010824980   -1.47948e-01   3.23847e-03 DIIS
-   @UHF iter   5:   -92.19435229757499   -4.27219e-03   1.70642e-03 DIIS
-   @UHF iter   6:   -92.19719788544015   -2.84559e-03   1.54850e-03 DIIS
-   @UHF iter   7:   -92.20005834388130   -2.86046e-03   1.46975e-03 DIIS
-   @UHF iter   8:   -92.20388282576390   -3.82448e-03   1.26920e-03 DIIS
-   @UHF iter   9:   -92.20580168585690   -1.91886e-03   1.28788e-03 DIIS
-   @UHF iter  10:   -92.20844867081900   -2.64698e-03   1.06704e-03 DIIS
-   @UHF iter  11:   -92.21246677039900   -4.01810e-03   8.93312e-04 DIIS
-   @UHF iter  12:   -92.21219405012241    2.72720e-04   7.87887e-04 DIIS
-   @UHF iter  13:   -92.21260172951906   -4.07679e-04   3.05289e-04 DIIS
-   @UHF iter  14:   -92.21276955775379   -1.67828e-04   7.97787e-05 DIIS
-   @UHF iter  15:   -92.21277667775183   -7.12000e-06   1.18621e-05 DIIS
-   @UHF iter  16:   -92.21277693989742   -2.62146e-07   3.30807e-06 DIIS
-   @UHF iter  17:   -92.21277694861512   -8.71769e-09   8.59957e-07 DIIS
-   @UHF iter  18:   -92.21277694960403   -9.88919e-10   7.59771e-08 DIIS
-   @UHF iter  19:   -92.21277694960747   -3.43903e-12   2.50589e-08 DIIS
-   @UHF iter  20:   -92.21277694960858   -1.10845e-12   3.06844e-09 DIIS
-   @UHF iter  21:   -92.21277694960864   -5.68434e-14   6.81442e-10 DIIS
-   @UHF iter  22:   -92.21277694960861    2.84217e-14   1.33798e-10 DIIS
-   @UHF iter  23:   -92.21277694960864   -2.84217e-14   9.14576e-12 DIIS
+   @UHF iter SAD:   -91.22667458514728   -9.12267e+01   0.00000e+00 
+   @UHF iter   1:   -92.12725706003171   -9.00582e-01   2.19691e-02 ADIIS/DIIS
+   @UHF iter   2:   -92.12500269727481    2.25436e-03   2.40770e-02 ADIIS/DIIS
+   @UHF iter   3:   -92.19641514058500   -7.14124e-02   2.40236e-03 ADIIS/DIIS
+   @UHF iter   4:   -92.19957806919193   -3.16293e-03   1.36943e-03 ADIIS/DIIS
+   @UHF iter   5:   -92.20122014268492   -1.64207e-03   1.31845e-03 ADIIS/DIIS
+   @UHF iter   6:   -92.20296861271224   -1.74847e-03   1.27644e-03 ADIIS/DIIS
+   @UHF iter   7:   -92.20631414291374   -3.34553e-03   1.16884e-03 ADIIS/DIIS
+   @UHF iter   8:   -92.21090903196884   -4.59489e-03   7.86345e-04 ADIIS/DIIS
+   @UHF iter   9:   -92.21221729661853   -1.30826e-03   6.32672e-04 ADIIS/DIIS
+   @UHF iter  10:   -92.21254136336577   -3.24067e-04   3.17201e-04 ADIIS/DIIS
+   @UHF iter  11:   -92.21277212687860   -2.30764e-04   4.87503e-05 DIIS
+   @UHF iter  12:   -92.21277576745224   -3.64057e-06   2.65313e-05 DIIS
+   @UHF iter  13:   -92.21277680872235   -1.04127e-06   9.63883e-06 DIIS
+   @UHF iter  14:   -92.21277694583256   -1.37110e-07   1.42660e-06 DIIS
+   @UHF iter  15:   -92.21277694977660   -3.94404e-09   2.03934e-07 DIIS
+   @UHF iter  16:   -92.21277694979419   -1.75930e-11   4.26409e-08 DIIS
+   @UHF iter  17:   -92.21277694979726   -3.06954e-12   1.30309e-08 DIIS
+   @UHF iter  18:   -92.21277694979761   -3.55271e-13   5.03733e-10 DIIS
+   @UHF iter  19:   -92.21277694979761    0.00000e+00   1.33786e-10 DIIS
+   @UHF iter  20:   -92.21277694979756    5.68434e-14   4.47041e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   4.123375277E-01
+   @Spin Contamination Metric:   4.123375094E-01
    @S^2 Expected:                7.500000000E-01
-   @S^2 Observed:                1.162337528E+00
+   @S^2 Observed:                1.162337509E+00
    @S   Expected:                5.000000000E-01
    @S   Observed:                5.000000000E-01
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
        1A1   -15.609649     2A1   -11.361901     3A1    -1.240449  
-       4A1    -0.739642     5A1    -0.563366     1B2    -0.515486  
-       1B1    -0.515486  
+       4A1    -0.739642     5A1    -0.563366     1B1    -0.515486  
+       1B2    -0.515486  
 
     Alpha Virtual:                                                        
 
-       2B2     0.185545     2B1     0.185545     6A1     0.371294  
+       2B1     0.185545     2B2     0.185545     6A1     0.371294  
        3B1     0.618208     3B2     0.618208     7A1     0.647664  
-       8A1     0.874611     9A1     1.016318     4B2     1.069923  
-       4B1     1.069923     1A2     1.276314    10A1     1.276314  
+       8A1     0.874611     9A1     1.016318     4B1     1.069923  
+       4B2     1.069923     1A2     1.276314    10A1     1.276314  
        5B2     1.477267     5B1     1.477267    11A1     1.568138  
-      12A1     2.197372     2A2     2.197372    13A1     2.235884  
+       2A2     2.197372    12A1     2.197372    13A1     2.235884  
        6B2     2.682841     6B1     2.682841    14A1     3.102221  
 
     Beta Occupied:                                                        
 
        1A1   -15.635827     2A1   -11.306231     3A1    -1.254501  
-       4A1    -0.616935     1B1    -0.533650     1B2    -0.533650  
+       4A1    -0.616935     1B2    -0.533650     1B1    -0.533650  
 
     Beta Virtual:                                                         
 
-       5A1    -0.011000     2B2     0.210416     2B1     0.210416  
-       6A1     0.399783     3B2     0.708996     3B1     0.708996  
-       7A1     0.800256     8A1     0.870942     4B2     1.008070  
-       4B1     1.008070     9A1     1.090983    10A1     1.361267  
+       5A1    -0.011000     2B1     0.210416     2B2     0.210416  
+       6A1     0.399783     3B1     0.708996     3B2     0.708996  
+       7A1     0.800256     8A1     0.870942     4B1     1.008070  
+       4B2     1.008070     9A1     1.090983    10A1     1.361267  
        1A2     1.361267     5B2     1.541385     5B1     1.541385  
       11A1     1.563544     2A2     2.124491    12A1     2.124491  
       13A1     2.286372     6B2     2.677621     6B1     2.677621  
@@ -237,58 +268,53 @@ energy('ccsd(t)')
     DOCC [     4,    0,    1,    1 ]
     SOCC [     1,    0,    0,    0 ]
 
-  Energy converged.
-
-  @UHF Final Energy:   -92.21277694960864
+  @UHF Final Energy:   -92.21277694979756
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             18.9152704347063789
-    One-Electron Energy =                -161.8293227213734440
-    Two-Electron Energy =                  50.7012753370584335
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -92.2127769496086387
-
+    Nuclear Repulsion Energy =             18.9152705090553148
+    One-Electron Energy =                -161.8293228690310457
+    Two-Electron Energy =                  50.7012754101781695
+    Total Energy =                        -92.2127769497975578
 
   UHF NO Occupations:
-  HONO-2 :    1 B1 1.8920315
-  HONO-1 :    1 B2 1.8920315
+  HONO-2 :    1 B2 1.8920315
+  HONO-1 :    1 B1 1.8920315
   HONO-0 :    5 A1 1.0000000
-  LUNO+0 :    2 B1 0.1079685
-  LUNO+1 :    2 B2 0.1079685
+  LUNO+0 :    2 B2 0.1079685
+  LUNO+1 :    2 B1 0.1079685
   LUNO+2 :    6 A1 0.0015115
   LUNO+3 :    7 A1 0.0003783
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.0016
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.8189
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.8205     Total:     0.8205
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -2.0855     Total:     2.0855
 
 
-*** tstop() called on psinet at Mon May 15 15:34:57 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:24:45 2022
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -303,19 +329,19 @@ Total time:
       Number of basis functions:        28
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  14    2    6    6 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 21245 non-zero two-electron integrals.
+      Computed 19125 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:57 2017
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:24:45 2022
 
 
 	Wfn Parameters:
@@ -340,7 +366,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -400,7 +426,7 @@ Total time:
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -86.99935295426690
+	Frozen core energy     =    -86.99935299321515
 
 	Size of irrep 0 of <AB|CD> integrals:      0.003 (MW) /      0.026 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.002 (MW) /      0.015 (MB)
@@ -450,37 +476,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.001 (MW) /      0.005 (MB)
 	Total:                                     0.002 (MW) /      0.020 (MB)
 
-	Nuclear Rep. energy          =     18.91527043470638
-	SCF energy                   =    -92.21277694960864
-	One-electron energy          =    -41.74422416237493
-	Two-electron (AA) energy     =      4.27920483483047
-	Two-electron (BB) energy     =      3.03649992591659
-	Two-electron (AB) energy     =     10.29982497157987
-	Two-electron energy          =     17.61552973232693
-	Reference energy             =    -92.21277694960853
+	Nuclear Rep. energy          =     18.91527050905531
+	SCF energy                   =    -92.21277694979756
+	One-electron energy          =    -41.74422422807553
+	Two-electron (AA) energy     =      4.27920484231701
+	Two-electron (BB) energy     =      3.03649992495415
+	Two-electron (AB) energy     =     10.29982499516661
+	Two-electron energy          =     17.61552976243777
+	Reference energy             =    -92.21277694979760
 
-*** tstop() called on psinet at Mon May 15 15:34:57 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:24:45 2022
 Module time:
 	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	user time   =       0.90 seconds =       0.01 minutes
+	system time =       0.28 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:57 2017
-
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   18.915270434706379
-    SCF energy          (wfn)     =  -92.212776949608639
-    Reference energy    (file100) =  -92.212776949608525
+    Nuclear Rep. energy (wfn)     =   18.915270509055315
+    SCF energy          (wfn)     =  -92.212776949797558
+    Reference energy    (file100) =  -92.212776949797600
 
     Input parameters:
     -----------------
@@ -508,128 +530,116 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2219961464413223
+MP2 correlation energy -0.2219961472230013
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.221996146441322    0.000e+00    0.000000    0.000000    0.000000    0.000000
-     1        -0.227318453268206    1.127e-01    0.034203    0.000000    0.000000    0.000000
-     2        -0.244460938602875    6.180e-02    0.055516    0.000000    0.000000    0.000000
-     3        -0.258959227723088    5.026e-02    0.096674    0.000000    0.000000    0.000000
-     4        -0.262343396443600    2.205e-02    0.117471    0.000000    0.000000    0.000000
-     5        -0.262908625734227    1.243e-02    0.122443    0.000000    0.000000    0.000000
-     6        -0.263757860618305    8.177e-03    0.126445    0.000000    0.000000    0.000000
-     7        -0.263879214116532    3.817e-03    0.128184    0.000000    0.000000    0.000000
-     8        -0.264014623095256    1.695e-03    0.128964    0.000000    0.000000    0.000000
-     9        -0.264066159569092    8.614e-04    0.129290    0.000000    0.000000    0.000000
-    10        -0.264071947529368    4.297e-04    0.129464    0.000000    0.000000    0.000000
-    11        -0.264057395034242    1.444e-04    0.129427    0.000000    0.000000    0.000000
-    12        -0.264050059948688    4.714e-05    0.129438    0.000000    0.000000    0.000000
-    13        -0.264053150214840    1.551e-05    0.129448    0.000000    0.000000    0.000000
-    14        -0.264053082558283    4.850e-06    0.129447    0.000000    0.000000    0.000000
-    15        -0.264053292495901    1.185e-06    0.129448    0.000000    0.000000    0.000000
-    16        -0.264053245059299    4.821e-07    0.129447    0.000000    0.000000    0.000000
-    17        -0.264053225842879    1.513e-07    0.129447    0.000000    0.000000    0.000000
-    18        -0.264053212839759    5.776e-08    0.129447    0.000000    0.000000    0.000000
-    19        -0.264053213720080    1.937e-08    0.129447    0.000000    0.000000    0.000000
-    20        -0.264053214056920    6.712e-09    0.129447    0.000000    0.000000    0.000000
-    21        -0.264053214701882    3.196e-09    0.129447    0.000000    0.000000    0.000000
-    22        -0.264053214789327    1.431e-09    0.129447    0.000000    0.000000    0.000000
-    23        -0.264053214821184    4.293e-10    0.129447    0.000000    0.000000    0.000000
-    24        -0.264053214798222    2.148e-10    0.129447    0.000000    0.000000    0.000000
-    25        -0.264053214783890    1.264e-10    0.129447    0.000000    0.000000    0.000000
-    26        -0.264053214779068    6.497e-11    0.129447    0.000000    0.000000    0.000000
+     0        -0.221996147223001    0.000e+00    0.000000    0.000000    0.000000    0.000000
+     1        -0.227318453802899    1.127e-01    0.034203    0.000000    0.000000    0.000000
+     2        -0.244460938844439    6.180e-02    0.055516    0.000000    0.000000    0.000000
+     3        -0.258959227396058    5.026e-02    0.096674    0.000000    0.000000    0.000000
+     4        -0.262343396027824    2.205e-02    0.117471    0.000000    0.000000    0.000000
+     5        -0.262908625301728    1.243e-02    0.122443    0.000000    0.000000    0.000000
+     6        -0.263757860159041    8.177e-03    0.126445    0.000000    0.000000    0.000000
+     7        -0.263879213670575    3.817e-03    0.128184    0.000000    0.000000    0.000000
+     8        -0.264014622641420    1.695e-03    0.128964    0.000000    0.000000    0.000000
+     9        -0.264066159113099    8.614e-04    0.129290    0.000000    0.000000    0.000000
+    10        -0.264071947073082    4.297e-04    0.129464    0.000000    0.000000    0.000000
+    11        -0.264057394578788    1.444e-04    0.129427    0.000000    0.000000    0.000000
+    12        -0.264050059493789    4.714e-05    0.129438    0.000000    0.000000    0.000000
+    13        -0.264053149759466    1.551e-05    0.129448    0.000000    0.000000    0.000000
+    14        -0.264053082102796    4.850e-06    0.129447    0.000000    0.000000    0.000000
+    15        -0.264053292040336    1.185e-06    0.129448    0.000000    0.000000    0.000000
+    16        -0.264053244603707    4.821e-07    0.129447    0.000000    0.000000    0.000000
+    17        -0.264053225387281    1.513e-07    0.129447    0.000000    0.000000    0.000000
+    18        -0.264053212384162    5.776e-08    0.129447    0.000000    0.000000    0.000000
+    19        -0.264053213264483    1.937e-08    0.129447    0.000000    0.000000    0.000000
+    20        -0.264053213601322    6.712e-09    0.129447    0.000000    0.000000    0.000000
+    21        -0.264053214246285    3.196e-09    0.129447    0.000000    0.000000    0.000000
+    22        -0.264053214333730    1.431e-09    0.129447    0.000000    0.000000    0.000000
+    23        -0.264053214365587    4.293e-10    0.129447    0.000000    0.000000    0.000000
+    24        -0.264053214342625    2.148e-10    0.129447    0.000000    0.000000    0.000000
+    25        -0.264053214328292    1.264e-10    0.129447    0.000000    0.000000    0.000000
+    26        -0.264053214323471    6.497e-11    0.129447    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              3  11        -0.1562916783
-              4  16        -0.1562916783
-              3  13        -0.0386837040
-              4  18        -0.0386837040
-              3  14         0.0217614515
-              4  19         0.0217614515
-              0   3         0.0109229455
+              3  11        -0.1562916738
+              4  16        -0.1562916738
+              3  13        -0.0386837032
+              4  18        -0.0386837032
+              3  14         0.0217614513
+              4  19         0.0217614513
+              0   3         0.0109229453
               1   1        -0.0077761744
-              3  12        -0.0076150463
-              4  17        -0.0076150463
+              3  12        -0.0076150461
+              4  17        -0.0076150461
 
     Largest Tia Amplitudes:
-              1   0         0.2352609875
-              2  12         0.1325985805
-              3  17         0.1325985805
-              2  13         0.0459911514
-              3  18         0.0459911514
-              1   2        -0.0413568414
+              1   0         0.2352609864
+              2  12         0.1325985768
+              3  17         0.1325985768
+              2  13         0.0459911505
+              3  18         0.0459911505
+              1   2        -0.0413568411
               2  15         0.0134656292
               3  20         0.0134656292
-              2  14         0.0119131203
-              3  19         0.0119131203
+              2  14         0.0119131199
+              3  19         0.0119131199
 
     Largest TIJAB Amplitudes:
-      4   3  16  11        -0.0398170903
-      3   2  11   3        -0.0234853058
-      4   2  16   3        -0.0234853058
-      4   3  17  12        -0.0206385188
+      4   3  16  11        -0.0398170900
+      3   2  11   3        -0.0234853057
+      4   2  16   3        -0.0234853057
+      4   3  17  12        -0.0206385187
       4   3   9   4        -0.0188072543
-      3   1  12   1        -0.0168567615
-      4   1  17   1        -0.0168567615
-      3   1  11   1        -0.0140526605
-      4   1  16   1        -0.0140526605
+      3   1  12   1        -0.0168567616
+      4   1  17   1        -0.0168567616
+      3   1  11   1        -0.0140526604
+      4   1  16   1        -0.0140526604
       3   1  11   4         0.0120691041
 
     Largest Tijab Amplitudes:
-      3   2  17  12        -0.0346069069
-      2   1  12   0        -0.0310243236
-      3   1  17   0        -0.0310243236
-      3   2  19  14        -0.0150424517
+      3   2  17  12        -0.0346069068
+      2   1  12   0        -0.0310243235
+      3   1  17   0        -0.0310243235
+      3   2  19  14        -0.0150424516
       3   2  17  14        -0.0147208146
       3   2  19  12        -0.0147208146
-      2   1  12   4         0.0144836228
-      3   1  17   4         0.0144836228
-      3   2  10   5        -0.0138482884
-      3   2  18  13        -0.0135177432
+      2   1  12   4         0.0144836227
+      3   1  17   4         0.0144836227
+      3   2  10   5        -0.0138482885
+      3   2  18  13        -0.0135177433
 
     Largest TIjAb Amplitudes:
-      3   2  11  12        -0.1090709891
-      4   3  16  17        -0.1090709891
-      3   1  11   0        -0.0876053248
-      4   1  16   0        -0.0876053248
-      3   3  11  17        -0.0648698713
-      4   2  16  12        -0.0648698713
-      1   2  11   0         0.0593336554
-      1   3  16   0         0.0593336554
-      1   1  11  12         0.0462409326
-      1   1  16  17         0.0462409326
+      3   2  11  12        -0.1090709879
+      4   3  16  17        -0.1090709879
+      3   1  11   0        -0.0876053239
+      4   1  16   0        -0.0876053239
+      3   3  11  17        -0.0648698706
+      4   2  16  12        -0.0648698706
+      1   2  11   0         0.0593336553
+      1   3  16   0         0.0593336553
+      1   1  11  12         0.0462409323
+      1   1  16  17         0.0462409323
 
-    SCF energy       (wfn)                    =  -92.212776949608639
-    Reference energy (file100)                =  -92.212776949608525
+    SCF energy       (wfn)                    =  -92.212776949797558
+    Reference energy (file100)                =  -92.212776949797600
 
-    Opposite-spin MP2 correlation energy      =   -0.157972638974820
-    Same-spin MP2 correlation energy          =   -0.064023507466502
-    MP2 correlation energy                    =   -0.221996146441322
-      * MP2 total energy                      =  -92.434773096049852
+    Opposite-spin MP2 correlation energy      =   -0.157972639688793
+    Same-spin MP2 correlation energy          =   -0.064023507534208
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.221996147223001
+      * MP2 total energy                      =  -92.434773097020596
 
-    Opposite-spin CCSD correlation energy     =   -0.213601690375620
-    Same-spin CCSD correlation energy         =   -0.050451524379719
-    CCSD correlation energy                   =   -0.264053214779068
-      * CCSD total energy                     =  -92.476830164387593
-
-
-*** tstop() called on psinet at Mon May 15 15:34:58 2017
-Module time:
-	user time   =       0.33 seconds =       0.01 minutes
-	system time =       0.51 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.71 seconds =       0.01 minutes
-	system time =       0.60 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:58 2017
+    Opposite-spin CCSD correlation energy     =   -0.213601689706702
+    Same-spin CCSD correlation energy         =   -0.050451524616768
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.264053214323471
+      * CCSD total energy                     =  -92.476830164121068
 
             **************************
             *                        *
@@ -641,33 +651,31 @@ Total time:
     Wave function   =    CCSD_T
     Reference wfn   =      UHF
 
-    Nuclear Rep. energy (wfn)                =   18.915270434706379
-    SCF energy          (wfn)                =  -92.212776949608639
-    Reference energy    (file100)            =  -92.212776949608525
-    CCSD energy         (file100)            =   -0.264053214779068
-    Total CCSD energy   (file100)            =  -92.476830164387593
+    Nuclear Rep. energy (wfn)                =   18.915270509055315
+    SCF energy          (wfn)                =  -92.212776949797558
+    Reference energy    (file100)            =  -92.212776949797600
+    CCSD energy         (file100)            =   -0.264053214323471
+    Total CCSD energy   (file100)            =  -92.476830164121068
 
     Number of ijk index combinations:
     Spin Case AAA:                                  10
     Spin Case BBB:                                   4
     Spin Case AAB:                                  40
     Spin Case ABB:                                  30
-    AAA (T) energy                             =   -0.000105841303423
-    BBB (T) energy                             =   -0.000012376413513
-    AAB (T) energy                             =   -0.007108814469372
-    ABB (T) energy                             =   -0.005234215460426
-    (T) energy                                   =   -0.012461247646734
-      * CCSD(T) total energy                     =  -92.489291412034333
+    AAA (T) energy                             =   -0.000105841308132
+    BBB (T) energy                             =   -0.000012376417532
+    AAB (T) energy                             =   -0.007108814404488
+    ABB (T) energy                             =   -0.005234215412327
+    (T) energy                                   =   -0.012461247542480
+      * CCSD(T) total energy                     =  -92.489291411663544
 
+    Nuclear repulsion energy..............................................................PASSED
+    SCF energy............................................................................PASSED
+    CCSD energy...........................................................................PASSED
+    CCSD(T) energy........................................................................PASSED
+    CCSD(T) energy........................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:58 2017
-Module time:
-	user time   =       0.05 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.76 seconds =       0.01 minutes
-	system time =       0.62 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+    Psi4 stopped on: Monday, 14 February 2022 12:24PM
+    Psi4 wall time for execution: 0:00:03.13
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc9/CMakeLists.txt
+++ b/tests/cc9/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc9 "psi;cc;autotest;noc1")
+add_regression_test(cc9 "psi;cc;noc1")

--- a/tests/cc9/input.dat
+++ b/tests/cc9/input.dat
@@ -23,3 +23,15 @@ set {
 }
 
 energy('ccsd(t)')
+
+refnuc  =  18.91527050905531  # TEST
+refscf  = -92.21277694979756  # TEST
+refccsd = -92.47683016412106  # TEST
+e_total = -92.48929141166354  # TEST
+
+compare_values(refnuc, CN.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(refscf, variable("SCF total energy"), 7, "SCF energy") #TEST
+compare_values(refccsd, variable("CCSD total energy"), 7, "CCSD energy") #TEST
+compare_values(e_total, variable("CCSD(T) total energy"), 7, "CCSD(T) energy") #TEST
+compare_values(e_total, variable("Current energy"), 7, "CCSD(T) energy") #TEST
+

--- a/tests/cc9/output.ref
+++ b/tests/cc9/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.6a1.dev52 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {ccdensity_fix} ecc1908 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 February 2022 12:25PM
 
-    Process ID:  13167
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 4686
+    Host:       dhcp189-242.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -53,23 +66,38 @@ set {
 }
 
 energy('ccsd(t)')
+
+refnuc  =  18.91527050905531  # TEST
+refscf  = -92.21277694979756  # TEST
+refccsd = -92.47683016412106  # TEST
+e_total = -92.48929141166354  # TEST
+
+compare_values(refnuc, CN.nuclear_repulsion_energy(), 9, "Nuclear repulsion energy") #TEST
+compare_values(refscf, variable("SCF total energy"), 7, "SCF energy") #TEST
+compare_values(refccsd, variable("CCSD total energy"), 7, "CCSD energy") #TEST
+compare_values(e_total, variable("CCSD(T) total energy"), 7, "CCSD(T) energy") #TEST
+compare_values(e_total, variable("Current energy"), 7, "CCSD(T) energy") #TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:58 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:25:06 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line   130 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2 entry N          line   160 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1 entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry N          line   168 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -83,14 +111,14 @@ energy('ccsd(t)')
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.632756417668    12.000000000000
-           N          0.000000000000     0.000000000000     0.542243582332    14.003074004780
+         C            0.000000000000     0.000000000000    -0.632756417661    12.000000000000
+         N            0.000000000000     0.000000000000     0.542243582339    14.003074004430
 
   Running in c2v symmetry.
 
   Rotational constants: A = ************  B =      1.88947  C =      1.88947 [cm^-1]
-  Rotational constants: A = ************  B =  56644.99264  C =  56644.99264 [MHz]
-  Nuclear repulsion =   18.915270434706379
+  Rotational constants: A = ************  B =  56644.99308  C =  56644.99308 [MHz]
+  Nuclear repulsion =   18.915270509055315
 
   Charge       = 0
   Multiplicity = 2
@@ -104,33 +132,20 @@ energy('ccsd(t)')
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 28
+    Number of basis functions: 28
     Number of Cartesian functions: 30
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        14      14       5       4       4       1
-     A2         2       2       0       0       0       0
-     B1         6       6       1       1       1       0
-     B2         6       6       1       1       1       0
-   -------------------------------------------------------
-    Total      28      28       7       6       6       1
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -149,58 +164,74 @@ energy('ccsd(t)')
   Using 165242 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 1.0795200227E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 1.0795200130E-02.
+  Reciprocal condition number of the overlap matrix is 3.4696262257E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         6       6 
+     B2         6       6 
+   -------------------------
+    Total      28      28
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter   1:   -91.19134628324666   -9.11913e+01   1.20557e-01 
-   @UHF iter   2:   -91.11800770331493    7.33386e-02   8.80228e-02 DIIS
-   @UHF iter   3:   -92.04213245265291   -9.24125e-01   3.40651e-02 DIIS
-   @UHF iter   4:   -92.19008010824987   -1.47948e-01   3.23847e-03 DIIS
-   @UHF iter   5:   -92.19435229757507   -4.27219e-03   1.70642e-03 DIIS
-   @UHF iter   6:   -92.19719788544012   -2.84559e-03   1.54850e-03 DIIS
-   @UHF iter   7:   -92.20005834388124   -2.86046e-03   1.46975e-03 DIIS
-   @UHF iter   8:   -92.20388282576386   -3.82448e-03   1.26920e-03 DIIS
-   @UHF iter   9:   -92.20580168585691   -1.91886e-03   1.28788e-03 DIIS
-   @UHF iter  10:   -92.20844867081898   -2.64698e-03   1.06704e-03 DIIS
-   @UHF iter  11:   -92.21246677039903   -4.01810e-03   8.93312e-04 DIIS
-   @UHF iter  12:   -92.21219405012236    2.72720e-04   7.87887e-04 DIIS
-   @UHF iter  13:   -92.21260172951912   -4.07679e-04   3.05289e-04 DIIS
-   @UHF iter  14:   -92.21276955775392   -1.67828e-04   7.97787e-05 DIIS
-   @UHF iter  15:   -92.21277667775180   -7.12000e-06   1.18621e-05 DIIS
-   @UHF iter  16:   -92.21277693989748   -2.62146e-07   3.30807e-06 DIIS
-   @UHF iter  17:   -92.21277694861510   -8.71762e-09   8.59957e-07 DIIS
-   @UHF iter  18:   -92.21277694960408   -9.88976e-10   7.59771e-08 DIIS
-   @UHF iter  19:   -92.21277694960744   -3.36797e-12   2.50589e-08 DIIS
-   @UHF iter  20:   -92.21277694960864   -1.19371e-12   3.06844e-09 DIIS
-   @UHF iter  21:   -92.21277694960867   -2.84217e-14   6.81443e-10 DIIS
-   @UHF iter  22:   -92.21277694960865    1.42109e-14   1.33799e-10 DIIS
-   @UHF iter  23:   -92.21277694960861    4.26326e-14   9.14560e-12 DIIS
+   @UHF iter SAD:   -91.22667458514728   -9.12267e+01   0.00000e+00 
+   @UHF iter   1:   -92.12725706003171   -9.00582e-01   2.19691e-02 DIIS/ADIIS
+   @UHF iter   2:   -92.12500269727481    2.25436e-03   2.40770e-02 DIIS/ADIIS
+   @UHF iter   3:   -92.19641514058500   -7.14124e-02   2.40236e-03 DIIS/ADIIS
+   @UHF iter   4:   -92.19957806919193   -3.16293e-03   1.36943e-03 DIIS/ADIIS
+   @UHF iter   5:   -92.20122014268492   -1.64207e-03   1.31845e-03 DIIS/ADIIS
+   @UHF iter   6:   -92.20296861271224   -1.74847e-03   1.27644e-03 DIIS/ADIIS
+   @UHF iter   7:   -92.20631414291374   -3.34553e-03   1.16884e-03 DIIS/ADIIS
+   @UHF iter   8:   -92.21090903196884   -4.59489e-03   7.86345e-04 DIIS/ADIIS
+   @UHF iter   9:   -92.21221729661853   -1.30826e-03   6.32672e-04 DIIS/ADIIS
+   @UHF iter  10:   -92.21254136336577   -3.24067e-04   3.17201e-04 DIIS/ADIIS
+   @UHF iter  11:   -92.21277212687860   -2.30764e-04   4.87503e-05 DIIS
+   @UHF iter  12:   -92.21277576745224   -3.64057e-06   2.65313e-05 DIIS
+   @UHF iter  13:   -92.21277680872235   -1.04127e-06   9.63883e-06 DIIS
+   @UHF iter  14:   -92.21277694583256   -1.37110e-07   1.42660e-06 DIIS
+   @UHF iter  15:   -92.21277694977660   -3.94404e-09   2.03934e-07 DIIS
+   @UHF iter  16:   -92.21277694979419   -1.75930e-11   4.26409e-08 DIIS
+   @UHF iter  17:   -92.21277694979726   -3.06954e-12   1.30309e-08 DIIS
+   @UHF iter  18:   -92.21277694979761   -3.55271e-13   5.03733e-10 DIIS
+   @UHF iter  19:   -92.21277694979761    0.00000e+00   1.33786e-10 DIIS
+   @UHF iter  20:   -92.21277694979756    5.68434e-14   4.47041e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   4.123375277E-01
+   @Spin Contamination Metric:   4.123375094E-01
    @S^2 Expected:                7.500000000E-01
-   @S^2 Observed:                1.162337528E+00
+   @S^2 Observed:                1.162337509E+00
    @S   Expected:                5.000000000E-01
    @S   Observed:                5.000000000E-01
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
@@ -210,10 +241,10 @@ energy('ccsd(t)')
 
     Alpha Virtual:                                                        
 
-       2B2     0.185545     2B1     0.185545     6A1     0.371294  
+       2B1     0.185545     2B2     0.185545     6A1     0.371294  
        3B1     0.618208     3B2     0.618208     7A1     0.647664  
-       8A1     0.874611     9A1     1.016318     4B2     1.069923  
-       4B1     1.069923    10A1     1.276314     1A2     1.276314  
+       8A1     0.874611     9A1     1.016318     4B1     1.069923  
+       4B2     1.069923     1A2     1.276314    10A1     1.276314  
        5B2     1.477267     5B1     1.477267    11A1     1.568138  
        2A2     2.197372    12A1     2.197372    13A1     2.235884  
        6B2     2.682841     6B1     2.682841    14A1     3.102221  
@@ -225,11 +256,11 @@ energy('ccsd(t)')
 
     Beta Virtual:                                                         
 
-       5A1    -0.011000     2B2     0.210416     2B1     0.210416  
-       6A1     0.399783     3B2     0.708996     3B1     0.708996  
-       7A1     0.800256     8A1     0.870942     4B2     1.008070  
-       4B1     1.008070     9A1     1.090983     1A2     1.361267  
-      10A1     1.361267     5B2     1.541385     5B1     1.541385  
+       5A1    -0.011000     2B1     0.210416     2B2     0.210416  
+       6A1     0.399783     3B1     0.708996     3B2     0.708996  
+       7A1     0.800256     8A1     0.870942     4B1     1.008070  
+       4B2     1.008070     9A1     1.090983    10A1     1.361267  
+       1A2     1.361267     5B2     1.541385     5B1     1.541385  
       11A1     1.563544     2A2     2.124491    12A1     2.124491  
       13A1     2.286372     6B2     2.677621     6B1     2.677621  
       14A1     3.100604  
@@ -239,25 +270,18 @@ energy('ccsd(t)')
     DOCC [     4,    0,    1,    1 ]
     SOCC [     1,    0,    0,    0 ]
 
-  Energy converged.
-
-  @UHF Final Energy:   -92.21277694960861
+  @UHF Final Energy:   -92.21277694979756
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             18.9152704347063789
-    One-Electron Energy =                -161.8293227213734724
-    Two-Electron Energy =                  50.7012753370584903
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -92.2127769496086103
-
+    Nuclear Repulsion Energy =             18.9152705090553148
+    One-Electron Energy =                -161.8293228690310457
+    Two-Electron Energy =                  50.7012754101781695
+    Total Energy =                        -92.2127769497975578
 
   UHF NO Occupations:
-  HONO-2 :    1 B1 1.8920315
-  HONO-1 :    1 B2 1.8920315
+  HONO-2 :    1 B2 1.8920315
+  HONO-1 :    1 B1 1.8920315
   HONO-0 :    5 A1 1.0000000
   LUNO+0 :    2 B2 0.1079685
   LUNO+1 :    2 B1 0.1079685
@@ -265,32 +289,34 @@ energy('ccsd(t)')
   LUNO+3 :    7 A1 0.0003783
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.0016
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.8189
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.8205     Total:     0.8205
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -2.0855     Total:     2.0855
 
 
-*** tstop() called on psinet at Mon May 15 15:34:59 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:25:07 2022
 Module time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.73 seconds =       0.01 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.73 seconds =       0.01 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -305,19 +331,19 @@ Total time:
       Number of basis functions:        28
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  14    2    6    6 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 21245 non-zero two-electron integrals.
+      Computed 19125 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:59 2017
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Mon Feb 14 12:25:07 2022
 
 
 	Wfn Parameters:
@@ -342,7 +368,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -402,7 +428,7 @@ Total time:
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -86.99935295426695
+	Frozen core energy     =    -86.99935299321515
 
 	Size of irrep 0 of <AB|CD> integrals:      0.003 (MW) /      0.026 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.002 (MW) /      0.015 (MB)
@@ -452,37 +478,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.001 (MW) /      0.005 (MB)
 	Total:                                     0.002 (MW) /      0.020 (MB)
 
-	Nuclear Rep. energy          =     18.91527043470638
-	SCF energy                   =    -92.21277694960861
-	One-electron energy          =    -41.74422416237492
-	Two-electron (AA) energy     =      4.27920483483047
-	Two-electron (BB) energy     =      3.03649992591658
-	Two-electron (AB) energy     =     10.29982497157988
-	Two-electron energy          =     17.61552973232693
-	Reference energy             =    -92.21277694960858
+	Nuclear Rep. energy          =     18.91527050905531
+	SCF energy                   =    -92.21277694979756
+	One-electron energy          =    -41.74422422807553
+	Two-electron (AA) energy     =      4.27920484231701
+	Two-electron (BB) energy     =      3.03649992495415
+	Two-electron (AB) energy     =     10.29982499516661
+	Two-electron energy          =     17.61552976243777
+	Reference energy             =    -92.21277694979760
 
-*** tstop() called on psinet at Mon May 15 15:34:59 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 12:25:07 2022
 Module time:
 	user time   =       0.05 seconds =       0.00 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.33 seconds =       0.01 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	user time   =       0.85 seconds =       0.01 minutes
+	system time =       0.25 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:59 2017
-
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   18.915270434706379
-    SCF energy          (wfn)     =  -92.212776949608610
-    Reference energy    (file100) =  -92.212776949608582
+    Nuclear Rep. energy (wfn)     =   18.915270509055315
+    SCF energy          (wfn)     =  -92.212776949797558
+    Reference energy    (file100) =  -92.212776949797600
 
     Input parameters:
     -----------------
@@ -510,128 +532,116 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2219961464413235
+MP2 correlation energy -0.2219961472230013
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.221996146441324    0.000e+00    0.000000    0.000000    0.000000    0.000000
-     1        -0.227318453268197    1.127e-01    0.034203    0.000000    0.000000    0.000000
-     2        -0.244460938602851    6.180e-02    0.055516    0.000000    0.000000    0.000000
-     3        -0.258959227723046    5.026e-02    0.096674    0.000000    0.000000    0.000000
-     4        -0.262343396443557    2.205e-02    0.117471    0.000000    0.000000    0.000000
-     5        -0.262908625734183    1.243e-02    0.122443    0.000000    0.000000    0.000000
-     6        -0.263757860618260    8.177e-03    0.126445    0.000000    0.000000    0.000000
-     7        -0.263879214116487    3.817e-03    0.128184    0.000000    0.000000    0.000000
-     8        -0.264014623095211    1.695e-03    0.128964    0.000000    0.000000    0.000000
-     9        -0.264066159569046    8.614e-04    0.129290    0.000000    0.000000    0.000000
-    10        -0.264071947529322    4.297e-04    0.129464    0.000000    0.000000    0.000000
-    11        -0.264057395034196    1.444e-04    0.129427    0.000000    0.000000    0.000000
-    12        -0.264050059948642    4.714e-05    0.129438    0.000000    0.000000    0.000000
-    13        -0.264053150214795    1.551e-05    0.129448    0.000000    0.000000    0.000000
-    14        -0.264053082558238    4.850e-06    0.129447    0.000000    0.000000    0.000000
-    15        -0.264053292495855    1.185e-06    0.129448    0.000000    0.000000    0.000000
-    16        -0.264053245059254    4.821e-07    0.129447    0.000000    0.000000    0.000000
-    17        -0.264053225842833    1.513e-07    0.129447    0.000000    0.000000    0.000000
-    18        -0.264053212839713    5.776e-08    0.129447    0.000000    0.000000    0.000000
-    19        -0.264053213720036    1.937e-08    0.129447    0.000000    0.000000    0.000000
-    20        -0.264053214056874    6.712e-09    0.129447    0.000000    0.000000    0.000000
-    21        -0.264053214701837    3.196e-09    0.129447    0.000000    0.000000    0.000000
-    22        -0.264053214789282    1.431e-09    0.129447    0.000000    0.000000    0.000000
-    23        -0.264053214821139    4.293e-10    0.129447    0.000000    0.000000    0.000000
-    24        -0.264053214798177    2.148e-10    0.129447    0.000000    0.000000    0.000000
-    25        -0.264053214783844    1.264e-10    0.129447    0.000000    0.000000    0.000000
-    26        -0.264053214779022    6.497e-11    0.129447    0.000000    0.000000    0.000000
+     0        -0.221996147223001    0.000e+00    0.000000    0.000000    0.000000    0.000000
+     1        -0.227318453802899    1.127e-01    0.034203    0.000000    0.000000    0.000000
+     2        -0.244460938844439    6.180e-02    0.055516    0.000000    0.000000    0.000000
+     3        -0.258959227396058    5.026e-02    0.096674    0.000000    0.000000    0.000000
+     4        -0.262343396027824    2.205e-02    0.117471    0.000000    0.000000    0.000000
+     5        -0.262908625301728    1.243e-02    0.122443    0.000000    0.000000    0.000000
+     6        -0.263757860159041    8.177e-03    0.126445    0.000000    0.000000    0.000000
+     7        -0.263879213670575    3.817e-03    0.128184    0.000000    0.000000    0.000000
+     8        -0.264014622641420    1.695e-03    0.128964    0.000000    0.000000    0.000000
+     9        -0.264066159113099    8.614e-04    0.129290    0.000000    0.000000    0.000000
+    10        -0.264071947073082    4.297e-04    0.129464    0.000000    0.000000    0.000000
+    11        -0.264057394578788    1.444e-04    0.129427    0.000000    0.000000    0.000000
+    12        -0.264050059493789    4.714e-05    0.129438    0.000000    0.000000    0.000000
+    13        -0.264053149759466    1.551e-05    0.129448    0.000000    0.000000    0.000000
+    14        -0.264053082102796    4.850e-06    0.129447    0.000000    0.000000    0.000000
+    15        -0.264053292040336    1.185e-06    0.129448    0.000000    0.000000    0.000000
+    16        -0.264053244603707    4.821e-07    0.129447    0.000000    0.000000    0.000000
+    17        -0.264053225387281    1.513e-07    0.129447    0.000000    0.000000    0.000000
+    18        -0.264053212384161    5.776e-08    0.129447    0.000000    0.000000    0.000000
+    19        -0.264053213264483    1.937e-08    0.129447    0.000000    0.000000    0.000000
+    20        -0.264053213601322    6.712e-09    0.129447    0.000000    0.000000    0.000000
+    21        -0.264053214246285    3.196e-09    0.129447    0.000000    0.000000    0.000000
+    22        -0.264053214333730    1.431e-09    0.129447    0.000000    0.000000    0.000000
+    23        -0.264053214365587    4.293e-10    0.129447    0.000000    0.000000    0.000000
+    24        -0.264053214342625    2.148e-10    0.129447    0.000000    0.000000    0.000000
+    25        -0.264053214328292    1.264e-10    0.129447    0.000000    0.000000    0.000000
+    26        -0.264053214323470    6.497e-11    0.129447    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              3  11        -0.1562916783
-              4  16        -0.1562916783
-              3  13        -0.0386837040
-              4  18        -0.0386837040
-              3  14         0.0217614515
-              4  19         0.0217614515
-              0   3         0.0109229455
+              3  11        -0.1562916738
+              4  16        -0.1562916738
+              3  13        -0.0386837032
+              4  18        -0.0386837032
+              3  14         0.0217614513
+              4  19         0.0217614513
+              0   3         0.0109229453
               1   1        -0.0077761744
-              3  12        -0.0076150463
-              4  17        -0.0076150463
+              3  12        -0.0076150461
+              4  17        -0.0076150461
 
     Largest Tia Amplitudes:
-              1   0         0.2352609875
-              2  12         0.1325985805
-              3  17         0.1325985805
-              2  13         0.0459911514
-              3  18         0.0459911514
-              1   2        -0.0413568414
+              1   0         0.2352609864
+              2  12         0.1325985768
+              3  17         0.1325985768
+              2  13         0.0459911505
+              3  18         0.0459911505
+              1   2        -0.0413568411
               2  15         0.0134656292
               3  20         0.0134656292
-              2  14         0.0119131203
-              3  19         0.0119131203
+              2  14         0.0119131199
+              3  19         0.0119131199
 
     Largest TIJAB Amplitudes:
-      4   3  16  11        -0.0398170903
-      3   2  11   3        -0.0234853058
-      4   2  16   3        -0.0234853058
-      4   3  17  12        -0.0206385188
+      4   3  16  11        -0.0398170900
+      3   2  11   3        -0.0234853057
+      4   2  16   3        -0.0234853057
+      4   3  17  12        -0.0206385187
       4   3   9   4        -0.0188072543
-      3   1  12   1        -0.0168567615
-      4   1  17   1        -0.0168567615
-      3   1  11   1        -0.0140526605
-      4   1  16   1        -0.0140526605
+      3   1  12   1        -0.0168567616
+      4   1  17   1        -0.0168567616
+      3   1  11   1        -0.0140526604
+      4   1  16   1        -0.0140526604
       3   1  11   4         0.0120691041
 
     Largest Tijab Amplitudes:
-      3   2  17  12        -0.0346069069
-      2   1  12   0        -0.0310243236
-      3   1  17   0        -0.0310243236
-      3   2  19  14        -0.0150424517
+      3   2  17  12        -0.0346069068
+      2   1  12   0        -0.0310243235
+      3   1  17   0        -0.0310243235
+      3   2  19  14        -0.0150424516
       3   2  17  14        -0.0147208146
       3   2  19  12        -0.0147208146
-      2   1  12   4         0.0144836228
-      3   1  17   4         0.0144836228
-      3   2  10   5        -0.0138482884
-      3   2  18  13        -0.0135177432
+      2   1  12   4         0.0144836227
+      3   1  17   4         0.0144836227
+      3   2  10   5        -0.0138482885
+      3   2  18  13        -0.0135177433
 
     Largest TIjAb Amplitudes:
-      3   2  11  12        -0.1090709891
-      4   3  16  17        -0.1090709891
-      3   1  11   0        -0.0876053248
-      4   1  16   0        -0.0876053248
-      3   3  11  17        -0.0648698713
-      4   2  16  12        -0.0648698713
-      1   2  11   0         0.0593336554
-      1   3  16   0         0.0593336554
-      1   1  11  12         0.0462409326
-      1   1  16  17         0.0462409326
+      3   2  11  12        -0.1090709879
+      4   3  16  17        -0.1090709879
+      3   1  11   0        -0.0876053239
+      4   1  16   0        -0.0876053239
+      3   3  11  17        -0.0648698706
+      4   2  16  12        -0.0648698706
+      1   2  11   0         0.0593336553
+      1   3  16   0         0.0593336553
+      1   1  11  12         0.0462409323
+      1   1  16  17         0.0462409323
 
-    SCF energy       (wfn)                    =  -92.212776949608610
-    Reference energy (file100)                =  -92.212776949608582
+    SCF energy       (wfn)                    =  -92.212776949797558
+    Reference energy (file100)                =  -92.212776949797600
 
-    Opposite-spin MP2 correlation energy      =   -0.157972638974821
-    Same-spin MP2 correlation energy          =   -0.064023507466503
-    MP2 correlation energy                    =   -0.221996146441324
-      * MP2 total energy                      =  -92.434773096049909
+    Opposite-spin MP2 correlation energy      =   -0.157972639688793
+    Same-spin MP2 correlation energy          =   -0.064023507534208
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.221996147223001
+      * MP2 total energy                      =  -92.434773097020596
 
-    Opposite-spin CCSD correlation energy     =   -0.213601690375581
-    Same-spin CCSD correlation energy         =   -0.050451524379731
-    CCSD correlation energy                   =   -0.264053214779022
-      * CCSD total energy                     =  -92.476830164387607
-
-
-*** tstop() called on psinet at Mon May 15 15:35:01 2017
-Module time:
-	user time   =       0.84 seconds =       0.01 minutes
-	system time =       0.55 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-Total time:
-	user time   =       1.17 seconds =       0.02 minutes
-	system time =       0.64 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:35:01 2017
+    Opposite-spin CCSD correlation energy     =   -0.213601689706702
+    Same-spin CCSD correlation energy         =   -0.050451524616768
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.264053214323470
+      * CCSD total energy                     =  -92.476830164121068
 
             **************************
             *                        *
@@ -643,33 +653,31 @@ Total time:
     Wave function   =    CCSD_T
     Reference wfn   =      UHF
 
-    Nuclear Rep. energy (wfn)                =   18.915270434706379
-    SCF energy          (wfn)                =  -92.212776949608610
-    Reference energy    (file100)            =  -92.212776949608582
-    CCSD energy         (file100)            =   -0.264053214779022
-    Total CCSD energy   (file100)            =  -92.476830164387607
+    Nuclear Rep. energy (wfn)                =   18.915270509055315
+    SCF energy          (wfn)                =  -92.212776949797558
+    Reference energy    (file100)            =  -92.212776949797600
+    CCSD energy         (file100)            =   -0.264053214323470
+    Total CCSD energy   (file100)            =  -92.476830164121068
 
     Number of ijk index combinations:
     Spin Case AAA:                                  10
     Spin Case BBB:                                   4
     Spin Case AAB:                                  40
     Spin Case ABB:                                  30
-    AAA (T) energy                             =   -0.000105841303424
-    BBB (T) energy                             =   -0.000012376413513
-    AAB (T) energy                             =   -0.007108814469370
-    ABB (T) energy                             =   -0.005234215460425
-    (T) energy                                   =   -0.012461247646732
-      * CCSD(T) total energy                     =  -92.489291412034333
+    AAA (T) energy                             =   -0.000105841308132
+    BBB (T) energy                             =   -0.000012376417532
+    AAB (T) energy                             =   -0.007108814404488
+    ABB (T) energy                             =   -0.005234215412327
+    (T) energy                                   =   -0.012461247542480
+      * CCSD(T) total energy                     =  -92.489291411663544
 
+    Nuclear repulsion energy..............................................................PASSED
+    SCF energy............................................................................PASSED
+    CCSD energy...........................................................................PASSED
+    CCSD(T) energy........................................................................PASSED
+    CCSD(T) energy........................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:35:01 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.19 seconds =       0.02 minutes
-	system time =       0.65 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+    Psi4 stopped on: Monday, 14 February 2022 12:25PM
+    Psi4 wall time for execution: 0:00:03.36
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This PR migrates 8 of the `cc` tests from using `autotest` to using standard `compare_values`. The 13 `cc` tests that still use `autotest` are all more delicate (usually because they involve properties) and are deferred to another PR. This PR handles the easy cases.

This is PR 3 in an ongoing series to make `ccdensity` compatible with the standard `Matrix` and `Wavefunction` machinery used elsewhere in Psi. Review requested from Lori for all things testing. Obligatory @lothian ping.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
