### PR TITLE
Loosen `adiis` BFGS Solution

### DIFF
--- a/psi4/driver/procrouting/diis.py
+++ b/psi4/driver/procrouting/diis.py
@@ -257,7 +257,7 @@ class DIIS:
         result = minimize(self.adiis_energy, np.ones(len(self.stored_vectors)), method="BFGS",
                 jac = self.adiis_gradient, tol=1e-6, options={"maxiter": 200})
 
-        if not result.success:
+        if np.linalg.norm(result.jac) > 1e-3: # Even if we didn't hit the tolerance, it may be good enough.
             raise Exception("ADIIS minimization failed. File a bug, and include your entire input and output files.")
 
         return normalize_input(result.x)
@@ -316,7 +316,7 @@ class DIIS:
         result = minimize(self.ediis_energy, np.ones(len(self.stored_vectors)), method="BFGS",
                 jac=self.ediis_gradient, tol=1e-6, options={"maxiter": 200})
 
-        if not result.success:
+        if np.linalg.norm(result.jac) > 1e-3: # Even if we didn't hit the tolerance, it may be good enough.
             raise Exception("EDIIS minimization failed. File a bug, and include your entire input and output files.")
 
         return normalize_input(result.x)


### PR DESCRIPTION
## Description
During review of the ADIIS PR, it was suggested that Psi raise an error if the BFGS doesn't meet the target convergence criteria. This PR changes that, so the error will be raised _if BFGS is very far from meeting the convergence criteria_. 1e-6 would be nice, but 1e-3 is good enough for our purposes.

@loriab, these are the last of the Psi tests on my list to heal.

## Checklist
- [x] Failing tests Lori pointed out work; Can't cause tests that previously passed to fail

## Status
- [x] Ready for review
- [x] Ready for merge
