### PR TITLE
Port `cc19`, `cc28`, modify `cc29`

### DIFF
--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -312,6 +312,11 @@ double CCLambdaWavefunction::compute_energy() {
             } else {
                 throw PsiException("cclambda: unknown wfn", __FILE__, __LINE__);
             }
+            // Inform Perl psivar scraper about these new variables
+            /*- Process::environment.globals["LEFT-RIGHT CC3 EIGENVECTOR OVERLAP"] -*/
+            /*- Process::environment.globals["LEFT-RIGHT CC2 EIGENVECTOR OVERLAP"] -*/
+            /*- Process::environment.globals["LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"] -*/
+            /*- Process::environment.globals["LEFT-RIGHT CCSD(T) EIGENVECTOR OVERLAP"] -*/
             reference_wavefunction_->set_scalar_variable("LEFT-RIGHT " + gs_name + " EIGENVECTOR OVERLAP", LR_overlap);
         }
     }

--- a/tests/cc19/CMakeLists.txt
+++ b/tests/cc19/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc19 "psi;cc;autotest;cart")
+add_regression_test(cc19 "psi;cc;cart")

--- a/tests/cc19/input.dat
+++ b/tests/cc19/input.dat
@@ -13,4 +13,29 @@ set {
     omega = [0.05, 0.1, au]
 }
 
-properties('ccsd', properties=['polarizability'])
+wfn = properties('ccsd', properties=['polarizability'], return_wfn=True)[1]
+
+refnre = 46.7803620583598061                      # TEST
+refscf = -174.4184330016244076                    # TEST
+refccsd = -174.787276104267534                    # TEST
+refoverlap = 0.92327310262                        # TEST
+ref911polar = 5.168927312011                      # TEST
+ref911tensor = psi4.core.Matrix.from_list(        # TEST
+   [[5.757358066510180, -1.826957734843812, 0],   # TEST
+    [-1.826957734843812, 6.559981880984797, 0],   # TEST
+    [0, 0, 3.189441988537673]])                   # TEST
+ref456polar = 5.320667099301                      # TEST
+ref456tensor = psi4.core.Matrix.from_list(        # TEST
+   [[5.861609123244674, -1.963176982523587, 0],   # TEST
+    [-1.963176982523587, 6.804320835644361, 0],   # TEST
+    [0, 0, 3.296071339013346]])                   # TEST
+
+compare_values(refnre, hof.nuclear_repulsion_energy(), 6, "Nuclear Repulsion Energy") # TEST
+compare_values(refscf, wfn.variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(refccsd, wfn.variable("CCSD TOTAL ENERGY"), 6, "CCSD Energy") # TEST
+compare_values(refoverlap, wfn.variable("Left-Right CCSD Eigenvector Overlap"), 5, "Left-Right CCSD Overlap") # TEST
+compare_values(ref911tensor, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 911NM"), 5, "Dipole Polarizability Tensor (911nm)") # TEST
+compare_values(ref911polar, variable("CCSD DIPOLE POLARIZABILITY @ 911NM"), 5, "Dipole Polarizability (911nm)") # TEST
+compare_values(ref456tensor, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 456NM"), 5, "Dipole Polarizability Tensor (456nm)") # TEST
+compare_values(ref456polar, variable("CCSD DIPOLE POLARIZABILITY @ 456NM"), 5, "Dipole Polarizability (456nm)") # TEST
+

--- a/tests/cc19/output.ref
+++ b/tests/cc19/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev51 
+                               Psi4 undefined 
 
-                         Git: Rev {ccdensity_fix} 4732348 dirty
+                         Git: Rev {cctest} b401a9d dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 12 February 2022 03:25PM
+    Psi4 started on: Friday, 18 February 2022 02:07PM
 
-    Process ID: 65766
-    Host:       Jonathons-MacBook-Pro.local
+    Process ID: 64285
+    Host:       dhcp189-242.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -56,11 +56,36 @@ set {
     omega = [0.05, 0.1, au]
 }
 
-properties('ccsd', properties=['polarizability'])
+wfn = properties('ccsd', properties=['polarizability'], return_wfn=True)[1]
+
+refnre = 46.7803620583598061                      # TEST
+refscf = -174.4184330016244076                    # TEST
+refccsd = -174.787276104267534                    # TEST
+refoverlap = 0.92327310262                        # TEST
+ref911polar = 5.168927312011                      # TEST
+ref911tensor = psi4.core.Matrix.from_list(        # TEST
+   [[5.757358066510180, -1.826957734843812, 0],   # TEST
+    [-1.826957734843812, 6.559981880984797, 0],   # TEST
+    [0, 0, 3.189441988537673]])                   # TEST
+ref456polar = 5.320667099301                      # TEST
+ref456tensor = psi4.core.Matrix.from_list(        # TEST
+   [[5.861609123244674, -1.963176982523587, 0],   # TEST
+    [-1.963176982523587, 6.804320835644361, 0],   # TEST
+    [0, 0, 3.296071339013346]])                   # TEST
+
+compare_values(refnre, hof.nuclear_repulsion_energy(), 6, "Nuclear Repulsion Energy") # TEST
+compare_values(refscf, wfn.variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(refccsd, wfn.variable("CCSD TOTAL ENERGY"), 6, "CCSD Energy") # TEST
+compare_values(refoverlap, wfn.variable("Left-Right CCSD Eigenvector Overlap"), 5, "Left-Right CCSD Overlap") # TEST
+compare_values(ref911tensor, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 911NM"), 5, "Dipole Polarizability Tensor (911nm)") # TEST
+compare_values(ref911polar, variable("CCSD DIPOLE POLARIZABILITY @ 911NM"), 5, "Dipole Polarizability (911nm)") # TEST
+compare_values(ref456tensor, wfn.variable("CCSD DIPOLE POLARIZABILITY TENSOR @ 456NM"), 5, "Dipole Polarizability Tensor (456nm)") # TEST
+compare_values(ref456polar, variable("CCSD DIPOLE POLARIZABILITY @ 456NM"), 5, "Dipole Polarizability (456nm)") # TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:25:37 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Fri Feb 18 14:07:44 2022
 
    => Loading Basis Set <=
 
@@ -247,15 +272,15 @@ Properties computed using the SCF density matrix
      X:    -0.1857      Y:     1.5531      Z:     0.0000     Total:     1.5642
 
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:39 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Fri Feb 18 14:07:45 2022
 Module time:
-	user time   =       1.01 seconds =       0.02 minutes
+	user time   =       0.60 seconds =       0.01 minutes
 	system time =       0.13 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.01 seconds =       0.02 minutes
+	user time   =       0.60 seconds =       0.01 minutes
 	system time =       0.13 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -280,8 +305,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:25:39 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Fri Feb 18 14:07:45 2022
 
 
 	Wfn Parameters:
@@ -360,15 +385,15 @@ Total time:
 	Two-electron energy          =    113.55889725731765
 	Reference energy             =   -174.41843300162446
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:39 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Fri Feb 18 14:07:45 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.18 seconds =       0.00 minutes
+	user time   =       0.04 seconds =       0.00 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.23 seconds =       0.02 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -853,8 +878,16 @@ MP2 correlation energy -0.3566362407166802
 	-----   ------ ----------------
 	0.050   911.27         5.16893
 	0.100   455.63         5.32067
+    Nuclear Repulsion Energy..............................................................PASSED
+    SCF Energy............................................................................PASSED
+    CCSD Energy...........................................................................PASSED
+    Left-Right CCSD Overlap...............................................................PASSED
+    Dipole Polarizability Tensor (911nm)..................................................PASSED
+    Dipole Polarizability (911nm).........................................................PASSED
+    Dipole Polarizability Tensor (456nm)..................................................PASSED
+    Dipole Polarizability (456nm).........................................................PASSED
 
-    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
-    Psi4 wall time for execution: 0:00:11.45
+    Psi4 stopped on: Friday, 18 February 2022 02:07PM
+    Psi4 wall time for execution: 0:00:06.78
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc28/CMakeLists.txt
+++ b/tests/cc28/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc28 "psi;quicktests;cc;autotest")
+add_regression_test(cc28 "psi;quicktests;cc")

--- a/tests/cc28/input.dat
+++ b/tests/cc28/input.dat
@@ -14,4 +14,29 @@ set {
   basis cc-pVDZ
 }
 
-properties('ccsd', properties=['rotation'])
+wfn = properties('ccsd', properties=['rotation'], return_wfn=True)[1]
+
+refnre = 38.2539685310425384                      # TEST
+refscf = -150.7791838721300337                    # TEST
+refccsd = -151.173863088601593                    # TEST
+refoverlap = 0.89177805643                        # TEST
+ref589tensor = psi4.core.Matrix.from_list(        # TEST
+   [[0.155734386263887, -0.064272428033447, 0],   # TEST
+    [-0.266268386856247, -0.012765731183706, 0],  # TEST
+    [0, 0, -0.127276954213308]])                  # TEST
+ref589rot = -76.93369                             # TEST
+ref355tensor = psi4.core.Matrix.from_list(        # TEST
+   [[0.273204707761102, -0.118930580636346, 0],   # TEST
+    [-0.474438446130291, -0.025397023393736, 0],  # TEST
+    [0, 0, -0.221410011414567]])                  # TEST
+ref355rot = -214.73317                            # TEST
+
+compare_values(refnre, h2o2.nuclear_repulsion_energy(), 6, "Nuclear Repulsion Energy") # TEST
+compare_values(refscf, wfn.variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(refccsd, wfn.variable("CCSD TOTAL ENERGY"), 6, "CCSD Energy") # TEST
+compare_values(refoverlap, wfn.variable("LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"), 5, "Left-Right CCSD Overlap") # TEST
+compare_values(ref589tensor, wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"), 5, "Optical Rotation Tensor (589nm)") # TEST
+compare_values(ref589rot, variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"), 5, "Specific Rotation (589nm)") # TEST
+compare_values(ref355tensor, wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM"), 5, "Optical Rotation Tensor (355nm)") # TEST
+compare_values(ref355rot, variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"), 5, "Specific Rotation (355nm)") # TEST
+

--- a/tests/cc28/output.ref
+++ b/tests/cc28/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev51 
+                               Psi4 undefined 
 
-                         Git: Rev {ccdensity_fix} 4732348 dirty
+                         Git: Rev {cctest} b401a9d dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 12 February 2022 03:24PM
+    Psi4 started on: Friday, 18 February 2022 02:07PM
 
-    Process ID: 65718
-    Host:       Jonathons-MacBook-Pro.local
+    Process ID: 64292
+    Host:       dhcp189-242.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -57,11 +57,36 @@ set {
   basis cc-pVDZ
 }
 
-properties('ccsd', properties=['rotation'])
+wfn = properties('ccsd', properties=['rotation'], return_wfn=True)[1]
+
+refnre = 38.2539685310425384                      # TEST
+refscf = -150.7791838721300337                    # TEST
+refccsd = -151.173863088601593                    # TEST
+refoverlap = 0.89177805643                        # TEST
+ref589tensor = psi4.core.Matrix.from_list(        # TEST
+   [[0.155734386263887, -0.064272428033447, 0],   # TEST
+    [-0.266268386856247, -0.012765731183706, 0],  # TEST
+    [0, 0, -0.127276954213308]])                  # TEST
+ref589rot = -76.93369                             # TEST
+ref355tensor = psi4.core.Matrix.from_list(        # TEST
+   [[0.273204707761102, -0.118930580636346, 0],   # TEST
+    [-0.474438446130291, -0.025397023393736, 0],  # TEST
+    [0, 0, -0.221410011414567]])                  # TEST
+ref355rot = -214.73317                            # TEST
+
+compare_values(refnre, h2o2.nuclear_repulsion_energy(), 6, "Nuclear Repulsion Energy") # TEST
+compare_values(refscf, wfn.variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(refccsd, wfn.variable("CCSD TOTAL ENERGY"), 6, "CCSD Energy") # TEST
+compare_values(refoverlap, wfn.variable("LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"), 5, "Left-Right CCSD Overlap") # TEST
+compare_values(ref589tensor, wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"), 5, "Optical Rotation Tensor (589nm)") # TEST
+compare_values(ref589rot, variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"), 5, "Specific Rotation (589nm)") # TEST
+compare_values(ref355tensor, wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM"), 5, "Optical Rotation Tensor (355nm)") # TEST
+compare_values(ref355rot, variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"), 5, "Specific Rotation (355nm)") # TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:24:47 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Fri Feb 18 14:07:55 2022
 
    => Loading Basis Set <=
 
@@ -177,10 +202,10 @@ properties('ccsd', properties=['rotation'])
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:  -150.13109142562024   -1.50131e+02   0.00000e+00 
-   @RHF iter   1:  -150.72994418505689   -5.98853e-01   1.20798e-02 ADIIS/DIIS
-   @RHF iter   2:  -150.77474437542560   -4.48002e-02   3.93712e-03 ADIIS/DIIS
-   @RHF iter   3:  -150.77872862263547   -3.98425e-03   9.99210e-04 ADIIS/DIIS
-   @RHF iter   4:  -150.77914039140384   -4.11769e-04   2.79341e-04 ADIIS/DIIS
+   @RHF iter   1:  -150.72994418505689   -5.98853e-01   1.20798e-02 DIIS/ADIIS
+   @RHF iter   2:  -150.77474437542560   -4.48002e-02   3.93712e-03 DIIS/ADIIS
+   @RHF iter   3:  -150.77872862263547   -3.98425e-03   9.99210e-04 DIIS/ADIIS
+   @RHF iter   4:  -150.77914039140384   -4.11769e-04   2.79341e-04 DIIS/ADIIS
    @RHF iter   5:  -150.77918120837066   -4.08170e-05   4.89524e-05 DIIS
    @RHF iter   6:  -150.77918362626531   -2.41789e-06   1.25560e-05 DIIS
    @RHF iter   7:  -150.77918384927895   -2.23014e-07   3.89300e-06 DIIS
@@ -251,15 +276,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:48 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Fri Feb 18 14:07:55 2022
 Module time:
-	user time   =       1.17 seconds =       0.02 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.17 seconds =       0.02 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -284,8 +309,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:24:49 2022
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Fri Feb 18 14:07:55 2022
 
 
 	Wfn Parameters:
@@ -364,15 +389,15 @@ Total time:
 	Two-electron energy          =     45.23861563748924
 	Reference energy             =   -150.77918387213009
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:24:49 2022
+*** tstop() called on dhcp189-242.emerson.emory.edu at Fri Feb 18 14:07:56 2022
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.43 seconds =       0.02 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.82 seconds =       0.01 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -1182,8 +1207,16 @@ MP2 correlation energy -0.3802563047354116
    -----   ------ ------------------
    0.077   589.00       -76.93369
    0.128   355.00      -214.73317
+    Nuclear Repulsion Energy..............................................................PASSED
+    SCF Energy............................................................................PASSED
+    CCSD Energy...........................................................................PASSED
+    Left-Right CCSD Overlap...............................................................PASSED
+    Optical Rotation Tensor (589nm).......................................................PASSED
+    Specific Rotation (589nm).............................................................PASSED
+    Optical Rotation Tensor (355nm).......................................................PASSED
+    Specific Rotation (355nm).............................................................PASSED
 
-    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
-    Psi4 wall time for execution: 0:00:21.60
+    Psi4 stopped on: Friday, 18 February 2022 02:08PM
+    Psi4 wall time for execution: 0:00:12.01
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc29/input.dat
+++ b/tests/cc29/input.dat
@@ -16,7 +16,7 @@ set {
   r_convergence 10
 }
 
-properties('ccsd',properties=['rotation'])
+wfn = properties('ccsd',properties=['rotation'], return_wfn=True)[1]
 
 reflen_589   =    -76.93388  #TEST
 refvel_589   =    850.24712  #TEST
@@ -29,5 +29,38 @@ compare_values(reflen_589,   variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  
 compare_values(refvel_589,   variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
 compare_values(refmvg_589,   variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
 compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
-compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
-compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
+compare_values(refvel_355,   variable("CCSD SPECIFIC ROTATION (VEL) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
+compare_values(refmvg_355,   variable("CCSD SPECIFIC ROTATION (MVG) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
+
+reflenT_589 = psi4.core.Matrix.from_list(        # TEST
+   [[0.141679367454342, -0.070714074525053, 0],  # TEST
+    [-0.272710108679977, 0.001289284927192, 0],  # TEST
+    [0, 0, -0.127276914384744]])                 # TEST
+refvelT_589 = psi4.core.Matrix.from_list(        # TEST
+   [[0.375624002172128, -0.374245931079431, 0],  # TEST
+    [-0.139409386151793, 0.012686792954725, 0],  # TEST
+    [0, 0, -0.401726050127889]])                 # TEST
+refmvgT_589 = psi4.core.Matrix.from_list(        # TEST
+   [[0.011921207729849, -0.011491041277978, 0],  # TEST
+    [-0.023088462037097, 0.000608303898894, 0],  # TEST
+    [0, 0, -0.009703846161106]])                 # TEST
+reflenT_355 = psi4.core.Matrix.from_list(        # TEST
+   [[0.247980570429615, -0.130332715357560, 0],  # TEST
+    [-0.485840586780009, -0.000172988287553, 0], # TEST
+    [0, 0, -0.221409966802105]])                 # TEST
+refvelT_355 = psi4.core.Matrix.from_list(        # TEST
+   [[0.399349644680690, -0.398490098672511, 0],  # TEST
+    [-0.184609678704297, 0.013642793674983, 0],  # TEST
+    [0, 0, -0.419065224393867]])                 # TEST
+refmvgT_355 = psi4.core.Matrix.from_list(        # TEST
+   [[0.035646850238411, -0.035735208871057, 0],  # TEST
+    [-0.068288754589601, 0.001564304619152, 0],  # TEST
+    [0, 0, -0.027043020427084]])                 # TEST
+
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+

--- a/tests/cc29/output.ref
+++ b/tests/cc29/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 undefined 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {cctest} b401a9d dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Friday, 18 February 2022 02:08PM
 
-    Process ID:  12709
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 64299
+    Host:       dhcp189-242.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -46,27 +59,72 @@ set {
   r_convergence 10
 }
 
-property('ccsd',properties=['rotation'])
+wfn = properties('ccsd',properties=['rotation'], return_wfn=True)[1]
+
+reflen_589   =    -76.93388  #TEST
+refvel_589   =    850.24712  #TEST
+refmvg_589   =   -179.08820  #TEST
+reflen_355   =   -214.73273  #TEST
+refvel_355   =    384.88786  #TEST
+refmvg_355   =   -644.44746  #TEST
+
+compare_values(reflen_589,   variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") #TEST
+compare_values(refvel_589,   variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
+compare_values(refmvg_589,   variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
+compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
+compare_values(refvel_355,   variable("CCSD SPECIFIC ROTATION (VEL) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
+compare_values(refmvg_355,   variable("CCSD SPECIFIC ROTATION (MVG) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
+
+reflenT_589 = psi4.core.Matrix.from_list(        # TEST
+   [[0.141679367454342, -0.070714074525053, 0],  # TEST
+    [-0.272710108679977, 0.001289284927192, 0],  # TEST
+    [0, 0, -0.127276914384744]])                 # TEST
+refvelT_589 = psi4.core.Matrix.from_list(        # TEST
+   [[0.375624002172128, -0.374245931079431, 0],  # TEST
+    [-0.139409386151793, 0.012686792954725, 0],  # TEST
+    [0, 0, -0.401726050127889]])                 # TEST
+refmvgT_589 = psi4.core.Matrix.from_list(        # TEST
+   [[0.011921207729849, -0.011491041277978, 0],  # TEST
+    [-0.023088462037097, 0.000608303898894, 0],  # TEST
+    [0, 0, -0.009703846161106]])                 # TEST
+reflenT_355 = psi4.core.Matrix.from_list(        # TEST
+   [[0.247980570429615, -0.130332715357560, 0],  # TEST
+    [-0.485840586780009, -0.000172988287553, 0], # TEST
+    [0, 0, -0.221409966802105]])                 # TEST
+refvelT_355 = psi4.core.Matrix.from_list(        # TEST
+   [[0.399349644680690, -0.398490098672511, 0],  # TEST
+    [-0.184609678704297, 0.013642793674983, 0],  # TEST
+    [0, 0, -0.419065224393867]])                 # TEST
+refmvgT_355 = psi4.core.Matrix.from_list(        # TEST
+   [[0.035646850238411, -0.035735208871057, 0],  # TEST
+    [-0.068288754589601, 0.001564304619152, 0],  # TEST
+    [0, 0, -0.027043020427084]])                 # TEST
+
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:31 2017
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Fri Feb 18 14:08:10 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 3-4 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1-2 entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3-4 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -80,16 +138,16 @@ property('ccsd',properties=['rotation'])
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O         -0.028962160801    -0.694396279686    -0.049338350190    15.994914619560
-           O          0.028962160801     0.694396279686    -0.049338350190    15.994914619560
-           H          0.350498145881    -0.910645626300     0.783035421467     1.007825032070
-           H         -0.350498145881     0.910645626300     0.783035421467     1.007825032070
+         O           -0.028962160801    -0.694396279686    -0.049338350197    15.994914619570
+         O            0.028962160801     0.694396279686    -0.049338350197    15.994914619570
+         H            0.350498145881    -0.910645626300     0.783035421460     1.007825032230
+         H           -0.350498145881     0.910645626300     0.783035421460     1.007825032230
 
   Running in c2 symmetry.
 
   Rotational constants: A =     10.61423  B =      0.97044  C =      0.91566 [cm^-1]
-  Rotational constants: A = 318206.57462  B =  29093.19738  C =  27450.82444 [MHz]
-  Nuclear repulsion =   38.253968380675488
+  Rotational constants: A = 318206.57700  B =  29093.19760  C =  27450.82465 [MHz]
+  Nuclear repulsion =   38.253968531037714
 
   Charge       = 0
   Multiplicity = 1
@@ -106,28 +164,17 @@ property('ccsd',properties=['rotation'])
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 18
-    Number of basis function: 38
+    Number of basis functions: 38
     Number of Cartesian functions: 40
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         19      19       0       0       0       0
-     B         19      19       0       0       0       0
-   -------------------------------------------------------
-    Total      38      38       9       9       9       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -146,45 +193,60 @@ property('ccsd',properties=['rotation'])
   Using 549822 doubles for integral storage.
   We computed 14706 shell quartets total.
   Whereas there are 14706 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.1870579153E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 3.0969235309E-02.
+  Reciprocal condition number of the overlap matrix is 8.7476056510E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+     B         19      19 
+   -------------------------
+    Total      38      38
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -151.03982301927678   -1.51040e+02   7.73419e-02 
-   @RHF iter   1:  -150.72622157532444    3.13601e-01   1.17513e-02 
-   @RHF iter   2:  -150.77380973312276   -4.75882e-02   3.71879e-03 DIIS
-   @RHF iter   3:  -150.77821101839413   -4.40129e-03   1.19494e-03 DIIS
-   @RHF iter   4:  -150.77904383428134   -8.32816e-04   4.05812e-04 DIIS
-   @RHF iter   5:  -150.77917079311280   -1.26959e-04   9.73127e-05 DIIS
-   @RHF iter   6:  -150.77918290908590   -1.21160e-05   2.51894e-05 DIIS
-   @RHF iter   7:  -150.77918382500638   -9.15920e-07   5.69339e-06 DIIS
-   @RHF iter   8:  -150.77918386990510   -4.48987e-08   1.27540e-06 DIIS
-   @RHF iter   9:  -150.77918387220203   -2.29693e-09   3.32064e-07 DIIS
-   @RHF iter  10:  -150.77918387234919   -1.47168e-10   8.15094e-08 DIIS
-   @RHF iter  11:  -150.77918387235815   -8.95284e-12   1.36964e-08 DIIS
-   @RHF iter  12:  -150.77918387235849   -3.41061e-13   3.48237e-09 DIIS
-   @RHF iter  13:  -150.77918387235857   -8.52651e-14   6.68838e-10 DIIS
-   @RHF iter  14:  -150.77918387235846    1.13687e-13   1.71118e-10 DIIS
-   @RHF iter  15:  -150.77918387235849   -2.84217e-14   4.64023e-11 DIIS
+   @RHF iter SAD:  -150.13109142561967   -1.50131e+02   0.00000e+00 
+   @RHF iter   1:  -150.72994418505715   -5.98853e-01   1.20798e-02 DIIS/ADIIS
+   @RHF iter   2:  -150.77474437542577   -4.48002e-02   3.93712e-03 DIIS/ADIIS
+   @RHF iter   3:  -150.77872862263564   -3.98425e-03   9.99210e-04 DIIS/ADIIS
+   @RHF iter   4:  -150.77914039140413   -4.11769e-04   2.79341e-04 DIIS/ADIIS
+   @RHF iter   5:  -150.77918120837077   -4.08170e-05   4.89524e-05 DIIS
+   @RHF iter   6:  -150.77918362626531   -2.41789e-06   1.25560e-05 DIIS
+   @RHF iter   7:  -150.77918384927912   -2.23014e-07   3.89300e-06 DIIS
+   @RHF iter   8:  -150.77918387131734   -2.20382e-08   8.16055e-07 DIIS
+   @RHF iter   9:  -150.77918387210687   -7.89527e-10   1.49865e-07 DIIS
+   @RHF iter  10:  -150.77918387212901   -2.21405e-11   3.10868e-08 DIIS
+   @RHF iter  11:  -150.77918387213020   -1.19371e-12   6.61624e-09 DIIS
+   @RHF iter  12:  -150.77918387213020    0.00000e+00   1.38474e-09 DIIS
+   @RHF iter  13:  -150.77918387213043   -2.27374e-13   3.05202e-10 DIIS
+   @RHF iter  14:  -150.77918387213020    2.27374e-13   6.31849e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -209,49 +271,44 @@ property('ccsd',properties=['rotation'])
               A     B 
     DOCC [     5,    4 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -150.77918387235849
+  @RHF Final Energy:  -150.77918387213020
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             38.2539683806754880
-    One-Electron Energy =                -284.0698921520927342
-    Two-Electron Energy =                  95.0367398990587731
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -150.7791838723584874
+    Nuclear Repulsion Energy =             38.2539685310377138
+    One-Electron Energy =                -284.0698924306669255
+    Two-Electron Energy =                  95.0367400274990075
+    Total Energy =                       -150.7791838721302042
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.2602
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.2074     Total:     1.2074
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on psinet at Mon May 15 15:34:31 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Fri Feb 18 14:08:11 2022
 Module time:
-	user time   =       0.55 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.55 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -265,19 +322,19 @@ Total time:
       Number of basis functions:        38
 
       Number of irreps:                  2
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  19   19 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 135219 non-zero two-electron integrals.
+      Computed 117739 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:31 2017
+*** tstart() called on dhcp189-242.emerson.emory.edu
+*** at Fri Feb 18 14:08:11 2022
 
 
 	Wfn Parameters:
@@ -300,7 +357,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -336,7 +393,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -132.27484824295519
+	Frozen core energy     =   -132.27484829822646
 
 	Size of irrep 0 of <ab|cd> integrals:      0.177 (MW) /      1.418 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.176 (MW) /      1.411 (MB)
@@ -350,34 +407,30 @@ Total time:
 	Size of irrep 1 of tijab amplitudes:       0.010 (MW) /      0.081 (MB)
 	Total:                                     0.021 (MW) /      0.165 (MB)
 
-	Nuclear Rep. energy          =     38.25396838067549
-	SCF energy                   =   -150.77918387235849
-	One-electron energy          =   -101.99691957006044
-	Two-electron energy          =     45.23861555998176
-	Reference energy             =   -150.77918387235837
+	Nuclear Rep. energy          =     38.25396853103771
+	SCF energy                   =   -150.77918387213020
+	One-electron energy          =   -101.99691974242856
+	Two-electron energy          =     45.23861563748702
+	Reference energy             =   -150.77918387213029
 
-*** tstop() called on psinet at Mon May 15 15:34:31 2017
+*** tstop() called on dhcp189-242.emerson.emory.edu at Fri Feb 18 14:08:11 2022
 Module time:
 	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.74 seconds =       0.01 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:31 2017
-
+	user time   =       0.81 seconds =       0.01 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =   38.253968380675488
-    SCF energy          (wfn)     = -150.779183872358487
-    Reference energy    (file100) = -150.779183872358374
+    Nuclear Rep. energy (wfn)     =   38.253968531037714
+    SCF energy          (wfn)     = -150.779183872130204
+    Reference energy    (file100) = -150.779183872130290
 
     Input parameters:
     -----------------
@@ -405,87 +458,75 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3802563054007333
+MP2 correlation energy -0.3802563047354497
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.380256305400733    0.000e+00    0.000000    0.000000    0.000000    0.143419
-     1        -0.384252700184141    4.172e-02    0.006281    0.014957    0.014957    0.146642
-     2        -0.393202764715465    1.580e-02    0.007156    0.016728    0.016728    0.156356
-     3        -0.394603278061782    5.260e-03    0.008061    0.018516    0.018516    0.160181
-     4        -0.394657650141864    1.398e-03    0.008198    0.018646    0.018646    0.161027
-     5        -0.394690572781597    5.030e-04    0.008266    0.018685    0.018685    0.161216
-     6        -0.394682677587834    1.898e-04    0.008293    0.018687    0.018687    0.161210
-     7        -0.394679309091063    5.979e-05    0.008301    0.018685    0.018685    0.161200
-     8        -0.394679268693150    2.095e-05    0.008303    0.018684    0.018684    0.161198
-     9        -0.394678919667468    7.909e-06    0.008304    0.018684    0.018684    0.161197
-    10        -0.394679205951505    3.344e-06    0.008304    0.018684    0.018684    0.161197
-    11        -0.394679180599406    1.110e-06    0.008304    0.018684    0.018684    0.161197
-    12        -0.394679218515408    3.658e-07    0.008304    0.018684    0.018684    0.161197
-    13        -0.394679216816816    1.105e-07    0.008304    0.018684    0.018684    0.161197
-    14        -0.394679217332234    3.761e-08    0.008304    0.018684    0.018684    0.161197
-    15        -0.394679217580842    1.359e-08    0.008304    0.018684    0.018684    0.161197
-    16        -0.394679217499455    4.980e-09    0.008304    0.018684    0.018684    0.161197
-    17        -0.394679217489496    2.200e-09    0.008304    0.018684    0.018684    0.161197
-    18        -0.394679217478652    8.813e-10    0.008304    0.018684    0.018684    0.161197
-    19        -0.394679217481823    3.643e-10    0.008304    0.018684    0.018684    0.161197
-    20        -0.394679217490337    1.280e-10    0.008304    0.018684    0.018684    0.161197
-    21        -0.394679217489688    4.824e-11    0.008304    0.018684    0.018684    0.161197
+     0        -0.380256304735450    0.000e+00    0.000000    0.000000    0.000000    0.143419
+     1        -0.384252699668255    4.172e-02    0.006281    0.014957    0.014957    0.146642
+     2        -0.393202764097162    1.580e-02    0.007156    0.016728    0.016728    0.156356
+     3        -0.394603277393187    5.260e-03    0.008061    0.018516    0.018516    0.160181
+     4        -0.394657649472716    1.398e-03    0.008198    0.018646    0.018646    0.161027
+     5        -0.394690572111267    5.030e-04    0.008266    0.018685    0.018685    0.161216
+     6        -0.394682676918534    1.898e-04    0.008293    0.018687    0.018687    0.161210
+     7        -0.394679308421949    5.979e-05    0.008301    0.018685    0.018685    0.161200
+     8        -0.394679268024016    2.095e-05    0.008303    0.018684    0.018684    0.161198
+     9        -0.394678918998358    7.909e-06    0.008304    0.018684    0.018684    0.161197
+    10        -0.394679205282363    3.344e-06    0.008304    0.018684    0.018684    0.161197
+    11        -0.394679179930269    1.110e-06    0.008304    0.018684    0.018684    0.161197
+    12        -0.394679217846268    3.658e-07    0.008304    0.018684    0.018684    0.161197
+    13        -0.394679216147674    1.105e-07    0.008304    0.018684    0.018684    0.161197
+    14        -0.394679216663093    3.761e-08    0.008304    0.018684    0.018684    0.161197
+    15        -0.394679216911701    1.359e-08    0.008304    0.018684    0.018684    0.161197
+    16        -0.394679216830315    4.980e-09    0.008304    0.018684    0.018684    0.161197
+    17        -0.394679216820356    2.200e-09    0.008304    0.018684    0.018684    0.161197
+    18        -0.394679216809511    8.813e-10    0.008304    0.018684    0.018684    0.161197
+    19        -0.394679216812683    3.643e-10    0.008304    0.018684    0.018684    0.161197
+    20        -0.394679216821198    1.280e-10    0.008304    0.018684    0.018684    0.161197
+    21        -0.394679216820548    4.824e-11    0.008304    0.018684    0.018684    0.161197
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              5  14        -0.0102219480
-              6  14        -0.0088239771
-              2   7        -0.0082621858
+              5  14        -0.0102219474
+              6  14        -0.0088239766
+              2   7        -0.0082621856
               2   9        -0.0079565233
-              2   4         0.0077446891
+              2   4         0.0077446889
               1   8        -0.0067312264
               1   0        -0.0066839225
-              5  17         0.0064483641
-              1   3         0.0061907939
-              6  16         0.0061070747
+              5  17         0.0064483639
+              1   3         0.0061907938
+              6  16         0.0061070746
 
     Largest TIjAb Amplitudes:
-      2   2  15  15        -0.0682113885
-      2   2  14  15         0.0337460417
-      2   2  15  14         0.0337460417
-      1   2  15  15         0.0313513392
-      2   1  15  15         0.0313513392
-      1   1  15  15        -0.0311200793
-      3   3  17  17        -0.0224518734
+      2   2  15  15        -0.0682113878
+      2   2  14  15         0.0337460405
+      2   2  15  14         0.0337460405
+      1   2  15  15         0.0313513390
+      2   1  15  15         0.0313513390
+      1   1  15  15        -0.0311200794
+      3   3  17  17        -0.0224518728
       3   3  15  15        -0.0219509880
-      1   1   1   1        -0.0213098149
-      2   2  14  14        -0.0200419727
+      1   1   1   1        -0.0213098148
+      2   2  14  14        -0.0200419717
 
-    SCF energy       (wfn)                    = -150.779183872358487
-    Reference energy (file100)                = -150.779183872358374
+    SCF energy       (wfn)                    = -150.779183872130204
+    Reference energy (file100)                = -150.779183872130290
 
-    Opposite-spin MP2 correlation energy      =   -0.282698987519240
-    Same-spin MP2 correlation energy          =   -0.097557317881493
-    MP2 correlation energy                    =   -0.380256305400733
-      * MP2 total energy                      = -151.159440177759109
+    Opposite-spin MP2 correlation energy      =   -0.282698986958705
+    Same-spin MP2 correlation energy          =   -0.097557317776745
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.380256304735450
+      * MP2 total energy                      = -151.159440176865729
 
-    Opposite-spin CCSD correlation energy     =   -0.309012026109140
-    Same-spin CCSD correlation energy         =   -0.085667191369121
-    CCSD correlation energy                   =   -0.394679217489688
-      * CCSD total energy                     = -151.173863089848055
-
-
-*** tstop() called on psinet at Mon May 15 15:34:33 2017
-Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.49 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-Total time:
-	user time   =       1.13 seconds =       0.02 minutes
-	system time =       0.59 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:33 2017
+    Opposite-spin CCSD correlation energy     =   -0.309012025444810
+    Same-spin CCSD correlation energy         =   -0.085667191375738
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.394679216820548
+      * CCSD total energy                     = -151.173863088950839
 
 
 			**************************
@@ -495,31 +536,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:33 2017
-Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.16 seconds =       0.02 minutes
-	system time =       0.62 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:33 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =   38.253968380675488
+	Nuclear Rep. energy (wfn)     =   38.253968531037714
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -150.779183872358487
-	Reference energy    (CC_INFO) = -150.779183872358374
-	CCSD energy         (CC_INFO) =   -0.394679217489688
-	Total CCSD energy   (CC_INFO) = -151.173863089848055
+	SCF energy          (wfn)     = -150.779183872130204
+	Reference energy    (CC_INFO) = -150.779183872130290
+	CCSD energy         (CC_INFO) =   -0.394679216820548
+	Total CCSD energy   (CC_INFO) = -151.173863088950839
 
 	Input parameters:
 	-----------------
@@ -532,7 +559,7 @@ Total time:
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -545,68 +572,54 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.394689328717566    0.000e+00
-	   1        -0.387349439711019    8.453e-03
-	   2        -0.386490854410735    2.123e-03
-	   3        -0.386312161154920    7.361e-04
-	   4        -0.386313416704314    2.605e-04
-	   5        -0.386314866088140    1.091e-04
-	   6        -0.386314215875374    3.723e-05
-	   7        -0.386314814666853    1.254e-05
-	   8        -0.386314851083708    4.681e-06
-	   9        -0.386314799943819    1.965e-06
-	  10        -0.386314796248046    6.926e-07
-	  11        -0.386314795982928    2.227e-07
-	  12        -0.386314799350927    7.185e-08
-	  13        -0.386314800252296    2.296e-08
-	  14        -0.386314800790252    6.757e-09
-	  15        -0.386314800876344    2.354e-09
-	  16        -0.386314800888722    1.011e-09
-	  17        -0.386314800880624    4.333e-10
-	  18        -0.386314800879261    1.820e-10
-	  19        -0.386314800880060    7.569e-11
+	   0        -0.394689328059554    0.000e+00
+	   1        -0.387349439153042    8.453e-03
+	   2        -0.386490853860475    2.123e-03
+	   3        -0.386312160608893    7.361e-04
+	   4        -0.386313416157696    2.605e-04
+	   5        -0.386314865541727    1.091e-04
+	   6        -0.386314215328944    3.723e-05
+	   7        -0.386314814120381    1.254e-05
+	   8        -0.386314850537239    4.681e-06
+	   9        -0.386314799397355    1.965e-06
+	  10        -0.386314795701580    6.926e-07
+	  11        -0.386314795436464    2.227e-07
+	  12        -0.386314798804461    7.185e-08
+	  13        -0.386314799705830    2.296e-08
+	  14        -0.386314800243787    6.757e-09
+	  15        -0.386314800329878    2.354e-09
+	  16        -0.386314800342256    1.011e-09
+	  17        -0.386314800334161    4.333e-10
+	  18        -0.386314800332795    1.820e-10
+	  19        -0.386314800333595    7.569e-11
 
 	Largest LIA Amplitudes:
-	          5  14        -0.0081755537
-	          2   7        -0.0070086011
-	          2   4         0.0069941945
-	          6  14        -0.0069135107
-	          2   9        -0.0068936809
-	          2   3        -0.0057514816
-	          1   8        -0.0055703121
-	          6  16         0.0053757485
+	          5  14        -0.0081755532
+	          2   7        -0.0070086010
+	          2   4         0.0069941943
+	          6  14        -0.0069135103
+	          2   9        -0.0068936808
+	          2   3        -0.0057514814
+	          1   8        -0.0055703120
+	          6  16         0.0053757484
 	          1   3         0.0053611524
-	          5  17         0.0051475839
+	          5  17         0.0051475837
 
 	Largest LIjAb Amplitudes:
-	  2   2  15  15        -0.0651684545
-	  2   2  14  15         0.0321208398
-	  2   2  15  14         0.0321208398
-	  1   2  15  15         0.0299871886
-	  2   1  15  15         0.0299871886
-	  1   1  15  15        -0.0299054272
-	  3   3  17  17        -0.0223852894
-	  3   3  15  15        -0.0208672036
-	  1   1   1   1        -0.0208322125
-	  2   2  14  14        -0.0191106855
+	  2   2  15  15        -0.0651684539
+	  2   2  14  15         0.0321208387
+	  2   2  15  14         0.0321208387
+	  1   2  15  15         0.0299871884
+	  2   1  15  15         0.0299871884
+	  1   1  15  15        -0.0299054273
+	  3   3  17  17        -0.0223852888
+	  3   3  15  15        -0.0208672037
+	  1   1   1   1        -0.0208322124
+	  2   2  14  14        -0.0191106845
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.89177805339
-
-*** tstop() called on psinet at Mon May 15 15:34:33 2017
-Module time:
-	user time   =       0.15 seconds =       0.00 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.31 seconds =       0.02 minutes
-	system time =       0.74 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:33 2017
-
+	Overlap <L|e^T> =        0.89177805416
 			**************************
 			*                        *
 			*       ccresponse       *
@@ -640,1525 +653,175 @@ Total time:
 	Local CC         =    No
 
 
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.031889834472336 -0.023590247545076  0.035886092938494  0.337391549003445 -0.230489171708387  0.118250549009017 -0.096738323803454 -0.039671560183731 -0.017417453829651
-    1  (  1) -0.115559689950866 -0.104792776753397  0.247387033439083 -0.112934750234786 -0.158582865358366 -0.232113447678658 -0.480247139929458 -0.012693240726205 -0.113321221450465
-    2  (  2) -0.001131177703134  0.023211512192057  0.030343999116351 -0.117346790992592 -0.046608524859420 -0.060486959905986  0.074531488676303 -0.295475469192925 -0.122604475218833
-    3  (  3)  0.102873669309261  0.075244498837150  0.074367347068194 -0.000375638324722 -0.045758296871777 -0.020335443185058  0.271454123369342  0.176011970959425 -0.750611882783894
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.122947556659096 -0.146970007635756  0.023111743424029  0.020418246285807 -0.062142160948575  0.033255482549981
-    1  (  1)  0.076207579709840  0.192925577520692  0.390086469193835  0.115462079698591  0.197836673375331 -0.137907169648961
-    2  (  2)  0.134390969563588 -0.739254686327757  0.083356064140144  0.116141777662631  0.130510808086193 -0.001880247368517
-    3  (  3) -0.051764093089206  0.135387754341373 -0.415703352371020  0.190964584562673  0.522938232986926  0.150011651631347
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.042351800770033  0.112741680738692  0.014470487647282 -0.277801496926584 -0.385189435070480  0.134005161803845 -0.094379155611825 -0.020287570327628  0.140758439500600
-    1  (  5) -0.196508002077728 -0.014780858316181  0.028613533348628  0.116961168140523 -0.038035850661534  0.390665250154868 -0.463278907259435  0.352765994784243 -0.083583027846786
-    2  (  6)  0.019055458304079  0.247824312911431  0.054496185583040  0.066069201280654  0.118739286724245  0.063124976744210 -0.269457866868641 -0.446911004649514  0.141690470973354
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.002049190521844  0.018587871477028  0.105121590063686 -0.083095581891635 -0.044923327383534
-    1  (  5) -0.420262633593224 -0.134089318231829  0.513153889470778  0.061105931999993 -0.094073822513972
-    2  (  6)  0.353380729793659  0.186026023919396  0.193632728665932  0.115179143357212  0.434468868354740
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.018374399490839  0.416488593986887 -0.155494936834365
-    1  (  1) -0.047368311899160  0.000904478695801  0.015838423501069
-    2  (  2)  0.012225877770952 -0.003811464066523  0.009363085606127
-    3  (  3)  0.381174834177280 -0.034408333237667 -0.006712264462944
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019805821822076  0.046970692298440 -0.012276706190185 -0.380984477985130
-    1  (  5) -0.412939155992870  0.002194461931656  0.004258479838447  0.030533770738735
-    2  (  6)  0.154188085677647 -0.014422732946647 -0.008150645104198  0.004478771817897
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.038950465210408  0.039866103962419  0.115245354720040  0.019880757349447 -0.101323212958542  0.044640126253266 -0.129219338527502  0.020955390039210 -0.007693672741339
-    1  (  1) -0.067773602054647 -0.069283024949896  0.045139676547490  0.092449762069831 -0.063419247150338 -0.006282596580831 -0.492661875976107 -0.179789795112656  0.023646534538890
-    2  (  2)  0.005352314371011 -0.023691171688012  0.168760303436833 -0.035584759327957 -0.098211154887201 -0.052999235803435 -0.267185888610491 -0.067710312606089 -0.133811638261923
-    3  (  3) -0.005028835575224  0.075710576153026  0.130936364707588 -0.013148449648183 -0.082341449946899  0.058281787875764 -0.148402947291289  0.019587692846107  0.265997802208991
-    4  (  4)  0.042953075620737  0.030493487545427  0.117329091588246 -0.053817176197377 -0.040927603944597  0.031345620246767 -0.084728650716813 -0.096010530091888  0.389039208842110
-    5  (  5) -0.147577168335343  0.025728183041877 -0.257869613090358  0.341457170976807  0.032938052439995  0.198776430410242  0.028905583055758 -0.151472913148495  0.076896803027349
-    6  (  6)  0.033968966510016  0.063980358522411  0.416860320865971 -0.162964164077810 -0.210735076964306 -0.174795271465028  0.081522253852315  0.108767294311016 -0.317254235279369
-    7  (  7) -0.041696032362294 -0.119804780003616  0.084367698623615  0.345939032777489 -0.297348524344951  0.115684273678453  0.157252021772075  0.234703179592689 -0.035619581257838
-    8  (  8) -0.096236509574225 -0.089744247655453  0.368376180782391 -0.147020988065185  0.073817404082631  0.134077968971220  0.072728534570006 -0.043556315720552 -0.010655784346597
-    9  (  9)  0.003143315235121  0.093361249518207  0.037863435444635 -0.438671101107247  0.422734146793725 -0.161824914084117 -0.027097474419921  0.004646312280086  0.023963694330478
-   10  ( 10)  0.063765122804891 -0.220080848656726  0.093077513515149 -0.266351828566493  0.049816576758865  0.073960829373608 -0.046357012710617 -0.183568506551021  0.007204953793047
-   11  ( 11) -0.219872786938586 -0.186770594833612  0.640901797018363  0.491983676516504 -0.063681968781172  0.412058888748144 -0.286040569517346 -0.094245081423241 -0.195000390736826
-   12  ( 12) -0.262279768280096  0.707696438447150  0.236718714106780  0.470497637927968  0.331060673088753 -0.597737469031289  0.173380785854979 -0.147387697786165 -0.044689499434261
-   13  ( 13) -0.008835795532905 -0.161415860688302  0.152613021782520 -0.281704813928099  0.459625631240495  0.096864143285054 -0.003153519140079 -0.109240738249078 -0.297347288310574
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.149413062150163  0.067008442584154  0.230363907047496  0.055319406680384  0.032530338298423 -0.068943043267331
-    1  (  1) -0.452149192521174 -0.000162578737685 -0.619971511564934 -0.066650257125370  0.061919053639708  0.084081056043438
-    2  (  2)  0.165489317663304 -0.127973451777841  0.447552906388176  0.305061991533250  0.384464561661781 -0.153275315561868
-    3  (  3) -0.025748260701304  0.486016697888281  0.411385821418048 -0.268874146594607 -0.396024014682121 -0.134171291763426
-    4  (  4) -0.009663093960960 -0.555568390799340  0.304477769378439 -0.081217704163073 -0.578918205858773 -0.101292064810745
-    5  (  5)  0.039175185913195 -0.166448012687766 -0.090139681441233 -0.019287349063250  0.248510643774710 -0.007841008760067
-    6  (  6) -0.086047592172498 -0.153815757637266  0.087940035478902 -0.097280378266502  0.044638073702240  0.047181412845043
-    7  (  7) -0.068735686796040  0.315926660510286  0.100190034017783  0.019688975059735 -0.019468668688484 -0.100670621907944
-    8  (  8)  0.002625726681395 -0.112681642341155 -0.368011821043785 -0.079699064807508 -0.320546285877417  0.355993882573800
-    9  (  9) -0.075057729747018  0.174223000470549 -0.018184022105450  0.008386747763061  0.022693973527319 -0.026587026978415
-   10  ( 10) -0.016901342145260  0.168627021082460 -0.003857305749161 -0.002354503414788 -0.061897957980197 -0.064750074462714
-   11  ( 11)  0.244307011097299  0.045968336616797 -0.036911026756575  0.051829082034064 -0.017536651163216 -0.002615905953443
-   12  ( 12)  0.003873917284711  0.069385416516337 -0.051822467558672  0.043776532172148  0.059978809347506  0.097816286584178
-   13  ( 13)  0.427124414952379  0.150719603419239 -0.021778839992094  0.006415728591880 -0.068010241427207 -0.070097593919817
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.041903329856192  0.070446987089633 -0.004348862670260  0.007003079501354 -0.042701021768788  0.152208197977204 -0.041433363682805  0.041287071942597  0.095743116708860
-    1  ( 15) -0.040650426082046  0.069515483196494  0.023795913068799 -0.076537618226998 -0.032568972577824 -0.025967830490469 -0.063333094204323  0.120545439258051  0.089130494820972
-    2  ( 16) -0.113176179395785 -0.046535614719910 -0.168596109891447 -0.133831005796173 -0.118353163778080  0.257041147370604 -0.414474865889011 -0.082742359298471 -0.367155116899390
-    3  ( 17) -0.018349375617923 -0.090713111977311  0.034093712018598  0.012384834825344  0.052502145904236 -0.343486696016333  0.164974261057850 -0.349385131049026  0.148282635861179
-    4  ( 18)  0.098178568139074  0.063160792106148  0.098378065635209  0.082360458708713  0.040147652473952 -0.031106641199237  0.209540876350175  0.299086324958894 -0.075290632015664
-    5  ( 19) -0.046124091442951  0.007623765782496  0.052346193543973 -0.056344470452290 -0.031632190145320 -0.198051654819200  0.173027351368421 -0.116400515734751 -0.135033433848762
-    6  ( 20)  0.125258904374540  0.493829059239401  0.267757316022715  0.150510471965499  0.082418952577180 -0.029074883870873 -0.082194266117060 -0.155370316095250 -0.076894749422472
-    7  ( 21) -0.022859113931115  0.180693607953724  0.067191017626113 -0.021636428920055  0.098628927025765  0.152535238685033 -0.108677282204199 -0.236476842996923  0.043474790742065
-    8  ( 22)  0.007846177507452 -0.026259809347121  0.131087450927184 -0.264309750556241 -0.389449878217689 -0.077877691250164  0.320396510359928  0.036029491362037  0.011294045928736
-    9  ( 23) -0.148409951194406  0.452946257596570 -0.165039879212225  0.026077898552925  0.007360117453756 -0.037616321096105  0.083049264354487  0.069293544687319 -0.001373481233291
-   10  ( 24) -0.069814067119157  0.002054394750299  0.126443354154776 -0.492431542405090  0.562191735747665  0.169229180172877  0.154296877725072 -0.322409563035094  0.115377045900281
-   11  ( 25) -0.226651470481047  0.617350999313901 -0.448004121314618 -0.411778499546043 -0.303855472735621  0.089854128437872 -0.086765588475993 -0.099221464205896  0.370890559100149
-   12  ( 26) -0.054331750206089  0.066935478840437 -0.304032185963088  0.268162029874351  0.080593616550667  0.019297703310245  0.096620293446142 -0.019137264306005  0.080001854035789
-   13  ( 27) -0.031924461994603 -0.060584366399270 -0.382102774779752  0.393995940746644  0.579313325412582 -0.247998914693769 -0.046380357788513  0.019293958639035  0.320706746040650
-   14  ( 28)  0.067906620182484 -0.083216384461386  0.153437200450035  0.134831736058858  0.101055763194935  0.007868050795063 -0.047806237375160  0.100652051992651 -0.357135809697123
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.004177372366322 -0.063406030244807  0.226823097367039  0.263896415513769  0.011701971027774
-    1  ( 15) -0.093319799498408  0.219967278758902  0.185954874184417 -0.708355904031754  0.160324223389966
-    2  ( 16) -0.039556125331154 -0.094087884995324 -0.643095059540316 -0.237777200414592 -0.155124222296969
-    3  ( 17)  0.442134529381327  0.268012766736270 -0.494385460966639 -0.470730896225858  0.283217803454197
-    4  ( 18) -0.425335538145780 -0.050712365592958  0.065507217070923 -0.331337452084829 -0.461074723403375
-    5  ( 19)  0.162698096167156 -0.073261920681232 -0.410435644212656  0.598344542892450 -0.095525074956441
-    6  ( 20)  0.027635092593548  0.046340546952519  0.285700437916237 -0.173636156485020  0.002143940822347
-    7  ( 21) -0.008238163113748  0.182885492783710  0.094441459467607  0.147424260377310  0.108554639474187
-    8  ( 22) -0.023401664118011 -0.007016046655171  0.194400535766778  0.044245864301010  0.296689970128693
-    9  ( 23)  0.076293063471948  0.017415507342648 -0.241569014205399 -0.003530677667797 -0.425824332982193
-   10  ( 24) -0.181769150588328 -0.169666705113788 -0.044965749792137 -0.069290251681075 -0.150967382108881
-   11  ( 25)  0.018153729708567  0.003519576560560  0.037031521345044  0.051758677298688  0.021630611787891
-   12  ( 26) -0.008082899537472  0.002256936856687 -0.051941569032630 -0.043823365289136 -0.006446621914376
-   13  ( 27) -0.023193966803115  0.061566730434681  0.017525541483092 -0.059863077024435  0.068202811059110
-   14  ( 28)  0.026844987381374  0.064909557534692  0.002683194869776 -0.097668274774952  0.070274371234661
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.022229155184796  0.019683929802812 -0.035292041013174 -0.323293424781682  0.225147178252232 -0.115004523407643  0.099141060334532  0.047575469407300  0.016976450104502
-    1  (  1)  0.127090569254626  0.123237269677512 -0.278422395650133  0.118685424416916  0.176184741653177  0.248988790809479  0.519015610990019  0.012154553055459  0.127798350335596
-    2  (  2)  0.008158213783958 -0.029679191576446 -0.037266849827848  0.110715312970774  0.059214718357965  0.062822080446559 -0.081276448160108  0.324586020412756  0.131224816829759
-    3  (  3) -0.084166098196409 -0.111710240594221 -0.099128613941891  0.014634036431124  0.052476493603890  0.027367672304797 -0.301909798936816 -0.191388056693055  0.790536316410543
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.129910363709357  0.163144685956702 -0.026485892679798 -0.022427536567571  0.063067550057929 -0.033737074439006
-    1  (  1) -0.086592793084052 -0.215472297553996 -0.416640948225414 -0.119951916043925 -0.207797355115153  0.145646111272154
-    2  (  2) -0.146364945461058  0.802840103887928 -0.083436228176863 -0.120990811620140 -0.133581214678389 -0.001202452323342
-    3  (  3)  0.043945078436053 -0.148601276694347  0.437804660682756 -0.201206970148648 -0.547031014916742 -0.155504170965970
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.037502076472662 -0.109335165777524 -0.012926428858581  0.269466726270333  0.379248563249398 -0.141530386330068  0.105411044336663  0.019979530625450 -0.148197571425260
-    1  (  5)  0.208585120229370  0.016639991768198 -0.025672499464384 -0.120166173976538  0.061231886196158 -0.410760689290169  0.504318342034080 -0.368734822068652  0.088923609423586
-    2  (  6) -0.008992532047250 -0.290540208998742 -0.060411739137707 -0.064704199164733 -0.124015323503734 -0.073936634004700  0.287919965087423  0.478723882674066 -0.159979306108318
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002904367944485 -0.019663391538446 -0.115584584455963  0.082318082980502  0.044061111248738
-    1  (  5)  0.445601944090184  0.141387522552248 -0.540419197978555 -0.056783987379620  0.093672186540934
-    2  (  6) -0.375252473148004 -0.198547338183254 -0.207529365108893 -0.114786400140461 -0.453839763908372
-
 	Computing P_X-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.113232240682
-	   1         9.188031241505    2.084e-01
-	   2         9.725533031039    1.009e-01
-	   3         9.746345848483    3.549e-02
-	   4         9.753259465604    1.352e-02
-	   5         9.754574954528    5.183e-03
-	   6         9.755136490216    2.237e-03
-	   7         9.755299368517    9.359e-04
-	   8         9.755216962832    3.810e-04
-	   9         9.755239988344    1.230e-04
-	  10         9.755248467480    4.739e-05
-	  11         9.755240698662    1.271e-05
-	  12         9.755234567963    3.529e-06
-	  13         9.755233400898    8.647e-07
-	  14         9.755233320624    3.251e-07
-	  15         9.755233305228    1.346e-07
-	  16         9.755233271181    5.832e-08
-	  17         9.755233244914    2.265e-08
-	  18         9.755233234696    9.908e-09
-	  19         9.755233235018    3.805e-09
-	  20         9.755233235002    1.084e-09
-	  21         9.755233234922    4.132e-10
-	  22         9.755233234745    1.607e-10
+	   0         8.113232255381
+	   1         9.188031256059    2.084e-01
+	   2         9.725533045157    1.009e-01
+	   3         9.746345862275    3.549e-02
+	   4         9.753259479291    1.352e-02
+	   5         9.754574968153    5.183e-03
+	   6         9.755136503824    2.237e-03
+	   7         9.755299382114    9.359e-04
+	   8         9.755216976431    3.810e-04
+	   9         9.755240001943    1.230e-04
+	  10         9.755248481078    4.739e-05
+	  11         9.755240712260    1.271e-05
+	  12         9.755234581562    3.529e-06
+	  13         9.755233414497    8.647e-07
+	  14         9.755233334223    3.251e-07
+	  15         9.755233318826    1.346e-07
+	  16         9.755233284779    5.832e-08
+	  17         9.755233258513    2.265e-08
+	  18         9.755233248294    9.908e-09
+	  19         9.755233248617    3.805e-09
+	  20         9.755233248601    1.084e-09
+	  21         9.755233248521    4.132e-10
+	  22         9.755233248343    1.607e-10
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 5.843e-11
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016009260748017  0.076567442214896 -0.125166328875802  0.007592491786253 -0.098480428135412 -0.089737912259519 -0.045486487849709  0.143199899460591  0.062916360524591
-    1  (  1) -0.038605185454593  0.325735593943764 -0.218009839696040  0.077381067334654  0.123187634769419  0.048889388601736 -0.262562813593255  0.048309424265131 -0.024346564570397
-    2  (  2) -0.014979357855892  0.182689410654369 -0.081658179778794  0.065473944506505  0.193719600231606  0.090995730111074 -0.143671186830441  0.007595230816929 -0.060244510498059
-    3  (  3) -0.067326890443488 -0.014019515203484  0.166079081195192 -0.050483560257990 -0.175920280282569 -0.180597777465204 -0.198820897294047 -0.109379576724081 -0.213777271147620
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159507026073975 -0.056302017965781  0.034397376897140 -0.068360328302061  0.100741673999881 -0.049850169389160
-    1  (  1) -0.121516035123580 -0.004562687000240  0.189568378403116  0.051932937377753 -0.189148856797612  0.205130706545356
-    2  (  2)  0.013364994269954 -0.072899210778933  0.147744909867102 -0.343128869068584  0.052918402885218  0.086660614771912
-    3  (  3)  0.064044282976220 -0.072658467037946  0.366494615509597  0.156516672080101  0.183833699925440 -0.043558655165224
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095334256028009 -0.133297788110144  0.233197415167998 -0.109601891242184 -0.034275483482361 -0.001203276521899 -0.083637993138604 -0.006960579869910 -0.188458856324837
-    1  (  5)  0.132031102549102 -0.218523085575864 -0.122630941119498 -0.145558608560396  0.033193771816160 -0.142560374903523 -0.001867880595405  0.178023294306114 -0.083084371409555
-    2  (  6)  0.307498011816596 -0.248791194429673 -0.171772234113843 -0.290615300494965  0.046349417939456 -0.102374827834141 -0.404689139483050 -0.035662684698487 -0.067098771977202
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011309857021213  0.047826432296259  0.011715243517174 -0.012087997768714  0.055738114510750
-    1  (  5) -0.060288763132101 -0.100230270339149 -0.175888842059756 -0.033113626293054 -0.296260944515875
-    2  (  6)  0.156436504590612 -0.054087388641550  0.405606872407349 -0.026699931968424 -0.143365753445289
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.021022954159736 -0.035142529018952 -0.107426415156770
-    1  (  1)  0.299993715747734 -0.100035165443054 -0.265269960401394
-    2  (  2)  0.260050498379079  0.124418562014598  0.440142593096703
-    3  (  3)  0.064425483075145 -0.021009721425282 -0.051333955965002
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019464542579225 -0.300930139088225 -0.262387611320763 -0.064713939337572
-    1  (  5)  0.034890763742270  0.099221858485008 -0.125525760672816  0.023652429329881
-    2  (  6)  0.106312135129399  0.261746631642973 -0.441788978603034  0.052491092120842
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.143156293779769  0.065598528855299 -0.058339068026871  0.095240471065162 -0.054936782763489 -0.158698528722424  0.005848694187148 -0.046188395629077  0.009225054657648
-    1  (  1)  0.090550568038988  0.201824271395705 -0.091142881495912 -0.093661370668859  0.161043059103147  0.077741533393123 -0.543233062251592  0.814467132908124 -0.067293744881760
-    2  (  2) -0.021713915694858  0.356864777307433 -0.273330805205094  0.263660970827611  0.358937742043094 -0.204650254826784 -0.313132956505956  0.064395695030077 -0.200390318671649
-    3  (  3) -0.101095906237726 -0.248350727445422  0.325477886952403 -0.022461371735421  0.220401580692866  0.053345914506007  0.023674029203873  0.049357473765327 -0.000470604618644
-    4  (  4)  0.053513495604287  0.177341679973179 -0.223511424991143 -0.043203647152663 -0.200439262362192 -0.109704630170554 -0.130967856844601  0.223696627843727  0.051893869816232
-    5  (  5)  0.218677797229873 -0.312515161252956  0.301873753556228 -0.119144839450133 -0.273881128961801 -0.291385277900658  0.214361739830069  0.197002465061645  0.071567227017470
-    6  (  6)  0.085282711177633 -0.152031995719920  0.395807072999312 -0.020599784121374 -0.230274381395846 -0.119204882075906  0.196967452454600  0.233009490057915 -0.074120843143850
-    7  (  7)  0.047734330576263  0.280574479547352 -0.366542906373812  0.110968913790478 -0.088449186452659  0.149744690480443  0.036915836576634 -0.394085559356064 -0.043430167100304
-    8  (  8)  0.213441732464272  0.108274495972316 -0.634437106058845 -0.069187196826565 -0.037919304236964 -0.161411654384539  0.081574595848630 -0.216961478694419  0.039208476463161
-    9  (  9) -0.053318703860192  0.090838807258297  0.086586369793027 -0.028327523211035  0.134553886805994 -0.073546423533118 -0.007047260326121 -0.447864900958376 -0.046310440012370
-   10  ( 10)  0.217342853211265 -0.434342746087742 -0.408844907117118 -0.321259899576754 -0.034276585378345  0.320138521202174 -0.023800296590577  0.279258907554493  0.028679862426656
-   11  ( 11) -0.043839064779065 -0.078964296226844  0.267354222620337 -0.331608707925144  0.435766271345975  0.066306681540143  0.247977502270279 -0.002757326539735 -0.128220536878281
-   12  ( 12)  0.056967765282221 -0.011496620916620 -0.132088307172842 -0.097918437653651 -0.064500672945760  0.001827098937393 -0.216796993378831  0.142477110991476 -0.129430197478051
-   13  ( 13)  0.037733039841652  0.226167830269728 -0.091049164317861 -0.252259768566517 -0.015512763459721 -0.284728528128491  0.105582553814486 -0.004845390965161  0.367721806594329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222313487267139 -0.016040998159682  0.082409874320982  0.002075539850870 -0.060366346946182  0.093408303465405
-    1  (  1)  0.558686428143613 -0.124842930483593 -0.159094597945824  0.170661450539848  0.081512715884899 -0.084548811099098
-    2  (  2) -0.171589661035630 -0.032363732574493  0.410356885754263 -0.223617160453788 -0.075311055642080  0.314379038887409
-    3  (  3) -0.113936852615240 -0.023263060013616 -0.282024826692995  0.174390257283436 -0.284646591950349 -0.036134249694962
-    4  (  4)  0.007238439897924 -0.039483311713766 -0.327400920910445 -0.428741395271426 -0.081911463055166  0.119323501144252
-    5  (  5) -0.007206698114830 -0.054871846748801  0.118753815309300  0.018469351897211 -0.153374179308602 -0.075608926558101
-    6  (  6) -0.092372497620457 -0.334623338930078 -0.214791656963667 -0.112964261573848 -0.018239773729085 -0.100594142805454
-    7  (  7)  0.151928519059447  0.104975965782044 -0.079311543670646  0.028608318007851 -0.093200761310883  0.234496518387966
-    8  (  8) -0.034328207301673  0.223808481631680  0.061242559094949 -0.498103653582096  0.749098707942318 -0.381141257037236
-    9  (  9) -0.119302126498580  0.308066314141465  0.075395221655780  0.759042960378927 -0.290000840041876  0.156436862917181
-   10  ( 10)  0.438316650507883  0.163958878572088 -0.419969142321592  0.045404841057508 -0.044939660158532 -0.568953527573990
-   11  ( 11) -0.012787507164606  0.354874435093949  0.016715712863870  0.314729329115790 -0.109367027564034 -0.038956857759457
-   12  ( 12)  0.278784619045113 -0.047236021517055  0.203283234646730  0.096945848185628  0.275889526129666 -0.187110942781753
-   13  ( 13) -0.588325776498883  0.141777398655530  0.127445383199618 -0.417479630696627  0.223570495101464  0.209733888357992
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.139188612693568 -0.095183099515076  0.018684491477480  0.097422162623446 -0.052864868482975 -0.221122027331105 -0.088706173679123 -0.046138783672279 -0.215068969553880
-    1  ( 15) -0.062949654944158 -0.202402030263201 -0.354633955608115  0.248176570557555 -0.178122375116496  0.312771607112475  0.152477622828494 -0.279557727250808 -0.106814721163754
-    2  ( 16)  0.053746164934604  0.094053172516910  0.275496238616186 -0.323601647464255  0.223358052203497 -0.300642069951494 -0.393858290336507  0.365390717289338  0.632984591272781
-    3  ( 17) -0.094021410291053  0.093446956362787 -0.262411805474378  0.022323156021381  0.042743443130518  0.119643171496185  0.019212092155216 -0.111729948135909  0.069344517807286
-    4  ( 18)  0.056361407951715 -0.163012412779377 -0.357847040556453 -0.219749386366483  0.199619718061283  0.273157948729405  0.231158276251819  0.090626116159486  0.037799150902146
-    5  ( 19)  0.160601962218735 -0.080044732518404  0.203861835009410 -0.053968884194125  0.109680630973887  0.290493189386329  0.118089200507037 -0.148837371744261  0.161317719017176
-    6  ( 20) -0.008652189032826  0.543672739191643  0.312260746368354 -0.021747391276478  0.131147878369811 -0.214266804924841 -0.195294510221963 -0.037324155238128 -0.082720193718919
-    7  ( 21)  0.047043957125951 -0.814756484486684 -0.065190092636916 -0.048606045400368 -0.224060646841072 -0.197248282512201 -0.232144218543584  0.394908869566567  0.217734911422747
-    8  ( 22) -0.009402914133539  0.067052868071270  0.200249024215418  0.001535377445924 -0.051944723647720 -0.071384974303961  0.075222552542562  0.043268063312178 -0.039055784643578
-    9  ( 23)  0.222713322415783 -0.560469323042930  0.171950144039822  0.112172774497996 -0.007083782785909  0.006435272424486  0.090200197520766 -0.151801615119284  0.031995099170652
-   10  ( 24)  0.015969660808332  0.124160280352778  0.031945357169913  0.022574658439251  0.040253136475423  0.054701591947166  0.334874112350668 -0.105285662958809 -0.223928209457468
-   11  ( 25) -0.081168660495960  0.159983923907575 -0.408650744438646  0.280675358230412  0.326885231204144 -0.118534279418464  0.213700195384120  0.079763618019830 -0.060689421297523
-   12  ( 26) -0.003652731302177 -0.169351937988896  0.223186850703667 -0.177435884273904  0.431821641248852 -0.017470249474556  0.113426087502892 -0.031984799215361  0.498979784707156
-   13  ( 27)  0.059460007596700 -0.080535877567365  0.075179690138888  0.285729932961758  0.080576308673493  0.153138615960011  0.017506919748356  0.094018188463908 -0.750480875221691
-   14  ( 28) -0.091778712898573  0.083756184222668 -0.314061943377694  0.035359431345057 -0.119047398405395  0.075525757634597  0.100522537659024 -0.234167701630633  0.382415314141466
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054192115098489 -0.218772067545687  0.045642231806083 -0.057541502908124 -0.042026312169826
-    1  ( 15) -0.090589594220003  0.434594274447356  0.078276612217069  0.011552267330405 -0.225173895359454
-    2  ( 16) -0.087809314060775  0.409613431079942 -0.269441429063588  0.132294826475095  0.092807551910873
-    3  ( 17)  0.029496711967634  0.321890318472494  0.333949687981794  0.098006508583727  0.253968229243978
-    4  ( 18) -0.133856062539151  0.034112562139975 -0.437342385549595  0.064344113622612  0.014887157054416
-    5  ( 19)  0.074762453522294 -0.320522646445325 -0.065103712350275 -0.002026903619864  0.283693559601974
-    6  ( 20)  0.006545565411461  0.024114390996231 -0.248934516268112  0.216845871250478 -0.105404222827927
-    7  ( 21)  0.447834620578749 -0.279310199694516  0.002046231690190 -0.142438484210793  0.004552777078072
-    8  ( 22)  0.046132212945001 -0.028293172679903  0.127980948576613  0.129504871571094 -0.367038613276140
-    9  ( 23)  0.119912706409769 -0.438601556174488  0.013921175995500 -0.279073471993608  0.587144581639703
-   10  ( 24) -0.308677963206646 -0.164180974317535 -0.355112983785913  0.047146799420307 -0.142329570216595
-   11  ( 25) -0.075357514307532  0.419786206774900 -0.016983461358500 -0.203268341742445 -0.127372692691209
-   12  ( 26) -0.762257766627436 -0.045741941689100 -0.314841853754996 -0.096926452085088  0.417500846668484
-   13  ( 27)  0.290827635505768  0.045087590967332  0.109301341928646 -0.275850981479361 -0.223796991125890
-   14  ( 28) -0.156281997482093  0.568696982960467  0.039100360028362  0.187067134074575 -0.209842829958128
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.008545475107476 -0.071680877089206  0.120459476636913 -0.008371471662446  0.090424858216027  0.087190000124570  0.049119105543224 -0.145928530657214 -0.062376143421355
-    1  (  1)  0.044572181787493 -0.342772635368155  0.233569654941350 -0.080704995470875 -0.127360357635352 -0.050248913608748  0.272733324148390 -0.042278800375679  0.013710430281526
-    2  (  2)  0.007154597183575 -0.182635894723101  0.088652103396483 -0.063130413574038 -0.192109998380945 -0.097062796293933  0.154759017819859 -0.027524119345809  0.057504913844805
-    3  (  3)  0.077052275000893  0.016814177051793 -0.184635905961744  0.049413266051267  0.188745223686842  0.186563337985988  0.210232732381490  0.116951639594811  0.221961452093225
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163872566981873  0.058478850756530 -0.036608142215322  0.074980328212796 -0.102514306635711  0.049419294250537
-    1  (  1)  0.131779111368958  0.004610196247654 -0.196879673097414 -0.065560333989646  0.202294566496281 -0.212677679948666
-    2  (  2) -0.021560095269691  0.083223144658810 -0.151678626872472  0.372667885980926 -0.062527480001262 -0.084301072064405
-    3  (  3) -0.068590860983671  0.076978943427677 -0.378848573533368 -0.165187920801172 -0.188975469384157  0.045051968107620
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.086725030779380  0.140001038265324 -0.215201398518350  0.106476373516199  0.037203797104343 -0.002684965595124  0.084210079065148  0.008500639419888  0.198745218470751
-    1  (  5) -0.141020111205039  0.238503069490028  0.123978991148198  0.150112816633559 -0.036264937723074  0.146138191093449 -0.002600464782236 -0.189526092315718  0.090546937772816
-    2  (  6) -0.314591250772654  0.266642343404836  0.168172023759533  0.305975417776500 -0.047767848718246  0.093136048513418  0.423942737612318  0.027493034904141  0.068648706999971
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.012967316151690 -0.053655915263561 -0.013296231482133  0.012509871140561 -0.053184722817966
-    1  (  5)  0.065459441432743  0.098590450512903  0.180288063245052  0.033076485246495  0.305944394837877
-    2  (  6) -0.160972461596512  0.052337284313257 -0.418780783100688  0.024563105423132  0.150128272333000
 
 	Computing L_X-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.511998361182
-	   1         5.673594864730    3.043e-01
-	   2         6.772311551052    1.786e-01
-	   3         6.818777703920    4.474e-02
-	   4         6.849742250351    1.874e-02
-	   5         6.851420720274    6.464e-03
-	   6         6.852208982445    3.085e-03
-	   7         6.852887439391    1.276e-03
-	   8         6.852760917874    5.099e-04
-	   9         6.852764894282    1.573e-04
-	  10         6.852768189672    5.372e-05
-	  11         6.852780117334    1.674e-05
-	  12         6.852780893288    6.073e-06
-	  13         6.852779614171    2.011e-06
-	  14         6.852779255351    7.213e-07
-	  15         6.852779099800    2.677e-07
-	  16         6.852779009296    1.039e-07
-	  17         6.852778938464    4.366e-08
-	  18         6.852778895744    1.948e-08
-	  19         6.852778887955    8.479e-09
-	  20         6.852778887417    3.996e-09
-	  21         6.852778888838    1.448e-09
-	  22         6.852778889234    5.343e-10
-	  23         6.852778889371    1.690e-10
+	   0         4.511998334770
+	   1         5.673594832034    3.043e-01
+	   2         6.772311509360    1.786e-01
+	   3         6.818777660815    4.474e-02
+	   4         6.849742206524    1.874e-02
+	   5         6.851420676259    6.464e-03
+	   6         6.852208938363    3.085e-03
+	   7         6.852887395272    1.276e-03
+	   8         6.852760873758    5.099e-04
+	   9         6.852764850168    1.573e-04
+	  10         6.852768145558    5.372e-05
+	  11         6.852780073219    1.674e-05
+	  12         6.852780849173    6.073e-06
+	  13         6.852779570057    2.011e-06
+	  14         6.852779211237    7.213e-07
+	  15         6.852779055686    2.677e-07
+	  16         6.852778965181    1.039e-07
+	  17         6.852778894349    4.366e-08
+	  18         6.852778851630    1.948e-08
+	  19         6.852778843841    8.479e-09
+	  20         6.852778843303    3.996e-09
+	  21         6.852778844724    1.448e-09
+	  22         6.852778845120    5.343e-10
+	  23         6.852778845256    1.690e-10
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 5.897e-11
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.060866725217215 -0.013869365716153  0.033894329784820  0.159389025617799  0.069390363085127 -0.262340609354303  0.067580095774763 -0.154103692822594  0.003154741180611
-    1  (  1)  0.233600860111356 -0.255443445273365 -0.070349772560976  0.002398009474053 -0.207738516934078 -0.107364483788669  0.128967864654634 -0.344368536680876  0.051213828740165
-    2  (  2) -0.320680073963752  0.499671518707847 -0.050574975509019 -0.147836128166420 -0.165479289930263  0.195838444506077 -0.035661712710790 -0.024470880763902 -0.075637541705411
-    3  (  3)  0.005421312030017 -0.086163397462206  0.087803119789529 -0.068180639639745  0.069970423577407 -0.155270176021826 -0.200857781343900  0.346742235116956  0.007432799783430
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031710204280855  0.011526541432890 -0.002976967089787  0.046060023193635  0.015318540884103  0.025207945945630
-    1  (  1) -0.042201291846948  0.011691902650686 -0.030342861979388  0.426260656604152 -0.267501393083778 -0.156199494500064
-    2  (  2) -0.105775984380200  0.124345432018223  0.012422860710314  0.254942186016171  0.141450345930572  0.594200168007018
-    3  (  3) -0.128190105083420  0.839978623039109  0.103083070851949  0.085126863174017 -0.034147172701768 -0.125845625439850
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.009655463605755  0.014837891728381 -0.030023518715064  0.453895242430490 -0.367783958834954 -0.001154952584878 -0.011095021636640  0.081922945493181 -0.106667436086225
-    1  (  5)  0.023315601126616 -0.114914590458087 -0.095889100679515  0.148408787561426  0.132591987973289  0.239441228065666  0.119891964360871 -0.197513600772232 -0.042785498899110
-    2  (  6)  0.044714484508884 -0.227037104077391 -0.243035253957641  0.057000070112492 -0.133863510185386  0.464640228230982  0.241815314958168 -0.250347946170699 -0.035567936134789
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.031225116244914  0.082892463758822 -0.008302957992736  0.084651532871555  0.076096297616606
-    1  (  5)  0.029094974835733 -0.031099102771742 -0.014865102267058  0.594144277291270 -0.111092561014338
-    2  (  6) -0.081030380750229  0.586465397694647  0.039125073332182 -0.210425560392843 -0.141728395903252
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.279550720476077  0.042202209735457  0.032616542291842
-    1  (  1)  0.188418637032763 -0.038238156575108 -0.176016679949417
-    2  (  2) -0.431618249575807  0.006066663258097 -0.050669745816719
-    3  (  3)  0.023823866701763 -0.194483208506600  0.036291334339584
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.276296231465594 -0.182684867311170  0.425780067610230 -0.021944883020485
-    1  (  5) -0.040904620230163  0.037124497156135 -0.000756874278417  0.193551621281851
-    2  (  6) -0.032612764478737  0.173214965518422  0.056257078994710 -0.032928243740138
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.064329222595920 -0.203089813678901 -0.060855379318360  0.045435578919151  0.038213040289734 -0.173918816066670  0.086597065761990 -0.088257727308079  0.042534449699908
-    1  (  1)  0.115560364126478 -0.109115953630201 -0.018643611831367 -0.061273729840918 -0.223462209948640 -0.111849786008387  0.082478525732492 -0.548790728777664 -0.099502382826804
-    2  (  2)  0.050280791567554 -0.042231736423558 -0.026516724550904 -0.035763580727561 -0.045242506762065  0.028791481906196  0.032080377274548 -0.393629321941294 -0.043590423594673
-    3  (  3)  0.027100682075659 -0.177196743119415 -0.360081085823777 -0.088267299794322  0.030083312860564  0.189916614239830 -0.016925829834322 -0.152132597277128 -0.199271802311320
-    4  (  4)  0.027032407915338  0.122816257943915  0.195859296476474  0.024440446904345 -0.000039632917188 -0.224837371747381  0.105878500705155 -0.149344729427051  0.220653682748276
-    5  (  5) -0.082124893882501  0.131610239391223 -0.172288241722190  0.172656004937721  0.186007370790890 -0.002386795157151  0.000883813901201 -0.015624959650018  0.120434685552584
-    6  (  6) -0.025918430251412  0.066213876287375 -0.159653356345571  0.138629355858437  0.114503563489713  0.052610164659059 -0.032724879295725  0.016321111589815  0.131203443877323
-    7  (  7) -0.031968463140566  0.359436078267880  0.239880075530440 -0.043941245996148  0.003566470797935 -0.121878346236622 -0.025216884092681  0.317033593343712 -0.204690345792582
-    8  (  8)  0.147136177075282 -0.147831155131360 -0.317027072645310 -0.094690347387101 -0.042376714203220  0.036223188856298 -0.061267998203209  0.078763236261723  0.025079679518920
-    9  (  9) -0.347335081804882  1.076651679527280  0.076631791966040  0.520228799901951  0.177614233521961 -0.752433601064110  0.098237100331302 -0.075609380299166 -0.029456370268690
-   10  ( 10) -0.226576210232703 -0.047966592312158  0.713544303894390 -0.117838109418108  0.538138175848963  0.110268365719488 -0.097090433542407  0.016639982577840 -0.202838989293283
-   11  ( 11) -0.013618237324107  0.042488040839621 -0.012305458432129 -0.002937365049260  0.051397702056966 -0.032793240631487  0.126424524316302 -0.018011286422360 -0.036334038133226
-   12  ( 12) -0.125114748700956 -0.150723454222537  0.252706221972763  0.731410520517111 -0.348252142829817  0.473299198843163  0.017472369731921  0.121992291563425 -0.064459445411663
-   13  ( 13)  0.081025878360433 -0.099169125996407 -0.096265824091433 -0.243412138793566 -0.157793004324879  0.232678786079147 -0.038715292983050  0.196706528651456  0.103460906909678
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.038639019968560 -0.081398838675921 -0.020974057309157  0.195126170432547 -0.136178596332978 -0.093793458598120
-    1  (  1)  0.192322326072867  0.434066427801228  0.033306653053185 -0.455360646532796  0.170900871888595 -0.012160177810098
-    2  (  2) -0.116655928700969  0.223206132473869 -0.015149664847910  0.750955420456732 -0.241651279575312  0.125278854183387
-    3  (  3)  0.037416152824649 -0.474871182487040 -0.095127781154357 -0.001912744200640 -0.218016361604134 -0.501866870283028
-    4  (  4)  0.093049020347900 -0.452195861353997 -0.097729965141961 -0.023670097100218  0.227089450225467  0.622604645621845
-    5  (  5)  0.095982951322369  0.025076643469587  0.083513090675399  0.093177906171499  0.163570537374778  0.411952379972310
-    6  (  6)  0.006971397366507  0.099975304872894 -0.089355028753419  0.082421061832647  0.109391578906264  0.177019076161536
-    7  (  7) -0.111482230592694 -0.119338627354550 -0.049072785699030 -0.135589681135474 -0.179997637886863 -0.225361657151226
-    8  (  8) -0.038036906175422  0.107593330918854  0.085211578523939 -0.251522137496260  0.415712152156179  0.133150454203045
-    9  (  9)  0.014149847264143 -0.014713228385967  0.003726551384159  0.024984081757333 -0.450053383369121 -0.804137197420648
-   10  ( 10)  0.262196667989143  0.030987669321987 -0.048528847001581 -0.326796645773778 -0.027460917972608 -0.213395133473708
-   11  ( 11)  0.037859730907863  0.067315614399965 -0.006033855211911  0.002081527339975  0.021566579415084 -0.043117037710347
-   12  ( 12)  0.214673577185777 -0.277038178296912  0.018443935481622 -0.031394459169126 -0.040697755419603 -0.037299553750268
-   13  ( 13) -0.293378255962317 -0.067739265985308  0.042216271726718  0.084600602041646  0.093366414785478  0.184919834112459
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.065579026427298 -0.118385281199840 -0.054417309773849 -0.028209393258605 -0.023855315776195  0.089481193550780  0.030082936540202  0.024881663706482 -0.145536117267929
-    1  ( 15)  0.203177895336562  0.108867238168314  0.044106918987014  0.183348816265157 -0.128730595279853 -0.134393743071560 -0.068034842363188 -0.353605430814672  0.144787054112687
-    2  ( 16)  0.059845833352457  0.020943033819428  0.028043633600698  0.360379351132063 -0.196224502327520  0.168965679426491  0.157686501214302 -0.238008876623444  0.316659608324193
-    3  ( 17) -0.045186255659105  0.061530291702097  0.034434066086584  0.088647496947582 -0.026282078792551 -0.172786891133660 -0.138287078850789  0.044103989261245  0.095122362978667
-    4  ( 18) -0.040062693221020  0.224606431868167  0.044510085277536 -0.028376706423002  0.000349345016747 -0.185972360522578 -0.114555914481331 -0.004506308196336  0.041018032849448
-    5  ( 19)  0.173210931444010  0.109857051233105 -0.028983625579256 -0.187756427423432  0.223643228642709  0.004090524106486 -0.051487512077316  0.121894819352182 -0.037656019931592
-    6  ( 20) -0.085313471751143 -0.082913275223549 -0.032277368285025  0.016777520509378 -0.105131359190815 -0.001944705429570  0.032875162874827  0.025732176012468  0.062579089976849
-    7  ( 21)  0.084545461298169  0.550907022405358  0.394733809745031  0.152212200092244  0.149602224208011  0.015559620185539 -0.017471440322135 -0.317632843442532 -0.081500770726977
-    8  ( 22) -0.042592304559205  0.100130074049971  0.043823098391038  0.199074070348154 -0.220614689373917 -0.121240505787734 -0.131566193321307  0.204777301446740 -0.024659128193111
-    9  ( 23)  0.038243209345809 -0.193731116803758  0.114571318389048 -0.035004741203238 -0.093870122022257 -0.093321089072005 -0.005098160430595  0.109514276861021  0.037449030782536
-   10  ( 24)  0.080611973441424 -0.431286815750366 -0.220674640182480  0.473291196073188  0.451373239023609 -0.023941120635386 -0.102282761545205  0.118683941595292 -0.109001254632288
-   11  ( 25)  0.020616437944253 -0.032806186227235  0.015536997280191  0.094946997217811  0.097687630516726 -0.083601240444185  0.088958677720268  0.049109842148345 -0.085549382706087
-   12  ( 26) -0.191260790058678  0.454455308246703 -0.749344104582772  0.000707785692927  0.023013062709295 -0.093408274808716 -0.083112755629054  0.137052732289414  0.253713944370040
-   13  ( 27)  0.135080067323690 -0.170977966348525  0.241626969335339  0.220294823738596 -0.228806715319375 -0.163956724293068 -0.109654396643640  0.181513709124625 -0.417706190063538
-   14  ( 28)  0.095355381240353  0.010487455238559 -0.123878379042330  0.506641747659321 -0.627627416886014 -0.413206867808258 -0.177986562206826  0.230596660977991 -0.135371993382099
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.343722354187842  0.231012307989939  0.013807799785149  0.129389520371901 -0.083476842933347
-    1  ( 15) -1.071757290590545  0.047500726309983 -0.042558977896784  0.150713322712323  0.100049386852298
-    2  ( 16) -0.076574555259838 -0.716811431044374  0.012053549717062 -0.252652945738414  0.097563356479072
-    3  ( 17) -0.521659456544164  0.119962089033513  0.003140019395332 -0.735502177464538  0.243874710004522
-    4  ( 18) -0.178111787275392 -0.539331111074153 -0.051602620031584  0.351369555964665  0.157776134348173
-    5  ( 19)  0.754028750268460 -0.108050332429524  0.032942772306297 -0.473084779433613 -0.233288261808526
-    6  ( 20) -0.098339349809287  0.095672012585071 -0.126453856435504 -0.016749320041424  0.038981069794775
-    7  ( 21)  0.075922415669002 -0.017338504286034  0.017821543323394 -0.121086080034894 -0.196694365560314
-    8  ( 22)  0.028707803808862  0.202101700693747  0.036280352248806  0.064076056309411 -0.102966425702512
-    9  ( 23) -0.015071264129229 -0.259603898636005 -0.037748702712212 -0.213449614969685  0.292741791249862
-   10  ( 24)  0.014441233365834 -0.031025326150192 -0.067581337213048  0.278218894918250  0.067639252890435
-   11  ( 25) -0.003655596016122  0.048301023976308  0.005987297290884 -0.018296972769386 -0.042182106266812
-   12  ( 26) -0.024290247830266  0.326430116080930 -0.002078223011543  0.031357186170846 -0.084451014704488
-   13  ( 27)  0.452065991443206  0.027871674423728 -0.021552868138498  0.040817220436517 -0.093503875768977
-   14  ( 28)  0.809538434042480  0.214197129891733  0.043194453416851  0.037242456347955 -0.184930829970208
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.066956274028954  0.044342976073165 -0.030268247936242 -0.149450540981950 -0.061066821271185  0.252770775339693 -0.067874222510686  0.158386767820771 -0.005381383883310
-    1  (  1) -0.238859813029081  0.286692386304328  0.066590681714602 -0.004012726688607  0.213066888677072  0.109131374118362 -0.135898330150995  0.364942966429774 -0.055660597243453
-    2  (  2)  0.359516386393285 -0.583008964100427  0.054707529711990  0.139557599023379  0.158230706301634 -0.196109522672398  0.038444807843767  0.030895199145175  0.086353045406069
-    3  (  3) -0.011142763994871  0.102467038295486 -0.096192280460040  0.086579830772614 -0.079151964917630  0.163781954562347  0.215517306973471 -0.369533969127049 -0.009330018051360
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.034197603653202 -0.011654401867379  0.002838793667518 -0.051120718575847 -0.018314210992950 -0.032583546094419
-    1  (  1)  0.044852295322472 -0.010374877421340  0.032495546570244 -0.442259071390682  0.284002451396915  0.172324881222561
-    2  (  2)  0.118470854957857 -0.130986078141729 -0.014085982845085 -0.260463332299674 -0.162310705486348 -0.635865895852574
-    3  (  3)  0.132535934596107 -0.876049792586578 -0.107203693425820 -0.087990410067908  0.037792879731323  0.134504535673653
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.032839390128313 -0.018959934247026  0.027098455785061 -0.458861483846452  0.368889100803161 -0.013730600662295  0.005961739971281 -0.088172859302616  0.109822626668940
-    1  (  5) -0.022776770324681  0.118542960649480  0.106023383328719 -0.155646887463115 -0.124038116346952 -0.247202807741244 -0.126320423057856  0.208868231513720  0.046770852934184
-    2  (  6) -0.048648484948535  0.245637911332038  0.270704645644036 -0.074067208651774  0.147538325129154 -0.486126744284417 -0.252803143713327  0.267246124084927  0.039768993904487
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.034234873438637 -0.088611347550410  0.008537759532833 -0.090451182938239 -0.075365836152160
-    1  (  5) -0.023972088194502  0.031376657235205  0.015685502279103 -0.611834232098808  0.112755958009069
-    2  (  6)  0.089906734942719 -0.607632221899844 -0.040204918187789  0.215818595847042  0.145730338373175
 
 	Computing P_Y-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.239967633919
-	   1         9.701088796240    2.775e-01
-	   2        10.647889089765    1.368e-01
-	   3        10.682723715047    3.193e-02
-	   4        10.692343022352    1.430e-02
-	   5        10.693776198743    3.679e-03
-	   6        10.693763393303    1.218e-03
-	   7        10.693954213345    3.738e-04
-	   8        10.693933910946    1.544e-04
-	   9        10.693912079071    7.834e-05
-	  10        10.693920339358    3.646e-05
-	  11        10.693926408299    1.254e-05
-	  12        10.693928204279    3.773e-06
-	  13        10.693926466901    1.302e-06
-	  14        10.693925922299    5.266e-07
-	  15        10.693925747070    1.782e-07
-	  16        10.693925759659    6.191e-08
-	  17        10.693925744089    2.377e-08
-	  18        10.693925739055    8.886e-09
-	  19        10.693925739070    3.336e-09
-	  20        10.693925739707    1.411e-09
-	  21        10.693925739659    7.910e-10
-	  22        10.693925739559    2.988e-10
+	   0         8.239967643344
+	   1         9.701088808520    2.775e-01
+	   2        10.647889101928    1.368e-01
+	   3        10.682723725945    3.193e-02
+	   4        10.692343033109    1.430e-02
+	   5        10.693776209441    3.679e-03
+	   6        10.693763404004    1.218e-03
+	   7        10.693954224038    3.738e-04
+	   8        10.693933921639    1.544e-04
+	   9        10.693912089765    7.834e-05
+	  10        10.693920350051    3.646e-05
+	  11        10.693926418992    1.254e-05
+	  12        10.693928214972    3.773e-06
+	  13        10.693926477594    1.302e-06
+	  14        10.693925932992    5.266e-07
+	  15        10.693925757763    1.782e-07
+	  16        10.693925770352    6.191e-08
+	  17        10.693925754782    2.377e-08
+	  18        10.693925749748    8.886e-09
+	  19        10.693925749763    3.336e-09
+	  20        10.693925750400    1.411e-09
+	  21        10.693925750352    7.910e-10
+	  22        10.693925750252    2.988e-10
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 8.392e-11
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002961765779100 -0.004522349171324  0.004971919287087 -0.008281709260186 -0.002230370021123 -0.014875581701851 -0.067042001167372 -0.013799182049252  0.003919895633432
-    1  (  1) -0.001156407591826 -0.011364234036016 -0.009216213637618  0.026466586550273 -0.045020897276730 -0.024548396390040 -0.151472003391729 -0.022837501049660  0.020115222648640
-    2  (  2)  0.011852353144693  0.003988649312187 -0.013577386237941  0.005526396491599 -0.001842043686662  0.004979012487137  0.016339527495633  0.010418266838825  0.006987142315452
-    3  (  3)  0.053414909238326  0.048153357581206 -0.085702791986601  0.002590768785420  0.032944657214652  0.019536458989955  0.058299722995214 -0.003474387569511  0.035804252701834
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.000158467148596  0.005351238219208  0.000795318433066  0.002864683250639 -0.001069112713473  0.000329369508724
-    1  (  1) -0.008857574490791 -0.013536712170937 -0.030733233064254 -0.004374373678073  0.001058558277179 -0.003465102179278
-    2  (  2) -0.011600433240152  0.024957487742010 -0.006847708052902  0.007864294541740 -0.004416463366055 -0.003633653136444
-    3  (  3) -0.033694386372795 -0.004962923837305  0.009297526391638 -0.012733700421545 -0.018367087946588 -0.009679397413178
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.004099418996737 -0.004975270717489 -0.011544453403942 -0.010294240373049 -0.015031167783122  0.051218543078986 -0.101906219668190 -0.009904937929980  0.005253311566155
-    1  (  5) -0.030335401615971  0.051022895540044  0.010476806750229 -0.022518303747979 -0.032764970727702  0.046697847750190 -0.082351506534871 -0.029648968337614  0.032167075005308
-    2  (  6)  0.044658147220588 -0.062597359445969 -0.000792773883945 -0.033784853569182 -0.053456383670095  0.070727579120646 -0.103493462669028  0.004470774917382 -0.021985039399781
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001406578222011 -0.001390228891514 -0.004138457631327  0.000537337712782 -0.000303816554518
-    1  (  5)  0.018025115903144  0.007054017557051 -0.018234657716208 -0.000615735236753  0.005903957155119
-    2  (  6) -0.015821399504368 -0.004485035916282 -0.033862858822880 -0.005131801318237 -0.004339292116808
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.001352471969094  0.045322075444733 -0.038349314552152
-    1  (  1)  0.023470923414908  0.379995390457559 -0.218263993898326
-    2  (  2)  0.020646215106669  0.203889457343544 -0.063634437124037
-    3  (  3)  0.097263397740302  0.216436926506454  0.416986973069653
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.001379673989061 -0.023464182377298 -0.020715625293986 -0.097608841144396
-    1  (  5) -0.045132209688744 -0.379406783605291 -0.203869208496661 -0.217739723605823
-    2  (  6)  0.038063072975973  0.217447630040656  0.062958922139319 -0.417725794235781
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.065653814142264  0.041946284375303  0.013161767706572 -0.111342796774500  0.110017778689743  0.028611074624176  0.087379776644865 -0.000506944002000  0.012737970563703
-    1  (  1) -0.002767473668146 -0.010697220027718  0.013506144228592  0.073913704778148 -0.217999207158693 -0.148131683228122 -0.817266423889027 -0.116806346540286  0.086848804711528
-    2  (  2)  0.048963138068012  0.019287255807937  0.016789870431812 -0.373432811546966  0.152152935578878 -0.191763986764781 -0.187319954974202 -0.050812933510948  0.023574454587241
-    3  (  3) -0.095762012298033 -0.056431105854389  0.178578325306558  0.038136923805617  0.140424655163157  0.089806364466590 -0.125801031634604 -0.116636753108288 -0.084794392657478
-    4  (  4) -0.100603170191617 -0.067705087958627  0.243617055985189  0.044363102282417  0.181215354983299  0.115079991268796 -0.179518597407386 -0.083927955619955 -0.086976764117441
-    5  (  5)  0.065265491800394  0.066327433491654 -0.367149548777650  0.044009709655582  0.156519624550140  0.073861464202985 -0.054146331819748 -0.093323533938862  0.170259582834842
-    6  (  6) -0.072248812824936 -0.071960211653410  0.684415406158707 -0.206867685302678 -0.380153305403406 -0.217464691746015  0.101286474206003  0.035777100475268 -0.341069042893403
-    7  (  7)  0.019742266764988  0.004654597124952  0.113800058767268 -0.000574265002983  0.010628342976831  0.072863781204177  0.376898463473803  0.139300622802210 -0.056085680972333
-    8  (  8)  0.000679953535081  0.001598902294011 -0.037525126251819  0.088614223995002 -0.068220130924204  0.039175761140296  0.208506736043279  0.056089637691589 -0.046057044816225
-    9  (  9) -0.002777732520373 -0.007429125774642 -0.024943116942350  0.022915921654072 -0.035702462515069 -0.020318534935527 -0.128837242689886  0.002259623765271 -0.005711714139269
-   10  ( 10) -0.005703803965392  0.023273876655766  0.027225029310730  0.026559677666667 -0.035399971500057 -0.015156942548385 -0.030152703916084 -0.170109037950347 -0.002596190944829
-   11  ( 11) -0.003384564196851 -0.002280327238919  0.118256580527015  0.004805921198873 -0.008748560057608  0.061729599159426  0.016174096583601 -0.021868118731471  0.291086759759657
-   12  ( 12)  0.020555722880272 -0.013540587399774  0.000211893937570 -0.008542727496112  0.013892940715707  0.041889105198929  0.006009166679671  0.135825768330791  0.000314961828297
-   13  ( 13)  0.004670677001798  0.000926772526536  0.016865034300282 -0.001908716884004 -0.008533776733402 -0.002600829800043 -0.067129999007525 -0.024630232805222 -0.002093287302057
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006448280903781 -0.007804174666870  0.001726589742279  0.009631719534244  0.002171109312827 -0.006916768929421
-    1  (  1) -0.039841759002053 -0.031613811363753 -0.126269993080286  0.005440038892529  0.010222632040274 -0.010738082177417
-    2  (  2) -0.049400367190082  0.028054173187029  0.027409200065905  0.001009289954765 -0.006677408446924 -0.009978484711828
-    3  (  3)  0.070460304013326 -0.083098595574193  0.035907224123551 -0.018802993269139  0.017169529769810  0.011284756920795
-    4  (  4)  0.035774264116816  0.067898270132826 -0.022183832964584  0.018305304819727  0.010768454734731  0.005255647674495
-    5  (  5)  0.149334153074510 -0.107123073600670 -0.046253700594295 -0.009064678078212  0.006568373775894  0.015962506593757
-    6  (  6) -0.264128081623912 -0.189717353125691  0.013846475545988 -0.034468738650004  0.018622793691907 -0.039125899611440
-    7  (  7) -0.078787498256752  0.137081801981432 -0.129024279783991  0.020540266029100 -0.010702305076213 -0.006363683572839
-    8  (  8)  0.066828272542120  0.061150331629768  0.661663512432504  0.064427579111988 -0.022787180611671 -0.001755054521373
-    9  (  9)  0.058361662206488  0.002765609007918  0.292979002594137 -0.024531884688023  0.033841964179834 -0.017477652244683
-   10  ( 10)  0.025537046615515 -0.402776836876724  0.195006548574470  0.143818217257362 -0.044952634158782  0.042833786526299
-   11  ( 11) -0.612581110120467 -0.030681983336889  0.052907112855315 -0.397594256764291 -0.644994698530558  0.225177415266176
-   12  ( 12)  0.078361827884296 -0.147641215292530  0.139659868964866 -0.415352806158415  0.111207746262217 -0.045767792834358
-   13  ( 13)  0.007555966012008 -0.007034052257820  0.662815283687025  0.034075798547008 -0.058439318318560  0.002857982237762
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.065636199611282  0.002920916198147 -0.048668219311498  0.095119636724795  0.099715491746342 -0.064115894757826  0.070288612362710 -0.020002036740183 -0.000648682346076
-    1  ( 15) -0.042164832302811  0.010965264984920 -0.019193267525749  0.056427120825921  0.067779126388374 -0.066346545701259  0.071818426884183 -0.004697793564429 -0.001719477062512
-    2  ( 16) -0.013293723744736 -0.013552393155520 -0.017152946073135 -0.178062131392816 -0.243207234696954  0.366656850670269 -0.683571699988320 -0.113725695300653  0.037674829370647
-    3  ( 17)  0.111833520478397 -0.074487105305844  0.373408686548039 -0.038278615402917 -0.044272326064866 -0.043920914820213  0.206763999327991  0.000718931757735 -0.088712771696387
-    4  ( 18) -0.110609556420903  0.218552165395166 -0.152101671319906 -0.140308960149057 -0.181388781196210 -0.156379821301524  0.379726625097930 -0.010777684689777  0.068071061617319
-    5  ( 19) -0.028752510181408  0.148103625807997  0.191866592233893 -0.089885426625568 -0.115404739185245 -0.073530988681885  0.216894531023559 -0.072888831186762 -0.039414155734701
-    6  ( 20) -0.088850262853694  0.817864717973160  0.187538432803728  0.126558510407503  0.179188313739966  0.053967785688344 -0.101346004734165 -0.376808265586346 -0.209641170142921
-    7  ( 21)  0.000236648626185  0.116954024007332  0.050876086441348  0.116850431043499  0.083855737312712  0.093201481422807 -0.035654753872492 -0.139240147731598 -0.056215130854042
-    8  ( 22) -0.012632241831446 -0.086750564455513 -0.023471210733819  0.084658255793584  0.087082440553447 -0.170291379307318  0.341029495907861  0.056080270650825  0.046130696703817
-    9  ( 23) -0.006387457988158  0.039627800428235  0.049236971359731 -0.070603541281575 -0.036093218300137 -0.148729935532572  0.263186790392662  0.078651937105263 -0.066792443994885
-   10  ( 24)  0.007794314356224  0.031645957507839 -0.027999240171264  0.083306839859372 -0.068240617920633  0.107186407568302  0.189422573537585 -0.136891913283426 -0.061228539916207
-   11  ( 25) -0.001991689460876  0.126407268625784 -0.027445392718538 -0.035776924599103  0.022144125160038  0.046221028292780 -0.013824022605635  0.129003528239796 -0.661853370394303
-   12  ( 26) -0.009599825104381 -0.005495331116759 -0.001034223219580  0.018933867742673 -0.018384105286375  0.009023661627231  0.034486124663305 -0.020439460919434 -0.064455521141270
-   13  ( 27) -0.002162721447509 -0.010273200862148  0.006630148558014 -0.017146542465354 -0.010737357070418 -0.006596929169183 -0.018510057851825  0.010689113270586  0.022830224344291
-   14  ( 28)  0.006906605609555  0.010703198677296  0.009943679074748 -0.011262720290334 -0.005261069281766 -0.015966561898017  0.039173616710326  0.006358426931312  0.001746833081562
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.002837339199042  0.005729990462521  0.002882667336321 -0.020606047818522 -0.004641004703607
-    1  ( 15)  0.007437286770332 -0.023276875493539  0.002358499534732  0.013557485629733 -0.000920107297989
-    2  ( 16)  0.025051827266470 -0.027193002752018 -0.117990698559769 -0.000179234372392 -0.016865743435032
-    3  ( 17) -0.023119196337007 -0.026652175278014 -0.004797499415929  0.008529905892743  0.001864545935891
-    4  ( 18)  0.035881897592302  0.035473538214569  0.008734163325355 -0.013878334987718  0.008565527202823
-    5  ( 19)  0.020360772275651  0.015171720613603 -0.061893166394059 -0.041911368342621  0.002602253507665
-    6  ( 20)  0.129299070691523  0.030292769804169 -0.016131950321938 -0.006006549470023  0.067162983124201
-    7  ( 21) -0.002077638821295  0.170151112881545  0.021893691209527 -0.135824125871701  0.024649373152539
-    8  ( 22)  0.005657792833300  0.002565321667606 -0.291029322280664 -0.000304358068315  0.002094832642432
-    9  ( 23) -0.058382869250631 -0.025529477410136  0.612383084135802 -0.078382756676553 -0.007563305586064
-   10  ( 24) -0.002481618081866  0.402824463109094  0.030640926554774  0.147639465945455  0.007047422246803
-   11  ( 25) -0.292947637539939 -0.194977050256941 -0.052900384325439 -0.139655182883169 -0.662817045986547
-   12  ( 26)  0.024630592497451 -0.143803605487111  0.397605464014331  0.415353658752820 -0.034075972250685
-   13  ( 27) -0.033850850098076  0.044956075971212  0.644991001235189 -0.111210374775728  0.058439332449029
-   14  ( 28)  0.017470247415045 -0.042829113212736 -0.225189876847489  0.045765194902991 -0.002860279243371
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.003220755761788  0.004741334513036 -0.005218491575352  0.008931308835907  0.002244102633378  0.015838687100919  0.070299613805989  0.014541519275327 -0.004023986014985
-    1  (  1)  0.000067503033474  0.012207317918030  0.007244793200988 -0.023892777130642  0.043438396740122  0.025220796440141  0.154461573863724  0.023000834887421 -0.019599055677926
-    2  (  2) -0.012578011879907 -0.003275100255966  0.012592919961383 -0.005684090399027  0.002169804380039 -0.004971061326221 -0.013552564477647 -0.009500984985895 -0.006299654057362
-    3  (  3) -0.059262075820670 -0.046181284980691  0.084603478568992 -0.003021949940787 -0.032496962809605 -0.021957384896270 -0.062320115832634  0.002770430488820 -0.031773062115651
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.000182000207227 -0.005588586167114 -0.000672702586966 -0.002964514553093  0.001105034523208 -0.000343253226041
-    1  (  1)  0.008618205903186  0.014153751191206  0.035995392865196  0.005123687397521 -0.001603958931174  0.003532153146744
-    2  (  2)  0.011268111146370 -0.024898784529351  0.008069485418761 -0.008185686323918  0.004533934142691  0.003585064891685
-    3  (  3)  0.031845177970419  0.004991052985520 -0.011188833991374  0.013257910424622  0.018832233173395  0.009593400754084
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.004231156729541  0.005431493649267  0.012529175724660  0.009596633242284  0.014606722988323 -0.052629799448244  0.104835250484967  0.010143068216584 -0.005577330897623
-    1  (  5)  0.032234138585390 -0.047805476204470 -0.011206420541453  0.021169463646392  0.032922137113452 -0.049263864001113  0.085142779220860  0.029187847712420 -0.030401159775617
-    2  (  6) -0.047014795193874  0.061420283989306  0.003243656996742  0.033537214796175  0.054307591623750 -0.073188368684598  0.108826461718921 -0.002713708723067  0.019591523301056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.001535925504297  0.001313736377570  0.005141735029325 -0.000303256666525  0.000317758840647
-    1  (  5) -0.017868281803487 -0.005956287092286  0.022125071354749 -0.000228679155762 -0.005956925492705
-    2  (  6)  0.014719284513933  0.004480852833973  0.038592140844884  0.004744813467982  0.004561240528551
 
 	Computing L_Y-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.248367212788
-	   1         0.330751944522    8.416e-02
-	   2         0.415463355484    5.142e-02
-	   3         0.421498321887    1.413e-02
-	   4         0.423281609975    3.672e-03
-	   5         0.423146786029    1.120e-03
-	   6         0.423130301035    4.528e-04
-	   7         0.423169481270    2.385e-04
-	   8         0.423155963611    9.755e-05
-	   9         0.423160048474    2.244e-05
-	  10         0.423160563592    8.149e-06
-	  11         0.423159982861    2.323e-06
-	  12         0.423159412486    8.158e-07
-	  13         0.423159367933    1.940e-07
-	  14         0.423159415410    8.872e-08
-	  15         0.423159436090    2.873e-08
-	  16         0.423159441493    1.029e-08
-	  17         0.423159440851    3.074e-09
-	  18         0.423159440757    9.318e-10
-	  19         0.423159440708    3.899e-10
-	  20         0.423159440714    1.141e-10
+	   0         0.248367209011
+	   1         0.330751939063    8.416e-02
+	   2         0.415463347279    5.142e-02
+	   3         0.421498313406    1.413e-02
+	   4         0.423281601410    3.672e-03
+	   5         0.423146777467    1.120e-03
+	   6         0.423130292473    4.528e-04
+	   7         0.423169472702    2.385e-04
+	   8         0.423155955045    9.755e-05
+	   9         0.423160039907    2.244e-05
+	  10         0.423160555025    8.149e-06
+	  11         0.423159974295    2.323e-06
+	  12         0.423159403919    8.158e-07
+	  13         0.423159359366    1.940e-07
+	  14         0.423159406843    8.872e-08
+	  15         0.423159427523    2.873e-08
+	  16         0.423159432926    1.029e-08
+	  17         0.423159432285    3.074e-09
+	  18         0.423159432190    9.318e-10
+	  19         0.423159432141    3.899e-10
+	  20         0.423159432147    1.141e-10
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 3.156e-11
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.068337016689787  0.096446452085002 -0.360475449255902  0.092239288443358  0.026203678993495  0.022509846768507  0.073478827109955  0.022464061635160  0.227372488687786
-    1  (  1) -0.348245092755920  0.473201941654281  0.285296343641650  0.183481268338497  0.077575420561894 -0.072099126128168  0.272473569750599  0.064219415174522  0.197165880642411
-    2  (  2) -0.067585908292999 -0.050372922066345  0.060758167722761  0.207525430724412 -0.124589544539336  0.366296688749942  0.319501792562117 -0.144609263860444 -0.034557292109121
-    3  (  3) -0.003490778195202 -0.176771187193881 -0.057522831084688 -0.000116418534514 -0.000778288025410 -0.154495740758279  0.307263828597453  0.311985415250579 -0.072067405639340
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009055593106319  0.169294476000973 -0.004376707887535  0.043035427356728 -0.152530590603305
-    1  (  1) -0.043732146234760 -0.133230210104999 -0.321492959537845  0.026647195864791  0.380687102971969
-    2  (  2) -0.166530147606704  0.613643715784952 -0.216790208689121  0.084469048821397  0.070950253018395
-    3  (  3) -0.193623455832778 -0.188085387415724 -0.577128561928036 -0.079182256648197 -0.329374829303748
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.094184605266262 -0.056664612736054  0.249611394695138 -0.001240336458214  0.251113263188388  0.167204840997487  0.053738355410164 -0.110451910680987 -0.110225244344066
-    1  (  5) -0.138889396156713 -0.115961679702950  0.323179744186602 -0.121252123334108 -0.292076432530947 -0.241576686483901 -0.062989099002905 -0.028273376499857 -0.195878521200942
-    2  (  6) -0.158880157732563 -0.136139940788991  0.265648578790447 -0.093877387310787 -0.142453752097511 -0.054140913394793  0.560779480905315  0.138233927938137  0.254132036776789
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.293992892777812  0.040800750874340 -0.057675088115477 -0.076602392476472 -0.065335333000425  0.026360508198711
-    1  (  5)  0.140101157116617 -0.119683195253936  0.266691635481371  0.245738117841371  0.344104644743715 -0.220704301427416
-    2  (  6)  0.056921768196805  0.103403744069325 -0.598429877433937  0.146214200704205  0.059974750990256 -0.323525482379135
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.001230860713981  0.365289920386496  0.190857780733096  0.072806514891183
-    1  (  1) -0.363063996519734  0.002070944913891 -0.019953639387757 -0.015606309990589
-    2  (  2) -0.188512451641916  0.023296206313487  0.001197811601800 -0.004047856267926
-    3  (  3) -0.072120339388755  0.013963148028330  0.003997486762190  0.001769349811859
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.002022249922950  0.099291954131021  0.350139400677067
-    1  (  5) -0.099326293970590  0.002387309533513  0.000598742894171
-    2  (  6) -0.349927147110668  0.003948627188178  0.004319113721388
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002890611897827  0.240828289147465 -0.015468829256935  0.064289689550120  0.058383569830779  0.095812515567057  0.080370871457874  0.173880009550648  0.326840838875860
-    1  (  1) -0.236387869752249 -0.001382669630591 -0.349729320543369 -0.093496466822455  0.041273060112661 -0.069307558569237  0.288342418689824 -0.111953342164375 -0.889210851252513
-    2  (  2)  0.015544382351172  0.348410608385966  0.001429161416738  0.082248932060638  0.073429593153274  0.232731056108987  0.287528082465130  0.229588952851785  0.234445801555499
-    3  (  3) -0.060246890669449  0.090324337254536 -0.083519076320930  0.000324034215630  0.021649503271248 -0.048962406316822 -0.003095140388789 -0.014925743106247  0.184209404061508
-    4  (  4) -0.058716691049654 -0.039386709518300 -0.072108814664522 -0.024079085224178  0.001156693016658  0.085015191809916  0.048842009764989 -0.153342114169621 -0.107404216975909
-    5  (  5) -0.094642233192625  0.068250996258109 -0.231656670305544  0.051858687640720 -0.087916533368054 -0.000989122777904  0.009520487792430  0.039816729579394 -0.148608670810212
-    6  (  6) -0.077504756735322 -0.287507697430236 -0.285105373436002  0.002029325573656 -0.050208524083414 -0.010159420768980 -0.001467122921747  0.173528931839685 -0.045843469905068
-    7  (  7) -0.174578233230593  0.112733771274507 -0.230104116799356  0.014289446324452  0.153589433005249 -0.035711031924118 -0.172129458752228 -0.001735515727976  0.038746380038624
-    8  (  8) -0.326735165366063  0.892352866716814 -0.233667611417982 -0.184059987656354  0.108456575602175  0.147444194487350  0.046899481546128 -0.038212214850091  0.001725987235386
-    9  (  9) -0.006854804424481  0.059010431241574  0.208380750196049 -0.285710704759075  0.014224723130698 -0.077940660528519  0.021832932968226  0.053507920192743 -0.072157293584336
-   10  ( 10)  0.009015167445598  0.189056046369736 -0.202903049397400  0.587323534808109 -0.635944176810841  0.025618734551668 -0.020134034262346  0.176546344509523 -0.134205354496214
-   11  ( 11)  0.122437005548569 -0.184498905511222  0.564613159164372 -0.437681527296080 -0.566648422271337  0.293176529113293 -0.283793106995897 -0.077656634404298 -0.171083550165875
-   12  ( 12) -0.036282129605470  0.108405322240863 -0.145144319486399  0.147400560062216 -0.198772870262719  0.103478363945228  0.121274561973686 -0.030820809232635 -0.001791413008569
-   13  ( 13) -0.133993098437568  0.204979468351056 -0.411230750510333 -0.299499940801943 -0.284167005433816 -0.162337236425275  0.004579295347321 -0.249620649972568  1.096399145752056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006645975778905 -0.006191073096114 -0.124463548213382  0.037116585439600  0.136645288902199
-    1  (  1) -0.060762525453402 -0.191336651087303  0.183339507039208 -0.108942947593767 -0.207176626622974
-    2  (  2) -0.210207260386098  0.203492326897454 -0.567390687945974  0.145012790104551  0.411652670240128
-    3  (  3)  0.286824149969646 -0.581772824662096  0.440352813995387 -0.146688228392261  0.298407000003058
-    4  (  4) -0.014289603545957  0.629957556120225  0.567078386368531  0.198070048922302  0.285394833836570
-    5  (  5)  0.081440068401990 -0.026939007614117 -0.293522941596266 -0.103773428535410  0.162374057747115
-    6  (  6) -0.019586412213072  0.018998130538312  0.285654409806091 -0.121258923814333 -0.003510620762243
-    7  (  7) -0.056312011236674 -0.170723193738545  0.077219135397651  0.031749253170040  0.249637927479938
-    8  (  8)  0.071982674840921  0.132152050589738  0.170190422759249  0.001965018222219 -1.093832298365480
-    9  (  9) -0.000915267084317 -0.167637668947108 -0.013751051322959 -0.007450195669904  0.054814043954704
-   10  ( 10)  0.173354835302090  0.000704252867558  0.044733752629381  0.097334496933118  0.081305131643713
-   11  ( 11)  0.013882987415659 -0.044298584291785  0.000143226462344  0.004568623078909 -0.075706346510396
-   12  ( 12)  0.008211247608944 -0.097266945197500 -0.004534234464270 -0.000000208770840 -0.036045640473786
-   13  ( 13) -0.055102354659947 -0.081583293844327  0.075692193037900  0.035962325349336  0.000089917983318
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.002852278466544  0.070108169829164  0.177721594116383 -0.062514278837043 -0.105491072743275  0.104380527192685  0.038787813666443 -0.108504673470162 -0.012481015325095
-    1  ( 15) -0.072271804263973  0.000288298261148  0.117173998738145 -0.011917535043052  0.080653916441483  0.081946299523319 -0.047103419787682  0.318790462890510  0.030711126191038
-    2  ( 16) -0.170911365853707 -0.116393519070210 -0.001806689323683  0.130836454259881  0.145067744851421  0.208275822041435  0.197865978670067 -0.179244423422815 -0.001428148574785
-    3  ( 17)  0.060580436051072  0.012481275961757 -0.130473629372401  0.000512552110579  0.018701012638838 -0.044411378106146  0.007770177955824  0.099727400679241  0.079606042617844
-    4  ( 18)  0.100932281141831 -0.079292941446829 -0.141623065968957 -0.016652442688780 -0.000246995954883 -0.188697276821427 -0.217824131948931  0.080386629630151 -0.270575530776454
-    5  ( 19) -0.108081312156271 -0.081589453393258 -0.205450509959137  0.045804817780756  0.187114674307730 -0.000693476015895 -0.073804885959376 -0.043943121718183  0.003771900693712
-    6  ( 20) -0.034173297967555  0.046256787847685 -0.201439095588816 -0.005429989019017  0.216650326151217  0.075792464986171 -0.001298711951572 -0.134518823042755  0.103151783377151
-    7  ( 21)  0.109536591257004 -0.319390106321481  0.177983470364268 -0.099546174339197 -0.081524885513579  0.044022674550874  0.133301399033515 -0.000096152383065  0.101549931240584
-    8  ( 22)  0.012926686041826 -0.031216971600686 -0.000265042168615 -0.077684860264792  0.270051031496744 -0.002422594418673 -0.104436054969569 -0.102375676350899 -0.000297123445281
-    9  ( 23) -0.258651046299275 -0.226438144249540  0.883671721861341  0.031897478817939 -0.145814145437369  0.329946962033578 -0.092842601161588 -0.020363787817155 -0.044542350196596
-   10  ( 24) -0.092725989784673  0.166988988746146  0.090659624845963 -0.033017773093490  0.181126079432095 -0.062617782388689 -0.131228570809863  0.125672600098950  0.010149266769676
-   11  ( 25)  0.085237213762517  0.052979715533519 -0.426249660673602  0.453470213118020 -0.668258866535746 -0.144399220062707 -0.422276654831122  0.144496027602971  0.151454753884708
-   12  ( 26) -0.278987852994131  0.538130802014502  0.337920384527610  0.681210215677631  0.181138167954142 -0.460304232360321  0.045963221041228 -0.472470739788982 -0.099740360833931
-   13  ( 27)  0.031684358569015 -0.364912365941556  0.009949817490826  0.264482144700383 -0.131463038932392  0.369715650064832 -0.160132940033673  0.216985322458037 -0.408494860009368
-   14  ( 28)  0.069145968160405  0.228577328281114 -0.182024373430158 -0.129259595360434 -0.172789096424754 -0.293202387537144  0.081435203747675  0.165066175829158  0.415625562015752
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.259264061861398  0.092073726700459 -0.087751332732921  0.282787087620371 -0.027646750760921 -0.074274663555944
-    1  ( 15)  0.226044227417799 -0.167220221608179 -0.052022484678322 -0.539067092148703  0.364060270057495 -0.227432738647077
-    2  ( 16) -0.880651861739234 -0.090070282095970  0.429004165056558 -0.339630379420043 -0.011398542008064  0.184603055576349
-    3  ( 17) -0.032407867048655  0.033969801861417 -0.457051817514276 -0.682605465628673 -0.266811035152933  0.129791361160984
-    4  ( 18)  0.146452241358061 -0.182164491681139  0.670578545718526 -0.180561730668713  0.132153760707793  0.172423147223622
-    5  ( 19) -0.329854516633489  0.062406355486158  0.142687713548999  0.461391108813659 -0.369113402446086  0.291406831399555
-    6  ( 20)  0.095123792939029  0.130974407921450  0.423504400080728 -0.046307780864123  0.160121658345768 -0.080587396654631
-    7  ( 21)  0.020196930650927 -0.126100208893374 -0.143365904721253  0.472616518696925 -0.216448635004369 -0.164811157431042
-    8  ( 22)  0.044862231258128 -0.010443804825893 -0.151200178059944  0.098979735611851  0.407862770190674 -0.414651419638203
-    9  ( 23)  0.001778806469034  0.018623025532445  0.107576400210487 -0.163068566891587 -0.647773862315846  0.636630491425454
-   10  ( 24) -0.017927592798993 -0.000180705630000  0.053297006124060 -0.074061342070591 -0.058210218158357  0.162911849208963
-   11  ( 25) -0.109490773836576 -0.052999955618224  0.000271745308396 -0.000305712333614  0.053078644790042 -0.055108565747960
-   12  ( 26)  0.164133552719503  0.074506459360537  0.000357731899204 -0.000072395693486 -0.003695078860291  0.023204687798386
-   13  ( 27)  0.648551410049995  0.058758186891588 -0.052984322168655  0.003827983869788  0.000211520166748 -0.203311556747168
-   14  ( 28) -0.638654673856620 -0.163384069601813  0.055052210134389 -0.022943426676923  0.203292568578009 -0.000202566783445
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.052480701259259 -0.089840503139985  0.350982482866049 -0.095116826178087 -0.022440054215652 -0.032862353821469 -0.081729096326081 -0.021425782595611 -0.235338088635135
-    1  (  1)  0.388124677168533 -0.534993889872660 -0.299624251031539 -0.203953129475389 -0.082377317359755  0.089624704115259 -0.293120840067825 -0.059715673164777 -0.225100704791756
-    2  (  2)  0.075046613139342  0.054595030850083 -0.042171893892626 -0.238878291709943  0.143368498448120 -0.391908199708447 -0.348187716284506  0.162007005374424  0.040145638710435
-    3  (  3) -0.003825096561586  0.209524975426966  0.061101725640115 -0.005733734477972 -0.005158862211836  0.174020624147332 -0.336061739172831 -0.336718503904961  0.081950585094521
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.010799235898820 -0.184179967846582  0.006278703826698 -0.045893168283343  0.154431576202783
-    1  (  1)  0.044872971637160  0.151970487630040  0.339396308854840 -0.025890953682133 -0.403821618486004
-    2  (  2)  0.178196793491180 -0.663646636739936  0.225638342179614 -0.089456735981001 -0.067546568678071
-    3  (  3)  0.206166573180735  0.202910686825648  0.607738412714145  0.084545705245042  0.343684996664701
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.080604406993543  0.052828007136127 -0.248271072214065  0.004621901958854 -0.238511508773077 -0.166464522338437 -0.059371420180247  0.108552798507517  0.113128199143937
-    1  (  5)  0.158176273521067  0.142741353513120 -0.372038467512456  0.124710545030248  0.314544785901233  0.257579395622657  0.074674230220199  0.033693630413225  0.220604268429912
-    2  (  6)  0.161070149264612  0.184008094688423 -0.303262375945924  0.100514546731462  0.134915075764794  0.049291968700981 -0.607921602195072 -0.146614082163667 -0.250955095397111
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.310847898937919 -0.042310959338363  0.062726869647814  0.073058032344468  0.064713071794420 -0.023951260296913
-    1  (  5) -0.157873658680268  0.125342133518717 -0.276221069932045 -0.249434379507851 -0.361715962690354  0.231044770920838
-    2  (  6) -0.062318733481263 -0.109385681434768  0.629646707936818 -0.147627705365700 -0.066774935973318  0.338752628544606
 
 	Computing P_Z-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.653595285284
-	   1         9.890166186966    2.481e-01
-	   2        10.634892327420    1.161e-01
-	   3        10.644599113676    2.795e-02
-	   4        10.648256968633    1.206e-02
-	   5        10.649541192067    3.652e-03
-	   6        10.649676377332    1.366e-03
-	   7        10.649833935077    5.788e-04
-	   8        10.649816163291    2.168e-04
-	   9        10.649803252190    6.256e-05
-	  10        10.649807538538    1.996e-05
-	  11        10.649809371496    7.394e-06
-	  12        10.649809975341    2.582e-06
-	  13        10.649809259028    9.325e-07
-	  14        10.649808976629    3.546e-07
-	  15        10.649808871615    1.326e-07
-	  16        10.649808862996    5.221e-08
-	  17        10.649808854366    2.144e-08
-	  18        10.649808850495    9.371e-09
-	  19        10.649808850795    3.673e-09
-	  20        10.649808851480    1.151e-09
-	  21        10.649808851669    3.450e-10
-	  22        10.649808851738    1.398e-10
+	   0         8.653595299400
+	   1         9.890166201003    2.481e-01
+	   2        10.634892339000    1.161e-01
+	   3        10.644599124981    2.795e-02
+	   4        10.648256979865    1.206e-02
+	   5        10.649541203260    3.652e-03
+	   6        10.649676388521    1.366e-03
+	   7        10.649833946261    5.788e-04
+	   8        10.649816174475    2.168e-04
+	   9        10.649803263375    6.256e-05
+	  10        10.649807549723    1.996e-05
+	  11        10.649809382681    7.394e-06
+	  12        10.649809986526    2.582e-06
+	  13        10.649809270213    9.325e-07
+	  14        10.649808987814    3.546e-07
+	  15        10.649808882800    1.326e-07
+	  16        10.649808874181    5.221e-08
+	  17        10.649808865551    2.144e-08
+	  18        10.649808861680    9.371e-09
+	  19        10.649808861980    3.673e-09
+	  20        10.649808862665    1.151e-09
+	  21        10.649808862854    3.450e-10
+	  22        10.649808862923    1.398e-10
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 6.049e-11
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440356479  0.058098623177060  0.000062770505092 -0.132305009105496 -0.206845253941622  0.090151367748423 -0.021622993143838 -0.039361662992191  0.081041759558226
-    1  (  1) -0.058446002702836  0.108172168386185  0.020491566051334  0.029038345992777 -0.075256281123738  0.197244333988945 -0.268904698641837 -0.104165934598637  0.067340388311649
-    2  (  2) -0.015395531848647  0.065975044836942  0.020693241330571  0.145278172814648  0.156811977452555  0.026190455636648 -0.072791620713754 -0.106379131933316  0.008110007352911
-    3  (  3)  0.209889648236101  0.051262205353483 -0.016792464647056 -0.095510023392087  0.095336437943254 -0.289116527068191  0.245753635975044 -0.379261907549404  0.084194488960217
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922070380 -0.024147628235135  0.039515998256435  0.082736569385204 -0.047511948407189
-    1  (  1)  0.028213287410066  0.067760885382258  0.238885785831598 -0.125969164417165  0.177609465299056
-    2  (  2)  0.077606299822139 -0.045313543977919  0.093141189528995  0.365274042010320  0.093447143662359
-    3  (  3)  0.414915648101425  0.159852566454575 -0.273568285244179 -0.034618677464967  0.200919751856191
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102682138215 -0.069778483618667  0.053388820705143  0.227201022061025 -0.199230027507757  0.049687576272545 -0.168877445324815 -0.014461225346720 -0.006078045787078
-    1  (  5)  0.058029574568631 -0.323045692556243  0.030451397480033 -0.087822399123219 -0.049669665073330 -0.052839306705253 -0.277652121487366 -0.149775076501372  0.305937155187615
-    2  (  6) -0.084055275416977  0.046073375264778  0.190725804844658 -0.087557818571264 -0.137785527535432 -0.205465571560117 -0.198777590794243 -0.118276962947747 -0.298899363411174
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985643121  0.083163093513445  0.059838819925541  0.009394325003249 -0.030439464334268  0.004211857989885
-    1  (  5)  0.056299327075830 -0.068872084822763  0.330916524082322 -0.053769676068525 -0.184435947342737 -0.103868547796473
-    2  (  6)  0.066328790095722 -0.124449756334111  0.113043685672814  0.144452726550473  0.299204372324576 -0.043729255630968
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000260799278180  0.008294549497458  0.017065509889387 -0.120823024347784
-    1  (  1) -0.008496132195710  0.000459229311004  0.070584548654847 -0.263658987971002
-    2  (  2) -0.016577243499005 -0.069994423923560  0.000663995662767  0.516189372162913
-    3  (  3)  0.119940673323058  0.260382743299108 -0.515797582139532  0.000896339388888
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000443199054119  0.381921104005874 -0.143832379423130
-    1  (  5) -0.379434119543787 -0.000485242459082  0.057931044964221
-    2  (  6)  0.142702240031722 -0.057674063898636  0.001442186569692
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000910226438200  0.057456315647344  0.021764054616564 -0.110121253697657 -0.041147685715423  0.038875248096137 -0.013658842816188  0.027740417762726  0.095876695371130
-    1  (  1) -0.055345619259075 -0.000114715934544 -0.161082100934535  0.114708094818496 -0.226148458324691  0.429581553751604 -0.364780572887542 -0.339773268987353 -0.220533774744399
-    2  (  2) -0.020999461515685  0.161288340725610  0.000052922970119  0.056734674713291  0.008992634403320  0.218257664918361 -0.249333786133602 -0.218109893723775  0.109339937360493
-    3  (  3)  0.109919099574174 -0.115822425715978 -0.056019356031194  0.000740007095007  0.462857615923727  0.122607299335305  0.103870366450161  0.116250705419353  0.000233457194456
-    4  (  4)  0.040147971736914  0.225934656930791 -0.007773114629988 -0.462818557889914 -0.000780254049361  0.292874409138683 -0.009409004020261 -0.051882584565833 -0.039822167749921
-    5  (  5) -0.036335623693882 -0.431140334679252 -0.219015877475265 -0.122742719044919 -0.292837706496088 -0.000258434125831  0.380099535662932  0.122521034451732  0.042311772982521
-    6  (  6)  0.010512439726471  0.366117332794119  0.249486244103056 -0.103549874519169  0.008542365779906 -0.379118456291524 -0.000620782572313  0.110534560584461 -0.061985573540389
-    7  (  7) -0.028794951664777  0.339121669867214  0.216809050490518 -0.114099993246667  0.053090461626524 -0.122152835981425 -0.109887843186158 -0.000210776402969 -0.084672807469555
-    8  (  8) -0.095808229399132  0.221323464482799 -0.109106314792845 -0.000875257457611  0.038544677386553 -0.040538328426676  0.059775641025623  0.084700205378613  0.000410389354257
-    9  (  9)  0.014690106491517 -0.105287842118522 -0.107275604483120  0.218821764375615  0.309676781731095 -0.105240911604621 -0.129641828566929  0.117997785339671  0.042511311192418
-   10  ( 10) -0.029204608817403  0.107752356880331 -0.099755035717731  0.053525818879341  0.138310129158905  0.190113742192741 -0.089997971579917 -0.050367401919439 -0.205935350574800
-   11  ( 11) -0.155172680813618  0.443695988859270 -0.328777258069509 -0.218798389099096 -0.215176387461835  0.086665175851153 -0.081418632205002 -0.042686048283827  0.076994698961746
-   12  ( 12)  0.047142387984938  0.056370877735219 -0.091886939990151  0.290638653877080 -0.241910292969431 -0.247337059928007  0.042831064524262  0.092379405612353 -0.274155000078483
-   13  ( 13) -0.050389463693039  0.050328281612189 -0.290240848494312  0.162056910726980  0.213783629964646 -0.103688020985272 -0.033887129957515 -0.045587144676475  0.299790508093838
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015162329261762  0.029089765310940  0.157702865584754 -0.046156688514328  0.051381785238624
-    1  (  1)  0.106899843708486 -0.107201618560176 -0.445393416001207 -0.057067668629351 -0.050060001886431
-    2  (  2)  0.108853020016321  0.100191021028451  0.328545989684712  0.092698579556052  0.291502735762344
-    3  (  3) -0.218857914732928 -0.054792818554564  0.218936510583978 -0.287400526650046 -0.163296274552526
-    4  (  4) -0.309023997649700 -0.137542449801745  0.215093936648757  0.238284970233362 -0.213551426731583
-    5  (  5)  0.105674820684469 -0.189857437820115 -0.086867271556711  0.246374813757869  0.103858683942188
-    6  (  6)  0.128168668490610  0.089874262580382  0.081958189888793 -0.043636026138960  0.033207564369726
-    7  (  7) -0.118048267554359  0.049676494199198  0.043691989598397 -0.088880392330239  0.045560837044954
-    8  (  8) -0.043185963759057  0.206226573210928 -0.075243165739987  0.272590964145289 -0.299131513308221
-    9  (  9) -0.000077812750263  0.416515228417900  0.033604308554634 -1.079153036382561  0.144875292418151
-   10  ( 10) -0.417421688656681 -0.000158782243602 -0.288840596220158 -0.322135887066066 -0.291543524694710
-   11  ( 11) -0.033233098605228  0.288689216150241  0.000098607070373  0.357467165030213 -0.110234432471254
-   12  ( 12)  1.082588809014081  0.322578291381663 -0.357464370732486 -0.000001008926324 -0.002433258902322
-   13  ( 13) -0.144961978586806  0.291352746525362  0.110198259116823  0.002466771848949  0.000072101869173
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000153758776117  0.016209320965105  0.024928923757993 -0.062060534746170 -0.021458157416245  0.118593249067004 -0.004670228294358 -0.089096779890278  0.035341469320983
-    1  ( 15) -0.019055649133697  0.000070152122919  0.073747919702930 -0.220440656283159  0.117173681778925 -0.070042107037530 -0.194626605110428  0.297284849336053 -0.000292612579198
-    2  ( 16) -0.022586057118123 -0.073725573957683 -0.001109122666778 -0.015411803389863 -0.086529842350705 -0.104871287980693 -0.398741646289671 -0.436619148331831  0.174927780649059
-    3  ( 17)  0.059798965916265  0.223563287458482  0.017237453392182  0.001072539123553  0.251308090392191 -0.316070038847548  0.194803920269306  0.070654457969027 -0.376473483655780
-    4  ( 18)  0.020063419612631 -0.119039349408291  0.086800563750570 -0.251653936305414 -0.000335080735996  0.043024303892643  0.031731210904760  0.166597040709751  0.162561043906122
-    5  ( 19) -0.121124499955847  0.070386002281353  0.107113059896318  0.315446439504518 -0.043168772215477 -0.000861181929967  0.084799445456534  0.176705933868056 -0.191684805801835
-    6  ( 20)  0.000233561036084  0.194646689461778  0.399810731825322 -0.193912344414617 -0.032510952578749 -0.085522667269840  0.000316476981181  0.483153682224173 -0.288298406144107
-    7  ( 21)  0.086715012513528 -0.297226361655840  0.437406683020490 -0.070307665212214 -0.166617940064674 -0.177260527643651 -0.482840792772829 -0.000014363804072  0.098144550576534
-    8  ( 22) -0.034848855831113  0.000859202110741 -0.174080336928834  0.374333295621785 -0.160768014942695  0.191629536777613  0.289445575791765 -0.097019024563133 -0.000025631190893
-    9  ( 23) -0.146128458859477  0.053492838723281  0.324237370304827  0.062951581962557  0.055209150392106  0.064149761275701  0.152989513320630  0.139473999081823 -0.103718919745517
-   10  ( 24)  0.228943772617007 -0.607904766836796 -0.190620042163283 -0.232958068554443 -0.097307404392685  0.308161168894475 -0.021743402571297  0.163623966328651  0.316399909940952
-   11  ( 25) -0.113574180450176 -0.174427793696739  0.418995996797932  0.308337203773489 -0.075443225258948  0.339087151000572 -0.159463644175662 -0.028413073183974 -0.098871219135018
-   12  ( 26) -0.037424667627758 -0.021650461815628  0.117304488555654 -0.051902638516337  0.180454397204301  0.010740660446775  0.081519307958206 -0.155893098286787  0.070546741513103
-   13  ( 27)  0.017280094917641 -0.067254948202109  0.031223412783479 -0.363810241712273  0.387221887172221  0.012090141232777  0.015814975888526  0.054980917535039 -0.199339784826487
-   14  ( 28)  0.034098865606387  0.073619427530260 -0.020485113762460 -0.085856422339691  0.016811589994319 -0.112843996612104 -0.014113720302883  0.178007823049380  0.110352388592064
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147079245976260 -0.230634884327798  0.118016008095876  0.038157145434167 -0.016510465499821 -0.035555014241919
-    1  ( 15) -0.054535973951003  0.607948556744402  0.173873449665646  0.021413077919509  0.066607274428011 -0.073358777560519
-    2  ( 16) -0.323553306716541  0.191880318233455 -0.420431580367675 -0.118056258433329 -0.032680374772067  0.021063792737754
-    3  ( 17) -0.062647993136989  0.233296910168052 -0.309972235049851  0.052767888000268  0.365466873103625  0.086191647721005
-    4  ( 18) -0.056463254581534  0.097267541950806  0.076718792428350 -0.181006281426179 -0.388581954607450 -0.017033118173935
-    5  ( 19) -0.064619380352855 -0.308870128837400 -0.338018875040100 -0.010262168024492 -0.011437556053144  0.112357517192840
-    6  ( 20) -0.155382617120808  0.021349499069868  0.159407311491110 -0.081840985740344 -0.016551112219655  0.014159445447452
-    7  ( 21) -0.140537868365913 -0.163950016139901  0.028635642703436  0.155664270522521 -0.055628199070781 -0.178154240957341
-    8  ( 22)  0.103340923981933 -0.315438553715367  0.098505861648548 -0.070640699178892  0.199194337948212 -0.110183696150063
-    9  ( 23)  0.000686334523005 -0.100169676705670 -0.098205409926821  0.175395135103276 -0.218110756133058  0.228152281729332
-   10  ( 24)  0.099945574901306 -0.000096874523801  0.318471840231024 -0.225312239057313 -0.500004280246570 -0.463864297141458
-   11  ( 25)  0.099841601903911 -0.317761699341874 -0.000010561898700  0.325597818757907 -0.211905875429043 -0.064803783303090
-   12  ( 26) -0.174935629969472  0.225292248952868 -0.325705390264674 -0.000017197242562 -0.212072627252549  0.098012445880115
-   13  ( 27)  0.218628597779198  0.499556536309007  0.211864150049234  0.212027765065009  0.000008829414452 -0.140826209095657
-   14  ( 28) -0.228628348644091  0.463533897425291  0.064881803408838 -0.097950839605716  0.140879063677935 -0.000044304452715
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019783280962491 -0.054735513036393  0.001137513221933  0.126035313397777  0.202288257068162 -0.093711193829816  0.024984212293499  0.040225532801761 -0.083002910227929
-    1  (  1)  0.062354133456812 -0.120130294655184 -0.021767958501026 -0.030544876872275  0.074729404941111 -0.202914227763797  0.283260339857543  0.110010624076740 -0.075144553244755
-    2  (  2)  0.020071793451970 -0.073560407589557 -0.021169787012452 -0.145854096701605 -0.150911678978076 -0.033300464776861  0.073764758000912  0.114546085873699 -0.006653295400428
-    3  (  3) -0.203743026628905 -0.061501992586247  0.012053004875485  0.096810295870523 -0.111136074888818  0.295383183736970 -0.262971263836652  0.383085480530365 -0.093214804722179
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009993046283887  0.025513386596424 -0.042737152836742 -0.089318312648033  0.047451575437880
-    1  (  1) -0.030039490649266 -0.071945227885317 -0.250267584137830  0.142236308614906 -0.184637048828095
-    2  (  2) -0.082997800944815  0.054871782095115 -0.094796172305804 -0.401103667111563 -0.092927166183836
-    3  (  3) -0.430981237821724 -0.170811685089178  0.282618320770360  0.039486333217088 -0.208093566455086
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.010424640140636  0.070076236901647 -0.057204661229737 -0.211582690126517  0.193468115965468 -0.043909115261545  0.178375291288102  0.011291008781060  0.006135050116210
-    1  (  5) -0.063097232722725  0.334472526495555 -0.025536894990807  0.078253601702773  0.050626850793128  0.056751425430030  0.294768356957907  0.157483239712855 -0.310569420319987
-    2  (  6)  0.095244048403721 -0.044264153982762 -0.212560989611836  0.091390108488898  0.149038965211255  0.211765484415775  0.210419446695478  0.121083327494802  0.309642081940379
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068004773266362 -0.092578615344634 -0.065573414828925 -0.010233554140998  0.030163257404408 -0.003064448161750
-    1  (  5) -0.053600127227434  0.069934324462776 -0.342538882666169  0.056907034018328  0.186630072086963  0.106323576616076
-    2  (  6) -0.072821378093083  0.126275999821165 -0.117600524675145 -0.149377060058828 -0.309029921623329  0.046031657791552
 
 	Computing L_Z-Perturbed Wave Function (0.000 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.012584688469
-	   1         4.944052771947    2.664e-01
-	   2         5.807369711412    1.696e-01
-	   3         5.905655551736    5.872e-02
-	   4         5.945872588917    1.934e-02
-	   5         5.944344304246    5.842e-03
-	   6         5.944950924585    2.206e-03
-	   7         5.945276394136    7.147e-04
-	   8         5.945106211297    2.702e-04
-	   9         5.945115864278    7.061e-05
-	  10         5.945114668222    2.405e-05
-	  11         5.945114516733    8.593e-06
-	  12         5.945110132666    3.743e-06
-	  13         5.945108932947    1.485e-06
-	  14         5.945109323125    6.070e-07
-	  15         5.945109639008    1.993e-07
-	  16         5.945109729375    6.737e-08
-	  17         5.945109730976    1.973e-08
-	  18         5.945109728718    6.334e-09
-	  19         5.945109729678    2.269e-09
-	  20         5.945109730124    5.633e-10
-	  21         5.945109730244    1.766e-10
+	   0         4.012584663606
+	   1         4.944052741629    2.664e-01
+	   2         5.807369673855    1.696e-01
+	   3         5.905655511729    5.872e-02
+	   4         5.945872547965    1.934e-02
+	   5         5.944344263211    5.842e-03
+	   6         5.944950883522    2.206e-03
+	   7         5.945276353058    7.147e-04
+	   8         5.945106170216    2.702e-04
+	   9         5.945115823197    7.061e-05
+	  10         5.945114627140    2.405e-05
+	  11         5.945114475651    8.593e-06
+	  12         5.945110091583    3.743e-06
+	  13         5.945108891865    1.485e-06
+	  14         5.945109282043    6.070e-07
+	  15         5.945109597926    1.993e-07
+	  16         5.945109688293    6.737e-08
+	  17         5.945109689893    1.973e-08
+	  18         5.945109687635    6.334e-09
+	  19         5.945109688595    2.269e-09
+	  20         5.945109689042    5.633e-10
+	  21         5.945109689162    1.766e-10
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 8.369e-11
 
@@ -2171,4590 +834,540 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.363702794442279    -0.362754889801453     0.000000000000000
-    1     -0.116320924114696     0.012078489055831     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.392022203966783
-
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027048397172827  0.015352704112429 -0.027966801428206 -0.165495930367099  0.113032293131079 -0.059172920617490  0.054022056893036  0.034114608641417  0.002886107104428
-    1  (  1)  0.197986831439807  0.163526093357892 -0.274966362484751  0.062421195117411  0.155967420230584  0.185920877152340  0.363704257460170  0.011868347502389  0.094068355200268
-    2  (  2)  0.001994785400509 -0.040665399791180 -0.057882185886799  0.076919743499300  0.080668892974906  0.050712045980973 -0.045932897295670  0.241652574031132  0.100470948740106
-    3  (  3) -0.134618148262870 -0.169475273759002 -0.112338313271068 -0.029804521352267  0.003944352681063  0.058729559824899 -0.233881451281742 -0.145241305284807  0.577534946997298
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.036861128446484  0.060248603479283 -0.005564054645453 -0.004146763273408  0.016591697834381 -0.007733796755325
-    1  (  1) -0.035918794247218 -0.084747615285920 -0.145084319526741 -0.032998082529710 -0.051841379309429  0.022806687326240
-    2  (  2) -0.084717069711908  0.396672019200134 -0.041908741386333 -0.023248477509422 -0.041530856301655  0.002269986110115
-    3  (  3)  0.038883132455574 -0.071756294192596  0.163991699742162 -0.069947324622934 -0.143620958659473 -0.040929670412834
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052809051974611 -0.081154565641459  0.006856441672465  0.153404070250162  0.196852318183927 -0.080976239577634  0.074658786299150  0.007719515837141 -0.043614904957346
-    1  (  5)  0.345238819329888  0.019785726463408 -0.050847186825376 -0.077921925096032  0.068975151229659 -0.351671921498224  0.386754555295523 -0.290601454575730  0.053302927070672
-    2  (  6)  0.016264209978667 -0.328366425365533 -0.028951141350709 -0.018921421012293 -0.077573679759545 -0.021800407750167  0.192628950256551  0.357488541894078 -0.081608454670559
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002259895960631 -0.008421832675073 -0.029392100940116  0.031369993361730  0.013404147466831
-    1  (  5)  0.208575493629327  0.067711703634065 -0.203628183391135 -0.030033358486437  0.027351411878278
-    2  (  6) -0.187162949376747 -0.097599552501240 -0.071289729935510 -0.047614074934521 -0.125833431363021
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.083683703090339 -0.629036417459351  0.187768409616308
-    1  (  1) -0.172602425643759 -0.014265091859115 -0.090495237140442
-    2  (  2)  0.012410708512386  0.140259555625425 -0.033093031733629
-    3  (  3)  0.617332033723984 -0.177002119872801 -0.059198789591033
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.083984489601084 -0.171922407137234  0.012476891672991  0.618883655109570
-    1  (  5) -0.628194576289392 -0.014487461121762  0.141926484654468 -0.177049320083612
-    2  (  6)  0.185974040475234 -0.088119347704351 -0.035357029662085 -0.057155078540436
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.828696203592025 -0.451233677364964 -0.217492273801626  0.586304584205470 -0.198651498309132 -0.103892077288677 -0.006625290696853 -0.001819921442022 -0.094028994790127
-    1  (  1) -0.134105565072084 -0.143652464482426 -0.611995940113886  0.241008731857517 -0.051449178692584 -0.174330855034171  0.232749848820746  0.145661004271388 -0.128120727077505
-    2  (  2)  0.012063899957181 -0.029490668702565  0.163575298648468 -0.247038876502286 -0.158753040652801 -0.232668473612314 -0.114948417424730 -0.088613836090719 -0.022645502108504
-    3  (  3) -0.387197557412670 -0.007622232234767 -0.010218748368993 -0.204814602539347  0.014944145142201  0.002431343194739 -0.270127586345773  0.245262578145958  0.504586982816530
-    4  (  4) -0.460895290297202 -0.083413276687337 -0.199944470395538 -0.175480967267008 -0.163722513813610  0.040241151316098 -0.067825190846260 -0.310807009269909  0.577783712019049
-    5  (  5) -0.141670378431748  0.052086036202433 -0.250889435285257 -0.425040439955416  0.233847348075332 -0.158351487033986  0.178722313644596  0.245879694116802 -0.083555978624952
-    6  (  6) -0.130215129741091 -0.059015562328244  0.175413123904883  0.193335335494377  0.081298931206816  0.027166944052244 -0.479004702191582  0.042682340773738 -0.241453523690860
-    7  (  7) -0.128547673529086 -0.164220156281948  0.072921190130196 -0.418244944504053  0.302491231669016 -0.324010640072614 -0.075458878798693 -0.283018425704598  0.036415017864410
-    8  (  8) -0.062134266770614 -0.089654327070673  0.258681583169725  0.013233242093465  0.089010222721713  0.141925171219203  0.145726898819659 -0.025159117142780  0.043087625590561
-    9  (  9)  0.009157475877293  0.060303564275152  0.008729628589478 -0.116950978984904  0.076882806093440 -0.036383180924410  0.025483369510244  0.084185310301748 -0.015374203474542
-   10  ( 10)  0.047802155117035 -0.149112906046527  0.075801259346579 -0.048947777837302 -0.067507042894011 -0.106234452747565  0.028517793153314 -0.172545779173849  0.080208086539212
-   11  ( 11) -0.167486808508145 -0.138908523197938  0.283706274113969  0.091574703729164 -0.067077172850546 -0.025283786004213 -0.222327209021950 -0.000487203355974 -0.057945510499956
-   12  ( 12) -0.037231281930006  0.362748649100666  0.118756733555108  0.060033069634811  0.015289792490319 -0.066371796214512  0.063049993784234 -0.118284085626097 -0.151871766112428
-   13  ( 13)  0.015283336962664 -0.071148654690618  0.097868838236954 -0.110089289416517  0.125070464978759 -0.056834800649528 -0.036033401521028 -0.003983216078506 -0.062348090726013
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.129554454626645 -0.009474588080129 -0.145878009069340 -0.063534624713007 -0.014264450989202  0.066217032610968
-    1  (  1)  0.281753304154040  0.090565863681328  0.289775851087277  0.012154255844323 -0.002972094129563 -0.002349687671183
-    2  (  2) -0.119860879107323 -0.017641780651255 -0.056884026698647 -0.114243277051592 -0.081965225578515  0.047553858250442
-    3  (  3)  0.046051897739571 -0.068234524007742 -0.078832315651282  0.147716570125616  0.178529070541059  0.041892492825571
-    4  (  4)  0.224634415651606  0.054726588873862 -0.049348904717282 -0.010497565899220  0.270816650862660  0.056280914540891
-    5  (  5) -0.031024580647590 -0.167869422275837  0.089185539311376  0.032869876236856 -0.093569757739340 -0.005458274862047
-    6  (  6)  0.000981392608875 -0.078803302525778 -0.231661065523126  0.077973096019011 -0.062231529668081 -0.004237870062293
-    7  (  7) -0.058902381932974  0.114392724110640 -0.121932201798416 -0.061774560961000  0.018069277572558  0.046890882022827
-    8  (  8) -0.513410839175549 -0.085343806911986  0.027485231745675  0.006687146984676  0.194553865700676 -0.182125622987063
-    9  (  9) -0.072026715715937  0.003186347104678  0.005511418401201  0.002695559377571  0.031996063695793  0.027434309505846
-   10  ( 10) -0.012941082780342  0.102602875317609  0.011650753905957  0.003161188417901  0.051176261016026  0.036262081394577
-   11  ( 11) -0.072389598964860 -0.058864168002652 -0.028128390537061 -0.005943934144729 -0.000119126931267 -0.005492981656650
-   12  ( 12) -0.054636974740175 -0.008287355979314 -0.024569715170625 -0.016528220340787 -0.046477458022406 -0.050873095371919
-   13  ( 13)  0.233743037101684  0.059061280447733 -0.024586559461861  0.004543245586431 -0.015684709596020  0.012075090111966
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.826691217716273 -0.135952995986678  0.011483190853402 -0.387418549613132 -0.461392423434393 -0.145485395838477 -0.124983069633084 -0.128330208269710 -0.063846145512012
-    1  ( 15) -0.452846199342112 -0.142299396923846 -0.028873680579439 -0.006282104582323 -0.083434971591043  0.052286846958797 -0.060366664959448 -0.164381491855687 -0.091103104723665
-    2  ( 16) -0.216318168271836 -0.610394122458981  0.164687829144547 -0.011212326508078 -0.198690499654959 -0.249888026637277  0.173149134305467  0.071382973187058  0.260544315437109
-    3  ( 17)  0.584300313840742  0.240136635172586 -0.247504197547440 -0.203677759108949 -0.175664930669504 -0.423103759080422  0.191640258021663 -0.415453280544989  0.012404695910308
-    4  ( 18) -0.199046601234260 -0.050380875227390 -0.159053876876033  0.015277075663832 -0.162367358631649  0.232430660796134  0.082724825485615  0.299791975181979  0.088348234646987
-    5  ( 19) -0.104272480193007 -0.175241820294404 -0.233618498225201  0.003347139508098  0.039544446804631 -0.159217030916535  0.028729750234265 -0.323094060438359  0.140740059020568
-    6  ( 20) -0.009429700555618  0.234933209114364 -0.114393727276615 -0.268466551242383 -0.069016344623676  0.178511125207222 -0.480183500829793 -0.075907755374260  0.143021582340266
-    7  ( 21) -0.002871019980141  0.147322100081013 -0.089022269698270  0.243063067023217 -0.308863060976325  0.246226696688424  0.042991460237403 -0.286148618462202 -0.024663467570559
-    8  ( 22) -0.094480909031128 -0.129736715593916 -0.024604248218242  0.506975842783889  0.578523602334509 -0.083635854955803 -0.240378319056804  0.036574430518098  0.043361894806843
-    9  ( 23) -0.127469850231581  0.279775306347553 -0.119965256355608  0.046842433309940  0.224627106687645 -0.032678040821047  0.003106740012385 -0.057480210886726 -0.513625849978234
-   10  ( 24) -0.010113608772280  0.091491204350202 -0.018677713812760 -0.071589894306377  0.058565690503593 -0.167584249262607 -0.077210943763034  0.110209847874266 -0.083926459961230
-   11  ( 25) -0.144415369890515  0.288923500809327 -0.057020258893375 -0.078932024592243 -0.049197678741037  0.089025916916400 -0.231280649793149 -0.121731391324011  0.028617795572466
-   12  ( 26) -0.063356880757476  0.012359494559817 -0.113921394225926  0.147470818074126 -0.010507483518380  0.032942784833780  0.077682178518205 -0.061765741733595  0.006769386889262
-   13  ( 27) -0.013995995859800 -0.002559954171790 -0.081334364324019  0.177743396826763  0.270580272329641 -0.093513472630021 -0.062576452638165  0.017989699080157  0.194659969913094
-   14  ( 28)  0.066065732055799 -0.002211449695904  0.047581100788566  0.041756948476168  0.056034974532939 -0.005464174123526 -0.004247545547791  0.046945122816871 -0.182306395720765
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.009977414948991  0.047795726251349 -0.170257794893058 -0.037938003385798  0.014458354771735
-    1  ( 15)  0.061029814509221 -0.148838977933651 -0.138622311676044  0.363027561331653 -0.070814310121723
-    2  ( 16)  0.008874691507393  0.075936125697402  0.284555367553991  0.119192422675493  0.098638859969366
-    3  ( 17) -0.119112210975481 -0.049599126168817  0.092584517631524  0.060254228139763 -0.110664977910194
-    4  ( 18)  0.077868925237217 -0.066966521216813 -0.067808172209585  0.015338001788660  0.125516910271684
-    5  ( 19) -0.036382791915003 -0.106250802464449 -0.025901673388436 -0.066582385072615 -0.057303328993872
-    6  ( 20)  0.027021717761366  0.029104182126986 -0.222331616975881  0.063168783761157 -0.035714374282977
-    7  ( 21)  0.082539979364650 -0.172536666253103 -0.000669172457815 -0.118274514306553 -0.003844186581139
-    8  ( 22) -0.015061746200930  0.080414802790268 -0.057448999880623 -0.151717132243101 -0.062253352906387
-    9  ( 23) -0.071494404128242 -0.013120612580941 -0.073373439067110 -0.054797723574814  0.233375251535298
-   10  ( 24) -0.000029429641055  0.102291625448331 -0.059321314850514 -0.008317623517552  0.059027698391220
-   11  ( 25)  0.005765327972253  0.011614880462470 -0.028065205779369 -0.024579424954359 -0.024526575892733
-   12  ( 26)  0.002692253200082  0.003132810553211 -0.005932245634366 -0.016507700544142  0.004577653394693
-   13  ( 27)  0.031988350963214  0.051121558533183 -0.000221075294856 -0.046532133387957 -0.015677394532699
-   14  ( 28)  0.027397767162108  0.036259397253953 -0.005558504489882 -0.050917091935213  0.012016157844186
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.025406566159268  0.023298635287253 -0.022289171225281 -0.168859399546037  0.107903085343053 -0.060918366478026  0.050893116255270  0.027117697569600  0.006137025962381
-    1  (  1)  0.191093901631364  0.147230293879877 -0.245327925746496  0.051184636572256  0.145804688312181  0.177082412956716  0.335688365255302  0.014738825150512  0.084927582076377
-    2  (  2) -0.003155042580293 -0.027233271764860 -0.053208296453271  0.087116448441961  0.072613171875510  0.049776562479710 -0.037069643141426  0.221123482833241  0.094081632463615
-    3  (  3) -0.148081532987297 -0.143795935425655 -0.095653656284437 -0.040581516151424  0.007002536737363  0.053388570274401 -0.215379283048700 -0.136731549228503  0.551441205232222
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.030005353497125  0.050795632899782 -0.002892294664254 -0.003533356466287  0.015218907421680 -0.007301899744305
-    1  (  1) -0.023556562941518 -0.073830002725756 -0.128862604566188 -0.028671951610704 -0.047866625740652  0.021732276920370
-    2  (  2) -0.073223983264692  0.364347296120169 -0.036743687154481 -0.019261211454008 -0.037116539662741  0.000181223309972
-    3  (  3)  0.040361740685149 -0.065239876693051  0.146174618322834 -0.062411658986300 -0.126965052748134 -0.038245290086936
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.049420429939020 -0.071369144027861  0.010967892434703  0.154003952784752  0.199243445955842 -0.070560943504312  0.064246991121544  0.009741916757203 -0.037796040806489
-    1  (  5)  0.343138545087365  0.025580231196086 -0.051475570317848 -0.074170810753422  0.055679775667351 -0.335513778030016  0.361763562256478 -0.278312996717472  0.053462866737909
-    2  (  6)  0.009023834056191 -0.297316159210662 -0.029288421962258 -0.011782745518153 -0.070184214173438 -0.014572213441163  0.183342019819766  0.338840705353917 -0.064096544850433
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.003020372683713 -0.006869864196192 -0.023893125242991  0.027343480005917  0.011586872808644
-    1  (  5)  0.191183605646494  0.061813805162100 -0.180211660376411 -0.027158850194505  0.022115988544494
-    2  (  6) -0.170812182146008 -0.089183247070529 -0.060689118587739 -0.041496923999492 -0.115713673600506
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.033754103488904  0.007555372231008 -0.012636539412206 -0.059168089266189 -0.007696166024660  0.117635610027585 -0.032183947570515  0.074301250166332  0.005019432091403
-    1  (  1) -0.423755974394480  0.394319832811341  0.072147771285996 -0.012389712258359  0.176348210158568  0.099930502723386 -0.086701753728859  0.210493567935760 -0.033589866390245
-    2  (  2)  0.731556552635086 -0.976828857219025  0.033351783092618  0.123378208756534  0.157072652564139 -0.117469430301404  0.019850790679398  0.009097984935670  0.052536003980734
-    3  (  3) -0.047142053921200  0.198059791670330 -0.117104106550805  0.059612555708172 -0.051540989544482  0.120490618164713  0.186894293315771 -0.315632131525439 -0.008321584703138
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.004809884959149 -0.006374181554658  0.001349973408295 -0.006100975957460  0.011138127142432  0.022680627009235
-    1  (  1)  0.028102393649998  0.000289730093568  0.008262915835035 -0.124989537199237  0.066219531536918  0.018649107137634
-    2  (  2)  0.064127657438793 -0.065272286524580 -0.003581214395138 -0.076462588539111 -0.021447992337748 -0.132206773204054
-    3  (  3)  0.084986028536621 -0.498497698329473 -0.040822633530773 -0.043076722957163  0.013585564451261  0.027785129671115
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.016730543671402 -0.000493178350680  0.017302982722459 -0.256616062196450  0.185493094009100 -0.020593262646150 -0.009463629803292 -0.002961983098477  0.026859263160767
-    1  (  5) -0.075519353333223  0.118875850027739  0.079935827799390 -0.178710173458091 -0.108180669642193 -0.177149189778534 -0.083450989109747  0.113241594567945  0.031859913963448
-    2  (  6) -0.130570312068760  0.286100740965062  0.219486021249390 -0.104893438221523  0.173427403577016 -0.413345988897352 -0.212934040260182  0.179032987184766  0.025997492049908
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021490597653360 -0.022287920558859  0.002597640544176 -0.020805616512876 -0.017185298510280
-    1  (  5) -0.023718660102006  0.015749627862868  0.008406851616741 -0.192275139478185  0.036883303753882
-    2  (  6)  0.028766539135724 -0.272291164468312 -0.017419741916350  0.092820056045692  0.043867791725602
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.239338426392564 -0.063574189159419 -0.037138721492623
-    1  (  1)  0.637136254562851  0.563345834986113  1.010359356370541
-    2  (  2) -1.018244537475946  0.319334895202255  0.761891810673220
-    3  (  3)  0.045207421457437 -1.211415382676948  0.547663980563646
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.240077996488429  0.636087166048540 -1.017448666598683  0.045094757983791
-    1  (  5) -0.063119844830318  0.559674519771415  0.326877163045745 -1.214495217986866
-    2  (  6) -0.036017040682083  1.005430771836738  0.769694801723881  0.546245988666419
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.840037313836020  0.879719351228572  0.280425530485763  0.209457510590770 -0.115971007140231 -0.005865677404341 -0.092534287825665  0.016878612757743 -0.000554227822991
-    1  (  1)  0.406955291511109 -0.250354570304778  1.752817026082590  0.218264636938841 -0.014952601145219  0.085173209047615 -0.020235302962366  0.502753766000685  0.012614402487781
-    2  (  2) -0.011947654987322 -0.087288086334953 -0.224335908490773 -0.261126688019980 -0.841762463275376 -0.627828907554534  0.172051366688234  0.617244504994475  0.119309262733021
-    3  (  3)  0.811182010574067 -0.188300264656061  0.222401504654110 -0.118806305641431  0.529562874381598 -1.235458279793789  0.515406670549199 -0.727585984163455 -0.017311451334544
-    4  (  4) -0.382877178063333  0.342160015383575  0.036035220830207 -1.515969153946585  0.125466254724712  0.736754668202047  0.136012972713827  0.102461498470004  0.013411116743442
-    5  (  5) -0.056666348930366  0.399251661739627 -0.011422755469852 -0.698119094644981 -1.282954629697895  0.508762695513963 -0.451449634220948 -0.904106936880537  0.596672635982258
-    6  (  6) -0.005527213521809  0.206039689350583 -0.144483993576148 -0.121247601463421 -0.485305002415323  0.548554310120049  1.475357051064366 -0.106842364972141 -0.027446822634470
-    7  (  7)  0.133565351861769  0.328960786484755  0.162326353593274  0.054193688082147  0.478136828850907  0.570702306118600 -0.024903308876874  0.585193831441818  0.835813795954640
-    8  (  8)  0.031082134068872 -0.063496391996010 -0.272771555688820 -0.132864368300259 -0.103453213303616  0.119428117809223 -0.197405807539525  0.153621429574163 -0.347696082487505
-    9  (  9) -0.117648127967179  0.675674455344672  0.057144753223871  0.137494275224088 -0.007401643263736 -0.153445689840736 -0.039660467466461 -0.125410015238965 -0.348925711100216
-   10  ( 10) -0.183218900015280 -0.105460278770619  0.367791083908301 -0.008056255919995  0.178869825089236 -0.183120759227084 -0.020135495201915  0.515209425517336 -0.117079814088000
-   11  ( 11) -0.007464482549715  0.021032905836050 -0.001689959480439 -0.009511863938863 -0.028294702186542 -0.022246363439352  0.137498694249546 -0.039431687760892 -0.108598715660792
-   12  ( 12) -0.123943400580450 -0.111733854742263  0.047511096154227  0.255974383794788  0.005125598158543  0.148074286896914  0.114005285118611 -0.069660405917942  0.028473614618333
-   13  ( 13) -0.017139778903114  0.000597229894230 -0.092098701078466 -0.096822642158100 -0.041570201760717  0.197811128787409 -0.008675665762269  0.009875145380093 -0.053724977580929
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.015271060368590  0.055897468396679  0.022597241061105 -0.097746276200326  0.101308246517630  0.083130674158184
-    1  (  1) -0.170077841267587 -0.306278912948529 -0.015343223805456  0.140911077413699 -0.086769343161678 -0.004428610402275
-    2  (  2)  0.122266526205533 -0.173859131387549 -0.008833802902653 -0.258485979502035  0.008602351060332 -0.030798632969086
-    3  (  3)  0.115160682049786  0.000168306649340 -0.007959105138980 -0.065254436598696 -0.027276553714500  0.039309215133697
-    4  (  4)  0.041448801667008 -0.223438700330986  0.042071183596141 -0.028071659294627  0.027228579441665 -0.074898825540824
-    5  (  5) -0.019058857013510  0.170849130048803 -0.086743087770944  0.110180684067332  0.041911344191976 -0.107077437297843
-    6  (  6)  0.021255870699759  0.392230842819920  0.124666046290611  0.015546514857889  0.011543222367899 -0.015718913239240
-    7  (  7)  0.300617707044268  0.028511951577123  0.099451065409571 -0.057624703208728  0.020680186596793  0.041210772734416
-    8  (  8)  1.560902789686190  0.259171353520895 -0.164601436985075 -0.034972573255346 -0.150377449452613 -0.038200704783867
-    9  (  9)  0.094514443562177 -0.031271005532013 -0.062263725106321 -0.058838957873498  0.760182137090868  0.950337382630766
-   10  ( 10) -0.066833413223948  0.207007631435691 -0.021103846805201  1.235346069959520 -0.166059589963498  0.166191905898816
-   11  ( 11)  0.166612835901501 -0.057714789963814  1.335141389249462  0.048926720734315 -0.084810123443347  0.094069041404757
-   12  ( 12)  0.208438787230328 -1.201605996005697 -0.134583025189360  0.366858420103389 -0.092230833884388  0.010845623464668
-   13  ( 13) -0.191515363269101 -0.044444589953201  0.113534652068488  0.222935332874317  0.996666807879559 -0.918946475319682
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.838261938125953  0.411783579911082 -0.011222177479730  0.801199436588318 -0.375306180891601 -0.060253817938356 -0.006525724615655  0.129557857631930  0.036205801526960
-    1  ( 15)  0.881558694801301 -0.253494731429581 -0.085421228751772 -0.179689412714139  0.333542664377779  0.397899463382726  0.204757675416354  0.337390689793974 -0.068236018271236
-    2  ( 16)  0.280699466651638  1.751444070796586 -0.225749579482049  0.222724309443776  0.035674220851777 -0.008396081497684 -0.143282250648261  0.160643678305862 -0.273482677804852
-    3  ( 17)  0.209621101203040  0.218341762403868 -0.261721827317418 -0.119292443469067 -1.513373925140781 -0.698058616179597 -0.120912446345617  0.053177597646066 -0.132398408764311
-    4  ( 18) -0.117749589449745 -0.014290802057305 -0.842585912658373  0.528480212857232  0.125620436909715 -1.282510147470767 -0.485022216108444  0.477099752728403 -0.104196524597516
-    5  ( 19) -0.007044544158153  0.085833731063079 -0.626602352540001 -1.234607574211689  0.736231003373149  0.506584871133556  0.547680268232320  0.572569559178554  0.118655251440909
-    6  ( 20) -0.091286539818598 -0.021685756074756  0.171006984274394  0.515577034801528  0.135942818875198 -0.450672680612861  1.476397473903694 -0.025200125211324 -0.196552429073982
-    7  ( 21)  0.014617007475273  0.504140575926305  0.617828254758316 -0.727391401463796  0.101524085740282 -0.903538681928281 -0.107568617019622  0.584678825668100  0.151735736187589
-    8  ( 22) -0.000237823420664  0.012124384227592  0.118807977471402 -0.017974774238044  0.014229470507378  0.597624885291520 -0.026926427408390  0.834871784840588 -0.347391080813467
-    9  ( 23) -0.016265284587164 -0.168715787569770  0.122968815716393  0.113284198302450  0.042943290149452 -0.021309190261859  0.020477672429448  0.301304618606591  1.561269376414732
-   10  ( 24)  0.055165623705948 -0.304174565565627 -0.172047420652933 -0.001660031801304 -0.223923016186918  0.170793818371478  0.390519343250458  0.028524302133373  0.258484158546987
-   11  ( 25)  0.022516344496095 -0.015268625075761 -0.008789463144050 -0.007966710860511  0.041912769223181 -0.086577370868099  0.124614837586422  0.099373675936837 -0.164728190655413
-   12  ( 26) -0.096631683724329  0.140629711782460 -0.257993906888811 -0.065720412418661 -0.028201117626138  0.110255501857704  0.015355688312895 -0.057301747761398 -0.034361742521519
-   13  ( 27)  0.100849821365822 -0.086662374683482  0.008639345451765 -0.026546017676244  0.026660167742260  0.041687326988987  0.011443920803067  0.021038625210724 -0.150878061048130
-   14  ( 28)  0.083365492537661 -0.004663028443678 -0.030268841557525  0.040380114857265 -0.076010028857183 -0.107569353616213 -0.016046780201203  0.042417265806974 -0.038629597007140
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124737520970567 -0.186432244849434 -0.007556173934213 -0.125048458790314 -0.016552020209549
-    1  ( 15)  0.684938290376393 -0.103735702852444  0.021157182854187 -0.111849169918717  0.000598582694869
-    2  ( 16)  0.056865870871391  0.369391836124585 -0.001636395160685  0.047382415225486 -0.092511884311165
-    3  ( 17)  0.136934156518159 -0.009055225169970 -0.009590382757559  0.257430334272387 -0.097052552691910
-    4  ( 18) -0.008312109924423  0.179598643669996 -0.028244191820460  0.004116010022868 -0.041623947269660
-    5  ( 19) -0.152106396286801 -0.183914202125923 -0.022266967951892  0.148019441595633  0.198105007663693
-    6  ( 20) -0.039829799204161 -0.019552759743993  0.137602535405962  0.113713715404123 -0.008789545170784
-    7  ( 21) -0.125502178629739  0.515709894296467 -0.039509503457082 -0.069986828128539  0.009910155465828
-    8  ( 22) -0.349425567476830 -0.116835672927993 -0.108584428663162  0.028578302642485 -0.053883081615012
-    9  ( 23)  0.094338880407330 -0.067969707543137  0.166597413367391  0.208167474360311 -0.191318590057359
-   10  ( 24) -0.031516356589242  0.206892773401202 -0.057842868800066 -1.201944585655949 -0.044330968677763
-   11  ( 25) -0.062291263803427 -0.020994462489648  1.335136332915063 -0.134637529250241  0.113529324930304
-   12  ( 26) -0.058655360066673  1.235296326813700  0.048926809978680  0.366850373682241  0.222951200118475
-   13  ( 27)  0.760531019832537 -0.165992770496603 -0.084811358078730 -0.092272088807521  0.996709535509256
-   14  ( 28)  0.951452405735214  0.166207367805620  0.094073590713281  0.010839332616852 -0.918866261119885
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062424152487093  0.006340337268482 -0.007129573994951 -0.068124969445001 -0.016536648970737  0.122839654890139 -0.029124555648029  0.069524525927009  0.016624796588470
-    1  (  1) -0.403752025492204  0.324343055871707  0.076420140656786 -0.003202781255002  0.185946708759860  0.105883952933980 -0.081054655409652  0.184341159829675 -0.032915937518265
-    2  (  2)  0.661672748869100 -0.861372726396764  0.035408787225401  0.124470554040362  0.167515771764057 -0.112285700010499  0.015950867409511  0.001232083495723  0.035574976981523
-    3  (  3) -0.034421465673628  0.179830504979566 -0.111544513847215  0.024097913531803 -0.030238246207055  0.104793216722198  0.173773469173217 -0.303193060944995 -0.006513662906792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.009334134343137 -0.006326528083054  0.001276536883825 -0.004159187336468  0.009674793406368  0.018903850771847
-    1  (  1)  0.023692877349552 -0.000748233659147  0.007572933338662 -0.110618865809947  0.058982973244648  0.020804020406208
-    2  (  2)  0.056439835248463 -0.059263779798462 -0.002854238464665 -0.070581535158609 -0.021806829149510 -0.125806190045722
-    3  (  3)  0.082847328899303 -0.459387875765944 -0.034524528441236 -0.040614390362782  0.013723967190574  0.025955752093967
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.017603663965705  0.003174083877041  0.014339522059496 -0.266660818847198  0.199602064605257  0.004780839495062  0.001108522960745 -0.004965069967999  0.030862088780690
-    1  (  5) -0.088113575807603  0.114873319929461  0.063166154639253 -0.188098449929865 -0.135702241550834 -0.170113296422216 -0.072240153498818  0.102270166350793  0.024891651267320
-    2  (  6) -0.139298038265852  0.270556959145684  0.173447642648828 -0.086085492397594  0.170302022343653 -0.397018505467907 -0.208262454149272  0.170239716749086  0.014885093941277
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.007377491418509 -0.019432502966035  0.002111593502676 -0.017924326928228 -0.015562648892606
-    1  (  5) -0.015992089252138  0.016902070355736  0.006260130611804 -0.170730300914524  0.032158624092886
-    2  (  6)  0.030768942376426 -0.242871623531964 -0.014807837846673  0.086333556064428  0.038627030320013
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130528946 -0.064555152924841  0.195953381452965 -0.041248493442142 -0.011229686954300 -0.030149441399628 -0.052245051060564 -0.006640144599606 -0.060816046841284
-    1  (  1)  0.618380750428757 -0.527850820486333 -0.215416501526368 -0.157035437852335 -0.069798458055575  0.063297476988332 -0.224803808736996 -0.036770088842034 -0.093292414352534
-    2  (  2)  0.089963765084418  0.016694193770404 -0.049894217008593 -0.224500363707256  0.100545586964082 -0.339808932191863 -0.300486601867879  0.103978674976873  0.003854593956757
-    3  (  3) -0.017912540048753  0.240051544243958  0.016875920304164 -0.019658112939729  0.000950481982654  0.139486308126505 -0.307526295570431 -0.245045411518121  0.038982174577009
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228157231 -0.053483299255732  0.001461399823215 -0.009996127162103  0.040844890740135
-    1  (  1)  0.010356156241345  0.045196494922430  0.123149462820863 -0.009608799088997 -0.092775098434661
-    2  (  2)  0.068261626747973 -0.266621644549134  0.090983468413283 -0.007824999548536 -0.015479677470817
-    3  (  3)  0.102991688132870  0.095940846021793  0.235195882815376  0.030438278902471  0.100331913658044
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713182343  0.055002400372953 -0.190701615216833 -0.008587073582699 -0.137456634335766 -0.102685174670731 -0.038575707285854  0.049077773971977  0.038775520895292
-    1  (  5)  0.266426121027506  0.201904502326533 -0.404472747758134  0.112355452471773  0.244543383226856  0.203488255104151  0.093346083645080  0.046662175787456  0.162564534029677
-    2  (  6)  0.310200496188946  0.275860886552205 -0.334362481107594  0.111323203472945  0.107269573355600 -0.015396506114788 -0.485347827879795 -0.115211810589159 -0.189399381435021
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448700903 -0.010182782827209  0.015536223734562  0.027148068645677  0.019304531549287 -0.012170541866764
-    1  (  5) -0.076359104734661  0.072719944842760 -0.105706045014198 -0.076791075691679 -0.095250630845942  0.044053081319363
-    2  (  6) -0.023401555353274 -0.060789750776477  0.233844071184097 -0.060200608251925 -0.022972229728472  0.078966373824930
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134471189914803 -0.662148890607048 -0.267935017575730 -0.078917514513460
-    1  (  1) -0.664666296280562 -0.209284548524716  0.147471335927792  0.068908464210939
-    2  (  2) -0.267133357554530  0.148425589032828  0.187317600183912  0.001813046044159
-    3  (  3) -0.077770523321569  0.066603013382230  0.004062963757785  0.013912154355475
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274832594142428 -0.278242095473143 -0.671654031875754
-    1  (  5) -0.278497835849508 -0.012090615801272 -0.010590436880494
-    2  (  6) -0.670432937480178 -0.009657206552315  0.097732020822376
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959652942443780 -0.408123540990243 -0.490401242893299  0.038728621520496 -0.077955848847628 -0.487356522820254 -0.107431644874248 -0.396098714695084 -0.237559092067117
-    1  (  1) -0.405287391714683 -1.324235802978493  0.174918475291447  0.249090287653660 -0.197882092902579 -0.317613214061072 -0.251158650058355 -0.030182263573247  0.632878894923950
-    2  (  2) -0.488736302148035  0.174537834224317  0.686802536456231  0.342698519251872 -0.009978504113557  0.483630952562764  0.287674546486731  0.302838065991480 -0.272076060462856
-    3  (  3)  0.037680750737500  0.250810426061315  0.345041313473359 -0.288921951476600  0.242065062503934 -0.302245036763640 -0.510968388336981  0.184732147309200 -0.217019518794602
-    4  (  4) -0.076474970303988 -0.199548329885190 -0.011318561816348  0.242358447532560 -0.131824013348934  0.385851084327112 -0.241519487669974 -0.375192533769848  0.062578612484494
-    5  (  5) -0.485852483644543 -0.318979279826184  0.484066634054750 -0.298903806636467  0.382610997595699 -0.557142551551020  0.333197792506285  0.111813059498605  0.019832042071129
-    6  (  6) -0.104965309325025 -0.251905850556084  0.289646446290464 -0.510970312004153 -0.243416542879353  0.333477452717118 -0.859910604691225 -0.040221092426954  0.015978091057726
-    7  (  7) -0.396757752805925 -0.028569556569604  0.303650553602711  0.181375877282891 -0.373315055683876  0.109082013989902 -0.042394080453042 -0.424453142550918 -0.165367340666656
-    8  (  8) -0.232577777741232  0.628634227275953 -0.273406824008824 -0.217896152147594  0.062014351622307  0.020854775528038  0.015643896352917 -0.165522517641184 -1.139943298313989
-    9  (  9)  0.005610937945933  0.056039777778849  0.162949812655036 -0.082447741116097  0.072872155292264 -0.108705186895719 -0.023485984983778  0.044747716582668 -0.147251711462478
-   10  ( 10) -0.006823140107367  0.054329320069732 -0.040599884216487  0.341771214963506 -0.179762239229163  0.323458315199162  0.128244534804048 -0.274646157470800 -0.052523948902062
-   11  ( 11)  0.095363270852437 -0.102111548052236  0.068440604856687 -0.163728434991873 -0.155636086206937  0.243236788520030 -0.456650415619116 -0.005317873090518 -0.049821847163774
-   12  ( 12) -0.031682366649886  0.049375813732146 -0.071598146136873  0.132087989350725 -0.108611785503928  0.096654485319462  0.079499450609138 -0.086710987294923 -0.054539911300598
-   13  ( 13) -0.055056204843758  0.125842892734663 -0.045965574233073 -0.019980233431093 -0.072417713533459 -0.032557591655033 -0.014098057282134 -0.073500277877371  0.566229267143538
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807523812671 -0.007359544445531  0.096092504153619 -0.031848084858648 -0.055774202583708
-    1  (  1)  0.055013732726191  0.054716327776958 -0.101499825301692  0.049505806374070  0.126450547773127
-    2  (  2)  0.163059205524790 -0.041368873195638  0.069581455391968 -0.071597196814435 -0.045866052289024
-    3  (  3) -0.081105673316398  0.339429555795348 -0.164728153281382  0.131959969253045 -0.019695233736278
-    4  (  4)  0.071393373323251 -0.177479193977683 -0.155859184096407 -0.108539407237796 -0.072773970199488
-    5  (  5) -0.105603312027129  0.324542336401662  0.243446189989531  0.096679109324856 -0.032469296684766
-    6  (  6) -0.022598073115881  0.128545265383103 -0.457503820066558  0.079428257830674 -0.014293355797493
-    7  (  7)  0.043846313801253 -0.277398721165106 -0.005217801503343 -0.086814141747281 -0.073528025025910
-    8  (  8) -0.147650558268387 -0.051824889076812 -0.049479655393433 -0.054623458164613  0.565538504818440
-    9  (  9)  0.072040995852218  0.045487481962658  0.010267944428546  0.009607395555640  0.026537979807784
-   10  ( 10)  0.047954867964362 -0.139047713462617 -0.006984668952712 -0.101926998578260 -0.021981627684010
-   11  ( 11)  0.010232694230356 -0.006895180971719 -0.093446496399543 -0.006456318213145  0.037416385389791
-   12  ( 12)  0.009698093592920 -0.101910194006554 -0.006447087192563  0.055515253372902  0.004586695976630
-   13  ( 13)  0.026517968066884 -0.022107111803180  0.037498264997396  0.004566515562682 -0.064482567844114
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532087830445926 -0.788053684507392 -0.217638660833197  0.182558741691964  0.602280863166455 -0.200093874423138  0.029411465990867 -0.008618445566170 -0.142345996690868
-    1  ( 15) -0.793296872955545 -0.320033246707737 -0.162598983453527  0.058726799927110  0.020874328230438 -0.223415347506574  0.107419197066742 -0.353928058607362 -0.096059895093397
-    2  ( 16) -0.212771964615612 -0.165330330084882 -1.296138478685232  0.042119030621194  0.273634362778554 -0.438879796184691 -0.121813090338313  0.097180424591982 -0.140937625632113
-    3  ( 17)  0.179954421761081  0.058841120611665  0.044127192643470  0.293105599691600  0.349356889255942  0.303438248960065  0.077097854674844  0.005877107377562  0.014045104815526
-    4  ( 18)  0.599465706538920  0.022235571311357  0.273958683710447  0.351252283345913  0.210835219542339  0.044587084446442 -0.439010194739272 -0.491004374374813 -0.399383596132888
-    5  ( 19) -0.200414127659350 -0.221453682461015 -0.440132543486983  0.305750504454767  0.044859549976743 -0.117462872288654 -0.191542018731891 -0.319736100846566 -0.359370858025094
-    6  ( 20)  0.032162128695933  0.105939422719644 -0.123876353231712  0.078981740804684 -0.440632986498194 -0.189872412133810 -1.110683989664156  0.246909463040471  0.255271007021977
-    7  ( 21) -0.008289240579773 -0.354493597907539  0.096614444500186  0.006342901541664 -0.491270269564264 -0.319008747231223  0.247402781824619 -1.005041339195380  0.329310525935830
-    8  ( 22) -0.142958112264996 -0.097022080198495 -0.141105576353547  0.015162721103223 -0.401346216617333 -0.359442000621317  0.255249867150800  0.329100137101793  0.052130295868829
-    9  ( 23) -0.219989065338878 -0.250001442147006  0.576446348090269  0.098959674934949 -0.020568114883162  0.097513800290254 -0.059902955979327  0.014734527182880  0.155046520232648
-   10  ( 24) -0.078950494593626  0.108193141540531  0.027256154056543  0.046487728419779  0.091306743921577  0.113368151014402 -0.170234458952828  0.302098295081586 -0.032847707902243
-   11  ( 25)  0.043326744763780  0.032363389765351 -0.179596320194099  0.107314642599215 -0.187556761662743 -0.097228134814891 -0.510755068213776 -0.080036249779472  0.081235508191006
-   12  ( 26) -0.068197976687722  0.217296898139221  0.162613838977633  0.182156526110652 -0.078640971353133 -0.138388418091556  0.046099139451725 -0.318339562821704 -0.094298996209138
-   13  ( 27)  0.012948053108673 -0.163156717293819  0.064963474439184  0.076423090035566 -0.116362948606428 -0.057051341664290  0.002572557283580  0.275506911043523 -0.101255941425000
-   14  ( 28)  0.072512090956400  0.116063474699758 -0.039414548907200 -0.060057426600154 -0.063414940197114 -0.039930823902922 -0.007406649424353  0.061654502657618  0.127196073451667
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223472856125742 -0.079380673671635  0.044417376178946 -0.069445497122295  0.011729893484114  0.073549727859122
-    1  ( 15) -0.252084320126442  0.107740778862871  0.032072824768773  0.217703433408601 -0.162976180926073  0.115649024793372
-    2  ( 16)  0.579843117211313  0.028377214598813 -0.180834874538440  0.163175611888439  0.065411291321188 -0.039948698403888
-    3  ( 17)  0.098340901264216  0.045586420114884  0.108734472654534  0.182606429756644  0.076964420454008 -0.060236205606042
-    4  ( 18) -0.021650833258616  0.091327714077226 -0.188512569777461 -0.078662641752143 -0.116896916465247 -0.063655160079575
-    5  ( 19)  0.097171540487668  0.112970498499516 -0.096626702541390 -0.138712839207192 -0.057497370879087 -0.039673289391880
-    6  ( 20) -0.058059330868561 -0.170134824581430 -0.511529953088092  0.046149842871006  0.002603003860136 -0.007423573856034
-    7  ( 21)  0.014906052393179  0.302176683660248 -0.080527272431049 -0.318411101353105  0.275449773210268  0.061692765696993
-    8  ( 22)  0.155151887415096 -0.033185457460157  0.080998651044629 -0.094073422594697 -0.101041326107855  0.127067437732620
-    9  ( 23) -1.153509668783001 -0.223849781346618  0.084925914727116 -0.000154347649926  0.401132279454500 -0.346054712948586
-   10  ( 24) -0.223987599199814 -0.015012978057576 -0.013160266828997  0.067286208756079 -0.009874035128650 -0.084312333173046
-   11  ( 25)  0.084246135638493 -0.012978110751430 -0.099616699052767  0.005046001107463 -0.012239544441460  0.023063802192487
-   12  ( 26)  0.000203295323483  0.067424132179953  0.005012434752789  0.014687484558096 -0.012600853140958 -0.022021985861034
-   13  ( 27)  0.401487062547390 -0.009674045105948 -0.012249675470802 -0.012688275811242 -0.008212565394913  0.091176394188195
-   14  ( 28) -0.346417777816096 -0.084403131840825  0.023147564238642 -0.022062212401564  0.091088265445589  0.040127117548266
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.056215172927916 -0.054500121508322  0.201919258778010 -0.031077763805510 -0.011710544286436 -0.013075909022680 -0.042346948343635 -0.000671828610738 -0.052291650154205
-    1  (  1)  0.580185867754678 -0.459972750936400 -0.203225406348613 -0.146383812909082 -0.059047716306621  0.052226207773922 -0.210466211081215 -0.032187368805259 -0.063260160660422
-    2  (  2)  0.093393210560188  0.013367711284029 -0.072500427251494 -0.188901437088884  0.080233215060989 -0.320461366545765 -0.281774577854691  0.095754687109263  0.009993944043533
-    3  (  3) -0.011006044771994  0.212772034365604  0.010016676236493 -0.008866166718285  0.020319326728203  0.122354060320048 -0.286521493894349 -0.227705676000915  0.024617045170947
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004784997819657 -0.045646414220092  0.000336480966462 -0.008910135153260  0.037229969984587
-    1  (  1)  0.012654368887265  0.038726053143637  0.110122850812823 -0.008163616619222 -0.088473965567598
-    2  (  2)  0.059858161338620 -0.242276960593359  0.080687948077563 -0.004783379620358 -0.010585827086864
-    3  (  3)  0.093190009488007  0.087625847683856  0.210676227172290  0.029310964936832  0.092669936157259
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.095387847271100  0.063707280070084 -0.166137683411008 -0.019021592855565 -0.149973759870001 -0.101204344306762 -0.031472575282315  0.053498473859926  0.042967624438521
-    1  (  5)  0.255913379011736  0.182084006874274 -0.358054748488889  0.117938321574845  0.215767331745706  0.198255948304019  0.082288393877684  0.046112468588943  0.145174585882671
-    2  (  6)  0.310255025939172  0.238379636947246 -0.293832074000714  0.096225461031061  0.113893650091632 -0.010350379528905 -0.451016712887586 -0.111857486176803 -0.191795343976766
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.073847869190148 -0.008654741710575  0.012693286782788  0.023668684158666  0.017789448486280 -0.009288640287720
-    1  (  5) -0.053437181209244  0.073043482844143 -0.095008049754430 -0.066955827698789 -0.087649070811154  0.040223508017977
-    2  (  6) -0.005363324155257 -0.054894453356376  0.206318087760035 -0.056446189403617 -0.025451704179473  0.074272027058522
-
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.031889834472336 -0.023590247545076  0.035886092938494  0.337391549003445 -0.230489171708387  0.118250549009017 -0.096738323803454 -0.039671560183731 -0.017417453829651
-    1  (  1) -0.115559689950866 -0.104792776753397  0.247387033439083 -0.112934750234786 -0.158582865358366 -0.232113447678658 -0.480247139929458 -0.012693240726205 -0.113321221450465
-    2  (  2) -0.001131177703134  0.023211512192057  0.030343999116351 -0.117346790992592 -0.046608524859420 -0.060486959905986  0.074531488676303 -0.295475469192925 -0.122604475218833
-    3  (  3)  0.102873669309261  0.075244498837150  0.074367347068194 -0.000375638324722 -0.045758296871777 -0.020335443185058  0.271454123369342  0.176011970959425 -0.750611882783894
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.122947556659096 -0.146970007635756  0.023111743424029  0.020418246285807 -0.062142160948575  0.033255482549981
-    1  (  1)  0.076207579709840  0.192925577520692  0.390086469193835  0.115462079698591  0.197836673375331 -0.137907169648961
-    2  (  2)  0.134390969563588 -0.739254686327757  0.083356064140144  0.116141777662631  0.130510808086193 -0.001880247368517
-    3  (  3) -0.051764093089206  0.135387754341373 -0.415703352371020  0.190964584562673  0.522938232986926  0.150011651631347
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.042351800770033  0.112741680738692  0.014470487647282 -0.277801496926584 -0.385189435070480  0.134005161803845 -0.094379155611825 -0.020287570327628  0.140758439500600
-    1  (  5) -0.196508002077728 -0.014780858316181  0.028613533348628  0.116961168140523 -0.038035850661534  0.390665250154868 -0.463278907259435  0.352765994784243 -0.083583027846786
-    2  (  6)  0.019055458304079  0.247824312911431  0.054496185583040  0.066069201280654  0.118739286724245  0.063124976744210 -0.269457866868641 -0.446911004649514  0.141690470973354
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.002049190521844  0.018587871477028  0.105121590063686 -0.083095581891635 -0.044923327383534
-    1  (  5) -0.420262633593224 -0.134089318231829  0.513153889470778  0.061105931999993 -0.094073822513972
-    2  (  6)  0.353380729793659  0.186026023919396  0.193632728665932  0.115179143357212  0.434468868354740
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.018374399490839  0.416488593986887 -0.155494936834365
-    1  (  1) -0.047368311899160  0.000904478695801  0.015838423501069
-    2  (  2)  0.012225877770952 -0.003811464066523  0.009363085606127
-    3  (  3)  0.381174834177280 -0.034408333237667 -0.006712264462944
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019805821822076  0.046970692298440 -0.012276706190185 -0.380984477985130
-    1  (  5) -0.412939155992870  0.002194461931656  0.004258479838447  0.030533770738735
-    2  (  6)  0.154188085677647 -0.014422732946647 -0.008150645104198  0.004478771817897
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.038950465210408  0.039866103962419  0.115245354720040  0.019880757349447 -0.101323212958542  0.044640126253266 -0.129219338527502  0.020955390039210 -0.007693672741339
-    1  (  1) -0.067773602054647 -0.069283024949896  0.045139676547490  0.092449762069831 -0.063419247150338 -0.006282596580831 -0.492661875976107 -0.179789795112656  0.023646534538890
-    2  (  2)  0.005352314371011 -0.023691171688012  0.168760303436833 -0.035584759327957 -0.098211154887201 -0.052999235803435 -0.267185888610491 -0.067710312606089 -0.133811638261923
-    3  (  3) -0.005028835575224  0.075710576153026  0.130936364707588 -0.013148449648183 -0.082341449946899  0.058281787875764 -0.148402947291289  0.019587692846107  0.265997802208991
-    4  (  4)  0.042953075620737  0.030493487545427  0.117329091588246 -0.053817176197377 -0.040927603944597  0.031345620246767 -0.084728650716813 -0.096010530091888  0.389039208842110
-    5  (  5) -0.147577168335343  0.025728183041877 -0.257869613090358  0.341457170976807  0.032938052439995  0.198776430410242  0.028905583055758 -0.151472913148495  0.076896803027349
-    6  (  6)  0.033968966510016  0.063980358522411  0.416860320865971 -0.162964164077810 -0.210735076964306 -0.174795271465028  0.081522253852315  0.108767294311016 -0.317254235279369
-    7  (  7) -0.041696032362294 -0.119804780003616  0.084367698623615  0.345939032777489 -0.297348524344951  0.115684273678453  0.157252021772075  0.234703179592689 -0.035619581257838
-    8  (  8) -0.096236509574225 -0.089744247655453  0.368376180782391 -0.147020988065185  0.073817404082631  0.134077968971220  0.072728534570006 -0.043556315720552 -0.010655784346597
-    9  (  9)  0.003143315235121  0.093361249518207  0.037863435444635 -0.438671101107247  0.422734146793725 -0.161824914084117 -0.027097474419921  0.004646312280086  0.023963694330478
-   10  ( 10)  0.063765122804891 -0.220080848656726  0.093077513515149 -0.266351828566493  0.049816576758865  0.073960829373608 -0.046357012710617 -0.183568506551021  0.007204953793047
-   11  ( 11) -0.219872786938586 -0.186770594833612  0.640901797018363  0.491983676516504 -0.063681968781172  0.412058888748144 -0.286040569517346 -0.094245081423241 -0.195000390736826
-   12  ( 12) -0.262279768280096  0.707696438447150  0.236718714106780  0.470497637927968  0.331060673088753 -0.597737469031289  0.173380785854979 -0.147387697786165 -0.044689499434261
-   13  ( 13) -0.008835795532905 -0.161415860688302  0.152613021782520 -0.281704813928099  0.459625631240495  0.096864143285054 -0.003153519140079 -0.109240738249078 -0.297347288310574
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.149413062150163  0.067008442584154  0.230363907047496  0.055319406680384  0.032530338298423 -0.068943043267331
-    1  (  1) -0.452149192521174 -0.000162578737685 -0.619971511564934 -0.066650257125370  0.061919053639708  0.084081056043438
-    2  (  2)  0.165489317663304 -0.127973451777841  0.447552906388176  0.305061991533250  0.384464561661781 -0.153275315561868
-    3  (  3) -0.025748260701304  0.486016697888281  0.411385821418048 -0.268874146594607 -0.396024014682121 -0.134171291763426
-    4  (  4) -0.009663093960960 -0.555568390799340  0.304477769378439 -0.081217704163073 -0.578918205858773 -0.101292064810745
-    5  (  5)  0.039175185913195 -0.166448012687766 -0.090139681441233 -0.019287349063250  0.248510643774710 -0.007841008760067
-    6  (  6) -0.086047592172498 -0.153815757637266  0.087940035478902 -0.097280378266502  0.044638073702240  0.047181412845043
-    7  (  7) -0.068735686796040  0.315926660510286  0.100190034017783  0.019688975059735 -0.019468668688484 -0.100670621907944
-    8  (  8)  0.002625726681395 -0.112681642341155 -0.368011821043785 -0.079699064807508 -0.320546285877417  0.355993882573800
-    9  (  9) -0.075057729747018  0.174223000470549 -0.018184022105450  0.008386747763061  0.022693973527319 -0.026587026978415
-   10  ( 10) -0.016901342145260  0.168627021082460 -0.003857305749161 -0.002354503414788 -0.061897957980197 -0.064750074462714
-   11  ( 11)  0.244307011097299  0.045968336616797 -0.036911026756575  0.051829082034064 -0.017536651163216 -0.002615905953443
-   12  ( 12)  0.003873917284711  0.069385416516337 -0.051822467558672  0.043776532172148  0.059978809347506  0.097816286584178
-   13  ( 13)  0.427124414952379  0.150719603419239 -0.021778839992094  0.006415728591880 -0.068010241427207 -0.070097593919817
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.041903329856192  0.070446987089633 -0.004348862670260  0.007003079501354 -0.042701021768788  0.152208197977204 -0.041433363682805  0.041287071942597  0.095743116708860
-    1  ( 15) -0.040650426082046  0.069515483196494  0.023795913068799 -0.076537618226998 -0.032568972577824 -0.025967830490469 -0.063333094204323  0.120545439258051  0.089130494820972
-    2  ( 16) -0.113176179395785 -0.046535614719910 -0.168596109891447 -0.133831005796173 -0.118353163778080  0.257041147370604 -0.414474865889011 -0.082742359298471 -0.367155116899390
-    3  ( 17) -0.018349375617923 -0.090713111977311  0.034093712018598  0.012384834825344  0.052502145904236 -0.343486696016333  0.164974261057850 -0.349385131049026  0.148282635861179
-    4  ( 18)  0.098178568139074  0.063160792106148  0.098378065635209  0.082360458708713  0.040147652473952 -0.031106641199237  0.209540876350175  0.299086324958894 -0.075290632015664
-    5  ( 19) -0.046124091442951  0.007623765782496  0.052346193543973 -0.056344470452290 -0.031632190145320 -0.198051654819200  0.173027351368421 -0.116400515734751 -0.135033433848762
-    6  ( 20)  0.125258904374540  0.493829059239401  0.267757316022715  0.150510471965499  0.082418952577180 -0.029074883870873 -0.082194266117060 -0.155370316095250 -0.076894749422472
-    7  ( 21) -0.022859113931115  0.180693607953724  0.067191017626113 -0.021636428920055  0.098628927025765  0.152535238685033 -0.108677282204199 -0.236476842996923  0.043474790742065
-    8  ( 22)  0.007846177507452 -0.026259809347121  0.131087450927184 -0.264309750556241 -0.389449878217689 -0.077877691250164  0.320396510359928  0.036029491362037  0.011294045928736
-    9  ( 23) -0.148409951194406  0.452946257596570 -0.165039879212225  0.026077898552925  0.007360117453756 -0.037616321096105  0.083049264354487  0.069293544687319 -0.001373481233291
-   10  ( 24) -0.069814067119157  0.002054394750299  0.126443354154776 -0.492431542405090  0.562191735747665  0.169229180172877  0.154296877725072 -0.322409563035094  0.115377045900281
-   11  ( 25) -0.226651470481047  0.617350999313901 -0.448004121314618 -0.411778499546043 -0.303855472735621  0.089854128437872 -0.086765588475993 -0.099221464205896  0.370890559100149
-   12  ( 26) -0.054331750206089  0.066935478840437 -0.304032185963088  0.268162029874351  0.080593616550667  0.019297703310245  0.096620293446142 -0.019137264306005  0.080001854035789
-   13  ( 27) -0.031924461994603 -0.060584366399270 -0.382102774779752  0.393995940746644  0.579313325412582 -0.247998914693769 -0.046380357788513  0.019293958639035  0.320706746040650
-   14  ( 28)  0.067906620182484 -0.083216384461386  0.153437200450035  0.134831736058858  0.101055763194935  0.007868050795063 -0.047806237375160  0.100652051992651 -0.357135809697123
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.004177372366322 -0.063406030244807  0.226823097367039  0.263896415513769  0.011701971027774
-    1  ( 15) -0.093319799498408  0.219967278758902  0.185954874184417 -0.708355904031754  0.160324223389966
-    2  ( 16) -0.039556125331154 -0.094087884995324 -0.643095059540316 -0.237777200414592 -0.155124222296969
-    3  ( 17)  0.442134529381327  0.268012766736270 -0.494385460966639 -0.470730896225858  0.283217803454197
-    4  ( 18) -0.425335538145780 -0.050712365592958  0.065507217070923 -0.331337452084829 -0.461074723403375
-    5  ( 19)  0.162698096167156 -0.073261920681232 -0.410435644212656  0.598344542892450 -0.095525074956441
-    6  ( 20)  0.027635092593548  0.046340546952519  0.285700437916237 -0.173636156485020  0.002143940822347
-    7  ( 21) -0.008238163113748  0.182885492783710  0.094441459467607  0.147424260377310  0.108554639474187
-    8  ( 22) -0.023401664118011 -0.007016046655171  0.194400535766778  0.044245864301010  0.296689970128693
-    9  ( 23)  0.076293063471948  0.017415507342648 -0.241569014205399 -0.003530677667797 -0.425824332982193
-   10  ( 24) -0.181769150588328 -0.169666705113788 -0.044965749792137 -0.069290251681075 -0.150967382108881
-   11  ( 25)  0.018153729708567  0.003519576560560  0.037031521345044  0.051758677298688  0.021630611787891
-   12  ( 26) -0.008082899537472  0.002256936856687 -0.051941569032630 -0.043823365289136 -0.006446621914376
-   13  ( 27) -0.023193966803115  0.061566730434681  0.017525541483092 -0.059863077024435  0.068202811059110
-   14  ( 28)  0.026844987381374  0.064909557534692  0.002683194869776 -0.097668274774952  0.070274371234661
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.022229155184796  0.019683929802812 -0.035292041013174 -0.323293424781682  0.225147178252232 -0.115004523407643  0.099141060334532  0.047575469407300  0.016976450104502
-    1  (  1)  0.127090569254626  0.123237269677512 -0.278422395650133  0.118685424416916  0.176184741653177  0.248988790809479  0.519015610990019  0.012154553055459  0.127798350335596
-    2  (  2)  0.008158213783958 -0.029679191576446 -0.037266849827848  0.110715312970774  0.059214718357965  0.062822080446559 -0.081276448160108  0.324586020412756  0.131224816829759
-    3  (  3) -0.084166098196409 -0.111710240594221 -0.099128613941891  0.014634036431124  0.052476493603890  0.027367672304797 -0.301909798936816 -0.191388056693055  0.790536316410543
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.129910363709357  0.163144685956702 -0.026485892679798 -0.022427536567571  0.063067550057929 -0.033737074439006
-    1  (  1) -0.086592793084052 -0.215472297553996 -0.416640948225414 -0.119951916043925 -0.207797355115153  0.145646111272154
-    2  (  2) -0.146364945461058  0.802840103887928 -0.083436228176863 -0.120990811620140 -0.133581214678389 -0.001202452323342
-    3  (  3)  0.043945078436053 -0.148601276694347  0.437804660682756 -0.201206970148648 -0.547031014916742 -0.155504170965970
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.037502076472662 -0.109335165777524 -0.012926428858581  0.269466726270333  0.379248563249398 -0.141530386330068  0.105411044336663  0.019979530625450 -0.148197571425260
-    1  (  5)  0.208585120229370  0.016639991768198 -0.025672499464384 -0.120166173976538  0.061231886196158 -0.410760689290169  0.504318342034080 -0.368734822068652  0.088923609423586
-    2  (  6) -0.008992532047250 -0.290540208998742 -0.060411739137707 -0.064704199164733 -0.124015323503734 -0.073936634004700  0.287919965087423  0.478723882674066 -0.159979306108318
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002904367944485 -0.019663391538446 -0.115584584455963  0.082318082980502  0.044061111248738
-    1  (  5)  0.445601944090184  0.141387522552248 -0.540419197978555 -0.056783987379620  0.093672186540934
-    2  (  6) -0.375252473148004 -0.198547338183254 -0.207529365108893 -0.114786400140461 -0.453839763908372
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.060866725217215 -0.013869365716153  0.033894329784820  0.159389025617799  0.069390363085127 -0.262340609354303  0.067580095774763 -0.154103692822594  0.003154741180611
-    1  (  1)  0.233600860111356 -0.255443445273365 -0.070349772560976  0.002398009474053 -0.207738516934078 -0.107364483788669  0.128967864654634 -0.344368536680876  0.051213828740165
-    2  (  2) -0.320680073963752  0.499671518707847 -0.050574975509019 -0.147836128166420 -0.165479289930263  0.195838444506077 -0.035661712710790 -0.024470880763902 -0.075637541705411
-    3  (  3)  0.005421312030017 -0.086163397462206  0.087803119789529 -0.068180639639745  0.069970423577407 -0.155270176021826 -0.200857781343900  0.346742235116956  0.007432799783430
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031710204280855  0.011526541432890 -0.002976967089787  0.046060023193635  0.015318540884103  0.025207945945630
-    1  (  1) -0.042201291846948  0.011691902650686 -0.030342861979388  0.426260656604152 -0.267501393083778 -0.156199494500064
-    2  (  2) -0.105775984380200  0.124345432018223  0.012422860710314  0.254942186016171  0.141450345930572  0.594200168007018
-    3  (  3) -0.128190105083420  0.839978623039109  0.103083070851949  0.085126863174017 -0.034147172701768 -0.125845625439850
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.009655463605755  0.014837891728381 -0.030023518715064  0.453895242430490 -0.367783958834954 -0.001154952584878 -0.011095021636640  0.081922945493181 -0.106667436086225
-    1  (  5)  0.023315601126616 -0.114914590458087 -0.095889100679515  0.148408787561426  0.132591987973289  0.239441228065666  0.119891964360871 -0.197513600772232 -0.042785498899110
-    2  (  6)  0.044714484508884 -0.227037104077391 -0.243035253957641  0.057000070112492 -0.133863510185386  0.464640228230982  0.241815314958168 -0.250347946170699 -0.035567936134789
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.031225116244914  0.082892463758822 -0.008302957992736  0.084651532871555  0.076096297616606
-    1  (  5)  0.029094974835733 -0.031099102771742 -0.014865102267058  0.594144277291270 -0.111092561014338
-    2  (  6) -0.081030380750229  0.586465397694647  0.039125073332182 -0.210425560392843 -0.141728395903252
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.279550720476077  0.042202209735457  0.032616542291842
-    1  (  1)  0.188418637032763 -0.038238156575108 -0.176016679949417
-    2  (  2) -0.431618249575807  0.006066663258097 -0.050669745816719
-    3  (  3)  0.023823866701763 -0.194483208506600  0.036291334339584
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.276296231465594 -0.182684867311170  0.425780067610230 -0.021944883020485
-    1  (  5) -0.040904620230163  0.037124497156135 -0.000756874278417  0.193551621281851
-    2  (  6) -0.032612764478737  0.173214965518422  0.056257078994710 -0.032928243740138
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.064329222595920 -0.203089813678901 -0.060855379318360  0.045435578919151  0.038213040289734 -0.173918816066670  0.086597065761990 -0.088257727308079  0.042534449699908
-    1  (  1)  0.115560364126478 -0.109115953630201 -0.018643611831367 -0.061273729840918 -0.223462209948640 -0.111849786008387  0.082478525732492 -0.548790728777664 -0.099502382826804
-    2  (  2)  0.050280791567554 -0.042231736423558 -0.026516724550904 -0.035763580727561 -0.045242506762065  0.028791481906196  0.032080377274548 -0.393629321941294 -0.043590423594673
-    3  (  3)  0.027100682075659 -0.177196743119415 -0.360081085823777 -0.088267299794322  0.030083312860564  0.189916614239830 -0.016925829834322 -0.152132597277128 -0.199271802311320
-    4  (  4)  0.027032407915338  0.122816257943915  0.195859296476474  0.024440446904345 -0.000039632917188 -0.224837371747381  0.105878500705155 -0.149344729427051  0.220653682748276
-    5  (  5) -0.082124893882501  0.131610239391223 -0.172288241722190  0.172656004937721  0.186007370790890 -0.002386795157151  0.000883813901201 -0.015624959650018  0.120434685552584
-    6  (  6) -0.025918430251412  0.066213876287375 -0.159653356345571  0.138629355858437  0.114503563489713  0.052610164659059 -0.032724879295725  0.016321111589815  0.131203443877323
-    7  (  7) -0.031968463140566  0.359436078267880  0.239880075530440 -0.043941245996148  0.003566470797935 -0.121878346236622 -0.025216884092681  0.317033593343712 -0.204690345792582
-    8  (  8)  0.147136177075282 -0.147831155131360 -0.317027072645310 -0.094690347387101 -0.042376714203220  0.036223188856298 -0.061267998203209  0.078763236261723  0.025079679518920
-    9  (  9) -0.347335081804882  1.076651679527280  0.076631791966040  0.520228799901951  0.177614233521961 -0.752433601064110  0.098237100331302 -0.075609380299166 -0.029456370268690
-   10  ( 10) -0.226576210232703 -0.047966592312158  0.713544303894390 -0.117838109418108  0.538138175848963  0.110268365719488 -0.097090433542407  0.016639982577840 -0.202838989293283
-   11  ( 11) -0.013618237324107  0.042488040839621 -0.012305458432129 -0.002937365049260  0.051397702056966 -0.032793240631487  0.126424524316302 -0.018011286422360 -0.036334038133226
-   12  ( 12) -0.125114748700956 -0.150723454222537  0.252706221972763  0.731410520517111 -0.348252142829817  0.473299198843163  0.017472369731921  0.121992291563425 -0.064459445411663
-   13  ( 13)  0.081025878360433 -0.099169125996407 -0.096265824091433 -0.243412138793566 -0.157793004324879  0.232678786079147 -0.038715292983050  0.196706528651456  0.103460906909678
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.038639019968560 -0.081398838675921 -0.020974057309157  0.195126170432547 -0.136178596332978 -0.093793458598120
-    1  (  1)  0.192322326072867  0.434066427801228  0.033306653053185 -0.455360646532796  0.170900871888595 -0.012160177810098
-    2  (  2) -0.116655928700969  0.223206132473869 -0.015149664847910  0.750955420456732 -0.241651279575312  0.125278854183387
-    3  (  3)  0.037416152824649 -0.474871182487040 -0.095127781154357 -0.001912744200640 -0.218016361604134 -0.501866870283028
-    4  (  4)  0.093049020347900 -0.452195861353997 -0.097729965141961 -0.023670097100218  0.227089450225467  0.622604645621845
-    5  (  5)  0.095982951322369  0.025076643469587  0.083513090675399  0.093177906171499  0.163570537374778  0.411952379972310
-    6  (  6)  0.006971397366507  0.099975304872894 -0.089355028753419  0.082421061832647  0.109391578906264  0.177019076161536
-    7  (  7) -0.111482230592694 -0.119338627354550 -0.049072785699030 -0.135589681135474 -0.179997637886863 -0.225361657151226
-    8  (  8) -0.038036906175422  0.107593330918854  0.085211578523939 -0.251522137496260  0.415712152156179  0.133150454203045
-    9  (  9)  0.014149847264143 -0.014713228385967  0.003726551384159  0.024984081757333 -0.450053383369121 -0.804137197420648
-   10  ( 10)  0.262196667989143  0.030987669321987 -0.048528847001581 -0.326796645773778 -0.027460917972608 -0.213395133473708
-   11  ( 11)  0.037859730907863  0.067315614399965 -0.006033855211911  0.002081527339975  0.021566579415084 -0.043117037710347
-   12  ( 12)  0.214673577185777 -0.277038178296912  0.018443935481622 -0.031394459169126 -0.040697755419603 -0.037299553750268
-   13  ( 13) -0.293378255962317 -0.067739265985308  0.042216271726718  0.084600602041646  0.093366414785478  0.184919834112459
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.065579026427298 -0.118385281199840 -0.054417309773849 -0.028209393258605 -0.023855315776195  0.089481193550780  0.030082936540202  0.024881663706482 -0.145536117267929
-    1  ( 15)  0.203177895336562  0.108867238168314  0.044106918987014  0.183348816265157 -0.128730595279853 -0.134393743071560 -0.068034842363188 -0.353605430814672  0.144787054112687
-    2  ( 16)  0.059845833352457  0.020943033819428  0.028043633600698  0.360379351132063 -0.196224502327520  0.168965679426491  0.157686501214302 -0.238008876623444  0.316659608324193
-    3  ( 17) -0.045186255659105  0.061530291702097  0.034434066086584  0.088647496947582 -0.026282078792551 -0.172786891133660 -0.138287078850789  0.044103989261245  0.095122362978667
-    4  ( 18) -0.040062693221020  0.224606431868167  0.044510085277536 -0.028376706423002  0.000349345016747 -0.185972360522578 -0.114555914481331 -0.004506308196336  0.041018032849448
-    5  ( 19)  0.173210931444010  0.109857051233105 -0.028983625579256 -0.187756427423432  0.223643228642709  0.004090524106486 -0.051487512077316  0.121894819352182 -0.037656019931592
-    6  ( 20) -0.085313471751143 -0.082913275223549 -0.032277368285025  0.016777520509378 -0.105131359190815 -0.001944705429570  0.032875162874827  0.025732176012468  0.062579089976849
-    7  ( 21)  0.084545461298169  0.550907022405358  0.394733809745031  0.152212200092244  0.149602224208011  0.015559620185539 -0.017471440322135 -0.317632843442532 -0.081500770726977
-    8  ( 22) -0.042592304559205  0.100130074049971  0.043823098391038  0.199074070348154 -0.220614689373917 -0.121240505787734 -0.131566193321307  0.204777301446740 -0.024659128193111
-    9  ( 23)  0.038243209345809 -0.193731116803758  0.114571318389048 -0.035004741203238 -0.093870122022257 -0.093321089072005 -0.005098160430595  0.109514276861021  0.037449030782536
-   10  ( 24)  0.080611973441424 -0.431286815750366 -0.220674640182480  0.473291196073188  0.451373239023609 -0.023941120635386 -0.102282761545205  0.118683941595292 -0.109001254632288
-   11  ( 25)  0.020616437944253 -0.032806186227235  0.015536997280191  0.094946997217811  0.097687630516726 -0.083601240444185  0.088958677720268  0.049109842148345 -0.085549382706087
-   12  ( 26) -0.191260790058678  0.454455308246703 -0.749344104582772  0.000707785692927  0.023013062709295 -0.093408274808716 -0.083112755629054  0.137052732289414  0.253713944370040
-   13  ( 27)  0.135080067323690 -0.170977966348525  0.241626969335339  0.220294823738596 -0.228806715319375 -0.163956724293068 -0.109654396643640  0.181513709124625 -0.417706190063538
-   14  ( 28)  0.095355381240353  0.010487455238559 -0.123878379042330  0.506641747659321 -0.627627416886014 -0.413206867808258 -0.177986562206826  0.230596660977991 -0.135371993382099
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.343722354187842  0.231012307989939  0.013807799785149  0.129389520371901 -0.083476842933347
-    1  ( 15) -1.071757290590545  0.047500726309983 -0.042558977896784  0.150713322712323  0.100049386852298
-    2  ( 16) -0.076574555259838 -0.716811431044374  0.012053549717062 -0.252652945738414  0.097563356479072
-    3  ( 17) -0.521659456544164  0.119962089033513  0.003140019395332 -0.735502177464538  0.243874710004522
-    4  ( 18) -0.178111787275392 -0.539331111074153 -0.051602620031584  0.351369555964665  0.157776134348173
-    5  ( 19)  0.754028750268460 -0.108050332429524  0.032942772306297 -0.473084779433613 -0.233288261808526
-    6  ( 20) -0.098339349809287  0.095672012585071 -0.126453856435504 -0.016749320041424  0.038981069794775
-    7  ( 21)  0.075922415669002 -0.017338504286034  0.017821543323394 -0.121086080034894 -0.196694365560314
-    8  ( 22)  0.028707803808862  0.202101700693747  0.036280352248806  0.064076056309411 -0.102966425702512
-    9  ( 23) -0.015071264129229 -0.259603898636005 -0.037748702712212 -0.213449614969685  0.292741791249862
-   10  ( 24)  0.014441233365834 -0.031025326150192 -0.067581337213048  0.278218894918250  0.067639252890435
-   11  ( 25) -0.003655596016122  0.048301023976308  0.005987297290884 -0.018296972769386 -0.042182106266812
-   12  ( 26) -0.024290247830266  0.326430116080930 -0.002078223011543  0.031357186170846 -0.084451014704488
-   13  ( 27)  0.452065991443206  0.027871674423728 -0.021552868138498  0.040817220436517 -0.093503875768977
-   14  ( 28)  0.809538434042480  0.214197129891733  0.043194453416851  0.037242456347955 -0.184930829970208
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.066956274028954  0.044342976073165 -0.030268247936242 -0.149450540981950 -0.061066821271185  0.252770775339693 -0.067874222510686  0.158386767820771 -0.005381383883310
-    1  (  1) -0.238859813029081  0.286692386304328  0.066590681714602 -0.004012726688607  0.213066888677072  0.109131374118362 -0.135898330150995  0.364942966429774 -0.055660597243453
-    2  (  2)  0.359516386393285 -0.583008964100427  0.054707529711990  0.139557599023379  0.158230706301634 -0.196109522672398  0.038444807843767  0.030895199145175  0.086353045406069
-    3  (  3) -0.011142763994871  0.102467038295486 -0.096192280460040  0.086579830772614 -0.079151964917630  0.163781954562347  0.215517306973471 -0.369533969127049 -0.009330018051360
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.034197603653202 -0.011654401867379  0.002838793667518 -0.051120718575847 -0.018314210992950 -0.032583546094419
-    1  (  1)  0.044852295322472 -0.010374877421340  0.032495546570244 -0.442259071390682  0.284002451396915  0.172324881222561
-    2  (  2)  0.118470854957857 -0.130986078141729 -0.014085982845085 -0.260463332299674 -0.162310705486348 -0.635865895852574
-    3  (  3)  0.132535934596107 -0.876049792586578 -0.107203693425820 -0.087990410067908  0.037792879731323  0.134504535673653
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.032839390128313 -0.018959934247026  0.027098455785061 -0.458861483846452  0.368889100803161 -0.013730600662295  0.005961739971281 -0.088172859302616  0.109822626668940
-    1  (  5) -0.022776770324681  0.118542960649480  0.106023383328719 -0.155646887463115 -0.124038116346952 -0.247202807741244 -0.126320423057856  0.208868231513720  0.046770852934184
-    2  (  6) -0.048648484948535  0.245637911332038  0.270704645644036 -0.074067208651774  0.147538325129154 -0.486126744284417 -0.252803143713327  0.267246124084927  0.039768993904487
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.034234873438637 -0.088611347550410  0.008537759532833 -0.090451182938239 -0.075365836152160
-    1  (  5) -0.023972088194502  0.031376657235205  0.015685502279103 -0.611834232098808  0.112755958009069
-    2  (  6)  0.089906734942719 -0.607632221899844 -0.040204918187789  0.215818595847042  0.145730338373175
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.068337016689787  0.096446452085002 -0.360475449255902  0.092239288443358  0.026203678993495  0.022509846768507  0.073478827109955  0.022464061635160  0.227372488687786
-    1  (  1) -0.348245092755920  0.473201941654281  0.285296343641650  0.183481268338497  0.077575420561894 -0.072099126128168  0.272473569750599  0.064219415174522  0.197165880642411
-    2  (  2) -0.067585908292999 -0.050372922066345  0.060758167722761  0.207525430724412 -0.124589544539336  0.366296688749942  0.319501792562117 -0.144609263860444 -0.034557292109121
-    3  (  3) -0.003490778195202 -0.176771187193881 -0.057522831084688 -0.000116418534514 -0.000778288025410 -0.154495740758279  0.307263828597453  0.311985415250579 -0.072067405639340
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009055593106319  0.169294476000973 -0.004376707887535  0.043035427356728 -0.152530590603305
-    1  (  1) -0.043732146234760 -0.133230210104999 -0.321492959537845  0.026647195864791  0.380687102971969
-    2  (  2) -0.166530147606704  0.613643715784952 -0.216790208689121  0.084469048821397  0.070950253018395
-    3  (  3) -0.193623455832778 -0.188085387415724 -0.577128561928036 -0.079182256648197 -0.329374829303748
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.094184605266262 -0.056664612736054  0.249611394695138 -0.001240336458214  0.251113263188388  0.167204840997487  0.053738355410164 -0.110451910680987 -0.110225244344066
-    1  (  5) -0.138889396156713 -0.115961679702950  0.323179744186602 -0.121252123334108 -0.292076432530947 -0.241576686483901 -0.062989099002905 -0.028273376499857 -0.195878521200942
-    2  (  6) -0.158880157732563 -0.136139940788991  0.265648578790447 -0.093877387310787 -0.142453752097511 -0.054140913394793  0.560779480905315  0.138233927938137  0.254132036776789
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.293992892777812  0.040800750874340 -0.057675088115477 -0.076602392476472 -0.065335333000425  0.026360508198711
-    1  (  5)  0.140101157116617 -0.119683195253936  0.266691635481371  0.245738117841371  0.344104644743715 -0.220704301427416
-    2  (  6)  0.056921768196805  0.103403744069325 -0.598429877433937  0.146214200704205  0.059974750990256 -0.323525482379135
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.001230860713981  0.365289920386496  0.190857780733096  0.072806514891183
-    1  (  1) -0.363063996519734  0.002070944913891 -0.019953639387757 -0.015606309990589
-    2  (  2) -0.188512451641916  0.023296206313487  0.001197811601800 -0.004047856267926
-    3  (  3) -0.072120339388755  0.013963148028330  0.003997486762190  0.001769349811859
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.002022249922950  0.099291954131021  0.350139400677067
-    1  (  5) -0.099326293970590  0.002387309533513  0.000598742894171
-    2  (  6) -0.349927147110668  0.003948627188178  0.004319113721388
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002890611897827  0.240828289147465 -0.015468829256935  0.064289689550120  0.058383569830779  0.095812515567057  0.080370871457874  0.173880009550648  0.326840838875860
-    1  (  1) -0.236387869752249 -0.001382669630591 -0.349729320543369 -0.093496466822455  0.041273060112661 -0.069307558569237  0.288342418689824 -0.111953342164375 -0.889210851252513
-    2  (  2)  0.015544382351172  0.348410608385966  0.001429161416738  0.082248932060638  0.073429593153274  0.232731056108987  0.287528082465130  0.229588952851785  0.234445801555499
-    3  (  3) -0.060246890669449  0.090324337254536 -0.083519076320930  0.000324034215630  0.021649503271248 -0.048962406316822 -0.003095140388789 -0.014925743106247  0.184209404061508
-    4  (  4) -0.058716691049654 -0.039386709518300 -0.072108814664522 -0.024079085224178  0.001156693016658  0.085015191809916  0.048842009764989 -0.153342114169621 -0.107404216975909
-    5  (  5) -0.094642233192625  0.068250996258109 -0.231656670305544  0.051858687640720 -0.087916533368054 -0.000989122777904  0.009520487792430  0.039816729579394 -0.148608670810212
-    6  (  6) -0.077504756735322 -0.287507697430236 -0.285105373436002  0.002029325573656 -0.050208524083414 -0.010159420768980 -0.001467122921747  0.173528931839685 -0.045843469905068
-    7  (  7) -0.174578233230593  0.112733771274507 -0.230104116799356  0.014289446324452  0.153589433005249 -0.035711031924118 -0.172129458752228 -0.001735515727976  0.038746380038624
-    8  (  8) -0.326735165366063  0.892352866716814 -0.233667611417982 -0.184059987656354  0.108456575602175  0.147444194487350  0.046899481546128 -0.038212214850091  0.001725987235386
-    9  (  9) -0.006854804424481  0.059010431241574  0.208380750196049 -0.285710704759075  0.014224723130698 -0.077940660528519  0.021832932968226  0.053507920192743 -0.072157293584336
-   10  ( 10)  0.009015167445598  0.189056046369736 -0.202903049397400  0.587323534808109 -0.635944176810841  0.025618734551668 -0.020134034262346  0.176546344509523 -0.134205354496214
-   11  ( 11)  0.122437005548569 -0.184498905511222  0.564613159164372 -0.437681527296080 -0.566648422271337  0.293176529113293 -0.283793106995897 -0.077656634404298 -0.171083550165875
-   12  ( 12) -0.036282129605470  0.108405322240863 -0.145144319486399  0.147400560062216 -0.198772870262719  0.103478363945228  0.121274561973686 -0.030820809232635 -0.001791413008569
-   13  ( 13) -0.133993098437568  0.204979468351056 -0.411230750510333 -0.299499940801943 -0.284167005433816 -0.162337236425275  0.004579295347321 -0.249620649972568  1.096399145752056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006645975778905 -0.006191073096114 -0.124463548213382  0.037116585439600  0.136645288902199
-    1  (  1) -0.060762525453402 -0.191336651087303  0.183339507039208 -0.108942947593767 -0.207176626622974
-    2  (  2) -0.210207260386098  0.203492326897454 -0.567390687945974  0.145012790104551  0.411652670240128
-    3  (  3)  0.286824149969646 -0.581772824662096  0.440352813995387 -0.146688228392261  0.298407000003058
-    4  (  4) -0.014289603545957  0.629957556120225  0.567078386368531  0.198070048922302  0.285394833836570
-    5  (  5)  0.081440068401990 -0.026939007614117 -0.293522941596266 -0.103773428535410  0.162374057747115
-    6  (  6) -0.019586412213072  0.018998130538312  0.285654409806091 -0.121258923814333 -0.003510620762243
-    7  (  7) -0.056312011236674 -0.170723193738545  0.077219135397651  0.031749253170040  0.249637927479938
-    8  (  8)  0.071982674840921  0.132152050589738  0.170190422759249  0.001965018222219 -1.093832298365480
-    9  (  9) -0.000915267084317 -0.167637668947108 -0.013751051322959 -0.007450195669904  0.054814043954704
-   10  ( 10)  0.173354835302090  0.000704252867558  0.044733752629381  0.097334496933118  0.081305131643713
-   11  ( 11)  0.013882987415659 -0.044298584291785  0.000143226462344  0.004568623078909 -0.075706346510396
-   12  ( 12)  0.008211247608944 -0.097266945197500 -0.004534234464270 -0.000000208770840 -0.036045640473786
-   13  ( 13) -0.055102354659947 -0.081583293844327  0.075692193037900  0.035962325349336  0.000089917983318
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.002852278466544  0.070108169829164  0.177721594116383 -0.062514278837043 -0.105491072743275  0.104380527192685  0.038787813666443 -0.108504673470162 -0.012481015325095
-    1  ( 15) -0.072271804263973  0.000288298261148  0.117173998738145 -0.011917535043052  0.080653916441483  0.081946299523319 -0.047103419787682  0.318790462890510  0.030711126191038
-    2  ( 16) -0.170911365853707 -0.116393519070210 -0.001806689323683  0.130836454259881  0.145067744851421  0.208275822041435  0.197865978670067 -0.179244423422815 -0.001428148574785
-    3  ( 17)  0.060580436051072  0.012481275961757 -0.130473629372401  0.000512552110579  0.018701012638838 -0.044411378106146  0.007770177955824  0.099727400679241  0.079606042617844
-    4  ( 18)  0.100932281141831 -0.079292941446829 -0.141623065968957 -0.016652442688780 -0.000246995954883 -0.188697276821427 -0.217824131948931  0.080386629630151 -0.270575530776454
-    5  ( 19) -0.108081312156271 -0.081589453393258 -0.205450509959137  0.045804817780756  0.187114674307730 -0.000693476015895 -0.073804885959376 -0.043943121718183  0.003771900693712
-    6  ( 20) -0.034173297967555  0.046256787847685 -0.201439095588816 -0.005429989019017  0.216650326151217  0.075792464986171 -0.001298711951572 -0.134518823042755  0.103151783377151
-    7  ( 21)  0.109536591257004 -0.319390106321481  0.177983470364268 -0.099546174339197 -0.081524885513579  0.044022674550874  0.133301399033515 -0.000096152383065  0.101549931240584
-    8  ( 22)  0.012926686041826 -0.031216971600686 -0.000265042168615 -0.077684860264792  0.270051031496744 -0.002422594418673 -0.104436054969569 -0.102375676350899 -0.000297123445281
-    9  ( 23) -0.258651046299275 -0.226438144249540  0.883671721861341  0.031897478817939 -0.145814145437369  0.329946962033578 -0.092842601161588 -0.020363787817155 -0.044542350196596
-   10  ( 24) -0.092725989784673  0.166988988746146  0.090659624845963 -0.033017773093490  0.181126079432095 -0.062617782388689 -0.131228570809863  0.125672600098950  0.010149266769676
-   11  ( 25)  0.085237213762517  0.052979715533519 -0.426249660673602  0.453470213118020 -0.668258866535746 -0.144399220062707 -0.422276654831122  0.144496027602971  0.151454753884708
-   12  ( 26) -0.278987852994131  0.538130802014502  0.337920384527610  0.681210215677631  0.181138167954142 -0.460304232360321  0.045963221041228 -0.472470739788982 -0.099740360833931
-   13  ( 27)  0.031684358569015 -0.364912365941556  0.009949817490826  0.264482144700383 -0.131463038932392  0.369715650064832 -0.160132940033673  0.216985322458037 -0.408494860009368
-   14  ( 28)  0.069145968160405  0.228577328281114 -0.182024373430158 -0.129259595360434 -0.172789096424754 -0.293202387537144  0.081435203747675  0.165066175829158  0.415625562015752
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.259264061861398  0.092073726700459 -0.087751332732921  0.282787087620371 -0.027646750760921 -0.074274663555944
-    1  ( 15)  0.226044227417799 -0.167220221608179 -0.052022484678322 -0.539067092148703  0.364060270057495 -0.227432738647077
-    2  ( 16) -0.880651861739234 -0.090070282095970  0.429004165056558 -0.339630379420043 -0.011398542008064  0.184603055576349
-    3  ( 17) -0.032407867048655  0.033969801861417 -0.457051817514276 -0.682605465628673 -0.266811035152933  0.129791361160984
-    4  ( 18)  0.146452241358061 -0.182164491681139  0.670578545718526 -0.180561730668713  0.132153760707793  0.172423147223622
-    5  ( 19) -0.329854516633489  0.062406355486158  0.142687713548999  0.461391108813659 -0.369113402446086  0.291406831399555
-    6  ( 20)  0.095123792939029  0.130974407921450  0.423504400080728 -0.046307780864123  0.160121658345768 -0.080587396654631
-    7  ( 21)  0.020196930650927 -0.126100208893374 -0.143365904721253  0.472616518696925 -0.216448635004369 -0.164811157431042
-    8  ( 22)  0.044862231258128 -0.010443804825893 -0.151200178059944  0.098979735611851  0.407862770190674 -0.414651419638203
-    9  ( 23)  0.001778806469034  0.018623025532445  0.107576400210487 -0.163068566891587 -0.647773862315846  0.636630491425454
-   10  ( 24) -0.017927592798993 -0.000180705630000  0.053297006124060 -0.074061342070591 -0.058210218158357  0.162911849208963
-   11  ( 25) -0.109490773836576 -0.052999955618224  0.000271745308396 -0.000305712333614  0.053078644790042 -0.055108565747960
-   12  ( 26)  0.164133552719503  0.074506459360537  0.000357731899204 -0.000072395693486 -0.003695078860291  0.023204687798386
-   13  ( 27)  0.648551410049995  0.058758186891588 -0.052984322168655  0.003827983869788  0.000211520166748 -0.203311556747168
-   14  ( 28) -0.638654673856620 -0.163384069601813  0.055052210134389 -0.022943426676923  0.203292568578009 -0.000202566783445
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.052480701259259 -0.089840503139985  0.350982482866049 -0.095116826178087 -0.022440054215652 -0.032862353821469 -0.081729096326081 -0.021425782595611 -0.235338088635135
-    1  (  1)  0.388124677168533 -0.534993889872660 -0.299624251031539 -0.203953129475389 -0.082377317359755  0.089624704115259 -0.293120840067825 -0.059715673164777 -0.225100704791756
-    2  (  2)  0.075046613139342  0.054595030850083 -0.042171893892626 -0.238878291709943  0.143368498448120 -0.391908199708447 -0.348187716284506  0.162007005374424  0.040145638710435
-    3  (  3) -0.003825096561586  0.209524975426966  0.061101725640115 -0.005733734477972 -0.005158862211836  0.174020624147332 -0.336061739172831 -0.336718503904961  0.081950585094521
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.010799235898820 -0.184179967846582  0.006278703826698 -0.045893168283343  0.154431576202783
-    1  (  1)  0.044872971637160  0.151970487630040  0.339396308854840 -0.025890953682133 -0.403821618486004
-    2  (  2)  0.178196793491180 -0.663646636739936  0.225638342179614 -0.089456735981001 -0.067546568678071
-    3  (  3)  0.206166573180735  0.202910686825648  0.607738412714145  0.084545705245042  0.343684996664701
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.080604406993543  0.052828007136127 -0.248271072214065  0.004621901958854 -0.238511508773077 -0.166464522338437 -0.059371420180247  0.108552798507517  0.113128199143937
-    1  (  5)  0.158176273521067  0.142741353513120 -0.372038467512456  0.124710545030248  0.314544785901233  0.257579395622657  0.074674230220199  0.033693630413225  0.220604268429912
-    2  (  6)  0.161070149264612  0.184008094688423 -0.303262375945924  0.100514546731462  0.134915075764794  0.049291968700981 -0.607921602195072 -0.146614082163667 -0.250955095397111
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.310847898937919 -0.042310959338363  0.062726869647814  0.073058032344468  0.064713071794420 -0.023951260296913
-    1  (  5) -0.157873658680268  0.125342133518717 -0.276221069932045 -0.249434379507851 -0.361715962690354  0.231044770920838
-    2  (  6) -0.062318733481263 -0.109385681434768  0.629646707936818 -0.147627705365700 -0.066774935973318  0.338752628544606
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016009260748017  0.076567442214896 -0.125166328875802  0.007592491786253 -0.098480428135412 -0.089737912259519 -0.045486487849709  0.143199899460591  0.062916360524591
-    1  (  1) -0.038605185454593  0.325735593943764 -0.218009839696040  0.077381067334654  0.123187634769419  0.048889388601736 -0.262562813593255  0.048309424265131 -0.024346564570397
-    2  (  2) -0.014979357855892  0.182689410654369 -0.081658179778794  0.065473944506505  0.193719600231606  0.090995730111074 -0.143671186830441  0.007595230816929 -0.060244510498059
-    3  (  3) -0.067326890443488 -0.014019515203484  0.166079081195192 -0.050483560257990 -0.175920280282569 -0.180597777465204 -0.198820897294047 -0.109379576724081 -0.213777271147620
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159507026073975 -0.056302017965781  0.034397376897140 -0.068360328302061  0.100741673999881 -0.049850169389160
-    1  (  1) -0.121516035123580 -0.004562687000240  0.189568378403116  0.051932937377753 -0.189148856797612  0.205130706545356
-    2  (  2)  0.013364994269954 -0.072899210778933  0.147744909867102 -0.343128869068584  0.052918402885218  0.086660614771912
-    3  (  3)  0.064044282976220 -0.072658467037946  0.366494615509597  0.156516672080101  0.183833699925440 -0.043558655165224
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095334256028009 -0.133297788110144  0.233197415167998 -0.109601891242184 -0.034275483482361 -0.001203276521899 -0.083637993138604 -0.006960579869910 -0.188458856324837
-    1  (  5)  0.132031102549102 -0.218523085575864 -0.122630941119498 -0.145558608560396  0.033193771816160 -0.142560374903523 -0.001867880595405  0.178023294306114 -0.083084371409555
-    2  (  6)  0.307498011816596 -0.248791194429673 -0.171772234113843 -0.290615300494965  0.046349417939456 -0.102374827834141 -0.404689139483050 -0.035662684698487 -0.067098771977202
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011309857021213  0.047826432296259  0.011715243517174 -0.012087997768714  0.055738114510750
-    1  (  5) -0.060288763132101 -0.100230270339149 -0.175888842059756 -0.033113626293054 -0.296260944515875
-    2  (  6)  0.156436504590612 -0.054087388641550  0.405606872407349 -0.026699931968424 -0.143365753445289
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.021022954159736 -0.035142529018952 -0.107426415156770
-    1  (  1)  0.299993715747734 -0.100035165443054 -0.265269960401394
-    2  (  2)  0.260050498379079  0.124418562014598  0.440142593096703
-    3  (  3)  0.064425483075145 -0.021009721425282 -0.051333955965002
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019464542579225 -0.300930139088225 -0.262387611320763 -0.064713939337572
-    1  (  5)  0.034890763742270  0.099221858485008 -0.125525760672816  0.023652429329881
-    2  (  6)  0.106312135129399  0.261746631642973 -0.441788978603034  0.052491092120842
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.143156293779769  0.065598528855299 -0.058339068026871  0.095240471065162 -0.054936782763489 -0.158698528722424  0.005848694187148 -0.046188395629077  0.009225054657648
-    1  (  1)  0.090550568038988  0.201824271395705 -0.091142881495912 -0.093661370668859  0.161043059103147  0.077741533393123 -0.543233062251592  0.814467132908124 -0.067293744881760
-    2  (  2) -0.021713915694858  0.356864777307433 -0.273330805205094  0.263660970827611  0.358937742043094 -0.204650254826784 -0.313132956505956  0.064395695030077 -0.200390318671649
-    3  (  3) -0.101095906237726 -0.248350727445422  0.325477886952403 -0.022461371735421  0.220401580692866  0.053345914506007  0.023674029203873  0.049357473765327 -0.000470604618644
-    4  (  4)  0.053513495604287  0.177341679973179 -0.223511424991143 -0.043203647152663 -0.200439262362192 -0.109704630170554 -0.130967856844601  0.223696627843727  0.051893869816232
-    5  (  5)  0.218677797229873 -0.312515161252956  0.301873753556228 -0.119144839450133 -0.273881128961801 -0.291385277900658  0.214361739830069  0.197002465061645  0.071567227017470
-    6  (  6)  0.085282711177633 -0.152031995719920  0.395807072999312 -0.020599784121374 -0.230274381395846 -0.119204882075906  0.196967452454600  0.233009490057915 -0.074120843143850
-    7  (  7)  0.047734330576263  0.280574479547352 -0.366542906373812  0.110968913790478 -0.088449186452659  0.149744690480443  0.036915836576634 -0.394085559356064 -0.043430167100304
-    8  (  8)  0.213441732464272  0.108274495972316 -0.634437106058845 -0.069187196826565 -0.037919304236964 -0.161411654384539  0.081574595848630 -0.216961478694419  0.039208476463161
-    9  (  9) -0.053318703860192  0.090838807258297  0.086586369793027 -0.028327523211035  0.134553886805994 -0.073546423533118 -0.007047260326121 -0.447864900958376 -0.046310440012370
-   10  ( 10)  0.217342853211265 -0.434342746087742 -0.408844907117118 -0.321259899576754 -0.034276585378345  0.320138521202174 -0.023800296590577  0.279258907554493  0.028679862426656
-   11  ( 11) -0.043839064779065 -0.078964296226844  0.267354222620337 -0.331608707925144  0.435766271345975  0.066306681540143  0.247977502270279 -0.002757326539735 -0.128220536878281
-   12  ( 12)  0.056967765282221 -0.011496620916620 -0.132088307172842 -0.097918437653651 -0.064500672945760  0.001827098937393 -0.216796993378831  0.142477110991476 -0.129430197478051
-   13  ( 13)  0.037733039841652  0.226167830269728 -0.091049164317861 -0.252259768566517 -0.015512763459721 -0.284728528128491  0.105582553814486 -0.004845390965161  0.367721806594329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222313487267139 -0.016040998159682  0.082409874320982  0.002075539850870 -0.060366346946182  0.093408303465405
-    1  (  1)  0.558686428143613 -0.124842930483593 -0.159094597945824  0.170661450539848  0.081512715884899 -0.084548811099098
-    2  (  2) -0.171589661035630 -0.032363732574493  0.410356885754263 -0.223617160453788 -0.075311055642080  0.314379038887409
-    3  (  3) -0.113936852615240 -0.023263060013616 -0.282024826692995  0.174390257283436 -0.284646591950349 -0.036134249694962
-    4  (  4)  0.007238439897924 -0.039483311713766 -0.327400920910445 -0.428741395271426 -0.081911463055166  0.119323501144252
-    5  (  5) -0.007206698114830 -0.054871846748801  0.118753815309300  0.018469351897211 -0.153374179308602 -0.075608926558101
-    6  (  6) -0.092372497620457 -0.334623338930078 -0.214791656963667 -0.112964261573848 -0.018239773729085 -0.100594142805454
-    7  (  7)  0.151928519059447  0.104975965782044 -0.079311543670646  0.028608318007851 -0.093200761310883  0.234496518387966
-    8  (  8) -0.034328207301673  0.223808481631680  0.061242559094949 -0.498103653582096  0.749098707942318 -0.381141257037236
-    9  (  9) -0.119302126498580  0.308066314141465  0.075395221655780  0.759042960378927 -0.290000840041876  0.156436862917181
-   10  ( 10)  0.438316650507883  0.163958878572088 -0.419969142321592  0.045404841057508 -0.044939660158532 -0.568953527573990
-   11  ( 11) -0.012787507164606  0.354874435093949  0.016715712863870  0.314729329115790 -0.109367027564034 -0.038956857759457
-   12  ( 12)  0.278784619045113 -0.047236021517055  0.203283234646730  0.096945848185628  0.275889526129666 -0.187110942781753
-   13  ( 13) -0.588325776498883  0.141777398655530  0.127445383199618 -0.417479630696627  0.223570495101464  0.209733888357992
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.139188612693568 -0.095183099515076  0.018684491477480  0.097422162623446 -0.052864868482975 -0.221122027331105 -0.088706173679123 -0.046138783672279 -0.215068969553880
-    1  ( 15) -0.062949654944158 -0.202402030263201 -0.354633955608115  0.248176570557555 -0.178122375116496  0.312771607112475  0.152477622828494 -0.279557727250808 -0.106814721163754
-    2  ( 16)  0.053746164934604  0.094053172516910  0.275496238616186 -0.323601647464255  0.223358052203497 -0.300642069951494 -0.393858290336507  0.365390717289338  0.632984591272781
-    3  ( 17) -0.094021410291053  0.093446956362787 -0.262411805474378  0.022323156021381  0.042743443130518  0.119643171496185  0.019212092155216 -0.111729948135909  0.069344517807286
-    4  ( 18)  0.056361407951715 -0.163012412779377 -0.357847040556453 -0.219749386366483  0.199619718061283  0.273157948729405  0.231158276251819  0.090626116159486  0.037799150902146
-    5  ( 19)  0.160601962218735 -0.080044732518404  0.203861835009410 -0.053968884194125  0.109680630973887  0.290493189386329  0.118089200507037 -0.148837371744261  0.161317719017176
-    6  ( 20) -0.008652189032826  0.543672739191643  0.312260746368354 -0.021747391276478  0.131147878369811 -0.214266804924841 -0.195294510221963 -0.037324155238128 -0.082720193718919
-    7  ( 21)  0.047043957125951 -0.814756484486684 -0.065190092636916 -0.048606045400368 -0.224060646841072 -0.197248282512201 -0.232144218543584  0.394908869566567  0.217734911422747
-    8  ( 22) -0.009402914133539  0.067052868071270  0.200249024215418  0.001535377445924 -0.051944723647720 -0.071384974303961  0.075222552542562  0.043268063312178 -0.039055784643578
-    9  ( 23)  0.222713322415783 -0.560469323042930  0.171950144039822  0.112172774497996 -0.007083782785909  0.006435272424486  0.090200197520766 -0.151801615119284  0.031995099170652
-   10  ( 24)  0.015969660808332  0.124160280352778  0.031945357169913  0.022574658439251  0.040253136475423  0.054701591947166  0.334874112350668 -0.105285662958809 -0.223928209457468
-   11  ( 25) -0.081168660495960  0.159983923907575 -0.408650744438646  0.280675358230412  0.326885231204144 -0.118534279418464  0.213700195384120  0.079763618019830 -0.060689421297523
-   12  ( 26) -0.003652731302177 -0.169351937988896  0.223186850703667 -0.177435884273904  0.431821641248852 -0.017470249474556  0.113426087502892 -0.031984799215361  0.498979784707156
-   13  ( 27)  0.059460007596700 -0.080535877567365  0.075179690138888  0.285729932961758  0.080576308673493  0.153138615960011  0.017506919748356  0.094018188463908 -0.750480875221691
-   14  ( 28) -0.091778712898573  0.083756184222668 -0.314061943377694  0.035359431345057 -0.119047398405395  0.075525757634597  0.100522537659024 -0.234167701630633  0.382415314141466
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054192115098489 -0.218772067545687  0.045642231806083 -0.057541502908124 -0.042026312169826
-    1  ( 15) -0.090589594220003  0.434594274447356  0.078276612217069  0.011552267330405 -0.225173895359454
-    2  ( 16) -0.087809314060775  0.409613431079942 -0.269441429063588  0.132294826475095  0.092807551910873
-    3  ( 17)  0.029496711967634  0.321890318472494  0.333949687981794  0.098006508583727  0.253968229243978
-    4  ( 18) -0.133856062539151  0.034112562139975 -0.437342385549595  0.064344113622612  0.014887157054416
-    5  ( 19)  0.074762453522294 -0.320522646445325 -0.065103712350275 -0.002026903619864  0.283693559601974
-    6  ( 20)  0.006545565411461  0.024114390996231 -0.248934516268112  0.216845871250478 -0.105404222827927
-    7  ( 21)  0.447834620578749 -0.279310199694516  0.002046231690190 -0.142438484210793  0.004552777078072
-    8  ( 22)  0.046132212945001 -0.028293172679903  0.127980948576613  0.129504871571094 -0.367038613276140
-    9  ( 23)  0.119912706409769 -0.438601556174488  0.013921175995500 -0.279073471993608  0.587144581639703
-   10  ( 24) -0.308677963206646 -0.164180974317535 -0.355112983785913  0.047146799420307 -0.142329570216595
-   11  ( 25) -0.075357514307532  0.419786206774900 -0.016983461358500 -0.203268341742445 -0.127372692691209
-   12  ( 26) -0.762257766627436 -0.045741941689100 -0.314841853754996 -0.096926452085088  0.417500846668484
-   13  ( 27)  0.290827635505768  0.045087590967332  0.109301341928646 -0.275850981479361 -0.223796991125890
-   14  ( 28) -0.156281997482093  0.568696982960467  0.039100360028362  0.187067134074575 -0.209842829958128
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.008545475107476 -0.071680877089206  0.120459476636913 -0.008371471662446  0.090424858216027  0.087190000124570  0.049119105543224 -0.145928530657214 -0.062376143421355
-    1  (  1)  0.044572181787493 -0.342772635368155  0.233569654941350 -0.080704995470875 -0.127360357635352 -0.050248913608748  0.272733324148390 -0.042278800375679  0.013710430281526
-    2  (  2)  0.007154597183575 -0.182635894723101  0.088652103396483 -0.063130413574038 -0.192109998380945 -0.097062796293933  0.154759017819859 -0.027524119345809  0.057504913844805
-    3  (  3)  0.077052275000893  0.016814177051793 -0.184635905961744  0.049413266051267  0.188745223686842  0.186563337985988  0.210232732381490  0.116951639594811  0.221961452093225
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163872566981873  0.058478850756530 -0.036608142215322  0.074980328212796 -0.102514306635711  0.049419294250537
-    1  (  1)  0.131779111368958  0.004610196247654 -0.196879673097414 -0.065560333989646  0.202294566496281 -0.212677679948666
-    2  (  2) -0.021560095269691  0.083223144658810 -0.151678626872472  0.372667885980926 -0.062527480001262 -0.084301072064405
-    3  (  3) -0.068590860983671  0.076978943427677 -0.378848573533368 -0.165187920801172 -0.188975469384157  0.045051968107620
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.086725030779380  0.140001038265324 -0.215201398518350  0.106476373516199  0.037203797104343 -0.002684965595124  0.084210079065148  0.008500639419888  0.198745218470751
-    1  (  5) -0.141020111205039  0.238503069490028  0.123978991148198  0.150112816633559 -0.036264937723074  0.146138191093449 -0.002600464782236 -0.189526092315718  0.090546937772816
-    2  (  6) -0.314591250772654  0.266642343404836  0.168172023759533  0.305975417776500 -0.047767848718246  0.093136048513418  0.423942737612318  0.027493034904141  0.068648706999971
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.012967316151690 -0.053655915263561 -0.013296231482133  0.012509871140561 -0.053184722817966
-    1  (  5)  0.065459441432743  0.098590450512903  0.180288063245052  0.033076485246495  0.305944394837877
-    2  (  6) -0.160972461596512  0.052337284313257 -0.418780783100688  0.024563105423132  0.150128272333000
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002961765779100 -0.004522349171324  0.004971919287087 -0.008281709260186 -0.002230370021123 -0.014875581701851 -0.067042001167372 -0.013799182049252  0.003919895633432
-    1  (  1) -0.001156407591826 -0.011364234036016 -0.009216213637618  0.026466586550273 -0.045020897276730 -0.024548396390040 -0.151472003391729 -0.022837501049660  0.020115222648640
-    2  (  2)  0.011852353144693  0.003988649312187 -0.013577386237941  0.005526396491599 -0.001842043686662  0.004979012487137  0.016339527495633  0.010418266838825  0.006987142315452
-    3  (  3)  0.053414909238326  0.048153357581206 -0.085702791986601  0.002590768785420  0.032944657214652  0.019536458989955  0.058299722995214 -0.003474387569511  0.035804252701834
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.000158467148596  0.005351238219208  0.000795318433066  0.002864683250639 -0.001069112713473  0.000329369508724
-    1  (  1) -0.008857574490791 -0.013536712170937 -0.030733233064254 -0.004374373678073  0.001058558277179 -0.003465102179278
-    2  (  2) -0.011600433240152  0.024957487742010 -0.006847708052902  0.007864294541740 -0.004416463366055 -0.003633653136444
-    3  (  3) -0.033694386372795 -0.004962923837305  0.009297526391638 -0.012733700421545 -0.018367087946588 -0.009679397413178
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.004099418996737 -0.004975270717489 -0.011544453403942 -0.010294240373049 -0.015031167783122  0.051218543078986 -0.101906219668190 -0.009904937929980  0.005253311566155
-    1  (  5) -0.030335401615971  0.051022895540044  0.010476806750229 -0.022518303747979 -0.032764970727702  0.046697847750190 -0.082351506534871 -0.029648968337614  0.032167075005308
-    2  (  6)  0.044658147220588 -0.062597359445969 -0.000792773883945 -0.033784853569182 -0.053456383670095  0.070727579120646 -0.103493462669028  0.004470774917382 -0.021985039399781
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001406578222011 -0.001390228891514 -0.004138457631327  0.000537337712782 -0.000303816554518
-    1  (  5)  0.018025115903144  0.007054017557051 -0.018234657716208 -0.000615735236753  0.005903957155119
-    2  (  6) -0.015821399504368 -0.004485035916282 -0.033862858822880 -0.005131801318237 -0.004339292116808
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.001352471969094  0.045322075444733 -0.038349314552152
-    1  (  1)  0.023470923414908  0.379995390457559 -0.218263993898326
-    2  (  2)  0.020646215106669  0.203889457343544 -0.063634437124037
-    3  (  3)  0.097263397740302  0.216436926506454  0.416986973069653
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.001379673989061 -0.023464182377298 -0.020715625293986 -0.097608841144396
-    1  (  5) -0.045132209688744 -0.379406783605291 -0.203869208496661 -0.217739723605823
-    2  (  6)  0.038063072975973  0.217447630040656  0.062958922139319 -0.417725794235781
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.065653814142264  0.041946284375303  0.013161767706572 -0.111342796774500  0.110017778689743  0.028611074624176  0.087379776644865 -0.000506944002000  0.012737970563703
-    1  (  1) -0.002767473668146 -0.010697220027718  0.013506144228592  0.073913704778148 -0.217999207158693 -0.148131683228122 -0.817266423889027 -0.116806346540286  0.086848804711528
-    2  (  2)  0.048963138068012  0.019287255807937  0.016789870431812 -0.373432811546966  0.152152935578878 -0.191763986764781 -0.187319954974202 -0.050812933510948  0.023574454587241
-    3  (  3) -0.095762012298033 -0.056431105854389  0.178578325306558  0.038136923805617  0.140424655163157  0.089806364466590 -0.125801031634604 -0.116636753108288 -0.084794392657478
-    4  (  4) -0.100603170191617 -0.067705087958627  0.243617055985189  0.044363102282417  0.181215354983299  0.115079991268796 -0.179518597407386 -0.083927955619955 -0.086976764117441
-    5  (  5)  0.065265491800394  0.066327433491654 -0.367149548777650  0.044009709655582  0.156519624550140  0.073861464202985 -0.054146331819748 -0.093323533938862  0.170259582834842
-    6  (  6) -0.072248812824936 -0.071960211653410  0.684415406158707 -0.206867685302678 -0.380153305403406 -0.217464691746015  0.101286474206003  0.035777100475268 -0.341069042893403
-    7  (  7)  0.019742266764988  0.004654597124952  0.113800058767268 -0.000574265002983  0.010628342976831  0.072863781204177  0.376898463473803  0.139300622802210 -0.056085680972333
-    8  (  8)  0.000679953535081  0.001598902294011 -0.037525126251819  0.088614223995002 -0.068220130924204  0.039175761140296  0.208506736043279  0.056089637691589 -0.046057044816225
-    9  (  9) -0.002777732520373 -0.007429125774642 -0.024943116942350  0.022915921654072 -0.035702462515069 -0.020318534935527 -0.128837242689886  0.002259623765271 -0.005711714139269
-   10  ( 10) -0.005703803965392  0.023273876655766  0.027225029310730  0.026559677666667 -0.035399971500057 -0.015156942548385 -0.030152703916084 -0.170109037950347 -0.002596190944829
-   11  ( 11) -0.003384564196851 -0.002280327238919  0.118256580527015  0.004805921198873 -0.008748560057608  0.061729599159426  0.016174096583601 -0.021868118731471  0.291086759759657
-   12  ( 12)  0.020555722880272 -0.013540587399774  0.000211893937570 -0.008542727496112  0.013892940715707  0.041889105198929  0.006009166679671  0.135825768330791  0.000314961828297
-   13  ( 13)  0.004670677001798  0.000926772526536  0.016865034300282 -0.001908716884004 -0.008533776733402 -0.002600829800043 -0.067129999007525 -0.024630232805222 -0.002093287302057
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006448280903781 -0.007804174666870  0.001726589742279  0.009631719534244  0.002171109312827 -0.006916768929421
-    1  (  1) -0.039841759002053 -0.031613811363753 -0.126269993080286  0.005440038892529  0.010222632040274 -0.010738082177417
-    2  (  2) -0.049400367190082  0.028054173187029  0.027409200065905  0.001009289954765 -0.006677408446924 -0.009978484711828
-    3  (  3)  0.070460304013326 -0.083098595574193  0.035907224123551 -0.018802993269139  0.017169529769810  0.011284756920795
-    4  (  4)  0.035774264116816  0.067898270132826 -0.022183832964584  0.018305304819727  0.010768454734731  0.005255647674495
-    5  (  5)  0.149334153074510 -0.107123073600670 -0.046253700594295 -0.009064678078212  0.006568373775894  0.015962506593757
-    6  (  6) -0.264128081623912 -0.189717353125691  0.013846475545988 -0.034468738650004  0.018622793691907 -0.039125899611440
-    7  (  7) -0.078787498256752  0.137081801981432 -0.129024279783991  0.020540266029100 -0.010702305076213 -0.006363683572839
-    8  (  8)  0.066828272542120  0.061150331629768  0.661663512432504  0.064427579111988 -0.022787180611671 -0.001755054521373
-    9  (  9)  0.058361662206488  0.002765609007918  0.292979002594137 -0.024531884688023  0.033841964179834 -0.017477652244683
-   10  ( 10)  0.025537046615515 -0.402776836876724  0.195006548574470  0.143818217257362 -0.044952634158782  0.042833786526299
-   11  ( 11) -0.612581110120467 -0.030681983336889  0.052907112855315 -0.397594256764291 -0.644994698530558  0.225177415266176
-   12  ( 12)  0.078361827884296 -0.147641215292530  0.139659868964866 -0.415352806158415  0.111207746262217 -0.045767792834358
-   13  ( 13)  0.007555966012008 -0.007034052257820  0.662815283687025  0.034075798547008 -0.058439318318560  0.002857982237762
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.065636199611282  0.002920916198147 -0.048668219311498  0.095119636724795  0.099715491746342 -0.064115894757826  0.070288612362710 -0.020002036740183 -0.000648682346076
-    1  ( 15) -0.042164832302811  0.010965264984920 -0.019193267525749  0.056427120825921  0.067779126388374 -0.066346545701259  0.071818426884183 -0.004697793564429 -0.001719477062512
-    2  ( 16) -0.013293723744736 -0.013552393155520 -0.017152946073135 -0.178062131392816 -0.243207234696954  0.366656850670269 -0.683571699988320 -0.113725695300653  0.037674829370647
-    3  ( 17)  0.111833520478397 -0.074487105305844  0.373408686548039 -0.038278615402917 -0.044272326064866 -0.043920914820213  0.206763999327991  0.000718931757735 -0.088712771696387
-    4  ( 18) -0.110609556420903  0.218552165395166 -0.152101671319906 -0.140308960149057 -0.181388781196210 -0.156379821301524  0.379726625097930 -0.010777684689777  0.068071061617319
-    5  ( 19) -0.028752510181408  0.148103625807997  0.191866592233893 -0.089885426625568 -0.115404739185245 -0.073530988681885  0.216894531023559 -0.072888831186762 -0.039414155734701
-    6  ( 20) -0.088850262853694  0.817864717973160  0.187538432803728  0.126558510407503  0.179188313739966  0.053967785688344 -0.101346004734165 -0.376808265586346 -0.209641170142921
-    7  ( 21)  0.000236648626185  0.116954024007332  0.050876086441348  0.116850431043499  0.083855737312712  0.093201481422807 -0.035654753872492 -0.139240147731598 -0.056215130854042
-    8  ( 22) -0.012632241831446 -0.086750564455513 -0.023471210733819  0.084658255793584  0.087082440553447 -0.170291379307318  0.341029495907861  0.056080270650825  0.046130696703817
-    9  ( 23) -0.006387457988158  0.039627800428235  0.049236971359731 -0.070603541281575 -0.036093218300137 -0.148729935532572  0.263186790392662  0.078651937105263 -0.066792443994885
-   10  ( 24)  0.007794314356224  0.031645957507839 -0.027999240171264  0.083306839859372 -0.068240617920633  0.107186407568302  0.189422573537585 -0.136891913283426 -0.061228539916207
-   11  ( 25) -0.001991689460876  0.126407268625784 -0.027445392718538 -0.035776924599103  0.022144125160038  0.046221028292780 -0.013824022605635  0.129003528239796 -0.661853370394303
-   12  ( 26) -0.009599825104381 -0.005495331116759 -0.001034223219580  0.018933867742673 -0.018384105286375  0.009023661627231  0.034486124663305 -0.020439460919434 -0.064455521141270
-   13  ( 27) -0.002162721447509 -0.010273200862148  0.006630148558014 -0.017146542465354 -0.010737357070418 -0.006596929169183 -0.018510057851825  0.010689113270586  0.022830224344291
-   14  ( 28)  0.006906605609555  0.010703198677296  0.009943679074748 -0.011262720290334 -0.005261069281766 -0.015966561898017  0.039173616710326  0.006358426931312  0.001746833081562
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.002837339199042  0.005729990462521  0.002882667336321 -0.020606047818522 -0.004641004703607
-    1  ( 15)  0.007437286770332 -0.023276875493539  0.002358499534732  0.013557485629733 -0.000920107297989
-    2  ( 16)  0.025051827266470 -0.027193002752018 -0.117990698559769 -0.000179234372392 -0.016865743435032
-    3  ( 17) -0.023119196337007 -0.026652175278014 -0.004797499415929  0.008529905892743  0.001864545935891
-    4  ( 18)  0.035881897592302  0.035473538214569  0.008734163325355 -0.013878334987718  0.008565527202823
-    5  ( 19)  0.020360772275651  0.015171720613603 -0.061893166394059 -0.041911368342621  0.002602253507665
-    6  ( 20)  0.129299070691523  0.030292769804169 -0.016131950321938 -0.006006549470023  0.067162983124201
-    7  ( 21) -0.002077638821295  0.170151112881545  0.021893691209527 -0.135824125871701  0.024649373152539
-    8  ( 22)  0.005657792833300  0.002565321667606 -0.291029322280664 -0.000304358068315  0.002094832642432
-    9  ( 23) -0.058382869250631 -0.025529477410136  0.612383084135802 -0.078382756676553 -0.007563305586064
-   10  ( 24) -0.002481618081866  0.402824463109094  0.030640926554774  0.147639465945455  0.007047422246803
-   11  ( 25) -0.292947637539939 -0.194977050256941 -0.052900384325439 -0.139655182883169 -0.662817045986547
-   12  ( 26)  0.024630592497451 -0.143803605487111  0.397605464014331  0.415353658752820 -0.034075972250685
-   13  ( 27) -0.033850850098076  0.044956075971212  0.644991001235189 -0.111210374775728  0.058439332449029
-   14  ( 28)  0.017470247415045 -0.042829113212736 -0.225189876847489  0.045765194902991 -0.002860279243371
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.003220755761788  0.004741334513036 -0.005218491575352  0.008931308835907  0.002244102633378  0.015838687100919  0.070299613805989  0.014541519275327 -0.004023986014985
-    1  (  1)  0.000067503033474  0.012207317918030  0.007244793200988 -0.023892777130642  0.043438396740122  0.025220796440141  0.154461573863724  0.023000834887421 -0.019599055677926
-    2  (  2) -0.012578011879907 -0.003275100255966  0.012592919961383 -0.005684090399027  0.002169804380039 -0.004971061326221 -0.013552564477647 -0.009500984985895 -0.006299654057362
-    3  (  3) -0.059262075820670 -0.046181284980691  0.084603478568992 -0.003021949940787 -0.032496962809605 -0.021957384896270 -0.062320115832634  0.002770430488820 -0.031773062115651
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.000182000207227 -0.005588586167114 -0.000672702586966 -0.002964514553093  0.001105034523208 -0.000343253226041
-    1  (  1)  0.008618205903186  0.014153751191206  0.035995392865196  0.005123687397521 -0.001603958931174  0.003532153146744
-    2  (  2)  0.011268111146370 -0.024898784529351  0.008069485418761 -0.008185686323918  0.004533934142691  0.003585064891685
-    3  (  3)  0.031845177970419  0.004991052985520 -0.011188833991374  0.013257910424622  0.018832233173395  0.009593400754084
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.004231156729541  0.005431493649267  0.012529175724660  0.009596633242284  0.014606722988323 -0.052629799448244  0.104835250484967  0.010143068216584 -0.005577330897623
-    1  (  5)  0.032234138585390 -0.047805476204470 -0.011206420541453  0.021169463646392  0.032922137113452 -0.049263864001113  0.085142779220860  0.029187847712420 -0.030401159775617
-    2  (  6) -0.047014795193874  0.061420283989306  0.003243656996742  0.033537214796175  0.054307591623750 -0.073188368684598  0.108826461718921 -0.002713708723067  0.019591523301056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.001535925504297  0.001313736377570  0.005141735029325 -0.000303256666525  0.000317758840647
-    1  (  5) -0.017868281803487 -0.005956287092286  0.022125071354749 -0.000228679155762 -0.005956925492705
-    2  (  6)  0.014719284513933  0.004480852833973  0.038592140844884  0.004744813467982  0.004561240528551
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440356479  0.058098623177060  0.000062770505092 -0.132305009105496 -0.206845253941622  0.090151367748423 -0.021622993143838 -0.039361662992191  0.081041759558226
-    1  (  1) -0.058446002702836  0.108172168386185  0.020491566051334  0.029038345992777 -0.075256281123738  0.197244333988945 -0.268904698641837 -0.104165934598637  0.067340388311649
-    2  (  2) -0.015395531848647  0.065975044836942  0.020693241330571  0.145278172814648  0.156811977452555  0.026190455636648 -0.072791620713754 -0.106379131933316  0.008110007352911
-    3  (  3)  0.209889648236101  0.051262205353483 -0.016792464647056 -0.095510023392087  0.095336437943254 -0.289116527068191  0.245753635975044 -0.379261907549404  0.084194488960217
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922070380 -0.024147628235135  0.039515998256435  0.082736569385204 -0.047511948407189
-    1  (  1)  0.028213287410066  0.067760885382258  0.238885785831598 -0.125969164417165  0.177609465299056
-    2  (  2)  0.077606299822139 -0.045313543977919  0.093141189528995  0.365274042010320  0.093447143662359
-    3  (  3)  0.414915648101425  0.159852566454575 -0.273568285244179 -0.034618677464967  0.200919751856191
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102682138215 -0.069778483618667  0.053388820705143  0.227201022061025 -0.199230027507757  0.049687576272545 -0.168877445324815 -0.014461225346720 -0.006078045787078
-    1  (  5)  0.058029574568631 -0.323045692556243  0.030451397480033 -0.087822399123219 -0.049669665073330 -0.052839306705253 -0.277652121487366 -0.149775076501372  0.305937155187615
-    2  (  6) -0.084055275416977  0.046073375264778  0.190725804844658 -0.087557818571264 -0.137785527535432 -0.205465571560117 -0.198777590794243 -0.118276962947747 -0.298899363411174
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985643121  0.083163093513445  0.059838819925541  0.009394325003249 -0.030439464334268  0.004211857989885
-    1  (  5)  0.056299327075830 -0.068872084822763  0.330916524082322 -0.053769676068525 -0.184435947342737 -0.103868547796473
-    2  (  6)  0.066328790095722 -0.124449756334111  0.113043685672814  0.144452726550473  0.299204372324576 -0.043729255630968
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000260799278180  0.008294549497458  0.017065509889387 -0.120823024347784
-    1  (  1) -0.008496132195710  0.000459229311004  0.070584548654847 -0.263658987971002
-    2  (  2) -0.016577243499005 -0.069994423923560  0.000663995662767  0.516189372162913
-    3  (  3)  0.119940673323058  0.260382743299108 -0.515797582139532  0.000896339388888
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000443199054119  0.381921104005874 -0.143832379423130
-    1  (  5) -0.379434119543787 -0.000485242459082  0.057931044964221
-    2  (  6)  0.142702240031722 -0.057674063898636  0.001442186569692
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000910226438200  0.057456315647344  0.021764054616564 -0.110121253697657 -0.041147685715423  0.038875248096137 -0.013658842816188  0.027740417762726  0.095876695371130
-    1  (  1) -0.055345619259075 -0.000114715934544 -0.161082100934535  0.114708094818496 -0.226148458324691  0.429581553751604 -0.364780572887542 -0.339773268987353 -0.220533774744399
-    2  (  2) -0.020999461515685  0.161288340725610  0.000052922970119  0.056734674713291  0.008992634403320  0.218257664918361 -0.249333786133602 -0.218109893723775  0.109339937360493
-    3  (  3)  0.109919099574174 -0.115822425715978 -0.056019356031194  0.000740007095007  0.462857615923727  0.122607299335305  0.103870366450161  0.116250705419353  0.000233457194456
-    4  (  4)  0.040147971736914  0.225934656930791 -0.007773114629988 -0.462818557889914 -0.000780254049361  0.292874409138683 -0.009409004020261 -0.051882584565833 -0.039822167749921
-    5  (  5) -0.036335623693882 -0.431140334679252 -0.219015877475265 -0.122742719044919 -0.292837706496088 -0.000258434125831  0.380099535662932  0.122521034451732  0.042311772982521
-    6  (  6)  0.010512439726471  0.366117332794119  0.249486244103056 -0.103549874519169  0.008542365779906 -0.379118456291524 -0.000620782572313  0.110534560584461 -0.061985573540389
-    7  (  7) -0.028794951664777  0.339121669867214  0.216809050490518 -0.114099993246667  0.053090461626524 -0.122152835981425 -0.109887843186158 -0.000210776402969 -0.084672807469555
-    8  (  8) -0.095808229399132  0.221323464482799 -0.109106314792845 -0.000875257457611  0.038544677386553 -0.040538328426676  0.059775641025623  0.084700205378613  0.000410389354257
-    9  (  9)  0.014690106491517 -0.105287842118522 -0.107275604483120  0.218821764375615  0.309676781731095 -0.105240911604621 -0.129641828566929  0.117997785339671  0.042511311192418
-   10  ( 10) -0.029204608817403  0.107752356880331 -0.099755035717731  0.053525818879341  0.138310129158905  0.190113742192741 -0.089997971579917 -0.050367401919439 -0.205935350574800
-   11  ( 11) -0.155172680813618  0.443695988859270 -0.328777258069509 -0.218798389099096 -0.215176387461835  0.086665175851153 -0.081418632205002 -0.042686048283827  0.076994698961746
-   12  ( 12)  0.047142387984938  0.056370877735219 -0.091886939990151  0.290638653877080 -0.241910292969431 -0.247337059928007  0.042831064524262  0.092379405612353 -0.274155000078483
-   13  ( 13) -0.050389463693039  0.050328281612189 -0.290240848494312  0.162056910726980  0.213783629964646 -0.103688020985272 -0.033887129957515 -0.045587144676475  0.299790508093838
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015162329261762  0.029089765310940  0.157702865584754 -0.046156688514328  0.051381785238624
-    1  (  1)  0.106899843708486 -0.107201618560176 -0.445393416001207 -0.057067668629351 -0.050060001886431
-    2  (  2)  0.108853020016321  0.100191021028451  0.328545989684712  0.092698579556052  0.291502735762344
-    3  (  3) -0.218857914732928 -0.054792818554564  0.218936510583978 -0.287400526650046 -0.163296274552526
-    4  (  4) -0.309023997649700 -0.137542449801745  0.215093936648757  0.238284970233362 -0.213551426731583
-    5  (  5)  0.105674820684469 -0.189857437820115 -0.086867271556711  0.246374813757869  0.103858683942188
-    6  (  6)  0.128168668490610  0.089874262580382  0.081958189888793 -0.043636026138960  0.033207564369726
-    7  (  7) -0.118048267554359  0.049676494199198  0.043691989598397 -0.088880392330239  0.045560837044954
-    8  (  8) -0.043185963759057  0.206226573210928 -0.075243165739987  0.272590964145289 -0.299131513308221
-    9  (  9) -0.000077812750263  0.416515228417900  0.033604308554634 -1.079153036382561  0.144875292418151
-   10  ( 10) -0.417421688656681 -0.000158782243602 -0.288840596220158 -0.322135887066066 -0.291543524694710
-   11  ( 11) -0.033233098605228  0.288689216150241  0.000098607070373  0.357467165030213 -0.110234432471254
-   12  ( 12)  1.082588809014081  0.322578291381663 -0.357464370732486 -0.000001008926324 -0.002433258902322
-   13  ( 13) -0.144961978586806  0.291352746525362  0.110198259116823  0.002466771848949  0.000072101869173
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000153758776117  0.016209320965105  0.024928923757993 -0.062060534746170 -0.021458157416245  0.118593249067004 -0.004670228294358 -0.089096779890278  0.035341469320983
-    1  ( 15) -0.019055649133697  0.000070152122919  0.073747919702930 -0.220440656283159  0.117173681778925 -0.070042107037530 -0.194626605110428  0.297284849336053 -0.000292612579198
-    2  ( 16) -0.022586057118123 -0.073725573957683 -0.001109122666778 -0.015411803389863 -0.086529842350705 -0.104871287980693 -0.398741646289671 -0.436619148331831  0.174927780649059
-    3  ( 17)  0.059798965916265  0.223563287458482  0.017237453392182  0.001072539123553  0.251308090392191 -0.316070038847548  0.194803920269306  0.070654457969027 -0.376473483655780
-    4  ( 18)  0.020063419612631 -0.119039349408291  0.086800563750570 -0.251653936305414 -0.000335080735996  0.043024303892643  0.031731210904760  0.166597040709751  0.162561043906122
-    5  ( 19) -0.121124499955847  0.070386002281353  0.107113059896318  0.315446439504518 -0.043168772215477 -0.000861181929967  0.084799445456534  0.176705933868056 -0.191684805801835
-    6  ( 20)  0.000233561036084  0.194646689461778  0.399810731825322 -0.193912344414617 -0.032510952578749 -0.085522667269840  0.000316476981181  0.483153682224173 -0.288298406144107
-    7  ( 21)  0.086715012513528 -0.297226361655840  0.437406683020490 -0.070307665212214 -0.166617940064674 -0.177260527643651 -0.482840792772829 -0.000014363804072  0.098144550576534
-    8  ( 22) -0.034848855831113  0.000859202110741 -0.174080336928834  0.374333295621785 -0.160768014942695  0.191629536777613  0.289445575791765 -0.097019024563133 -0.000025631190893
-    9  ( 23) -0.146128458859477  0.053492838723281  0.324237370304827  0.062951581962557  0.055209150392106  0.064149761275701  0.152989513320630  0.139473999081823 -0.103718919745517
-   10  ( 24)  0.228943772617007 -0.607904766836796 -0.190620042163283 -0.232958068554443 -0.097307404392685  0.308161168894475 -0.021743402571297  0.163623966328651  0.316399909940952
-   11  ( 25) -0.113574180450176 -0.174427793696739  0.418995996797932  0.308337203773489 -0.075443225258948  0.339087151000572 -0.159463644175662 -0.028413073183974 -0.098871219135018
-   12  ( 26) -0.037424667627758 -0.021650461815628  0.117304488555654 -0.051902638516337  0.180454397204301  0.010740660446775  0.081519307958206 -0.155893098286787  0.070546741513103
-   13  ( 27)  0.017280094917641 -0.067254948202109  0.031223412783479 -0.363810241712273  0.387221887172221  0.012090141232777  0.015814975888526  0.054980917535039 -0.199339784826487
-   14  ( 28)  0.034098865606387  0.073619427530260 -0.020485113762460 -0.085856422339691  0.016811589994319 -0.112843996612104 -0.014113720302883  0.178007823049380  0.110352388592064
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147079245976260 -0.230634884327798  0.118016008095876  0.038157145434167 -0.016510465499821 -0.035555014241919
-    1  ( 15) -0.054535973951003  0.607948556744402  0.173873449665646  0.021413077919509  0.066607274428011 -0.073358777560519
-    2  ( 16) -0.323553306716541  0.191880318233455 -0.420431580367675 -0.118056258433329 -0.032680374772067  0.021063792737754
-    3  ( 17) -0.062647993136989  0.233296910168052 -0.309972235049851  0.052767888000268  0.365466873103625  0.086191647721005
-    4  ( 18) -0.056463254581534  0.097267541950806  0.076718792428350 -0.181006281426179 -0.388581954607450 -0.017033118173935
-    5  ( 19) -0.064619380352855 -0.308870128837400 -0.338018875040100 -0.010262168024492 -0.011437556053144  0.112357517192840
-    6  ( 20) -0.155382617120808  0.021349499069868  0.159407311491110 -0.081840985740344 -0.016551112219655  0.014159445447452
-    7  ( 21) -0.140537868365913 -0.163950016139901  0.028635642703436  0.155664270522521 -0.055628199070781 -0.178154240957341
-    8  ( 22)  0.103340923981933 -0.315438553715367  0.098505861648548 -0.070640699178892  0.199194337948212 -0.110183696150063
-    9  ( 23)  0.000686334523005 -0.100169676705670 -0.098205409926821  0.175395135103276 -0.218110756133058  0.228152281729332
-   10  ( 24)  0.099945574901306 -0.000096874523801  0.318471840231024 -0.225312239057313 -0.500004280246570 -0.463864297141458
-   11  ( 25)  0.099841601903911 -0.317761699341874 -0.000010561898700  0.325597818757907 -0.211905875429043 -0.064803783303090
-   12  ( 26) -0.174935629969472  0.225292248952868 -0.325705390264674 -0.000017197242562 -0.212072627252549  0.098012445880115
-   13  ( 27)  0.218628597779198  0.499556536309007  0.211864150049234  0.212027765065009  0.000008829414452 -0.140826209095657
-   14  ( 28) -0.228628348644091  0.463533897425291  0.064881803408838 -0.097950839605716  0.140879063677935 -0.000044304452715
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019783280962491 -0.054735513036393  0.001137513221933  0.126035313397777  0.202288257068162 -0.093711193829816  0.024984212293499  0.040225532801761 -0.083002910227929
-    1  (  1)  0.062354133456812 -0.120130294655184 -0.021767958501026 -0.030544876872275  0.074729404941111 -0.202914227763797  0.283260339857543  0.110010624076740 -0.075144553244755
-    2  (  2)  0.020071793451970 -0.073560407589557 -0.021169787012452 -0.145854096701605 -0.150911678978076 -0.033300464776861  0.073764758000912  0.114546085873699 -0.006653295400428
-    3  (  3) -0.203743026628905 -0.061501992586247  0.012053004875485  0.096810295870523 -0.111136074888818  0.295383183736970 -0.262971263836652  0.383085480530365 -0.093214804722179
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009993046283887  0.025513386596424 -0.042737152836742 -0.089318312648033  0.047451575437880
-    1  (  1) -0.030039490649266 -0.071945227885317 -0.250267584137830  0.142236308614906 -0.184637048828095
-    2  (  2) -0.082997800944815  0.054871782095115 -0.094796172305804 -0.401103667111563 -0.092927166183836
-    3  (  3) -0.430981237821724 -0.170811685089178  0.282618320770360  0.039486333217088 -0.208093566455086
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.010424640140636  0.070076236901647 -0.057204661229737 -0.211582690126517  0.193468115965468 -0.043909115261545  0.178375291288102  0.011291008781060  0.006135050116210
-    1  (  5) -0.063097232722725  0.334472526495555 -0.025536894990807  0.078253601702773  0.050626850793128  0.056751425430030  0.294768356957907  0.157483239712855 -0.310569420319987
-    2  (  6)  0.095244048403721 -0.044264153982762 -0.212560989611836  0.091390108488898  0.149038965211255  0.211765484415775  0.210419446695478  0.121083327494802  0.309642081940379
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068004773266362 -0.092578615344634 -0.065573414828925 -0.010233554140998  0.030163257404408 -0.003064448161750
-    1  (  5) -0.053600127227434  0.069934324462776 -0.342538882666169  0.056907034018328  0.186630072086963  0.106323576616076
-    2  (  6) -0.072821378093083  0.126275999821165 -0.117600524675145 -0.149377060058828 -0.309029921623329  0.046031657791552
+    0      0.363702792459799    -0.362754886434693     0.000000000000000
+    1     -0.116320922974629     0.012078489119707     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.392022201675664
 
 	Computing Mu_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.701184623099
-	   1         4.466332122628    2.237e-01
-	   2         5.048530436953    1.153e-01
-	   3         5.053341692319    2.407e-02
-	   4         5.060192186381    8.581e-03
-	   5         5.060643261182    2.456e-03
-	   6         5.060601043862    6.650e-04
-	   7         5.060683603718    2.644e-04
-	   8         5.060648613045    9.083e-05
-	   9         5.060642799724    3.515e-05
-	  10         5.060643376272    1.589e-05
-	  11         5.060644593447    4.964e-06
-	  12         5.060644201448    1.094e-06
-	  13         5.060643864368    2.768e-07
-	  14         5.060643808959    8.338e-08
-	  15         5.060643811101    2.647e-08
-	  16         5.060643817661    9.235e-09
-	  17         5.060643819475    2.870e-09
-	  18         5.060643819480    1.083e-09
-	  19         5.060643819497    2.850e-10
-	  20         5.060643819549    1.181e-10
+	   0         3.701184611663
+	   1         4.466332106197    2.237e-01
+	   2         5.048530413775    1.153e-01
+	   3         5.053341668785    2.407e-02
+	   4         5.060192162706    8.581e-03
+	   5         5.060643237466    2.456e-03
+	   6         5.060601020150    6.650e-04
+	   7         5.060683580003    2.644e-04
+	   8         5.060648589330    9.083e-05
+	   9         5.060642776010    3.515e-05
+	  10         5.060643352557    1.589e-05
+	  11         5.060644569732    4.964e-06
+	  12         5.060644177734    1.094e-06
+	  13         5.060643840654    2.768e-07
+	  14         5.060643785244    8.338e-08
+	  15         5.060643787387    2.647e-08
+	  16         5.060643793947    9.235e-09
+	  17         5.060643795761    2.870e-09
+	  18         5.060643795766    1.083e-09
+	  19         5.060643795783    2.850e-10
+	  20         5.060643795834    1.181e-10
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 4.663e-11
 
 	Computing P_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.866534056559
-	   1         8.865878359152    1.879e-01
-	   2         9.321768215834    8.332e-02
-	   3         9.332009063587    2.534e-02
-	   4         9.334500300677    8.772e-03
-	   5         9.334993415041    2.963e-03
-	   6         9.335227447217    1.133e-03
-	   7         9.335292394677    4.278e-04
-	   8         9.335256681323    1.576e-04
-	   9         9.335262864849    4.346e-05
-	  10         9.335265216859    1.530e-05
-	  11         9.335263137529    4.244e-06
-	  12         9.335261446096    1.140e-06
-	  13         9.335261116953    2.473e-07
-	  14         9.335261093712    7.760e-08
-	  15         9.335261089344    2.811e-08
-	  16         9.335261083093    1.117e-08
-	  17         9.335261078525    3.943e-09
-	  18         9.335261076684    1.481e-09
-	  19         9.335261076611    5.110e-10
-	  20         9.335261076659    1.363e-10
+	   0         7.866534067597
+	   1         8.865878369114    1.879e-01
+	   2         9.321768224524    8.332e-02
+	   3         9.332009071979    2.534e-02
+	   4         9.334500308997    8.772e-03
+	   5         9.334993423331    2.963e-03
+	   6         9.335227455499    1.133e-03
+	   7         9.335292402954    4.278e-04
+	   8         9.335256689601    1.576e-04
+	   9         9.335262873127    4.346e-05
+	  10         9.335265225137    1.530e-05
+	  11         9.335263145807    4.244e-06
+	  12         9.335261454375    1.140e-06
+	  13         9.335261125231    2.473e-07
+	  14         9.335261101990    7.760e-08
+	  15         9.335261097622    2.811e-08
+	  16         9.335261091371    1.117e-08
+	  17         9.335261086804    3.943e-09
+	  18         9.335261084962    1.481e-09
+	  19         9.335261084890    5.110e-10
+	  20         9.335261084937    1.363e-10
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 4.052e-11
 
 	Computing L_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.734366128629
-	   1         6.039740990066    3.521e-01
-	   2         7.477018826499    2.246e-01
-	   3         7.582057687252    6.663e-02
-	   4         7.648203630932    3.104e-02
-	   5         7.653797876182    1.253e-02
-	   6         7.656631463616    6.753e-03
-	   7         7.658737837077    3.217e-03
-	   8         7.658511007606    1.563e-03
-	   9         7.658606434730    5.634e-04
-	  10         7.658638919672    2.133e-04
-	  11         7.658683037777    7.378e-05
-	  12         7.658676111998    3.191e-05
-	  13         7.658667829833    1.114e-05
-	  14         7.658666757061    4.283e-06
-	  15         7.658666279588    1.796e-06
-	  16         7.658665624497    8.471e-07
-	  17         7.658664872532    3.959e-07
-	  18         7.658664505079    1.954e-07
-	  19         7.658664389539    1.141e-07
-	  20         7.658664382657    5.691e-08
-	  21         7.658664397107    2.282e-08
-	  22         7.658664400361    9.518e-09
-	  23         7.658664403386    3.629e-09
-	  24         7.658664404131    1.032e-09
-	  25         7.658664404216    3.553e-10
-	  26         7.658664404288    1.643e-10
+	   0         4.734366103925
+	   1         6.039740960229    3.521e-01
+	   2         7.477018789867    2.246e-01
+	   3         7.582057649157    6.663e-02
+	   4         7.648203591999    3.104e-02
+	   5         7.653797836829    1.253e-02
+	   6         7.656631424056    6.753e-03
+	   7         7.658737797405    3.217e-03
+	   8         7.658510967926    1.563e-03
+	   9         7.658606395054    5.634e-04
+	  10         7.658638879995    2.133e-04
+	  11         7.658682998100    7.378e-05
+	  12         7.658676072320    3.191e-05
+	  13         7.658667790155    1.114e-05
+	  14         7.658666717383    4.283e-06
+	  15         7.658666239910    1.796e-06
+	  16         7.658665584819    8.471e-07
+	  17         7.658664832854    3.959e-07
+	  18         7.658664465401    1.954e-07
+	  19         7.658664349861    1.141e-07
+	  20         7.658664342979    5.691e-08
+	  21         7.658664357429    2.282e-08
+	  22         7.658664360683    9.518e-09
+	  23         7.658664363708    3.629e-09
+	  24         7.658664364453    1.032e-09
+	  25         7.658664364538    3.553e-10
+	  26         7.658664364610    1.643e-10
 	-----------------------------------------
 	Converged L_X-Perturbed Wfn to 6.080e-11
 
 	Computing Mu_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.683224910490
-	   1         9.714405267611    4.039e-01
-	   2        11.687621147642    2.140e-01
-	   3        11.709288551850    3.628e-02
-	   4        11.736025286452    1.721e-02
-	   5        11.739344958787    4.374e-03
-	   6        11.738944417020    1.364e-03
-	   7        11.739200006263    5.941e-04
-	   8        11.739217179098    2.538e-04
-	   9        11.739156779018    8.183e-05
-	  10        11.739164959056    2.147e-05
-	  11        11.739181135986    7.105e-06
-	  12        11.739189255155    1.634e-06
-	  13        11.739189422375    4.679e-07
-	  14        11.739188970935    2.116e-07
-	  15        11.739188631709    6.983e-08
-	  16        11.739188594017    2.552e-08
-	  17        11.739188596033    8.258e-09
-	  18        11.739188599191    2.908e-09
-	  19        11.739188598626    1.404e-09
-	  20        11.739188598298    5.201e-10
-	  21        11.739188598199    1.729e-10
+	   0         7.683224840388
+	   1         9.714405173844    4.039e-01
+	   2        11.687621016357    2.140e-01
+	   3        11.709288418459    3.628e-02
+	   4        11.736025152191    1.721e-02
+	   5        11.739344824344    4.374e-03
+	   6        11.738944282594    1.364e-03
+	   7        11.739199871821    5.941e-04
+	   8        11.739217044654    2.538e-04
+	   9        11.739156644578    8.183e-05
+	  10        11.739164824615    2.147e-05
+	  11        11.739181001544    7.105e-06
+	  12        11.739189120713    1.634e-06
+	  13        11.739189287933    4.679e-07
+	  14        11.739188836493    2.116e-07
+	  15        11.739188497267    6.983e-08
+	  16        11.739188459575    2.552e-08
+	  17        11.739188461591    8.258e-09
+	  18        11.739188464749    2.908e-09
+	  19        11.739188464184    1.404e-09
+	  20        11.739188463856    5.201e-10
+	  21        11.739188463757    1.729e-10
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 5.907e-11
 
 	Computing P_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.914235382981
-	   1         9.250158690749    2.487e-01
-	   2        10.037451687262    1.145e-01
-	   3        10.059001449539    2.417e-02
-	   4        10.063414652458    1.012e-02
-	   5        10.064118019880    2.321e-03
-	   6        10.064098519755    7.047e-04
-	   7        10.064201081057    2.032e-04
-	   8        10.064191831321    6.571e-05
-	   9        10.064182055047    2.841e-05
-	  10        10.064184470811    1.277e-05
-	  11        10.064186877035    4.624e-06
-	  12        10.064187658441    1.130e-06
-	  13        10.064187189414    3.034e-07
-	  14        10.064187031752    1.156e-07
-	  15        10.064186968468    3.839e-08
-	  16        10.064186968431    1.109e-08
-	  17        10.064186967402    3.766e-09
-	  18        10.064186966925    1.417e-09
-	  19        10.064186966896    4.591e-10
-	  20        10.064186966945    1.345e-10
+	   0         7.914235388345
+	   1         9.250158697421    2.487e-01
+	   2        10.037451692516    1.145e-01
+	   3        10.059001453863    2.417e-02
+	   4        10.063414656698    1.012e-02
+	   5        10.064118024085    2.321e-03
+	   6        10.064098523961    7.047e-04
+	   7        10.064201085258    2.032e-04
+	   8        10.064191835523    6.571e-05
+	   9        10.064182059249    2.841e-05
+	  10        10.064184475013    1.277e-05
+	  11        10.064186881237    4.624e-06
+	  12        10.064187662643    1.130e-06
+	  13        10.064187193616    3.034e-07
+	  14        10.064187035954    1.156e-07
+	  15        10.064186972670    3.839e-08
+	  16        10.064186972633    1.109e-08
+	  17        10.064186971603    3.766e-09
+	  18        10.064186971127    1.417e-09
+	  19        10.064186971098    4.591e-10
+	  20        10.064186971147    1.345e-10
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 5.415e-11
 
 	Computing L_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.260905032428
-	   1         0.353171707150    9.756e-02
-	   2         0.464811471179    6.517e-02
-	   3         0.479121762179    2.190e-02
-	   4         0.483278772665    6.564e-03
-	   5         0.483108743284    2.517e-03
-	   6         0.483088276558    1.297e-03
-	   7         0.483272143195    7.649e-04
-	   8         0.483220657459    2.937e-04
-	   9         0.483236856788    7.748e-05
-	  10         0.483238108360    3.405e-05
-	  11         0.483235076496    9.968e-06
-	  12         0.483232161388    3.960e-06
-	  13         0.483231942925    1.261e-06
-	  14         0.483232363766    6.810e-07
-	  15         0.483232554135    2.279e-07
-	  16         0.483232606999    9.221e-08
-	  17         0.483232600794    2.966e-08
-	  18         0.483232601407    1.138e-08
-	  19         0.483232601314    5.684e-09
-	  20         0.483232601748    1.536e-09
-	  21         0.483232601768    4.567e-10
-	  22         0.483232601873    2.048e-10
+	   0         0.260905028552
+	   1         0.353171701457    9.756e-02
+	   2         0.464811462018    6.517e-02
+	   3         0.479121752485    2.190e-02
+	   4         0.483278762811    6.564e-03
+	   5         0.483108733423    2.517e-03
+	   6         0.483088266695    1.297e-03
+	   7         0.483272133306    7.649e-04
+	   8         0.483220647574    2.937e-04
+	   9         0.483236846901    7.748e-05
+	  10         0.483238098474    3.405e-05
+	  11         0.483235066609    9.968e-06
+	  12         0.483232151502    3.960e-06
+	  13         0.483231933039    1.261e-06
+	  14         0.483232353880    6.810e-07
+	  15         0.483232544249    2.279e-07
+	  16         0.483232597113    9.221e-08
+	  17         0.483232590908    2.966e-08
+	  18         0.483232591521    1.138e-08
+	  19         0.483232591427    5.684e-09
+	  20         0.483232591862    1.536e-09
+	  21         0.483232591882    4.567e-10
+	  22         0.483232591987    2.048e-10
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 7.815e-11
 
 	Computing Mu_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.589662399139
-	   1         6.874619198679    3.050e-01
-	   2         7.928633766028    1.502e-01
-	   3         7.927595393970    2.448e-02
-	   4         7.935133305730    1.041e-02
-	   5         7.936327601992    2.530e-03
-	   6         7.936232328307    8.148e-04
-	   7         7.936306884063    3.309e-04
-	   8         7.936293661584    1.056e-04
-	   9         7.936274453796    3.199e-05
-	  10         7.936276429908    1.019e-05
-	  11         7.936280342829    3.815e-06
-	  12         7.936282454429    1.063e-06
-	  13         7.936282458009    3.664e-07
-	  14         7.936282240689    1.314e-07
-	  15         7.936282128420    4.186e-08
-	  16         7.936282109925    1.335e-08
-	  17         7.936282109164    4.483e-09
-	  18         7.936282109335    1.606e-09
-	  19         7.936282109304    5.691e-10
-	  20         7.936282109203    2.270e-10
+	   0         5.589662355577
+	   1         6.874619139383    3.050e-01
+	   2         7.928633686909    1.502e-01
+	   3         7.927595314620    2.448e-02
+	   4         7.935133226091    1.041e-02
+	   5         7.936327522299    2.530e-03
+	   6         7.936232248617    8.148e-04
+	   7         7.936306804371    3.309e-04
+	   8         7.936293581892    1.056e-04
+	   9         7.936274374105    3.199e-05
+	  10         7.936276350218    1.019e-05
+	  11         7.936280263138    3.815e-06
+	  12         7.936282374738    1.063e-06
+	  13         7.936282378318    3.664e-07
+	  14         7.936282160998    1.314e-07
+	  15         7.936282048729    4.186e-08
+	  16         7.936282030234    1.335e-08
+	  17         7.936282029473    4.483e-09
+	  18         7.936282029644    1.606e-09
+	  19         7.936282029613    5.691e-10
+	  20         7.936282029512    2.270e-10
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 8.007e-11
 
 	Computing P_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.340107626228
-	   1         9.473558086770    2.226e-01
-	   2        10.095265081802    9.682e-02
-	   3        10.099645816409    2.050e-02
-	   4        10.100379229050    8.210e-03
-	   5        10.100989609659    2.225e-03
-	   6        10.101040072012    7.462e-04
-	   7        10.101117764962    2.883e-04
-	   8        10.101111255636    9.801e-05
-	   9        10.101104530551    2.631e-05
-	  10        10.101106044900    7.810e-06
-	  11        10.101106847027    2.784e-06
-	  12        10.101107220181    8.783e-07
-	  13        10.101107022682    2.873e-07
-	  14        10.101106939006    9.947e-08
-	  15        10.101106909524    3.253e-08
-	  16        10.101106908868    1.054e-08
-	  17        10.101106908418    3.894e-09
-	  18        10.101106907816    1.602e-09
-	  19        10.101106907807    5.216e-10
-	  20        10.101106907802    1.956e-10
+	   0         8.340107636357
+	   1         9.473558095810    2.226e-01
+	   2        10.095265087799    9.682e-02
+	   3        10.099645822192    2.050e-02
+	   4        10.100379234791    8.210e-03
+	   5        10.100989615376    2.225e-03
+	   6        10.101040077726    7.462e-04
+	   7        10.101117770674    2.883e-04
+	   8        10.101111261348    9.801e-05
+	   9        10.101104536263    2.631e-05
+	  10        10.101106050612    7.810e-06
+	  11        10.101106852739    2.784e-06
+	  12        10.101107225893    8.783e-07
+	  13        10.101107028394    2.873e-07
+	  14        10.101106944718    9.947e-08
+	  15        10.101106915237    3.253e-08
+	  16        10.101106914580    1.054e-08
+	  17        10.101106914130    3.894e-09
+	  18        10.101106913528    1.602e-09
+	  19        10.101106913519    5.216e-10
+	  20        10.101106913514    1.956e-10
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 6.090e-11
 
 	Computing L_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.182431483318
-	   1         5.219803995763    3.102e-01
-	   2         6.347230441651    2.169e-01
-	   3         6.576925990739    9.235e-02
-	   4         6.676221569242    3.600e-02
-	   5         6.676646006228    1.323e-02
-	   6         6.679514835768    5.742e-03
-	   7         6.680633746707    2.070e-03
-	   8         6.679982613653    8.770e-04
-	   9         6.680026378226    2.992e-04
-	  10         6.680023275915    1.468e-04
-	  11         6.680011352400    6.537e-05
-	  12         6.679968064564    2.891e-05
-	  13         6.679961987859    9.692e-06
-	  14         6.679966795023    3.295e-06
-	  15         6.679968998792    1.139e-06
-	  16         6.679969687410    4.283e-07
-	  17         6.679969720889    1.324e-07
-	  18         6.679969747626    4.713e-08
-	  19         6.679969784296    1.974e-08
-	  20         6.679969798726    7.428e-09
-	  21         6.679969806007    3.603e-09
-	  22         6.679969810045    1.748e-09
-	  23         6.679969812090    7.136e-10
-	  24         6.679969812545    2.194e-10
+	   0         4.182431459881
+	   1         5.219803967823    3.102e-01
+	   2         6.347230408682    2.169e-01
+	   3         6.576925955946    9.235e-02
+	   4         6.676221533786    3.600e-02
+	   5         6.676645970599    1.323e-02
+	   6         6.679514800148    5.742e-03
+	   7         6.680633711060    2.070e-03
+	   8         6.679982577990    8.770e-04
+	   9         6.680026342565    2.992e-04
+	  10         6.680023240254    1.468e-04
+	  11         6.680011316738    6.537e-05
+	  12         6.679968028902    2.891e-05
+	  13         6.679961952198    9.692e-06
+	  14         6.679966759362    3.295e-06
+	  15         6.679968963131    1.139e-06
+	  16         6.679969651749    4.283e-07
+	  17         6.679969685227    1.324e-07
+	  18         6.679969711964    4.713e-08
+	  19         6.679969748634    1.974e-08
+	  20         6.679969763064    7.428e-09
+	  21         6.679969770346    3.603e-09
+	  22         6.679969774384    1.748e-09
+	  23         6.679969776429    7.136e-10
+	  24         6.679969776883    2.194e-10
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 9.118e-11
 
 	Computing 1/2 <<Mu;L>>_(0.077) tensor.
 	Computing 1/2 <<P;L>>_(0.077) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027048397172827  0.015352704112429 -0.027966801428206 -0.165495930367099  0.113032293131079 -0.059172920617490  0.054022056893036  0.034114608641417  0.002886107104428
-    1  (  1)  0.197986831439807  0.163526093357892 -0.274966362484751  0.062421195117411  0.155967420230584  0.185920877152340  0.363704257460170  0.011868347502389  0.094068355200268
-    2  (  2)  0.001994785400509 -0.040665399791180 -0.057882185886799  0.076919743499300  0.080668892974906  0.050712045980973 -0.045932897295670  0.241652574031132  0.100470948740106
-    3  (  3) -0.134618148262870 -0.169475273759002 -0.112338313271068 -0.029804521352267  0.003944352681063  0.058729559824899 -0.233881451281742 -0.145241305284807  0.577534946997298
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.036861128446484  0.060248603479283 -0.005564054645453 -0.004146763273408  0.016591697834381 -0.007733796755325
-    1  (  1) -0.035918794247218 -0.084747615285920 -0.145084319526741 -0.032998082529710 -0.051841379309429  0.022806687326240
-    2  (  2) -0.084717069711908  0.396672019200134 -0.041908741386333 -0.023248477509422 -0.041530856301655  0.002269986110115
-    3  (  3)  0.038883132455574 -0.071756294192596  0.163991699742162 -0.069947324622934 -0.143620958659473 -0.040929670412834
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052809051974611 -0.081154565641459  0.006856441672465  0.153404070250162  0.196852318183927 -0.080976239577634  0.074658786299150  0.007719515837141 -0.043614904957346
-    1  (  5)  0.345238819329888  0.019785726463408 -0.050847186825376 -0.077921925096032  0.068975151229659 -0.351671921498224  0.386754555295523 -0.290601454575730  0.053302927070672
-    2  (  6)  0.016264209978667 -0.328366425365533 -0.028951141350709 -0.018921421012293 -0.077573679759545 -0.021800407750167  0.192628950256551  0.357488541894078 -0.081608454670559
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002259895960631 -0.008421832675073 -0.029392100940116  0.031369993361730  0.013404147466831
-    1  (  5)  0.208575493629327  0.067711703634065 -0.203628183391135 -0.030033358486437  0.027351411878278
-    2  (  6) -0.187162949376747 -0.097599552501240 -0.071289729935510 -0.047614074934521 -0.125833431363021
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.083683703090339 -0.629036417459351  0.187768409616308
-    1  (  1) -0.172602425643759 -0.014265091859115 -0.090495237140442
-    2  (  2)  0.012410708512386  0.140259555625425 -0.033093031733629
-    3  (  3)  0.617332033723984 -0.177002119872801 -0.059198789591033
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.083984489601084 -0.171922407137234  0.012476891672991  0.618883655109570
-    1  (  5) -0.628194576289392 -0.014487461121762  0.141926484654468 -0.177049320083612
-    2  (  6)  0.185974040475234 -0.088119347704351 -0.035357029662085 -0.057155078540436
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.828696203592025 -0.451233677364964 -0.217492273801626  0.586304584205470 -0.198651498309132 -0.103892077288677 -0.006625290696853 -0.001819921442022 -0.094028994790127
-    1  (  1) -0.134105565072084 -0.143652464482426 -0.611995940113886  0.241008731857517 -0.051449178692584 -0.174330855034171  0.232749848820746  0.145661004271388 -0.128120727077505
-    2  (  2)  0.012063899957181 -0.029490668702565  0.163575298648468 -0.247038876502286 -0.158753040652801 -0.232668473612314 -0.114948417424730 -0.088613836090719 -0.022645502108504
-    3  (  3) -0.387197557412670 -0.007622232234767 -0.010218748368993 -0.204814602539347  0.014944145142201  0.002431343194739 -0.270127586345773  0.245262578145958  0.504586982816530
-    4  (  4) -0.460895290297202 -0.083413276687337 -0.199944470395538 -0.175480967267008 -0.163722513813610  0.040241151316098 -0.067825190846260 -0.310807009269909  0.577783712019049
-    5  (  5) -0.141670378431748  0.052086036202433 -0.250889435285257 -0.425040439955416  0.233847348075332 -0.158351487033986  0.178722313644596  0.245879694116802 -0.083555978624952
-    6  (  6) -0.130215129741091 -0.059015562328244  0.175413123904883  0.193335335494377  0.081298931206816  0.027166944052244 -0.479004702191582  0.042682340773738 -0.241453523690860
-    7  (  7) -0.128547673529086 -0.164220156281948  0.072921190130196 -0.418244944504053  0.302491231669016 -0.324010640072614 -0.075458878798693 -0.283018425704598  0.036415017864410
-    8  (  8) -0.062134266770614 -0.089654327070673  0.258681583169725  0.013233242093465  0.089010222721713  0.141925171219203  0.145726898819659 -0.025159117142780  0.043087625590561
-    9  (  9)  0.009157475877293  0.060303564275152  0.008729628589478 -0.116950978984904  0.076882806093440 -0.036383180924410  0.025483369510244  0.084185310301748 -0.015374203474542
-   10  ( 10)  0.047802155117035 -0.149112906046527  0.075801259346579 -0.048947777837302 -0.067507042894011 -0.106234452747565  0.028517793153314 -0.172545779173849  0.080208086539212
-   11  ( 11) -0.167486808508145 -0.138908523197938  0.283706274113969  0.091574703729164 -0.067077172850546 -0.025283786004213 -0.222327209021950 -0.000487203355974 -0.057945510499956
-   12  ( 12) -0.037231281930006  0.362748649100666  0.118756733555108  0.060033069634811  0.015289792490319 -0.066371796214512  0.063049993784234 -0.118284085626097 -0.151871766112428
-   13  ( 13)  0.015283336962664 -0.071148654690618  0.097868838236954 -0.110089289416517  0.125070464978759 -0.056834800649528 -0.036033401521028 -0.003983216078506 -0.062348090726013
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.129554454626645 -0.009474588080129 -0.145878009069340 -0.063534624713007 -0.014264450989202  0.066217032610968
-    1  (  1)  0.281753304154040  0.090565863681328  0.289775851087277  0.012154255844323 -0.002972094129563 -0.002349687671183
-    2  (  2) -0.119860879107323 -0.017641780651255 -0.056884026698647 -0.114243277051592 -0.081965225578515  0.047553858250442
-    3  (  3)  0.046051897739571 -0.068234524007742 -0.078832315651282  0.147716570125616  0.178529070541059  0.041892492825571
-    4  (  4)  0.224634415651606  0.054726588873862 -0.049348904717282 -0.010497565899220  0.270816650862660  0.056280914540891
-    5  (  5) -0.031024580647590 -0.167869422275837  0.089185539311376  0.032869876236856 -0.093569757739340 -0.005458274862047
-    6  (  6)  0.000981392608875 -0.078803302525778 -0.231661065523126  0.077973096019011 -0.062231529668081 -0.004237870062293
-    7  (  7) -0.058902381932974  0.114392724110640 -0.121932201798416 -0.061774560961000  0.018069277572558  0.046890882022827
-    8  (  8) -0.513410839175549 -0.085343806911986  0.027485231745675  0.006687146984676  0.194553865700676 -0.182125622987063
-    9  (  9) -0.072026715715937  0.003186347104678  0.005511418401201  0.002695559377571  0.031996063695793  0.027434309505846
-   10  ( 10) -0.012941082780342  0.102602875317609  0.011650753905957  0.003161188417901  0.051176261016026  0.036262081394577
-   11  ( 11) -0.072389598964860 -0.058864168002652 -0.028128390537061 -0.005943934144729 -0.000119126931267 -0.005492981656650
-   12  ( 12) -0.054636974740175 -0.008287355979314 -0.024569715170625 -0.016528220340787 -0.046477458022406 -0.050873095371919
-   13  ( 13)  0.233743037101684  0.059061280447733 -0.024586559461861  0.004543245586431 -0.015684709596020  0.012075090111966
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.826691217716273 -0.135952995986678  0.011483190853402 -0.387418549613132 -0.461392423434393 -0.145485395838477 -0.124983069633084 -0.128330208269710 -0.063846145512012
-    1  ( 15) -0.452846199342112 -0.142299396923846 -0.028873680579439 -0.006282104582323 -0.083434971591043  0.052286846958797 -0.060366664959448 -0.164381491855687 -0.091103104723665
-    2  ( 16) -0.216318168271836 -0.610394122458981  0.164687829144547 -0.011212326508078 -0.198690499654959 -0.249888026637277  0.173149134305467  0.071382973187058  0.260544315437109
-    3  ( 17)  0.584300313840742  0.240136635172586 -0.247504197547440 -0.203677759108949 -0.175664930669504 -0.423103759080422  0.191640258021663 -0.415453280544989  0.012404695910308
-    4  ( 18) -0.199046601234260 -0.050380875227390 -0.159053876876033  0.015277075663832 -0.162367358631649  0.232430660796134  0.082724825485615  0.299791975181979  0.088348234646987
-    5  ( 19) -0.104272480193007 -0.175241820294404 -0.233618498225201  0.003347139508098  0.039544446804631 -0.159217030916535  0.028729750234265 -0.323094060438359  0.140740059020568
-    6  ( 20) -0.009429700555618  0.234933209114364 -0.114393727276615 -0.268466551242383 -0.069016344623676  0.178511125207222 -0.480183500829793 -0.075907755374260  0.143021582340266
-    7  ( 21) -0.002871019980141  0.147322100081013 -0.089022269698270  0.243063067023217 -0.308863060976325  0.246226696688424  0.042991460237403 -0.286148618462202 -0.024663467570559
-    8  ( 22) -0.094480909031128 -0.129736715593916 -0.024604248218242  0.506975842783889  0.578523602334509 -0.083635854955803 -0.240378319056804  0.036574430518098  0.043361894806843
-    9  ( 23) -0.127469850231581  0.279775306347553 -0.119965256355608  0.046842433309940  0.224627106687645 -0.032678040821047  0.003106740012385 -0.057480210886726 -0.513625849978234
-   10  ( 24) -0.010113608772280  0.091491204350202 -0.018677713812760 -0.071589894306377  0.058565690503593 -0.167584249262607 -0.077210943763034  0.110209847874266 -0.083926459961230
-   11  ( 25) -0.144415369890515  0.288923500809327 -0.057020258893375 -0.078932024592243 -0.049197678741037  0.089025916916400 -0.231280649793149 -0.121731391324011  0.028617795572466
-   12  ( 26) -0.063356880757476  0.012359494559817 -0.113921394225926  0.147470818074126 -0.010507483518380  0.032942784833780  0.077682178518205 -0.061765741733595  0.006769386889262
-   13  ( 27) -0.013995995859800 -0.002559954171790 -0.081334364324019  0.177743396826763  0.270580272329641 -0.093513472630021 -0.062576452638165  0.017989699080157  0.194659969913094
-   14  ( 28)  0.066065732055799 -0.002211449695904  0.047581100788566  0.041756948476168  0.056034974532939 -0.005464174123526 -0.004247545547791  0.046945122816871 -0.182306395720765
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.009977414948991  0.047795726251349 -0.170257794893058 -0.037938003385798  0.014458354771735
-    1  ( 15)  0.061029814509221 -0.148838977933651 -0.138622311676044  0.363027561331653 -0.070814310121723
-    2  ( 16)  0.008874691507393  0.075936125697402  0.284555367553991  0.119192422675493  0.098638859969366
-    3  ( 17) -0.119112210975481 -0.049599126168817  0.092584517631524  0.060254228139763 -0.110664977910194
-    4  ( 18)  0.077868925237217 -0.066966521216813 -0.067808172209585  0.015338001788660  0.125516910271684
-    5  ( 19) -0.036382791915003 -0.106250802464449 -0.025901673388436 -0.066582385072615 -0.057303328993872
-    6  ( 20)  0.027021717761366  0.029104182126986 -0.222331616975881  0.063168783761157 -0.035714374282977
-    7  ( 21)  0.082539979364650 -0.172536666253103 -0.000669172457815 -0.118274514306553 -0.003844186581139
-    8  ( 22) -0.015061746200930  0.080414802790268 -0.057448999880623 -0.151717132243101 -0.062253352906387
-    9  ( 23) -0.071494404128242 -0.013120612580941 -0.073373439067110 -0.054797723574814  0.233375251535298
-   10  ( 24) -0.000029429641055  0.102291625448331 -0.059321314850514 -0.008317623517552  0.059027698391220
-   11  ( 25)  0.005765327972253  0.011614880462470 -0.028065205779369 -0.024579424954359 -0.024526575892733
-   12  ( 26)  0.002692253200082  0.003132810553211 -0.005932245634366 -0.016507700544142  0.004577653394693
-   13  ( 27)  0.031988350963214  0.051121558533183 -0.000221075294856 -0.046532133387957 -0.015677394532699
-   14  ( 28)  0.027397767162108  0.036259397253953 -0.005558504489882 -0.050917091935213  0.012016157844186
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.025406566159268  0.023298635287253 -0.022289171225281 -0.168859399546037  0.107903085343053 -0.060918366478026  0.050893116255270  0.027117697569600  0.006137025962381
-    1  (  1)  0.191093901631364  0.147230293879877 -0.245327925746496  0.051184636572256  0.145804688312181  0.177082412956716  0.335688365255302  0.014738825150512  0.084927582076377
-    2  (  2) -0.003155042580293 -0.027233271764860 -0.053208296453271  0.087116448441961  0.072613171875510  0.049776562479710 -0.037069643141426  0.221123482833241  0.094081632463615
-    3  (  3) -0.148081532987297 -0.143795935425655 -0.095653656284437 -0.040581516151424  0.007002536737363  0.053388570274401 -0.215379283048700 -0.136731549228503  0.551441205232222
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.030005353497125  0.050795632899782 -0.002892294664254 -0.003533356466287  0.015218907421680 -0.007301899744305
-    1  (  1) -0.023556562941518 -0.073830002725756 -0.128862604566188 -0.028671951610704 -0.047866625740652  0.021732276920370
-    2  (  2) -0.073223983264692  0.364347296120169 -0.036743687154481 -0.019261211454008 -0.037116539662741  0.000181223309972
-    3  (  3)  0.040361740685149 -0.065239876693051  0.146174618322834 -0.062411658986300 -0.126965052748134 -0.038245290086936
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.049420429939020 -0.071369144027861  0.010967892434703  0.154003952784752  0.199243445955842 -0.070560943504312  0.064246991121544  0.009741916757203 -0.037796040806489
-    1  (  5)  0.343138545087365  0.025580231196086 -0.051475570317848 -0.074170810753422  0.055679775667351 -0.335513778030016  0.361763562256478 -0.278312996717472  0.053462866737909
-    2  (  6)  0.009023834056191 -0.297316159210662 -0.029288421962258 -0.011782745518153 -0.070184214173438 -0.014572213441163  0.183342019819766  0.338840705353917 -0.064096544850433
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.003020372683713 -0.006869864196192 -0.023893125242991  0.027343480005917  0.011586872808644
-    1  (  5)  0.191183605646494  0.061813805162100 -0.180211660376411 -0.027158850194505  0.022115988544494
-    2  (  6) -0.170812182146008 -0.089183247070529 -0.060689118587739 -0.041496923999492 -0.115713673600506
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.033754103488904  0.007555372231008 -0.012636539412206 -0.059168089266189 -0.007696166024660  0.117635610027585 -0.032183947570515  0.074301250166332  0.005019432091403
-    1  (  1) -0.423755974394480  0.394319832811341  0.072147771285996 -0.012389712258359  0.176348210158568  0.099930502723386 -0.086701753728859  0.210493567935760 -0.033589866390245
-    2  (  2)  0.731556552635086 -0.976828857219025  0.033351783092618  0.123378208756534  0.157072652564139 -0.117469430301404  0.019850790679398  0.009097984935670  0.052536003980734
-    3  (  3) -0.047142053921200  0.198059791670330 -0.117104106550805  0.059612555708172 -0.051540989544482  0.120490618164713  0.186894293315771 -0.315632131525439 -0.008321584703138
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.004809884959149 -0.006374181554658  0.001349973408295 -0.006100975957460  0.011138127142432  0.022680627009235
-    1  (  1)  0.028102393649998  0.000289730093568  0.008262915835035 -0.124989537199237  0.066219531536918  0.018649107137634
-    2  (  2)  0.064127657438793 -0.065272286524580 -0.003581214395138 -0.076462588539111 -0.021447992337748 -0.132206773204054
-    3  (  3)  0.084986028536621 -0.498497698329473 -0.040822633530773 -0.043076722957163  0.013585564451261  0.027785129671115
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.016730543671402 -0.000493178350680  0.017302982722459 -0.256616062196450  0.185493094009100 -0.020593262646150 -0.009463629803292 -0.002961983098477  0.026859263160767
-    1  (  5) -0.075519353333223  0.118875850027739  0.079935827799390 -0.178710173458091 -0.108180669642193 -0.177149189778534 -0.083450989109747  0.113241594567945  0.031859913963448
-    2  (  6) -0.130570312068760  0.286100740965062  0.219486021249390 -0.104893438221523  0.173427403577016 -0.413345988897352 -0.212934040260182  0.179032987184766  0.025997492049908
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021490597653360 -0.022287920558859  0.002597640544176 -0.020805616512876 -0.017185298510280
-    1  (  5) -0.023718660102006  0.015749627862868  0.008406851616741 -0.192275139478185  0.036883303753882
-    2  (  6)  0.028766539135724 -0.272291164468312 -0.017419741916350  0.092820056045692  0.043867791725602
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.239338426392564 -0.063574189159419 -0.037138721492623
-    1  (  1)  0.637136254562851  0.563345834986113  1.010359356370541
-    2  (  2) -1.018244537475946  0.319334895202255  0.761891810673220
-    3  (  3)  0.045207421457437 -1.211415382676948  0.547663980563646
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.240077996488429  0.636087166048540 -1.017448666598683  0.045094757983791
-    1  (  5) -0.063119844830318  0.559674519771415  0.326877163045745 -1.214495217986866
-    2  (  6) -0.036017040682083  1.005430771836738  0.769694801723881  0.546245988666419
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.840037313836020  0.879719351228572  0.280425530485763  0.209457510590770 -0.115971007140231 -0.005865677404341 -0.092534287825665  0.016878612757743 -0.000554227822991
-    1  (  1)  0.406955291511109 -0.250354570304778  1.752817026082590  0.218264636938841 -0.014952601145219  0.085173209047615 -0.020235302962366  0.502753766000685  0.012614402487781
-    2  (  2) -0.011947654987322 -0.087288086334953 -0.224335908490773 -0.261126688019980 -0.841762463275376 -0.627828907554534  0.172051366688234  0.617244504994475  0.119309262733021
-    3  (  3)  0.811182010574067 -0.188300264656061  0.222401504654110 -0.118806305641431  0.529562874381598 -1.235458279793789  0.515406670549199 -0.727585984163455 -0.017311451334544
-    4  (  4) -0.382877178063333  0.342160015383575  0.036035220830207 -1.515969153946585  0.125466254724712  0.736754668202047  0.136012972713827  0.102461498470004  0.013411116743442
-    5  (  5) -0.056666348930366  0.399251661739627 -0.011422755469852 -0.698119094644981 -1.282954629697895  0.508762695513963 -0.451449634220948 -0.904106936880537  0.596672635982258
-    6  (  6) -0.005527213521809  0.206039689350583 -0.144483993576148 -0.121247601463421 -0.485305002415323  0.548554310120049  1.475357051064366 -0.106842364972141 -0.027446822634470
-    7  (  7)  0.133565351861769  0.328960786484755  0.162326353593274  0.054193688082147  0.478136828850907  0.570702306118600 -0.024903308876874  0.585193831441818  0.835813795954640
-    8  (  8)  0.031082134068872 -0.063496391996010 -0.272771555688820 -0.132864368300259 -0.103453213303616  0.119428117809223 -0.197405807539525  0.153621429574163 -0.347696082487505
-    9  (  9) -0.117648127967179  0.675674455344672  0.057144753223871  0.137494275224088 -0.007401643263736 -0.153445689840736 -0.039660467466461 -0.125410015238965 -0.348925711100216
-   10  ( 10) -0.183218900015280 -0.105460278770619  0.367791083908301 -0.008056255919995  0.178869825089236 -0.183120759227084 -0.020135495201915  0.515209425517336 -0.117079814088000
-   11  ( 11) -0.007464482549715  0.021032905836050 -0.001689959480439 -0.009511863938863 -0.028294702186542 -0.022246363439352  0.137498694249546 -0.039431687760892 -0.108598715660792
-   12  ( 12) -0.123943400580450 -0.111733854742263  0.047511096154227  0.255974383794788  0.005125598158543  0.148074286896914  0.114005285118611 -0.069660405917942  0.028473614618333
-   13  ( 13) -0.017139778903114  0.000597229894230 -0.092098701078466 -0.096822642158100 -0.041570201760717  0.197811128787409 -0.008675665762269  0.009875145380093 -0.053724977580929
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.015271060368590  0.055897468396679  0.022597241061105 -0.097746276200326  0.101308246517630  0.083130674158184
-    1  (  1) -0.170077841267587 -0.306278912948529 -0.015343223805456  0.140911077413699 -0.086769343161678 -0.004428610402275
-    2  (  2)  0.122266526205533 -0.173859131387549 -0.008833802902653 -0.258485979502035  0.008602351060332 -0.030798632969086
-    3  (  3)  0.115160682049786  0.000168306649340 -0.007959105138980 -0.065254436598696 -0.027276553714500  0.039309215133697
-    4  (  4)  0.041448801667008 -0.223438700330986  0.042071183596141 -0.028071659294627  0.027228579441665 -0.074898825540824
-    5  (  5) -0.019058857013510  0.170849130048803 -0.086743087770944  0.110180684067332  0.041911344191976 -0.107077437297843
-    6  (  6)  0.021255870699759  0.392230842819920  0.124666046290611  0.015546514857889  0.011543222367899 -0.015718913239240
-    7  (  7)  0.300617707044268  0.028511951577123  0.099451065409571 -0.057624703208728  0.020680186596793  0.041210772734416
-    8  (  8)  1.560902789686190  0.259171353520895 -0.164601436985075 -0.034972573255346 -0.150377449452613 -0.038200704783867
-    9  (  9)  0.094514443562177 -0.031271005532013 -0.062263725106321 -0.058838957873498  0.760182137090868  0.950337382630766
-   10  ( 10) -0.066833413223948  0.207007631435691 -0.021103846805201  1.235346069959520 -0.166059589963498  0.166191905898816
-   11  ( 11)  0.166612835901501 -0.057714789963814  1.335141389249462  0.048926720734315 -0.084810123443347  0.094069041404757
-   12  ( 12)  0.208438787230328 -1.201605996005697 -0.134583025189360  0.366858420103389 -0.092230833884388  0.010845623464668
-   13  ( 13) -0.191515363269101 -0.044444589953201  0.113534652068488  0.222935332874317  0.996666807879559 -0.918946475319682
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.838261938125953  0.411783579911082 -0.011222177479730  0.801199436588318 -0.375306180891601 -0.060253817938356 -0.006525724615655  0.129557857631930  0.036205801526960
-    1  ( 15)  0.881558694801301 -0.253494731429581 -0.085421228751772 -0.179689412714139  0.333542664377779  0.397899463382726  0.204757675416354  0.337390689793974 -0.068236018271236
-    2  ( 16)  0.280699466651638  1.751444070796586 -0.225749579482049  0.222724309443776  0.035674220851777 -0.008396081497684 -0.143282250648261  0.160643678305862 -0.273482677804852
-    3  ( 17)  0.209621101203040  0.218341762403868 -0.261721827317418 -0.119292443469067 -1.513373925140781 -0.698058616179597 -0.120912446345617  0.053177597646066 -0.132398408764311
-    4  ( 18) -0.117749589449745 -0.014290802057305 -0.842585912658373  0.528480212857232  0.125620436909715 -1.282510147470767 -0.485022216108444  0.477099752728403 -0.104196524597516
-    5  ( 19) -0.007044544158153  0.085833731063079 -0.626602352540001 -1.234607574211689  0.736231003373149  0.506584871133556  0.547680268232320  0.572569559178554  0.118655251440909
-    6  ( 20) -0.091286539818598 -0.021685756074756  0.171006984274394  0.515577034801528  0.135942818875198 -0.450672680612861  1.476397473903694 -0.025200125211324 -0.196552429073982
-    7  ( 21)  0.014617007475273  0.504140575926305  0.617828254758316 -0.727391401463796  0.101524085740282 -0.903538681928281 -0.107568617019622  0.584678825668100  0.151735736187589
-    8  ( 22) -0.000237823420664  0.012124384227592  0.118807977471402 -0.017974774238044  0.014229470507378  0.597624885291520 -0.026926427408390  0.834871784840588 -0.347391080813467
-    9  ( 23) -0.016265284587164 -0.168715787569770  0.122968815716393  0.113284198302450  0.042943290149452 -0.021309190261859  0.020477672429448  0.301304618606591  1.561269376414732
-   10  ( 24)  0.055165623705948 -0.304174565565627 -0.172047420652933 -0.001660031801304 -0.223923016186918  0.170793818371478  0.390519343250458  0.028524302133373  0.258484158546987
-   11  ( 25)  0.022516344496095 -0.015268625075761 -0.008789463144050 -0.007966710860511  0.041912769223181 -0.086577370868099  0.124614837586422  0.099373675936837 -0.164728190655413
-   12  ( 26) -0.096631683724329  0.140629711782460 -0.257993906888811 -0.065720412418661 -0.028201117626138  0.110255501857704  0.015355688312895 -0.057301747761398 -0.034361742521519
-   13  ( 27)  0.100849821365822 -0.086662374683482  0.008639345451765 -0.026546017676244  0.026660167742260  0.041687326988987  0.011443920803067  0.021038625210724 -0.150878061048130
-   14  ( 28)  0.083365492537661 -0.004663028443678 -0.030268841557525  0.040380114857265 -0.076010028857183 -0.107569353616213 -0.016046780201203  0.042417265806974 -0.038629597007140
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124737520970567 -0.186432244849434 -0.007556173934213 -0.125048458790314 -0.016552020209549
-    1  ( 15)  0.684938290376393 -0.103735702852444  0.021157182854187 -0.111849169918717  0.000598582694869
-    2  ( 16)  0.056865870871391  0.369391836124585 -0.001636395160685  0.047382415225486 -0.092511884311165
-    3  ( 17)  0.136934156518159 -0.009055225169970 -0.009590382757559  0.257430334272387 -0.097052552691910
-    4  ( 18) -0.008312109924423  0.179598643669996 -0.028244191820460  0.004116010022868 -0.041623947269660
-    5  ( 19) -0.152106396286801 -0.183914202125923 -0.022266967951892  0.148019441595633  0.198105007663693
-    6  ( 20) -0.039829799204161 -0.019552759743993  0.137602535405962  0.113713715404123 -0.008789545170784
-    7  ( 21) -0.125502178629739  0.515709894296467 -0.039509503457082 -0.069986828128539  0.009910155465828
-    8  ( 22) -0.349425567476830 -0.116835672927993 -0.108584428663162  0.028578302642485 -0.053883081615012
-    9  ( 23)  0.094338880407330 -0.067969707543137  0.166597413367391  0.208167474360311 -0.191318590057359
-   10  ( 24) -0.031516356589242  0.206892773401202 -0.057842868800066 -1.201944585655949 -0.044330968677763
-   11  ( 25) -0.062291263803427 -0.020994462489648  1.335136332915063 -0.134637529250241  0.113529324930304
-   12  ( 26) -0.058655360066673  1.235296326813700  0.048926809978680  0.366850373682241  0.222951200118475
-   13  ( 27)  0.760531019832537 -0.165992770496603 -0.084811358078730 -0.092272088807521  0.996709535509256
-   14  ( 28)  0.951452405735214  0.166207367805620  0.094073590713281  0.010839332616852 -0.918866261119885
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062424152487093  0.006340337268482 -0.007129573994951 -0.068124969445001 -0.016536648970737  0.122839654890139 -0.029124555648029  0.069524525927009  0.016624796588470
-    1  (  1) -0.403752025492204  0.324343055871707  0.076420140656786 -0.003202781255002  0.185946708759860  0.105883952933980 -0.081054655409652  0.184341159829675 -0.032915937518265
-    2  (  2)  0.661672748869100 -0.861372726396764  0.035408787225401  0.124470554040362  0.167515771764057 -0.112285700010499  0.015950867409511  0.001232083495723  0.035574976981523
-    3  (  3) -0.034421465673628  0.179830504979566 -0.111544513847215  0.024097913531803 -0.030238246207055  0.104793216722198  0.173773469173217 -0.303193060944995 -0.006513662906792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.009334134343137 -0.006326528083054  0.001276536883825 -0.004159187336468  0.009674793406368  0.018903850771847
-    1  (  1)  0.023692877349552 -0.000748233659147  0.007572933338662 -0.110618865809947  0.058982973244648  0.020804020406208
-    2  (  2)  0.056439835248463 -0.059263779798462 -0.002854238464665 -0.070581535158609 -0.021806829149510 -0.125806190045722
-    3  (  3)  0.082847328899303 -0.459387875765944 -0.034524528441236 -0.040614390362782  0.013723967190574  0.025955752093967
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.017603663965705  0.003174083877041  0.014339522059496 -0.266660818847198  0.199602064605257  0.004780839495062  0.001108522960745 -0.004965069967999  0.030862088780690
-    1  (  5) -0.088113575807603  0.114873319929461  0.063166154639253 -0.188098449929865 -0.135702241550834 -0.170113296422216 -0.072240153498818  0.102270166350793  0.024891651267320
-    2  (  6) -0.139298038265852  0.270556959145684  0.173447642648828 -0.086085492397594  0.170302022343653 -0.397018505467907 -0.208262454149272  0.170239716749086  0.014885093941277
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.007377491418509 -0.019432502966035  0.002111593502676 -0.017924326928228 -0.015562648892606
-    1  (  5) -0.015992089252138  0.016902070355736  0.006260130611804 -0.170730300914524  0.032158624092886
-    2  (  6)  0.030768942376426 -0.242871623531964 -0.014807837846673  0.086333556064428  0.038627030320013
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130528946 -0.064555152924841  0.195953381452965 -0.041248493442142 -0.011229686954300 -0.030149441399628 -0.052245051060564 -0.006640144599606 -0.060816046841284
-    1  (  1)  0.618380750428757 -0.527850820486333 -0.215416501526368 -0.157035437852335 -0.069798458055575  0.063297476988332 -0.224803808736996 -0.036770088842034 -0.093292414352534
-    2  (  2)  0.089963765084418  0.016694193770404 -0.049894217008593 -0.224500363707256  0.100545586964082 -0.339808932191863 -0.300486601867879  0.103978674976873  0.003854593956757
-    3  (  3) -0.017912540048753  0.240051544243958  0.016875920304164 -0.019658112939729  0.000950481982654  0.139486308126505 -0.307526295570431 -0.245045411518121  0.038982174577009
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228157231 -0.053483299255732  0.001461399823215 -0.009996127162103  0.040844890740135
-    1  (  1)  0.010356156241345  0.045196494922430  0.123149462820863 -0.009608799088997 -0.092775098434661
-    2  (  2)  0.068261626747973 -0.266621644549134  0.090983468413283 -0.007824999548536 -0.015479677470817
-    3  (  3)  0.102991688132870  0.095940846021793  0.235195882815376  0.030438278902471  0.100331913658044
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713182343  0.055002400372953 -0.190701615216833 -0.008587073582699 -0.137456634335766 -0.102685174670731 -0.038575707285854  0.049077773971977  0.038775520895292
-    1  (  5)  0.266426121027506  0.201904502326533 -0.404472747758134  0.112355452471773  0.244543383226856  0.203488255104151  0.093346083645080  0.046662175787456  0.162564534029677
-    2  (  6)  0.310200496188946  0.275860886552205 -0.334362481107594  0.111323203472945  0.107269573355600 -0.015396506114788 -0.485347827879795 -0.115211810589159 -0.189399381435021
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448700903 -0.010182782827209  0.015536223734562  0.027148068645677  0.019304531549287 -0.012170541866764
-    1  (  5) -0.076359104734661  0.072719944842760 -0.105706045014198 -0.076791075691679 -0.095250630845942  0.044053081319363
-    2  (  6) -0.023401555353274 -0.060789750776477  0.233844071184097 -0.060200608251925 -0.022972229728472  0.078966373824930
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134471189914803 -0.662148890607048 -0.267935017575730 -0.078917514513460
-    1  (  1) -0.664666296280562 -0.209284548524716  0.147471335927792  0.068908464210939
-    2  (  2) -0.267133357554530  0.148425589032828  0.187317600183912  0.001813046044159
-    3  (  3) -0.077770523321569  0.066603013382230  0.004062963757785  0.013912154355475
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274832594142428 -0.278242095473143 -0.671654031875754
-    1  (  5) -0.278497835849508 -0.012090615801272 -0.010590436880494
-    2  (  6) -0.670432937480178 -0.009657206552315  0.097732020822376
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959652942443780 -0.408123540990243 -0.490401242893299  0.038728621520496 -0.077955848847628 -0.487356522820254 -0.107431644874248 -0.396098714695084 -0.237559092067117
-    1  (  1) -0.405287391714683 -1.324235802978493  0.174918475291447  0.249090287653660 -0.197882092902579 -0.317613214061072 -0.251158650058355 -0.030182263573247  0.632878894923950
-    2  (  2) -0.488736302148035  0.174537834224317  0.686802536456231  0.342698519251872 -0.009978504113557  0.483630952562764  0.287674546486731  0.302838065991480 -0.272076060462856
-    3  (  3)  0.037680750737500  0.250810426061315  0.345041313473359 -0.288921951476600  0.242065062503934 -0.302245036763640 -0.510968388336981  0.184732147309200 -0.217019518794602
-    4  (  4) -0.076474970303988 -0.199548329885190 -0.011318561816348  0.242358447532560 -0.131824013348934  0.385851084327112 -0.241519487669974 -0.375192533769848  0.062578612484494
-    5  (  5) -0.485852483644543 -0.318979279826184  0.484066634054750 -0.298903806636467  0.382610997595699 -0.557142551551020  0.333197792506285  0.111813059498605  0.019832042071129
-    6  (  6) -0.104965309325025 -0.251905850556084  0.289646446290464 -0.510970312004153 -0.243416542879353  0.333477452717118 -0.859910604691225 -0.040221092426954  0.015978091057726
-    7  (  7) -0.396757752805925 -0.028569556569604  0.303650553602711  0.181375877282891 -0.373315055683876  0.109082013989902 -0.042394080453042 -0.424453142550918 -0.165367340666656
-    8  (  8) -0.232577777741232  0.628634227275953 -0.273406824008824 -0.217896152147594  0.062014351622307  0.020854775528038  0.015643896352917 -0.165522517641184 -1.139943298313989
-    9  (  9)  0.005610937945933  0.056039777778849  0.162949812655036 -0.082447741116097  0.072872155292264 -0.108705186895719 -0.023485984983778  0.044747716582668 -0.147251711462478
-   10  ( 10) -0.006823140107367  0.054329320069732 -0.040599884216487  0.341771214963506 -0.179762239229163  0.323458315199162  0.128244534804048 -0.274646157470800 -0.052523948902062
-   11  ( 11)  0.095363270852437 -0.102111548052236  0.068440604856687 -0.163728434991873 -0.155636086206937  0.243236788520030 -0.456650415619116 -0.005317873090518 -0.049821847163774
-   12  ( 12) -0.031682366649886  0.049375813732146 -0.071598146136873  0.132087989350725 -0.108611785503928  0.096654485319462  0.079499450609138 -0.086710987294923 -0.054539911300598
-   13  ( 13) -0.055056204843758  0.125842892734663 -0.045965574233073 -0.019980233431093 -0.072417713533459 -0.032557591655033 -0.014098057282134 -0.073500277877371  0.566229267143538
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807523812671 -0.007359544445531  0.096092504153619 -0.031848084858648 -0.055774202583708
-    1  (  1)  0.055013732726191  0.054716327776958 -0.101499825301692  0.049505806374070  0.126450547773127
-    2  (  2)  0.163059205524790 -0.041368873195638  0.069581455391968 -0.071597196814435 -0.045866052289024
-    3  (  3) -0.081105673316398  0.339429555795348 -0.164728153281382  0.131959969253045 -0.019695233736278
-    4  (  4)  0.071393373323251 -0.177479193977683 -0.155859184096407 -0.108539407237796 -0.072773970199488
-    5  (  5) -0.105603312027129  0.324542336401662  0.243446189989531  0.096679109324856 -0.032469296684766
-    6  (  6) -0.022598073115881  0.128545265383103 -0.457503820066558  0.079428257830674 -0.014293355797493
-    7  (  7)  0.043846313801253 -0.277398721165106 -0.005217801503343 -0.086814141747281 -0.073528025025910
-    8  (  8) -0.147650558268387 -0.051824889076812 -0.049479655393433 -0.054623458164613  0.565538504818440
-    9  (  9)  0.072040995852218  0.045487481962658  0.010267944428546  0.009607395555640  0.026537979807784
-   10  ( 10)  0.047954867964362 -0.139047713462617 -0.006984668952712 -0.101926998578260 -0.021981627684010
-   11  ( 11)  0.010232694230356 -0.006895180971719 -0.093446496399543 -0.006456318213145  0.037416385389791
-   12  ( 12)  0.009698093592920 -0.101910194006554 -0.006447087192563  0.055515253372902  0.004586695976630
-   13  ( 13)  0.026517968066884 -0.022107111803180  0.037498264997396  0.004566515562682 -0.064482567844114
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532087830445926 -0.788053684507392 -0.217638660833197  0.182558741691964  0.602280863166455 -0.200093874423138  0.029411465990867 -0.008618445566170 -0.142345996690868
-    1  ( 15) -0.793296872955545 -0.320033246707737 -0.162598983453527  0.058726799927110  0.020874328230438 -0.223415347506574  0.107419197066742 -0.353928058607362 -0.096059895093397
-    2  ( 16) -0.212771964615612 -0.165330330084882 -1.296138478685232  0.042119030621194  0.273634362778554 -0.438879796184691 -0.121813090338313  0.097180424591982 -0.140937625632113
-    3  ( 17)  0.179954421761081  0.058841120611665  0.044127192643470  0.293105599691600  0.349356889255942  0.303438248960065  0.077097854674844  0.005877107377562  0.014045104815526
-    4  ( 18)  0.599465706538920  0.022235571311357  0.273958683710447  0.351252283345913  0.210835219542339  0.044587084446442 -0.439010194739272 -0.491004374374813 -0.399383596132888
-    5  ( 19) -0.200414127659350 -0.221453682461015 -0.440132543486983  0.305750504454767  0.044859549976743 -0.117462872288654 -0.191542018731891 -0.319736100846566 -0.359370858025094
-    6  ( 20)  0.032162128695933  0.105939422719644 -0.123876353231712  0.078981740804684 -0.440632986498194 -0.189872412133810 -1.110683989664156  0.246909463040471  0.255271007021977
-    7  ( 21) -0.008289240579773 -0.354493597907539  0.096614444500186  0.006342901541664 -0.491270269564264 -0.319008747231223  0.247402781824619 -1.005041339195380  0.329310525935830
-    8  ( 22) -0.142958112264996 -0.097022080198495 -0.141105576353547  0.015162721103223 -0.401346216617333 -0.359442000621317  0.255249867150800  0.329100137101793  0.052130295868829
-    9  ( 23) -0.219989065338878 -0.250001442147006  0.576446348090269  0.098959674934949 -0.020568114883162  0.097513800290254 -0.059902955979327  0.014734527182880  0.155046520232648
-   10  ( 24) -0.078950494593626  0.108193141540531  0.027256154056543  0.046487728419779  0.091306743921577  0.113368151014402 -0.170234458952828  0.302098295081586 -0.032847707902243
-   11  ( 25)  0.043326744763780  0.032363389765351 -0.179596320194099  0.107314642599215 -0.187556761662743 -0.097228134814891 -0.510755068213776 -0.080036249779472  0.081235508191006
-   12  ( 26) -0.068197976687722  0.217296898139221  0.162613838977633  0.182156526110652 -0.078640971353133 -0.138388418091556  0.046099139451725 -0.318339562821704 -0.094298996209138
-   13  ( 27)  0.012948053108673 -0.163156717293819  0.064963474439184  0.076423090035566 -0.116362948606428 -0.057051341664290  0.002572557283580  0.275506911043523 -0.101255941425000
-   14  ( 28)  0.072512090956400  0.116063474699758 -0.039414548907200 -0.060057426600154 -0.063414940197114 -0.039930823902922 -0.007406649424353  0.061654502657618  0.127196073451667
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223472856125742 -0.079380673671635  0.044417376178946 -0.069445497122295  0.011729893484114  0.073549727859122
-    1  ( 15) -0.252084320126442  0.107740778862871  0.032072824768773  0.217703433408601 -0.162976180926073  0.115649024793372
-    2  ( 16)  0.579843117211313  0.028377214598813 -0.180834874538440  0.163175611888439  0.065411291321188 -0.039948698403888
-    3  ( 17)  0.098340901264216  0.045586420114884  0.108734472654534  0.182606429756644  0.076964420454008 -0.060236205606042
-    4  ( 18) -0.021650833258616  0.091327714077226 -0.188512569777461 -0.078662641752143 -0.116896916465247 -0.063655160079575
-    5  ( 19)  0.097171540487668  0.112970498499516 -0.096626702541390 -0.138712839207192 -0.057497370879087 -0.039673289391880
-    6  ( 20) -0.058059330868561 -0.170134824581430 -0.511529953088092  0.046149842871006  0.002603003860136 -0.007423573856034
-    7  ( 21)  0.014906052393179  0.302176683660248 -0.080527272431049 -0.318411101353105  0.275449773210268  0.061692765696993
-    8  ( 22)  0.155151887415096 -0.033185457460157  0.080998651044629 -0.094073422594697 -0.101041326107855  0.127067437732620
-    9  ( 23) -1.153509668783001 -0.223849781346618  0.084925914727116 -0.000154347649926  0.401132279454500 -0.346054712948586
-   10  ( 24) -0.223987599199814 -0.015012978057576 -0.013160266828997  0.067286208756079 -0.009874035128650 -0.084312333173046
-   11  ( 25)  0.084246135638493 -0.012978110751430 -0.099616699052767  0.005046001107463 -0.012239544441460  0.023063802192487
-   12  ( 26)  0.000203295323483  0.067424132179953  0.005012434752789  0.014687484558096 -0.012600853140958 -0.022021985861034
-   13  ( 27)  0.401487062547390 -0.009674045105948 -0.012249675470802 -0.012688275811242 -0.008212565394913  0.091176394188195
-   14  ( 28) -0.346417777816096 -0.084403131840825  0.023147564238642 -0.022062212401564  0.091088265445589  0.040127117548266
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.056215172927916 -0.054500121508322  0.201919258778010 -0.031077763805510 -0.011710544286436 -0.013075909022680 -0.042346948343635 -0.000671828610738 -0.052291650154205
-    1  (  1)  0.580185867754678 -0.459972750936400 -0.203225406348613 -0.146383812909082 -0.059047716306621  0.052226207773922 -0.210466211081215 -0.032187368805259 -0.063260160660422
-    2  (  2)  0.093393210560188  0.013367711284029 -0.072500427251494 -0.188901437088884  0.080233215060989 -0.320461366545765 -0.281774577854691  0.095754687109263  0.009993944043533
-    3  (  3) -0.011006044771994  0.212772034365604  0.010016676236493 -0.008866166718285  0.020319326728203  0.122354060320048 -0.286521493894349 -0.227705676000915  0.024617045170947
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004784997819657 -0.045646414220092  0.000336480966462 -0.008910135153260  0.037229969984587
-    1  (  1)  0.012654368887265  0.038726053143637  0.110122850812823 -0.008163616619222 -0.088473965567598
-    2  (  2)  0.059858161338620 -0.242276960593359  0.080687948077563 -0.004783379620358 -0.010585827086864
-    3  (  3)  0.093190009488007  0.087625847683856  0.210676227172290  0.029310964936832  0.092669936157259
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.095387847271100  0.063707280070084 -0.166137683411008 -0.019021592855565 -0.149973759870001 -0.101204344306762 -0.031472575282315  0.053498473859926  0.042967624438521
-    1  (  5)  0.255913379011736  0.182084006874274 -0.358054748488889  0.117938321574845  0.215767331745706  0.198255948304019  0.082288393877684  0.046112468588943  0.145174585882671
-    2  (  6)  0.310255025939172  0.238379636947246 -0.293832074000714  0.096225461031061  0.113893650091632 -0.010350379528905 -0.451016712887586 -0.111857486176803 -0.191795343976766
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.073847869190148 -0.008654741710575  0.012693286782788  0.023668684158666  0.017789448486280 -0.009288640287720
-    1  (  5) -0.053437181209244  0.073043482844143 -0.095008049754430 -0.066955827698789 -0.087649070811154  0.040223508017977
-    2  (  6) -0.005363324155257 -0.054894453356376  0.206318087760035 -0.056446189403617 -0.025451704179473  0.074272027058522
-
-	DPD File2: P*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.031889834472336  0.023590247545076 -0.035886092938494 -0.337391549003445  0.230489171708387 -0.118250549009017  0.096738323803454  0.039671560183731  0.017417453829651
-    1  (  1)  0.115559689950866  0.104792776753397 -0.247387033439083  0.112934750234786  0.158582865358366  0.232113447678658  0.480247139929458  0.012693240726205  0.113321221450465
-    2  (  2)  0.001131177703134 -0.023211512192057 -0.030343999116351  0.117346790992592  0.046608524859420  0.060486959905986 -0.074531488676303  0.295475469192925  0.122604475218833
-    3  (  3) -0.102873669309261 -0.075244498837150 -0.074367347068194  0.000375638324722  0.045758296871777  0.020335443185058 -0.271454123369342 -0.176011970959425  0.750611882783894
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.122947556659096  0.146970007635756 -0.023111743424029 -0.020418246285807  0.062142160948575 -0.033255482549981
-    1  (  1) -0.076207579709840 -0.192925577520692 -0.390086469193835 -0.115462079698591 -0.197836673375331  0.137907169648961
-    2  (  2) -0.134390969563588  0.739254686327757 -0.083356064140144 -0.116141777662631 -0.130510808086193  0.001880247368517
-    3  (  3)  0.051764093089206 -0.135387754341373  0.415703352371020 -0.190964584562673 -0.522938232986926 -0.150011651631347
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.042351800770033 -0.112741680738692 -0.014470487647282  0.277801496926584  0.385189435070480 -0.134005161803845  0.094379155611825  0.020287570327628 -0.140758439500600
-    1  (  5)  0.196508002077728  0.014780858316181 -0.028613533348628 -0.116961168140523  0.038035850661534 -0.390665250154868  0.463278907259435 -0.352765994784243  0.083583027846786
-    2  (  6) -0.019055458304079 -0.247824312911431 -0.054496185583040 -0.066069201280654 -0.118739286724245 -0.063124976744210  0.269457866868641  0.446911004649514 -0.141690470973354
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002049190521844 -0.018587871477028 -0.105121590063686  0.083095581891635  0.044923327383534
-    1  (  5)  0.420262633593224  0.134089318231829 -0.513153889470778 -0.061105931999993  0.094073822513972
-    2  (  6) -0.353380729793659 -0.186026023919396 -0.193632728665932 -0.115179143357212 -0.434468868354740
-
-	DPD File2: P*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.018374399490839 -0.416488593986887  0.155494936834365
-    1  (  1)  0.047368311899160 -0.000904478695801 -0.015838423501069
-    2  (  2) -0.012225877770952  0.003811464066523 -0.009363085606127
-    3  (  3) -0.381174834177280  0.034408333237667  0.006712264462944
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019805821822076 -0.046970692298440  0.012276706190185  0.380984477985130
-    1  (  5)  0.412939155992870 -0.002194461931656 -0.004258479838447 -0.030533770738735
-    2  (  6) -0.154188085677647  0.014422732946647  0.008150645104198 -0.004478771817897
-
-	DPD File2: P*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.038950465210408 -0.039866103962419 -0.115245354720040 -0.019880757349447  0.101323212958542 -0.044640126253266  0.129219338527502 -0.020955390039210  0.007693672741339
-    1  (  1)  0.067773602054647  0.069283024949896 -0.045139676547490 -0.092449762069831  0.063419247150338  0.006282596580831  0.492661875976107  0.179789795112656 -0.023646534538890
-    2  (  2) -0.005352314371011  0.023691171688012 -0.168760303436833  0.035584759327957  0.098211154887201  0.052999235803435  0.267185888610491  0.067710312606089  0.133811638261923
-    3  (  3)  0.005028835575224 -0.075710576153026 -0.130936364707588  0.013148449648183  0.082341449946899 -0.058281787875764  0.148402947291289 -0.019587692846107 -0.265997802208991
-    4  (  4) -0.042953075620737 -0.030493487545427 -0.117329091588246  0.053817176197377  0.040927603944597 -0.031345620246767  0.084728650716813  0.096010530091888 -0.389039208842110
-    5  (  5)  0.147577168335343 -0.025728183041877  0.257869613090358 -0.341457170976807 -0.032938052439995 -0.198776430410242 -0.028905583055758  0.151472913148495 -0.076896803027349
-    6  (  6) -0.033968966510016 -0.063980358522411 -0.416860320865971  0.162964164077810  0.210735076964306  0.174795271465028 -0.081522253852315 -0.108767294311016  0.317254235279369
-    7  (  7)  0.041696032362294  0.119804780003616 -0.084367698623615 -0.345939032777489  0.297348524344951 -0.115684273678453 -0.157252021772075 -0.234703179592689  0.035619581257838
-    8  (  8)  0.096236509574225  0.089744247655453 -0.368376180782391  0.147020988065185 -0.073817404082631 -0.134077968971220 -0.072728534570006  0.043556315720552  0.010655784346597
-    9  (  9) -0.003143315235121 -0.093361249518207 -0.037863435444635  0.438671101107247 -0.422734146793725  0.161824914084117  0.027097474419921 -0.004646312280086 -0.023963694330478
-   10  ( 10) -0.063765122804891  0.220080848656726 -0.093077513515149  0.266351828566493 -0.049816576758865 -0.073960829373608  0.046357012710617  0.183568506551021 -0.007204953793047
-   11  ( 11)  0.219872786938586  0.186770594833612 -0.640901797018363 -0.491983676516504  0.063681968781172 -0.412058888748144  0.286040569517346  0.094245081423241  0.195000390736826
-   12  ( 12)  0.262279768280096 -0.707696438447150 -0.236718714106780 -0.470497637927968 -0.331060673088753  0.597737469031289 -0.173380785854979  0.147387697786165  0.044689499434261
-   13  ( 13)  0.008835795532905  0.161415860688302 -0.152613021782520  0.281704813928099 -0.459625631240495 -0.096864143285054  0.003153519140079  0.109240738249078  0.297347288310574
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.149413062150163 -0.067008442584154 -0.230363907047496 -0.055319406680384 -0.032530338298423  0.068943043267331
-    1  (  1)  0.452149192521174  0.000162578737685  0.619971511564934  0.066650257125370 -0.061919053639708 -0.084081056043438
-    2  (  2) -0.165489317663304  0.127973451777841 -0.447552906388176 -0.305061991533250 -0.384464561661781  0.153275315561868
-    3  (  3)  0.025748260701304 -0.486016697888281 -0.411385821418048  0.268874146594607  0.396024014682121  0.134171291763426
-    4  (  4)  0.009663093960960  0.555568390799340 -0.304477769378439  0.081217704163073  0.578918205858773  0.101292064810745
-    5  (  5) -0.039175185913195  0.166448012687766  0.090139681441233  0.019287349063250 -0.248510643774710  0.007841008760067
-    6  (  6)  0.086047592172498  0.153815757637266 -0.087940035478902  0.097280378266502 -0.044638073702240 -0.047181412845043
-    7  (  7)  0.068735686796040 -0.315926660510286 -0.100190034017783 -0.019688975059735  0.019468668688484  0.100670621907944
-    8  (  8) -0.002625726681395  0.112681642341155  0.368011821043785  0.079699064807508  0.320546285877417 -0.355993882573800
-    9  (  9)  0.075057729747018 -0.174223000470549  0.018184022105450 -0.008386747763061 -0.022693973527319  0.026587026978415
-   10  ( 10)  0.016901342145260 -0.168627021082460  0.003857305749161  0.002354503414788  0.061897957980197  0.064750074462714
-   11  ( 11) -0.244307011097299 -0.045968336616797  0.036911026756575 -0.051829082034064  0.017536651163216  0.002615905953443
-   12  ( 12) -0.003873917284711 -0.069385416516337  0.051822467558672 -0.043776532172148 -0.059978809347506 -0.097816286584178
-   13  ( 13) -0.427124414952379 -0.150719603419239  0.021778839992094 -0.006415728591880  0.068010241427207  0.070097593919817
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.041903329856192 -0.070446987089633  0.004348862670260 -0.007003079501354  0.042701021768788 -0.152208197977204  0.041433363682805 -0.041287071942597 -0.095743116708860
-    1  ( 15)  0.040650426082046 -0.069515483196494 -0.023795913068799  0.076537618226998  0.032568972577824  0.025967830490469  0.063333094204323 -0.120545439258051 -0.089130494820972
-    2  ( 16)  0.113176179395785  0.046535614719910  0.168596109891447  0.133831005796173  0.118353163778080 -0.257041147370604  0.414474865889011  0.082742359298471  0.367155116899390
-    3  ( 17)  0.018349375617923  0.090713111977311 -0.034093712018598 -0.012384834825344 -0.052502145904236  0.343486696016333 -0.164974261057850  0.349385131049026 -0.148282635861179
-    4  ( 18) -0.098178568139074 -0.063160792106148 -0.098378065635209 -0.082360458708713 -0.040147652473952  0.031106641199237 -0.209540876350175 -0.299086324958894  0.075290632015664
-    5  ( 19)  0.046124091442951 -0.007623765782496 -0.052346193543973  0.056344470452290  0.031632190145320  0.198051654819200 -0.173027351368421  0.116400515734751  0.135033433848762
-    6  ( 20) -0.125258904374540 -0.493829059239401 -0.267757316022715 -0.150510471965499 -0.082418952577180  0.029074883870873  0.082194266117060  0.155370316095250  0.076894749422472
-    7  ( 21)  0.022859113931115 -0.180693607953724 -0.067191017626113  0.021636428920055 -0.098628927025765 -0.152535238685033  0.108677282204199  0.236476842996923 -0.043474790742065
-    8  ( 22) -0.007846177507452  0.026259809347121 -0.131087450927184  0.264309750556241  0.389449878217689  0.077877691250164 -0.320396510359928 -0.036029491362037 -0.011294045928736
-    9  ( 23)  0.148409951194406 -0.452946257596570  0.165039879212225 -0.026077898552925 -0.007360117453756  0.037616321096105 -0.083049264354487 -0.069293544687319  0.001373481233291
-   10  ( 24)  0.069814067119157 -0.002054394750299 -0.126443354154776  0.492431542405090 -0.562191735747665 -0.169229180172877 -0.154296877725072  0.322409563035094 -0.115377045900281
-   11  ( 25)  0.226651470481047 -0.617350999313901  0.448004121314618  0.411778499546043  0.303855472735621 -0.089854128437872  0.086765588475993  0.099221464205896 -0.370890559100149
-   12  ( 26)  0.054331750206089 -0.066935478840437  0.304032185963088 -0.268162029874351 -0.080593616550667 -0.019297703310245 -0.096620293446142  0.019137264306005 -0.080001854035789
-   13  ( 27)  0.031924461994603  0.060584366399270  0.382102774779752 -0.393995940746644 -0.579313325412582  0.247998914693769  0.046380357788513 -0.019293958639035 -0.320706746040650
-   14  ( 28) -0.067906620182484  0.083216384461386 -0.153437200450035 -0.134831736058858 -0.101055763194935 -0.007868050795063  0.047806237375160 -0.100652051992651  0.357135809697123
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.004177372366322  0.063406030244807 -0.226823097367039 -0.263896415513769 -0.011701971027774
-    1  ( 15)  0.093319799498408 -0.219967278758902 -0.185954874184417  0.708355904031754 -0.160324223389966
-    2  ( 16)  0.039556125331154  0.094087884995324  0.643095059540316  0.237777200414592  0.155124222296969
-    3  ( 17) -0.442134529381327 -0.268012766736270  0.494385460966639  0.470730896225858 -0.283217803454197
-    4  ( 18)  0.425335538145780  0.050712365592958 -0.065507217070923  0.331337452084829  0.461074723403375
-    5  ( 19) -0.162698096167156  0.073261920681232  0.410435644212656 -0.598344542892450  0.095525074956441
-    6  ( 20) -0.027635092593548 -0.046340546952519 -0.285700437916237  0.173636156485020 -0.002143940822347
-    7  ( 21)  0.008238163113748 -0.182885492783710 -0.094441459467607 -0.147424260377310 -0.108554639474187
-    8  ( 22)  0.023401664118011  0.007016046655171 -0.194400535766778 -0.044245864301010 -0.296689970128693
-    9  ( 23) -0.076293063471948 -0.017415507342648  0.241569014205399  0.003530677667797  0.425824332982193
-   10  ( 24)  0.181769150588328  0.169666705113788  0.044965749792137  0.069290251681075  0.150967382108881
-   11  ( 25) -0.018153729708567 -0.003519576560560 -0.037031521345044 -0.051758677298688 -0.021630611787891
-   12  ( 26)  0.008082899537472 -0.002256936856687  0.051941569032630  0.043823365289136  0.006446621914376
-   13  ( 27)  0.023193966803115 -0.061566730434681 -0.017525541483092  0.059863077024435 -0.068202811059110
-   14  ( 28) -0.026844987381374 -0.064909557534692 -0.002683194869776  0.097668274774952 -0.070274371234661
-
-	DPD File2: P*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.022229155184796 -0.019683929802812  0.035292041013174  0.323293424781682 -0.225147178252232  0.115004523407643 -0.099141060334532 -0.047575469407300 -0.016976450104502
-    1  (  1) -0.127090569254626 -0.123237269677512  0.278422395650133 -0.118685424416916 -0.176184741653177 -0.248988790809479 -0.519015610990019 -0.012154553055459 -0.127798350335596
-    2  (  2) -0.008158213783958  0.029679191576446  0.037266849827848 -0.110715312970774 -0.059214718357965 -0.062822080446559  0.081276448160108 -0.324586020412756 -0.131224816829759
-    3  (  3)  0.084166098196409  0.111710240594221  0.099128613941891 -0.014634036431124 -0.052476493603890 -0.027367672304797  0.301909798936816  0.191388056693055 -0.790536316410543
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.129910363709357 -0.163144685956702  0.026485892679798  0.022427536567571 -0.063067550057929  0.033737074439006
-    1  (  1)  0.086592793084052  0.215472297553996  0.416640948225414  0.119951916043925  0.207797355115153 -0.145646111272154
-    2  (  2)  0.146364945461058 -0.802840103887928  0.083436228176863  0.120990811620140  0.133581214678389  0.001202452323342
-    3  (  3) -0.043945078436053  0.148601276694347 -0.437804660682756  0.201206970148648  0.547031014916742  0.155504170965970
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.037502076472662  0.109335165777524  0.012926428858581 -0.269466726270333 -0.379248563249398  0.141530386330068 -0.105411044336663 -0.019979530625450  0.148197571425260
-    1  (  5) -0.208585120229370 -0.016639991768198  0.025672499464384  0.120166173976538 -0.061231886196158  0.410760689290169 -0.504318342034080  0.368734822068652 -0.088923609423586
-    2  (  6)  0.008992532047250  0.290540208998742  0.060411739137707  0.064704199164733  0.124015323503734  0.073936634004700 -0.287919965087423 -0.478723882674066  0.159979306108318
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.002904367944485  0.019663391538446  0.115584584455963 -0.082318082980502 -0.044061111248738
-    1  (  5) -0.445601944090184 -0.141387522552248  0.540419197978555  0.056783987379620 -0.093672186540934
-    2  (  6)  0.375252473148004  0.198547338183254  0.207529365108893  0.114786400140461  0.453839763908372
-
-	DPD File2: P*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.060866725217215  0.013869365716153 -0.033894329784820 -0.159389025617799 -0.069390363085127  0.262340609354303 -0.067580095774763  0.154103692822594 -0.003154741180611
-    1  (  1) -0.233600860111356  0.255443445273365  0.070349772560976 -0.002398009474053  0.207738516934078  0.107364483788669 -0.128967864654634  0.344368536680876 -0.051213828740165
-    2  (  2)  0.320680073963752 -0.499671518707847  0.050574975509019  0.147836128166420  0.165479289930263 -0.195838444506077  0.035661712710790  0.024470880763902  0.075637541705411
-    3  (  3) -0.005421312030017  0.086163397462206 -0.087803119789529  0.068180639639745 -0.069970423577407  0.155270176021826  0.200857781343900 -0.346742235116956 -0.007432799783430
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.031710204280855 -0.011526541432890  0.002976967089787 -0.046060023193635 -0.015318540884103 -0.025207945945630
-    1  (  1)  0.042201291846948 -0.011691902650686  0.030342861979388 -0.426260656604152  0.267501393083778  0.156199494500064
-    2  (  2)  0.105775984380200 -0.124345432018223 -0.012422860710314 -0.254942186016171 -0.141450345930572 -0.594200168007018
-    3  (  3)  0.128190105083420 -0.839978623039109 -0.103083070851949 -0.085126863174017  0.034147172701768  0.125845625439850
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.009655463605755 -0.014837891728381  0.030023518715064 -0.453895242430490  0.367783958834954  0.001154952584878  0.011095021636640 -0.081922945493181  0.106667436086225
-    1  (  5) -0.023315601126616  0.114914590458087  0.095889100679515 -0.148408787561426 -0.132591987973289 -0.239441228065666 -0.119891964360871  0.197513600772232  0.042785498899110
-    2  (  6) -0.044714484508884  0.227037104077391  0.243035253957641 -0.057000070112492  0.133863510185386 -0.464640228230982 -0.241815314958168  0.250347946170699  0.035567936134789
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.031225116244914 -0.082892463758822  0.008302957992736 -0.084651532871555 -0.076096297616606
-    1  (  5) -0.029094974835733  0.031099102771742  0.014865102267058 -0.594144277291270  0.111092561014338
-    2  (  6)  0.081030380750229 -0.586465397694647 -0.039125073332182  0.210425560392843  0.141728395903252
-
-	DPD File2: P*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.279550720476077 -0.042202209735457 -0.032616542291842
-    1  (  1) -0.188418637032763  0.038238156575108  0.176016679949417
-    2  (  2)  0.431618249575807 -0.006066663258097  0.050669745816719
-    3  (  3) -0.023823866701763  0.194483208506600 -0.036291334339584
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.276296231465594  0.182684867311170 -0.425780067610230  0.021944883020485
-    1  (  5)  0.040904620230163 -0.037124497156135  0.000756874278417 -0.193551621281851
-    2  (  6)  0.032612764478737 -0.173214965518422 -0.056257078994710  0.032928243740138
-
-	DPD File2: P*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.064329222595920  0.203089813678901  0.060855379318360 -0.045435578919151 -0.038213040289734  0.173918816066670 -0.086597065761990  0.088257727308079 -0.042534449699908
-    1  (  1) -0.115560364126478  0.109115953630201  0.018643611831367  0.061273729840918  0.223462209948640  0.111849786008387 -0.082478525732492  0.548790728777664  0.099502382826804
-    2  (  2) -0.050280791567554  0.042231736423558  0.026516724550904  0.035763580727561  0.045242506762065 -0.028791481906196 -0.032080377274548  0.393629321941294  0.043590423594673
-    3  (  3) -0.027100682075659  0.177196743119415  0.360081085823777  0.088267299794322 -0.030083312860564 -0.189916614239830  0.016925829834322  0.152132597277128  0.199271802311320
-    4  (  4) -0.027032407915338 -0.122816257943915 -0.195859296476474 -0.024440446904345  0.000039632917188  0.224837371747381 -0.105878500705155  0.149344729427051 -0.220653682748276
-    5  (  5)  0.082124893882501 -0.131610239391223  0.172288241722190 -0.172656004937721 -0.186007370790890  0.002386795157151 -0.000883813901201  0.015624959650018 -0.120434685552584
-    6  (  6)  0.025918430251412 -0.066213876287375  0.159653356345571 -0.138629355858437 -0.114503563489713 -0.052610164659059  0.032724879295725 -0.016321111589815 -0.131203443877323
-    7  (  7)  0.031968463140566 -0.359436078267880 -0.239880075530440  0.043941245996148 -0.003566470797935  0.121878346236622  0.025216884092681 -0.317033593343712  0.204690345792582
-    8  (  8) -0.147136177075282  0.147831155131360  0.317027072645310  0.094690347387101  0.042376714203220 -0.036223188856298  0.061267998203209 -0.078763236261723 -0.025079679518920
-    9  (  9)  0.347335081804882 -1.076651679527280 -0.076631791966040 -0.520228799901951 -0.177614233521961  0.752433601064110 -0.098237100331302  0.075609380299166  0.029456370268690
-   10  ( 10)  0.226576210232703  0.047966592312158 -0.713544303894390  0.117838109418108 -0.538138175848963 -0.110268365719488  0.097090433542407 -0.016639982577840  0.202838989293283
-   11  ( 11)  0.013618237324107 -0.042488040839621  0.012305458432129  0.002937365049260 -0.051397702056966  0.032793240631487 -0.126424524316302  0.018011286422360  0.036334038133226
-   12  ( 12)  0.125114748700956  0.150723454222537 -0.252706221972763 -0.731410520517111  0.348252142829817 -0.473299198843163 -0.017472369731921 -0.121992291563425  0.064459445411663
-   13  ( 13) -0.081025878360433  0.099169125996407  0.096265824091433  0.243412138793566  0.157793004324879 -0.232678786079147  0.038715292983050 -0.196706528651456 -0.103460906909678
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.038639019968560  0.081398838675921  0.020974057309157 -0.195126170432547  0.136178596332978  0.093793458598120
-    1  (  1) -0.192322326072867 -0.434066427801228 -0.033306653053185  0.455360646532796 -0.170900871888595  0.012160177810098
-    2  (  2)  0.116655928700969 -0.223206132473869  0.015149664847910 -0.750955420456732  0.241651279575312 -0.125278854183387
-    3  (  3) -0.037416152824649  0.474871182487040  0.095127781154357  0.001912744200640  0.218016361604134  0.501866870283028
-    4  (  4) -0.093049020347900  0.452195861353997  0.097729965141961  0.023670097100218 -0.227089450225467 -0.622604645621845
-    5  (  5) -0.095982951322369 -0.025076643469587 -0.083513090675399 -0.093177906171499 -0.163570537374778 -0.411952379972310
-    6  (  6) -0.006971397366507 -0.099975304872894  0.089355028753419 -0.082421061832647 -0.109391578906264 -0.177019076161536
-    7  (  7)  0.111482230592694  0.119338627354550  0.049072785699030  0.135589681135474  0.179997637886863  0.225361657151226
-    8  (  8)  0.038036906175422 -0.107593330918854 -0.085211578523939  0.251522137496260 -0.415712152156179 -0.133150454203045
-    9  (  9) -0.014149847264143  0.014713228385967 -0.003726551384159 -0.024984081757333  0.450053383369121  0.804137197420648
-   10  ( 10) -0.262196667989143 -0.030987669321987  0.048528847001581  0.326796645773778  0.027460917972608  0.213395133473708
-   11  ( 11) -0.037859730907863 -0.067315614399965  0.006033855211911 -0.002081527339975 -0.021566579415084  0.043117037710347
-   12  ( 12) -0.214673577185777  0.277038178296912 -0.018443935481622  0.031394459169126  0.040697755419603  0.037299553750268
-   13  ( 13)  0.293378255962317  0.067739265985308 -0.042216271726718 -0.084600602041646 -0.093366414785478 -0.184919834112459
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.065579026427298  0.118385281199840  0.054417309773849  0.028209393258605  0.023855315776195 -0.089481193550780 -0.030082936540202 -0.024881663706482  0.145536117267929
-    1  ( 15) -0.203177895336562 -0.108867238168314 -0.044106918987014 -0.183348816265157  0.128730595279853  0.134393743071560  0.068034842363188  0.353605430814672 -0.144787054112687
-    2  ( 16) -0.059845833352457 -0.020943033819428 -0.028043633600698 -0.360379351132063  0.196224502327520 -0.168965679426491 -0.157686501214302  0.238008876623444 -0.316659608324193
-    3  ( 17)  0.045186255659105 -0.061530291702097 -0.034434066086584 -0.088647496947582  0.026282078792551  0.172786891133660  0.138287078850789 -0.044103989261245 -0.095122362978667
-    4  ( 18)  0.040062693221020 -0.224606431868167 -0.044510085277536  0.028376706423002 -0.000349345016747  0.185972360522578  0.114555914481331  0.004506308196336 -0.041018032849448
-    5  ( 19) -0.173210931444010 -0.109857051233105  0.028983625579256  0.187756427423432 -0.223643228642709 -0.004090524106486  0.051487512077316 -0.121894819352182  0.037656019931592
-    6  ( 20)  0.085313471751143  0.082913275223549  0.032277368285025 -0.016777520509378  0.105131359190815  0.001944705429570 -0.032875162874827 -0.025732176012468 -0.062579089976849
-    7  ( 21) -0.084545461298169 -0.550907022405358 -0.394733809745031 -0.152212200092244 -0.149602224208011 -0.015559620185539  0.017471440322135  0.317632843442532  0.081500770726977
-    8  ( 22)  0.042592304559205 -0.100130074049971 -0.043823098391038 -0.199074070348154  0.220614689373917  0.121240505787734  0.131566193321307 -0.204777301446740  0.024659128193111
-    9  ( 23) -0.038243209345809  0.193731116803758 -0.114571318389048  0.035004741203238  0.093870122022257  0.093321089072005  0.005098160430595 -0.109514276861021 -0.037449030782536
-   10  ( 24) -0.080611973441424  0.431286815750366  0.220674640182480 -0.473291196073188 -0.451373239023609  0.023941120635386  0.102282761545205 -0.118683941595292  0.109001254632288
-   11  ( 25) -0.020616437944253  0.032806186227235 -0.015536997280191 -0.094946997217811 -0.097687630516726  0.083601240444185 -0.088958677720268 -0.049109842148345  0.085549382706087
-   12  ( 26)  0.191260790058678 -0.454455308246703  0.749344104582772 -0.000707785692927 -0.023013062709295  0.093408274808716  0.083112755629054 -0.137052732289414 -0.253713944370040
-   13  ( 27) -0.135080067323690  0.170977966348525 -0.241626969335339 -0.220294823738596  0.228806715319375  0.163956724293068  0.109654396643640 -0.181513709124625  0.417706190063538
-   14  ( 28) -0.095355381240353 -0.010487455238559  0.123878379042330 -0.506641747659321  0.627627416886014  0.413206867808258  0.177986562206826 -0.230596660977991  0.135371993382099
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.343722354187842 -0.231012307989939 -0.013807799785149 -0.129389520371901  0.083476842933347
-    1  ( 15)  1.071757290590545 -0.047500726309983  0.042558977896784 -0.150713322712323 -0.100049386852298
-    2  ( 16)  0.076574555259838  0.716811431044374 -0.012053549717062  0.252652945738414 -0.097563356479072
-    3  ( 17)  0.521659456544164 -0.119962089033513 -0.003140019395332  0.735502177464538 -0.243874710004522
-    4  ( 18)  0.178111787275392  0.539331111074153  0.051602620031584 -0.351369555964665 -0.157776134348173
-    5  ( 19) -0.754028750268460  0.108050332429524 -0.032942772306297  0.473084779433613  0.233288261808526
-    6  ( 20)  0.098339349809287 -0.095672012585071  0.126453856435504  0.016749320041424 -0.038981069794775
-    7  ( 21) -0.075922415669002  0.017338504286034 -0.017821543323394  0.121086080034894  0.196694365560314
-    8  ( 22) -0.028707803808862 -0.202101700693747 -0.036280352248806 -0.064076056309411  0.102966425702512
-    9  ( 23)  0.015071264129229  0.259603898636005  0.037748702712212  0.213449614969685 -0.292741791249862
-   10  ( 24) -0.014441233365834  0.031025326150192  0.067581337213048 -0.278218894918250 -0.067639252890435
-   11  ( 25)  0.003655596016122 -0.048301023976308 -0.005987297290884  0.018296972769386  0.042182106266812
-   12  ( 26)  0.024290247830266 -0.326430116080930  0.002078223011543 -0.031357186170846  0.084451014704488
-   13  ( 27) -0.452065991443206 -0.027871674423728  0.021552868138498 -0.040817220436517  0.093503875768977
-   14  ( 28) -0.809538434042480 -0.214197129891733 -0.043194453416851 -0.037242456347955  0.184930829970208
-
-	DPD File2: P*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.066956274028954 -0.044342976073165  0.030268247936242  0.149450540981950  0.061066821271185 -0.252770775339693  0.067874222510686 -0.158386767820771  0.005381383883310
-    1  (  1)  0.238859813029081 -0.286692386304328 -0.066590681714602  0.004012726688607 -0.213066888677072 -0.109131374118362  0.135898330150995 -0.364942966429774  0.055660597243453
-    2  (  2) -0.359516386393285  0.583008964100427 -0.054707529711990 -0.139557599023379 -0.158230706301634  0.196109522672398 -0.038444807843767 -0.030895199145175 -0.086353045406069
-    3  (  3)  0.011142763994871 -0.102467038295486  0.096192280460040 -0.086579830772614  0.079151964917630 -0.163781954562347 -0.215517306973471  0.369533969127049  0.009330018051360
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.034197603653202  0.011654401867379 -0.002838793667518  0.051120718575847  0.018314210992950  0.032583546094419
-    1  (  1) -0.044852295322472  0.010374877421340 -0.032495546570244  0.442259071390682 -0.284002451396915 -0.172324881222561
-    2  (  2) -0.118470854957857  0.130986078141729  0.014085982845085  0.260463332299674  0.162310705486348  0.635865895852574
-    3  (  3) -0.132535934596107  0.876049792586578  0.107203693425820  0.087990410067908 -0.037792879731323 -0.134504535673653
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.032839390128313  0.018959934247026 -0.027098455785061  0.458861483846452 -0.368889100803161  0.013730600662295 -0.005961739971281  0.088172859302616 -0.109822626668940
-    1  (  5)  0.022776770324681 -0.118542960649480 -0.106023383328719  0.155646887463115  0.124038116346952  0.247202807741244  0.126320423057856 -0.208868231513720 -0.046770852934184
-    2  (  6)  0.048648484948535 -0.245637911332038 -0.270704645644036  0.074067208651774 -0.147538325129154  0.486126744284417  0.252803143713327 -0.267246124084927 -0.039768993904487
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.034234873438637  0.088611347550410 -0.008537759532833  0.090451182938239  0.075365836152160
-    1  (  5)  0.023972088194502 -0.031376657235205 -0.015685502279103  0.611834232098808 -0.112755958009069
-    2  (  6) -0.089906734942719  0.607632221899844  0.040204918187789 -0.215818595847042 -0.145730338373175
-
-	DPD File2: P*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.068337016689787 -0.096446452085002  0.360475449255902 -0.092239288443358 -0.026203678993495 -0.022509846768507 -0.073478827109955 -0.022464061635160 -0.227372488687786
-    1  (  1)  0.348245092755920 -0.473201941654281 -0.285296343641650 -0.183481268338497 -0.077575420561894  0.072099126128168 -0.272473569750599 -0.064219415174522 -0.197165880642411
-    2  (  2)  0.067585908292999  0.050372922066345 -0.060758167722761 -0.207525430724412  0.124589544539336 -0.366296688749942 -0.319501792562117  0.144609263860444  0.034557292109121
-    3  (  3)  0.003490778195202  0.176771187193881  0.057522831084688  0.000116418534514  0.000778288025410  0.154495740758279 -0.307263828597453 -0.311985415250579  0.072067405639340
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009055593106319 -0.169294476000973  0.004376707887535 -0.043035427356728  0.152530590603305
-    1  (  1)  0.043732146234760  0.133230210104999  0.321492959537845 -0.026647195864791 -0.380687102971969
-    2  (  2)  0.166530147606704 -0.613643715784952  0.216790208689121 -0.084469048821397 -0.070950253018395
-    3  (  3)  0.193623455832778  0.188085387415724  0.577128561928036  0.079182256648197  0.329374829303748
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.094184605266262  0.056664612736054 -0.249611394695138  0.001240336458214 -0.251113263188388 -0.167204840997487 -0.053738355410164  0.110451910680987  0.110225244344066
-    1  (  5)  0.138889396156713  0.115961679702950 -0.323179744186602  0.121252123334108  0.292076432530947  0.241576686483901  0.062989099002905  0.028273376499857  0.195878521200942
-    2  (  6)  0.158880157732563  0.136139940788991 -0.265648578790447  0.093877387310787  0.142453752097511  0.054140913394793 -0.560779480905315 -0.138233927938137 -0.254132036776789
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.293992892777812 -0.040800750874340  0.057675088115477  0.076602392476472  0.065335333000425 -0.026360508198711
-    1  (  5) -0.140101157116617  0.119683195253936 -0.266691635481371 -0.245738117841371 -0.344104644743715  0.220704301427416
-    2  (  6) -0.056921768196805 -0.103403744069325  0.598429877433937 -0.146214200704205 -0.059974750990256  0.323525482379135
-
-	DPD File2: P*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.001230860713981 -0.365289920386496 -0.190857780733096 -0.072806514891183
-    1  (  1)  0.363063996519734 -0.002070944913891  0.019953639387757  0.015606309990589
-    2  (  2)  0.188512451641916 -0.023296206313487 -0.001197811601800  0.004047856267926
-    3  (  3)  0.072120339388755 -0.013963148028330 -0.003997486762190 -0.001769349811859
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.002022249922950 -0.099291954131021 -0.350139400677067
-    1  (  5)  0.099326293970590 -0.002387309533513 -0.000598742894171
-    2  (  6)  0.349927147110668 -0.003948627188178 -0.004319113721388
-
-	DPD File2: P*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.002890611897827 -0.240828289147465  0.015468829256935 -0.064289689550120 -0.058383569830779 -0.095812515567057 -0.080370871457874 -0.173880009550648 -0.326840838875860
-    1  (  1)  0.236387869752249  0.001382669630591  0.349729320543369  0.093496466822455 -0.041273060112661  0.069307558569237 -0.288342418689824  0.111953342164375  0.889210851252513
-    2  (  2) -0.015544382351172 -0.348410608385966 -0.001429161416738 -0.082248932060638 -0.073429593153274 -0.232731056108987 -0.287528082465130 -0.229588952851785 -0.234445801555499
-    3  (  3)  0.060246890669449 -0.090324337254536  0.083519076320930 -0.000324034215630 -0.021649503271248  0.048962406316822  0.003095140388789  0.014925743106247 -0.184209404061508
-    4  (  4)  0.058716691049654  0.039386709518300  0.072108814664522  0.024079085224178 -0.001156693016658 -0.085015191809916 -0.048842009764989  0.153342114169621  0.107404216975909
-    5  (  5)  0.094642233192625 -0.068250996258109  0.231656670305544 -0.051858687640720  0.087916533368054  0.000989122777904 -0.009520487792430 -0.039816729579394  0.148608670810212
-    6  (  6)  0.077504756735322  0.287507697430236  0.285105373436002 -0.002029325573656  0.050208524083414  0.010159420768980  0.001467122921747 -0.173528931839685  0.045843469905068
-    7  (  7)  0.174578233230593 -0.112733771274507  0.230104116799356 -0.014289446324452 -0.153589433005249  0.035711031924118  0.172129458752228  0.001735515727976 -0.038746380038624
-    8  (  8)  0.326735165366063 -0.892352866716814  0.233667611417982  0.184059987656354 -0.108456575602175 -0.147444194487350 -0.046899481546128  0.038212214850091 -0.001725987235386
-    9  (  9)  0.006854804424481 -0.059010431241574 -0.208380750196049  0.285710704759075 -0.014224723130698  0.077940660528519 -0.021832932968226 -0.053507920192743  0.072157293584336
-   10  ( 10) -0.009015167445598 -0.189056046369736  0.202903049397400 -0.587323534808109  0.635944176810841 -0.025618734551668  0.020134034262346 -0.176546344509523  0.134205354496214
-   11  ( 11) -0.122437005548569  0.184498905511222 -0.564613159164372  0.437681527296080  0.566648422271337 -0.293176529113293  0.283793106995897  0.077656634404298  0.171083550165875
-   12  ( 12)  0.036282129605470 -0.108405322240863  0.145144319486399 -0.147400560062216  0.198772870262719 -0.103478363945228 -0.121274561973686  0.030820809232635  0.001791413008569
-   13  ( 13)  0.133993098437568 -0.204979468351056  0.411230750510333  0.299499940801943  0.284167005433816  0.162337236425275 -0.004579295347321  0.249620649972568 -1.096399145752056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.006645975778905  0.006191073096114  0.124463548213382 -0.037116585439600 -0.136645288902199
-    1  (  1)  0.060762525453402  0.191336651087303 -0.183339507039208  0.108942947593767  0.207176626622974
-    2  (  2)  0.210207260386098 -0.203492326897454  0.567390687945974 -0.145012790104551 -0.411652670240128
-    3  (  3) -0.286824149969646  0.581772824662096 -0.440352813995387  0.146688228392261 -0.298407000003058
-    4  (  4)  0.014289603545957 -0.629957556120225 -0.567078386368531 -0.198070048922302 -0.285394833836570
-    5  (  5) -0.081440068401990  0.026939007614117  0.293522941596266  0.103773428535410 -0.162374057747115
-    6  (  6)  0.019586412213072 -0.018998130538312 -0.285654409806091  0.121258923814333  0.003510620762243
-    7  (  7)  0.056312011236674  0.170723193738545 -0.077219135397651 -0.031749253170040 -0.249637927479938
-    8  (  8) -0.071982674840921 -0.132152050589738 -0.170190422759249 -0.001965018222219  1.093832298365480
-    9  (  9)  0.000915267084317  0.167637668947108  0.013751051322959  0.007450195669904 -0.054814043954704
-   10  ( 10) -0.173354835302090 -0.000704252867558 -0.044733752629381 -0.097334496933118 -0.081305131643713
-   11  ( 11) -0.013882987415659  0.044298584291785 -0.000143226462344 -0.004568623078909  0.075706346510396
-   12  ( 12) -0.008211247608944  0.097266945197500  0.004534234464270  0.000000208770840  0.036045640473786
-   13  ( 13)  0.055102354659947  0.081583293844327 -0.075692193037900 -0.035962325349336 -0.000089917983318
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.002852278466544 -0.070108169829164 -0.177721594116383  0.062514278837043  0.105491072743275 -0.104380527192685 -0.038787813666443  0.108504673470162  0.012481015325095
-    1  ( 15)  0.072271804263973 -0.000288298261148 -0.117173998738145  0.011917535043052 -0.080653916441483 -0.081946299523319  0.047103419787682 -0.318790462890510 -0.030711126191038
-    2  ( 16)  0.170911365853707  0.116393519070210  0.001806689323683 -0.130836454259881 -0.145067744851421 -0.208275822041435 -0.197865978670067  0.179244423422815  0.001428148574785
-    3  ( 17) -0.060580436051072 -0.012481275961757  0.130473629372401 -0.000512552110579 -0.018701012638838  0.044411378106146 -0.007770177955824 -0.099727400679241 -0.079606042617844
-    4  ( 18) -0.100932281141831  0.079292941446829  0.141623065968957  0.016652442688780  0.000246995954883  0.188697276821427  0.217824131948931 -0.080386629630151  0.270575530776454
-    5  ( 19)  0.108081312156271  0.081589453393258  0.205450509959137 -0.045804817780756 -0.187114674307730  0.000693476015895  0.073804885959376  0.043943121718183 -0.003771900693712
-    6  ( 20)  0.034173297967555 -0.046256787847685  0.201439095588816  0.005429989019017 -0.216650326151217 -0.075792464986171  0.001298711951572  0.134518823042755 -0.103151783377151
-    7  ( 21) -0.109536591257004  0.319390106321481 -0.177983470364268  0.099546174339197  0.081524885513579 -0.044022674550874 -0.133301399033515  0.000096152383065 -0.101549931240584
-    8  ( 22) -0.012926686041826  0.031216971600686  0.000265042168615  0.077684860264792 -0.270051031496744  0.002422594418673  0.104436054969569  0.102375676350899  0.000297123445281
-    9  ( 23)  0.258651046299275  0.226438144249540 -0.883671721861341 -0.031897478817939  0.145814145437369 -0.329946962033578  0.092842601161588  0.020363787817155  0.044542350196596
-   10  ( 24)  0.092725989784673 -0.166988988746146 -0.090659624845963  0.033017773093490 -0.181126079432095  0.062617782388689  0.131228570809863 -0.125672600098950 -0.010149266769676
-   11  ( 25) -0.085237213762517 -0.052979715533519  0.426249660673602 -0.453470213118020  0.668258866535746  0.144399220062707  0.422276654831122 -0.144496027602971 -0.151454753884708
-   12  ( 26)  0.278987852994131 -0.538130802014502 -0.337920384527610 -0.681210215677631 -0.181138167954142  0.460304232360321 -0.045963221041228  0.472470739788982  0.099740360833931
-   13  ( 27) -0.031684358569015  0.364912365941556 -0.009949817490826 -0.264482144700383  0.131463038932392 -0.369715650064832  0.160132940033673 -0.216985322458037  0.408494860009368
-   14  ( 28) -0.069145968160405 -0.228577328281114  0.182024373430158  0.129259595360434  0.172789096424754  0.293202387537144 -0.081435203747675 -0.165066175829158 -0.415625562015752
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.259264061861398 -0.092073726700459  0.087751332732921 -0.282787087620371  0.027646750760921  0.074274663555944
-    1  ( 15) -0.226044227417799  0.167220221608179  0.052022484678322  0.539067092148703 -0.364060270057495  0.227432738647077
-    2  ( 16)  0.880651861739234  0.090070282095970 -0.429004165056558  0.339630379420043  0.011398542008064 -0.184603055576349
-    3  ( 17)  0.032407867048655 -0.033969801861417  0.457051817514276  0.682605465628673  0.266811035152933 -0.129791361160984
-    4  ( 18) -0.146452241358061  0.182164491681139 -0.670578545718526  0.180561730668713 -0.132153760707793 -0.172423147223622
-    5  ( 19)  0.329854516633489 -0.062406355486158 -0.142687713548999 -0.461391108813659  0.369113402446086 -0.291406831399555
-    6  ( 20) -0.095123792939029 -0.130974407921450 -0.423504400080728  0.046307780864123 -0.160121658345768  0.080587396654631
-    7  ( 21) -0.020196930650927  0.126100208893374  0.143365904721253 -0.472616518696925  0.216448635004369  0.164811157431042
-    8  ( 22) -0.044862231258128  0.010443804825893  0.151200178059944 -0.098979735611851 -0.407862770190674  0.414651419638203
-    9  ( 23) -0.001778806469034 -0.018623025532445 -0.107576400210487  0.163068566891587  0.647773862315846 -0.636630491425454
-   10  ( 24)  0.017927592798993  0.000180705630000 -0.053297006124060  0.074061342070591  0.058210218158357 -0.162911849208963
-   11  ( 25)  0.109490773836576  0.052999955618224 -0.000271745308396  0.000305712333614 -0.053078644790042  0.055108565747960
-   12  ( 26) -0.164133552719503 -0.074506459360537 -0.000357731899204  0.000072395693486  0.003695078860291 -0.023204687798386
-   13  ( 27) -0.648551410049995 -0.058758186891588  0.052984322168655 -0.003827983869788 -0.000211520166748  0.203311556747168
-   14  ( 28)  0.638654673856620  0.163384069601813 -0.055052210134389  0.022943426676923 -0.203292568578009  0.000202566783445
-
-	DPD File2: P*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.052480701259259  0.089840503139985 -0.350982482866049  0.095116826178087  0.022440054215652  0.032862353821469  0.081729096326081  0.021425782595611  0.235338088635135
-    1  (  1) -0.388124677168533  0.534993889872660  0.299624251031539  0.203953129475389  0.082377317359755 -0.089624704115259  0.293120840067825  0.059715673164777  0.225100704791756
-    2  (  2) -0.075046613139342 -0.054595030850083  0.042171893892626  0.238878291709943 -0.143368498448120  0.391908199708447  0.348187716284506 -0.162007005374424 -0.040145638710435
-    3  (  3)  0.003825096561586 -0.209524975426966 -0.061101725640115  0.005733734477972  0.005158862211836 -0.174020624147332  0.336061739172831  0.336718503904961 -0.081950585094521
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.010799235898820  0.184179967846582 -0.006278703826698  0.045893168283343 -0.154431576202783
-    1  (  1) -0.044872971637160 -0.151970487630040 -0.339396308854840  0.025890953682133  0.403821618486004
-    2  (  2) -0.178196793491180  0.663646636739936 -0.225638342179614  0.089456735981001  0.067546568678071
-    3  (  3) -0.206166573180735 -0.202910686825648 -0.607738412714145 -0.084545705245042 -0.343684996664701
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.080604406993543 -0.052828007136127  0.248271072214065 -0.004621901958854  0.238511508773077  0.166464522338437  0.059371420180247 -0.108552798507517 -0.113128199143937
-    1  (  5) -0.158176273521067 -0.142741353513120  0.372038467512456 -0.124710545030248 -0.314544785901233 -0.257579395622657 -0.074674230220199 -0.033693630413225 -0.220604268429912
-    2  (  6) -0.161070149264612 -0.184008094688423  0.303262375945924 -0.100514546731462 -0.134915075764794 -0.049291968700981  0.607921602195072  0.146614082163667  0.250955095397111
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.310847898937919  0.042310959338363 -0.062726869647814 -0.073058032344468 -0.064713071794420  0.023951260296913
-    1  (  5)  0.157873658680268 -0.125342133518717  0.276221069932045  0.249434379507851  0.361715962690354 -0.231044770920838
-    2  (  6)  0.062318733481263  0.109385681434768 -0.629646707936818  0.147627705365700  0.066774935973318 -0.338752628544606
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.016009260748017 -0.076567442214896  0.125166328875802 -0.007592491786253  0.098480428135412  0.089737912259519  0.045486487849709 -0.143199899460591 -0.062916360524591
-    1  (  1)  0.038605185454593 -0.325735593943764  0.218009839696040 -0.077381067334654 -0.123187634769419 -0.048889388601736  0.262562813593255 -0.048309424265131  0.024346564570397
-    2  (  2)  0.014979357855892 -0.182689410654369  0.081658179778794 -0.065473944506505 -0.193719600231606 -0.090995730111074  0.143671186830441 -0.007595230816929  0.060244510498059
-    3  (  3)  0.067326890443488  0.014019515203484 -0.166079081195192  0.050483560257990  0.175920280282569  0.180597777465204  0.198820897294047  0.109379576724081  0.213777271147620
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.159507026073975  0.056302017965781 -0.034397376897140  0.068360328302061 -0.100741673999881  0.049850169389160
-    1  (  1)  0.121516035123580  0.004562687000240 -0.189568378403116 -0.051932937377753  0.189148856797612 -0.205130706545356
-    2  (  2) -0.013364994269954  0.072899210778933 -0.147744909867102  0.343128869068584 -0.052918402885218 -0.086660614771912
-    3  (  3) -0.064044282976220  0.072658467037946 -0.366494615509597 -0.156516672080101 -0.183833699925440  0.043558655165224
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.095334256028009  0.133297788110144 -0.233197415167998  0.109601891242184  0.034275483482361  0.001203276521899  0.083637993138604  0.006960579869910  0.188458856324837
-    1  (  5) -0.132031102549102  0.218523085575864  0.122630941119498  0.145558608560396 -0.033193771816160  0.142560374903523  0.001867880595405 -0.178023294306114  0.083084371409555
-    2  (  6) -0.307498011816596  0.248791194429673  0.171772234113843  0.290615300494965 -0.046349417939456  0.102374827834141  0.404689139483050  0.035662684698487  0.067098771977202
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.011309857021213 -0.047826432296259 -0.011715243517174  0.012087997768714 -0.055738114510750
-    1  (  5)  0.060288763132101  0.100230270339149  0.175888842059756  0.033113626293054  0.296260944515875
-    2  (  6) -0.156436504590612  0.054087388641550 -0.405606872407349  0.026699931968424  0.143365753445289
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.021022954159736  0.035142529018952  0.107426415156770
-    1  (  1) -0.299993715747734  0.100035165443054  0.265269960401394
-    2  (  2) -0.260050498379079 -0.124418562014598 -0.440142593096703
-    3  (  3) -0.064425483075145  0.021009721425282  0.051333955965002
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019464542579225  0.300930139088225  0.262387611320763  0.064713939337572
-    1  (  5) -0.034890763742270 -0.099221858485008  0.125525760672816 -0.023652429329881
-    2  (  6) -0.106312135129399 -0.261746631642973  0.441788978603034 -0.052491092120842
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.143156293779769 -0.065598528855299  0.058339068026871 -0.095240471065162  0.054936782763489  0.158698528722424 -0.005848694187148  0.046188395629077 -0.009225054657648
-    1  (  1) -0.090550568038988 -0.201824271395705  0.091142881495912  0.093661370668859 -0.161043059103147 -0.077741533393123  0.543233062251592 -0.814467132908124  0.067293744881760
-    2  (  2)  0.021713915694858 -0.356864777307433  0.273330805205094 -0.263660970827611 -0.358937742043094  0.204650254826784  0.313132956505956 -0.064395695030077  0.200390318671649
-    3  (  3)  0.101095906237726  0.248350727445422 -0.325477886952403  0.022461371735421 -0.220401580692866 -0.053345914506007 -0.023674029203873 -0.049357473765327  0.000470604618644
-    4  (  4) -0.053513495604287 -0.177341679973179  0.223511424991143  0.043203647152663  0.200439262362192  0.109704630170554  0.130967856844601 -0.223696627843727 -0.051893869816232
-    5  (  5) -0.218677797229873  0.312515161252956 -0.301873753556228  0.119144839450133  0.273881128961801  0.291385277900658 -0.214361739830069 -0.197002465061645 -0.071567227017470
-    6  (  6) -0.085282711177633  0.152031995719920 -0.395807072999312  0.020599784121374  0.230274381395846  0.119204882075906 -0.196967452454600 -0.233009490057915  0.074120843143850
-    7  (  7) -0.047734330576263 -0.280574479547352  0.366542906373812 -0.110968913790478  0.088449186452659 -0.149744690480443 -0.036915836576634  0.394085559356064  0.043430167100304
-    8  (  8) -0.213441732464272 -0.108274495972316  0.634437106058845  0.069187196826565  0.037919304236964  0.161411654384539 -0.081574595848630  0.216961478694419 -0.039208476463161
-    9  (  9)  0.053318703860192 -0.090838807258297 -0.086586369793027  0.028327523211035 -0.134553886805994  0.073546423533118  0.007047260326121  0.447864900958376  0.046310440012370
-   10  ( 10) -0.217342853211265  0.434342746087742  0.408844907117118  0.321259899576754  0.034276585378345 -0.320138521202174  0.023800296590577 -0.279258907554493 -0.028679862426656
-   11  ( 11)  0.043839064779065  0.078964296226844 -0.267354222620337  0.331608707925144 -0.435766271345975 -0.066306681540143 -0.247977502270279  0.002757326539735  0.128220536878281
-   12  ( 12) -0.056967765282221  0.011496620916620  0.132088307172842  0.097918437653651  0.064500672945760 -0.001827098937393  0.216796993378831 -0.142477110991476  0.129430197478051
-   13  ( 13) -0.037733039841652 -0.226167830269728  0.091049164317861  0.252259768566517  0.015512763459721  0.284728528128491 -0.105582553814486  0.004845390965161 -0.367721806594329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222313487267139  0.016040998159682 -0.082409874320982 -0.002075539850870  0.060366346946182 -0.093408303465405
-    1  (  1) -0.558686428143613  0.124842930483593  0.159094597945824 -0.170661450539848 -0.081512715884899  0.084548811099098
-    2  (  2)  0.171589661035630  0.032363732574493 -0.410356885754263  0.223617160453788  0.075311055642080 -0.314379038887409
-    3  (  3)  0.113936852615240  0.023263060013616  0.282024826692995 -0.174390257283436  0.284646591950349  0.036134249694962
-    4  (  4) -0.007238439897924  0.039483311713766  0.327400920910445  0.428741395271426  0.081911463055166 -0.119323501144252
-    5  (  5)  0.007206698114830  0.054871846748801 -0.118753815309300 -0.018469351897211  0.153374179308602  0.075608926558101
-    6  (  6)  0.092372497620457  0.334623338930078  0.214791656963667  0.112964261573848  0.018239773729085  0.100594142805454
-    7  (  7) -0.151928519059447 -0.104975965782044  0.079311543670646 -0.028608318007851  0.093200761310883 -0.234496518387966
-    8  (  8)  0.034328207301673 -0.223808481631680 -0.061242559094949  0.498103653582096 -0.749098707942318  0.381141257037236
-    9  (  9)  0.119302126498580 -0.308066314141465 -0.075395221655780 -0.759042960378927  0.290000840041876 -0.156436862917181
-   10  ( 10) -0.438316650507883 -0.163958878572088  0.419969142321592 -0.045404841057508  0.044939660158532  0.568953527573990
-   11  ( 11)  0.012787507164606 -0.354874435093949 -0.016715712863870 -0.314729329115790  0.109367027564034  0.038956857759457
-   12  ( 12) -0.278784619045113  0.047236021517055 -0.203283234646730 -0.096945848185628 -0.275889526129666  0.187110942781753
-   13  ( 13)  0.588325776498883 -0.141777398655530 -0.127445383199618  0.417479630696627 -0.223570495101464 -0.209733888357992
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.139188612693568  0.095183099515076 -0.018684491477480 -0.097422162623446  0.052864868482975  0.221122027331105  0.088706173679123  0.046138783672279  0.215068969553880
-    1  ( 15)  0.062949654944158  0.202402030263201  0.354633955608115 -0.248176570557555  0.178122375116496 -0.312771607112475 -0.152477622828494  0.279557727250808  0.106814721163754
-    2  ( 16) -0.053746164934604 -0.094053172516910 -0.275496238616186  0.323601647464255 -0.223358052203497  0.300642069951494  0.393858290336507 -0.365390717289338 -0.632984591272781
-    3  ( 17)  0.094021410291053 -0.093446956362787  0.262411805474378 -0.022323156021381 -0.042743443130518 -0.119643171496185 -0.019212092155216  0.111729948135909 -0.069344517807286
-    4  ( 18) -0.056361407951715  0.163012412779377  0.357847040556453  0.219749386366483 -0.199619718061283 -0.273157948729405 -0.231158276251819 -0.090626116159486 -0.037799150902146
-    5  ( 19) -0.160601962218735  0.080044732518404 -0.203861835009410  0.053968884194125 -0.109680630973887 -0.290493189386329 -0.118089200507037  0.148837371744261 -0.161317719017176
-    6  ( 20)  0.008652189032826 -0.543672739191643 -0.312260746368354  0.021747391276478 -0.131147878369811  0.214266804924841  0.195294510221963  0.037324155238128  0.082720193718919
-    7  ( 21) -0.047043957125951  0.814756484486684  0.065190092636916  0.048606045400368  0.224060646841072  0.197248282512201  0.232144218543584 -0.394908869566567 -0.217734911422747
-    8  ( 22)  0.009402914133539 -0.067052868071270 -0.200249024215418 -0.001535377445924  0.051944723647720  0.071384974303961 -0.075222552542562 -0.043268063312178  0.039055784643578
-    9  ( 23) -0.222713322415783  0.560469323042930 -0.171950144039822 -0.112172774497996  0.007083782785909 -0.006435272424486 -0.090200197520766  0.151801615119284 -0.031995099170652
-   10  ( 24) -0.015969660808332 -0.124160280352778 -0.031945357169913 -0.022574658439251 -0.040253136475423 -0.054701591947166 -0.334874112350668  0.105285662958809  0.223928209457468
-   11  ( 25)  0.081168660495960 -0.159983923907575  0.408650744438646 -0.280675358230412 -0.326885231204144  0.118534279418464 -0.213700195384120 -0.079763618019830  0.060689421297523
-   12  ( 26)  0.003652731302177  0.169351937988896 -0.223186850703667  0.177435884273904 -0.431821641248852  0.017470249474556 -0.113426087502892  0.031984799215361 -0.498979784707156
-   13  ( 27) -0.059460007596700  0.080535877567365 -0.075179690138888 -0.285729932961758 -0.080576308673493 -0.153138615960011 -0.017506919748356 -0.094018188463908  0.750480875221691
-   14  ( 28)  0.091778712898573 -0.083756184222668  0.314061943377694 -0.035359431345057  0.119047398405395 -0.075525757634597 -0.100522537659024  0.234167701630633 -0.382415314141466
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054192115098489  0.218772067545687 -0.045642231806083  0.057541502908124  0.042026312169826
-    1  ( 15)  0.090589594220003 -0.434594274447356 -0.078276612217069 -0.011552267330405  0.225173895359454
-    2  ( 16)  0.087809314060775 -0.409613431079942  0.269441429063588 -0.132294826475095 -0.092807551910873
-    3  ( 17) -0.029496711967634 -0.321890318472494 -0.333949687981794 -0.098006508583727 -0.253968229243978
-    4  ( 18)  0.133856062539151 -0.034112562139975  0.437342385549595 -0.064344113622612 -0.014887157054416
-    5  ( 19) -0.074762453522294  0.320522646445325  0.065103712350275  0.002026903619864 -0.283693559601974
-    6  ( 20) -0.006545565411461 -0.024114390996231  0.248934516268112 -0.216845871250478  0.105404222827927
-    7  ( 21) -0.447834620578749  0.279310199694516 -0.002046231690190  0.142438484210793 -0.004552777078072
-    8  ( 22) -0.046132212945001  0.028293172679903 -0.127980948576613 -0.129504871571094  0.367038613276140
-    9  ( 23) -0.119912706409769  0.438601556174488 -0.013921175995500  0.279073471993608 -0.587144581639703
-   10  ( 24)  0.308677963206646  0.164180974317535  0.355112983785913 -0.047146799420307  0.142329570216595
-   11  ( 25)  0.075357514307532 -0.419786206774900  0.016983461358500  0.203268341742445  0.127372692691209
-   12  ( 26)  0.762257766627436  0.045741941689100  0.314841853754996  0.096926452085088 -0.417500846668484
-   13  ( 27) -0.290827635505768 -0.045087590967332 -0.109301341928646  0.275850981479361  0.223796991125890
-   14  ( 28)  0.156281997482093 -0.568696982960467 -0.039100360028362 -0.187067134074575  0.209842829958128
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.008545475107476  0.071680877089206 -0.120459476636913  0.008371471662446 -0.090424858216027 -0.087190000124570 -0.049119105543224  0.145928530657214  0.062376143421355
-    1  (  1) -0.044572181787493  0.342772635368155 -0.233569654941350  0.080704995470875  0.127360357635352  0.050248913608748 -0.272733324148390  0.042278800375679 -0.013710430281526
-    2  (  2) -0.007154597183575  0.182635894723101 -0.088652103396483  0.063130413574038  0.192109998380945  0.097062796293933 -0.154759017819859  0.027524119345809 -0.057504913844805
-    3  (  3) -0.077052275000893 -0.016814177051793  0.184635905961744 -0.049413266051267 -0.188745223686842 -0.186563337985988 -0.210232732381490 -0.116951639594811 -0.221961452093225
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.163872566981873 -0.058478850756530  0.036608142215322 -0.074980328212796  0.102514306635711 -0.049419294250537
-    1  (  1) -0.131779111368958 -0.004610196247654  0.196879673097414  0.065560333989646 -0.202294566496281  0.212677679948666
-    2  (  2)  0.021560095269691 -0.083223144658810  0.151678626872472 -0.372667885980926  0.062527480001262  0.084301072064405
-    3  (  3)  0.068590860983671 -0.076978943427677  0.378848573533368  0.165187920801172  0.188975469384157 -0.045051968107620
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.086725030779380 -0.140001038265324  0.215201398518350 -0.106476373516199 -0.037203797104343  0.002684965595124 -0.084210079065148 -0.008500639419888 -0.198745218470751
-    1  (  5)  0.141020111205039 -0.238503069490028 -0.123978991148198 -0.150112816633559  0.036264937723074 -0.146138191093449  0.002600464782236  0.189526092315718 -0.090546937772816
-    2  (  6)  0.314591250772654 -0.266642343404836 -0.168172023759533 -0.305975417776500  0.047767848718246 -0.093136048513418 -0.423942737612318 -0.027493034904141 -0.068648706999971
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.012967316151690  0.053655915263561  0.013296231482133 -0.012509871140561  0.053184722817966
-    1  (  5) -0.065459441432743 -0.098590450512903 -0.180288063245052 -0.033076485246495 -0.305944394837877
-    2  (  6)  0.160972461596512 -0.052337284313257  0.418780783100688 -0.024563105423132 -0.150128272333000
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002961765779100  0.004522349171324 -0.004971919287087  0.008281709260186  0.002230370021123  0.014875581701851  0.067042001167372  0.013799182049252 -0.003919895633432
-    1  (  1)  0.001156407591826  0.011364234036016  0.009216213637618 -0.026466586550273  0.045020897276730  0.024548396390040  0.151472003391729  0.022837501049660 -0.020115222648640
-    2  (  2) -0.011852353144693 -0.003988649312187  0.013577386237941 -0.005526396491599  0.001842043686662 -0.004979012487137 -0.016339527495633 -0.010418266838825 -0.006987142315452
-    3  (  3) -0.053414909238326 -0.048153357581206  0.085702791986601 -0.002590768785420 -0.032944657214652 -0.019536458989955 -0.058299722995214  0.003474387569511 -0.035804252701834
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.000158467148596 -0.005351238219208 -0.000795318433066 -0.002864683250639  0.001069112713473 -0.000329369508724
-    1  (  1)  0.008857574490791  0.013536712170937  0.030733233064254  0.004374373678073 -0.001058558277179  0.003465102179278
-    2  (  2)  0.011600433240152 -0.024957487742010  0.006847708052902 -0.007864294541740  0.004416463366055  0.003633653136444
-    3  (  3)  0.033694386372795  0.004962923837305 -0.009297526391638  0.012733700421545  0.018367087946588  0.009679397413178
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.004099418996737  0.004975270717489  0.011544453403942  0.010294240373049  0.015031167783122 -0.051218543078986  0.101906219668190  0.009904937929980 -0.005253311566155
-    1  (  5)  0.030335401615971 -0.051022895540044 -0.010476806750229  0.022518303747979  0.032764970727702 -0.046697847750190  0.082351506534871  0.029648968337614 -0.032167075005308
-    2  (  6) -0.044658147220588  0.062597359445969  0.000792773883945  0.033784853569182  0.053456383670095 -0.070727579120646  0.103493462669028 -0.004470774917382  0.021985039399781
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.001406578222011  0.001390228891514  0.004138457631327 -0.000537337712782  0.000303816554518
-    1  (  5) -0.018025115903144 -0.007054017557051  0.018234657716208  0.000615735236753 -0.005903957155119
-    2  (  6)  0.015821399504368  0.004485035916282  0.033862858822880  0.005131801318237  0.004339292116808
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.001352471969094 -0.045322075444733  0.038349314552152
-    1  (  1) -0.023470923414908 -0.379995390457559  0.218263993898326
-    2  (  2) -0.020646215106669 -0.203889457343544  0.063634437124037
-    3  (  3) -0.097263397740302 -0.216436926506454 -0.416986973069653
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.001379673989061  0.023464182377298  0.020715625293986  0.097608841144396
-    1  (  5)  0.045132209688744  0.379406783605291  0.203869208496661  0.217739723605823
-    2  (  6) -0.038063072975973 -0.217447630040656 -0.062958922139319  0.417725794235781
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.065653814142264 -0.041946284375303 -0.013161767706572  0.111342796774500 -0.110017778689743 -0.028611074624176 -0.087379776644865  0.000506944002000 -0.012737970563703
-    1  (  1)  0.002767473668146  0.010697220027718 -0.013506144228592 -0.073913704778148  0.217999207158693  0.148131683228122  0.817266423889027  0.116806346540286 -0.086848804711528
-    2  (  2) -0.048963138068012 -0.019287255807937 -0.016789870431812  0.373432811546966 -0.152152935578878  0.191763986764781  0.187319954974202  0.050812933510948 -0.023574454587241
-    3  (  3)  0.095762012298033  0.056431105854389 -0.178578325306558 -0.038136923805617 -0.140424655163157 -0.089806364466590  0.125801031634604  0.116636753108288  0.084794392657478
-    4  (  4)  0.100603170191617  0.067705087958627 -0.243617055985189 -0.044363102282417 -0.181215354983299 -0.115079991268796  0.179518597407386  0.083927955619955  0.086976764117441
-    5  (  5) -0.065265491800394 -0.066327433491654  0.367149548777650 -0.044009709655582 -0.156519624550140 -0.073861464202985  0.054146331819748  0.093323533938862 -0.170259582834842
-    6  (  6)  0.072248812824936  0.071960211653410 -0.684415406158707  0.206867685302678  0.380153305403406  0.217464691746015 -0.101286474206003 -0.035777100475268  0.341069042893403
-    7  (  7) -0.019742266764988 -0.004654597124952 -0.113800058767268  0.000574265002983 -0.010628342976831 -0.072863781204177 -0.376898463473803 -0.139300622802210  0.056085680972333
-    8  (  8) -0.000679953535081 -0.001598902294011  0.037525126251819 -0.088614223995002  0.068220130924204 -0.039175761140296 -0.208506736043279 -0.056089637691589  0.046057044816225
-    9  (  9)  0.002777732520373  0.007429125774642  0.024943116942350 -0.022915921654072  0.035702462515069  0.020318534935527  0.128837242689886 -0.002259623765271  0.005711714139269
-   10  ( 10)  0.005703803965392 -0.023273876655766 -0.027225029310730 -0.026559677666667  0.035399971500057  0.015156942548385  0.030152703916084  0.170109037950347  0.002596190944829
-   11  ( 11)  0.003384564196851  0.002280327238919 -0.118256580527015 -0.004805921198873  0.008748560057608 -0.061729599159426 -0.016174096583601  0.021868118731471 -0.291086759759657
-   12  ( 12) -0.020555722880272  0.013540587399774 -0.000211893937570  0.008542727496112 -0.013892940715707 -0.041889105198929 -0.006009166679671 -0.135825768330791 -0.000314961828297
-   13  ( 13) -0.004670677001798 -0.000926772526536 -0.016865034300282  0.001908716884004  0.008533776733402  0.002600829800043  0.067129999007525  0.024630232805222  0.002093287302057
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006448280903781  0.007804174666870 -0.001726589742279 -0.009631719534244 -0.002171109312827  0.006916768929421
-    1  (  1)  0.039841759002053  0.031613811363753  0.126269993080286 -0.005440038892529 -0.010222632040274  0.010738082177417
-    2  (  2)  0.049400367190082 -0.028054173187029 -0.027409200065905 -0.001009289954765  0.006677408446924  0.009978484711828
-    3  (  3) -0.070460304013326  0.083098595574193 -0.035907224123551  0.018802993269139 -0.017169529769810 -0.011284756920795
-    4  (  4) -0.035774264116816 -0.067898270132826  0.022183832964584 -0.018305304819727 -0.010768454734731 -0.005255647674495
-    5  (  5) -0.149334153074510  0.107123073600670  0.046253700594295  0.009064678078212 -0.006568373775894 -0.015962506593757
-    6  (  6)  0.264128081623912  0.189717353125691 -0.013846475545988  0.034468738650004 -0.018622793691907  0.039125899611440
-    7  (  7)  0.078787498256752 -0.137081801981432  0.129024279783991 -0.020540266029100  0.010702305076213  0.006363683572839
-    8  (  8) -0.066828272542120 -0.061150331629768 -0.661663512432504 -0.064427579111988  0.022787180611671  0.001755054521373
-    9  (  9) -0.058361662206488 -0.002765609007918 -0.292979002594137  0.024531884688023 -0.033841964179834  0.017477652244683
-   10  ( 10) -0.025537046615515  0.402776836876724 -0.195006548574470 -0.143818217257362  0.044952634158782 -0.042833786526299
-   11  ( 11)  0.612581110120467  0.030681983336889 -0.052907112855315  0.397594256764291  0.644994698530558 -0.225177415266176
-   12  ( 12) -0.078361827884296  0.147641215292530 -0.139659868964866  0.415352806158415 -0.111207746262217  0.045767792834358
-   13  ( 13) -0.007555966012008  0.007034052257820 -0.662815283687025 -0.034075798547008  0.058439318318560 -0.002857982237762
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.065636199611282 -0.002920916198147  0.048668219311498 -0.095119636724795 -0.099715491746342  0.064115894757826 -0.070288612362710  0.020002036740183  0.000648682346076
-    1  ( 15)  0.042164832302811 -0.010965264984920  0.019193267525749 -0.056427120825921 -0.067779126388374  0.066346545701259 -0.071818426884183  0.004697793564429  0.001719477062512
-    2  ( 16)  0.013293723744736  0.013552393155520  0.017152946073135  0.178062131392816  0.243207234696954 -0.366656850670269  0.683571699988320  0.113725695300653 -0.037674829370647
-    3  ( 17) -0.111833520478397  0.074487105305844 -0.373408686548039  0.038278615402917  0.044272326064866  0.043920914820213 -0.206763999327991 -0.000718931757735  0.088712771696387
-    4  ( 18)  0.110609556420903 -0.218552165395166  0.152101671319906  0.140308960149057  0.181388781196210  0.156379821301524 -0.379726625097930  0.010777684689777 -0.068071061617319
-    5  ( 19)  0.028752510181408 -0.148103625807997 -0.191866592233893  0.089885426625568  0.115404739185245  0.073530988681885 -0.216894531023559  0.072888831186762  0.039414155734701
-    6  ( 20)  0.088850262853694 -0.817864717973160 -0.187538432803728 -0.126558510407503 -0.179188313739966 -0.053967785688344  0.101346004734165  0.376808265586346  0.209641170142921
-    7  ( 21) -0.000236648626185 -0.116954024007332 -0.050876086441348 -0.116850431043499 -0.083855737312712 -0.093201481422807  0.035654753872492  0.139240147731598  0.056215130854042
-    8  ( 22)  0.012632241831446  0.086750564455513  0.023471210733819 -0.084658255793584 -0.087082440553447  0.170291379307318 -0.341029495907861 -0.056080270650825 -0.046130696703817
-    9  ( 23)  0.006387457988158 -0.039627800428235 -0.049236971359731  0.070603541281575  0.036093218300137  0.148729935532572 -0.263186790392662 -0.078651937105263  0.066792443994885
-   10  ( 24) -0.007794314356224 -0.031645957507839  0.027999240171264 -0.083306839859372  0.068240617920633 -0.107186407568302 -0.189422573537585  0.136891913283426  0.061228539916207
-   11  ( 25)  0.001991689460876 -0.126407268625784  0.027445392718538  0.035776924599103 -0.022144125160038 -0.046221028292780  0.013824022605635 -0.129003528239796  0.661853370394303
-   12  ( 26)  0.009599825104381  0.005495331116759  0.001034223219580 -0.018933867742673  0.018384105286375 -0.009023661627231 -0.034486124663305  0.020439460919434  0.064455521141270
-   13  ( 27)  0.002162721447509  0.010273200862148 -0.006630148558014  0.017146542465354  0.010737357070418  0.006596929169183  0.018510057851825 -0.010689113270586 -0.022830224344291
-   14  ( 28) -0.006906605609555 -0.010703198677296 -0.009943679074748  0.011262720290334  0.005261069281766  0.015966561898017 -0.039173616710326 -0.006358426931312 -0.001746833081562
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.002837339199042 -0.005729990462521 -0.002882667336321  0.020606047818522  0.004641004703607
-    1  ( 15) -0.007437286770332  0.023276875493539 -0.002358499534732 -0.013557485629733  0.000920107297989
-    2  ( 16) -0.025051827266470  0.027193002752018  0.117990698559769  0.000179234372392  0.016865743435032
-    3  ( 17)  0.023119196337007  0.026652175278014  0.004797499415929 -0.008529905892743 -0.001864545935891
-    4  ( 18) -0.035881897592302 -0.035473538214569 -0.008734163325355  0.013878334987718 -0.008565527202823
-    5  ( 19) -0.020360772275651 -0.015171720613603  0.061893166394059  0.041911368342621 -0.002602253507665
-    6  ( 20) -0.129299070691523 -0.030292769804169  0.016131950321938  0.006006549470023 -0.067162983124201
-    7  ( 21)  0.002077638821295 -0.170151112881545 -0.021893691209527  0.135824125871701 -0.024649373152539
-    8  ( 22) -0.005657792833300 -0.002565321667606  0.291029322280664  0.000304358068315 -0.002094832642432
-    9  ( 23)  0.058382869250631  0.025529477410136 -0.612383084135802  0.078382756676553  0.007563305586064
-   10  ( 24)  0.002481618081866 -0.402824463109094 -0.030640926554774 -0.147639465945455 -0.007047422246803
-   11  ( 25)  0.292947637539939  0.194977050256941  0.052900384325439  0.139655182883169  0.662817045986547
-   12  ( 26) -0.024630592497451  0.143803605487111 -0.397605464014331 -0.415353658752820  0.034075972250685
-   13  ( 27)  0.033850850098076 -0.044956075971212 -0.644991001235189  0.111210374775728 -0.058439332449029
-   14  ( 28) -0.017470247415045  0.042829113212736  0.225189876847489 -0.045765194902991  0.002860279243371
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.003220755761788 -0.004741334513036  0.005218491575352 -0.008931308835907 -0.002244102633378 -0.015838687100919 -0.070299613805989 -0.014541519275327  0.004023986014985
-    1  (  1) -0.000067503033474 -0.012207317918030 -0.007244793200988  0.023892777130642 -0.043438396740122 -0.025220796440141 -0.154461573863724 -0.023000834887421  0.019599055677926
-    2  (  2)  0.012578011879907  0.003275100255966 -0.012592919961383  0.005684090399027 -0.002169804380039  0.004971061326221  0.013552564477647  0.009500984985895  0.006299654057362
-    3  (  3)  0.059262075820670  0.046181284980691 -0.084603478568992  0.003021949940787  0.032496962809605  0.021957384896270  0.062320115832634 -0.002770430488820  0.031773062115651
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.000182000207227  0.005588586167114  0.000672702586966  0.002964514553093 -0.001105034523208  0.000343253226041
-    1  (  1) -0.008618205903186 -0.014153751191206 -0.035995392865196 -0.005123687397521  0.001603958931174 -0.003532153146744
-    2  (  2) -0.011268111146370  0.024898784529351 -0.008069485418761  0.008185686323918 -0.004533934142691 -0.003585064891685
-    3  (  3) -0.031845177970419 -0.004991052985520  0.011188833991374 -0.013257910424622 -0.018832233173395 -0.009593400754084
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.004231156729541 -0.005431493649267 -0.012529175724660 -0.009596633242284 -0.014606722988323  0.052629799448244 -0.104835250484967 -0.010143068216584  0.005577330897623
-    1  (  5) -0.032234138585390  0.047805476204470  0.011206420541453 -0.021169463646392 -0.032922137113452  0.049263864001113 -0.085142779220860 -0.029187847712420  0.030401159775617
-    2  (  6)  0.047014795193874 -0.061420283989306 -0.003243656996742 -0.033537214796175 -0.054307591623750  0.073188368684598 -0.108826461718921  0.002713708723067 -0.019591523301056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001535925504297 -0.001313736377570 -0.005141735029325  0.000303256666525 -0.000317758840647
-    1  (  5)  0.017868281803487  0.005956287092286 -0.022125071354749  0.000228679155762  0.005956925492705
-    2  (  6) -0.014719284513933 -0.004480852833973 -0.038592140844884 -0.004744813467982 -0.004561240528551
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.022503440356479 -0.058098623177060 -0.000062770505092  0.132305009105496  0.206845253941622 -0.090151367748423  0.021622993143838  0.039361662992191 -0.081041759558226
-    1  (  1)  0.058446002702836 -0.108172168386185 -0.020491566051334 -0.029038345992777  0.075256281123738 -0.197244333988945  0.268904698641837  0.104165934598637 -0.067340388311649
-    2  (  2)  0.015395531848647 -0.065975044836942 -0.020693241330571 -0.145278172814648 -0.156811977452555 -0.026190455636648  0.072791620713754  0.106379131933316 -0.008110007352911
-    3  (  3) -0.209889648236101 -0.051262205353483  0.016792464647056  0.095510023392087 -0.095336437943254  0.289116527068191 -0.245753635975044  0.379261907549404 -0.084194488960217
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009235922070380  0.024147628235135 -0.039515998256435 -0.082736569385204  0.047511948407189
-    1  (  1) -0.028213287410066 -0.067760885382258 -0.238885785831598  0.125969164417165 -0.177609465299056
-    2  (  2) -0.077606299822139  0.045313543977919 -0.093141189528995 -0.365274042010320 -0.093447143662359
-    3  (  3) -0.414915648101425 -0.159852566454575  0.273568285244179  0.034618677464967 -0.200919751856191
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.016102682138215  0.069778483618667 -0.053388820705143 -0.227201022061025  0.199230027507757 -0.049687576272545  0.168877445324815  0.014461225346720  0.006078045787078
-    1  (  5) -0.058029574568631  0.323045692556243 -0.030451397480033  0.087822399123219  0.049669665073330  0.052839306705253  0.277652121487366  0.149775076501372 -0.305937155187615
-    2  (  6)  0.084055275416977 -0.046073375264778 -0.190725804844658  0.087557818571264  0.137785527535432  0.205465571560117  0.198777590794243  0.118276962947747  0.298899363411174
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.065173985643121 -0.083163093513445 -0.059838819925541 -0.009394325003249  0.030439464334268 -0.004211857989885
-    1  (  5) -0.056299327075830  0.068872084822763 -0.330916524082322  0.053769676068525  0.184435947342737  0.103868547796473
-    2  (  6) -0.066328790095722  0.124449756334111 -0.113043685672814 -0.144452726550473 -0.299204372324576  0.043729255630968
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.000260799278180 -0.008294549497458 -0.017065509889387  0.120823024347784
-    1  (  1)  0.008496132195710 -0.000459229311004 -0.070584548654847  0.263658987971002
-    2  (  2)  0.016577243499005  0.069994423923560 -0.000663995662767 -0.516189372162913
-    3  (  3) -0.119940673323058 -0.260382743299108  0.515797582139532 -0.000896339388888
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.000443199054119 -0.381921104005874  0.143832379423130
-    1  (  5)  0.379434119543787  0.000485242459082 -0.057931044964221
-    2  (  6) -0.142702240031722  0.057674063898636 -0.001442186569692
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000910226438200 -0.057456315647344 -0.021764054616564  0.110121253697657  0.041147685715423 -0.038875248096137  0.013658842816188 -0.027740417762726 -0.095876695371130
-    1  (  1)  0.055345619259075  0.000114715934544  0.161082100934535 -0.114708094818496  0.226148458324691 -0.429581553751604  0.364780572887542  0.339773268987353  0.220533774744399
-    2  (  2)  0.020999461515685 -0.161288340725610 -0.000052922970119 -0.056734674713291 -0.008992634403320 -0.218257664918361  0.249333786133602  0.218109893723775 -0.109339937360493
-    3  (  3) -0.109919099574174  0.115822425715978  0.056019356031194 -0.000740007095007 -0.462857615923727 -0.122607299335305 -0.103870366450161 -0.116250705419353 -0.000233457194456
-    4  (  4) -0.040147971736914 -0.225934656930791  0.007773114629988  0.462818557889914  0.000780254049361 -0.292874409138683  0.009409004020261  0.051882584565833  0.039822167749921
-    5  (  5)  0.036335623693882  0.431140334679252  0.219015877475265  0.122742719044919  0.292837706496088  0.000258434125831 -0.380099535662932 -0.122521034451732 -0.042311772982521
-    6  (  6) -0.010512439726471 -0.366117332794119 -0.249486244103056  0.103549874519169 -0.008542365779906  0.379118456291524  0.000620782572313 -0.110534560584461  0.061985573540389
-    7  (  7)  0.028794951664777 -0.339121669867214 -0.216809050490518  0.114099993246667 -0.053090461626524  0.122152835981425  0.109887843186158  0.000210776402969  0.084672807469555
-    8  (  8)  0.095808229399132 -0.221323464482799  0.109106314792845  0.000875257457611 -0.038544677386553  0.040538328426676 -0.059775641025623 -0.084700205378613 -0.000410389354257
-    9  (  9) -0.014690106491517  0.105287842118522  0.107275604483120 -0.218821764375615 -0.309676781731095  0.105240911604621  0.129641828566929 -0.117997785339671 -0.042511311192418
-   10  ( 10)  0.029204608817403 -0.107752356880331  0.099755035717731 -0.053525818879341 -0.138310129158905 -0.190113742192741  0.089997971579917  0.050367401919439  0.205935350574800
-   11  ( 11)  0.155172680813618 -0.443695988859270  0.328777258069509  0.218798389099096  0.215176387461835 -0.086665175851153  0.081418632205002  0.042686048283827 -0.076994698961746
-   12  ( 12) -0.047142387984938 -0.056370877735219  0.091886939990151 -0.290638653877080  0.241910292969431  0.247337059928007 -0.042831064524262 -0.092379405612353  0.274155000078483
-   13  ( 13)  0.050389463693039 -0.050328281612189  0.290240848494312 -0.162056910726980 -0.213783629964646  0.103688020985272  0.033887129957515  0.045587144676475 -0.299790508093838
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015162329261762 -0.029089765310940 -0.157702865584754  0.046156688514328 -0.051381785238624
-    1  (  1) -0.106899843708486  0.107201618560176  0.445393416001207  0.057067668629351  0.050060001886431
-    2  (  2) -0.108853020016321 -0.100191021028451 -0.328545989684712 -0.092698579556052 -0.291502735762344
-    3  (  3)  0.218857914732928  0.054792818554564 -0.218936510583978  0.287400526650046  0.163296274552526
-    4  (  4)  0.309023997649700  0.137542449801745 -0.215093936648757 -0.238284970233362  0.213551426731583
-    5  (  5) -0.105674820684469  0.189857437820115  0.086867271556711 -0.246374813757869 -0.103858683942188
-    6  (  6) -0.128168668490610 -0.089874262580382 -0.081958189888793  0.043636026138960 -0.033207564369726
-    7  (  7)  0.118048267554359 -0.049676494199198 -0.043691989598397  0.088880392330239 -0.045560837044954
-    8  (  8)  0.043185963759057 -0.206226573210928  0.075243165739987 -0.272590964145289  0.299131513308221
-    9  (  9)  0.000077812750263 -0.416515228417900 -0.033604308554634  1.079153036382561 -0.144875292418151
-   10  ( 10)  0.417421688656681  0.000158782243602  0.288840596220158  0.322135887066066  0.291543524694710
-   11  ( 11)  0.033233098605228 -0.288689216150241 -0.000098607070373 -0.357467165030213  0.110234432471254
-   12  ( 12) -1.082588809014081 -0.322578291381663  0.357464370732486  0.000001008926324  0.002433258902322
-   13  ( 13)  0.144961978586806 -0.291352746525362 -0.110198259116823 -0.002466771848949 -0.000072101869173
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000153758776117 -0.016209320965105 -0.024928923757993  0.062060534746170  0.021458157416245 -0.118593249067004  0.004670228294358  0.089096779890278 -0.035341469320983
-    1  ( 15)  0.019055649133697 -0.000070152122919 -0.073747919702930  0.220440656283159 -0.117173681778925  0.070042107037530  0.194626605110428 -0.297284849336053  0.000292612579198
-    2  ( 16)  0.022586057118123  0.073725573957683  0.001109122666778  0.015411803389863  0.086529842350705  0.104871287980693  0.398741646289671  0.436619148331831 -0.174927780649059
-    3  ( 17) -0.059798965916265 -0.223563287458482 -0.017237453392182 -0.001072539123553 -0.251308090392191  0.316070038847548 -0.194803920269306 -0.070654457969027  0.376473483655780
-    4  ( 18) -0.020063419612631  0.119039349408291 -0.086800563750570  0.251653936305414  0.000335080735996 -0.043024303892643 -0.031731210904760 -0.166597040709751 -0.162561043906122
-    5  ( 19)  0.121124499955847 -0.070386002281353 -0.107113059896318 -0.315446439504518  0.043168772215477  0.000861181929967 -0.084799445456534 -0.176705933868056  0.191684805801835
-    6  ( 20) -0.000233561036084 -0.194646689461778 -0.399810731825322  0.193912344414617  0.032510952578749  0.085522667269840 -0.000316476981181 -0.483153682224173  0.288298406144107
-    7  ( 21) -0.086715012513528  0.297226361655840 -0.437406683020490  0.070307665212214  0.166617940064674  0.177260527643651  0.482840792772829  0.000014363804072 -0.098144550576534
-    8  ( 22)  0.034848855831113 -0.000859202110741  0.174080336928834 -0.374333295621785  0.160768014942695 -0.191629536777613 -0.289445575791765  0.097019024563133  0.000025631190893
-    9  ( 23)  0.146128458859477 -0.053492838723281 -0.324237370304827 -0.062951581962557 -0.055209150392106 -0.064149761275701 -0.152989513320630 -0.139473999081823  0.103718919745517
-   10  ( 24) -0.228943772617007  0.607904766836796  0.190620042163283  0.232958068554443  0.097307404392685 -0.308161168894475  0.021743402571297 -0.163623966328651 -0.316399909940952
-   11  ( 25)  0.113574180450176  0.174427793696739 -0.418995996797932 -0.308337203773489  0.075443225258948 -0.339087151000572  0.159463644175662  0.028413073183974  0.098871219135018
-   12  ( 26)  0.037424667627758  0.021650461815628 -0.117304488555654  0.051902638516337 -0.180454397204301 -0.010740660446775 -0.081519307958206  0.155893098286787 -0.070546741513103
-   13  ( 27) -0.017280094917641  0.067254948202109 -0.031223412783479  0.363810241712273 -0.387221887172221 -0.012090141232777 -0.015814975888526 -0.054980917535039  0.199339784826487
-   14  ( 28) -0.034098865606387 -0.073619427530260  0.020485113762460  0.085856422339691 -0.016811589994319  0.112843996612104  0.014113720302883 -0.178007823049380 -0.110352388592064
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147079245976260  0.230634884327798 -0.118016008095876 -0.038157145434167  0.016510465499821  0.035555014241919
-    1  ( 15)  0.054535973951003 -0.607948556744402 -0.173873449665646 -0.021413077919509 -0.066607274428011  0.073358777560519
-    2  ( 16)  0.323553306716541 -0.191880318233455  0.420431580367675  0.118056258433329  0.032680374772067 -0.021063792737754
-    3  ( 17)  0.062647993136989 -0.233296910168052  0.309972235049851 -0.052767888000268 -0.365466873103625 -0.086191647721005
-    4  ( 18)  0.056463254581534 -0.097267541950806 -0.076718792428350  0.181006281426179  0.388581954607450  0.017033118173935
-    5  ( 19)  0.064619380352855  0.308870128837400  0.338018875040100  0.010262168024492  0.011437556053144 -0.112357517192840
-    6  ( 20)  0.155382617120808 -0.021349499069868 -0.159407311491110  0.081840985740344  0.016551112219655 -0.014159445447452
-    7  ( 21)  0.140537868365913  0.163950016139901 -0.028635642703436 -0.155664270522521  0.055628199070781  0.178154240957341
-    8  ( 22) -0.103340923981933  0.315438553715367 -0.098505861648548  0.070640699178892 -0.199194337948212  0.110183696150063
-    9  ( 23) -0.000686334523005  0.100169676705670  0.098205409926821 -0.175395135103276  0.218110756133058 -0.228152281729332
-   10  ( 24) -0.099945574901306  0.000096874523801 -0.318471840231024  0.225312239057313  0.500004280246570  0.463864297141458
-   11  ( 25) -0.099841601903911  0.317761699341874  0.000010561898700 -0.325597818757907  0.211905875429043  0.064803783303090
-   12  ( 26)  0.174935629969472 -0.225292248952868  0.325705390264674  0.000017197242562  0.212072627252549 -0.098012445880115
-   13  ( 27) -0.218628597779198 -0.499556536309007 -0.211864150049234 -0.212027765065009 -0.000008829414452  0.140826209095657
-   14  ( 28)  0.228628348644091 -0.463533897425291 -0.064881803408838  0.097950839605716 -0.140879063677935  0.000044304452715
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019783280962491  0.054735513036393 -0.001137513221933 -0.126035313397777 -0.202288257068162  0.093711193829816 -0.024984212293499 -0.040225532801761  0.083002910227929
-    1  (  1) -0.062354133456812  0.120130294655184  0.021767958501026  0.030544876872275 -0.074729404941111  0.202914227763797 -0.283260339857543 -0.110010624076740  0.075144553244755
-    2  (  2) -0.020071793451970  0.073560407589557  0.021169787012452  0.145854096701605  0.150911678978076  0.033300464776861 -0.073764758000912 -0.114546085873699  0.006653295400428
-    3  (  3)  0.203743026628905  0.061501992586247 -0.012053004875485 -0.096810295870523  0.111136074888818 -0.295383183736970  0.262971263836652 -0.383085480530365  0.093214804722179
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009993046283887 -0.025513386596424  0.042737152836742  0.089318312648033 -0.047451575437880
-    1  (  1)  0.030039490649266  0.071945227885317  0.250267584137830 -0.142236308614906  0.184637048828095
-    2  (  2)  0.082997800944815 -0.054871782095115  0.094796172305804  0.401103667111563  0.092927166183836
-    3  (  3)  0.430981237821724  0.170811685089178 -0.282618320770360 -0.039486333217088  0.208093566455086
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.010424640140636 -0.070076236901647  0.057204661229737  0.211582690126517 -0.193468115965468  0.043909115261545 -0.178375291288102 -0.011291008781060 -0.006135050116210
-    1  (  5)  0.063097232722725 -0.334472526495555  0.025536894990807 -0.078253601702773 -0.050626850793128 -0.056751425430030 -0.294768356957907 -0.157483239712855  0.310569420319987
-    2  (  6) -0.095244048403721  0.044264153982762  0.212560989611836 -0.091390108488898 -0.149038965211255 -0.211765484415775 -0.210419446695478 -0.121083327494802 -0.309642081940379
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.068004773266362  0.092578615344634  0.065573414828925  0.010233554140998 -0.030163257404408  0.003064448161750
-    1  (  5)  0.053600127227434 -0.069934324462776  0.342538882666169 -0.056907034018328 -0.186630072086963 -0.106323576616076
-    2  (  6)  0.072821378093083 -0.126275999821165  0.117600524675145  0.149377060058828  0.309029921623329 -0.046031657791552
-
 	Computing Mu_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.057030552355
-	   1         5.012954436284    2.954e-01
-	   2         5.975394512788    1.793e-01
-	   3         6.016952198192    5.180e-02
-	   4         6.052072079082    2.320e-02
-	   5         6.056066210319    9.314e-03
-	   6         6.056038874971    3.801e-03
-	   7         6.056774039812    2.031e-03
-	   8         6.056404314719    9.788e-04
-	   9         6.056399720402    4.945e-04
-	  10         6.056420660749    2.001e-04
-	  11         6.056411190643    5.138e-05
-	  12         6.056393105805    1.771e-05
-	  13         6.056386940795    6.797e-06
-	  14         6.056388743683    3.146e-06
-	  15         6.056390699688    1.282e-06
-	  16         6.056391330548    4.577e-07
-	  17         6.056391318835    1.887e-07
-	  18         6.056391260170    7.849e-08
-	  19         6.056391240205    3.637e-08
-	  20         6.056391236823    1.577e-08
-	  21         6.056391232504    8.343e-09
-	  22         6.056391231581    2.671e-09
-	  23         6.056391231452    7.590e-10
-	  24         6.056391231801    3.339e-10
-	  25         6.056391232003    1.332e-10
+	   0         4.057030543999
+	   1         5.012954424042    2.954e-01
+	   2         5.975394494733    1.793e-01
+	   3         6.016952179686    5.180e-02
+	   4         6.052072060449    2.320e-02
+	   5         6.056066191506    9.314e-03
+	   6         6.056038856173    3.801e-03
+	   7         6.056774020984    2.031e-03
+	   8         6.056404295893    9.788e-04
+	   9         6.056399701578    4.945e-04
+	  10         6.056420641924    2.001e-04
+	  11         6.056411171818    5.138e-05
+	  12         6.056393086980    1.771e-05
+	  13         6.056386921971    6.797e-06
+	  14         6.056388724858    3.146e-06
+	  15         6.056390680864    1.282e-06
+	  16         6.056391311723    4.577e-07
+	  17         6.056391300010    1.887e-07
+	  18         6.056391241346    7.849e-08
+	  19         6.056391221380    3.637e-08
+	  20         6.056391217998    1.577e-08
+	  21         6.056391213680    8.343e-09
+	  22         6.056391212757    2.671e-09
+	  23         6.056391212627    7.590e-10
+	  24         6.056391212976    3.339e-10
+	  25         6.056391213178    1.332e-10
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 5.536e-11
 
 	Computing P*_X-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.379428422871
-	   1         9.541496632643    2.343e-01
-	   2        10.187801527890    1.252e-01
-	   3        10.232314947639    5.207e-02
-	   4        10.251531937193    2.260e-02
-	   5        10.255713456455    1.016e-02
-	   6        10.257526360338    5.067e-03
-	   7        10.258148745186    2.429e-03
-	   8        10.257969965190    1.125e-03
-	   9        10.258089658298    4.404e-04
-	  10        10.258130232367    1.816e-04
-	  11        10.258095894586    4.692e-05
-	  12        10.258068996864    1.442e-05
-	  13        10.258063787209    4.576e-06
-	  14        10.258063763659    2.195e-06
-	  15        10.258063918527    9.864e-07
-	  16        10.258063768538    4.281e-07
-	  17        10.258063569098    1.939e-07
-	  18        10.258063472200    1.064e-07
-	  19        10.258063458973    4.636e-08
-	  20        10.258063444717    1.662e-08
-	  21        10.258063438547    6.719e-09
-	  22        10.258063435041    2.373e-09
-	  23        10.258063434379    1.139e-09
-	  24        10.258063434082    4.760e-10
-	  25        10.258063433977    1.807e-10
+	   0         8.379428441775
+	   1         9.541496652643    2.343e-01
+	   2        10.187801548982    1.252e-01
+	   3        10.232314968654    5.207e-02
+	   4        10.251531958174    2.260e-02
+	   5        10.255713477321    1.016e-02
+	   6        10.257526381169    5.067e-03
+	   7        10.258148765977    2.429e-03
+	   8        10.257969985982    1.125e-03
+	   9        10.258089679086    4.404e-04
+	  10        10.258130253154    1.816e-04
+	  11        10.258095915374    4.692e-05
+	  12        10.258069017653    1.442e-05
+	  13        10.258063807998    4.576e-06
+	  14        10.258063784448    2.195e-06
+	  15        10.258063939316    9.864e-07
+	  16        10.258063789327    4.281e-07
+	  17        10.258063589887    1.939e-07
+	  18        10.258063492988    1.064e-07
+	  19        10.258063479762    4.636e-08
+	  20        10.258063465506    1.662e-08
+	  21        10.258063459336    6.719e-09
+	  22        10.258063455830    2.373e-09
+	  23        10.258063455168    1.139e-09
+	  24        10.258063454871    4.760e-10
+	  25        10.258063454766    1.807e-10
 	-----------------------------------------
 	Converged P*_X-Perturbed Wfn to 6.733e-11
 
 	Computing L*_X-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.314801475461
-	   1         5.359210006272    2.672e-01
-	   2         6.226202898958    1.456e-01
-	   3         6.248617018856    3.195e-02
-	   4         6.264713377860    1.225e-02
-	   5         6.265331460717    3.713e-03
-	   6         6.265622820616    1.583e-03
-	   7         6.265901229906    5.961e-04
-	   8         6.265844093081    2.068e-04
-	   9         6.265840573602    5.665e-05
-	  10         6.265840883243    1.749e-05
-	  11         6.265845023706    4.983e-06
-	  12         6.265845679735    1.445e-06
-	  13         6.265845403958    4.391e-07
-	  14         6.265845274537    1.600e-07
-	  15         6.265845219961    5.668e-08
-	  16         6.265845204252    1.840e-08
-	  17         6.265845196671    6.359e-09
-	  18         6.265845192119    2.387e-09
-	  19         6.265845191275    8.389e-10
-	  20         6.265845191042    3.717e-10
-	  21         6.265845191088    1.455e-10
+	   0         4.314801447826
+	   1         5.359209971705    2.672e-01
+	   2         6.226202855033    1.456e-01
+	   3         6.248616973914    3.195e-02
+	   4         6.264713332425    1.225e-02
+	   5         6.265331415192    3.713e-03
+	   6         6.265622775064    1.583e-03
+	   7         6.265901184340    5.961e-04
+	   8         6.265844047517    2.068e-04
+	   9         6.265840528039    5.665e-05
+	  10         6.265840837679    1.749e-05
+	  11         6.265844978143    4.983e-06
+	  12         6.265845634171    1.445e-06
+	  13         6.265845358394    4.391e-07
+	  14         6.265845228973    1.600e-07
+	  15         6.265845174397    5.668e-08
+	  16         6.265845158689    1.840e-08
+	  17         6.265845151108    6.359e-09
+	  18         6.265845146556    2.387e-09
+	  19         6.265845145712    8.389e-10
+	  20         6.265845145478    3.717e-10
+	  21         6.265845145525    1.455e-10
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 5.316e-11
 
 	Computing Mu_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.736109491168
-	   1        11.378062271335    5.273e-01
-	   2        14.627093272316    3.171e-01
-	   3        14.709692635023    6.752e-02
-	   4        14.804697133556    3.802e-02
-	   5        14.818984874917    1.310e-02
-	   6        14.818103326205    5.517e-03
-	   7        14.819707076619    3.288e-03
-	   8        14.820119414261    1.697e-03
-	   9        14.819709121107    5.868e-04
-	  10        14.819761248610    2.113e-04
-	  11        14.819955372434    9.946e-05
-	  12        14.820082462248    3.531e-05
-	  13        14.820069963469    1.275e-05
-	  14        14.820045993260    6.139e-06
-	  15        14.820032910698    2.913e-06
-	  16        14.820031041274    1.119e-06
-	  17        14.820031204037    3.255e-07
-	  18        14.820031140524    1.975e-07
-	  19        14.820031083990    1.053e-07
-	  20        14.820031058474    3.394e-08
-	  21        14.820031061660    1.553e-08
-	  22        14.820031060384    4.129e-09
-	  23        14.820031061242    1.361e-09
-	  24        14.820031062286    6.868e-10
-	  25        14.820031062884    3.049e-10
-	  26        14.820031063094    1.499e-10
+	   0         8.736109420317
+	   1        11.378062175411    5.273e-01
+	   2        14.627093128034    3.171e-01
+	   3        14.709692485812    6.752e-02
+	   4        14.804696982284    3.802e-02
+	   5        14.818984723041    1.310e-02
+	   6        14.818103174358    5.517e-03
+	   7        14.819706924667    3.288e-03
+	   8        14.820119262279    1.697e-03
+	   9        14.819708969149    5.868e-04
+	  10        14.819761096650    2.113e-04
+	  11        14.819955220468    9.946e-05
+	  12        14.820082310276    3.531e-05
+	  13        14.820069811497    1.275e-05
+	  14        14.820045841289    6.139e-06
+	  15        14.820032758728    2.913e-06
+	  16        14.820030889304    1.119e-06
+	  17        14.820031052067    3.255e-07
+	  18        14.820030988554    1.975e-07
+	  19        14.820030932020    1.053e-07
+	  20        14.820030906504    3.394e-08
+	  21        14.820030909689    1.553e-08
+	  22        14.820030908414    4.129e-09
+	  23        14.820030909272    1.361e-09
+	  24        14.820030910316    6.868e-10
+	  25        14.820030910914    3.049e-10
+	  26        14.820030911124    1.499e-10
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 5.177e-11
 
 	Computing P*_Y-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.602328690984
-	   1        10.212748217723    3.131e-01
-	   2        11.374664331668    1.665e-01
-	   3        11.434205015051    4.368e-02
-	   4        11.455271241012    2.114e-02
-	   5        11.458498275879    6.298e-03
-	   6        11.458565350810    2.302e-03
-	   7        11.458963344267    8.033e-04
-	   8        11.458912321701    4.302e-04
-	   9        11.458856747098    2.457e-04
-	  10        11.458891752066    1.211e-04
-	  11        11.458912930281    4.729e-05
-	  12        11.458918045447    2.017e-05
-	  13        11.458908309189    7.585e-06
-	  14        11.458905526886    2.792e-06
-	  15        11.458904685915    1.060e-06
-	  16        11.458904571832    4.336e-07
-	  17        11.458904332974    1.878e-07
-	  18        11.458904295287    7.017e-08
-	  19        11.458904310429    3.097e-08
-	  20        11.458904321209    1.795e-08
-	  21        11.458904319322    1.055e-08
-	  22        11.458904316638    3.113e-09
-	  23        11.458904315711    1.578e-09
-	  24        11.458904315834    6.660e-10
-	  25        11.458904315920    2.728e-10
-	  26        11.458904316005    1.113e-10
+	   0         8.602328705283
+	   1        10.212748236952    3.131e-01
+	   2        11.374664353137    1.665e-01
+	   3        11.434205034824    4.368e-02
+	   4        11.455271260595    2.114e-02
+	   5        11.458498295365    6.298e-03
+	   6        11.458565370299    2.302e-03
+	   7        11.458963363742    8.033e-04
+	   8        11.458912341174    4.302e-04
+	   9        11.458856766572    2.457e-04
+	  10        11.458891771539    1.211e-04
+	  11        11.458912949755    4.729e-05
+	  12        11.458918064920    2.017e-05
+	  13        11.458908328662    7.585e-06
+	  14        11.458905546359    2.792e-06
+	  15        11.458904705388    1.060e-06
+	  16        11.458904591305    4.336e-07
+	  17        11.458904352447    1.878e-07
+	  18        11.458904314760    7.017e-08
+	  19        11.458904329902    3.097e-08
+	  20        11.458904340682    1.795e-08
+	  21        11.458904338795    1.055e-08
+	  22        11.458904336111    3.113e-09
+	  23        11.458904335184    1.578e-09
+	  24        11.458904335307    6.660e-10
+	  25        11.458904335393    2.728e-10
+	  26        11.458904335478    1.113e-10
 	-----------------------------------------
 	Converged P*_Y-Perturbed Wfn to 4.058e-11
 
 	Computing L*_Y-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.237260247705
-	   1         0.311581398536    7.385e-02
-	   2         0.378113943945    4.166e-02
-	   3         0.380946552514    9.775e-03
-	   4         0.381824010659    2.281e-03
-	   5         0.381739941874    5.843e-04
-	   6         0.381731872606    1.865e-04
-	   7         0.381743052732    8.249e-05
-	   8         0.381739008153    3.574e-05
-	   9         0.381740341965    8.640e-06
-	  10         0.381740570802    2.637e-06
-	  11         0.381740426612    7.129e-07
-	  12         0.381740269802    2.318e-07
-	  13         0.381740255381    4.605e-08
-	  14         0.381740262807    1.650e-08
-	  15         0.381740266193    5.307e-09
-	  16         0.381740267072    1.679e-09
-	  17         0.381740267036    5.328e-10
-	  18         0.381740267007    1.498e-10
+	   0         0.237260244024
+	   1         0.311581393293    7.385e-02
+	   2         0.378113936487    4.166e-02
+	   3         0.380946544907    9.775e-03
+	   4         0.381824003006    2.281e-03
+	   5         0.381739934224    5.843e-04
+	   6         0.381731864957    1.865e-04
+	   7         0.381743045081    8.249e-05
+	   8         0.381739000502    3.574e-05
+	   9         0.381740334315    8.640e-06
+	  10         0.381740563151    2.637e-06
+	  11         0.381740418962    7.129e-07
+	  12         0.381740262152    2.318e-07
+	  13         0.381740247730    4.605e-08
+	  14         0.381740255156    1.650e-08
+	  15         0.381740258542    5.307e-09
+	  16         0.381740259422    1.679e-09
+	  17         0.381740259385    5.328e-10
+	  18         0.381740259356    1.498e-10
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 5.276e-11
 
 	Computing Mu_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.253972420770
-	   1         7.898889075369    3.989e-01
-	   2         9.620960304333    2.265e-01
-	   3         9.639820761678    4.893e-02
-	   4         9.676371564021    2.481e-02
-	   5         9.682172648543    8.187e-03
-	   6         9.681947110282    3.248e-03
-	   7         9.682407630903    1.660e-03
-	   8         9.682362904170    6.262e-04
-	   9         9.682261738360    2.144e-04
-	  10         9.682281458130    7.611e-05
-	  11         9.682312913453    3.356e-05
-	  12         9.682333522516    1.315e-05
-	  13         9.682331208227    6.023e-06
-	  14         9.682325993006    2.901e-06
-	  15         9.682323133938    1.391e-06
-	  16         9.682322918455    6.136e-07
-	  17         9.682323132908    2.665e-07
-	  18         9.682323256266    1.180e-07
-	  19         9.682323285135    4.930e-08
-	  20         9.682323290607    1.396e-08
-	  21         9.682323291504    4.983e-09
-	  22         9.682323292892    2.287e-09
-	  23         9.682323292637    8.236e-10
-	  24         9.682323292445    3.770e-10
-	  25         9.682323292118    1.928e-10
+	   0         6.253972378165
+	   1         7.898889016246    3.989e-01
+	   2         9.620960220458    2.265e-01
+	   3         9.639820677325    4.893e-02
+	   4         9.676371479021    2.481e-02
+	   5         9.682172563380    8.187e-03
+	   6         9.681947025118    3.248e-03
+	   7         9.682407545729    1.660e-03
+	   8         9.682362818993    6.262e-04
+	   9         9.682261653189    2.144e-04
+	  10         9.682281372959    7.611e-05
+	  11         9.682312828281    3.356e-05
+	  12         9.682333437343    1.315e-05
+	  13         9.682331123054    6.023e-06
+	  14         9.682325907833    2.901e-06
+	  15         9.682323048765    1.391e-06
+	  16         9.682322833282    6.136e-07
+	  17         9.682323047735    2.665e-07
+	  18         9.682323171093    1.180e-07
+	  19         9.682323199962    4.930e-08
+	  20         9.682323205434    1.396e-08
+	  21         9.682323206331    4.983e-09
+	  22         9.682323207719    2.287e-09
+	  23         9.682323207464    8.236e-10
+	  24         9.682323207272    3.770e-10
+	  25         9.682323206945    1.928e-10
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 7.671e-11
 
 	Computing P*_Z-Perturbed Wave Function (0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.998024159966
-	   1        10.356708146394    2.799e-01
-	   2        11.267860436720    1.421e-01
-	   3        11.289448032866    3.965e-02
-	   4        11.300667010667    1.866e-02
-	   5        11.303696934878    6.518e-03
-	   6        11.304126214856    2.776e-03
-	   7        11.304514250311    1.328e-03
-	   8        11.304475479554    5.660e-04
-	   9        11.304453765744    1.843e-04
-	  10        11.304472289736    6.947e-05
-	  11        11.304478306289    3.220e-05
-	  12        11.304477988932    1.579e-05
-	  13        11.304472963034    7.070e-06
-	  14        11.304471516596    3.099e-06
-	  15        11.304471112899    1.358e-06
-	  16        11.304471038789    5.488e-07
-	  17        11.304470886718    2.110e-07
-	  18        11.304470847655    9.651e-08
-	  19        11.304470850517    4.259e-08
-	  20        11.304470854314    1.187e-08
-	  21        11.304470851944    4.733e-09
-	  22        11.304470849460    2.290e-09
-	  23        11.304470848329    6.855e-10
-	  24        11.304470848021    2.556e-10
-	  25        11.304470847933    1.046e-10
+	   0         8.998024178782
+	   1        10.356708166524    2.799e-01
+	   2        11.267860455666    1.421e-01
+	   3        11.289448051550    3.965e-02
+	   4        11.300667029295    1.866e-02
+	   5        11.303696953448    6.518e-03
+	   6        11.304126233416    2.776e-03
+	   7        11.304514268863    1.328e-03
+	   8        11.304475498106    5.660e-04
+	   9        11.304453784297    1.843e-04
+	  10        11.304472308289    6.947e-05
+	  11        11.304478324842    3.220e-05
+	  12        11.304478007485    1.579e-05
+	  13        11.304472981587    7.070e-06
+	  14        11.304471535149    3.099e-06
+	  15        11.304471131452    1.358e-06
+	  16        11.304471057342    5.488e-07
+	  17        11.304470905271    2.110e-07
+	  18        11.304470866208    9.651e-08
+	  19        11.304470869070    4.259e-08
+	  20        11.304470872867    1.187e-08
+	  21        11.304470870497    4.733e-09
+	  22        11.304470868012    2.290e-09
+	  23        11.304470866881    6.855e-10
+	  24        11.304470866573    2.556e-10
+	  25        11.304470866486    1.046e-10
 	-----------------------------------------
 	Converged P*_Z-Perturbed Wfn to 3.916e-11
 
 	Computing L*_Z-Perturbed Wave Function (-0.077 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.860227168161
-	   1         4.705081704402    2.330e-01
-	   2         5.385168150575    1.365e-01
-	   3         5.432836571732    4.047e-02
-	   4         5.452279886874    1.183e-02
-	   5         5.451216223690    3.137e-03
-	   6         5.451449274726    1.047e-03
-	   7         5.451588723466    3.198e-04
-	   8         5.451534628180    1.148e-04
-	   9         5.451540512883    2.980e-05
-	  10         5.451541111982    9.450e-06
-	  11         5.451541682895    3.019e-06
-	  12         5.451540877878    1.187e-06
-	  13         5.451540790091    3.992e-07
-	  14         5.451540962022    1.499e-07
-	  15         5.451541044243    4.863e-08
-	  16         5.451541067785    1.412e-08
-	  17         5.451541070874    3.882e-09
-	  18         5.451541070924    1.178e-09
-	  19         5.451541071212    3.578e-10
-	  20         5.451541071365    1.190e-10
+	   0         3.860227142248
+	   1         4.705081672501    2.330e-01
+	   2         5.385168110928    1.365e-01
+	   3         5.432836530273    4.047e-02
+	   4         5.452279844754    1.183e-02
+	   5         5.451216181546    3.137e-03
+	   6         5.451449232565    1.047e-03
+	   7         5.451588681295    3.198e-04
+	   8         5.451534586010    1.148e-04
+	   9         5.451540470711    2.980e-05
+	  10         5.451541069811    9.450e-06
+	  11         5.451541640723    3.019e-06
+	  12         5.451540835707    1.187e-06
+	  13         5.451540747920    3.992e-07
+	  14         5.451540919850    1.499e-07
+	  15         5.451541002072    4.863e-08
+	  16         5.451541025613    1.412e-08
+	  17         5.451541028702    3.882e-09
+	  18         5.451541028752    1.178e-09
+	  19         5.451541029041    3.578e-10
+	  20         5.451541029193    1.190e-10
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 4.339e-11
 
@@ -6769,9 +1382,9 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.141679367454342    -0.070714074525053     0.000000000000000
-    1     -0.272710108679977     0.001289284927192     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.127276914384744
+    0      0.141679366346852    -0.070714073848342     0.000000000000000
+    1     -0.272710107838364     0.001289285224465     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.127276912258661
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
 	[alpha]_(0.077) =  -76.93388 deg/[dm (g/cm^3)]
@@ -6783,12 +1396,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.375624002172128    -0.374245931079431     0.000000000000000
-    1     -0.139409386151793     0.012686792954725     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.401726050127889
+    0      0.375624000190495    -0.374245927681760     0.000000000000000
+    1     -0.139409385269470     0.012686793056731     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.401726047794974
 
    Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.077) =  850.24712 deg/[dm (g/cm^3)]
+	[alpha]_(0.077) =  850.24697 deg/[dm (g/cm^3)]
 
         CCSD Optical Rotation Tensor (Modified Velocity Gauge):
   -------------------------------------------------------------------------
@@ -6797,4606 +1410,556 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.011921207729849    -0.011491041277978     0.000000000000000
-    1     -0.023088462037097     0.000608303898894     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.009703846161106
+    0      0.011921207730697    -0.011491041247067     0.000000000000000
+    1     -0.023088462294841     0.000608303937024     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.009703846119309
 
    Specific rotation using modified velocity-gauge Rosenfeld tensor.
-	[alpha]_(0.077) = -179.08820 deg/[dm (g/cm^3)]
+	[alpha]_(0.077) = -179.08818 deg/[dm (g/cm^3)]
 
    Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.
      Delta_x =   0.00   Delta_y =   0.00   Delta_z = -19.65
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027048397172827  0.015352704112429 -0.027966801428206 -0.165495930367099  0.113032293131079 -0.059172920617490  0.054022056893036  0.034114608641417  0.002886107104428
-    1  (  1)  0.197986831439807  0.163526093357892 -0.274966362484751  0.062421195117411  0.155967420230584  0.185920877152340  0.363704257460170  0.011868347502389  0.094068355200268
-    2  (  2)  0.001994785400509 -0.040665399791180 -0.057882185886799  0.076919743499300  0.080668892974906  0.050712045980973 -0.045932897295670  0.241652574031132  0.100470948740106
-    3  (  3) -0.134618148262870 -0.169475273759002 -0.112338313271068 -0.029804521352267  0.003944352681063  0.058729559824899 -0.233881451281742 -0.145241305284807  0.577534946997298
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.036861128446484  0.060248603479283 -0.005564054645453 -0.004146763273408  0.016591697834381 -0.007733796755325
-    1  (  1) -0.035918794247218 -0.084747615285920 -0.145084319526741 -0.032998082529710 -0.051841379309429  0.022806687326240
-    2  (  2) -0.084717069711908  0.396672019200134 -0.041908741386333 -0.023248477509422 -0.041530856301655  0.002269986110115
-    3  (  3)  0.038883132455574 -0.071756294192596  0.163991699742162 -0.069947324622934 -0.143620958659473 -0.040929670412834
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052809051974611 -0.081154565641459  0.006856441672465  0.153404070250162  0.196852318183927 -0.080976239577634  0.074658786299150  0.007719515837141 -0.043614904957346
-    1  (  5)  0.345238819329888  0.019785726463408 -0.050847186825376 -0.077921925096032  0.068975151229659 -0.351671921498224  0.386754555295523 -0.290601454575730  0.053302927070672
-    2  (  6)  0.016264209978667 -0.328366425365533 -0.028951141350709 -0.018921421012293 -0.077573679759545 -0.021800407750167  0.192628950256551  0.357488541894078 -0.081608454670559
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002259895960631 -0.008421832675073 -0.029392100940116  0.031369993361730  0.013404147466831
-    1  (  5)  0.208575493629327  0.067711703634065 -0.203628183391135 -0.030033358486437  0.027351411878278
-    2  (  6) -0.187162949376747 -0.097599552501240 -0.071289729935510 -0.047614074934521 -0.125833431363021
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.083683703090339 -0.629036417459351  0.187768409616308
-    1  (  1) -0.172602425643759 -0.014265091859115 -0.090495237140442
-    2  (  2)  0.012410708512386  0.140259555625425 -0.033093031733629
-    3  (  3)  0.617332033723984 -0.177002119872801 -0.059198789591033
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.083984489601084 -0.171922407137234  0.012476891672991  0.618883655109570
-    1  (  5) -0.628194576289392 -0.014487461121762  0.141926484654468 -0.177049320083612
-    2  (  6)  0.185974040475234 -0.088119347704351 -0.035357029662085 -0.057155078540436
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.828696203592025 -0.451233677364964 -0.217492273801626  0.586304584205470 -0.198651498309132 -0.103892077288677 -0.006625290696853 -0.001819921442022 -0.094028994790127
-    1  (  1) -0.134105565072084 -0.143652464482426 -0.611995940113886  0.241008731857517 -0.051449178692584 -0.174330855034171  0.232749848820746  0.145661004271388 -0.128120727077505
-    2  (  2)  0.012063899957181 -0.029490668702565  0.163575298648468 -0.247038876502286 -0.158753040652801 -0.232668473612314 -0.114948417424730 -0.088613836090719 -0.022645502108504
-    3  (  3) -0.387197557412670 -0.007622232234767 -0.010218748368993 -0.204814602539347  0.014944145142201  0.002431343194739 -0.270127586345773  0.245262578145958  0.504586982816530
-    4  (  4) -0.460895290297202 -0.083413276687337 -0.199944470395538 -0.175480967267008 -0.163722513813610  0.040241151316098 -0.067825190846260 -0.310807009269909  0.577783712019049
-    5  (  5) -0.141670378431748  0.052086036202433 -0.250889435285257 -0.425040439955416  0.233847348075332 -0.158351487033986  0.178722313644596  0.245879694116802 -0.083555978624952
-    6  (  6) -0.130215129741091 -0.059015562328244  0.175413123904883  0.193335335494377  0.081298931206816  0.027166944052244 -0.479004702191582  0.042682340773738 -0.241453523690860
-    7  (  7) -0.128547673529086 -0.164220156281948  0.072921190130196 -0.418244944504053  0.302491231669016 -0.324010640072614 -0.075458878798693 -0.283018425704598  0.036415017864410
-    8  (  8) -0.062134266770614 -0.089654327070673  0.258681583169725  0.013233242093465  0.089010222721713  0.141925171219203  0.145726898819659 -0.025159117142780  0.043087625590561
-    9  (  9)  0.009157475877293  0.060303564275152  0.008729628589478 -0.116950978984904  0.076882806093440 -0.036383180924410  0.025483369510244  0.084185310301748 -0.015374203474542
-   10  ( 10)  0.047802155117035 -0.149112906046527  0.075801259346579 -0.048947777837302 -0.067507042894011 -0.106234452747565  0.028517793153314 -0.172545779173849  0.080208086539212
-   11  ( 11) -0.167486808508145 -0.138908523197938  0.283706274113969  0.091574703729164 -0.067077172850546 -0.025283786004213 -0.222327209021950 -0.000487203355974 -0.057945510499956
-   12  ( 12) -0.037231281930006  0.362748649100666  0.118756733555108  0.060033069634811  0.015289792490319 -0.066371796214512  0.063049993784234 -0.118284085626097 -0.151871766112428
-   13  ( 13)  0.015283336962664 -0.071148654690618  0.097868838236954 -0.110089289416517  0.125070464978759 -0.056834800649528 -0.036033401521028 -0.003983216078506 -0.062348090726013
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.129554454626645 -0.009474588080129 -0.145878009069340 -0.063534624713007 -0.014264450989202  0.066217032610968
-    1  (  1)  0.281753304154040  0.090565863681328  0.289775851087277  0.012154255844323 -0.002972094129563 -0.002349687671183
-    2  (  2) -0.119860879107323 -0.017641780651255 -0.056884026698647 -0.114243277051592 -0.081965225578515  0.047553858250442
-    3  (  3)  0.046051897739571 -0.068234524007742 -0.078832315651282  0.147716570125616  0.178529070541059  0.041892492825571
-    4  (  4)  0.224634415651606  0.054726588873862 -0.049348904717282 -0.010497565899220  0.270816650862660  0.056280914540891
-    5  (  5) -0.031024580647590 -0.167869422275837  0.089185539311376  0.032869876236856 -0.093569757739340 -0.005458274862047
-    6  (  6)  0.000981392608875 -0.078803302525778 -0.231661065523126  0.077973096019011 -0.062231529668081 -0.004237870062293
-    7  (  7) -0.058902381932974  0.114392724110640 -0.121932201798416 -0.061774560961000  0.018069277572558  0.046890882022827
-    8  (  8) -0.513410839175549 -0.085343806911986  0.027485231745675  0.006687146984676  0.194553865700676 -0.182125622987063
-    9  (  9) -0.072026715715937  0.003186347104678  0.005511418401201  0.002695559377571  0.031996063695793  0.027434309505846
-   10  ( 10) -0.012941082780342  0.102602875317609  0.011650753905957  0.003161188417901  0.051176261016026  0.036262081394577
-   11  ( 11) -0.072389598964860 -0.058864168002652 -0.028128390537061 -0.005943934144729 -0.000119126931267 -0.005492981656650
-   12  ( 12) -0.054636974740175 -0.008287355979314 -0.024569715170625 -0.016528220340787 -0.046477458022406 -0.050873095371919
-   13  ( 13)  0.233743037101684  0.059061280447733 -0.024586559461861  0.004543245586431 -0.015684709596020  0.012075090111966
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.826691217716273 -0.135952995986678  0.011483190853402 -0.387418549613132 -0.461392423434393 -0.145485395838477 -0.124983069633084 -0.128330208269710 -0.063846145512012
-    1  ( 15) -0.452846199342112 -0.142299396923846 -0.028873680579439 -0.006282104582323 -0.083434971591043  0.052286846958797 -0.060366664959448 -0.164381491855687 -0.091103104723665
-    2  ( 16) -0.216318168271836 -0.610394122458981  0.164687829144547 -0.011212326508078 -0.198690499654959 -0.249888026637277  0.173149134305467  0.071382973187058  0.260544315437109
-    3  ( 17)  0.584300313840742  0.240136635172586 -0.247504197547440 -0.203677759108949 -0.175664930669504 -0.423103759080422  0.191640258021663 -0.415453280544989  0.012404695910308
-    4  ( 18) -0.199046601234260 -0.050380875227390 -0.159053876876033  0.015277075663832 -0.162367358631649  0.232430660796134  0.082724825485615  0.299791975181979  0.088348234646987
-    5  ( 19) -0.104272480193007 -0.175241820294404 -0.233618498225201  0.003347139508098  0.039544446804631 -0.159217030916535  0.028729750234265 -0.323094060438359  0.140740059020568
-    6  ( 20) -0.009429700555618  0.234933209114364 -0.114393727276615 -0.268466551242383 -0.069016344623676  0.178511125207222 -0.480183500829793 -0.075907755374260  0.143021582340266
-    7  ( 21) -0.002871019980141  0.147322100081013 -0.089022269698270  0.243063067023217 -0.308863060976325  0.246226696688424  0.042991460237403 -0.286148618462202 -0.024663467570559
-    8  ( 22) -0.094480909031128 -0.129736715593916 -0.024604248218242  0.506975842783889  0.578523602334509 -0.083635854955803 -0.240378319056804  0.036574430518098  0.043361894806843
-    9  ( 23) -0.127469850231581  0.279775306347553 -0.119965256355608  0.046842433309940  0.224627106687645 -0.032678040821047  0.003106740012385 -0.057480210886726 -0.513625849978234
-   10  ( 24) -0.010113608772280  0.091491204350202 -0.018677713812760 -0.071589894306377  0.058565690503593 -0.167584249262607 -0.077210943763034  0.110209847874266 -0.083926459961230
-   11  ( 25) -0.144415369890515  0.288923500809327 -0.057020258893375 -0.078932024592243 -0.049197678741037  0.089025916916400 -0.231280649793149 -0.121731391324011  0.028617795572466
-   12  ( 26) -0.063356880757476  0.012359494559817 -0.113921394225926  0.147470818074126 -0.010507483518380  0.032942784833780  0.077682178518205 -0.061765741733595  0.006769386889262
-   13  ( 27) -0.013995995859800 -0.002559954171790 -0.081334364324019  0.177743396826763  0.270580272329641 -0.093513472630021 -0.062576452638165  0.017989699080157  0.194659969913094
-   14  ( 28)  0.066065732055799 -0.002211449695904  0.047581100788566  0.041756948476168  0.056034974532939 -0.005464174123526 -0.004247545547791  0.046945122816871 -0.182306395720765
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.009977414948991  0.047795726251349 -0.170257794893058 -0.037938003385798  0.014458354771735
-    1  ( 15)  0.061029814509221 -0.148838977933651 -0.138622311676044  0.363027561331653 -0.070814310121723
-    2  ( 16)  0.008874691507393  0.075936125697402  0.284555367553991  0.119192422675493  0.098638859969366
-    3  ( 17) -0.119112210975481 -0.049599126168817  0.092584517631524  0.060254228139763 -0.110664977910194
-    4  ( 18)  0.077868925237217 -0.066966521216813 -0.067808172209585  0.015338001788660  0.125516910271684
-    5  ( 19) -0.036382791915003 -0.106250802464449 -0.025901673388436 -0.066582385072615 -0.057303328993872
-    6  ( 20)  0.027021717761366  0.029104182126986 -0.222331616975881  0.063168783761157 -0.035714374282977
-    7  ( 21)  0.082539979364650 -0.172536666253103 -0.000669172457815 -0.118274514306553 -0.003844186581139
-    8  ( 22) -0.015061746200930  0.080414802790268 -0.057448999880623 -0.151717132243101 -0.062253352906387
-    9  ( 23) -0.071494404128242 -0.013120612580941 -0.073373439067110 -0.054797723574814  0.233375251535298
-   10  ( 24) -0.000029429641055  0.102291625448331 -0.059321314850514 -0.008317623517552  0.059027698391220
-   11  ( 25)  0.005765327972253  0.011614880462470 -0.028065205779369 -0.024579424954359 -0.024526575892733
-   12  ( 26)  0.002692253200082  0.003132810553211 -0.005932245634366 -0.016507700544142  0.004577653394693
-   13  ( 27)  0.031988350963214  0.051121558533183 -0.000221075294856 -0.046532133387957 -0.015677394532699
-   14  ( 28)  0.027397767162108  0.036259397253953 -0.005558504489882 -0.050917091935213  0.012016157844186
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.025406566159268  0.023298635287253 -0.022289171225281 -0.168859399546037  0.107903085343053 -0.060918366478026  0.050893116255270  0.027117697569600  0.006137025962381
-    1  (  1)  0.191093901631364  0.147230293879877 -0.245327925746496  0.051184636572256  0.145804688312181  0.177082412956716  0.335688365255302  0.014738825150512  0.084927582076377
-    2  (  2) -0.003155042580293 -0.027233271764860 -0.053208296453271  0.087116448441961  0.072613171875510  0.049776562479710 -0.037069643141426  0.221123482833241  0.094081632463615
-    3  (  3) -0.148081532987297 -0.143795935425655 -0.095653656284437 -0.040581516151424  0.007002536737363  0.053388570274401 -0.215379283048700 -0.136731549228503  0.551441205232222
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.030005353497125  0.050795632899782 -0.002892294664254 -0.003533356466287  0.015218907421680 -0.007301899744305
-    1  (  1) -0.023556562941518 -0.073830002725756 -0.128862604566188 -0.028671951610704 -0.047866625740652  0.021732276920370
-    2  (  2) -0.073223983264692  0.364347296120169 -0.036743687154481 -0.019261211454008 -0.037116539662741  0.000181223309972
-    3  (  3)  0.040361740685149 -0.065239876693051  0.146174618322834 -0.062411658986300 -0.126965052748134 -0.038245290086936
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.049420429939020 -0.071369144027861  0.010967892434703  0.154003952784752  0.199243445955842 -0.070560943504312  0.064246991121544  0.009741916757203 -0.037796040806489
-    1  (  5)  0.343138545087365  0.025580231196086 -0.051475570317848 -0.074170810753422  0.055679775667351 -0.335513778030016  0.361763562256478 -0.278312996717472  0.053462866737909
-    2  (  6)  0.009023834056191 -0.297316159210662 -0.029288421962258 -0.011782745518153 -0.070184214173438 -0.014572213441163  0.183342019819766  0.338840705353917 -0.064096544850433
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.003020372683713 -0.006869864196192 -0.023893125242991  0.027343480005917  0.011586872808644
-    1  (  5)  0.191183605646494  0.061813805162100 -0.180211660376411 -0.027158850194505  0.022115988544494
-    2  (  6) -0.170812182146008 -0.089183247070529 -0.060689118587739 -0.041496923999492 -0.115713673600506
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.033754103488904  0.007555372231008 -0.012636539412206 -0.059168089266189 -0.007696166024660  0.117635610027585 -0.032183947570515  0.074301250166332  0.005019432091403
-    1  (  1) -0.423755974394480  0.394319832811341  0.072147771285996 -0.012389712258359  0.176348210158568  0.099930502723386 -0.086701753728859  0.210493567935760 -0.033589866390245
-    2  (  2)  0.731556552635086 -0.976828857219025  0.033351783092618  0.123378208756534  0.157072652564139 -0.117469430301404  0.019850790679398  0.009097984935670  0.052536003980734
-    3  (  3) -0.047142053921200  0.198059791670330 -0.117104106550805  0.059612555708172 -0.051540989544482  0.120490618164713  0.186894293315771 -0.315632131525439 -0.008321584703138
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.004809884959149 -0.006374181554658  0.001349973408295 -0.006100975957460  0.011138127142432  0.022680627009235
-    1  (  1)  0.028102393649998  0.000289730093568  0.008262915835035 -0.124989537199237  0.066219531536918  0.018649107137634
-    2  (  2)  0.064127657438793 -0.065272286524580 -0.003581214395138 -0.076462588539111 -0.021447992337748 -0.132206773204054
-    3  (  3)  0.084986028536621 -0.498497698329473 -0.040822633530773 -0.043076722957163  0.013585564451261  0.027785129671115
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.016730543671402 -0.000493178350680  0.017302982722459 -0.256616062196450  0.185493094009100 -0.020593262646150 -0.009463629803292 -0.002961983098477  0.026859263160767
-    1  (  5) -0.075519353333223  0.118875850027739  0.079935827799390 -0.178710173458091 -0.108180669642193 -0.177149189778534 -0.083450989109747  0.113241594567945  0.031859913963448
-    2  (  6) -0.130570312068760  0.286100740965062  0.219486021249390 -0.104893438221523  0.173427403577016 -0.413345988897352 -0.212934040260182  0.179032987184766  0.025997492049908
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021490597653360 -0.022287920558859  0.002597640544176 -0.020805616512876 -0.017185298510280
-    1  (  5) -0.023718660102006  0.015749627862868  0.008406851616741 -0.192275139478185  0.036883303753882
-    2  (  6)  0.028766539135724 -0.272291164468312 -0.017419741916350  0.092820056045692  0.043867791725602
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.239338426392564 -0.063574189159419 -0.037138721492623
-    1  (  1)  0.637136254562851  0.563345834986113  1.010359356370541
-    2  (  2) -1.018244537475946  0.319334895202255  0.761891810673220
-    3  (  3)  0.045207421457437 -1.211415382676948  0.547663980563646
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.240077996488429  0.636087166048540 -1.017448666598683  0.045094757983791
-    1  (  5) -0.063119844830318  0.559674519771415  0.326877163045745 -1.214495217986866
-    2  (  6) -0.036017040682083  1.005430771836738  0.769694801723881  0.546245988666419
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.840037313836020  0.879719351228572  0.280425530485763  0.209457510590770 -0.115971007140231 -0.005865677404341 -0.092534287825665  0.016878612757743 -0.000554227822991
-    1  (  1)  0.406955291511109 -0.250354570304778  1.752817026082590  0.218264636938841 -0.014952601145219  0.085173209047615 -0.020235302962366  0.502753766000685  0.012614402487781
-    2  (  2) -0.011947654987322 -0.087288086334953 -0.224335908490773 -0.261126688019980 -0.841762463275376 -0.627828907554534  0.172051366688234  0.617244504994475  0.119309262733021
-    3  (  3)  0.811182010574067 -0.188300264656061  0.222401504654110 -0.118806305641431  0.529562874381598 -1.235458279793789  0.515406670549199 -0.727585984163455 -0.017311451334544
-    4  (  4) -0.382877178063333  0.342160015383575  0.036035220830207 -1.515969153946585  0.125466254724712  0.736754668202047  0.136012972713827  0.102461498470004  0.013411116743442
-    5  (  5) -0.056666348930366  0.399251661739627 -0.011422755469852 -0.698119094644981 -1.282954629697895  0.508762695513963 -0.451449634220948 -0.904106936880537  0.596672635982258
-    6  (  6) -0.005527213521809  0.206039689350583 -0.144483993576148 -0.121247601463421 -0.485305002415323  0.548554310120049  1.475357051064366 -0.106842364972141 -0.027446822634470
-    7  (  7)  0.133565351861769  0.328960786484755  0.162326353593274  0.054193688082147  0.478136828850907  0.570702306118600 -0.024903308876874  0.585193831441818  0.835813795954640
-    8  (  8)  0.031082134068872 -0.063496391996010 -0.272771555688820 -0.132864368300259 -0.103453213303616  0.119428117809223 -0.197405807539525  0.153621429574163 -0.347696082487505
-    9  (  9) -0.117648127967179  0.675674455344672  0.057144753223871  0.137494275224088 -0.007401643263736 -0.153445689840736 -0.039660467466461 -0.125410015238965 -0.348925711100216
-   10  ( 10) -0.183218900015280 -0.105460278770619  0.367791083908301 -0.008056255919995  0.178869825089236 -0.183120759227084 -0.020135495201915  0.515209425517336 -0.117079814088000
-   11  ( 11) -0.007464482549715  0.021032905836050 -0.001689959480439 -0.009511863938863 -0.028294702186542 -0.022246363439352  0.137498694249546 -0.039431687760892 -0.108598715660792
-   12  ( 12) -0.123943400580450 -0.111733854742263  0.047511096154227  0.255974383794788  0.005125598158543  0.148074286896914  0.114005285118611 -0.069660405917942  0.028473614618333
-   13  ( 13) -0.017139778903114  0.000597229894230 -0.092098701078466 -0.096822642158100 -0.041570201760717  0.197811128787409 -0.008675665762269  0.009875145380093 -0.053724977580929
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.015271060368590  0.055897468396679  0.022597241061105 -0.097746276200326  0.101308246517630  0.083130674158184
-    1  (  1) -0.170077841267587 -0.306278912948529 -0.015343223805456  0.140911077413699 -0.086769343161678 -0.004428610402275
-    2  (  2)  0.122266526205533 -0.173859131387549 -0.008833802902653 -0.258485979502035  0.008602351060332 -0.030798632969086
-    3  (  3)  0.115160682049786  0.000168306649340 -0.007959105138980 -0.065254436598696 -0.027276553714500  0.039309215133697
-    4  (  4)  0.041448801667008 -0.223438700330986  0.042071183596141 -0.028071659294627  0.027228579441665 -0.074898825540824
-    5  (  5) -0.019058857013510  0.170849130048803 -0.086743087770944  0.110180684067332  0.041911344191976 -0.107077437297843
-    6  (  6)  0.021255870699759  0.392230842819920  0.124666046290611  0.015546514857889  0.011543222367899 -0.015718913239240
-    7  (  7)  0.300617707044268  0.028511951577123  0.099451065409571 -0.057624703208728  0.020680186596793  0.041210772734416
-    8  (  8)  1.560902789686190  0.259171353520895 -0.164601436985075 -0.034972573255346 -0.150377449452613 -0.038200704783867
-    9  (  9)  0.094514443562177 -0.031271005532013 -0.062263725106321 -0.058838957873498  0.760182137090868  0.950337382630766
-   10  ( 10) -0.066833413223948  0.207007631435691 -0.021103846805201  1.235346069959520 -0.166059589963498  0.166191905898816
-   11  ( 11)  0.166612835901501 -0.057714789963814  1.335141389249462  0.048926720734315 -0.084810123443347  0.094069041404757
-   12  ( 12)  0.208438787230328 -1.201605996005697 -0.134583025189360  0.366858420103389 -0.092230833884388  0.010845623464668
-   13  ( 13) -0.191515363269101 -0.044444589953201  0.113534652068488  0.222935332874317  0.996666807879559 -0.918946475319682
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.838261938125953  0.411783579911082 -0.011222177479730  0.801199436588318 -0.375306180891601 -0.060253817938356 -0.006525724615655  0.129557857631930  0.036205801526960
-    1  ( 15)  0.881558694801301 -0.253494731429581 -0.085421228751772 -0.179689412714139  0.333542664377779  0.397899463382726  0.204757675416354  0.337390689793974 -0.068236018271236
-    2  ( 16)  0.280699466651638  1.751444070796586 -0.225749579482049  0.222724309443776  0.035674220851777 -0.008396081497684 -0.143282250648261  0.160643678305862 -0.273482677804852
-    3  ( 17)  0.209621101203040  0.218341762403868 -0.261721827317418 -0.119292443469067 -1.513373925140781 -0.698058616179597 -0.120912446345617  0.053177597646066 -0.132398408764311
-    4  ( 18) -0.117749589449745 -0.014290802057305 -0.842585912658373  0.528480212857232  0.125620436909715 -1.282510147470767 -0.485022216108444  0.477099752728403 -0.104196524597516
-    5  ( 19) -0.007044544158153  0.085833731063079 -0.626602352540001 -1.234607574211689  0.736231003373149  0.506584871133556  0.547680268232320  0.572569559178554  0.118655251440909
-    6  ( 20) -0.091286539818598 -0.021685756074756  0.171006984274394  0.515577034801528  0.135942818875198 -0.450672680612861  1.476397473903694 -0.025200125211324 -0.196552429073982
-    7  ( 21)  0.014617007475273  0.504140575926305  0.617828254758316 -0.727391401463796  0.101524085740282 -0.903538681928281 -0.107568617019622  0.584678825668100  0.151735736187589
-    8  ( 22) -0.000237823420664  0.012124384227592  0.118807977471402 -0.017974774238044  0.014229470507378  0.597624885291520 -0.026926427408390  0.834871784840588 -0.347391080813467
-    9  ( 23) -0.016265284587164 -0.168715787569770  0.122968815716393  0.113284198302450  0.042943290149452 -0.021309190261859  0.020477672429448  0.301304618606591  1.561269376414732
-   10  ( 24)  0.055165623705948 -0.304174565565627 -0.172047420652933 -0.001660031801304 -0.223923016186918  0.170793818371478  0.390519343250458  0.028524302133373  0.258484158546987
-   11  ( 25)  0.022516344496095 -0.015268625075761 -0.008789463144050 -0.007966710860511  0.041912769223181 -0.086577370868099  0.124614837586422  0.099373675936837 -0.164728190655413
-   12  ( 26) -0.096631683724329  0.140629711782460 -0.257993906888811 -0.065720412418661 -0.028201117626138  0.110255501857704  0.015355688312895 -0.057301747761398 -0.034361742521519
-   13  ( 27)  0.100849821365822 -0.086662374683482  0.008639345451765 -0.026546017676244  0.026660167742260  0.041687326988987  0.011443920803067  0.021038625210724 -0.150878061048130
-   14  ( 28)  0.083365492537661 -0.004663028443678 -0.030268841557525  0.040380114857265 -0.076010028857183 -0.107569353616213 -0.016046780201203  0.042417265806974 -0.038629597007140
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124737520970567 -0.186432244849434 -0.007556173934213 -0.125048458790314 -0.016552020209549
-    1  ( 15)  0.684938290376393 -0.103735702852444  0.021157182854187 -0.111849169918717  0.000598582694869
-    2  ( 16)  0.056865870871391  0.369391836124585 -0.001636395160685  0.047382415225486 -0.092511884311165
-    3  ( 17)  0.136934156518159 -0.009055225169970 -0.009590382757559  0.257430334272387 -0.097052552691910
-    4  ( 18) -0.008312109924423  0.179598643669996 -0.028244191820460  0.004116010022868 -0.041623947269660
-    5  ( 19) -0.152106396286801 -0.183914202125923 -0.022266967951892  0.148019441595633  0.198105007663693
-    6  ( 20) -0.039829799204161 -0.019552759743993  0.137602535405962  0.113713715404123 -0.008789545170784
-    7  ( 21) -0.125502178629739  0.515709894296467 -0.039509503457082 -0.069986828128539  0.009910155465828
-    8  ( 22) -0.349425567476830 -0.116835672927993 -0.108584428663162  0.028578302642485 -0.053883081615012
-    9  ( 23)  0.094338880407330 -0.067969707543137  0.166597413367391  0.208167474360311 -0.191318590057359
-   10  ( 24) -0.031516356589242  0.206892773401202 -0.057842868800066 -1.201944585655949 -0.044330968677763
-   11  ( 25) -0.062291263803427 -0.020994462489648  1.335136332915063 -0.134637529250241  0.113529324930304
-   12  ( 26) -0.058655360066673  1.235296326813700  0.048926809978680  0.366850373682241  0.222951200118475
-   13  ( 27)  0.760531019832537 -0.165992770496603 -0.084811358078730 -0.092272088807521  0.996709535509256
-   14  ( 28)  0.951452405735214  0.166207367805620  0.094073590713281  0.010839332616852 -0.918866261119885
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062424152487093  0.006340337268482 -0.007129573994951 -0.068124969445001 -0.016536648970737  0.122839654890139 -0.029124555648029  0.069524525927009  0.016624796588470
-    1  (  1) -0.403752025492204  0.324343055871707  0.076420140656786 -0.003202781255002  0.185946708759860  0.105883952933980 -0.081054655409652  0.184341159829675 -0.032915937518265
-    2  (  2)  0.661672748869100 -0.861372726396764  0.035408787225401  0.124470554040362  0.167515771764057 -0.112285700010499  0.015950867409511  0.001232083495723  0.035574976981523
-    3  (  3) -0.034421465673628  0.179830504979566 -0.111544513847215  0.024097913531803 -0.030238246207055  0.104793216722198  0.173773469173217 -0.303193060944995 -0.006513662906792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.009334134343137 -0.006326528083054  0.001276536883825 -0.004159187336468  0.009674793406368  0.018903850771847
-    1  (  1)  0.023692877349552 -0.000748233659147  0.007572933338662 -0.110618865809947  0.058982973244648  0.020804020406208
-    2  (  2)  0.056439835248463 -0.059263779798462 -0.002854238464665 -0.070581535158609 -0.021806829149510 -0.125806190045722
-    3  (  3)  0.082847328899303 -0.459387875765944 -0.034524528441236 -0.040614390362782  0.013723967190574  0.025955752093967
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.017603663965705  0.003174083877041  0.014339522059496 -0.266660818847198  0.199602064605257  0.004780839495062  0.001108522960745 -0.004965069967999  0.030862088780690
-    1  (  5) -0.088113575807603  0.114873319929461  0.063166154639253 -0.188098449929865 -0.135702241550834 -0.170113296422216 -0.072240153498818  0.102270166350793  0.024891651267320
-    2  (  6) -0.139298038265852  0.270556959145684  0.173447642648828 -0.086085492397594  0.170302022343653 -0.397018505467907 -0.208262454149272  0.170239716749086  0.014885093941277
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.007377491418509 -0.019432502966035  0.002111593502676 -0.017924326928228 -0.015562648892606
-    1  (  5) -0.015992089252138  0.016902070355736  0.006260130611804 -0.170730300914524  0.032158624092886
-    2  (  6)  0.030768942376426 -0.242871623531964 -0.014807837846673  0.086333556064428  0.038627030320013
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130528946 -0.064555152924841  0.195953381452965 -0.041248493442142 -0.011229686954300 -0.030149441399628 -0.052245051060564 -0.006640144599606 -0.060816046841284
-    1  (  1)  0.618380750428757 -0.527850820486333 -0.215416501526368 -0.157035437852335 -0.069798458055575  0.063297476988332 -0.224803808736996 -0.036770088842034 -0.093292414352534
-    2  (  2)  0.089963765084418  0.016694193770404 -0.049894217008593 -0.224500363707256  0.100545586964082 -0.339808932191863 -0.300486601867879  0.103978674976873  0.003854593956757
-    3  (  3) -0.017912540048753  0.240051544243958  0.016875920304164 -0.019658112939729  0.000950481982654  0.139486308126505 -0.307526295570431 -0.245045411518121  0.038982174577009
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228157231 -0.053483299255732  0.001461399823215 -0.009996127162103  0.040844890740135
-    1  (  1)  0.010356156241345  0.045196494922430  0.123149462820863 -0.009608799088997 -0.092775098434661
-    2  (  2)  0.068261626747973 -0.266621644549134  0.090983468413283 -0.007824999548536 -0.015479677470817
-    3  (  3)  0.102991688132870  0.095940846021793  0.235195882815376  0.030438278902471  0.100331913658044
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713182343  0.055002400372953 -0.190701615216833 -0.008587073582699 -0.137456634335766 -0.102685174670731 -0.038575707285854  0.049077773971977  0.038775520895292
-    1  (  5)  0.266426121027506  0.201904502326533 -0.404472747758134  0.112355452471773  0.244543383226856  0.203488255104151  0.093346083645080  0.046662175787456  0.162564534029677
-    2  (  6)  0.310200496188946  0.275860886552205 -0.334362481107594  0.111323203472945  0.107269573355600 -0.015396506114788 -0.485347827879795 -0.115211810589159 -0.189399381435021
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448700903 -0.010182782827209  0.015536223734562  0.027148068645677  0.019304531549287 -0.012170541866764
-    1  (  5) -0.076359104734661  0.072719944842760 -0.105706045014198 -0.076791075691679 -0.095250630845942  0.044053081319363
-    2  (  6) -0.023401555353274 -0.060789750776477  0.233844071184097 -0.060200608251925 -0.022972229728472  0.078966373824930
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134471189914803 -0.662148890607048 -0.267935017575730 -0.078917514513460
-    1  (  1) -0.664666296280562 -0.209284548524716  0.147471335927792  0.068908464210939
-    2  (  2) -0.267133357554530  0.148425589032828  0.187317600183912  0.001813046044159
-    3  (  3) -0.077770523321569  0.066603013382230  0.004062963757785  0.013912154355475
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274832594142428 -0.278242095473143 -0.671654031875754
-    1  (  5) -0.278497835849508 -0.012090615801272 -0.010590436880494
-    2  (  6) -0.670432937480178 -0.009657206552315  0.097732020822376
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959652942443780 -0.408123540990243 -0.490401242893299  0.038728621520496 -0.077955848847628 -0.487356522820254 -0.107431644874248 -0.396098714695084 -0.237559092067117
-    1  (  1) -0.405287391714683 -1.324235802978493  0.174918475291447  0.249090287653660 -0.197882092902579 -0.317613214061072 -0.251158650058355 -0.030182263573247  0.632878894923950
-    2  (  2) -0.488736302148035  0.174537834224317  0.686802536456231  0.342698519251872 -0.009978504113557  0.483630952562764  0.287674546486731  0.302838065991480 -0.272076060462856
-    3  (  3)  0.037680750737500  0.250810426061315  0.345041313473359 -0.288921951476600  0.242065062503934 -0.302245036763640 -0.510968388336981  0.184732147309200 -0.217019518794602
-    4  (  4) -0.076474970303988 -0.199548329885190 -0.011318561816348  0.242358447532560 -0.131824013348934  0.385851084327112 -0.241519487669974 -0.375192533769848  0.062578612484494
-    5  (  5) -0.485852483644543 -0.318979279826184  0.484066634054750 -0.298903806636467  0.382610997595699 -0.557142551551020  0.333197792506285  0.111813059498605  0.019832042071129
-    6  (  6) -0.104965309325025 -0.251905850556084  0.289646446290464 -0.510970312004153 -0.243416542879353  0.333477452717118 -0.859910604691225 -0.040221092426954  0.015978091057726
-    7  (  7) -0.396757752805925 -0.028569556569604  0.303650553602711  0.181375877282891 -0.373315055683876  0.109082013989902 -0.042394080453042 -0.424453142550918 -0.165367340666656
-    8  (  8) -0.232577777741232  0.628634227275953 -0.273406824008824 -0.217896152147594  0.062014351622307  0.020854775528038  0.015643896352917 -0.165522517641184 -1.139943298313989
-    9  (  9)  0.005610937945933  0.056039777778849  0.162949812655036 -0.082447741116097  0.072872155292264 -0.108705186895719 -0.023485984983778  0.044747716582668 -0.147251711462478
-   10  ( 10) -0.006823140107367  0.054329320069732 -0.040599884216487  0.341771214963506 -0.179762239229163  0.323458315199162  0.128244534804048 -0.274646157470800 -0.052523948902062
-   11  ( 11)  0.095363270852437 -0.102111548052236  0.068440604856687 -0.163728434991873 -0.155636086206937  0.243236788520030 -0.456650415619116 -0.005317873090518 -0.049821847163774
-   12  ( 12) -0.031682366649886  0.049375813732146 -0.071598146136873  0.132087989350725 -0.108611785503928  0.096654485319462  0.079499450609138 -0.086710987294923 -0.054539911300598
-   13  ( 13) -0.055056204843758  0.125842892734663 -0.045965574233073 -0.019980233431093 -0.072417713533459 -0.032557591655033 -0.014098057282134 -0.073500277877371  0.566229267143538
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807523812671 -0.007359544445531  0.096092504153619 -0.031848084858648 -0.055774202583708
-    1  (  1)  0.055013732726191  0.054716327776958 -0.101499825301692  0.049505806374070  0.126450547773127
-    2  (  2)  0.163059205524790 -0.041368873195638  0.069581455391968 -0.071597196814435 -0.045866052289024
-    3  (  3) -0.081105673316398  0.339429555795348 -0.164728153281382  0.131959969253045 -0.019695233736278
-    4  (  4)  0.071393373323251 -0.177479193977683 -0.155859184096407 -0.108539407237796 -0.072773970199488
-    5  (  5) -0.105603312027129  0.324542336401662  0.243446189989531  0.096679109324856 -0.032469296684766
-    6  (  6) -0.022598073115881  0.128545265383103 -0.457503820066558  0.079428257830674 -0.014293355797493
-    7  (  7)  0.043846313801253 -0.277398721165106 -0.005217801503343 -0.086814141747281 -0.073528025025910
-    8  (  8) -0.147650558268387 -0.051824889076812 -0.049479655393433 -0.054623458164613  0.565538504818440
-    9  (  9)  0.072040995852218  0.045487481962658  0.010267944428546  0.009607395555640  0.026537979807784
-   10  ( 10)  0.047954867964362 -0.139047713462617 -0.006984668952712 -0.101926998578260 -0.021981627684010
-   11  ( 11)  0.010232694230356 -0.006895180971719 -0.093446496399543 -0.006456318213145  0.037416385389791
-   12  ( 12)  0.009698093592920 -0.101910194006554 -0.006447087192563  0.055515253372902  0.004586695976630
-   13  ( 13)  0.026517968066884 -0.022107111803180  0.037498264997396  0.004566515562682 -0.064482567844114
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532087830445926 -0.788053684507392 -0.217638660833197  0.182558741691964  0.602280863166455 -0.200093874423138  0.029411465990867 -0.008618445566170 -0.142345996690868
-    1  ( 15) -0.793296872955545 -0.320033246707737 -0.162598983453527  0.058726799927110  0.020874328230438 -0.223415347506574  0.107419197066742 -0.353928058607362 -0.096059895093397
-    2  ( 16) -0.212771964615612 -0.165330330084882 -1.296138478685232  0.042119030621194  0.273634362778554 -0.438879796184691 -0.121813090338313  0.097180424591982 -0.140937625632113
-    3  ( 17)  0.179954421761081  0.058841120611665  0.044127192643470  0.293105599691600  0.349356889255942  0.303438248960065  0.077097854674844  0.005877107377562  0.014045104815526
-    4  ( 18)  0.599465706538920  0.022235571311357  0.273958683710447  0.351252283345913  0.210835219542339  0.044587084446442 -0.439010194739272 -0.491004374374813 -0.399383596132888
-    5  ( 19) -0.200414127659350 -0.221453682461015 -0.440132543486983  0.305750504454767  0.044859549976743 -0.117462872288654 -0.191542018731891 -0.319736100846566 -0.359370858025094
-    6  ( 20)  0.032162128695933  0.105939422719644 -0.123876353231712  0.078981740804684 -0.440632986498194 -0.189872412133810 -1.110683989664156  0.246909463040471  0.255271007021977
-    7  ( 21) -0.008289240579773 -0.354493597907539  0.096614444500186  0.006342901541664 -0.491270269564264 -0.319008747231223  0.247402781824619 -1.005041339195380  0.329310525935830
-    8  ( 22) -0.142958112264996 -0.097022080198495 -0.141105576353547  0.015162721103223 -0.401346216617333 -0.359442000621317  0.255249867150800  0.329100137101793  0.052130295868829
-    9  ( 23) -0.219989065338878 -0.250001442147006  0.576446348090269  0.098959674934949 -0.020568114883162  0.097513800290254 -0.059902955979327  0.014734527182880  0.155046520232648
-   10  ( 24) -0.078950494593626  0.108193141540531  0.027256154056543  0.046487728419779  0.091306743921577  0.113368151014402 -0.170234458952828  0.302098295081586 -0.032847707902243
-   11  ( 25)  0.043326744763780  0.032363389765351 -0.179596320194099  0.107314642599215 -0.187556761662743 -0.097228134814891 -0.510755068213776 -0.080036249779472  0.081235508191006
-   12  ( 26) -0.068197976687722  0.217296898139221  0.162613838977633  0.182156526110652 -0.078640971353133 -0.138388418091556  0.046099139451725 -0.318339562821704 -0.094298996209138
-   13  ( 27)  0.012948053108673 -0.163156717293819  0.064963474439184  0.076423090035566 -0.116362948606428 -0.057051341664290  0.002572557283580  0.275506911043523 -0.101255941425000
-   14  ( 28)  0.072512090956400  0.116063474699758 -0.039414548907200 -0.060057426600154 -0.063414940197114 -0.039930823902922 -0.007406649424353  0.061654502657618  0.127196073451667
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223472856125742 -0.079380673671635  0.044417376178946 -0.069445497122295  0.011729893484114  0.073549727859122
-    1  ( 15) -0.252084320126442  0.107740778862871  0.032072824768773  0.217703433408601 -0.162976180926073  0.115649024793372
-    2  ( 16)  0.579843117211313  0.028377214598813 -0.180834874538440  0.163175611888439  0.065411291321188 -0.039948698403888
-    3  ( 17)  0.098340901264216  0.045586420114884  0.108734472654534  0.182606429756644  0.076964420454008 -0.060236205606042
-    4  ( 18) -0.021650833258616  0.091327714077226 -0.188512569777461 -0.078662641752143 -0.116896916465247 -0.063655160079575
-    5  ( 19)  0.097171540487668  0.112970498499516 -0.096626702541390 -0.138712839207192 -0.057497370879087 -0.039673289391880
-    6  ( 20) -0.058059330868561 -0.170134824581430 -0.511529953088092  0.046149842871006  0.002603003860136 -0.007423573856034
-    7  ( 21)  0.014906052393179  0.302176683660248 -0.080527272431049 -0.318411101353105  0.275449773210268  0.061692765696993
-    8  ( 22)  0.155151887415096 -0.033185457460157  0.080998651044629 -0.094073422594697 -0.101041326107855  0.127067437732620
-    9  ( 23) -1.153509668783001 -0.223849781346618  0.084925914727116 -0.000154347649926  0.401132279454500 -0.346054712948586
-   10  ( 24) -0.223987599199814 -0.015012978057576 -0.013160266828997  0.067286208756079 -0.009874035128650 -0.084312333173046
-   11  ( 25)  0.084246135638493 -0.012978110751430 -0.099616699052767  0.005046001107463 -0.012239544441460  0.023063802192487
-   12  ( 26)  0.000203295323483  0.067424132179953  0.005012434752789  0.014687484558096 -0.012600853140958 -0.022021985861034
-   13  ( 27)  0.401487062547390 -0.009674045105948 -0.012249675470802 -0.012688275811242 -0.008212565394913  0.091176394188195
-   14  ( 28) -0.346417777816096 -0.084403131840825  0.023147564238642 -0.022062212401564  0.091088265445589  0.040127117548266
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.056215172927916 -0.054500121508322  0.201919258778010 -0.031077763805510 -0.011710544286436 -0.013075909022680 -0.042346948343635 -0.000671828610738 -0.052291650154205
-    1  (  1)  0.580185867754678 -0.459972750936400 -0.203225406348613 -0.146383812909082 -0.059047716306621  0.052226207773922 -0.210466211081215 -0.032187368805259 -0.063260160660422
-    2  (  2)  0.093393210560188  0.013367711284029 -0.072500427251494 -0.188901437088884  0.080233215060989 -0.320461366545765 -0.281774577854691  0.095754687109263  0.009993944043533
-    3  (  3) -0.011006044771994  0.212772034365604  0.010016676236493 -0.008866166718285  0.020319326728203  0.122354060320048 -0.286521493894349 -0.227705676000915  0.024617045170947
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004784997819657 -0.045646414220092  0.000336480966462 -0.008910135153260  0.037229969984587
-    1  (  1)  0.012654368887265  0.038726053143637  0.110122850812823 -0.008163616619222 -0.088473965567598
-    2  (  2)  0.059858161338620 -0.242276960593359  0.080687948077563 -0.004783379620358 -0.010585827086864
-    3  (  3)  0.093190009488007  0.087625847683856  0.210676227172290  0.029310964936832  0.092669936157259
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.095387847271100  0.063707280070084 -0.166137683411008 -0.019021592855565 -0.149973759870001 -0.101204344306762 -0.031472575282315  0.053498473859926  0.042967624438521
-    1  (  5)  0.255913379011736  0.182084006874274 -0.358054748488889  0.117938321574845  0.215767331745706  0.198255948304019  0.082288393877684  0.046112468588943  0.145174585882671
-    2  (  6)  0.310255025939172  0.238379636947246 -0.293832074000714  0.096225461031061  0.113893650091632 -0.010350379528905 -0.451016712887586 -0.111857486176803 -0.191795343976766
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.073847869190148 -0.008654741710575  0.012693286782788  0.023668684158666  0.017789448486280 -0.009288640287720
-    1  (  5) -0.053437181209244  0.073043482844143 -0.095008049754430 -0.066955827698789 -0.087649070811154  0.040223508017977
-    2  (  6) -0.005363324155257 -0.054894453356376  0.206318087760035 -0.056446189403617 -0.025451704179473  0.074272027058522
-
-	DPD File2: P_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.031889834472336 -0.023590247545076  0.035886092938494  0.337391549003445 -0.230489171708387  0.118250549009017 -0.096738323803454 -0.039671560183731 -0.017417453829651
-    1  (  1) -0.115559689950866 -0.104792776753397  0.247387033439083 -0.112934750234786 -0.158582865358366 -0.232113447678658 -0.480247139929458 -0.012693240726205 -0.113321221450465
-    2  (  2) -0.001131177703134  0.023211512192057  0.030343999116351 -0.117346790992592 -0.046608524859420 -0.060486959905986  0.074531488676303 -0.295475469192925 -0.122604475218833
-    3  (  3)  0.102873669309261  0.075244498837150  0.074367347068194 -0.000375638324722 -0.045758296871777 -0.020335443185058  0.271454123369342  0.176011970959425 -0.750611882783894
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.122947556659096 -0.146970007635756  0.023111743424029  0.020418246285807 -0.062142160948575  0.033255482549981
-    1  (  1)  0.076207579709840  0.192925577520692  0.390086469193835  0.115462079698591  0.197836673375331 -0.137907169648961
-    2  (  2)  0.134390969563588 -0.739254686327757  0.083356064140144  0.116141777662631  0.130510808086193 -0.001880247368517
-    3  (  3) -0.051764093089206  0.135387754341373 -0.415703352371020  0.190964584562673  0.522938232986926  0.150011651631347
-
-	File 101 DPD File2: P_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.042351800770033  0.112741680738692  0.014470487647282 -0.277801496926584 -0.385189435070480  0.134005161803845 -0.094379155611825 -0.020287570327628  0.140758439500600
-    1  (  5) -0.196508002077728 -0.014780858316181  0.028613533348628  0.116961168140523 -0.038035850661534  0.390665250154868 -0.463278907259435  0.352765994784243 -0.083583027846786
-    2  (  6)  0.019055458304079  0.247824312911431  0.054496185583040  0.066069201280654  0.118739286724245  0.063124976744210 -0.269457866868641 -0.446911004649514  0.141690470973354
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.002049190521844  0.018587871477028  0.105121590063686 -0.083095581891635 -0.044923327383534
-    1  (  5) -0.420262633593224 -0.134089318231829  0.513153889470778  0.061105931999993 -0.094073822513972
-    2  (  6)  0.353380729793659  0.186026023919396  0.193632728665932  0.115179143357212  0.434468868354740
-
-	DPD File2: P_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.018374399490839  0.416488593986887 -0.155494936834365
-    1  (  1) -0.047368311899160  0.000904478695801  0.015838423501069
-    2  (  2)  0.012225877770952 -0.003811464066523  0.009363085606127
-    3  (  3)  0.381174834177280 -0.034408333237667 -0.006712264462944
-
-	File 101 DPD File2: P_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019805821822076  0.046970692298440 -0.012276706190185 -0.380984477985130
-    1  (  5) -0.412939155992870  0.002194461931656  0.004258479838447  0.030533770738735
-    2  (  6)  0.154188085677647 -0.014422732946647 -0.008150645104198  0.004478771817897
-
-	DPD File2: P_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.038950465210408  0.039866103962419  0.115245354720040  0.019880757349447 -0.101323212958542  0.044640126253266 -0.129219338527502  0.020955390039210 -0.007693672741339
-    1  (  1) -0.067773602054647 -0.069283024949896  0.045139676547490  0.092449762069831 -0.063419247150338 -0.006282596580831 -0.492661875976107 -0.179789795112656  0.023646534538890
-    2  (  2)  0.005352314371011 -0.023691171688012  0.168760303436833 -0.035584759327957 -0.098211154887201 -0.052999235803435 -0.267185888610491 -0.067710312606089 -0.133811638261923
-    3  (  3) -0.005028835575224  0.075710576153026  0.130936364707588 -0.013148449648183 -0.082341449946899  0.058281787875764 -0.148402947291289  0.019587692846107  0.265997802208991
-    4  (  4)  0.042953075620737  0.030493487545427  0.117329091588246 -0.053817176197377 -0.040927603944597  0.031345620246767 -0.084728650716813 -0.096010530091888  0.389039208842110
-    5  (  5) -0.147577168335343  0.025728183041877 -0.257869613090358  0.341457170976807  0.032938052439995  0.198776430410242  0.028905583055758 -0.151472913148495  0.076896803027349
-    6  (  6)  0.033968966510016  0.063980358522411  0.416860320865971 -0.162964164077810 -0.210735076964306 -0.174795271465028  0.081522253852315  0.108767294311016 -0.317254235279369
-    7  (  7) -0.041696032362294 -0.119804780003616  0.084367698623615  0.345939032777489 -0.297348524344951  0.115684273678453  0.157252021772075  0.234703179592689 -0.035619581257838
-    8  (  8) -0.096236509574225 -0.089744247655453  0.368376180782391 -0.147020988065185  0.073817404082631  0.134077968971220  0.072728534570006 -0.043556315720552 -0.010655784346597
-    9  (  9)  0.003143315235121  0.093361249518207  0.037863435444635 -0.438671101107247  0.422734146793725 -0.161824914084117 -0.027097474419921  0.004646312280086  0.023963694330478
-   10  ( 10)  0.063765122804891 -0.220080848656726  0.093077513515149 -0.266351828566493  0.049816576758865  0.073960829373608 -0.046357012710617 -0.183568506551021  0.007204953793047
-   11  ( 11) -0.219872786938586 -0.186770594833612  0.640901797018363  0.491983676516504 -0.063681968781172  0.412058888748144 -0.286040569517346 -0.094245081423241 -0.195000390736826
-   12  ( 12) -0.262279768280096  0.707696438447150  0.236718714106780  0.470497637927968  0.331060673088753 -0.597737469031289  0.173380785854979 -0.147387697786165 -0.044689499434261
-   13  ( 13) -0.008835795532905 -0.161415860688302  0.152613021782520 -0.281704813928099  0.459625631240495  0.096864143285054 -0.003153519140079 -0.109240738249078 -0.297347288310574
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.149413062150163  0.067008442584154  0.230363907047496  0.055319406680384  0.032530338298423 -0.068943043267331
-    1  (  1) -0.452149192521174 -0.000162578737685 -0.619971511564934 -0.066650257125370  0.061919053639708  0.084081056043438
-    2  (  2)  0.165489317663304 -0.127973451777841  0.447552906388176  0.305061991533250  0.384464561661781 -0.153275315561868
-    3  (  3) -0.025748260701304  0.486016697888281  0.411385821418048 -0.268874146594607 -0.396024014682121 -0.134171291763426
-    4  (  4) -0.009663093960960 -0.555568390799340  0.304477769378439 -0.081217704163073 -0.578918205858773 -0.101292064810745
-    5  (  5)  0.039175185913195 -0.166448012687766 -0.090139681441233 -0.019287349063250  0.248510643774710 -0.007841008760067
-    6  (  6) -0.086047592172498 -0.153815757637266  0.087940035478902 -0.097280378266502  0.044638073702240  0.047181412845043
-    7  (  7) -0.068735686796040  0.315926660510286  0.100190034017783  0.019688975059735 -0.019468668688484 -0.100670621907944
-    8  (  8)  0.002625726681395 -0.112681642341155 -0.368011821043785 -0.079699064807508 -0.320546285877417  0.355993882573800
-    9  (  9) -0.075057729747018  0.174223000470549 -0.018184022105450  0.008386747763061  0.022693973527319 -0.026587026978415
-   10  ( 10) -0.016901342145260  0.168627021082460 -0.003857305749161 -0.002354503414788 -0.061897957980197 -0.064750074462714
-   11  ( 11)  0.244307011097299  0.045968336616797 -0.036911026756575  0.051829082034064 -0.017536651163216 -0.002615905953443
-   12  ( 12)  0.003873917284711  0.069385416516337 -0.051822467558672  0.043776532172148  0.059978809347506  0.097816286584178
-   13  ( 13)  0.427124414952379  0.150719603419239 -0.021778839992094  0.006415728591880 -0.068010241427207 -0.070097593919817
-
-	File 101 DPD File2: P_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.041903329856192  0.070446987089633 -0.004348862670260  0.007003079501354 -0.042701021768788  0.152208197977204 -0.041433363682805  0.041287071942597  0.095743116708860
-    1  ( 15) -0.040650426082046  0.069515483196494  0.023795913068799 -0.076537618226998 -0.032568972577824 -0.025967830490469 -0.063333094204323  0.120545439258051  0.089130494820972
-    2  ( 16) -0.113176179395785 -0.046535614719910 -0.168596109891447 -0.133831005796173 -0.118353163778080  0.257041147370604 -0.414474865889011 -0.082742359298471 -0.367155116899390
-    3  ( 17) -0.018349375617923 -0.090713111977311  0.034093712018598  0.012384834825344  0.052502145904236 -0.343486696016333  0.164974261057850 -0.349385131049026  0.148282635861179
-    4  ( 18)  0.098178568139074  0.063160792106148  0.098378065635209  0.082360458708713  0.040147652473952 -0.031106641199237  0.209540876350175  0.299086324958894 -0.075290632015664
-    5  ( 19) -0.046124091442951  0.007623765782496  0.052346193543973 -0.056344470452290 -0.031632190145320 -0.198051654819200  0.173027351368421 -0.116400515734751 -0.135033433848762
-    6  ( 20)  0.125258904374540  0.493829059239401  0.267757316022715  0.150510471965499  0.082418952577180 -0.029074883870873 -0.082194266117060 -0.155370316095250 -0.076894749422472
-    7  ( 21) -0.022859113931115  0.180693607953724  0.067191017626113 -0.021636428920055  0.098628927025765  0.152535238685033 -0.108677282204199 -0.236476842996923  0.043474790742065
-    8  ( 22)  0.007846177507452 -0.026259809347121  0.131087450927184 -0.264309750556241 -0.389449878217689 -0.077877691250164  0.320396510359928  0.036029491362037  0.011294045928736
-    9  ( 23) -0.148409951194406  0.452946257596570 -0.165039879212225  0.026077898552925  0.007360117453756 -0.037616321096105  0.083049264354487  0.069293544687319 -0.001373481233291
-   10  ( 24) -0.069814067119157  0.002054394750299  0.126443354154776 -0.492431542405090  0.562191735747665  0.169229180172877  0.154296877725072 -0.322409563035094  0.115377045900281
-   11  ( 25) -0.226651470481047  0.617350999313901 -0.448004121314618 -0.411778499546043 -0.303855472735621  0.089854128437872 -0.086765588475993 -0.099221464205896  0.370890559100149
-   12  ( 26) -0.054331750206089  0.066935478840437 -0.304032185963088  0.268162029874351  0.080593616550667  0.019297703310245  0.096620293446142 -0.019137264306005  0.080001854035789
-   13  ( 27) -0.031924461994603 -0.060584366399270 -0.382102774779752  0.393995940746644  0.579313325412582 -0.247998914693769 -0.046380357788513  0.019293958639035  0.320706746040650
-   14  ( 28)  0.067906620182484 -0.083216384461386  0.153437200450035  0.134831736058858  0.101055763194935  0.007868050795063 -0.047806237375160  0.100652051992651 -0.357135809697123
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.004177372366322 -0.063406030244807  0.226823097367039  0.263896415513769  0.011701971027774
-    1  ( 15) -0.093319799498408  0.219967278758902  0.185954874184417 -0.708355904031754  0.160324223389966
-    2  ( 16) -0.039556125331154 -0.094087884995324 -0.643095059540316 -0.237777200414592 -0.155124222296969
-    3  ( 17)  0.442134529381327  0.268012766736270 -0.494385460966639 -0.470730896225858  0.283217803454197
-    4  ( 18) -0.425335538145780 -0.050712365592958  0.065507217070923 -0.331337452084829 -0.461074723403375
-    5  ( 19)  0.162698096167156 -0.073261920681232 -0.410435644212656  0.598344542892450 -0.095525074956441
-    6  ( 20)  0.027635092593548  0.046340546952519  0.285700437916237 -0.173636156485020  0.002143940822347
-    7  ( 21) -0.008238163113748  0.182885492783710  0.094441459467607  0.147424260377310  0.108554639474187
-    8  ( 22) -0.023401664118011 -0.007016046655171  0.194400535766778  0.044245864301010  0.296689970128693
-    9  ( 23)  0.076293063471948  0.017415507342648 -0.241569014205399 -0.003530677667797 -0.425824332982193
-   10  ( 24) -0.181769150588328 -0.169666705113788 -0.044965749792137 -0.069290251681075 -0.150967382108881
-   11  ( 25)  0.018153729708567  0.003519576560560  0.037031521345044  0.051758677298688  0.021630611787891
-   12  ( 26) -0.008082899537472  0.002256936856687 -0.051941569032630 -0.043823365289136 -0.006446621914376
-   13  ( 27) -0.023193966803115  0.061566730434681  0.017525541483092 -0.059863077024435  0.068202811059110
-   14  ( 28)  0.026844987381374  0.064909557534692  0.002683194869776 -0.097668274774952  0.070274371234661
-
-	DPD File2: P_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.022229155184796  0.019683929802812 -0.035292041013174 -0.323293424781682  0.225147178252232 -0.115004523407643  0.099141060334532  0.047575469407300  0.016976450104502
-    1  (  1)  0.127090569254626  0.123237269677512 -0.278422395650133  0.118685424416916  0.176184741653177  0.248988790809479  0.519015610990019  0.012154553055459  0.127798350335596
-    2  (  2)  0.008158213783958 -0.029679191576446 -0.037266849827848  0.110715312970774  0.059214718357965  0.062822080446559 -0.081276448160108  0.324586020412756  0.131224816829759
-    3  (  3) -0.084166098196409 -0.111710240594221 -0.099128613941891  0.014634036431124  0.052476493603890  0.027367672304797 -0.301909798936816 -0.191388056693055  0.790536316410543
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.129910363709357  0.163144685956702 -0.026485892679798 -0.022427536567571  0.063067550057929 -0.033737074439006
-    1  (  1) -0.086592793084052 -0.215472297553996 -0.416640948225414 -0.119951916043925 -0.207797355115153  0.145646111272154
-    2  (  2) -0.146364945461058  0.802840103887928 -0.083436228176863 -0.120990811620140 -0.133581214678389 -0.001202452323342
-    3  (  3)  0.043945078436053 -0.148601276694347  0.437804660682756 -0.201206970148648 -0.547031014916742 -0.155504170965970
-
-	File 101 DPD File2: P_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.037502076472662 -0.109335165777524 -0.012926428858581  0.269466726270333  0.379248563249398 -0.141530386330068  0.105411044336663  0.019979530625450 -0.148197571425260
-    1  (  5)  0.208585120229370  0.016639991768198 -0.025672499464384 -0.120166173976538  0.061231886196158 -0.410760689290169  0.504318342034080 -0.368734822068652  0.088923609423586
-    2  (  6) -0.008992532047250 -0.290540208998742 -0.060411739137707 -0.064704199164733 -0.124015323503734 -0.073936634004700  0.287919965087423  0.478723882674066 -0.159979306108318
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002904367944485 -0.019663391538446 -0.115584584455963  0.082318082980502  0.044061111248738
-    1  (  5)  0.445601944090184  0.141387522552248 -0.540419197978555 -0.056783987379620  0.093672186540934
-    2  (  6) -0.375252473148004 -0.198547338183254 -0.207529365108893 -0.114786400140461 -0.453839763908372
-
-	DPD File2: P_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.060866725217215 -0.013869365716153  0.033894329784820  0.159389025617799  0.069390363085127 -0.262340609354303  0.067580095774763 -0.154103692822594  0.003154741180611
-    1  (  1)  0.233600860111356 -0.255443445273365 -0.070349772560976  0.002398009474053 -0.207738516934078 -0.107364483788669  0.128967864654634 -0.344368536680876  0.051213828740165
-    2  (  2) -0.320680073963752  0.499671518707847 -0.050574975509019 -0.147836128166420 -0.165479289930263  0.195838444506077 -0.035661712710790 -0.024470880763902 -0.075637541705411
-    3  (  3)  0.005421312030017 -0.086163397462206  0.087803119789529 -0.068180639639745  0.069970423577407 -0.155270176021826 -0.200857781343900  0.346742235116956  0.007432799783430
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.031710204280855  0.011526541432890 -0.002976967089787  0.046060023193635  0.015318540884103  0.025207945945630
-    1  (  1) -0.042201291846948  0.011691902650686 -0.030342861979388  0.426260656604152 -0.267501393083778 -0.156199494500064
-    2  (  2) -0.105775984380200  0.124345432018223  0.012422860710314  0.254942186016171  0.141450345930572  0.594200168007018
-    3  (  3) -0.128190105083420  0.839978623039109  0.103083070851949  0.085126863174017 -0.034147172701768 -0.125845625439850
-
-	File 101 DPD File2: P_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.009655463605755  0.014837891728381 -0.030023518715064  0.453895242430490 -0.367783958834954 -0.001154952584878 -0.011095021636640  0.081922945493181 -0.106667436086225
-    1  (  5)  0.023315601126616 -0.114914590458087 -0.095889100679515  0.148408787561426  0.132591987973289  0.239441228065666  0.119891964360871 -0.197513600772232 -0.042785498899110
-    2  (  6)  0.044714484508884 -0.227037104077391 -0.243035253957641  0.057000070112492 -0.133863510185386  0.464640228230982  0.241815314958168 -0.250347946170699 -0.035567936134789
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.031225116244914  0.082892463758822 -0.008302957992736  0.084651532871555  0.076096297616606
-    1  (  5)  0.029094974835733 -0.031099102771742 -0.014865102267058  0.594144277291270 -0.111092561014338
-    2  (  6) -0.081030380750229  0.586465397694647  0.039125073332182 -0.210425560392843 -0.141728395903252
-
-	DPD File2: P_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.279550720476077  0.042202209735457  0.032616542291842
-    1  (  1)  0.188418637032763 -0.038238156575108 -0.176016679949417
-    2  (  2) -0.431618249575807  0.006066663258097 -0.050669745816719
-    3  (  3)  0.023823866701763 -0.194483208506600  0.036291334339584
-
-	File 101 DPD File2: P_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.276296231465594 -0.182684867311170  0.425780067610230 -0.021944883020485
-    1  (  5) -0.040904620230163  0.037124497156135 -0.000756874278417  0.193551621281851
-    2  (  6) -0.032612764478737  0.173214965518422  0.056257078994710 -0.032928243740138
-
-	DPD File2: P_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.064329222595920 -0.203089813678901 -0.060855379318360  0.045435578919151  0.038213040289734 -0.173918816066670  0.086597065761990 -0.088257727308079  0.042534449699908
-    1  (  1)  0.115560364126478 -0.109115953630201 -0.018643611831367 -0.061273729840918 -0.223462209948640 -0.111849786008387  0.082478525732492 -0.548790728777664 -0.099502382826804
-    2  (  2)  0.050280791567554 -0.042231736423558 -0.026516724550904 -0.035763580727561 -0.045242506762065  0.028791481906196  0.032080377274548 -0.393629321941294 -0.043590423594673
-    3  (  3)  0.027100682075659 -0.177196743119415 -0.360081085823777 -0.088267299794322  0.030083312860564  0.189916614239830 -0.016925829834322 -0.152132597277128 -0.199271802311320
-    4  (  4)  0.027032407915338  0.122816257943915  0.195859296476474  0.024440446904345 -0.000039632917188 -0.224837371747381  0.105878500705155 -0.149344729427051  0.220653682748276
-    5  (  5) -0.082124893882501  0.131610239391223 -0.172288241722190  0.172656004937721  0.186007370790890 -0.002386795157151  0.000883813901201 -0.015624959650018  0.120434685552584
-    6  (  6) -0.025918430251412  0.066213876287375 -0.159653356345571  0.138629355858437  0.114503563489713  0.052610164659059 -0.032724879295725  0.016321111589815  0.131203443877323
-    7  (  7) -0.031968463140566  0.359436078267880  0.239880075530440 -0.043941245996148  0.003566470797935 -0.121878346236622 -0.025216884092681  0.317033593343712 -0.204690345792582
-    8  (  8)  0.147136177075282 -0.147831155131360 -0.317027072645310 -0.094690347387101 -0.042376714203220  0.036223188856298 -0.061267998203209  0.078763236261723  0.025079679518920
-    9  (  9) -0.347335081804882  1.076651679527280  0.076631791966040  0.520228799901951  0.177614233521961 -0.752433601064110  0.098237100331302 -0.075609380299166 -0.029456370268690
-   10  ( 10) -0.226576210232703 -0.047966592312158  0.713544303894390 -0.117838109418108  0.538138175848963  0.110268365719488 -0.097090433542407  0.016639982577840 -0.202838989293283
-   11  ( 11) -0.013618237324107  0.042488040839621 -0.012305458432129 -0.002937365049260  0.051397702056966 -0.032793240631487  0.126424524316302 -0.018011286422360 -0.036334038133226
-   12  ( 12) -0.125114748700956 -0.150723454222537  0.252706221972763  0.731410520517111 -0.348252142829817  0.473299198843163  0.017472369731921  0.121992291563425 -0.064459445411663
-   13  ( 13)  0.081025878360433 -0.099169125996407 -0.096265824091433 -0.243412138793566 -0.157793004324879  0.232678786079147 -0.038715292983050  0.196706528651456  0.103460906909678
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.038639019968560 -0.081398838675921 -0.020974057309157  0.195126170432547 -0.136178596332978 -0.093793458598120
-    1  (  1)  0.192322326072867  0.434066427801228  0.033306653053185 -0.455360646532796  0.170900871888595 -0.012160177810098
-    2  (  2) -0.116655928700969  0.223206132473869 -0.015149664847910  0.750955420456732 -0.241651279575312  0.125278854183387
-    3  (  3)  0.037416152824649 -0.474871182487040 -0.095127781154357 -0.001912744200640 -0.218016361604134 -0.501866870283028
-    4  (  4)  0.093049020347900 -0.452195861353997 -0.097729965141961 -0.023670097100218  0.227089450225467  0.622604645621845
-    5  (  5)  0.095982951322369  0.025076643469587  0.083513090675399  0.093177906171499  0.163570537374778  0.411952379972310
-    6  (  6)  0.006971397366507  0.099975304872894 -0.089355028753419  0.082421061832647  0.109391578906264  0.177019076161536
-    7  (  7) -0.111482230592694 -0.119338627354550 -0.049072785699030 -0.135589681135474 -0.179997637886863 -0.225361657151226
-    8  (  8) -0.038036906175422  0.107593330918854  0.085211578523939 -0.251522137496260  0.415712152156179  0.133150454203045
-    9  (  9)  0.014149847264143 -0.014713228385967  0.003726551384159  0.024984081757333 -0.450053383369121 -0.804137197420648
-   10  ( 10)  0.262196667989143  0.030987669321987 -0.048528847001581 -0.326796645773778 -0.027460917972608 -0.213395133473708
-   11  ( 11)  0.037859730907863  0.067315614399965 -0.006033855211911  0.002081527339975  0.021566579415084 -0.043117037710347
-   12  ( 12)  0.214673577185777 -0.277038178296912  0.018443935481622 -0.031394459169126 -0.040697755419603 -0.037299553750268
-   13  ( 13) -0.293378255962317 -0.067739265985308  0.042216271726718  0.084600602041646  0.093366414785478  0.184919834112459
-
-	File 101 DPD File2: P_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.065579026427298 -0.118385281199840 -0.054417309773849 -0.028209393258605 -0.023855315776195  0.089481193550780  0.030082936540202  0.024881663706482 -0.145536117267929
-    1  ( 15)  0.203177895336562  0.108867238168314  0.044106918987014  0.183348816265157 -0.128730595279853 -0.134393743071560 -0.068034842363188 -0.353605430814672  0.144787054112687
-    2  ( 16)  0.059845833352457  0.020943033819428  0.028043633600698  0.360379351132063 -0.196224502327520  0.168965679426491  0.157686501214302 -0.238008876623444  0.316659608324193
-    3  ( 17) -0.045186255659105  0.061530291702097  0.034434066086584  0.088647496947582 -0.026282078792551 -0.172786891133660 -0.138287078850789  0.044103989261245  0.095122362978667
-    4  ( 18) -0.040062693221020  0.224606431868167  0.044510085277536 -0.028376706423002  0.000349345016747 -0.185972360522578 -0.114555914481331 -0.004506308196336  0.041018032849448
-    5  ( 19)  0.173210931444010  0.109857051233105 -0.028983625579256 -0.187756427423432  0.223643228642709  0.004090524106486 -0.051487512077316  0.121894819352182 -0.037656019931592
-    6  ( 20) -0.085313471751143 -0.082913275223549 -0.032277368285025  0.016777520509378 -0.105131359190815 -0.001944705429570  0.032875162874827  0.025732176012468  0.062579089976849
-    7  ( 21)  0.084545461298169  0.550907022405358  0.394733809745031  0.152212200092244  0.149602224208011  0.015559620185539 -0.017471440322135 -0.317632843442532 -0.081500770726977
-    8  ( 22) -0.042592304559205  0.100130074049971  0.043823098391038  0.199074070348154 -0.220614689373917 -0.121240505787734 -0.131566193321307  0.204777301446740 -0.024659128193111
-    9  ( 23)  0.038243209345809 -0.193731116803758  0.114571318389048 -0.035004741203238 -0.093870122022257 -0.093321089072005 -0.005098160430595  0.109514276861021  0.037449030782536
-   10  ( 24)  0.080611973441424 -0.431286815750366 -0.220674640182480  0.473291196073188  0.451373239023609 -0.023941120635386 -0.102282761545205  0.118683941595292 -0.109001254632288
-   11  ( 25)  0.020616437944253 -0.032806186227235  0.015536997280191  0.094946997217811  0.097687630516726 -0.083601240444185  0.088958677720268  0.049109842148345 -0.085549382706087
-   12  ( 26) -0.191260790058678  0.454455308246703 -0.749344104582772  0.000707785692927  0.023013062709295 -0.093408274808716 -0.083112755629054  0.137052732289414  0.253713944370040
-   13  ( 27)  0.135080067323690 -0.170977966348525  0.241626969335339  0.220294823738596 -0.228806715319375 -0.163956724293068 -0.109654396643640  0.181513709124625 -0.417706190063538
-   14  ( 28)  0.095355381240353  0.010487455238559 -0.123878379042330  0.506641747659321 -0.627627416886014 -0.413206867808258 -0.177986562206826  0.230596660977991 -0.135371993382099
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.343722354187842  0.231012307989939  0.013807799785149  0.129389520371901 -0.083476842933347
-    1  ( 15) -1.071757290590545  0.047500726309983 -0.042558977896784  0.150713322712323  0.100049386852298
-    2  ( 16) -0.076574555259838 -0.716811431044374  0.012053549717062 -0.252652945738414  0.097563356479072
-    3  ( 17) -0.521659456544164  0.119962089033513  0.003140019395332 -0.735502177464538  0.243874710004522
-    4  ( 18) -0.178111787275392 -0.539331111074153 -0.051602620031584  0.351369555964665  0.157776134348173
-    5  ( 19)  0.754028750268460 -0.108050332429524  0.032942772306297 -0.473084779433613 -0.233288261808526
-    6  ( 20) -0.098339349809287  0.095672012585071 -0.126453856435504 -0.016749320041424  0.038981069794775
-    7  ( 21)  0.075922415669002 -0.017338504286034  0.017821543323394 -0.121086080034894 -0.196694365560314
-    8  ( 22)  0.028707803808862  0.202101700693747  0.036280352248806  0.064076056309411 -0.102966425702512
-    9  ( 23) -0.015071264129229 -0.259603898636005 -0.037748702712212 -0.213449614969685  0.292741791249862
-   10  ( 24)  0.014441233365834 -0.031025326150192 -0.067581337213048  0.278218894918250  0.067639252890435
-   11  ( 25) -0.003655596016122  0.048301023976308  0.005987297290884 -0.018296972769386 -0.042182106266812
-   12  ( 26) -0.024290247830266  0.326430116080930 -0.002078223011543  0.031357186170846 -0.084451014704488
-   13  ( 27)  0.452065991443206  0.027871674423728 -0.021552868138498  0.040817220436517 -0.093503875768977
-   14  ( 28)  0.809538434042480  0.214197129891733  0.043194453416851  0.037242456347955 -0.184930829970208
-
-	DPD File2: P_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.066956274028954  0.044342976073165 -0.030268247936242 -0.149450540981950 -0.061066821271185  0.252770775339693 -0.067874222510686  0.158386767820771 -0.005381383883310
-    1  (  1) -0.238859813029081  0.286692386304328  0.066590681714602 -0.004012726688607  0.213066888677072  0.109131374118362 -0.135898330150995  0.364942966429774 -0.055660597243453
-    2  (  2)  0.359516386393285 -0.583008964100427  0.054707529711990  0.139557599023379  0.158230706301634 -0.196109522672398  0.038444807843767  0.030895199145175  0.086353045406069
-    3  (  3) -0.011142763994871  0.102467038295486 -0.096192280460040  0.086579830772614 -0.079151964917630  0.163781954562347  0.215517306973471 -0.369533969127049 -0.009330018051360
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.034197603653202 -0.011654401867379  0.002838793667518 -0.051120718575847 -0.018314210992950 -0.032583546094419
-    1  (  1)  0.044852295322472 -0.010374877421340  0.032495546570244 -0.442259071390682  0.284002451396915  0.172324881222561
-    2  (  2)  0.118470854957857 -0.130986078141729 -0.014085982845085 -0.260463332299674 -0.162310705486348 -0.635865895852574
-    3  (  3)  0.132535934596107 -0.876049792586578 -0.107203693425820 -0.087990410067908  0.037792879731323  0.134504535673653
-
-	File 101 DPD File2: P_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.032839390128313 -0.018959934247026  0.027098455785061 -0.458861483846452  0.368889100803161 -0.013730600662295  0.005961739971281 -0.088172859302616  0.109822626668940
-    1  (  5) -0.022776770324681  0.118542960649480  0.106023383328719 -0.155646887463115 -0.124038116346952 -0.247202807741244 -0.126320423057856  0.208868231513720  0.046770852934184
-    2  (  6) -0.048648484948535  0.245637911332038  0.270704645644036 -0.074067208651774  0.147538325129154 -0.486126744284417 -0.252803143713327  0.267246124084927  0.039768993904487
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.034234873438637 -0.088611347550410  0.008537759532833 -0.090451182938239 -0.075365836152160
-    1  (  5) -0.023972088194502  0.031376657235205  0.015685502279103 -0.611834232098808  0.112755958009069
-    2  (  6)  0.089906734942719 -0.607632221899844 -0.040204918187789  0.215818595847042  0.145730338373175
-
-	DPD File2: P_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.068337016689787  0.096446452085002 -0.360475449255902  0.092239288443358  0.026203678993495  0.022509846768507  0.073478827109955  0.022464061635160  0.227372488687786
-    1  (  1) -0.348245092755920  0.473201941654281  0.285296343641650  0.183481268338497  0.077575420561894 -0.072099126128168  0.272473569750599  0.064219415174522  0.197165880642411
-    2  (  2) -0.067585908292999 -0.050372922066345  0.060758167722761  0.207525430724412 -0.124589544539336  0.366296688749942  0.319501792562117 -0.144609263860444 -0.034557292109121
-    3  (  3) -0.003490778195202 -0.176771187193881 -0.057522831084688 -0.000116418534514 -0.000778288025410 -0.154495740758279  0.307263828597453  0.311985415250579 -0.072067405639340
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009055593106319  0.169294476000973 -0.004376707887535  0.043035427356728 -0.152530590603305
-    1  (  1) -0.043732146234760 -0.133230210104999 -0.321492959537845  0.026647195864791  0.380687102971969
-    2  (  2) -0.166530147606704  0.613643715784952 -0.216790208689121  0.084469048821397  0.070950253018395
-    3  (  3) -0.193623455832778 -0.188085387415724 -0.577128561928036 -0.079182256648197 -0.329374829303748
-
-	File 101 DPD File2: P_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.094184605266262 -0.056664612736054  0.249611394695138 -0.001240336458214  0.251113263188388  0.167204840997487  0.053738355410164 -0.110451910680987 -0.110225244344066
-    1  (  5) -0.138889396156713 -0.115961679702950  0.323179744186602 -0.121252123334108 -0.292076432530947 -0.241576686483901 -0.062989099002905 -0.028273376499857 -0.195878521200942
-    2  (  6) -0.158880157732563 -0.136139940788991  0.265648578790447 -0.093877387310787 -0.142453752097511 -0.054140913394793  0.560779480905315  0.138233927938137  0.254132036776789
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.293992892777812  0.040800750874340 -0.057675088115477 -0.076602392476472 -0.065335333000425  0.026360508198711
-    1  (  5)  0.140101157116617 -0.119683195253936  0.266691635481371  0.245738117841371  0.344104644743715 -0.220704301427416
-    2  (  6)  0.056921768196805  0.103403744069325 -0.598429877433937  0.146214200704205  0.059974750990256 -0.323525482379135
-
-	DPD File2: P_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.001230860713981  0.365289920386496  0.190857780733096  0.072806514891183
-    1  (  1) -0.363063996519734  0.002070944913891 -0.019953639387757 -0.015606309990589
-    2  (  2) -0.188512451641916  0.023296206313487  0.001197811601800 -0.004047856267926
-    3  (  3) -0.072120339388755  0.013963148028330  0.003997486762190  0.001769349811859
-
-	File 101 DPD File2: P_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.002022249922950  0.099291954131021  0.350139400677067
-    1  (  5) -0.099326293970590  0.002387309533513  0.000598742894171
-    2  (  6) -0.349927147110668  0.003948627188178  0.004319113721388
-
-	DPD File2: P_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.002890611897827  0.240828289147465 -0.015468829256935  0.064289689550120  0.058383569830779  0.095812515567057  0.080370871457874  0.173880009550648  0.326840838875860
-    1  (  1) -0.236387869752249 -0.001382669630591 -0.349729320543369 -0.093496466822455  0.041273060112661 -0.069307558569237  0.288342418689824 -0.111953342164375 -0.889210851252513
-    2  (  2)  0.015544382351172  0.348410608385966  0.001429161416738  0.082248932060638  0.073429593153274  0.232731056108987  0.287528082465130  0.229588952851785  0.234445801555499
-    3  (  3) -0.060246890669449  0.090324337254536 -0.083519076320930  0.000324034215630  0.021649503271248 -0.048962406316822 -0.003095140388789 -0.014925743106247  0.184209404061508
-    4  (  4) -0.058716691049654 -0.039386709518300 -0.072108814664522 -0.024079085224178  0.001156693016658  0.085015191809916  0.048842009764989 -0.153342114169621 -0.107404216975909
-    5  (  5) -0.094642233192625  0.068250996258109 -0.231656670305544  0.051858687640720 -0.087916533368054 -0.000989122777904  0.009520487792430  0.039816729579394 -0.148608670810212
-    6  (  6) -0.077504756735322 -0.287507697430236 -0.285105373436002  0.002029325573656 -0.050208524083414 -0.010159420768980 -0.001467122921747  0.173528931839685 -0.045843469905068
-    7  (  7) -0.174578233230593  0.112733771274507 -0.230104116799356  0.014289446324452  0.153589433005249 -0.035711031924118 -0.172129458752228 -0.001735515727976  0.038746380038624
-    8  (  8) -0.326735165366063  0.892352866716814 -0.233667611417982 -0.184059987656354  0.108456575602175  0.147444194487350  0.046899481546128 -0.038212214850091  0.001725987235386
-    9  (  9) -0.006854804424481  0.059010431241574  0.208380750196049 -0.285710704759075  0.014224723130698 -0.077940660528519  0.021832932968226  0.053507920192743 -0.072157293584336
-   10  ( 10)  0.009015167445598  0.189056046369736 -0.202903049397400  0.587323534808109 -0.635944176810841  0.025618734551668 -0.020134034262346  0.176546344509523 -0.134205354496214
-   11  ( 11)  0.122437005548569 -0.184498905511222  0.564613159164372 -0.437681527296080 -0.566648422271337  0.293176529113293 -0.283793106995897 -0.077656634404298 -0.171083550165875
-   12  ( 12) -0.036282129605470  0.108405322240863 -0.145144319486399  0.147400560062216 -0.198772870262719  0.103478363945228  0.121274561973686 -0.030820809232635 -0.001791413008569
-   13  ( 13) -0.133993098437568  0.204979468351056 -0.411230750510333 -0.299499940801943 -0.284167005433816 -0.162337236425275  0.004579295347321 -0.249620649972568  1.096399145752056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006645975778905 -0.006191073096114 -0.124463548213382  0.037116585439600  0.136645288902199
-    1  (  1) -0.060762525453402 -0.191336651087303  0.183339507039208 -0.108942947593767 -0.207176626622974
-    2  (  2) -0.210207260386098  0.203492326897454 -0.567390687945974  0.145012790104551  0.411652670240128
-    3  (  3)  0.286824149969646 -0.581772824662096  0.440352813995387 -0.146688228392261  0.298407000003058
-    4  (  4) -0.014289603545957  0.629957556120225  0.567078386368531  0.198070048922302  0.285394833836570
-    5  (  5)  0.081440068401990 -0.026939007614117 -0.293522941596266 -0.103773428535410  0.162374057747115
-    6  (  6) -0.019586412213072  0.018998130538312  0.285654409806091 -0.121258923814333 -0.003510620762243
-    7  (  7) -0.056312011236674 -0.170723193738545  0.077219135397651  0.031749253170040  0.249637927479938
-    8  (  8)  0.071982674840921  0.132152050589738  0.170190422759249  0.001965018222219 -1.093832298365480
-    9  (  9) -0.000915267084317 -0.167637668947108 -0.013751051322959 -0.007450195669904  0.054814043954704
-   10  ( 10)  0.173354835302090  0.000704252867558  0.044733752629381  0.097334496933118  0.081305131643713
-   11  ( 11)  0.013882987415659 -0.044298584291785  0.000143226462344  0.004568623078909 -0.075706346510396
-   12  ( 12)  0.008211247608944 -0.097266945197500 -0.004534234464270 -0.000000208770840 -0.036045640473786
-   13  ( 13) -0.055102354659947 -0.081583293844327  0.075692193037900  0.035962325349336  0.000089917983318
-
-	File 101 DPD File2: P_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.002852278466544  0.070108169829164  0.177721594116383 -0.062514278837043 -0.105491072743275  0.104380527192685  0.038787813666443 -0.108504673470162 -0.012481015325095
-    1  ( 15) -0.072271804263973  0.000288298261148  0.117173998738145 -0.011917535043052  0.080653916441483  0.081946299523319 -0.047103419787682  0.318790462890510  0.030711126191038
-    2  ( 16) -0.170911365853707 -0.116393519070210 -0.001806689323683  0.130836454259881  0.145067744851421  0.208275822041435  0.197865978670067 -0.179244423422815 -0.001428148574785
-    3  ( 17)  0.060580436051072  0.012481275961757 -0.130473629372401  0.000512552110579  0.018701012638838 -0.044411378106146  0.007770177955824  0.099727400679241  0.079606042617844
-    4  ( 18)  0.100932281141831 -0.079292941446829 -0.141623065968957 -0.016652442688780 -0.000246995954883 -0.188697276821427 -0.217824131948931  0.080386629630151 -0.270575530776454
-    5  ( 19) -0.108081312156271 -0.081589453393258 -0.205450509959137  0.045804817780756  0.187114674307730 -0.000693476015895 -0.073804885959376 -0.043943121718183  0.003771900693712
-    6  ( 20) -0.034173297967555  0.046256787847685 -0.201439095588816 -0.005429989019017  0.216650326151217  0.075792464986171 -0.001298711951572 -0.134518823042755  0.103151783377151
-    7  ( 21)  0.109536591257004 -0.319390106321481  0.177983470364268 -0.099546174339197 -0.081524885513579  0.044022674550874  0.133301399033515 -0.000096152383065  0.101549931240584
-    8  ( 22)  0.012926686041826 -0.031216971600686 -0.000265042168615 -0.077684860264792  0.270051031496744 -0.002422594418673 -0.104436054969569 -0.102375676350899 -0.000297123445281
-    9  ( 23) -0.258651046299275 -0.226438144249540  0.883671721861341  0.031897478817939 -0.145814145437369  0.329946962033578 -0.092842601161588 -0.020363787817155 -0.044542350196596
-   10  ( 24) -0.092725989784673  0.166988988746146  0.090659624845963 -0.033017773093490  0.181126079432095 -0.062617782388689 -0.131228570809863  0.125672600098950  0.010149266769676
-   11  ( 25)  0.085237213762517  0.052979715533519 -0.426249660673602  0.453470213118020 -0.668258866535746 -0.144399220062707 -0.422276654831122  0.144496027602971  0.151454753884708
-   12  ( 26) -0.278987852994131  0.538130802014502  0.337920384527610  0.681210215677631  0.181138167954142 -0.460304232360321  0.045963221041228 -0.472470739788982 -0.099740360833931
-   13  ( 27)  0.031684358569015 -0.364912365941556  0.009949817490826  0.264482144700383 -0.131463038932392  0.369715650064832 -0.160132940033673  0.216985322458037 -0.408494860009368
-   14  ( 28)  0.069145968160405  0.228577328281114 -0.182024373430158 -0.129259595360434 -0.172789096424754 -0.293202387537144  0.081435203747675  0.165066175829158  0.415625562015752
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.259264061861398  0.092073726700459 -0.087751332732921  0.282787087620371 -0.027646750760921 -0.074274663555944
-    1  ( 15)  0.226044227417799 -0.167220221608179 -0.052022484678322 -0.539067092148703  0.364060270057495 -0.227432738647077
-    2  ( 16) -0.880651861739234 -0.090070282095970  0.429004165056558 -0.339630379420043 -0.011398542008064  0.184603055576349
-    3  ( 17) -0.032407867048655  0.033969801861417 -0.457051817514276 -0.682605465628673 -0.266811035152933  0.129791361160984
-    4  ( 18)  0.146452241358061 -0.182164491681139  0.670578545718526 -0.180561730668713  0.132153760707793  0.172423147223622
-    5  ( 19) -0.329854516633489  0.062406355486158  0.142687713548999  0.461391108813659 -0.369113402446086  0.291406831399555
-    6  ( 20)  0.095123792939029  0.130974407921450  0.423504400080728 -0.046307780864123  0.160121658345768 -0.080587396654631
-    7  ( 21)  0.020196930650927 -0.126100208893374 -0.143365904721253  0.472616518696925 -0.216448635004369 -0.164811157431042
-    8  ( 22)  0.044862231258128 -0.010443804825893 -0.151200178059944  0.098979735611851  0.407862770190674 -0.414651419638203
-    9  ( 23)  0.001778806469034  0.018623025532445  0.107576400210487 -0.163068566891587 -0.647773862315846  0.636630491425454
-   10  ( 24) -0.017927592798993 -0.000180705630000  0.053297006124060 -0.074061342070591 -0.058210218158357  0.162911849208963
-   11  ( 25) -0.109490773836576 -0.052999955618224  0.000271745308396 -0.000305712333614  0.053078644790042 -0.055108565747960
-   12  ( 26)  0.164133552719503  0.074506459360537  0.000357731899204 -0.000072395693486 -0.003695078860291  0.023204687798386
-   13  ( 27)  0.648551410049995  0.058758186891588 -0.052984322168655  0.003827983869788  0.000211520166748 -0.203311556747168
-   14  ( 28) -0.638654673856620 -0.163384069601813  0.055052210134389 -0.022943426676923  0.203292568578009 -0.000202566783445
-
-	DPD File2: P_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.052480701259259 -0.089840503139985  0.350982482866049 -0.095116826178087 -0.022440054215652 -0.032862353821469 -0.081729096326081 -0.021425782595611 -0.235338088635135
-    1  (  1)  0.388124677168533 -0.534993889872660 -0.299624251031539 -0.203953129475389 -0.082377317359755  0.089624704115259 -0.293120840067825 -0.059715673164777 -0.225100704791756
-    2  (  2)  0.075046613139342  0.054595030850083 -0.042171893892626 -0.238878291709943  0.143368498448120 -0.391908199708447 -0.348187716284506  0.162007005374424  0.040145638710435
-    3  (  3) -0.003825096561586  0.209524975426966  0.061101725640115 -0.005733734477972 -0.005158862211836  0.174020624147332 -0.336061739172831 -0.336718503904961  0.081950585094521
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.010799235898820 -0.184179967846582  0.006278703826698 -0.045893168283343  0.154431576202783
-    1  (  1)  0.044872971637160  0.151970487630040  0.339396308854840 -0.025890953682133 -0.403821618486004
-    2  (  2)  0.178196793491180 -0.663646636739936  0.225638342179614 -0.089456735981001 -0.067546568678071
-    3  (  3)  0.206166573180735  0.202910686825648  0.607738412714145  0.084545705245042  0.343684996664701
-
-	File 101 DPD File2: P_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.080604406993543  0.052828007136127 -0.248271072214065  0.004621901958854 -0.238511508773077 -0.166464522338437 -0.059371420180247  0.108552798507517  0.113128199143937
-    1  (  5)  0.158176273521067  0.142741353513120 -0.372038467512456  0.124710545030248  0.314544785901233  0.257579395622657  0.074674230220199  0.033693630413225  0.220604268429912
-    2  (  6)  0.161070149264612  0.184008094688423 -0.303262375945924  0.100514546731462  0.134915075764794  0.049291968700981 -0.607921602195072 -0.146614082163667 -0.250955095397111
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.310847898937919 -0.042310959338363  0.062726869647814  0.073058032344468  0.064713071794420 -0.023951260296913
-    1  (  5) -0.157873658680268  0.125342133518717 -0.276221069932045 -0.249434379507851 -0.361715962690354  0.231044770920838
-    2  (  6) -0.062318733481263 -0.109385681434768  0.629646707936818 -0.147627705365700 -0.066774935973318  0.338752628544606
-
-	DPD File2: L_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.016009260748017  0.076567442214896 -0.125166328875802  0.007592491786253 -0.098480428135412 -0.089737912259519 -0.045486487849709  0.143199899460591  0.062916360524591
-    1  (  1) -0.038605185454593  0.325735593943764 -0.218009839696040  0.077381067334654  0.123187634769419  0.048889388601736 -0.262562813593255  0.048309424265131 -0.024346564570397
-    2  (  2) -0.014979357855892  0.182689410654369 -0.081658179778794  0.065473944506505  0.193719600231606  0.090995730111074 -0.143671186830441  0.007595230816929 -0.060244510498059
-    3  (  3) -0.067326890443488 -0.014019515203484  0.166079081195192 -0.050483560257990 -0.175920280282569 -0.180597777465204 -0.198820897294047 -0.109379576724081 -0.213777271147620
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.159507026073975 -0.056302017965781  0.034397376897140 -0.068360328302061  0.100741673999881 -0.049850169389160
-    1  (  1) -0.121516035123580 -0.004562687000240  0.189568378403116  0.051932937377753 -0.189148856797612  0.205130706545356
-    2  (  2)  0.013364994269954 -0.072899210778933  0.147744909867102 -0.343128869068584  0.052918402885218  0.086660614771912
-    3  (  3)  0.064044282976220 -0.072658467037946  0.366494615509597  0.156516672080101  0.183833699925440 -0.043558655165224
-
-	File 101 DPD File2: L_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.095334256028009 -0.133297788110144  0.233197415167998 -0.109601891242184 -0.034275483482361 -0.001203276521899 -0.083637993138604 -0.006960579869910 -0.188458856324837
-    1  (  5)  0.132031102549102 -0.218523085575864 -0.122630941119498 -0.145558608560396  0.033193771816160 -0.142560374903523 -0.001867880595405  0.178023294306114 -0.083084371409555
-    2  (  6)  0.307498011816596 -0.248791194429673 -0.171772234113843 -0.290615300494965  0.046349417939456 -0.102374827834141 -0.404689139483050 -0.035662684698487 -0.067098771977202
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.011309857021213  0.047826432296259  0.011715243517174 -0.012087997768714  0.055738114510750
-    1  (  5) -0.060288763132101 -0.100230270339149 -0.175888842059756 -0.033113626293054 -0.296260944515875
-    2  (  6)  0.156436504590612 -0.054087388641550  0.405606872407349 -0.026699931968424 -0.143365753445289
-
-	DPD File2: L_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.021022954159736 -0.035142529018952 -0.107426415156770
-    1  (  1)  0.299993715747734 -0.100035165443054 -0.265269960401394
-    2  (  2)  0.260050498379079  0.124418562014598  0.440142593096703
-    3  (  3)  0.064425483075145 -0.021009721425282 -0.051333955965002
-
-	File 101 DPD File2: L_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.019464542579225 -0.300930139088225 -0.262387611320763 -0.064713939337572
-    1  (  5)  0.034890763742270  0.099221858485008 -0.125525760672816  0.023652429329881
-    2  (  6)  0.106312135129399  0.261746631642973 -0.441788978603034  0.052491092120842
-
-	DPD File2: L_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.143156293779769  0.065598528855299 -0.058339068026871  0.095240471065162 -0.054936782763489 -0.158698528722424  0.005848694187148 -0.046188395629077  0.009225054657648
-    1  (  1)  0.090550568038988  0.201824271395705 -0.091142881495912 -0.093661370668859  0.161043059103147  0.077741533393123 -0.543233062251592  0.814467132908124 -0.067293744881760
-    2  (  2) -0.021713915694858  0.356864777307433 -0.273330805205094  0.263660970827611  0.358937742043094 -0.204650254826784 -0.313132956505956  0.064395695030077 -0.200390318671649
-    3  (  3) -0.101095906237726 -0.248350727445422  0.325477886952403 -0.022461371735421  0.220401580692866  0.053345914506007  0.023674029203873  0.049357473765327 -0.000470604618644
-    4  (  4)  0.053513495604287  0.177341679973179 -0.223511424991143 -0.043203647152663 -0.200439262362192 -0.109704630170554 -0.130967856844601  0.223696627843727  0.051893869816232
-    5  (  5)  0.218677797229873 -0.312515161252956  0.301873753556228 -0.119144839450133 -0.273881128961801 -0.291385277900658  0.214361739830069  0.197002465061645  0.071567227017470
-    6  (  6)  0.085282711177633 -0.152031995719920  0.395807072999312 -0.020599784121374 -0.230274381395846 -0.119204882075906  0.196967452454600  0.233009490057915 -0.074120843143850
-    7  (  7)  0.047734330576263  0.280574479547352 -0.366542906373812  0.110968913790478 -0.088449186452659  0.149744690480443  0.036915836576634 -0.394085559356064 -0.043430167100304
-    8  (  8)  0.213441732464272  0.108274495972316 -0.634437106058845 -0.069187196826565 -0.037919304236964 -0.161411654384539  0.081574595848630 -0.216961478694419  0.039208476463161
-    9  (  9) -0.053318703860192  0.090838807258297  0.086586369793027 -0.028327523211035  0.134553886805994 -0.073546423533118 -0.007047260326121 -0.447864900958376 -0.046310440012370
-   10  ( 10)  0.217342853211265 -0.434342746087742 -0.408844907117118 -0.321259899576754 -0.034276585378345  0.320138521202174 -0.023800296590577  0.279258907554493  0.028679862426656
-   11  ( 11) -0.043839064779065 -0.078964296226844  0.267354222620337 -0.331608707925144  0.435766271345975  0.066306681540143  0.247977502270279 -0.002757326539735 -0.128220536878281
-   12  ( 12)  0.056967765282221 -0.011496620916620 -0.132088307172842 -0.097918437653651 -0.064500672945760  0.001827098937393 -0.216796993378831  0.142477110991476 -0.129430197478051
-   13  ( 13)  0.037733039841652  0.226167830269728 -0.091049164317861 -0.252259768566517 -0.015512763459721 -0.284728528128491  0.105582553814486 -0.004845390965161  0.367721806594329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.222313487267139 -0.016040998159682  0.082409874320982  0.002075539850870 -0.060366346946182  0.093408303465405
-    1  (  1)  0.558686428143613 -0.124842930483593 -0.159094597945824  0.170661450539848  0.081512715884899 -0.084548811099098
-    2  (  2) -0.171589661035630 -0.032363732574493  0.410356885754263 -0.223617160453788 -0.075311055642080  0.314379038887409
-    3  (  3) -0.113936852615240 -0.023263060013616 -0.282024826692995  0.174390257283436 -0.284646591950349 -0.036134249694962
-    4  (  4)  0.007238439897924 -0.039483311713766 -0.327400920910445 -0.428741395271426 -0.081911463055166  0.119323501144252
-    5  (  5) -0.007206698114830 -0.054871846748801  0.118753815309300  0.018469351897211 -0.153374179308602 -0.075608926558101
-    6  (  6) -0.092372497620457 -0.334623338930078 -0.214791656963667 -0.112964261573848 -0.018239773729085 -0.100594142805454
-    7  (  7)  0.151928519059447  0.104975965782044 -0.079311543670646  0.028608318007851 -0.093200761310883  0.234496518387966
-    8  (  8) -0.034328207301673  0.223808481631680  0.061242559094949 -0.498103653582096  0.749098707942318 -0.381141257037236
-    9  (  9) -0.119302126498580  0.308066314141465  0.075395221655780  0.759042960378927 -0.290000840041876  0.156436862917181
-   10  ( 10)  0.438316650507883  0.163958878572088 -0.419969142321592  0.045404841057508 -0.044939660158532 -0.568953527573990
-   11  ( 11) -0.012787507164606  0.354874435093949  0.016715712863870  0.314729329115790 -0.109367027564034 -0.038956857759457
-   12  ( 12)  0.278784619045113 -0.047236021517055  0.203283234646730  0.096945848185628  0.275889526129666 -0.187110942781753
-   13  ( 13) -0.588325776498883  0.141777398655530  0.127445383199618 -0.417479630696627  0.223570495101464  0.209733888357992
-
-	File 101 DPD File2: L_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.139188612693568 -0.095183099515076  0.018684491477480  0.097422162623446 -0.052864868482975 -0.221122027331105 -0.088706173679123 -0.046138783672279 -0.215068969553880
-    1  ( 15) -0.062949654944158 -0.202402030263201 -0.354633955608115  0.248176570557555 -0.178122375116496  0.312771607112475  0.152477622828494 -0.279557727250808 -0.106814721163754
-    2  ( 16)  0.053746164934604  0.094053172516910  0.275496238616186 -0.323601647464255  0.223358052203497 -0.300642069951494 -0.393858290336507  0.365390717289338  0.632984591272781
-    3  ( 17) -0.094021410291053  0.093446956362787 -0.262411805474378  0.022323156021381  0.042743443130518  0.119643171496185  0.019212092155216 -0.111729948135909  0.069344517807286
-    4  ( 18)  0.056361407951715 -0.163012412779377 -0.357847040556453 -0.219749386366483  0.199619718061283  0.273157948729405  0.231158276251819  0.090626116159486  0.037799150902146
-    5  ( 19)  0.160601962218735 -0.080044732518404  0.203861835009410 -0.053968884194125  0.109680630973887  0.290493189386329  0.118089200507037 -0.148837371744261  0.161317719017176
-    6  ( 20) -0.008652189032826  0.543672739191643  0.312260746368354 -0.021747391276478  0.131147878369811 -0.214266804924841 -0.195294510221963 -0.037324155238128 -0.082720193718919
-    7  ( 21)  0.047043957125951 -0.814756484486684 -0.065190092636916 -0.048606045400368 -0.224060646841072 -0.197248282512201 -0.232144218543584  0.394908869566567  0.217734911422747
-    8  ( 22) -0.009402914133539  0.067052868071270  0.200249024215418  0.001535377445924 -0.051944723647720 -0.071384974303961  0.075222552542562  0.043268063312178 -0.039055784643578
-    9  ( 23)  0.222713322415783 -0.560469323042930  0.171950144039822  0.112172774497996 -0.007083782785909  0.006435272424486  0.090200197520766 -0.151801615119284  0.031995099170652
-   10  ( 24)  0.015969660808332  0.124160280352778  0.031945357169913  0.022574658439251  0.040253136475423  0.054701591947166  0.334874112350668 -0.105285662958809 -0.223928209457468
-   11  ( 25) -0.081168660495960  0.159983923907575 -0.408650744438646  0.280675358230412  0.326885231204144 -0.118534279418464  0.213700195384120  0.079763618019830 -0.060689421297523
-   12  ( 26) -0.003652731302177 -0.169351937988896  0.223186850703667 -0.177435884273904  0.431821641248852 -0.017470249474556  0.113426087502892 -0.031984799215361  0.498979784707156
-   13  ( 27)  0.059460007596700 -0.080535877567365  0.075179690138888  0.285729932961758  0.080576308673493  0.153138615960011  0.017506919748356  0.094018188463908 -0.750480875221691
-   14  ( 28) -0.091778712898573  0.083756184222668 -0.314061943377694  0.035359431345057 -0.119047398405395  0.075525757634597  0.100522537659024 -0.234167701630633  0.382415314141466
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.054192115098489 -0.218772067545687  0.045642231806083 -0.057541502908124 -0.042026312169826
-    1  ( 15) -0.090589594220003  0.434594274447356  0.078276612217069  0.011552267330405 -0.225173895359454
-    2  ( 16) -0.087809314060775  0.409613431079942 -0.269441429063588  0.132294826475095  0.092807551910873
-    3  ( 17)  0.029496711967634  0.321890318472494  0.333949687981794  0.098006508583727  0.253968229243978
-    4  ( 18) -0.133856062539151  0.034112562139975 -0.437342385549595  0.064344113622612  0.014887157054416
-    5  ( 19)  0.074762453522294 -0.320522646445325 -0.065103712350275 -0.002026903619864  0.283693559601974
-    6  ( 20)  0.006545565411461  0.024114390996231 -0.248934516268112  0.216845871250478 -0.105404222827927
-    7  ( 21)  0.447834620578749 -0.279310199694516  0.002046231690190 -0.142438484210793  0.004552777078072
-    8  ( 22)  0.046132212945001 -0.028293172679903  0.127980948576613  0.129504871571094 -0.367038613276140
-    9  ( 23)  0.119912706409769 -0.438601556174488  0.013921175995500 -0.279073471993608  0.587144581639703
-   10  ( 24) -0.308677963206646 -0.164180974317535 -0.355112983785913  0.047146799420307 -0.142329570216595
-   11  ( 25) -0.075357514307532  0.419786206774900 -0.016983461358500 -0.203268341742445 -0.127372692691209
-   12  ( 26) -0.762257766627436 -0.045741941689100 -0.314841853754996 -0.096926452085088  0.417500846668484
-   13  ( 27)  0.290827635505768  0.045087590967332  0.109301341928646 -0.275850981479361 -0.223796991125890
-   14  ( 28) -0.156281997482093  0.568696982960467  0.039100360028362  0.187067134074575 -0.209842829958128
-
-	DPD File2: L_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.008545475107476 -0.071680877089206  0.120459476636913 -0.008371471662446  0.090424858216027  0.087190000124570  0.049119105543224 -0.145928530657214 -0.062376143421355
-    1  (  1)  0.044572181787493 -0.342772635368155  0.233569654941350 -0.080704995470875 -0.127360357635352 -0.050248913608748  0.272733324148390 -0.042278800375679  0.013710430281526
-    2  (  2)  0.007154597183575 -0.182635894723101  0.088652103396483 -0.063130413574038 -0.192109998380945 -0.097062796293933  0.154759017819859 -0.027524119345809  0.057504913844805
-    3  (  3)  0.077052275000893  0.016814177051793 -0.184635905961744  0.049413266051267  0.188745223686842  0.186563337985988  0.210232732381490  0.116951639594811  0.221961452093225
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.163872566981873  0.058478850756530 -0.036608142215322  0.074980328212796 -0.102514306635711  0.049419294250537
-    1  (  1)  0.131779111368958  0.004610196247654 -0.196879673097414 -0.065560333989646  0.202294566496281 -0.212677679948666
-    2  (  2) -0.021560095269691  0.083223144658810 -0.151678626872472  0.372667885980926 -0.062527480001262 -0.084301072064405
-    3  (  3) -0.068590860983671  0.076978943427677 -0.378848573533368 -0.165187920801172 -0.188975469384157  0.045051968107620
-
-	File 101 DPD File2: L_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.086725030779380  0.140001038265324 -0.215201398518350  0.106476373516199  0.037203797104343 -0.002684965595124  0.084210079065148  0.008500639419888  0.198745218470751
-    1  (  5) -0.141020111205039  0.238503069490028  0.123978991148198  0.150112816633559 -0.036264937723074  0.146138191093449 -0.002600464782236 -0.189526092315718  0.090546937772816
-    2  (  6) -0.314591250772654  0.266642343404836  0.168172023759533  0.305975417776500 -0.047767848718246  0.093136048513418  0.423942737612318  0.027493034904141  0.068648706999971
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.012967316151690 -0.053655915263561 -0.013296231482133  0.012509871140561 -0.053184722817966
-    1  (  5)  0.065459441432743  0.098590450512903  0.180288063245052  0.033076485246495  0.305944394837877
-    2  (  6) -0.160972461596512  0.052337284313257 -0.418780783100688  0.024563105423132  0.150128272333000
-
-	DPD File2: L_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.002961765779100 -0.004522349171324  0.004971919287087 -0.008281709260186 -0.002230370021123 -0.014875581701851 -0.067042001167372 -0.013799182049252  0.003919895633432
-    1  (  1) -0.001156407591826 -0.011364234036016 -0.009216213637618  0.026466586550273 -0.045020897276730 -0.024548396390040 -0.151472003391729 -0.022837501049660  0.020115222648640
-    2  (  2)  0.011852353144693  0.003988649312187 -0.013577386237941  0.005526396491599 -0.001842043686662  0.004979012487137  0.016339527495633  0.010418266838825  0.006987142315452
-    3  (  3)  0.053414909238326  0.048153357581206 -0.085702791986601  0.002590768785420  0.032944657214652  0.019536458989955  0.058299722995214 -0.003474387569511  0.035804252701834
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.000158467148596  0.005351238219208  0.000795318433066  0.002864683250639 -0.001069112713473  0.000329369508724
-    1  (  1) -0.008857574490791 -0.013536712170937 -0.030733233064254 -0.004374373678073  0.001058558277179 -0.003465102179278
-    2  (  2) -0.011600433240152  0.024957487742010 -0.006847708052902  0.007864294541740 -0.004416463366055 -0.003633653136444
-    3  (  3) -0.033694386372795 -0.004962923837305  0.009297526391638 -0.012733700421545 -0.018367087946588 -0.009679397413178
-
-	File 101 DPD File2: L_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.004099418996737 -0.004975270717489 -0.011544453403942 -0.010294240373049 -0.015031167783122  0.051218543078986 -0.101906219668190 -0.009904937929980  0.005253311566155
-    1  (  5) -0.030335401615971  0.051022895540044  0.010476806750229 -0.022518303747979 -0.032764970727702  0.046697847750190 -0.082351506534871 -0.029648968337614  0.032167075005308
-    2  (  6)  0.044658147220588 -0.062597359445969 -0.000792773883945 -0.033784853569182 -0.053456383670095  0.070727579120646 -0.103493462669028  0.004470774917382 -0.021985039399781
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001406578222011 -0.001390228891514 -0.004138457631327  0.000537337712782 -0.000303816554518
-    1  (  5)  0.018025115903144  0.007054017557051 -0.018234657716208 -0.000615735236753  0.005903957155119
-    2  (  6) -0.015821399504368 -0.004485035916282 -0.033862858822880 -0.005131801318237 -0.004339292116808
-
-	DPD File2: L_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.001352471969094  0.045322075444733 -0.038349314552152
-    1  (  1)  0.023470923414908  0.379995390457559 -0.218263993898326
-    2  (  2)  0.020646215106669  0.203889457343544 -0.063634437124037
-    3  (  3)  0.097263397740302  0.216436926506454  0.416986973069653
-
-	File 101 DPD File2: L_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.001379673989061 -0.023464182377298 -0.020715625293986 -0.097608841144396
-    1  (  5) -0.045132209688744 -0.379406783605291 -0.203869208496661 -0.217739723605823
-    2  (  6)  0.038063072975973  0.217447630040656  0.062958922139319 -0.417725794235781
-
-	DPD File2: L_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.065653814142264  0.041946284375303  0.013161767706572 -0.111342796774500  0.110017778689743  0.028611074624176  0.087379776644865 -0.000506944002000  0.012737970563703
-    1  (  1) -0.002767473668146 -0.010697220027718  0.013506144228592  0.073913704778148 -0.217999207158693 -0.148131683228122 -0.817266423889027 -0.116806346540286  0.086848804711528
-    2  (  2)  0.048963138068012  0.019287255807937  0.016789870431812 -0.373432811546966  0.152152935578878 -0.191763986764781 -0.187319954974202 -0.050812933510948  0.023574454587241
-    3  (  3) -0.095762012298033 -0.056431105854389  0.178578325306558  0.038136923805617  0.140424655163157  0.089806364466590 -0.125801031634604 -0.116636753108288 -0.084794392657478
-    4  (  4) -0.100603170191617 -0.067705087958627  0.243617055985189  0.044363102282417  0.181215354983299  0.115079991268796 -0.179518597407386 -0.083927955619955 -0.086976764117441
-    5  (  5)  0.065265491800394  0.066327433491654 -0.367149548777650  0.044009709655582  0.156519624550140  0.073861464202985 -0.054146331819748 -0.093323533938862  0.170259582834842
-    6  (  6) -0.072248812824936 -0.071960211653410  0.684415406158707 -0.206867685302678 -0.380153305403406 -0.217464691746015  0.101286474206003  0.035777100475268 -0.341069042893403
-    7  (  7)  0.019742266764988  0.004654597124952  0.113800058767268 -0.000574265002983  0.010628342976831  0.072863781204177  0.376898463473803  0.139300622802210 -0.056085680972333
-    8  (  8)  0.000679953535081  0.001598902294011 -0.037525126251819  0.088614223995002 -0.068220130924204  0.039175761140296  0.208506736043279  0.056089637691589 -0.046057044816225
-    9  (  9) -0.002777732520373 -0.007429125774642 -0.024943116942350  0.022915921654072 -0.035702462515069 -0.020318534935527 -0.128837242689886  0.002259623765271 -0.005711714139269
-   10  ( 10) -0.005703803965392  0.023273876655766  0.027225029310730  0.026559677666667 -0.035399971500057 -0.015156942548385 -0.030152703916084 -0.170109037950347 -0.002596190944829
-   11  ( 11) -0.003384564196851 -0.002280327238919  0.118256580527015  0.004805921198873 -0.008748560057608  0.061729599159426  0.016174096583601 -0.021868118731471  0.291086759759657
-   12  ( 12)  0.020555722880272 -0.013540587399774  0.000211893937570 -0.008542727496112  0.013892940715707  0.041889105198929  0.006009166679671  0.135825768330791  0.000314961828297
-   13  ( 13)  0.004670677001798  0.000926772526536  0.016865034300282 -0.001908716884004 -0.008533776733402 -0.002600829800043 -0.067129999007525 -0.024630232805222 -0.002093287302057
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.006448280903781 -0.007804174666870  0.001726589742279  0.009631719534244  0.002171109312827 -0.006916768929421
-    1  (  1) -0.039841759002053 -0.031613811363753 -0.126269993080286  0.005440038892529  0.010222632040274 -0.010738082177417
-    2  (  2) -0.049400367190082  0.028054173187029  0.027409200065905  0.001009289954765 -0.006677408446924 -0.009978484711828
-    3  (  3)  0.070460304013326 -0.083098595574193  0.035907224123551 -0.018802993269139  0.017169529769810  0.011284756920795
-    4  (  4)  0.035774264116816  0.067898270132826 -0.022183832964584  0.018305304819727  0.010768454734731  0.005255647674495
-    5  (  5)  0.149334153074510 -0.107123073600670 -0.046253700594295 -0.009064678078212  0.006568373775894  0.015962506593757
-    6  (  6) -0.264128081623912 -0.189717353125691  0.013846475545988 -0.034468738650004  0.018622793691907 -0.039125899611440
-    7  (  7) -0.078787498256752  0.137081801981432 -0.129024279783991  0.020540266029100 -0.010702305076213 -0.006363683572839
-    8  (  8)  0.066828272542120  0.061150331629768  0.661663512432504  0.064427579111988 -0.022787180611671 -0.001755054521373
-    9  (  9)  0.058361662206488  0.002765609007918  0.292979002594137 -0.024531884688023  0.033841964179834 -0.017477652244683
-   10  ( 10)  0.025537046615515 -0.402776836876724  0.195006548574470  0.143818217257362 -0.044952634158782  0.042833786526299
-   11  ( 11) -0.612581110120467 -0.030681983336889  0.052907112855315 -0.397594256764291 -0.644994698530558  0.225177415266176
-   12  ( 12)  0.078361827884296 -0.147641215292530  0.139659868964866 -0.415352806158415  0.111207746262217 -0.045767792834358
-   13  ( 13)  0.007555966012008 -0.007034052257820  0.662815283687025  0.034075798547008 -0.058439318318560  0.002857982237762
-
-	File 101 DPD File2: L_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.065636199611282  0.002920916198147 -0.048668219311498  0.095119636724795  0.099715491746342 -0.064115894757826  0.070288612362710 -0.020002036740183 -0.000648682346076
-    1  ( 15) -0.042164832302811  0.010965264984920 -0.019193267525749  0.056427120825921  0.067779126388374 -0.066346545701259  0.071818426884183 -0.004697793564429 -0.001719477062512
-    2  ( 16) -0.013293723744736 -0.013552393155520 -0.017152946073135 -0.178062131392816 -0.243207234696954  0.366656850670269 -0.683571699988320 -0.113725695300653  0.037674829370647
-    3  ( 17)  0.111833520478397 -0.074487105305844  0.373408686548039 -0.038278615402917 -0.044272326064866 -0.043920914820213  0.206763999327991  0.000718931757735 -0.088712771696387
-    4  ( 18) -0.110609556420903  0.218552165395166 -0.152101671319906 -0.140308960149057 -0.181388781196210 -0.156379821301524  0.379726625097930 -0.010777684689777  0.068071061617319
-    5  ( 19) -0.028752510181408  0.148103625807997  0.191866592233893 -0.089885426625568 -0.115404739185245 -0.073530988681885  0.216894531023559 -0.072888831186762 -0.039414155734701
-    6  ( 20) -0.088850262853694  0.817864717973160  0.187538432803728  0.126558510407503  0.179188313739966  0.053967785688344 -0.101346004734165 -0.376808265586346 -0.209641170142921
-    7  ( 21)  0.000236648626185  0.116954024007332  0.050876086441348  0.116850431043499  0.083855737312712  0.093201481422807 -0.035654753872492 -0.139240147731598 -0.056215130854042
-    8  ( 22) -0.012632241831446 -0.086750564455513 -0.023471210733819  0.084658255793584  0.087082440553447 -0.170291379307318  0.341029495907861  0.056080270650825  0.046130696703817
-    9  ( 23) -0.006387457988158  0.039627800428235  0.049236971359731 -0.070603541281575 -0.036093218300137 -0.148729935532572  0.263186790392662  0.078651937105263 -0.066792443994885
-   10  ( 24)  0.007794314356224  0.031645957507839 -0.027999240171264  0.083306839859372 -0.068240617920633  0.107186407568302  0.189422573537585 -0.136891913283426 -0.061228539916207
-   11  ( 25) -0.001991689460876  0.126407268625784 -0.027445392718538 -0.035776924599103  0.022144125160038  0.046221028292780 -0.013824022605635  0.129003528239796 -0.661853370394303
-   12  ( 26) -0.009599825104381 -0.005495331116759 -0.001034223219580  0.018933867742673 -0.018384105286375  0.009023661627231  0.034486124663305 -0.020439460919434 -0.064455521141270
-   13  ( 27) -0.002162721447509 -0.010273200862148  0.006630148558014 -0.017146542465354 -0.010737357070418 -0.006596929169183 -0.018510057851825  0.010689113270586  0.022830224344291
-   14  ( 28)  0.006906605609555  0.010703198677296  0.009943679074748 -0.011262720290334 -0.005261069281766 -0.015966561898017  0.039173616710326  0.006358426931312  0.001746833081562
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.002837339199042  0.005729990462521  0.002882667336321 -0.020606047818522 -0.004641004703607
-    1  ( 15)  0.007437286770332 -0.023276875493539  0.002358499534732  0.013557485629733 -0.000920107297989
-    2  ( 16)  0.025051827266470 -0.027193002752018 -0.117990698559769 -0.000179234372392 -0.016865743435032
-    3  ( 17) -0.023119196337007 -0.026652175278014 -0.004797499415929  0.008529905892743  0.001864545935891
-    4  ( 18)  0.035881897592302  0.035473538214569  0.008734163325355 -0.013878334987718  0.008565527202823
-    5  ( 19)  0.020360772275651  0.015171720613603 -0.061893166394059 -0.041911368342621  0.002602253507665
-    6  ( 20)  0.129299070691523  0.030292769804169 -0.016131950321938 -0.006006549470023  0.067162983124201
-    7  ( 21) -0.002077638821295  0.170151112881545  0.021893691209527 -0.135824125871701  0.024649373152539
-    8  ( 22)  0.005657792833300  0.002565321667606 -0.291029322280664 -0.000304358068315  0.002094832642432
-    9  ( 23) -0.058382869250631 -0.025529477410136  0.612383084135802 -0.078382756676553 -0.007563305586064
-   10  ( 24) -0.002481618081866  0.402824463109094  0.030640926554774  0.147639465945455  0.007047422246803
-   11  ( 25) -0.292947637539939 -0.194977050256941 -0.052900384325439 -0.139655182883169 -0.662817045986547
-   12  ( 26)  0.024630592497451 -0.143803605487111  0.397605464014331  0.415353658752820 -0.034075972250685
-   13  ( 27) -0.033850850098076  0.044956075971212  0.644991001235189 -0.111210374775728  0.058439332449029
-   14  ( 28)  0.017470247415045 -0.042829113212736 -0.225189876847489  0.045765194902991 -0.002860279243371
-
-	DPD File2: L_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.003220755761788  0.004741334513036 -0.005218491575352  0.008931308835907  0.002244102633378  0.015838687100919  0.070299613805989  0.014541519275327 -0.004023986014985
-    1  (  1)  0.000067503033474  0.012207317918030  0.007244793200988 -0.023892777130642  0.043438396740122  0.025220796440141  0.154461573863724  0.023000834887421 -0.019599055677926
-    2  (  2) -0.012578011879907 -0.003275100255966  0.012592919961383 -0.005684090399027  0.002169804380039 -0.004971061326221 -0.013552564477647 -0.009500984985895 -0.006299654057362
-    3  (  3) -0.059262075820670 -0.046181284980691  0.084603478568992 -0.003021949940787 -0.032496962809605 -0.021957384896270 -0.062320115832634  0.002770430488820 -0.031773062115651
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.000182000207227 -0.005588586167114 -0.000672702586966 -0.002964514553093  0.001105034523208 -0.000343253226041
-    1  (  1)  0.008618205903186  0.014153751191206  0.035995392865196  0.005123687397521 -0.001603958931174  0.003532153146744
-    2  (  2)  0.011268111146370 -0.024898784529351  0.008069485418761 -0.008185686323918  0.004533934142691  0.003585064891685
-    3  (  3)  0.031845177970419  0.004991052985520 -0.011188833991374  0.013257910424622  0.018832233173395  0.009593400754084
-
-	File 101 DPD File2: L_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.004231156729541  0.005431493649267  0.012529175724660  0.009596633242284  0.014606722988323 -0.052629799448244  0.104835250484967  0.010143068216584 -0.005577330897623
-    1  (  5)  0.032234138585390 -0.047805476204470 -0.011206420541453  0.021169463646392  0.032922137113452 -0.049263864001113  0.085142779220860  0.029187847712420 -0.030401159775617
-    2  (  6) -0.047014795193874  0.061420283989306  0.003243656996742  0.033537214796175  0.054307591623750 -0.073188368684598  0.108826461718921 -0.002713708723067  0.019591523301056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.001535925504297  0.001313736377570  0.005141735029325 -0.000303256666525  0.000317758840647
-    1  (  5) -0.017868281803487 -0.005956287092286  0.022125071354749 -0.000228679155762 -0.005956925492705
-    2  (  6)  0.014719284513933  0.004480852833973  0.038592140844884  0.004744813467982  0.004561240528551
-
-	DPD File2: L_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.022503440356479  0.058098623177060  0.000062770505092 -0.132305009105496 -0.206845253941622  0.090151367748423 -0.021622993143838 -0.039361662992191  0.081041759558226
-    1  (  1) -0.058446002702836  0.108172168386185  0.020491566051334  0.029038345992777 -0.075256281123738  0.197244333988945 -0.268904698641837 -0.104165934598637  0.067340388311649
-    2  (  2) -0.015395531848647  0.065975044836942  0.020693241330571  0.145278172814648  0.156811977452555  0.026190455636648 -0.072791620713754 -0.106379131933316  0.008110007352911
-    3  (  3)  0.209889648236101  0.051262205353483 -0.016792464647056 -0.095510023392087  0.095336437943254 -0.289116527068191  0.245753635975044 -0.379261907549404  0.084194488960217
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009235922070380 -0.024147628235135  0.039515998256435  0.082736569385204 -0.047511948407189
-    1  (  1)  0.028213287410066  0.067760885382258  0.238885785831598 -0.125969164417165  0.177609465299056
-    2  (  2)  0.077606299822139 -0.045313543977919  0.093141189528995  0.365274042010320  0.093447143662359
-    3  (  3)  0.414915648101425  0.159852566454575 -0.273568285244179 -0.034618677464967  0.200919751856191
-
-	File 101 DPD File2: L_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.016102682138215 -0.069778483618667  0.053388820705143  0.227201022061025 -0.199230027507757  0.049687576272545 -0.168877445324815 -0.014461225346720 -0.006078045787078
-    1  (  5)  0.058029574568631 -0.323045692556243  0.030451397480033 -0.087822399123219 -0.049669665073330 -0.052839306705253 -0.277652121487366 -0.149775076501372  0.305937155187615
-    2  (  6) -0.084055275416977  0.046073375264778  0.190725804844658 -0.087557818571264 -0.137785527535432 -0.205465571560117 -0.198777590794243 -0.118276962947747 -0.298899363411174
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.065173985643121  0.083163093513445  0.059838819925541  0.009394325003249 -0.030439464334268  0.004211857989885
-    1  (  5)  0.056299327075830 -0.068872084822763  0.330916524082322 -0.053769676068525 -0.184435947342737 -0.103868547796473
-    2  (  6)  0.066328790095722 -0.124449756334111  0.113043685672814  0.144452726550473  0.299204372324576 -0.043729255630968
-
-	DPD File2: L_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.000260799278180  0.008294549497458  0.017065509889387 -0.120823024347784
-    1  (  1) -0.008496132195710  0.000459229311004  0.070584548654847 -0.263658987971002
-    2  (  2) -0.016577243499005 -0.069994423923560  0.000663995662767  0.516189372162913
-    3  (  3)  0.119940673323058  0.260382743299108 -0.515797582139532  0.000896339388888
-
-	File 101 DPD File2: L_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.000443199054119  0.381921104005874 -0.143832379423130
-    1  (  5) -0.379434119543787 -0.000485242459082  0.057931044964221
-    2  (  6)  0.142702240031722 -0.057674063898636  0.001442186569692
-
-	DPD File2: L_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.000910226438200  0.057456315647344  0.021764054616564 -0.110121253697657 -0.041147685715423  0.038875248096137 -0.013658842816188  0.027740417762726  0.095876695371130
-    1  (  1) -0.055345619259075 -0.000114715934544 -0.161082100934535  0.114708094818496 -0.226148458324691  0.429581553751604 -0.364780572887542 -0.339773268987353 -0.220533774744399
-    2  (  2) -0.020999461515685  0.161288340725610  0.000052922970119  0.056734674713291  0.008992634403320  0.218257664918361 -0.249333786133602 -0.218109893723775  0.109339937360493
-    3  (  3)  0.109919099574174 -0.115822425715978 -0.056019356031194  0.000740007095007  0.462857615923727  0.122607299335305  0.103870366450161  0.116250705419353  0.000233457194456
-    4  (  4)  0.040147971736914  0.225934656930791 -0.007773114629988 -0.462818557889914 -0.000780254049361  0.292874409138683 -0.009409004020261 -0.051882584565833 -0.039822167749921
-    5  (  5) -0.036335623693882 -0.431140334679252 -0.219015877475265 -0.122742719044919 -0.292837706496088 -0.000258434125831  0.380099535662932  0.122521034451732  0.042311772982521
-    6  (  6)  0.010512439726471  0.366117332794119  0.249486244103056 -0.103549874519169  0.008542365779906 -0.379118456291524 -0.000620782572313  0.110534560584461 -0.061985573540389
-    7  (  7) -0.028794951664777  0.339121669867214  0.216809050490518 -0.114099993246667  0.053090461626524 -0.122152835981425 -0.109887843186158 -0.000210776402969 -0.084672807469555
-    8  (  8) -0.095808229399132  0.221323464482799 -0.109106314792845 -0.000875257457611  0.038544677386553 -0.040538328426676  0.059775641025623  0.084700205378613  0.000410389354257
-    9  (  9)  0.014690106491517 -0.105287842118522 -0.107275604483120  0.218821764375615  0.309676781731095 -0.105240911604621 -0.129641828566929  0.117997785339671  0.042511311192418
-   10  ( 10) -0.029204608817403  0.107752356880331 -0.099755035717731  0.053525818879341  0.138310129158905  0.190113742192741 -0.089997971579917 -0.050367401919439 -0.205935350574800
-   11  ( 11) -0.155172680813618  0.443695988859270 -0.328777258069509 -0.218798389099096 -0.215176387461835  0.086665175851153 -0.081418632205002 -0.042686048283827  0.076994698961746
-   12  ( 12)  0.047142387984938  0.056370877735219 -0.091886939990151  0.290638653877080 -0.241910292969431 -0.247337059928007  0.042831064524262  0.092379405612353 -0.274155000078483
-   13  ( 13) -0.050389463693039  0.050328281612189 -0.290240848494312  0.162056910726980  0.213783629964646 -0.103688020985272 -0.033887129957515 -0.045587144676475  0.299790508093838
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.015162329261762  0.029089765310940  0.157702865584754 -0.046156688514328  0.051381785238624
-    1  (  1)  0.106899843708486 -0.107201618560176 -0.445393416001207 -0.057067668629351 -0.050060001886431
-    2  (  2)  0.108853020016321  0.100191021028451  0.328545989684712  0.092698579556052  0.291502735762344
-    3  (  3) -0.218857914732928 -0.054792818554564  0.218936510583978 -0.287400526650046 -0.163296274552526
-    4  (  4) -0.309023997649700 -0.137542449801745  0.215093936648757  0.238284970233362 -0.213551426731583
-    5  (  5)  0.105674820684469 -0.189857437820115 -0.086867271556711  0.246374813757869  0.103858683942188
-    6  (  6)  0.128168668490610  0.089874262580382  0.081958189888793 -0.043636026138960  0.033207564369726
-    7  (  7) -0.118048267554359  0.049676494199198  0.043691989598397 -0.088880392330239  0.045560837044954
-    8  (  8) -0.043185963759057  0.206226573210928 -0.075243165739987  0.272590964145289 -0.299131513308221
-    9  (  9) -0.000077812750263  0.416515228417900  0.033604308554634 -1.079153036382561  0.144875292418151
-   10  ( 10) -0.417421688656681 -0.000158782243602 -0.288840596220158 -0.322135887066066 -0.291543524694710
-   11  ( 11) -0.033233098605228  0.288689216150241  0.000098607070373  0.357467165030213 -0.110234432471254
-   12  ( 12)  1.082588809014081  0.322578291381663 -0.357464370732486 -0.000001008926324 -0.002433258902322
-   13  ( 13) -0.144961978586806  0.291352746525362  0.110198259116823  0.002466771848949  0.000072101869173
-
-	File 101 DPD File2: L_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -0.000153758776117  0.016209320965105  0.024928923757993 -0.062060534746170 -0.021458157416245  0.118593249067004 -0.004670228294358 -0.089096779890278  0.035341469320983
-    1  ( 15) -0.019055649133697  0.000070152122919  0.073747919702930 -0.220440656283159  0.117173681778925 -0.070042107037530 -0.194626605110428  0.297284849336053 -0.000292612579198
-    2  ( 16) -0.022586057118123 -0.073725573957683 -0.001109122666778 -0.015411803389863 -0.086529842350705 -0.104871287980693 -0.398741646289671 -0.436619148331831  0.174927780649059
-    3  ( 17)  0.059798965916265  0.223563287458482  0.017237453392182  0.001072539123553  0.251308090392191 -0.316070038847548  0.194803920269306  0.070654457969027 -0.376473483655780
-    4  ( 18)  0.020063419612631 -0.119039349408291  0.086800563750570 -0.251653936305414 -0.000335080735996  0.043024303892643  0.031731210904760  0.166597040709751  0.162561043906122
-    5  ( 19) -0.121124499955847  0.070386002281353  0.107113059896318  0.315446439504518 -0.043168772215477 -0.000861181929967  0.084799445456534  0.176705933868056 -0.191684805801835
-    6  ( 20)  0.000233561036084  0.194646689461778  0.399810731825322 -0.193912344414617 -0.032510952578749 -0.085522667269840  0.000316476981181  0.483153682224173 -0.288298406144107
-    7  ( 21)  0.086715012513528 -0.297226361655840  0.437406683020490 -0.070307665212214 -0.166617940064674 -0.177260527643651 -0.482840792772829 -0.000014363804072  0.098144550576534
-    8  ( 22) -0.034848855831113  0.000859202110741 -0.174080336928834  0.374333295621785 -0.160768014942695  0.191629536777613  0.289445575791765 -0.097019024563133 -0.000025631190893
-    9  ( 23) -0.146128458859477  0.053492838723281  0.324237370304827  0.062951581962557  0.055209150392106  0.064149761275701  0.152989513320630  0.139473999081823 -0.103718919745517
-   10  ( 24)  0.228943772617007 -0.607904766836796 -0.190620042163283 -0.232958068554443 -0.097307404392685  0.308161168894475 -0.021743402571297  0.163623966328651  0.316399909940952
-   11  ( 25) -0.113574180450176 -0.174427793696739  0.418995996797932  0.308337203773489 -0.075443225258948  0.339087151000572 -0.159463644175662 -0.028413073183974 -0.098871219135018
-   12  ( 26) -0.037424667627758 -0.021650461815628  0.117304488555654 -0.051902638516337  0.180454397204301  0.010740660446775  0.081519307958206 -0.155893098286787  0.070546741513103
-   13  ( 27)  0.017280094917641 -0.067254948202109  0.031223412783479 -0.363810241712273  0.387221887172221  0.012090141232777  0.015814975888526  0.054980917535039 -0.199339784826487
-   14  ( 28)  0.034098865606387  0.073619427530260 -0.020485113762460 -0.085856422339691  0.016811589994319 -0.112843996612104 -0.014113720302883  0.178007823049380  0.110352388592064
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14)  0.147079245976260 -0.230634884327798  0.118016008095876  0.038157145434167 -0.016510465499821 -0.035555014241919
-    1  ( 15) -0.054535973951003  0.607948556744402  0.173873449665646  0.021413077919509  0.066607274428011 -0.073358777560519
-    2  ( 16) -0.323553306716541  0.191880318233455 -0.420431580367675 -0.118056258433329 -0.032680374772067  0.021063792737754
-    3  ( 17) -0.062647993136989  0.233296910168052 -0.309972235049851  0.052767888000268  0.365466873103625  0.086191647721005
-    4  ( 18) -0.056463254581534  0.097267541950806  0.076718792428350 -0.181006281426179 -0.388581954607450 -0.017033118173935
-    5  ( 19) -0.064619380352855 -0.308870128837400 -0.338018875040100 -0.010262168024492 -0.011437556053144  0.112357517192840
-    6  ( 20) -0.155382617120808  0.021349499069868  0.159407311491110 -0.081840985740344 -0.016551112219655  0.014159445447452
-    7  ( 21) -0.140537868365913 -0.163950016139901  0.028635642703436  0.155664270522521 -0.055628199070781 -0.178154240957341
-    8  ( 22)  0.103340923981933 -0.315438553715367  0.098505861648548 -0.070640699178892  0.199194337948212 -0.110183696150063
-    9  ( 23)  0.000686334523005 -0.100169676705670 -0.098205409926821  0.175395135103276 -0.218110756133058  0.228152281729332
-   10  ( 24)  0.099945574901306 -0.000096874523801  0.318471840231024 -0.225312239057313 -0.500004280246570 -0.463864297141458
-   11  ( 25)  0.099841601903911 -0.317761699341874 -0.000010561898700  0.325597818757907 -0.211905875429043 -0.064803783303090
-   12  ( 26) -0.174935629969472  0.225292248952868 -0.325705390264674 -0.000017197242562 -0.212072627252549  0.098012445880115
-   13  ( 27)  0.218628597779198  0.499556536309007  0.211864150049234  0.212027765065009  0.000008829414452 -0.140826209095657
-   14  ( 28) -0.228628348644091  0.463533897425291  0.064881803408838 -0.097950839605716  0.140879063677935 -0.000044304452715
-
-	DPD File2: L_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.019783280962491 -0.054735513036393  0.001137513221933  0.126035313397777  0.202288257068162 -0.093711193829816  0.024984212293499  0.040225532801761 -0.083002910227929
-    1  (  1)  0.062354133456812 -0.120130294655184 -0.021767958501026 -0.030544876872275  0.074729404941111 -0.202914227763797  0.283260339857543  0.110010624076740 -0.075144553244755
-    2  (  2)  0.020071793451970 -0.073560407589557 -0.021169787012452 -0.145854096701605 -0.150911678978076 -0.033300464776861  0.073764758000912  0.114546085873699 -0.006653295400428
-    3  (  3) -0.203743026628905 -0.061501992586247  0.012053004875485  0.096810295870523 -0.111136074888818  0.295383183736970 -0.262971263836652  0.383085480530365 -0.093214804722179
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009993046283887  0.025513386596424 -0.042737152836742 -0.089318312648033  0.047451575437880
-    1  (  1) -0.030039490649266 -0.071945227885317 -0.250267584137830  0.142236308614906 -0.184637048828095
-    2  (  2) -0.082997800944815  0.054871782095115 -0.094796172305804 -0.401103667111563 -0.092927166183836
-    3  (  3) -0.430981237821724 -0.170811685089178  0.282618320770360  0.039486333217088 -0.208093566455086
-
-	File 101 DPD File2: L_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.010424640140636  0.070076236901647 -0.057204661229737 -0.211582690126517  0.193468115965468 -0.043909115261545  0.178375291288102  0.011291008781060  0.006135050116210
-    1  (  5) -0.063097232722725  0.334472526495555 -0.025536894990807  0.078253601702773  0.050626850793128  0.056751425430030  0.294768356957907  0.157483239712855 -0.310569420319987
-    2  (  6)  0.095244048403721 -0.044264153982762 -0.212560989611836  0.091390108488898  0.149038965211255  0.211765484415775  0.210419446695478  0.121083327494802  0.309642081940379
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.068004773266362 -0.092578615344634 -0.065573414828925 -0.010233554140998  0.030163257404408 -0.003064448161750
-    1  (  5) -0.053600127227434  0.069934324462776 -0.342538882666169  0.056907034018328  0.186630072086963  0.106323576616076
-    2  (  6) -0.072821378093083  0.126275999821165 -0.117600524675145 -0.149377060058828 -0.309029921623329  0.046031657791552
-
 	Computing Mu_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.600101280533
-	   1         4.316927044889    2.067e-01
-	   2         4.822990086611    1.016e-01
-	   3         4.824705800017    1.953e-02
-	   4         4.828981012265    6.593e-03
-	   5         4.829239662852    1.742e-03
-	   6         4.829216801865    4.271e-04
-	   7         4.829267999246    1.537e-04
-	   8         4.829250741593    4.680e-05
-	   9         4.829247431990    1.563e-05
-	  10         4.829247700151    7.041e-06
-	  11         4.829248534276    2.588e-06
-	  12         4.829248460975    5.668e-07
-	  13         4.829248304292    1.335e-07
-	  14         4.829248271460    3.749e-08
-	  15         4.829248268386    1.064e-08
-	  16         4.829248269647    3.249e-09
-	  17         4.829248270092    9.092e-10
-	  18         4.829248270045    3.293e-10
+	   0         3.600101268377
+	   1         4.316927027596    2.067e-01
+	   2         4.822990062821    1.016e-01
+	   3         4.824705775961    1.953e-02
+	   4         4.828980988105    6.593e-03
+	   5         4.829239638666    1.742e-03
+	   6         4.829216777681    4.271e-04
+	   7         4.829267975060    1.537e-04
+	   8         4.829250717408    4.680e-05
+	   9         4.829247407805    1.563e-05
+	  10         4.829247675967    7.041e-06
+	  11         4.829248510091    2.588e-06
+	  12         4.829248436790    5.668e-07
+	  13         4.829248280107    1.335e-07
+	  14         4.829248247275    3.749e-08
+	  15         4.829248244201    1.064e-08
+	  16         4.829248245462    3.249e-09
+	  17         4.829248245907    9.092e-10
+	  18         4.829248245860    3.293e-10
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 9.663e-11
 
 	Computing P_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.713341540516
-	   1         8.668177713501    1.765e-01
-	   2         9.080893217365    7.431e-02
-	   3         9.087440518461    2.071e-02
-	   4         9.088617776459    6.813e-03
-	   5         9.088891220443    2.148e-03
-	   6         9.089037311239    7.646e-04
-	   7         9.089077789837    2.726e-04
-	   8         9.089056512257    9.491e-05
-	   9         9.089059445326    2.406e-05
-	  10         9.089060563422    7.909e-06
-	  11         9.089059633039    2.212e-06
-	  12         9.089058861517    5.900e-07
-	  13         9.089058707748    1.222e-07
-	  14         9.089058698169    3.486e-08
-	  15         9.089058696864    1.152e-08
-	  16         9.089058694964    4.179e-09
-	  17         9.089058693451    1.398e-09
-	  18         9.089058692794    4.890e-10
-	  19         9.089058692724    1.592e-10
+	   0         7.713341549392
+	   1         8.668177720809    1.765e-01
+	   2         9.080893223071    7.431e-02
+	   3         9.087440523917    2.071e-02
+	   4         9.088617781866    6.813e-03
+	   5         9.088891225829    2.148e-03
+	   6         9.089037316619    7.646e-04
+	   7         9.089077795215    2.726e-04
+	   8         9.089056517636    9.491e-05
+	   9         9.089059450704    2.406e-05
+	  10         9.089060568800    7.909e-06
+	  11         9.089059638417    2.212e-06
+	  12         9.089058866895    5.900e-07
+	  13         9.089058713127    1.222e-07
+	  14         9.089058703548    3.486e-08
+	  15         9.089058702243    1.152e-08
+	  16         9.089058700343    4.179e-09
+	  17         9.089058698830    1.398e-09
+	  18         9.089058698173    4.890e-10
+	  19         9.089058698103    1.592e-10
 	-----------------------------------------
 	Converged P_X-Perturbed Wfn to 4.478e-11
 
 	Computing L_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.897796649982
-	   1         6.317365241610    3.918e-01
-	   2         8.067299903766    2.656e-01
-	   3         8.259545789219    9.071e-02
-	   4         8.377742082729    4.595e-02
-	   5         8.392064211386    2.096e-02
-	   6         8.399976306217    1.239e-02
-	   7         8.405463500965    6.767e-03
-	   8         8.405624436984    3.868e-03
-	   9         8.406188796279    1.590e-03
-	  10         8.406367326576    6.480e-04
-	  11         8.406509626676    2.469e-04
-	  12         8.406461597527    1.199e-04
-	  13         8.406425982206    4.517e-05
-	  14         8.406422636795    1.928e-05
-	  15         8.406420754319    8.975e-06
-	  16         8.406416695287    4.501e-06
-	  17         8.406411974985    2.130e-06
-	  18         8.406409925890    1.162e-06
-	  19         8.406408710547    7.871e-07
-	  20         8.406408539884    4.189e-07
-	  21         8.406408540075    2.090e-07
-	  22         8.406408562880    9.494e-08
-	  23         8.406408601597    3.929e-08
-	  24         8.406408610582    1.192e-08
-	  25         8.406408615984    5.579e-09
-	  26         8.406408619764    2.300e-09
-	  27         8.406408621214    8.876e-10
-	  28         8.406408622178    4.742e-10
-	  29         8.406408622164    2.221e-10
+	   0         4.897796626771
+	   1         6.317365214472    3.918e-01
+	   2         8.067299873377    2.656e-01
+	   3         8.259545758585    9.071e-02
+	   4         8.377742051807    4.595e-02
+	   5         8.392064179775    2.096e-02
+	   6         8.399976274138    1.239e-02
+	   7         8.405463468594    6.767e-03
+	   8         8.405624404528    3.868e-03
+	   9         8.406188763830    1.590e-03
+	  10         8.406367294121    6.480e-04
+	  11         8.406509594222    2.469e-04
+	  12         8.406461565071    1.199e-04
+	  13         8.406425949750    4.517e-05
+	  14         8.406422604339    1.928e-05
+	  15         8.406420721862    8.975e-06
+	  16         8.406416662830    4.501e-06
+	  17         8.406411942529    2.130e-06
+	  18         8.406409893434    1.162e-06
+	  19         8.406408678091    7.871e-07
+	  20         8.406408507428    4.189e-07
+	  21         8.406408507619    2.090e-07
+	  22         8.406408530424    9.494e-08
+	  23         8.406408569141    3.929e-08
+	  24         8.406408578126    1.192e-08
+	  25         8.406408583528    5.579e-09
+	  26         8.406408587308    2.300e-09
+	  27         8.406408588758    8.876e-10
+	  28         8.406408589722    4.742e-10
+	  29         8.406408589708    2.221e-10
 	-----------------------------------------
-	Converged L_X-Perturbed Wfn to 9.103e-11
+	Converged L_X-Perturbed Wfn to 9.102e-11
 
 	Computing Mu_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.394062516423
-	   1         9.273057992286    3.735e-01
-	   2        10.982677269955    1.906e-01
-	   3        10.997182310482    3.057e-02
-	   4        11.015795178497    1.384e-02
-	   5        11.018076754586    3.256e-03
-	   6        11.017792705497    9.467e-04
-	   7        11.017955110484    3.746e-04
-	   8        11.017962718105    1.505e-04
-	   9        11.017927251552    4.916e-05
-	  10        11.017932177775    1.265e-05
-	  11        11.017941031399    3.993e-06
-	  12        11.017945218326    8.237e-07
-	  13        11.017945331953    2.060e-07
-	  14        11.017945179588    8.748e-08
-	  15        11.017945042479    2.755e-08
-	  16        11.017945024966    8.267e-09
-	  17        11.017945024501    2.916e-09
-	  18        11.017945025522    9.727e-10
-	  19        11.017945025499    3.792e-10
-	  20        11.017945025390    1.556e-10
+	   0         7.394062446936
+	   1         9.273057899833    3.735e-01
+	   2        10.982677143284    1.906e-01
+	   3        10.997182182183    3.057e-02
+	   4        11.015795049545    1.384e-02
+	   5        11.018076625504    3.256e-03
+	   6        11.017792576429    9.467e-04
+	   7        11.017954981406    3.746e-04
+	   8        11.017962589026    1.505e-04
+	   9        11.017927122476    4.916e-05
+	  10        11.017932048699    1.265e-05
+	  11        11.017940902322    3.993e-06
+	  12        11.017945089248    8.237e-07
+	  13        11.017945202875    2.060e-07
+	  14        11.017945050510    8.748e-08
+	  15        11.017944913401    2.755e-08
+	  16        11.017944895888    8.267e-09
+	  17        11.017944895424    2.916e-09
+	  18        11.017944896444    9.727e-10
+	  19        11.017944896421    3.792e-10
+	  20        11.017944896313    1.556e-10
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 5.049e-11
 
 	Computing P_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         7.716547784245
-	   1         8.980384650765    2.326e-01
-	   2         9.684086684858    1.026e-01
-	   3         9.700197784685    2.043e-02
-	   4         9.702773062785    8.217e-03
-	   5         9.703227746527    1.771e-03
-	   6         9.703210364643    5.096e-04
-	   7         9.703281361795    1.440e-04
-	   8         9.703275474931    4.076e-05
-	   9         9.703269349713    1.553e-05
-	  10         9.703270574828    6.650e-06
-	  11         9.703271970152    2.553e-06
-	  12         9.703272444618    6.143e-07
-	  13         9.703272206335    1.488e-07
-	  14         9.703272127185    5.261e-08
-	  15         9.703272094257    1.696e-08
-	  16         9.703272093271    4.381e-09
-	  17         9.703272092897    1.381e-09
-	  18         9.703272092684    5.151e-10
-	  19         9.703272092663    1.585e-10
+	   0         7.716547787288
+	   1         8.980384654307    2.326e-01
+	   2         9.684086686461    1.026e-01
+	   3         9.700197785526    2.043e-02
+	   4         9.702773063571    8.217e-03
+	   5         9.703227747287    1.771e-03
+	   6         9.703210365405    5.096e-04
+	   7         9.703281362553    1.440e-04
+	   8         9.703275475690    4.076e-05
+	   9         9.703269350472    1.553e-05
+	  10         9.703270575587    6.650e-06
+	  11         9.703271970911    2.553e-06
+	  12         9.703272445377    6.143e-07
+	  13         9.703272207094    1.488e-07
+	  14         9.703272127944    5.261e-08
+	  15         9.703272095015    1.696e-08
+	  16         9.703272094030    4.381e-09
+	  17         9.703272093655    1.381e-09
+	  18         9.703272093443    5.151e-10
+	  19         9.703272093421    1.585e-10
 	-----------------------------------------
 	Converged P_Y-Perturbed Wfn to 4.349e-11
 
 	Computing L_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.270133897598
-	   1         0.370251987384    1.088e-01
-	   2         0.506867859180    7.757e-02
-	   3         0.534370737314    3.082e-02
-	   4         0.542494574788    1.048e-02
-	   5         0.542508002858    4.811e-03
-	   6         0.542565799839    2.897e-03
-	   7         0.543220499427    1.840e-03
-	   8         0.543094021521    7.165e-04
-	   9         0.543150055173    2.254e-04
-	  10         0.543151906380    1.105e-04
-	  11         0.543141088664    3.292e-05
-	  12         0.543129523977    1.505e-05
-	  13         0.543128646196    5.978e-06
-	  14         0.543131072881    3.369e-06
-	  15         0.543132189646    1.183e-06
-	  16         0.543132483070    5.119e-07
-	  17         0.543132449927    1.838e-07
-	  18         0.543132453577    8.193e-08
-	  19         0.543132456062    4.247e-08
-	  20         0.543132458178    9.667e-09
-	  21         0.543132458175    3.327e-09
-	  22         0.543132458874    1.397e-09
-	  23         0.543132459226    5.862e-10
-	  24         0.543132459365    2.405e-10
+	   0         0.270133893656
+	   1         0.370251981529    1.088e-01
+	   2         0.506867849248    7.757e-02
+	   3         0.534370726558    3.082e-02
+	   4         0.542494563790    1.048e-02
+	   5         0.542507991825    4.811e-03
+	   6         0.542565788782    2.897e-03
+	   7         0.543220488293    1.840e-03
+	   8         0.543094010393    7.165e-04
+	   9         0.543150044042    2.254e-04
+	  10         0.543151895249    1.105e-04
+	  11         0.543141077534    3.292e-05
+	  12         0.543129512847    1.505e-05
+	  13         0.543128635066    5.978e-06
+	  14         0.543131061751    3.369e-06
+	  15         0.543132178516    1.183e-06
+	  16         0.543132471940    5.119e-07
+	  17         0.543132438797    1.838e-07
+	  18         0.543132442447    8.193e-08
+	  19         0.543132444932    4.247e-08
+	  20         0.543132447048    9.667e-09
+	  21         0.543132447045    3.327e-09
+	  22         0.543132447744    1.397e-09
+	  23         0.543132448096    5.862e-10
+	  24         0.543132448235    2.405e-10
 	-----------------------------------------
 	Converged L_Y-Perturbed Wfn to 7.744e-11
 
 	Computing Mu_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         5.404411500422
-	   1         6.598966253353    2.821e-01
-	   2         7.515826515103    1.333e-01
-	   3         7.513416885056    2.023e-02
-	   4         7.518023971706    8.199e-03
-	   5         7.518815964583    1.834e-03
-	   6         7.518752576723    5.596e-04
-	   7         7.518801593256    2.130e-04
-	   8         7.518793983874    6.505e-05
-	   9         7.518782075469    1.891e-05
-	  10         7.518783193244    5.849e-06
-	  11         7.518785363683    2.143e-06
-	  12         7.518786502465    5.634e-07
-	  13         7.518786517767    1.849e-07
-	  14         7.518786423134    6.421e-08
-	  15         7.518786374169    1.911e-08
-	  16         7.518786366650    5.663e-09
-	  17         7.518786366455    1.831e-09
-	  18         7.518786366546    6.117e-10
-	  19         7.518786366562    2.006e-10
+	   0         5.404411456861
+	   1         6.598966194486    2.821e-01
+	   2         7.515826438048    1.333e-01
+	   3         7.513416807840    2.023e-02
+	   4         7.518023894283    8.199e-03
+	   5         7.518815887120    1.834e-03
+	   6         7.518752499264    5.596e-04
+	   7         7.518801515795    2.130e-04
+	   8         7.518793906412    6.505e-05
+	   9         7.518781998009    1.891e-05
+	  10         7.518783115784    5.849e-06
+	  11         7.518785286222    2.143e-06
+	  12         7.518786425004    5.634e-07
+	  13         7.518786440307    1.849e-07
+	  14         7.518786345674    6.421e-08
+	  15         7.518786296709    1.911e-08
+	  16         7.518786289189    5.663e-09
+	  17         7.518786288994    1.831e-09
+	  18         7.518786289086    6.117e-10
+	  19         7.518786289101    2.006e-10
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 7.727e-11
 
 	Computing P_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.148089782335
-	   1         9.221847301701    2.084e-01
-	   2         9.779104903304    8.671e-02
-	   3         9.781648662390    1.702e-02
-	   4         9.781515789651    6.518e-03
-	   5         9.781904587039    1.664e-03
-	   6         9.781932239721    5.236e-04
-	   7         9.781984129523    1.921e-04
-	   8         9.781980996421    6.189e-05
-	   9         9.781976603859    1.602e-05
-	  10         9.781977497276    4.562e-06
-	  11         9.781977995612    1.615e-06
-	  12         9.781978248451    4.934e-07
-	  13         9.781978149684    1.549e-07
-	  14         9.781978106597    5.147e-08
-	  15         9.781978091732    1.614e-08
-	  16         9.781978091836    4.863e-09
-	  17         9.781978092016    1.703e-09
-	  18         9.781978091884    6.579e-10
-	  19         9.781978091890    1.960e-10
+	   0         8.148089790155
+	   1         9.221847307914    2.084e-01
+	   2         9.779104906294    8.671e-02
+	   3         9.781648665207    1.702e-02
+	   4         9.781515792444    6.518e-03
+	   5         9.781904589815    1.664e-03
+	   6         9.781932242495    5.236e-04
+	   7         9.781984132296    1.921e-04
+	   8         9.781980999194    6.189e-05
+	   9         9.781976606632    1.602e-05
+	  10         9.781977500048    4.562e-06
+	  11         9.781977998385    1.615e-06
+	  12         9.781978251224    4.934e-07
+	  13         9.781978152456    1.549e-07
+	  14         9.781978109370    5.147e-08
+	  15         9.781978094504    1.614e-08
+	  16         9.781978094608    4.863e-09
+	  17         9.781978094788    1.703e-09
+	  18         9.781978094657    6.579e-10
+	  19         9.781978094662    1.960e-10
 	-----------------------------------------
 	Converged P_Z-Perturbed Wfn to 6.891e-11
 
 	Computing L_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.306076632445
-	   1         5.427542169124    3.475e-01
-	   2         6.784160869607    2.603e-01
-	   3         7.225526839020    1.323e-01
-	   4         7.434835853653    6.019e-02
-	   5         7.450406844207    2.621e-02
-	   6         7.462308720709    1.252e-02
-	   7         7.466061496284    4.987e-03
-	   8         7.464335624596    2.351e-03
-	   9         7.464570345271    9.851e-04
-	  10         7.464580609603    5.391e-04
-	  11         7.464536119819    2.304e-04
-	  12         7.464350570316    9.836e-05
-	  13         7.464331292682    3.332e-05
-	  14         7.464350084147    1.192e-05
-	  15         7.464356772378    4.310e-06
-	  16         7.464358090118    1.778e-06
-	  17         7.464357412943    5.880e-07
-	  18         7.464357233308    2.086e-07
-	  19         7.464357244410    8.619e-08
-	  20         7.464357248604    3.107e-08
-	  21         7.464357247395    1.465e-08
-	  22         7.464357248584    6.353e-09
-	  23         7.464357253226    2.983e-09
-	  24         7.464357256943    1.428e-09
-	  25         7.464357259963    8.524e-10
-	  26         7.464357261675    3.889e-10
-	  27         7.464357261849    1.262e-10
+	   0         4.306076610237
+	   1         5.427542143419    3.475e-01
+	   2         6.784160841539    2.603e-01
+	   3         7.225526813839    1.323e-01
+	   4         7.434835830686    6.019e-02
+	   5         7.450406821669    2.621e-02
+	   6         7.462308698648    1.252e-02
+	   7         7.466061474225    4.987e-03
+	   8         7.464335602474    2.351e-03
+	   9         7.464570323166    9.851e-04
+	  10         7.464580587497    5.391e-04
+	  11         7.464536097714    2.304e-04
+	  12         7.464350548212    9.836e-05
+	  13         7.464331270579    3.332e-05
+	  14         7.464350062044    1.192e-05
+	  15         7.464356750274    4.310e-06
+	  16         7.464358068014    1.778e-06
+	  17         7.464357390839    5.880e-07
+	  18         7.464357211204    2.086e-07
+	  19         7.464357222307    8.619e-08
+	  20         7.464357226500    3.107e-08
+	  21         7.464357225291    1.465e-08
+	  22         7.464357226480    6.353e-09
+	  23         7.464357231122    2.983e-09
+	  24         7.464357234839    1.428e-09
+	  25         7.464357237859    8.524e-10
+	  26         7.464357239571    3.889e-10
+	  27         7.464357239745    1.262e-10
 	-----------------------------------------
 	Converged L_Z-Perturbed Wfn to 5.246e-11
 
 	Computing 1/2 <<Mu;L>>_(0.128) tensor.
 	Computing 1/2 <<P;L>>_(0.128) tensor.
 
-	DPD File2: Mu_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.027048397172827  0.015352704112429 -0.027966801428206 -0.165495930367099  0.113032293131079 -0.059172920617490  0.054022056893036  0.034114608641417  0.002886107104428
-    1  (  1)  0.197986831439807  0.163526093357892 -0.274966362484751  0.062421195117411  0.155967420230584  0.185920877152340  0.363704257460170  0.011868347502389  0.094068355200268
-    2  (  2)  0.001994785400509 -0.040665399791180 -0.057882185886799  0.076919743499300  0.080668892974906  0.050712045980973 -0.045932897295670  0.241652574031132  0.100470948740106
-    3  (  3) -0.134618148262870 -0.169475273759002 -0.112338313271068 -0.029804521352267  0.003944352681063  0.058729559824899 -0.233881451281742 -0.145241305284807  0.577534946997298
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.036861128446484  0.060248603479283 -0.005564054645453 -0.004146763273408  0.016591697834381 -0.007733796755325
-    1  (  1) -0.035918794247218 -0.084747615285920 -0.145084319526741 -0.032998082529710 -0.051841379309429  0.022806687326240
-    2  (  2) -0.084717069711908  0.396672019200134 -0.041908741386333 -0.023248477509422 -0.041530856301655  0.002269986110115
-    3  (  3)  0.038883132455574 -0.071756294192596  0.163991699742162 -0.069947324622934 -0.143620958659473 -0.040929670412834
-
-	File 101 DPD File2: Mu_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.052809051974611 -0.081154565641459  0.006856441672465  0.153404070250162  0.196852318183927 -0.080976239577634  0.074658786299150  0.007719515837141 -0.043614904957346
-    1  (  5)  0.345238819329888  0.019785726463408 -0.050847186825376 -0.077921925096032  0.068975151229659 -0.351671921498224  0.386754555295523 -0.290601454575730  0.053302927070672
-    2  (  6)  0.016264209978667 -0.328366425365533 -0.028951141350709 -0.018921421012293 -0.077573679759545 -0.021800407750167  0.192628950256551  0.357488541894078 -0.081608454670559
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002259895960631 -0.008421832675073 -0.029392100940116  0.031369993361730  0.013404147466831
-    1  (  5)  0.208575493629327  0.067711703634065 -0.203628183391135 -0.030033358486437  0.027351411878278
-    2  (  6) -0.187162949376747 -0.097599552501240 -0.071289729935510 -0.047614074934521 -0.125833431363021
-
-	DPD File2: Mu_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.083683703090339 -0.629036417459351  0.187768409616308
-    1  (  1) -0.172602425643759 -0.014265091859115 -0.090495237140442
-    2  (  2)  0.012410708512386  0.140259555625425 -0.033093031733629
-    3  (  3)  0.617332033723984 -0.177002119872801 -0.059198789591033
-
-	File 101 DPD File2: Mu_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.083984489601084 -0.171922407137234  0.012476891672991  0.618883655109570
-    1  (  5) -0.628194576289392 -0.014487461121762  0.141926484654468 -0.177049320083612
-    2  (  6)  0.185974040475234 -0.088119347704351 -0.035357029662085 -0.057155078540436
-
-	DPD File2: Mu_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.828696203592025 -0.451233677364964 -0.217492273801626  0.586304584205470 -0.198651498309132 -0.103892077288677 -0.006625290696853 -0.001819921442022 -0.094028994790127
-    1  (  1) -0.134105565072084 -0.143652464482426 -0.611995940113886  0.241008731857517 -0.051449178692584 -0.174330855034171  0.232749848820746  0.145661004271388 -0.128120727077505
-    2  (  2)  0.012063899957181 -0.029490668702565  0.163575298648468 -0.247038876502286 -0.158753040652801 -0.232668473612314 -0.114948417424730 -0.088613836090719 -0.022645502108504
-    3  (  3) -0.387197557412670 -0.007622232234767 -0.010218748368993 -0.204814602539347  0.014944145142201  0.002431343194739 -0.270127586345773  0.245262578145958  0.504586982816530
-    4  (  4) -0.460895290297202 -0.083413276687337 -0.199944470395538 -0.175480967267008 -0.163722513813610  0.040241151316098 -0.067825190846260 -0.310807009269909  0.577783712019049
-    5  (  5) -0.141670378431748  0.052086036202433 -0.250889435285257 -0.425040439955416  0.233847348075332 -0.158351487033986  0.178722313644596  0.245879694116802 -0.083555978624952
-    6  (  6) -0.130215129741091 -0.059015562328244  0.175413123904883  0.193335335494377  0.081298931206816  0.027166944052244 -0.479004702191582  0.042682340773738 -0.241453523690860
-    7  (  7) -0.128547673529086 -0.164220156281948  0.072921190130196 -0.418244944504053  0.302491231669016 -0.324010640072614 -0.075458878798693 -0.283018425704598  0.036415017864410
-    8  (  8) -0.062134266770614 -0.089654327070673  0.258681583169725  0.013233242093465  0.089010222721713  0.141925171219203  0.145726898819659 -0.025159117142780  0.043087625590561
-    9  (  9)  0.009157475877293  0.060303564275152  0.008729628589478 -0.116950978984904  0.076882806093440 -0.036383180924410  0.025483369510244  0.084185310301748 -0.015374203474542
-   10  ( 10)  0.047802155117035 -0.149112906046527  0.075801259346579 -0.048947777837302 -0.067507042894011 -0.106234452747565  0.028517793153314 -0.172545779173849  0.080208086539212
-   11  ( 11) -0.167486808508145 -0.138908523197938  0.283706274113969  0.091574703729164 -0.067077172850546 -0.025283786004213 -0.222327209021950 -0.000487203355974 -0.057945510499956
-   12  ( 12) -0.037231281930006  0.362748649100666  0.118756733555108  0.060033069634811  0.015289792490319 -0.066371796214512  0.063049993784234 -0.118284085626097 -0.151871766112428
-   13  ( 13)  0.015283336962664 -0.071148654690618  0.097868838236954 -0.110089289416517  0.125070464978759 -0.056834800649528 -0.036033401521028 -0.003983216078506 -0.062348090726013
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.129554454626645 -0.009474588080129 -0.145878009069340 -0.063534624713007 -0.014264450989202  0.066217032610968
-    1  (  1)  0.281753304154040  0.090565863681328  0.289775851087277  0.012154255844323 -0.002972094129563 -0.002349687671183
-    2  (  2) -0.119860879107323 -0.017641780651255 -0.056884026698647 -0.114243277051592 -0.081965225578515  0.047553858250442
-    3  (  3)  0.046051897739571 -0.068234524007742 -0.078832315651282  0.147716570125616  0.178529070541059  0.041892492825571
-    4  (  4)  0.224634415651606  0.054726588873862 -0.049348904717282 -0.010497565899220  0.270816650862660  0.056280914540891
-    5  (  5) -0.031024580647590 -0.167869422275837  0.089185539311376  0.032869876236856 -0.093569757739340 -0.005458274862047
-    6  (  6)  0.000981392608875 -0.078803302525778 -0.231661065523126  0.077973096019011 -0.062231529668081 -0.004237870062293
-    7  (  7) -0.058902381932974  0.114392724110640 -0.121932201798416 -0.061774560961000  0.018069277572558  0.046890882022827
-    8  (  8) -0.513410839175549 -0.085343806911986  0.027485231745675  0.006687146984676  0.194553865700676 -0.182125622987063
-    9  (  9) -0.072026715715937  0.003186347104678  0.005511418401201  0.002695559377571  0.031996063695793  0.027434309505846
-   10  ( 10) -0.012941082780342  0.102602875317609  0.011650753905957  0.003161188417901  0.051176261016026  0.036262081394577
-   11  ( 11) -0.072389598964860 -0.058864168002652 -0.028128390537061 -0.005943934144729 -0.000119126931267 -0.005492981656650
-   12  ( 12) -0.054636974740175 -0.008287355979314 -0.024569715170625 -0.016528220340787 -0.046477458022406 -0.050873095371919
-   13  ( 13)  0.233743037101684  0.059061280447733 -0.024586559461861  0.004543245586431 -0.015684709596020  0.012075090111966
-
-	File 101 DPD File2: Mu_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.826691217716273 -0.135952995986678  0.011483190853402 -0.387418549613132 -0.461392423434393 -0.145485395838477 -0.124983069633084 -0.128330208269710 -0.063846145512012
-    1  ( 15) -0.452846199342112 -0.142299396923846 -0.028873680579439 -0.006282104582323 -0.083434971591043  0.052286846958797 -0.060366664959448 -0.164381491855687 -0.091103104723665
-    2  ( 16) -0.216318168271836 -0.610394122458981  0.164687829144547 -0.011212326508078 -0.198690499654959 -0.249888026637277  0.173149134305467  0.071382973187058  0.260544315437109
-    3  ( 17)  0.584300313840742  0.240136635172586 -0.247504197547440 -0.203677759108949 -0.175664930669504 -0.423103759080422  0.191640258021663 -0.415453280544989  0.012404695910308
-    4  ( 18) -0.199046601234260 -0.050380875227390 -0.159053876876033  0.015277075663832 -0.162367358631649  0.232430660796134  0.082724825485615  0.299791975181979  0.088348234646987
-    5  ( 19) -0.104272480193007 -0.175241820294404 -0.233618498225201  0.003347139508098  0.039544446804631 -0.159217030916535  0.028729750234265 -0.323094060438359  0.140740059020568
-    6  ( 20) -0.009429700555618  0.234933209114364 -0.114393727276615 -0.268466551242383 -0.069016344623676  0.178511125207222 -0.480183500829793 -0.075907755374260  0.143021582340266
-    7  ( 21) -0.002871019980141  0.147322100081013 -0.089022269698270  0.243063067023217 -0.308863060976325  0.246226696688424  0.042991460237403 -0.286148618462202 -0.024663467570559
-    8  ( 22) -0.094480909031128 -0.129736715593916 -0.024604248218242  0.506975842783889  0.578523602334509 -0.083635854955803 -0.240378319056804  0.036574430518098  0.043361894806843
-    9  ( 23) -0.127469850231581  0.279775306347553 -0.119965256355608  0.046842433309940  0.224627106687645 -0.032678040821047  0.003106740012385 -0.057480210886726 -0.513625849978234
-   10  ( 24) -0.010113608772280  0.091491204350202 -0.018677713812760 -0.071589894306377  0.058565690503593 -0.167584249262607 -0.077210943763034  0.110209847874266 -0.083926459961230
-   11  ( 25) -0.144415369890515  0.288923500809327 -0.057020258893375 -0.078932024592243 -0.049197678741037  0.089025916916400 -0.231280649793149 -0.121731391324011  0.028617795572466
-   12  ( 26) -0.063356880757476  0.012359494559817 -0.113921394225926  0.147470818074126 -0.010507483518380  0.032942784833780  0.077682178518205 -0.061765741733595  0.006769386889262
-   13  ( 27) -0.013995995859800 -0.002559954171790 -0.081334364324019  0.177743396826763  0.270580272329641 -0.093513472630021 -0.062576452638165  0.017989699080157  0.194659969913094
-   14  ( 28)  0.066065732055799 -0.002211449695904  0.047581100788566  0.041756948476168  0.056034974532939 -0.005464174123526 -0.004247545547791  0.046945122816871 -0.182306395720765
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.009977414948991  0.047795726251349 -0.170257794893058 -0.037938003385798  0.014458354771735
-    1  ( 15)  0.061029814509221 -0.148838977933651 -0.138622311676044  0.363027561331653 -0.070814310121723
-    2  ( 16)  0.008874691507393  0.075936125697402  0.284555367553991  0.119192422675493  0.098638859969366
-    3  ( 17) -0.119112210975481 -0.049599126168817  0.092584517631524  0.060254228139763 -0.110664977910194
-    4  ( 18)  0.077868925237217 -0.066966521216813 -0.067808172209585  0.015338001788660  0.125516910271684
-    5  ( 19) -0.036382791915003 -0.106250802464449 -0.025901673388436 -0.066582385072615 -0.057303328993872
-    6  ( 20)  0.027021717761366  0.029104182126986 -0.222331616975881  0.063168783761157 -0.035714374282977
-    7  ( 21)  0.082539979364650 -0.172536666253103 -0.000669172457815 -0.118274514306553 -0.003844186581139
-    8  ( 22) -0.015061746200930  0.080414802790268 -0.057448999880623 -0.151717132243101 -0.062253352906387
-    9  ( 23) -0.071494404128242 -0.013120612580941 -0.073373439067110 -0.054797723574814  0.233375251535298
-   10  ( 24) -0.000029429641055  0.102291625448331 -0.059321314850514 -0.008317623517552  0.059027698391220
-   11  ( 25)  0.005765327972253  0.011614880462470 -0.028065205779369 -0.024579424954359 -0.024526575892733
-   12  ( 26)  0.002692253200082  0.003132810553211 -0.005932245634366 -0.016507700544142  0.004577653394693
-   13  ( 27)  0.031988350963214  0.051121558533183 -0.000221075294856 -0.046532133387957 -0.015677394532699
-   14  ( 28)  0.027397767162108  0.036259397253953 -0.005558504489882 -0.050917091935213  0.012016157844186
-
-	DPD File2: Mu_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.025406566159268  0.023298635287253 -0.022289171225281 -0.168859399546037  0.107903085343053 -0.060918366478026  0.050893116255270  0.027117697569600  0.006137025962381
-    1  (  1)  0.191093901631364  0.147230293879877 -0.245327925746496  0.051184636572256  0.145804688312181  0.177082412956716  0.335688365255302  0.014738825150512  0.084927582076377
-    2  (  2) -0.003155042580293 -0.027233271764860 -0.053208296453271  0.087116448441961  0.072613171875510  0.049776562479710 -0.037069643141426  0.221123482833241  0.094081632463615
-    3  (  3) -0.148081532987297 -0.143795935425655 -0.095653656284437 -0.040581516151424  0.007002536737363  0.053388570274401 -0.215379283048700 -0.136731549228503  0.551441205232222
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.030005353497125  0.050795632899782 -0.002892294664254 -0.003533356466287  0.015218907421680 -0.007301899744305
-    1  (  1) -0.023556562941518 -0.073830002725756 -0.128862604566188 -0.028671951610704 -0.047866625740652  0.021732276920370
-    2  (  2) -0.073223983264692  0.364347296120169 -0.036743687154481 -0.019261211454008 -0.037116539662741  0.000181223309972
-    3  (  3)  0.040361740685149 -0.065239876693051  0.146174618322834 -0.062411658986300 -0.126965052748134 -0.038245290086936
-
-	File 101 DPD File2: Mu_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.049420429939020 -0.071369144027861  0.010967892434703  0.154003952784752  0.199243445955842 -0.070560943504312  0.064246991121544  0.009741916757203 -0.037796040806489
-    1  (  5)  0.343138545087365  0.025580231196086 -0.051475570317848 -0.074170810753422  0.055679775667351 -0.335513778030016  0.361763562256478 -0.278312996717472  0.053462866737909
-    2  (  6)  0.009023834056191 -0.297316159210662 -0.029288421962258 -0.011782745518153 -0.070184214173438 -0.014572213441163  0.183342019819766  0.338840705353917 -0.064096544850433
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.003020372683713 -0.006869864196192 -0.023893125242991  0.027343480005917  0.011586872808644
-    1  (  5)  0.191183605646494  0.061813805162100 -0.180211660376411 -0.027158850194505  0.022115988544494
-    2  (  6) -0.170812182146008 -0.089183247070529 -0.060689118587739 -0.041496923999492 -0.115713673600506
-
-	DPD File2: Mu_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.033754103488904  0.007555372231008 -0.012636539412206 -0.059168089266189 -0.007696166024660  0.117635610027585 -0.032183947570515  0.074301250166332  0.005019432091403
-    1  (  1) -0.423755974394480  0.394319832811341  0.072147771285996 -0.012389712258359  0.176348210158568  0.099930502723386 -0.086701753728859  0.210493567935760 -0.033589866390245
-    2  (  2)  0.731556552635086 -0.976828857219025  0.033351783092618  0.123378208756534  0.157072652564139 -0.117469430301404  0.019850790679398  0.009097984935670  0.052536003980734
-    3  (  3) -0.047142053921200  0.198059791670330 -0.117104106550805  0.059612555708172 -0.051540989544482  0.120490618164713  0.186894293315771 -0.315632131525439 -0.008321584703138
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.004809884959149 -0.006374181554658  0.001349973408295 -0.006100975957460  0.011138127142432  0.022680627009235
-    1  (  1)  0.028102393649998  0.000289730093568  0.008262915835035 -0.124989537199237  0.066219531536918  0.018649107137634
-    2  (  2)  0.064127657438793 -0.065272286524580 -0.003581214395138 -0.076462588539111 -0.021447992337748 -0.132206773204054
-    3  (  3)  0.084986028536621 -0.498497698329473 -0.040822633530773 -0.043076722957163  0.013585564451261  0.027785129671115
-
-	File 101 DPD File2: Mu_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.016730543671402 -0.000493178350680  0.017302982722459 -0.256616062196450  0.185493094009100 -0.020593262646150 -0.009463629803292 -0.002961983098477  0.026859263160767
-    1  (  5) -0.075519353333223  0.118875850027739  0.079935827799390 -0.178710173458091 -0.108180669642193 -0.177149189778534 -0.083450989109747  0.113241594567945  0.031859913963448
-    2  (  6) -0.130570312068760  0.286100740965062  0.219486021249390 -0.104893438221523  0.173427403577016 -0.413345988897352 -0.212934040260182  0.179032987184766  0.025997492049908
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.021490597653360 -0.022287920558859  0.002597640544176 -0.020805616512876 -0.017185298510280
-    1  (  5) -0.023718660102006  0.015749627862868  0.008406851616741 -0.192275139478185  0.036883303753882
-    2  (  6)  0.028766539135724 -0.272291164468312 -0.017419741916350  0.092820056045692  0.043867791725602
-
-	DPD File2: Mu_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  1.239338426392564 -0.063574189159419 -0.037138721492623
-    1  (  1)  0.637136254562851  0.563345834986113  1.010359356370541
-    2  (  2) -1.018244537475946  0.319334895202255  0.761891810673220
-    3  (  3)  0.045207421457437 -1.211415382676948  0.547663980563646
-
-	File 101 DPD File2: Mu_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  1.240077996488429  0.636087166048540 -1.017448666598683  0.045094757983791
-    1  (  5) -0.063119844830318  0.559674519771415  0.326877163045745 -1.214495217986866
-    2  (  6) -0.036017040682083  1.005430771836738  0.769694801723881  0.546245988666419
-
-	DPD File2: Mu_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  1.840037313836020  0.879719351228572  0.280425530485763  0.209457510590770 -0.115971007140231 -0.005865677404341 -0.092534287825665  0.016878612757743 -0.000554227822991
-    1  (  1)  0.406955291511109 -0.250354570304778  1.752817026082590  0.218264636938841 -0.014952601145219  0.085173209047615 -0.020235302962366  0.502753766000685  0.012614402487781
-    2  (  2) -0.011947654987322 -0.087288086334953 -0.224335908490773 -0.261126688019980 -0.841762463275376 -0.627828907554534  0.172051366688234  0.617244504994475  0.119309262733021
-    3  (  3)  0.811182010574067 -0.188300264656061  0.222401504654110 -0.118806305641431  0.529562874381598 -1.235458279793789  0.515406670549199 -0.727585984163455 -0.017311451334544
-    4  (  4) -0.382877178063333  0.342160015383575  0.036035220830207 -1.515969153946585  0.125466254724712  0.736754668202047  0.136012972713827  0.102461498470004  0.013411116743442
-    5  (  5) -0.056666348930366  0.399251661739627 -0.011422755469852 -0.698119094644981 -1.282954629697895  0.508762695513963 -0.451449634220948 -0.904106936880537  0.596672635982258
-    6  (  6) -0.005527213521809  0.206039689350583 -0.144483993576148 -0.121247601463421 -0.485305002415323  0.548554310120049  1.475357051064366 -0.106842364972141 -0.027446822634470
-    7  (  7)  0.133565351861769  0.328960786484755  0.162326353593274  0.054193688082147  0.478136828850907  0.570702306118600 -0.024903308876874  0.585193831441818  0.835813795954640
-    8  (  8)  0.031082134068872 -0.063496391996010 -0.272771555688820 -0.132864368300259 -0.103453213303616  0.119428117809223 -0.197405807539525  0.153621429574163 -0.347696082487505
-    9  (  9) -0.117648127967179  0.675674455344672  0.057144753223871  0.137494275224088 -0.007401643263736 -0.153445689840736 -0.039660467466461 -0.125410015238965 -0.348925711100216
-   10  ( 10) -0.183218900015280 -0.105460278770619  0.367791083908301 -0.008056255919995  0.178869825089236 -0.183120759227084 -0.020135495201915  0.515209425517336 -0.117079814088000
-   11  ( 11) -0.007464482549715  0.021032905836050 -0.001689959480439 -0.009511863938863 -0.028294702186542 -0.022246363439352  0.137498694249546 -0.039431687760892 -0.108598715660792
-   12  ( 12) -0.123943400580450 -0.111733854742263  0.047511096154227  0.255974383794788  0.005125598158543  0.148074286896914  0.114005285118611 -0.069660405917942  0.028473614618333
-   13  ( 13) -0.017139778903114  0.000597229894230 -0.092098701078466 -0.096822642158100 -0.041570201760717  0.197811128787409 -0.008675665762269  0.009875145380093 -0.053724977580929
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.015271060368590  0.055897468396679  0.022597241061105 -0.097746276200326  0.101308246517630  0.083130674158184
-    1  (  1) -0.170077841267587 -0.306278912948529 -0.015343223805456  0.140911077413699 -0.086769343161678 -0.004428610402275
-    2  (  2)  0.122266526205533 -0.173859131387549 -0.008833802902653 -0.258485979502035  0.008602351060332 -0.030798632969086
-    3  (  3)  0.115160682049786  0.000168306649340 -0.007959105138980 -0.065254436598696 -0.027276553714500  0.039309215133697
-    4  (  4)  0.041448801667008 -0.223438700330986  0.042071183596141 -0.028071659294627  0.027228579441665 -0.074898825540824
-    5  (  5) -0.019058857013510  0.170849130048803 -0.086743087770944  0.110180684067332  0.041911344191976 -0.107077437297843
-    6  (  6)  0.021255870699759  0.392230842819920  0.124666046290611  0.015546514857889  0.011543222367899 -0.015718913239240
-    7  (  7)  0.300617707044268  0.028511951577123  0.099451065409571 -0.057624703208728  0.020680186596793  0.041210772734416
-    8  (  8)  1.560902789686190  0.259171353520895 -0.164601436985075 -0.034972573255346 -0.150377449452613 -0.038200704783867
-    9  (  9)  0.094514443562177 -0.031271005532013 -0.062263725106321 -0.058838957873498  0.760182137090868  0.950337382630766
-   10  ( 10) -0.066833413223948  0.207007631435691 -0.021103846805201  1.235346069959520 -0.166059589963498  0.166191905898816
-   11  ( 11)  0.166612835901501 -0.057714789963814  1.335141389249462  0.048926720734315 -0.084810123443347  0.094069041404757
-   12  ( 12)  0.208438787230328 -1.201605996005697 -0.134583025189360  0.366858420103389 -0.092230833884388  0.010845623464668
-   13  ( 13) -0.191515363269101 -0.044444589953201  0.113534652068488  0.222935332874317  0.996666807879559 -0.918946475319682
-
-	File 101 DPD File2: Mu_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  1.838261938125953  0.411783579911082 -0.011222177479730  0.801199436588318 -0.375306180891601 -0.060253817938356 -0.006525724615655  0.129557857631930  0.036205801526960
-    1  ( 15)  0.881558694801301 -0.253494731429581 -0.085421228751772 -0.179689412714139  0.333542664377779  0.397899463382726  0.204757675416354  0.337390689793974 -0.068236018271236
-    2  ( 16)  0.280699466651638  1.751444070796586 -0.225749579482049  0.222724309443776  0.035674220851777 -0.008396081497684 -0.143282250648261  0.160643678305862 -0.273482677804852
-    3  ( 17)  0.209621101203040  0.218341762403868 -0.261721827317418 -0.119292443469067 -1.513373925140781 -0.698058616179597 -0.120912446345617  0.053177597646066 -0.132398408764311
-    4  ( 18) -0.117749589449745 -0.014290802057305 -0.842585912658373  0.528480212857232  0.125620436909715 -1.282510147470767 -0.485022216108444  0.477099752728403 -0.104196524597516
-    5  ( 19) -0.007044544158153  0.085833731063079 -0.626602352540001 -1.234607574211689  0.736231003373149  0.506584871133556  0.547680268232320  0.572569559178554  0.118655251440909
-    6  ( 20) -0.091286539818598 -0.021685756074756  0.171006984274394  0.515577034801528  0.135942818875198 -0.450672680612861  1.476397473903694 -0.025200125211324 -0.196552429073982
-    7  ( 21)  0.014617007475273  0.504140575926305  0.617828254758316 -0.727391401463796  0.101524085740282 -0.903538681928281 -0.107568617019622  0.584678825668100  0.151735736187589
-    8  ( 22) -0.000237823420664  0.012124384227592  0.118807977471402 -0.017974774238044  0.014229470507378  0.597624885291520 -0.026926427408390  0.834871784840588 -0.347391080813467
-    9  ( 23) -0.016265284587164 -0.168715787569770  0.122968815716393  0.113284198302450  0.042943290149452 -0.021309190261859  0.020477672429448  0.301304618606591  1.561269376414732
-   10  ( 24)  0.055165623705948 -0.304174565565627 -0.172047420652933 -0.001660031801304 -0.223923016186918  0.170793818371478  0.390519343250458  0.028524302133373  0.258484158546987
-   11  ( 25)  0.022516344496095 -0.015268625075761 -0.008789463144050 -0.007966710860511  0.041912769223181 -0.086577370868099  0.124614837586422  0.099373675936837 -0.164728190655413
-   12  ( 26) -0.096631683724329  0.140629711782460 -0.257993906888811 -0.065720412418661 -0.028201117626138  0.110255501857704  0.015355688312895 -0.057301747761398 -0.034361742521519
-   13  ( 27)  0.100849821365822 -0.086662374683482  0.008639345451765 -0.026546017676244  0.026660167742260  0.041687326988987  0.011443920803067  0.021038625210724 -0.150878061048130
-   14  ( 28)  0.083365492537661 -0.004663028443678 -0.030268841557525  0.040380114857265 -0.076010028857183 -0.107569353616213 -0.016046780201203  0.042417265806974 -0.038629597007140
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.124737520970567 -0.186432244849434 -0.007556173934213 -0.125048458790314 -0.016552020209549
-    1  ( 15)  0.684938290376393 -0.103735702852444  0.021157182854187 -0.111849169918717  0.000598582694869
-    2  ( 16)  0.056865870871391  0.369391836124585 -0.001636395160685  0.047382415225486 -0.092511884311165
-    3  ( 17)  0.136934156518159 -0.009055225169970 -0.009590382757559  0.257430334272387 -0.097052552691910
-    4  ( 18) -0.008312109924423  0.179598643669996 -0.028244191820460  0.004116010022868 -0.041623947269660
-    5  ( 19) -0.152106396286801 -0.183914202125923 -0.022266967951892  0.148019441595633  0.198105007663693
-    6  ( 20) -0.039829799204161 -0.019552759743993  0.137602535405962  0.113713715404123 -0.008789545170784
-    7  ( 21) -0.125502178629739  0.515709894296467 -0.039509503457082 -0.069986828128539  0.009910155465828
-    8  ( 22) -0.349425567476830 -0.116835672927993 -0.108584428663162  0.028578302642485 -0.053883081615012
-    9  ( 23)  0.094338880407330 -0.067969707543137  0.166597413367391  0.208167474360311 -0.191318590057359
-   10  ( 24) -0.031516356589242  0.206892773401202 -0.057842868800066 -1.201944585655949 -0.044330968677763
-   11  ( 25) -0.062291263803427 -0.020994462489648  1.335136332915063 -0.134637529250241  0.113529324930304
-   12  ( 26) -0.058655360066673  1.235296326813700  0.048926809978680  0.366850373682241  0.222951200118475
-   13  ( 27)  0.760531019832537 -0.165992770496603 -0.084811358078730 -0.092272088807521  0.996709535509256
-   14  ( 28)  0.951452405735214  0.166207367805620  0.094073590713281  0.010839332616852 -0.918866261119885
-
-	DPD File2: Mu_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.062424152487093  0.006340337268482 -0.007129573994951 -0.068124969445001 -0.016536648970737  0.122839654890139 -0.029124555648029  0.069524525927009  0.016624796588470
-    1  (  1) -0.403752025492204  0.324343055871707  0.076420140656786 -0.003202781255002  0.185946708759860  0.105883952933980 -0.081054655409652  0.184341159829675 -0.032915937518265
-    2  (  2)  0.661672748869100 -0.861372726396764  0.035408787225401  0.124470554040362  0.167515771764057 -0.112285700010499  0.015950867409511  0.001232083495723  0.035574976981523
-    3  (  3) -0.034421465673628  0.179830504979566 -0.111544513847215  0.024097913531803 -0.030238246207055  0.104793216722198  0.173773469173217 -0.303193060944995 -0.006513662906792
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.009334134343137 -0.006326528083054  0.001276536883825 -0.004159187336468  0.009674793406368  0.018903850771847
-    1  (  1)  0.023692877349552 -0.000748233659147  0.007572933338662 -0.110618865809947  0.058982973244648  0.020804020406208
-    2  (  2)  0.056439835248463 -0.059263779798462 -0.002854238464665 -0.070581535158609 -0.021806829149510 -0.125806190045722
-    3  (  3)  0.082847328899303 -0.459387875765944 -0.034524528441236 -0.040614390362782  0.013723967190574  0.025955752093967
-
-	File 101 DPD File2: Mu_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.017603663965705  0.003174083877041  0.014339522059496 -0.266660818847198  0.199602064605257  0.004780839495062  0.001108522960745 -0.004965069967999  0.030862088780690
-    1  (  5) -0.088113575807603  0.114873319929461  0.063166154639253 -0.188098449929865 -0.135702241550834 -0.170113296422216 -0.072240153498818  0.102270166350793  0.024891651267320
-    2  (  6) -0.139298038265852  0.270556959145684  0.173447642648828 -0.086085492397594  0.170302022343653 -0.397018505467907 -0.208262454149272  0.170239716749086  0.014885093941277
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.007377491418509 -0.019432502966035  0.002111593502676 -0.017924326928228 -0.015562648892606
-    1  (  5) -0.015992089252138  0.016902070355736  0.006260130611804 -0.170730300914524  0.032158624092886
-    2  (  6)  0.030768942376426 -0.242871623531964 -0.014807837846673  0.086333556064428  0.038627030320013
-
-	DPD File2: Mu_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.055004130528946 -0.064555152924841  0.195953381452965 -0.041248493442142 -0.011229686954300 -0.030149441399628 -0.052245051060564 -0.006640144599606 -0.060816046841284
-    1  (  1)  0.618380750428757 -0.527850820486333 -0.215416501526368 -0.157035437852335 -0.069798458055575  0.063297476988332 -0.224803808736996 -0.036770088842034 -0.093292414352534
-    2  (  2)  0.089963765084418  0.016694193770404 -0.049894217008593 -0.224500363707256  0.100545586964082 -0.339808932191863 -0.300486601867879  0.103978674976873  0.003854593956757
-    3  (  3) -0.017912540048753  0.240051544243958  0.016875920304164 -0.019658112939729  0.000950481982654  0.139486308126505 -0.307526295570431 -0.245045411518121  0.038982174577009
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004110228157231 -0.053483299255732  0.001461399823215 -0.009996127162103  0.040844890740135
-    1  (  1)  0.010356156241345  0.045196494922430  0.123149462820863 -0.009608799088997 -0.092775098434661
-    2  (  2)  0.068261626747973 -0.266621644549134  0.090983468413283 -0.007824999548536 -0.015479677470817
-    3  (  3)  0.102991688132870  0.095940846021793  0.235195882815376  0.030438278902471  0.100331913658044
-
-	File 101 DPD File2: Mu_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.110154713182343  0.055002400372953 -0.190701615216833 -0.008587073582699 -0.137456634335766 -0.102685174670731 -0.038575707285854  0.049077773971977  0.038775520895292
-    1  (  5)  0.266426121027506  0.201904502326533 -0.404472747758134  0.112355452471773  0.244543383226856  0.203488255104151  0.093346083645080  0.046662175787456  0.162564534029677
-    2  (  6)  0.310200496188946  0.275860886552205 -0.334362481107594  0.111323203472945  0.107269573355600 -0.015396506114788 -0.485347827879795 -0.115211810589159 -0.189399381435021
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.089155448700903 -0.010182782827209  0.015536223734562  0.027148068645677  0.019304531549287 -0.012170541866764
-    1  (  5) -0.076359104734661  0.072719944842760 -0.105706045014198 -0.076791075691679 -0.095250630845942  0.044053081319363
-    2  (  6) -0.023401555353274 -0.060789750776477  0.233844071184097 -0.060200608251925 -0.022972229728472  0.078966373824930
-
-	DPD File2: Mu_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0) -0.134471189914803 -0.662148890607048 -0.267935017575730 -0.078917514513460
-    1  (  1) -0.664666296280562 -0.209284548524716  0.147471335927792  0.068908464210939
-    2  (  2) -0.267133357554530  0.148425589032828  0.187317600183912  0.001813046044159
-    3  (  3) -0.077770523321569  0.066603013382230  0.004062963757785  0.013912154355475
-
-	File 101 DPD File2: Mu_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4) -0.274832594142428 -0.278242095473143 -0.671654031875754
-    1  (  5) -0.278497835849508 -0.012090615801272 -0.010590436880494
-    2  (  6) -0.670432937480178 -0.009657206552315  0.097732020822376
-
-	DPD File2: Mu_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -1.959652942443780 -0.408123540990243 -0.490401242893299  0.038728621520496 -0.077955848847628 -0.487356522820254 -0.107431644874248 -0.396098714695084 -0.237559092067117
-    1  (  1) -0.405287391714683 -1.324235802978493  0.174918475291447  0.249090287653660 -0.197882092902579 -0.317613214061072 -0.251158650058355 -0.030182263573247  0.632878894923950
-    2  (  2) -0.488736302148035  0.174537834224317  0.686802536456231  0.342698519251872 -0.009978504113557  0.483630952562764  0.287674546486731  0.302838065991480 -0.272076060462856
-    3  (  3)  0.037680750737500  0.250810426061315  0.345041313473359 -0.288921951476600  0.242065062503934 -0.302245036763640 -0.510968388336981  0.184732147309200 -0.217019518794602
-    4  (  4) -0.076474970303988 -0.199548329885190 -0.011318561816348  0.242358447532560 -0.131824013348934  0.385851084327112 -0.241519487669974 -0.375192533769848  0.062578612484494
-    5  (  5) -0.485852483644543 -0.318979279826184  0.484066634054750 -0.298903806636467  0.382610997595699 -0.557142551551020  0.333197792506285  0.111813059498605  0.019832042071129
-    6  (  6) -0.104965309325025 -0.251905850556084  0.289646446290464 -0.510970312004153 -0.243416542879353  0.333477452717118 -0.859910604691225 -0.040221092426954  0.015978091057726
-    7  (  7) -0.396757752805925 -0.028569556569604  0.303650553602711  0.181375877282891 -0.373315055683876  0.109082013989902 -0.042394080453042 -0.424453142550918 -0.165367340666656
-    8  (  8) -0.232577777741232  0.628634227275953 -0.273406824008824 -0.217896152147594  0.062014351622307  0.020854775528038  0.015643896352917 -0.165522517641184 -1.139943298313989
-    9  (  9)  0.005610937945933  0.056039777778849  0.162949812655036 -0.082447741116097  0.072872155292264 -0.108705186895719 -0.023485984983778  0.044747716582668 -0.147251711462478
-   10  ( 10) -0.006823140107367  0.054329320069732 -0.040599884216487  0.341771214963506 -0.179762239229163  0.323458315199162  0.128244534804048 -0.274646157470800 -0.052523948902062
-   11  ( 11)  0.095363270852437 -0.102111548052236  0.068440604856687 -0.163728434991873 -0.155636086206937  0.243236788520030 -0.456650415619116 -0.005317873090518 -0.049821847163774
-   12  ( 12) -0.031682366649886  0.049375813732146 -0.071598146136873  0.132087989350725 -0.108611785503928  0.096654485319462  0.079499450609138 -0.086710987294923 -0.054539911300598
-   13  ( 13) -0.055056204843758  0.125842892734663 -0.045965574233073 -0.019980233431093 -0.072417713533459 -0.032557591655033 -0.014098057282134 -0.073500277877371  0.566229267143538
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.006807523812671 -0.007359544445531  0.096092504153619 -0.031848084858648 -0.055774202583708
-    1  (  1)  0.055013732726191  0.054716327776958 -0.101499825301692  0.049505806374070  0.126450547773127
-    2  (  2)  0.163059205524790 -0.041368873195638  0.069581455391968 -0.071597196814435 -0.045866052289024
-    3  (  3) -0.081105673316398  0.339429555795348 -0.164728153281382  0.131959969253045 -0.019695233736278
-    4  (  4)  0.071393373323251 -0.177479193977683 -0.155859184096407 -0.108539407237796 -0.072773970199488
-    5  (  5) -0.105603312027129  0.324542336401662  0.243446189989531  0.096679109324856 -0.032469296684766
-    6  (  6) -0.022598073115881  0.128545265383103 -0.457503820066558  0.079428257830674 -0.014293355797493
-    7  (  7)  0.043846313801253 -0.277398721165106 -0.005217801503343 -0.086814141747281 -0.073528025025910
-    8  (  8) -0.147650558268387 -0.051824889076812 -0.049479655393433 -0.054623458164613  0.565538504818440
-    9  (  9)  0.072040995852218  0.045487481962658  0.010267944428546  0.009607395555640  0.026537979807784
-   10  ( 10)  0.047954867964362 -0.139047713462617 -0.006984668952712 -0.101926998578260 -0.021981627684010
-   11  ( 11)  0.010232694230356 -0.006895180971719 -0.093446496399543 -0.006456318213145  0.037416385389791
-   12  ( 12)  0.009698093592920 -0.101910194006554 -0.006447087192563  0.055515253372902  0.004586695976630
-   13  ( 13)  0.026517968066884 -0.022107111803180  0.037498264997396  0.004566515562682 -0.064482567844114
-
-	File 101 DPD File2: Mu_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14) -1.532087830445926 -0.788053684507392 -0.217638660833197  0.182558741691964  0.602280863166455 -0.200093874423138  0.029411465990867 -0.008618445566170 -0.142345996690868
-    1  ( 15) -0.793296872955545 -0.320033246707737 -0.162598983453527  0.058726799927110  0.020874328230438 -0.223415347506574  0.107419197066742 -0.353928058607362 -0.096059895093397
-    2  ( 16) -0.212771964615612 -0.165330330084882 -1.296138478685232  0.042119030621194  0.273634362778554 -0.438879796184691 -0.121813090338313  0.097180424591982 -0.140937625632113
-    3  ( 17)  0.179954421761081  0.058841120611665  0.044127192643470  0.293105599691600  0.349356889255942  0.303438248960065  0.077097854674844  0.005877107377562  0.014045104815526
-    4  ( 18)  0.599465706538920  0.022235571311357  0.273958683710447  0.351252283345913  0.210835219542339  0.044587084446442 -0.439010194739272 -0.491004374374813 -0.399383596132888
-    5  ( 19) -0.200414127659350 -0.221453682461015 -0.440132543486983  0.305750504454767  0.044859549976743 -0.117462872288654 -0.191542018731891 -0.319736100846566 -0.359370858025094
-    6  ( 20)  0.032162128695933  0.105939422719644 -0.123876353231712  0.078981740804684 -0.440632986498194 -0.189872412133810 -1.110683989664156  0.246909463040471  0.255271007021977
-    7  ( 21) -0.008289240579773 -0.354493597907539  0.096614444500186  0.006342901541664 -0.491270269564264 -0.319008747231223  0.247402781824619 -1.005041339195380  0.329310525935830
-    8  ( 22) -0.142958112264996 -0.097022080198495 -0.141105576353547  0.015162721103223 -0.401346216617333 -0.359442000621317  0.255249867150800  0.329100137101793  0.052130295868829
-    9  ( 23) -0.219989065338878 -0.250001442147006  0.576446348090269  0.098959674934949 -0.020568114883162  0.097513800290254 -0.059902955979327  0.014734527182880  0.155046520232648
-   10  ( 24) -0.078950494593626  0.108193141540531  0.027256154056543  0.046487728419779  0.091306743921577  0.113368151014402 -0.170234458952828  0.302098295081586 -0.032847707902243
-   11  ( 25)  0.043326744763780  0.032363389765351 -0.179596320194099  0.107314642599215 -0.187556761662743 -0.097228134814891 -0.510755068213776 -0.080036249779472  0.081235508191006
-   12  ( 26) -0.068197976687722  0.217296898139221  0.162613838977633  0.182156526110652 -0.078640971353133 -0.138388418091556  0.046099139451725 -0.318339562821704 -0.094298996209138
-   13  ( 27)  0.012948053108673 -0.163156717293819  0.064963474439184  0.076423090035566 -0.116362948606428 -0.057051341664290  0.002572557283580  0.275506911043523 -0.101255941425000
-   14  ( 28)  0.072512090956400  0.116063474699758 -0.039414548907200 -0.060057426600154 -0.063414940197114 -0.039930823902922 -0.007406649424353  0.061654502657618  0.127196073451667
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.223472856125742 -0.079380673671635  0.044417376178946 -0.069445497122295  0.011729893484114  0.073549727859122
-    1  ( 15) -0.252084320126442  0.107740778862871  0.032072824768773  0.217703433408601 -0.162976180926073  0.115649024793372
-    2  ( 16)  0.579843117211313  0.028377214598813 -0.180834874538440  0.163175611888439  0.065411291321188 -0.039948698403888
-    3  ( 17)  0.098340901264216  0.045586420114884  0.108734472654534  0.182606429756644  0.076964420454008 -0.060236205606042
-    4  ( 18) -0.021650833258616  0.091327714077226 -0.188512569777461 -0.078662641752143 -0.116896916465247 -0.063655160079575
-    5  ( 19)  0.097171540487668  0.112970498499516 -0.096626702541390 -0.138712839207192 -0.057497370879087 -0.039673289391880
-    6  ( 20) -0.058059330868561 -0.170134824581430 -0.511529953088092  0.046149842871006  0.002603003860136 -0.007423573856034
-    7  ( 21)  0.014906052393179  0.302176683660248 -0.080527272431049 -0.318411101353105  0.275449773210268  0.061692765696993
-    8  ( 22)  0.155151887415096 -0.033185457460157  0.080998651044629 -0.094073422594697 -0.101041326107855  0.127067437732620
-    9  ( 23) -1.153509668783001 -0.223849781346618  0.084925914727116 -0.000154347649926  0.401132279454500 -0.346054712948586
-   10  ( 24) -0.223987599199814 -0.015012978057576 -0.013160266828997  0.067286208756079 -0.009874035128650 -0.084312333173046
-   11  ( 25)  0.084246135638493 -0.012978110751430 -0.099616699052767  0.005046001107463 -0.012239544441460  0.023063802192487
-   12  ( 26)  0.000203295323483  0.067424132179953  0.005012434752789  0.014687484558096 -0.012600853140958 -0.022021985861034
-   13  ( 27)  0.401487062547390 -0.009674045105948 -0.012249675470802 -0.012688275811242 -0.008212565394913  0.091176394188195
-   14  ( 28) -0.346417777816096 -0.084403131840825  0.023147564238642 -0.022062212401564  0.091088265445589  0.040127117548266
-
-	DPD File2: Mu_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.056215172927916 -0.054500121508322  0.201919258778010 -0.031077763805510 -0.011710544286436 -0.013075909022680 -0.042346948343635 -0.000671828610738 -0.052291650154205
-    1  (  1)  0.580185867754678 -0.459972750936400 -0.203225406348613 -0.146383812909082 -0.059047716306621  0.052226207773922 -0.210466211081215 -0.032187368805259 -0.063260160660422
-    2  (  2)  0.093393210560188  0.013367711284029 -0.072500427251494 -0.188901437088884  0.080233215060989 -0.320461366545765 -0.281774577854691  0.095754687109263  0.009993944043533
-    3  (  3) -0.011006044771994  0.212772034365604  0.010016676236493 -0.008866166718285  0.020319326728203  0.122354060320048 -0.286521493894349 -0.227705676000915  0.024617045170947
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.004784997819657 -0.045646414220092  0.000336480966462 -0.008910135153260  0.037229969984587
-    1  (  1)  0.012654368887265  0.038726053143637  0.110122850812823 -0.008163616619222 -0.088473965567598
-    2  (  2)  0.059858161338620 -0.242276960593359  0.080687948077563 -0.004783379620358 -0.010585827086864
-    3  (  3)  0.093190009488007  0.087625847683856  0.210676227172290  0.029310964936832  0.092669936157259
-
-	File 101 DPD File2: Mu_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.095387847271100  0.063707280070084 -0.166137683411008 -0.019021592855565 -0.149973759870001 -0.101204344306762 -0.031472575282315  0.053498473859926  0.042967624438521
-    1  (  5)  0.255913379011736  0.182084006874274 -0.358054748488889  0.117938321574845  0.215767331745706  0.198255948304019  0.082288393877684  0.046112468588943  0.145174585882671
-    2  (  6)  0.310255025939172  0.238379636947246 -0.293832074000714  0.096225461031061  0.113893650091632 -0.010350379528905 -0.451016712887586 -0.111857486176803 -0.191795343976766
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.073847869190148 -0.008654741710575  0.012693286782788  0.023668684158666  0.017789448486280 -0.009288640287720
-    1  (  5) -0.053437181209244  0.073043482844143 -0.095008049754430 -0.066955827698789 -0.087649070811154  0.040223508017977
-    2  (  6) -0.005363324155257 -0.054894453356376  0.206318087760035 -0.056446189403617 -0.025451704179473  0.074272027058522
-
-	DPD File2: P*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.031889834472336  0.023590247545076 -0.035886092938494 -0.337391549003445  0.230489171708387 -0.118250549009017  0.096738323803454  0.039671560183731  0.017417453829651
-    1  (  1)  0.115559689950866  0.104792776753397 -0.247387033439083  0.112934750234786  0.158582865358366  0.232113447678658  0.480247139929458  0.012693240726205  0.113321221450465
-    2  (  2)  0.001131177703134 -0.023211512192057 -0.030343999116351  0.117346790992592  0.046608524859420  0.060486959905986 -0.074531488676303  0.295475469192925  0.122604475218833
-    3  (  3) -0.102873669309261 -0.075244498837150 -0.074367347068194  0.000375638324722  0.045758296871777  0.020335443185058 -0.271454123369342 -0.176011970959425  0.750611882783894
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.122947556659096  0.146970007635756 -0.023111743424029 -0.020418246285807  0.062142160948575 -0.033255482549981
-    1  (  1) -0.076207579709840 -0.192925577520692 -0.390086469193835 -0.115462079698591 -0.197836673375331  0.137907169648961
-    2  (  2) -0.134390969563588  0.739254686327757 -0.083356064140144 -0.116141777662631 -0.130510808086193  0.001880247368517
-    3  (  3)  0.051764093089206 -0.135387754341373  0.415703352371020 -0.190964584562673 -0.522938232986926 -0.150011651631347
-
-	File 101 DPD File2: P*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.042351800770033 -0.112741680738692 -0.014470487647282  0.277801496926584  0.385189435070480 -0.134005161803845  0.094379155611825  0.020287570327628 -0.140758439500600
-    1  (  5)  0.196508002077728  0.014780858316181 -0.028613533348628 -0.116961168140523  0.038035850661534 -0.390665250154868  0.463278907259435 -0.352765994784243  0.083583027846786
-    2  (  6) -0.019055458304079 -0.247824312911431 -0.054496185583040 -0.066069201280654 -0.118739286724245 -0.063124976744210  0.269457866868641  0.446911004649514 -0.141690470973354
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.002049190521844 -0.018587871477028 -0.105121590063686  0.083095581891635  0.044923327383534
-    1  (  5)  0.420262633593224  0.134089318231829 -0.513153889470778 -0.061105931999993  0.094073822513972
-    2  (  6) -0.353380729793659 -0.186026023919396 -0.193632728665932 -0.115179143357212 -0.434468868354740
-
-	DPD File2: P*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.018374399490839 -0.416488593986887  0.155494936834365
-    1  (  1)  0.047368311899160 -0.000904478695801 -0.015838423501069
-    2  (  2) -0.012225877770952  0.003811464066523 -0.009363085606127
-    3  (  3) -0.381174834177280  0.034408333237667  0.006712264462944
-
-	File 101 DPD File2: P*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019805821822076 -0.046970692298440  0.012276706190185  0.380984477985130
-    1  (  5)  0.412939155992870 -0.002194461931656 -0.004258479838447 -0.030533770738735
-    2  (  6) -0.154188085677647  0.014422732946647  0.008150645104198 -0.004478771817897
-
-	DPD File2: P*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.038950465210408 -0.039866103962419 -0.115245354720040 -0.019880757349447  0.101323212958542 -0.044640126253266  0.129219338527502 -0.020955390039210  0.007693672741339
-    1  (  1)  0.067773602054647  0.069283024949896 -0.045139676547490 -0.092449762069831  0.063419247150338  0.006282596580831  0.492661875976107  0.179789795112656 -0.023646534538890
-    2  (  2) -0.005352314371011  0.023691171688012 -0.168760303436833  0.035584759327957  0.098211154887201  0.052999235803435  0.267185888610491  0.067710312606089  0.133811638261923
-    3  (  3)  0.005028835575224 -0.075710576153026 -0.130936364707588  0.013148449648183  0.082341449946899 -0.058281787875764  0.148402947291289 -0.019587692846107 -0.265997802208991
-    4  (  4) -0.042953075620737 -0.030493487545427 -0.117329091588246  0.053817176197377  0.040927603944597 -0.031345620246767  0.084728650716813  0.096010530091888 -0.389039208842110
-    5  (  5)  0.147577168335343 -0.025728183041877  0.257869613090358 -0.341457170976807 -0.032938052439995 -0.198776430410242 -0.028905583055758  0.151472913148495 -0.076896803027349
-    6  (  6) -0.033968966510016 -0.063980358522411 -0.416860320865971  0.162964164077810  0.210735076964306  0.174795271465028 -0.081522253852315 -0.108767294311016  0.317254235279369
-    7  (  7)  0.041696032362294  0.119804780003616 -0.084367698623615 -0.345939032777489  0.297348524344951 -0.115684273678453 -0.157252021772075 -0.234703179592689  0.035619581257838
-    8  (  8)  0.096236509574225  0.089744247655453 -0.368376180782391  0.147020988065185 -0.073817404082631 -0.134077968971220 -0.072728534570006  0.043556315720552  0.010655784346597
-    9  (  9) -0.003143315235121 -0.093361249518207 -0.037863435444635  0.438671101107247 -0.422734146793725  0.161824914084117  0.027097474419921 -0.004646312280086 -0.023963694330478
-   10  ( 10) -0.063765122804891  0.220080848656726 -0.093077513515149  0.266351828566493 -0.049816576758865 -0.073960829373608  0.046357012710617  0.183568506551021 -0.007204953793047
-   11  ( 11)  0.219872786938586  0.186770594833612 -0.640901797018363 -0.491983676516504  0.063681968781172 -0.412058888748144  0.286040569517346  0.094245081423241  0.195000390736826
-   12  ( 12)  0.262279768280096 -0.707696438447150 -0.236718714106780 -0.470497637927968 -0.331060673088753  0.597737469031289 -0.173380785854979  0.147387697786165  0.044689499434261
-   13  ( 13)  0.008835795532905  0.161415860688302 -0.152613021782520  0.281704813928099 -0.459625631240495 -0.096864143285054  0.003153519140079  0.109240738249078  0.297347288310574
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.149413062150163 -0.067008442584154 -0.230363907047496 -0.055319406680384 -0.032530338298423  0.068943043267331
-    1  (  1)  0.452149192521174  0.000162578737685  0.619971511564934  0.066650257125370 -0.061919053639708 -0.084081056043438
-    2  (  2) -0.165489317663304  0.127973451777841 -0.447552906388176 -0.305061991533250 -0.384464561661781  0.153275315561868
-    3  (  3)  0.025748260701304 -0.486016697888281 -0.411385821418048  0.268874146594607  0.396024014682121  0.134171291763426
-    4  (  4)  0.009663093960960  0.555568390799340 -0.304477769378439  0.081217704163073  0.578918205858773  0.101292064810745
-    5  (  5) -0.039175185913195  0.166448012687766  0.090139681441233  0.019287349063250 -0.248510643774710  0.007841008760067
-    6  (  6)  0.086047592172498  0.153815757637266 -0.087940035478902  0.097280378266502 -0.044638073702240 -0.047181412845043
-    7  (  7)  0.068735686796040 -0.315926660510286 -0.100190034017783 -0.019688975059735  0.019468668688484  0.100670621907944
-    8  (  8) -0.002625726681395  0.112681642341155  0.368011821043785  0.079699064807508  0.320546285877417 -0.355993882573800
-    9  (  9)  0.075057729747018 -0.174223000470549  0.018184022105450 -0.008386747763061 -0.022693973527319  0.026587026978415
-   10  ( 10)  0.016901342145260 -0.168627021082460  0.003857305749161  0.002354503414788  0.061897957980197  0.064750074462714
-   11  ( 11) -0.244307011097299 -0.045968336616797  0.036911026756575 -0.051829082034064  0.017536651163216  0.002615905953443
-   12  ( 12) -0.003873917284711 -0.069385416516337  0.051822467558672 -0.043776532172148 -0.059978809347506 -0.097816286584178
-   13  ( 13) -0.427124414952379 -0.150719603419239  0.021778839992094 -0.006415728591880  0.068010241427207  0.070097593919817
-
-	File 101 DPD File2: P*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.041903329856192 -0.070446987089633  0.004348862670260 -0.007003079501354  0.042701021768788 -0.152208197977204  0.041433363682805 -0.041287071942597 -0.095743116708860
-    1  ( 15)  0.040650426082046 -0.069515483196494 -0.023795913068799  0.076537618226998  0.032568972577824  0.025967830490469  0.063333094204323 -0.120545439258051 -0.089130494820972
-    2  ( 16)  0.113176179395785  0.046535614719910  0.168596109891447  0.133831005796173  0.118353163778080 -0.257041147370604  0.414474865889011  0.082742359298471  0.367155116899390
-    3  ( 17)  0.018349375617923  0.090713111977311 -0.034093712018598 -0.012384834825344 -0.052502145904236  0.343486696016333 -0.164974261057850  0.349385131049026 -0.148282635861179
-    4  ( 18) -0.098178568139074 -0.063160792106148 -0.098378065635209 -0.082360458708713 -0.040147652473952  0.031106641199237 -0.209540876350175 -0.299086324958894  0.075290632015664
-    5  ( 19)  0.046124091442951 -0.007623765782496 -0.052346193543973  0.056344470452290  0.031632190145320  0.198051654819200 -0.173027351368421  0.116400515734751  0.135033433848762
-    6  ( 20) -0.125258904374540 -0.493829059239401 -0.267757316022715 -0.150510471965499 -0.082418952577180  0.029074883870873  0.082194266117060  0.155370316095250  0.076894749422472
-    7  ( 21)  0.022859113931115 -0.180693607953724 -0.067191017626113  0.021636428920055 -0.098628927025765 -0.152535238685033  0.108677282204199  0.236476842996923 -0.043474790742065
-    8  ( 22) -0.007846177507452  0.026259809347121 -0.131087450927184  0.264309750556241  0.389449878217689  0.077877691250164 -0.320396510359928 -0.036029491362037 -0.011294045928736
-    9  ( 23)  0.148409951194406 -0.452946257596570  0.165039879212225 -0.026077898552925 -0.007360117453756  0.037616321096105 -0.083049264354487 -0.069293544687319  0.001373481233291
-   10  ( 24)  0.069814067119157 -0.002054394750299 -0.126443354154776  0.492431542405090 -0.562191735747665 -0.169229180172877 -0.154296877725072  0.322409563035094 -0.115377045900281
-   11  ( 25)  0.226651470481047 -0.617350999313901  0.448004121314618  0.411778499546043  0.303855472735621 -0.089854128437872  0.086765588475993  0.099221464205896 -0.370890559100149
-   12  ( 26)  0.054331750206089 -0.066935478840437  0.304032185963088 -0.268162029874351 -0.080593616550667 -0.019297703310245 -0.096620293446142  0.019137264306005 -0.080001854035789
-   13  ( 27)  0.031924461994603  0.060584366399270  0.382102774779752 -0.393995940746644 -0.579313325412582  0.247998914693769  0.046380357788513 -0.019293958639035 -0.320706746040650
-   14  ( 28) -0.067906620182484  0.083216384461386 -0.153437200450035 -0.134831736058858 -0.101055763194935 -0.007868050795063  0.047806237375160 -0.100652051992651  0.357135809697123
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14)  0.004177372366322  0.063406030244807 -0.226823097367039 -0.263896415513769 -0.011701971027774
-    1  ( 15)  0.093319799498408 -0.219967278758902 -0.185954874184417  0.708355904031754 -0.160324223389966
-    2  ( 16)  0.039556125331154  0.094087884995324  0.643095059540316  0.237777200414592  0.155124222296969
-    3  ( 17) -0.442134529381327 -0.268012766736270  0.494385460966639  0.470730896225858 -0.283217803454197
-    4  ( 18)  0.425335538145780  0.050712365592958 -0.065507217070923  0.331337452084829  0.461074723403375
-    5  ( 19) -0.162698096167156  0.073261920681232  0.410435644212656 -0.598344542892450  0.095525074956441
-    6  ( 20) -0.027635092593548 -0.046340546952519 -0.285700437916237  0.173636156485020 -0.002143940822347
-    7  ( 21)  0.008238163113748 -0.182885492783710 -0.094441459467607 -0.147424260377310 -0.108554639474187
-    8  ( 22)  0.023401664118011  0.007016046655171 -0.194400535766778 -0.044245864301010 -0.296689970128693
-    9  ( 23) -0.076293063471948 -0.017415507342648  0.241569014205399  0.003530677667797  0.425824332982193
-   10  ( 24)  0.181769150588328  0.169666705113788  0.044965749792137  0.069290251681075  0.150967382108881
-   11  ( 25) -0.018153729708567 -0.003519576560560 -0.037031521345044 -0.051758677298688 -0.021630611787891
-   12  ( 26)  0.008082899537472 -0.002256936856687  0.051941569032630  0.043823365289136  0.006446621914376
-   13  ( 27)  0.023193966803115 -0.061566730434681 -0.017525541483092  0.059863077024435 -0.068202811059110
-   14  ( 28) -0.026844987381374 -0.064909557534692 -0.002683194869776  0.097668274774952 -0.070274371234661
-
-	DPD File2: P*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.022229155184796 -0.019683929802812  0.035292041013174  0.323293424781682 -0.225147178252232  0.115004523407643 -0.099141060334532 -0.047575469407300 -0.016976450104502
-    1  (  1) -0.127090569254626 -0.123237269677512  0.278422395650133 -0.118685424416916 -0.176184741653177 -0.248988790809479 -0.519015610990019 -0.012154553055459 -0.127798350335596
-    2  (  2) -0.008158213783958  0.029679191576446  0.037266849827848 -0.110715312970774 -0.059214718357965 -0.062822080446559  0.081276448160108 -0.324586020412756 -0.131224816829759
-    3  (  3)  0.084166098196409  0.111710240594221  0.099128613941891 -0.014634036431124 -0.052476493603890 -0.027367672304797  0.301909798936816  0.191388056693055 -0.790536316410543
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.129910363709357 -0.163144685956702  0.026485892679798  0.022427536567571 -0.063067550057929  0.033737074439006
-    1  (  1)  0.086592793084052  0.215472297553996  0.416640948225414  0.119951916043925  0.207797355115153 -0.145646111272154
-    2  (  2)  0.146364945461058 -0.802840103887928  0.083436228176863  0.120990811620140  0.133581214678389  0.001202452323342
-    3  (  3) -0.043945078436053  0.148601276694347 -0.437804660682756  0.201206970148648  0.547031014916742  0.155504170965970
-
-	File 101 DPD File2: P*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.037502076472662  0.109335165777524  0.012926428858581 -0.269466726270333 -0.379248563249398  0.141530386330068 -0.105411044336663 -0.019979530625450  0.148197571425260
-    1  (  5) -0.208585120229370 -0.016639991768198  0.025672499464384  0.120166173976538 -0.061231886196158  0.410760689290169 -0.504318342034080  0.368734822068652 -0.088923609423586
-    2  (  6)  0.008992532047250  0.290540208998742  0.060411739137707  0.064704199164733  0.124015323503734  0.073936634004700 -0.287919965087423 -0.478723882674066  0.159979306108318
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.002904367944485  0.019663391538446  0.115584584455963 -0.082318082980502 -0.044061111248738
-    1  (  5) -0.445601944090184 -0.141387522552248  0.540419197978555  0.056783987379620 -0.093672186540934
-    2  (  6)  0.375252473148004  0.198547338183254  0.207529365108893  0.114786400140461  0.453839763908372
-
-	DPD File2: P*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.060866725217215  0.013869365716153 -0.033894329784820 -0.159389025617799 -0.069390363085127  0.262340609354303 -0.067580095774763  0.154103692822594 -0.003154741180611
-    1  (  1) -0.233600860111356  0.255443445273365  0.070349772560976 -0.002398009474053  0.207738516934078  0.107364483788669 -0.128967864654634  0.344368536680876 -0.051213828740165
-    2  (  2)  0.320680073963752 -0.499671518707847  0.050574975509019  0.147836128166420  0.165479289930263 -0.195838444506077  0.035661712710790  0.024470880763902  0.075637541705411
-    3  (  3) -0.005421312030017  0.086163397462206 -0.087803119789529  0.068180639639745 -0.069970423577407  0.155270176021826  0.200857781343900 -0.346742235116956 -0.007432799783430
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.031710204280855 -0.011526541432890  0.002976967089787 -0.046060023193635 -0.015318540884103 -0.025207945945630
-    1  (  1)  0.042201291846948 -0.011691902650686  0.030342861979388 -0.426260656604152  0.267501393083778  0.156199494500064
-    2  (  2)  0.105775984380200 -0.124345432018223 -0.012422860710314 -0.254942186016171 -0.141450345930572 -0.594200168007018
-    3  (  3)  0.128190105083420 -0.839978623039109 -0.103083070851949 -0.085126863174017  0.034147172701768  0.125845625439850
-
-	File 101 DPD File2: P*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.009655463605755 -0.014837891728381  0.030023518715064 -0.453895242430490  0.367783958834954  0.001154952584878  0.011095021636640 -0.081922945493181  0.106667436086225
-    1  (  5) -0.023315601126616  0.114914590458087  0.095889100679515 -0.148408787561426 -0.132591987973289 -0.239441228065666 -0.119891964360871  0.197513600772232  0.042785498899110
-    2  (  6) -0.044714484508884  0.227037104077391  0.243035253957641 -0.057000070112492  0.133863510185386 -0.464640228230982 -0.241815314958168  0.250347946170699  0.035567936134789
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.031225116244914 -0.082892463758822  0.008302957992736 -0.084651532871555 -0.076096297616606
-    1  (  5) -0.029094974835733  0.031099102771742  0.014865102267058 -0.594144277291270  0.111092561014338
-    2  (  6)  0.081030380750229 -0.586465397694647 -0.039125073332182  0.210425560392843  0.141728395903252
-
-	DPD File2: P*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0)  0.279550720476077 -0.042202209735457 -0.032616542291842
-    1  (  1) -0.188418637032763  0.038238156575108  0.176016679949417
-    2  (  2)  0.431618249575807 -0.006066663258097  0.050669745816719
-    3  (  3) -0.023823866701763  0.194483208506600 -0.036291334339584
-
-	File 101 DPD File2: P*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4) -0.276296231465594  0.182684867311170 -0.425780067610230  0.021944883020485
-    1  (  5)  0.040904620230163 -0.037124497156135  0.000756874278417 -0.193551621281851
-    2  (  6)  0.032612764478737 -0.173214965518422 -0.056257078994710  0.032928243740138
-
-	DPD File2: P*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.064329222595920  0.203089813678901  0.060855379318360 -0.045435578919151 -0.038213040289734  0.173918816066670 -0.086597065761990  0.088257727308079 -0.042534449699908
-    1  (  1) -0.115560364126478  0.109115953630201  0.018643611831367  0.061273729840918  0.223462209948640  0.111849786008387 -0.082478525732492  0.548790728777664  0.099502382826804
-    2  (  2) -0.050280791567554  0.042231736423558  0.026516724550904  0.035763580727561  0.045242506762065 -0.028791481906196 -0.032080377274548  0.393629321941294  0.043590423594673
-    3  (  3) -0.027100682075659  0.177196743119415  0.360081085823777  0.088267299794322 -0.030083312860564 -0.189916614239830  0.016925829834322  0.152132597277128  0.199271802311320
-    4  (  4) -0.027032407915338 -0.122816257943915 -0.195859296476474 -0.024440446904345  0.000039632917188  0.224837371747381 -0.105878500705155  0.149344729427051 -0.220653682748276
-    5  (  5)  0.082124893882501 -0.131610239391223  0.172288241722190 -0.172656004937721 -0.186007370790890  0.002386795157151 -0.000883813901201  0.015624959650018 -0.120434685552584
-    6  (  6)  0.025918430251412 -0.066213876287375  0.159653356345571 -0.138629355858437 -0.114503563489713 -0.052610164659059  0.032724879295725 -0.016321111589815 -0.131203443877323
-    7  (  7)  0.031968463140566 -0.359436078267880 -0.239880075530440  0.043941245996148 -0.003566470797935  0.121878346236622  0.025216884092681 -0.317033593343712  0.204690345792582
-    8  (  8) -0.147136177075282  0.147831155131360  0.317027072645310  0.094690347387101  0.042376714203220 -0.036223188856298  0.061267998203209 -0.078763236261723 -0.025079679518920
-    9  (  9)  0.347335081804882 -1.076651679527280 -0.076631791966040 -0.520228799901951 -0.177614233521961  0.752433601064110 -0.098237100331302  0.075609380299166  0.029456370268690
-   10  ( 10)  0.226576210232703  0.047966592312158 -0.713544303894390  0.117838109418108 -0.538138175848963 -0.110268365719488  0.097090433542407 -0.016639982577840  0.202838989293283
-   11  ( 11)  0.013618237324107 -0.042488040839621  0.012305458432129  0.002937365049260 -0.051397702056966  0.032793240631487 -0.126424524316302  0.018011286422360  0.036334038133226
-   12  ( 12)  0.125114748700956  0.150723454222537 -0.252706221972763 -0.731410520517111  0.348252142829817 -0.473299198843163 -0.017472369731921 -0.121992291563425  0.064459445411663
-   13  ( 13) -0.081025878360433  0.099169125996407  0.096265824091433  0.243412138793566  0.157793004324879 -0.232678786079147  0.038715292983050 -0.196706528651456 -0.103460906909678
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.038639019968560  0.081398838675921  0.020974057309157 -0.195126170432547  0.136178596332978  0.093793458598120
-    1  (  1) -0.192322326072867 -0.434066427801228 -0.033306653053185  0.455360646532796 -0.170900871888595  0.012160177810098
-    2  (  2)  0.116655928700969 -0.223206132473869  0.015149664847910 -0.750955420456732  0.241651279575312 -0.125278854183387
-    3  (  3) -0.037416152824649  0.474871182487040  0.095127781154357  0.001912744200640  0.218016361604134  0.501866870283028
-    4  (  4) -0.093049020347900  0.452195861353997  0.097729965141961  0.023670097100218 -0.227089450225467 -0.622604645621845
-    5  (  5) -0.095982951322369 -0.025076643469587 -0.083513090675399 -0.093177906171499 -0.163570537374778 -0.411952379972310
-    6  (  6) -0.006971397366507 -0.099975304872894  0.089355028753419 -0.082421061832647 -0.109391578906264 -0.177019076161536
-    7  (  7)  0.111482230592694  0.119338627354550  0.049072785699030  0.135589681135474  0.179997637886863  0.225361657151226
-    8  (  8)  0.038036906175422 -0.107593330918854 -0.085211578523939  0.251522137496260 -0.415712152156179 -0.133150454203045
-    9  (  9) -0.014149847264143  0.014713228385967 -0.003726551384159 -0.024984081757333  0.450053383369121  0.804137197420648
-   10  ( 10) -0.262196667989143 -0.030987669321987  0.048528847001581  0.326796645773778  0.027460917972608  0.213395133473708
-   11  ( 11) -0.037859730907863 -0.067315614399965  0.006033855211911 -0.002081527339975 -0.021566579415084  0.043117037710347
-   12  ( 12) -0.214673577185777  0.277038178296912 -0.018443935481622  0.031394459169126  0.040697755419603  0.037299553750268
-   13  ( 13)  0.293378255962317  0.067739265985308 -0.042216271726718 -0.084600602041646 -0.093366414785478 -0.184919834112459
-
-	File 101 DPD File2: P*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14) -0.065579026427298  0.118385281199840  0.054417309773849  0.028209393258605  0.023855315776195 -0.089481193550780 -0.030082936540202 -0.024881663706482  0.145536117267929
-    1  ( 15) -0.203177895336562 -0.108867238168314 -0.044106918987014 -0.183348816265157  0.128730595279853  0.134393743071560  0.068034842363188  0.353605430814672 -0.144787054112687
-    2  ( 16) -0.059845833352457 -0.020943033819428 -0.028043633600698 -0.360379351132063  0.196224502327520 -0.168965679426491 -0.157686501214302  0.238008876623444 -0.316659608324193
-    3  ( 17)  0.045186255659105 -0.061530291702097 -0.034434066086584 -0.088647496947582  0.026282078792551  0.172786891133660  0.138287078850789 -0.044103989261245 -0.095122362978667
-    4  ( 18)  0.040062693221020 -0.224606431868167 -0.044510085277536  0.028376706423002 -0.000349345016747  0.185972360522578  0.114555914481331  0.004506308196336 -0.041018032849448
-    5  ( 19) -0.173210931444010 -0.109857051233105  0.028983625579256  0.187756427423432 -0.223643228642709 -0.004090524106486  0.051487512077316 -0.121894819352182  0.037656019931592
-    6  ( 20)  0.085313471751143  0.082913275223549  0.032277368285025 -0.016777520509378  0.105131359190815  0.001944705429570 -0.032875162874827 -0.025732176012468 -0.062579089976849
-    7  ( 21) -0.084545461298169 -0.550907022405358 -0.394733809745031 -0.152212200092244 -0.149602224208011 -0.015559620185539  0.017471440322135  0.317632843442532  0.081500770726977
-    8  ( 22)  0.042592304559205 -0.100130074049971 -0.043823098391038 -0.199074070348154  0.220614689373917  0.121240505787734  0.131566193321307 -0.204777301446740  0.024659128193111
-    9  ( 23) -0.038243209345809  0.193731116803758 -0.114571318389048  0.035004741203238  0.093870122022257  0.093321089072005  0.005098160430595 -0.109514276861021 -0.037449030782536
-   10  ( 24) -0.080611973441424  0.431286815750366  0.220674640182480 -0.473291196073188 -0.451373239023609  0.023941120635386  0.102282761545205 -0.118683941595292  0.109001254632288
-   11  ( 25) -0.020616437944253  0.032806186227235 -0.015536997280191 -0.094946997217811 -0.097687630516726  0.083601240444185 -0.088958677720268 -0.049109842148345  0.085549382706087
-   12  ( 26)  0.191260790058678 -0.454455308246703  0.749344104582772 -0.000707785692927 -0.023013062709295  0.093408274808716  0.083112755629054 -0.137052732289414 -0.253713944370040
-   13  ( 27) -0.135080067323690  0.170977966348525 -0.241626969335339 -0.220294823738596  0.228806715319375  0.163956724293068  0.109654396643640 -0.181513709124625  0.417706190063538
-   14  ( 28) -0.095355381240353 -0.010487455238559  0.123878379042330 -0.506641747659321  0.627627416886014  0.413206867808258  0.177986562206826 -0.230596660977991  0.135371993382099
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.343722354187842 -0.231012307989939 -0.013807799785149 -0.129389520371901  0.083476842933347
-    1  ( 15)  1.071757290590545 -0.047500726309983  0.042558977896784 -0.150713322712323 -0.100049386852298
-    2  ( 16)  0.076574555259838  0.716811431044374 -0.012053549717062  0.252652945738414 -0.097563356479072
-    3  ( 17)  0.521659456544164 -0.119962089033513 -0.003140019395332  0.735502177464538 -0.243874710004522
-    4  ( 18)  0.178111787275392  0.539331111074153  0.051602620031584 -0.351369555964665 -0.157776134348173
-    5  ( 19) -0.754028750268460  0.108050332429524 -0.032942772306297  0.473084779433613  0.233288261808526
-    6  ( 20)  0.098339349809287 -0.095672012585071  0.126453856435504  0.016749320041424 -0.038981069794775
-    7  ( 21) -0.075922415669002  0.017338504286034 -0.017821543323394  0.121086080034894  0.196694365560314
-    8  ( 22) -0.028707803808862 -0.202101700693747 -0.036280352248806 -0.064076056309411  0.102966425702512
-    9  ( 23)  0.015071264129229  0.259603898636005  0.037748702712212  0.213449614969685 -0.292741791249862
-   10  ( 24) -0.014441233365834  0.031025326150192  0.067581337213048 -0.278218894918250 -0.067639252890435
-   11  ( 25)  0.003655596016122 -0.048301023976308 -0.005987297290884  0.018296972769386  0.042182106266812
-   12  ( 26)  0.024290247830266 -0.326430116080930  0.002078223011543 -0.031357186170846  0.084451014704488
-   13  ( 27) -0.452065991443206 -0.027871674423728  0.021552868138498 -0.040817220436517  0.093503875768977
-   14  ( 28) -0.809538434042480 -0.214197129891733 -0.043194453416851 -0.037242456347955  0.184930829970208
-
-	DPD File2: P*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.066956274028954 -0.044342976073165  0.030268247936242  0.149450540981950  0.061066821271185 -0.252770775339693  0.067874222510686 -0.158386767820771  0.005381383883310
-    1  (  1)  0.238859813029081 -0.286692386304328 -0.066590681714602  0.004012726688607 -0.213066888677072 -0.109131374118362  0.135898330150995 -0.364942966429774  0.055660597243453
-    2  (  2) -0.359516386393285  0.583008964100427 -0.054707529711990 -0.139557599023379 -0.158230706301634  0.196109522672398 -0.038444807843767 -0.030895199145175 -0.086353045406069
-    3  (  3)  0.011142763994871 -0.102467038295486  0.096192280460040 -0.086579830772614  0.079151964917630 -0.163781954562347 -0.215517306973471  0.369533969127049  0.009330018051360
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.034197603653202  0.011654401867379 -0.002838793667518  0.051120718575847  0.018314210992950  0.032583546094419
-    1  (  1) -0.044852295322472  0.010374877421340 -0.032495546570244  0.442259071390682 -0.284002451396915 -0.172324881222561
-    2  (  2) -0.118470854957857  0.130986078141729  0.014085982845085  0.260463332299674  0.162310705486348  0.635865895852574
-    3  (  3) -0.132535934596107  0.876049792586578  0.107203693425820  0.087990410067908 -0.037792879731323 -0.134504535673653
-
-	File 101 DPD File2: P*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.032839390128313  0.018959934247026 -0.027098455785061  0.458861483846452 -0.368889100803161  0.013730600662295 -0.005961739971281  0.088172859302616 -0.109822626668940
-    1  (  5)  0.022776770324681 -0.118542960649480 -0.106023383328719  0.155646887463115  0.124038116346952  0.247202807741244  0.126320423057856 -0.208868231513720 -0.046770852934184
-    2  (  6)  0.048648484948535 -0.245637911332038 -0.270704645644036  0.074067208651774 -0.147538325129154  0.486126744284417  0.252803143713327 -0.267246124084927 -0.039768993904487
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.034234873438637  0.088611347550410 -0.008537759532833  0.090451182938239  0.075365836152160
-    1  (  5)  0.023972088194502 -0.031376657235205 -0.015685502279103  0.611834232098808 -0.112755958009069
-    2  (  6) -0.089906734942719  0.607632221899844  0.040204918187789 -0.215818595847042 -0.145730338373175
-
-	DPD File2: P*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.068337016689787 -0.096446452085002  0.360475449255902 -0.092239288443358 -0.026203678993495 -0.022509846768507 -0.073478827109955 -0.022464061635160 -0.227372488687786
-    1  (  1)  0.348245092755920 -0.473201941654281 -0.285296343641650 -0.183481268338497 -0.077575420561894  0.072099126128168 -0.272473569750599 -0.064219415174522 -0.197165880642411
-    2  (  2)  0.067585908292999  0.050372922066345 -0.060758167722761 -0.207525430724412  0.124589544539336 -0.366296688749942 -0.319501792562117  0.144609263860444  0.034557292109121
-    3  (  3)  0.003490778195202  0.176771187193881  0.057522831084688  0.000116418534514  0.000778288025410  0.154495740758279 -0.307263828597453 -0.311985415250579  0.072067405639340
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009055593106319 -0.169294476000973  0.004376707887535 -0.043035427356728  0.152530590603305
-    1  (  1)  0.043732146234760  0.133230210104999  0.321492959537845 -0.026647195864791 -0.380687102971969
-    2  (  2)  0.166530147606704 -0.613643715784952  0.216790208689121 -0.084469048821397 -0.070950253018395
-    3  (  3)  0.193623455832778  0.188085387415724  0.577128561928036  0.079182256648197  0.329374829303748
-
-	File 101 DPD File2: P*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.094184605266262  0.056664612736054 -0.249611394695138  0.001240336458214 -0.251113263188388 -0.167204840997487 -0.053738355410164  0.110451910680987  0.110225244344066
-    1  (  5)  0.138889396156713  0.115961679702950 -0.323179744186602  0.121252123334108  0.292076432530947  0.241576686483901  0.062989099002905  0.028273376499857  0.195878521200942
-    2  (  6)  0.158880157732563  0.136139940788991 -0.265648578790447  0.093877387310787  0.142453752097511  0.054140913394793 -0.560779480905315 -0.138233927938137 -0.254132036776789
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.293992892777812 -0.040800750874340  0.057675088115477  0.076602392476472  0.065335333000425 -0.026360508198711
-    1  (  5) -0.140101157116617  0.119683195253936 -0.266691635481371 -0.245738117841371 -0.344104644743715  0.220704301427416
-    2  (  6) -0.056921768196805 -0.103403744069325  0.598429877433937 -0.146214200704205 -0.059974750990256  0.323525482379135
-
-	DPD File2: P*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.001230860713981 -0.365289920386496 -0.190857780733096 -0.072806514891183
-    1  (  1)  0.363063996519734 -0.002070944913891  0.019953639387757  0.015606309990589
-    2  (  2)  0.188512451641916 -0.023296206313487 -0.001197811601800  0.004047856267926
-    3  (  3)  0.072120339388755 -0.013963148028330 -0.003997486762190 -0.001769349811859
-
-	File 101 DPD File2: P*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.002022249922950 -0.099291954131021 -0.350139400677067
-    1  (  5)  0.099326293970590 -0.002387309533513 -0.000598742894171
-    2  (  6)  0.349927147110668 -0.003948627188178 -0.004319113721388
-
-	DPD File2: P*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.002890611897827 -0.240828289147465  0.015468829256935 -0.064289689550120 -0.058383569830779 -0.095812515567057 -0.080370871457874 -0.173880009550648 -0.326840838875860
-    1  (  1)  0.236387869752249  0.001382669630591  0.349729320543369  0.093496466822455 -0.041273060112661  0.069307558569237 -0.288342418689824  0.111953342164375  0.889210851252513
-    2  (  2) -0.015544382351172 -0.348410608385966 -0.001429161416738 -0.082248932060638 -0.073429593153274 -0.232731056108987 -0.287528082465130 -0.229588952851785 -0.234445801555499
-    3  (  3)  0.060246890669449 -0.090324337254536  0.083519076320930 -0.000324034215630 -0.021649503271248  0.048962406316822  0.003095140388789  0.014925743106247 -0.184209404061508
-    4  (  4)  0.058716691049654  0.039386709518300  0.072108814664522  0.024079085224178 -0.001156693016658 -0.085015191809916 -0.048842009764989  0.153342114169621  0.107404216975909
-    5  (  5)  0.094642233192625 -0.068250996258109  0.231656670305544 -0.051858687640720  0.087916533368054  0.000989122777904 -0.009520487792430 -0.039816729579394  0.148608670810212
-    6  (  6)  0.077504756735322  0.287507697430236  0.285105373436002 -0.002029325573656  0.050208524083414  0.010159420768980  0.001467122921747 -0.173528931839685  0.045843469905068
-    7  (  7)  0.174578233230593 -0.112733771274507  0.230104116799356 -0.014289446324452 -0.153589433005249  0.035711031924118  0.172129458752228  0.001735515727976 -0.038746380038624
-    8  (  8)  0.326735165366063 -0.892352866716814  0.233667611417982  0.184059987656354 -0.108456575602175 -0.147444194487350 -0.046899481546128  0.038212214850091 -0.001725987235386
-    9  (  9)  0.006854804424481 -0.059010431241574 -0.208380750196049  0.285710704759075 -0.014224723130698  0.077940660528519 -0.021832932968226 -0.053507920192743  0.072157293584336
-   10  ( 10) -0.009015167445598 -0.189056046369736  0.202903049397400 -0.587323534808109  0.635944176810841 -0.025618734551668  0.020134034262346 -0.176546344509523  0.134205354496214
-   11  ( 11) -0.122437005548569  0.184498905511222 -0.564613159164372  0.437681527296080  0.566648422271337 -0.293176529113293  0.283793106995897  0.077656634404298  0.171083550165875
-   12  ( 12)  0.036282129605470 -0.108405322240863  0.145144319486399 -0.147400560062216  0.198772870262719 -0.103478363945228 -0.121274561973686  0.030820809232635  0.001791413008569
-   13  ( 13)  0.133993098437568 -0.204979468351056  0.411230750510333  0.299499940801943  0.284167005433816  0.162337236425275 -0.004579295347321  0.249620649972568 -1.096399145752056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.006645975778905  0.006191073096114  0.124463548213382 -0.037116585439600 -0.136645288902199
-    1  (  1)  0.060762525453402  0.191336651087303 -0.183339507039208  0.108942947593767  0.207176626622974
-    2  (  2)  0.210207260386098 -0.203492326897454  0.567390687945974 -0.145012790104551 -0.411652670240128
-    3  (  3) -0.286824149969646  0.581772824662096 -0.440352813995387  0.146688228392261 -0.298407000003058
-    4  (  4)  0.014289603545957 -0.629957556120225 -0.567078386368531 -0.198070048922302 -0.285394833836570
-    5  (  5) -0.081440068401990  0.026939007614117  0.293522941596266  0.103773428535410 -0.162374057747115
-    6  (  6)  0.019586412213072 -0.018998130538312 -0.285654409806091  0.121258923814333  0.003510620762243
-    7  (  7)  0.056312011236674  0.170723193738545 -0.077219135397651 -0.031749253170040 -0.249637927479938
-    8  (  8) -0.071982674840921 -0.132152050589738 -0.170190422759249 -0.001965018222219  1.093832298365480
-    9  (  9)  0.000915267084317  0.167637668947108  0.013751051322959  0.007450195669904 -0.054814043954704
-   10  ( 10) -0.173354835302090 -0.000704252867558 -0.044733752629381 -0.097334496933118 -0.081305131643713
-   11  ( 11) -0.013882987415659  0.044298584291785 -0.000143226462344 -0.004568623078909  0.075706346510396
-   12  ( 12) -0.008211247608944  0.097266945197500  0.004534234464270  0.000000208770840  0.036045640473786
-   13  ( 13)  0.055102354659947  0.081583293844327 -0.075692193037900 -0.035962325349336 -0.000089917983318
-
-	File 101 DPD File2: P*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.002852278466544 -0.070108169829164 -0.177721594116383  0.062514278837043  0.105491072743275 -0.104380527192685 -0.038787813666443  0.108504673470162  0.012481015325095
-    1  ( 15)  0.072271804263973 -0.000288298261148 -0.117173998738145  0.011917535043052 -0.080653916441483 -0.081946299523319  0.047103419787682 -0.318790462890510 -0.030711126191038
-    2  ( 16)  0.170911365853707  0.116393519070210  0.001806689323683 -0.130836454259881 -0.145067744851421 -0.208275822041435 -0.197865978670067  0.179244423422815  0.001428148574785
-    3  ( 17) -0.060580436051072 -0.012481275961757  0.130473629372401 -0.000512552110579 -0.018701012638838  0.044411378106146 -0.007770177955824 -0.099727400679241 -0.079606042617844
-    4  ( 18) -0.100932281141831  0.079292941446829  0.141623065968957  0.016652442688780  0.000246995954883  0.188697276821427  0.217824131948931 -0.080386629630151  0.270575530776454
-    5  ( 19)  0.108081312156271  0.081589453393258  0.205450509959137 -0.045804817780756 -0.187114674307730  0.000693476015895  0.073804885959376  0.043943121718183 -0.003771900693712
-    6  ( 20)  0.034173297967555 -0.046256787847685  0.201439095588816  0.005429989019017 -0.216650326151217 -0.075792464986171  0.001298711951572  0.134518823042755 -0.103151783377151
-    7  ( 21) -0.109536591257004  0.319390106321481 -0.177983470364268  0.099546174339197  0.081524885513579 -0.044022674550874 -0.133301399033515  0.000096152383065 -0.101549931240584
-    8  ( 22) -0.012926686041826  0.031216971600686  0.000265042168615  0.077684860264792 -0.270051031496744  0.002422594418673  0.104436054969569  0.102375676350899  0.000297123445281
-    9  ( 23)  0.258651046299275  0.226438144249540 -0.883671721861341 -0.031897478817939  0.145814145437369 -0.329946962033578  0.092842601161588  0.020363787817155  0.044542350196596
-   10  ( 24)  0.092725989784673 -0.166988988746146 -0.090659624845963  0.033017773093490 -0.181126079432095  0.062617782388689  0.131228570809863 -0.125672600098950 -0.010149266769676
-   11  ( 25) -0.085237213762517 -0.052979715533519  0.426249660673602 -0.453470213118020  0.668258866535746  0.144399220062707  0.422276654831122 -0.144496027602971 -0.151454753884708
-   12  ( 26)  0.278987852994131 -0.538130802014502 -0.337920384527610 -0.681210215677631 -0.181138167954142  0.460304232360321 -0.045963221041228  0.472470739788982  0.099740360833931
-   13  ( 27) -0.031684358569015  0.364912365941556 -0.009949817490826 -0.264482144700383  0.131463038932392 -0.369715650064832  0.160132940033673 -0.216985322458037  0.408494860009368
-   14  ( 28) -0.069145968160405 -0.228577328281114  0.182024373430158  0.129259595360434  0.172789096424754  0.293202387537144 -0.081435203747675 -0.165066175829158 -0.415625562015752
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.259264061861398 -0.092073726700459  0.087751332732921 -0.282787087620371  0.027646750760921  0.074274663555944
-    1  ( 15) -0.226044227417799  0.167220221608179  0.052022484678322  0.539067092148703 -0.364060270057495  0.227432738647077
-    2  ( 16)  0.880651861739234  0.090070282095970 -0.429004165056558  0.339630379420043  0.011398542008064 -0.184603055576349
-    3  ( 17)  0.032407867048655 -0.033969801861417  0.457051817514276  0.682605465628673  0.266811035152933 -0.129791361160984
-    4  ( 18) -0.146452241358061  0.182164491681139 -0.670578545718526  0.180561730668713 -0.132153760707793 -0.172423147223622
-    5  ( 19)  0.329854516633489 -0.062406355486158 -0.142687713548999 -0.461391108813659  0.369113402446086 -0.291406831399555
-    6  ( 20) -0.095123792939029 -0.130974407921450 -0.423504400080728  0.046307780864123 -0.160121658345768  0.080587396654631
-    7  ( 21) -0.020196930650927  0.126100208893374  0.143365904721253 -0.472616518696925  0.216448635004369  0.164811157431042
-    8  ( 22) -0.044862231258128  0.010443804825893  0.151200178059944 -0.098979735611851 -0.407862770190674  0.414651419638203
-    9  ( 23) -0.001778806469034 -0.018623025532445 -0.107576400210487  0.163068566891587  0.647773862315846 -0.636630491425454
-   10  ( 24)  0.017927592798993  0.000180705630000 -0.053297006124060  0.074061342070591  0.058210218158357 -0.162911849208963
-   11  ( 25)  0.109490773836576  0.052999955618224 -0.000271745308396  0.000305712333614 -0.053078644790042  0.055108565747960
-   12  ( 26) -0.164133552719503 -0.074506459360537 -0.000357731899204  0.000072395693486  0.003695078860291 -0.023204687798386
-   13  ( 27) -0.648551410049995 -0.058758186891588  0.052984322168655 -0.003827983869788 -0.000211520166748  0.203311556747168
-   14  ( 28)  0.638654673856620  0.163384069601813 -0.055052210134389  0.022943426676923 -0.203292568578009  0.000202566783445
-
-	DPD File2: P*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.052480701259259  0.089840503139985 -0.350982482866049  0.095116826178087  0.022440054215652  0.032862353821469  0.081729096326081  0.021425782595611  0.235338088635135
-    1  (  1) -0.388124677168533  0.534993889872660  0.299624251031539  0.203953129475389  0.082377317359755 -0.089624704115259  0.293120840067825  0.059715673164777  0.225100704791756
-    2  (  2) -0.075046613139342 -0.054595030850083  0.042171893892626  0.238878291709943 -0.143368498448120  0.391908199708447  0.348187716284506 -0.162007005374424 -0.040145638710435
-    3  (  3)  0.003825096561586 -0.209524975426966 -0.061101725640115  0.005733734477972  0.005158862211836 -0.174020624147332  0.336061739172831  0.336718503904961 -0.081950585094521
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.010799235898820  0.184179967846582 -0.006278703826698  0.045893168283343 -0.154431576202783
-    1  (  1) -0.044872971637160 -0.151970487630040 -0.339396308854840  0.025890953682133  0.403821618486004
-    2  (  2) -0.178196793491180  0.663646636739936 -0.225638342179614  0.089456735981001  0.067546568678071
-    3  (  3) -0.206166573180735 -0.202910686825648 -0.607738412714145 -0.084545705245042 -0.343684996664701
-
-	File 101 DPD File2: P*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.080604406993543 -0.052828007136127  0.248271072214065 -0.004621901958854  0.238511508773077  0.166464522338437  0.059371420180247 -0.108552798507517 -0.113128199143937
-    1  (  5) -0.158176273521067 -0.142741353513120  0.372038467512456 -0.124710545030248 -0.314544785901233 -0.257579395622657 -0.074674230220199 -0.033693630413225 -0.220604268429912
-    2  (  6) -0.161070149264612 -0.184008094688423  0.303262375945924 -0.100514546731462 -0.134915075764794 -0.049291968700981  0.607921602195072  0.146614082163667  0.250955095397111
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.310847898937919  0.042310959338363 -0.062726869647814 -0.073058032344468 -0.064713071794420  0.023951260296913
-    1  (  5)  0.157873658680268 -0.125342133518717  0.276221069932045  0.249434379507851  0.361715962690354 -0.231044770920838
-    2  (  6)  0.062318733481263  0.109385681434768 -0.629646707936818  0.147627705365700  0.066774935973318 -0.338752628544606
-
-	DPD File2: L*_X_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.016009260748017 -0.076567442214896  0.125166328875802 -0.007592491786253  0.098480428135412  0.089737912259519  0.045486487849709 -0.143199899460591 -0.062916360524591
-    1  (  1)  0.038605185454593 -0.325735593943764  0.218009839696040 -0.077381067334654 -0.123187634769419 -0.048889388601736  0.262562813593255 -0.048309424265131  0.024346564570397
-    2  (  2)  0.014979357855892 -0.182689410654369  0.081658179778794 -0.065473944506505 -0.193719600231606 -0.090995730111074  0.143671186830441 -0.007595230816929  0.060244510498059
-    3  (  3)  0.067326890443488  0.014019515203484 -0.166079081195192  0.050483560257990  0.175920280282569  0.180597777465204  0.198820897294047  0.109379576724081  0.213777271147620
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.159507026073975  0.056302017965781 -0.034397376897140  0.068360328302061 -0.100741673999881  0.049850169389160
-    1  (  1)  0.121516035123580  0.004562687000240 -0.189568378403116 -0.051932937377753  0.189148856797612 -0.205130706545356
-    2  (  2) -0.013364994269954  0.072899210778933 -0.147744909867102  0.343128869068584 -0.052918402885218 -0.086660614771912
-    3  (  3) -0.064044282976220  0.072658467037946 -0.366494615509597 -0.156516672080101 -0.183833699925440  0.043558655165224
-
-	File 101 DPD File2: L*_X_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.095334256028009  0.133297788110144 -0.233197415167998  0.109601891242184  0.034275483482361  0.001203276521899  0.083637993138604  0.006960579869910  0.188458856324837
-    1  (  5) -0.132031102549102  0.218523085575864  0.122630941119498  0.145558608560396 -0.033193771816160  0.142560374903523  0.001867880595405 -0.178023294306114  0.083084371409555
-    2  (  6) -0.307498011816596  0.248791194429673  0.171772234113843  0.290615300494965 -0.046349417939456  0.102374827834141  0.404689139483050  0.035662684698487  0.067098771977202
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.011309857021213 -0.047826432296259 -0.011715243517174  0.012087997768714 -0.055738114510750
-    1  (  5)  0.060288763132101  0.100230270339149  0.175888842059756  0.033113626293054  0.296260944515875
-    2  (  6) -0.156436504590612  0.054087388641550 -0.405606872407349  0.026699931968424  0.143365753445289
-
-	DPD File2: L*_XBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.021022954159736  0.035142529018952  0.107426415156770
-    1  (  1) -0.299993715747734  0.100035165443054  0.265269960401394
-    2  (  2) -0.260050498379079 -0.124418562014598 -0.440142593096703
-    3  (  3) -0.064425483075145  0.021009721425282  0.051333955965002
-
-	File 101 DPD File2: L*_XBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.019464542579225  0.300930139088225  0.262387611320763  0.064713939337572
-    1  (  5) -0.034890763742270 -0.099221858485008  0.125525760672816 -0.023652429329881
-    2  (  6) -0.106312135129399 -0.261746631642973  0.441788978603034 -0.052491092120842
-
-	DPD File2: L*_XBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.143156293779769 -0.065598528855299  0.058339068026871 -0.095240471065162  0.054936782763489  0.158698528722424 -0.005848694187148  0.046188395629077 -0.009225054657648
-    1  (  1) -0.090550568038988 -0.201824271395705  0.091142881495912  0.093661370668859 -0.161043059103147 -0.077741533393123  0.543233062251592 -0.814467132908124  0.067293744881760
-    2  (  2)  0.021713915694858 -0.356864777307433  0.273330805205094 -0.263660970827611 -0.358937742043094  0.204650254826784  0.313132956505956 -0.064395695030077  0.200390318671649
-    3  (  3)  0.101095906237726  0.248350727445422 -0.325477886952403  0.022461371735421 -0.220401580692866 -0.053345914506007 -0.023674029203873 -0.049357473765327  0.000470604618644
-    4  (  4) -0.053513495604287 -0.177341679973179  0.223511424991143  0.043203647152663  0.200439262362192  0.109704630170554  0.130967856844601 -0.223696627843727 -0.051893869816232
-    5  (  5) -0.218677797229873  0.312515161252956 -0.301873753556228  0.119144839450133  0.273881128961801  0.291385277900658 -0.214361739830069 -0.197002465061645 -0.071567227017470
-    6  (  6) -0.085282711177633  0.152031995719920 -0.395807072999312  0.020599784121374  0.230274381395846  0.119204882075906 -0.196967452454600 -0.233009490057915  0.074120843143850
-    7  (  7) -0.047734330576263 -0.280574479547352  0.366542906373812 -0.110968913790478  0.088449186452659 -0.149744690480443 -0.036915836576634  0.394085559356064  0.043430167100304
-    8  (  8) -0.213441732464272 -0.108274495972316  0.634437106058845  0.069187196826565  0.037919304236964  0.161411654384539 -0.081574595848630  0.216961478694419 -0.039208476463161
-    9  (  9)  0.053318703860192 -0.090838807258297 -0.086586369793027  0.028327523211035 -0.134553886805994  0.073546423533118  0.007047260326121  0.447864900958376  0.046310440012370
-   10  ( 10) -0.217342853211265  0.434342746087742  0.408844907117118  0.321259899576754  0.034276585378345 -0.320138521202174  0.023800296590577 -0.279258907554493 -0.028679862426656
-   11  ( 11)  0.043839064779065  0.078964296226844 -0.267354222620337  0.331608707925144 -0.435766271345975 -0.066306681540143 -0.247977502270279  0.002757326539735  0.128220536878281
-   12  ( 12) -0.056967765282221  0.011496620916620  0.132088307172842  0.097918437653651  0.064500672945760 -0.001827098937393  0.216796993378831 -0.142477110991476  0.129430197478051
-   13  ( 13) -0.037733039841652 -0.226167830269728  0.091049164317861  0.252259768566517  0.015512763459721  0.284728528128491 -0.105582553814486  0.004845390965161 -0.367721806594329
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.222313487267139  0.016040998159682 -0.082409874320982 -0.002075539850870  0.060366346946182 -0.093408303465405
-    1  (  1) -0.558686428143613  0.124842930483593  0.159094597945824 -0.170661450539848 -0.081512715884899  0.084548811099098
-    2  (  2)  0.171589661035630  0.032363732574493 -0.410356885754263  0.223617160453788  0.075311055642080 -0.314379038887409
-    3  (  3)  0.113936852615240  0.023263060013616  0.282024826692995 -0.174390257283436  0.284646591950349  0.036134249694962
-    4  (  4) -0.007238439897924  0.039483311713766  0.327400920910445  0.428741395271426  0.081911463055166 -0.119323501144252
-    5  (  5)  0.007206698114830  0.054871846748801 -0.118753815309300 -0.018469351897211  0.153374179308602  0.075608926558101
-    6  (  6)  0.092372497620457  0.334623338930078  0.214791656963667  0.112964261573848  0.018239773729085  0.100594142805454
-    7  (  7) -0.151928519059447 -0.104975965782044  0.079311543670646 -0.028608318007851  0.093200761310883 -0.234496518387966
-    8  (  8)  0.034328207301673 -0.223808481631680 -0.061242559094949  0.498103653582096 -0.749098707942318  0.381141257037236
-    9  (  9)  0.119302126498580 -0.308066314141465 -0.075395221655780 -0.759042960378927  0.290000840041876 -0.156436862917181
-   10  ( 10) -0.438316650507883 -0.163958878572088  0.419969142321592 -0.045404841057508  0.044939660158532  0.568953527573990
-   11  ( 11)  0.012787507164606 -0.354874435093949 -0.016715712863870 -0.314729329115790  0.109367027564034  0.038956857759457
-   12  ( 12) -0.278784619045113  0.047236021517055 -0.203283234646730 -0.096945848185628 -0.275889526129666  0.187110942781753
-   13  ( 13)  0.588325776498883 -0.141777398655530 -0.127445383199618  0.417479630696627 -0.223570495101464 -0.209733888357992
-
-	File 101 DPD File2: L*_XBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.139188612693568  0.095183099515076 -0.018684491477480 -0.097422162623446  0.052864868482975  0.221122027331105  0.088706173679123  0.046138783672279  0.215068969553880
-    1  ( 15)  0.062949654944158  0.202402030263201  0.354633955608115 -0.248176570557555  0.178122375116496 -0.312771607112475 -0.152477622828494  0.279557727250808  0.106814721163754
-    2  ( 16) -0.053746164934604 -0.094053172516910 -0.275496238616186  0.323601647464255 -0.223358052203497  0.300642069951494  0.393858290336507 -0.365390717289338 -0.632984591272781
-    3  ( 17)  0.094021410291053 -0.093446956362787  0.262411805474378 -0.022323156021381 -0.042743443130518 -0.119643171496185 -0.019212092155216  0.111729948135909 -0.069344517807286
-    4  ( 18) -0.056361407951715  0.163012412779377  0.357847040556453  0.219749386366483 -0.199619718061283 -0.273157948729405 -0.231158276251819 -0.090626116159486 -0.037799150902146
-    5  ( 19) -0.160601962218735  0.080044732518404 -0.203861835009410  0.053968884194125 -0.109680630973887 -0.290493189386329 -0.118089200507037  0.148837371744261 -0.161317719017176
-    6  ( 20)  0.008652189032826 -0.543672739191643 -0.312260746368354  0.021747391276478 -0.131147878369811  0.214266804924841  0.195294510221963  0.037324155238128  0.082720193718919
-    7  ( 21) -0.047043957125951  0.814756484486684  0.065190092636916  0.048606045400368  0.224060646841072  0.197248282512201  0.232144218543584 -0.394908869566567 -0.217734911422747
-    8  ( 22)  0.009402914133539 -0.067052868071270 -0.200249024215418 -0.001535377445924  0.051944723647720  0.071384974303961 -0.075222552542562 -0.043268063312178  0.039055784643578
-    9  ( 23) -0.222713322415783  0.560469323042930 -0.171950144039822 -0.112172774497996  0.007083782785909 -0.006435272424486 -0.090200197520766  0.151801615119284 -0.031995099170652
-   10  ( 24) -0.015969660808332 -0.124160280352778 -0.031945357169913 -0.022574658439251 -0.040253136475423 -0.054701591947166 -0.334874112350668  0.105285662958809  0.223928209457468
-   11  ( 25)  0.081168660495960 -0.159983923907575  0.408650744438646 -0.280675358230412 -0.326885231204144  0.118534279418464 -0.213700195384120 -0.079763618019830  0.060689421297523
-   12  ( 26)  0.003652731302177  0.169351937988896 -0.223186850703667  0.177435884273904 -0.431821641248852  0.017470249474556 -0.113426087502892  0.031984799215361 -0.498979784707156
-   13  ( 27) -0.059460007596700  0.080535877567365 -0.075179690138888 -0.285729932961758 -0.080576308673493 -0.153138615960011 -0.017506919748356 -0.094018188463908  0.750480875221691
-   14  ( 28)  0.091778712898573 -0.083756184222668  0.314061943377694 -0.035359431345057  0.119047398405395 -0.075525757634597 -0.100522537659024  0.234167701630633 -0.382415314141466
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.054192115098489  0.218772067545687 -0.045642231806083  0.057541502908124  0.042026312169826
-    1  ( 15)  0.090589594220003 -0.434594274447356 -0.078276612217069 -0.011552267330405  0.225173895359454
-    2  ( 16)  0.087809314060775 -0.409613431079942  0.269441429063588 -0.132294826475095 -0.092807551910873
-    3  ( 17) -0.029496711967634 -0.321890318472494 -0.333949687981794 -0.098006508583727 -0.253968229243978
-    4  ( 18)  0.133856062539151 -0.034112562139975  0.437342385549595 -0.064344113622612 -0.014887157054416
-    5  ( 19) -0.074762453522294  0.320522646445325  0.065103712350275  0.002026903619864 -0.283693559601974
-    6  ( 20) -0.006545565411461 -0.024114390996231  0.248934516268112 -0.216845871250478  0.105404222827927
-    7  ( 21) -0.447834620578749  0.279310199694516 -0.002046231690190  0.142438484210793 -0.004552777078072
-    8  ( 22) -0.046132212945001  0.028293172679903 -0.127980948576613 -0.129504871571094  0.367038613276140
-    9  ( 23) -0.119912706409769  0.438601556174488 -0.013921175995500  0.279073471993608 -0.587144581639703
-   10  ( 24)  0.308677963206646  0.164180974317535  0.355112983785913 -0.047146799420307  0.142329570216595
-   11  ( 25)  0.075357514307532 -0.419786206774900  0.016983461358500  0.203268341742445  0.127372692691209
-   12  ( 26)  0.762257766627436  0.045741941689100  0.314841853754996  0.096926452085088 -0.417500846668484
-   13  ( 27) -0.290827635505768 -0.045087590967332 -0.109301341928646  0.275850981479361  0.223796991125890
-   14  ( 28)  0.156281997482093 -0.568696982960467 -0.039100360028362 -0.187067134074575  0.209842829958128
-
-	DPD File2: L*_XBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.008545475107476  0.071680877089206 -0.120459476636913  0.008371471662446 -0.090424858216027 -0.087190000124570 -0.049119105543224  0.145928530657214  0.062376143421355
-    1  (  1) -0.044572181787493  0.342772635368155 -0.233569654941350  0.080704995470875  0.127360357635352  0.050248913608748 -0.272733324148390  0.042278800375679 -0.013710430281526
-    2  (  2) -0.007154597183575  0.182635894723101 -0.088652103396483  0.063130413574038  0.192109998380945  0.097062796293933 -0.154759017819859  0.027524119345809 -0.057504913844805
-    3  (  3) -0.077052275000893 -0.016814177051793  0.184635905961744 -0.049413266051267 -0.188745223686842 -0.186563337985988 -0.210232732381490 -0.116951639594811 -0.221961452093225
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.163872566981873 -0.058478850756530  0.036608142215322 -0.074980328212796  0.102514306635711 -0.049419294250537
-    1  (  1) -0.131779111368958 -0.004610196247654  0.196879673097414  0.065560333989646 -0.202294566496281  0.212677679948666
-    2  (  2)  0.021560095269691 -0.083223144658810  0.151678626872472 -0.372667885980926  0.062527480001262  0.084301072064405
-    3  (  3)  0.068590860983671 -0.076978943427677  0.378848573533368  0.165187920801172  0.188975469384157 -0.045051968107620
-
-	File 101 DPD File2: L*_XBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.086725030779380 -0.140001038265324  0.215201398518350 -0.106476373516199 -0.037203797104343  0.002684965595124 -0.084210079065148 -0.008500639419888 -0.198745218470751
-    1  (  5)  0.141020111205039 -0.238503069490028 -0.123978991148198 -0.150112816633559  0.036264937723074 -0.146138191093449  0.002600464782236  0.189526092315718 -0.090546937772816
-    2  (  6)  0.314591250772654 -0.266642343404836 -0.168172023759533 -0.305975417776500  0.047767848718246 -0.093136048513418 -0.423942737612318 -0.027493034904141 -0.068648706999971
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.012967316151690  0.053655915263561  0.013296231482133 -0.012509871140561  0.053184722817966
-    1  (  5) -0.065459441432743 -0.098590450512903 -0.180288063245052 -0.033076485246495 -0.305944394837877
-    2  (  6)  0.160972461596512 -0.052337284313257  0.418780783100688 -0.024563105423132 -0.150128272333000
-
-	DPD File2: L*_Y_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0)  0.002961765779100  0.004522349171324 -0.004971919287087  0.008281709260186  0.002230370021123  0.014875581701851  0.067042001167372  0.013799182049252 -0.003919895633432
-    1  (  1)  0.001156407591826  0.011364234036016  0.009216213637618 -0.026466586550273  0.045020897276730  0.024548396390040  0.151472003391729  0.022837501049660 -0.020115222648640
-    2  (  2) -0.011852353144693 -0.003988649312187  0.013577386237941 -0.005526396491599  0.001842043686662 -0.004979012487137 -0.016339527495633 -0.010418266838825 -0.006987142315452
-    3  (  3) -0.053414909238326 -0.048153357581206  0.085702791986601 -0.002590768785420 -0.032944657214652 -0.019536458989955 -0.058299722995214  0.003474387569511 -0.035804252701834
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0)  0.000158467148596 -0.005351238219208 -0.000795318433066 -0.002864683250639  0.001069112713473 -0.000329369508724
-    1  (  1)  0.008857574490791  0.013536712170937  0.030733233064254  0.004374373678073 -0.001058558277179  0.003465102179278
-    2  (  2)  0.011600433240152 -0.024957487742010  0.006847708052902 -0.007864294541740  0.004416463366055  0.003633653136444
-    3  (  3)  0.033694386372795  0.004962923837305 -0.009297526391638  0.012733700421545  0.018367087946588  0.009679397413178
-
-	File 101 DPD File2: L*_Y_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4) -0.004099418996737  0.004975270717489  0.011544453403942  0.010294240373049  0.015031167783122 -0.051218543078986  0.101906219668190  0.009904937929980 -0.005253311566155
-    1  (  5)  0.030335401615971 -0.051022895540044 -0.010476806750229  0.022518303747979  0.032764970727702 -0.046697847750190  0.082351506534871  0.029648968337614 -0.032167075005308
-    2  (  6) -0.044658147220588  0.062597359445969  0.000792773883945  0.033784853569182  0.053456383670095 -0.070727579120646  0.103493462669028 -0.004470774917382  0.021985039399781
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4) -0.001406578222011  0.001390228891514  0.004138457631327 -0.000537337712782  0.000303816554518
-    1  (  5) -0.018025115903144 -0.007054017557051  0.018234657716208  0.000615735236753 -0.005903957155119
-    2  (  6)  0.015821399504368  0.004485035916282  0.033862858822880  0.005131801318237  0.004339292116808
-
-	DPD File2: L*_YBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     3
-	   Irrep: 1 row =     3	col =     4
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  0) -0.001352471969094 -0.045322075444733  0.038349314552152
-    1  (  1) -0.023470923414908 -0.379995390457559  0.218263993898326
-    2  (  2) -0.020646215106669 -0.203889457343544  0.063634437124037
-    3  (  3) -0.097263397740302 -0.216436926506454 -0.416986973069653
-
-	File 101 DPD File2: L*_YBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  4)  0.001379673989061  0.023464182377298  0.020715625293986  0.097608841144396
-    1  (  5)  0.045132209688744  0.379406783605291  0.203869208496661  0.217739723605823
-    2  (  6) -0.038063072975973 -0.217447630040656 -0.062958922139319  0.417725794235781
-
-	DPD File2: L*_YBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    15
-	   Irrep: 1 row =    15	col =    14
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.065653814142264 -0.041946284375303 -0.013161767706572  0.111342796774500 -0.110017778689743 -0.028611074624176 -0.087379776644865  0.000506944002000 -0.012737970563703
-    1  (  1)  0.002767473668146  0.010697220027718 -0.013506144228592 -0.073913704778148  0.217999207158693  0.148131683228122  0.817266423889027  0.116806346540286 -0.086848804711528
-    2  (  2) -0.048963138068012 -0.019287255807937 -0.016789870431812  0.373432811546966 -0.152152935578878  0.191763986764781  0.187319954974202  0.050812933510948 -0.023574454587241
-    3  (  3)  0.095762012298033  0.056431105854389 -0.178578325306558 -0.038136923805617 -0.140424655163157 -0.089806364466590  0.125801031634604  0.116636753108288  0.084794392657478
-    4  (  4)  0.100603170191617  0.067705087958627 -0.243617055985189 -0.044363102282417 -0.181215354983299 -0.115079991268796  0.179518597407386  0.083927955619955  0.086976764117441
-    5  (  5) -0.065265491800394 -0.066327433491654  0.367149548777650 -0.044009709655582 -0.156519624550140 -0.073861464202985  0.054146331819748  0.093323533938862 -0.170259582834842
-    6  (  6)  0.072248812824936  0.071960211653410 -0.684415406158707  0.206867685302678  0.380153305403406  0.217464691746015 -0.101286474206003 -0.035777100475268  0.341069042893403
-    7  (  7) -0.019742266764988 -0.004654597124952 -0.113800058767268  0.000574265002983 -0.010628342976831 -0.072863781204177 -0.376898463473803 -0.139300622802210  0.056085680972333
-    8  (  8) -0.000679953535081 -0.001598902294011  0.037525126251819 -0.088614223995002  0.068220130924204 -0.039175761140296 -0.208506736043279 -0.056089637691589  0.046057044816225
-    9  (  9)  0.002777732520373  0.007429125774642  0.024943116942350 -0.022915921654072  0.035702462515069  0.020318534935527  0.128837242689886 -0.002259623765271  0.005711714139269
-   10  ( 10)  0.005703803965392 -0.023273876655766 -0.027225029310730 -0.026559677666667  0.035399971500057  0.015156942548385  0.030152703916084  0.170109037950347  0.002596190944829
-   11  ( 11)  0.003384564196851  0.002280327238919 -0.118256580527015 -0.004805921198873  0.008748560057608 -0.061729599159426 -0.016174096583601  0.021868118731471 -0.291086759759657
-   12  ( 12) -0.020555722880272  0.013540587399774 -0.000211893937570  0.008542727496112 -0.013892940715707 -0.041889105198929 -0.006009166679671 -0.135825768330791 -0.000314961828297
-   13  ( 13) -0.004670677001798 -0.000926772526536 -0.016865034300282  0.001908716884004  0.008533776733402  0.002600829800043  0.067129999007525  0.024630232805222  0.002093287302057
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.006448280903781  0.007804174666870 -0.001726589742279 -0.009631719534244 -0.002171109312827  0.006916768929421
-    1  (  1)  0.039841759002053  0.031613811363753  0.126269993080286 -0.005440038892529 -0.010222632040274  0.010738082177417
-    2  (  2)  0.049400367190082 -0.028054173187029 -0.027409200065905 -0.001009289954765  0.006677408446924  0.009978484711828
-    3  (  3) -0.070460304013326  0.083098595574193 -0.035907224123551  0.018802993269139 -0.017169529769810 -0.011284756920795
-    4  (  4) -0.035774264116816 -0.067898270132826  0.022183832964584 -0.018305304819727 -0.010768454734731 -0.005255647674495
-    5  (  5) -0.149334153074510  0.107123073600670  0.046253700594295  0.009064678078212 -0.006568373775894 -0.015962506593757
-    6  (  6)  0.264128081623912  0.189717353125691 -0.013846475545988  0.034468738650004 -0.018622793691907  0.039125899611440
-    7  (  7)  0.078787498256752 -0.137081801981432  0.129024279783991 -0.020540266029100  0.010702305076213  0.006363683572839
-    8  (  8) -0.066828272542120 -0.061150331629768 -0.661663512432504 -0.064427579111988  0.022787180611671  0.001755054521373
-    9  (  9) -0.058361662206488 -0.002765609007918 -0.292979002594137  0.024531884688023 -0.033841964179834  0.017477652244683
-   10  ( 10) -0.025537046615515  0.402776836876724 -0.195006548574470 -0.143818217257362  0.044952634158782 -0.042833786526299
-   11  ( 11)  0.612581110120467  0.030681983336889 -0.052907112855315  0.397594256764291  0.644994698530558 -0.225177415266176
-   12  ( 12) -0.078361827884296  0.147641215292530 -0.139659868964866  0.415352806158415 -0.111207746262217  0.045767792834358
-   13  ( 13) -0.007555966012008  0.007034052257820 -0.662815283687025 -0.034075798547008  0.058439318318560 -0.002857982237762
-
-	File 101 DPD File2: L*_YBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  ( 14)  0.065636199611282 -0.002920916198147  0.048668219311498 -0.095119636724795 -0.099715491746342  0.064115894757826 -0.070288612362710  0.020002036740183  0.000648682346076
-    1  ( 15)  0.042164832302811 -0.010965264984920  0.019193267525749 -0.056427120825921 -0.067779126388374  0.066346545701259 -0.071818426884183  0.004697793564429  0.001719477062512
-    2  ( 16)  0.013293723744736  0.013552393155520  0.017152946073135  0.178062131392816  0.243207234696954 -0.366656850670269  0.683571699988320  0.113725695300653 -0.037674829370647
-    3  ( 17) -0.111833520478397  0.074487105305844 -0.373408686548039  0.038278615402917  0.044272326064866  0.043920914820213 -0.206763999327991 -0.000718931757735  0.088712771696387
-    4  ( 18)  0.110609556420903 -0.218552165395166  0.152101671319906  0.140308960149057  0.181388781196210  0.156379821301524 -0.379726625097930  0.010777684689777 -0.068071061617319
-    5  ( 19)  0.028752510181408 -0.148103625807997 -0.191866592233893  0.089885426625568  0.115404739185245  0.073530988681885 -0.216894531023559  0.072888831186762  0.039414155734701
-    6  ( 20)  0.088850262853694 -0.817864717973160 -0.187538432803728 -0.126558510407503 -0.179188313739966 -0.053967785688344  0.101346004734165  0.376808265586346  0.209641170142921
-    7  ( 21) -0.000236648626185 -0.116954024007332 -0.050876086441348 -0.116850431043499 -0.083855737312712 -0.093201481422807  0.035654753872492  0.139240147731598  0.056215130854042
-    8  ( 22)  0.012632241831446  0.086750564455513  0.023471210733819 -0.084658255793584 -0.087082440553447  0.170291379307318 -0.341029495907861 -0.056080270650825 -0.046130696703817
-    9  ( 23)  0.006387457988158 -0.039627800428235 -0.049236971359731  0.070603541281575  0.036093218300137  0.148729935532572 -0.263186790392662 -0.078651937105263  0.066792443994885
-   10  ( 24) -0.007794314356224 -0.031645957507839  0.027999240171264 -0.083306839859372  0.068240617920633 -0.107186407568302 -0.189422573537585  0.136891913283426  0.061228539916207
-   11  ( 25)  0.001991689460876 -0.126407268625784  0.027445392718538  0.035776924599103 -0.022144125160038 -0.046221028292780  0.013824022605635 -0.129003528239796  0.661853370394303
-   12  ( 26)  0.009599825104381  0.005495331116759  0.001034223219580 -0.018933867742673  0.018384105286375 -0.009023661627231 -0.034486124663305  0.020439460919434  0.064455521141270
-   13  ( 27)  0.002162721447509  0.010273200862148 -0.006630148558014  0.017146542465354  0.010737357070418  0.006596929169183  0.018510057851825 -0.010689113270586 -0.022830224344291
-   14  ( 28) -0.006906605609555 -0.010703198677296 -0.009943679074748  0.011262720290334  0.005261069281766  0.015966561898017 -0.039173616710326 -0.006358426931312 -0.001746833081562
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  ( 14) -0.002837339199042 -0.005729990462521 -0.002882667336321  0.020606047818522  0.004641004703607
-    1  ( 15) -0.007437286770332  0.023276875493539 -0.002358499534732 -0.013557485629733  0.000920107297989
-    2  ( 16) -0.025051827266470  0.027193002752018  0.117990698559769  0.000179234372392  0.016865743435032
-    3  ( 17)  0.023119196337007  0.026652175278014  0.004797499415929 -0.008529905892743 -0.001864545935891
-    4  ( 18) -0.035881897592302 -0.035473538214569 -0.008734163325355  0.013878334987718 -0.008565527202823
-    5  ( 19) -0.020360772275651 -0.015171720613603  0.061893166394059  0.041911368342621 -0.002602253507665
-    6  ( 20) -0.129299070691523 -0.030292769804169  0.016131950321938  0.006006549470023 -0.067162983124201
-    7  ( 21)  0.002077638821295 -0.170151112881545 -0.021893691209527  0.135824125871701 -0.024649373152539
-    8  ( 22) -0.005657792833300 -0.002565321667606  0.291029322280664  0.000304358068315 -0.002094832642432
-    9  ( 23)  0.058382869250631  0.025529477410136 -0.612383084135802  0.078382756676553  0.007563305586064
-   10  ( 24)  0.002481618081866 -0.402824463109094 -0.030640926554774 -0.147639465945455 -0.007047422246803
-   11  ( 25)  0.292947637539939  0.194977050256941  0.052900384325439  0.139655182883169  0.662817045986547
-   12  ( 26) -0.024630592497451  0.143803605487111 -0.397605464014331 -0.415353658752820  0.034075972250685
-   13  ( 27)  0.033850850098076 -0.044956075971212 -0.644991001235189  0.111210374775728 -0.058439332449029
-   14  ( 28) -0.017470247415045  0.042829113212736  0.225189876847489 -0.045765194902991  0.002860279243371
-
-	DPD File2: L*_YBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 1 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    15
-	   Irrep: 1 row =     3	col =    14
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  0) -0.003220755761788 -0.004741334513036  0.005218491575352 -0.008931308835907 -0.002244102633378 -0.015838687100919 -0.070299613805989 -0.014541519275327  0.004023986014985
-    1  (  1) -0.000067503033474 -0.012207317918030 -0.007244793200988  0.023892777130642 -0.043438396740122 -0.025220796440141 -0.154461573863724 -0.023000834887421  0.019599055677926
-    2  (  2)  0.012578011879907  0.003275100255966 -0.012592919961383  0.005684090399027 -0.002169804380039  0.004971061326221  0.013552564477647  0.009500984985895  0.006299654057362
-    3  (  3)  0.059262075820670  0.046181284980691 -0.084603478568992  0.003021949940787  0.032496962809605  0.021957384896270  0.062320115832634 -0.002770430488820  0.031773062115651
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  0) -0.000182000207227  0.005588586167114  0.000672702586966  0.002964514553093 -0.001105034523208  0.000343253226041
-    1  (  1) -0.008618205903186 -0.014153751191206 -0.035995392865196 -0.005123687397521  0.001603958931174 -0.003532153146744
-    2  (  2) -0.011268111146370  0.024898784529351 -0.008069485418761  0.008185686323918 -0.004533934142691 -0.003585064891685
-    3  (  3) -0.031845177970419 -0.004991052985520  0.011188833991374 -0.013257910424622 -0.018832233173395 -0.009593400754084
-
-	File 101 DPD File2: L*_YBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  4)  0.004231156729541 -0.005431493649267 -0.012529175724660 -0.009596633242284 -0.014606722988323  0.052629799448244 -0.104835250484967 -0.010143068216584  0.005577330897623
-    1  (  5) -0.032234138585390  0.047805476204470  0.011206420541453 -0.021169463646392 -0.032922137113452  0.049263864001113 -0.085142779220860 -0.029187847712420  0.030401159775617
-    2  (  6)  0.047014795193874 -0.061420283989306 -0.003243656996742 -0.033537214796175 -0.054307591623750  0.073188368684598 -0.108826461718921  0.002713708723067 -0.019591523301056
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  4)  0.001535925504297 -0.001313736377570 -0.005141735029325  0.000303256666525 -0.000317758840647
-    1  (  5)  0.017868281803487  0.005956287092286 -0.022125071354749  0.000228679155762  0.005956925492705
-    2  (  6) -0.014719284513933 -0.004480852833973 -0.038592140844884 -0.004744813467982 -0.004561240528551
-
-	DPD File2: L*_Z_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.022503440356479 -0.058098623177060 -0.000062770505092  0.132305009105496  0.206845253941622 -0.090151367748423  0.021622993143838  0.039361662992191 -0.081041759558226
-    1  (  1)  0.058446002702836 -0.108172168386185 -0.020491566051334 -0.029038345992777  0.075256281123738 -0.197244333988945  0.268904698641837  0.104165934598637 -0.067340388311649
-    2  (  2)  0.015395531848647 -0.065975044836942 -0.020693241330571 -0.145278172814648 -0.156811977452555 -0.026190455636648  0.072791620713754  0.106379131933316 -0.008110007352911
-    3  (  3) -0.209889648236101 -0.051262205353483  0.016792464647056  0.095510023392087 -0.095336437943254  0.289116527068191 -0.245753635975044  0.379261907549404 -0.084194488960217
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0) -0.009235922070380  0.024147628235135 -0.039515998256435 -0.082736569385204  0.047511948407189
-    1  (  1) -0.028213287410066 -0.067760885382258 -0.238885785831598  0.125969164417165 -0.177609465299056
-    2  (  2) -0.077606299822139  0.045313543977919 -0.093141189528995 -0.365274042010320 -0.093447143662359
-    3  (  3) -0.414915648101425 -0.159852566454575  0.273568285244179  0.034618677464967 -0.200919751856191
-
-	File 101 DPD File2: L*_Z_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4)  0.016102682138215  0.069778483618667 -0.053388820705143 -0.227201022061025  0.199230027507757 -0.049687576272545  0.168877445324815  0.014461225346720  0.006078045787078
-    1  (  5) -0.058029574568631  0.323045692556243 -0.030451397480033  0.087822399123219  0.049669665073330  0.052839306705253  0.277652121487366  0.149775076501372 -0.305937155187615
-    2  (  6)  0.084055275416977 -0.046073375264778 -0.190725804844658  0.087557818571264  0.137785527535432  0.205465571560117  0.198777590794243  0.118276962947747  0.298899363411174
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4) -0.065173985643121 -0.083163093513445 -0.059838819925541 -0.009394325003249  0.030439464334268 -0.004211857989885
-    1  (  5) -0.056299327075830  0.068872084822763 -0.330916524082322  0.053769676068525  0.184435947342737  0.103868547796473
-    2  (  6) -0.066328790095722  0.124449756334111 -0.113043685672814 -0.144452726550473 -0.299204372324576  0.043729255630968
-
-	DPD File2: L*_ZBAR_MI
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 0   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =     4
-	   Irrep: 1 row =     3	col =     3
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3     
-                      (  0)              (  1)              (  2)              (  3)    
-
-    0  (  0)  0.000260799278180 -0.008294549497458 -0.017065509889387  0.120823024347784
-    1  (  1)  0.008496132195710 -0.000459229311004 -0.070584548654847  0.263658987971002
-    2  (  2)  0.016577243499005  0.069994423923560 -0.000663995662767 -0.516189372162913
-    3  (  3) -0.119940673323058 -0.260382743299108  0.515797582139532 -0.000896339388888
-
-	File 101 DPD File2: L*_ZBAR_MI
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2     
-                      (  4)              (  5)              (  6)    
-
-    0  (  4)  0.000443199054119 -0.381921104005874  0.143832379423130
-    1  (  5)  0.379434119543787  0.000485242459082 -0.057931044964221
-    2  (  6) -0.142702240031722  0.057674063898636 -0.001442186569692
-
-	DPD File2: L*_ZBAR_AE
-	DPD Parameters:
-	------------------
-	pnum = 1   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =    14	col =    14
-	   Irrep: 1 row =    15	col =    15
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0)  0.000910226438200 -0.057456315647344 -0.021764054616564  0.110121253697657  0.041147685715423 -0.038875248096137  0.013658842816188 -0.027740417762726 -0.095876695371130
-    1  (  1)  0.055345619259075  0.000114715934544  0.161082100934535 -0.114708094818496  0.226148458324691 -0.429581553751604  0.364780572887542  0.339773268987353  0.220533774744399
-    2  (  2)  0.020999461515685 -0.161288340725610 -0.000052922970119 -0.056734674713291 -0.008992634403320 -0.218257664918361  0.249333786133602  0.218109893723775 -0.109339937360493
-    3  (  3) -0.109919099574174  0.115822425715978  0.056019356031194 -0.000740007095007 -0.462857615923727 -0.122607299335305 -0.103870366450161 -0.116250705419353 -0.000233457194456
-    4  (  4) -0.040147971736914 -0.225934656930791  0.007773114629988  0.462818557889914  0.000780254049361 -0.292874409138683  0.009409004020261  0.051882584565833  0.039822167749921
-    5  (  5)  0.036335623693882  0.431140334679252  0.219015877475265  0.122742719044919  0.292837706496088  0.000258434125831 -0.380099535662932 -0.122521034451732 -0.042311772982521
-    6  (  6) -0.010512439726471 -0.366117332794119 -0.249486244103056  0.103549874519169 -0.008542365779906  0.379118456291524  0.000620782572313 -0.110534560584461  0.061985573540389
-    7  (  7)  0.028794951664777 -0.339121669867214 -0.216809050490518  0.114099993246667 -0.053090461626524  0.122152835981425  0.109887843186158  0.000210776402969  0.084672807469555
-    8  (  8)  0.095808229399132 -0.221323464482799  0.109106314792845  0.000875257457611 -0.038544677386553  0.040538328426676 -0.059775641025623 -0.084700205378613 -0.000410389354257
-    9  (  9) -0.014690106491517  0.105287842118522  0.107275604483120 -0.218821764375615 -0.309676781731095  0.105240911604621  0.129641828566929 -0.117997785339671 -0.042511311192418
-   10  ( 10)  0.029204608817403 -0.107752356880331  0.099755035717731 -0.053525818879341 -0.138310129158905 -0.190113742192741  0.089997971579917  0.050367401919439  0.205935350574800
-   11  ( 11)  0.155172680813618 -0.443695988859270  0.328777258069509  0.218798389099096  0.215176387461835 -0.086665175851153  0.081418632205002  0.042686048283827 -0.076994698961746
-   12  ( 12) -0.047142387984938 -0.056370877735219  0.091886939990151 -0.290638653877080  0.241910292969431  0.247337059928007 -0.042831064524262 -0.092379405612353  0.274155000078483
-   13  ( 13)  0.050389463693039 -0.050328281612189  0.290240848494312 -0.162056910726980 -0.213783629964646  0.103688020985272  0.033887129957515  0.045587144676475 -0.299790508093838
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.015162329261762 -0.029089765310940 -0.157702865584754  0.046156688514328 -0.051381785238624
-    1  (  1) -0.106899843708486  0.107201618560176  0.445393416001207  0.057067668629351  0.050060001886431
-    2  (  2) -0.108853020016321 -0.100191021028451 -0.328545989684712 -0.092698579556052 -0.291502735762344
-    3  (  3)  0.218857914732928  0.054792818554564 -0.218936510583978  0.287400526650046  0.163296274552526
-    4  (  4)  0.309023997649700  0.137542449801745 -0.215093936648757 -0.238284970233362  0.213551426731583
-    5  (  5) -0.105674820684469  0.189857437820115  0.086867271556711 -0.246374813757869 -0.103858683942188
-    6  (  6) -0.128168668490610 -0.089874262580382 -0.081958189888793  0.043636026138960 -0.033207564369726
-    7  (  7)  0.118048267554359 -0.049676494199198 -0.043691989598397  0.088880392330239 -0.045560837044954
-    8  (  8)  0.043185963759057 -0.206226573210928  0.075243165739987 -0.272590964145289  0.299131513308221
-    9  (  9)  0.000077812750263 -0.416515228417900 -0.033604308554634  1.079153036382561 -0.144875292418151
-   10  ( 10)  0.417421688656681  0.000158782243602  0.288840596220158  0.322135887066066  0.291543524694710
-   11  ( 11)  0.033233098605228 -0.288689216150241 -0.000098607070373 -0.357467165030213  0.110234432471254
-   12  ( 12) -1.082588809014081 -0.322578291381663  0.357464370732486  0.000001008926324  0.002433258902322
-   13  ( 13)  0.144961978586806 -0.291352746525362 -0.110198259116823 -0.002466771848949 -0.000072101869173
-
-	File 101 DPD File2: L*_ZBAR_AE
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  ( 14)  0.000153758776117 -0.016209320965105 -0.024928923757993  0.062060534746170  0.021458157416245 -0.118593249067004  0.004670228294358  0.089096779890278 -0.035341469320983
-    1  ( 15)  0.019055649133697 -0.000070152122919 -0.073747919702930  0.220440656283159 -0.117173681778925  0.070042107037530  0.194626605110428 -0.297284849336053  0.000292612579198
-    2  ( 16)  0.022586057118123  0.073725573957683  0.001109122666778  0.015411803389863  0.086529842350705  0.104871287980693  0.398741646289671  0.436619148331831 -0.174927780649059
-    3  ( 17) -0.059798965916265 -0.223563287458482 -0.017237453392182 -0.001072539123553 -0.251308090392191  0.316070038847548 -0.194803920269306 -0.070654457969027  0.376473483655780
-    4  ( 18) -0.020063419612631  0.119039349408291 -0.086800563750570  0.251653936305414  0.000335080735996 -0.043024303892643 -0.031731210904760 -0.166597040709751 -0.162561043906122
-    5  ( 19)  0.121124499955847 -0.070386002281353 -0.107113059896318 -0.315446439504518  0.043168772215477  0.000861181929967 -0.084799445456534 -0.176705933868056  0.191684805801835
-    6  ( 20) -0.000233561036084 -0.194646689461778 -0.399810731825322  0.193912344414617  0.032510952578749  0.085522667269840 -0.000316476981181 -0.483153682224173  0.288298406144107
-    7  ( 21) -0.086715012513528  0.297226361655840 -0.437406683020490  0.070307665212214  0.166617940064674  0.177260527643651  0.482840792772829  0.000014363804072 -0.098144550576534
-    8  ( 22)  0.034848855831113 -0.000859202110741  0.174080336928834 -0.374333295621785  0.160768014942695 -0.191629536777613 -0.289445575791765  0.097019024563133  0.000025631190893
-    9  ( 23)  0.146128458859477 -0.053492838723281 -0.324237370304827 -0.062951581962557 -0.055209150392106 -0.064149761275701 -0.152989513320630 -0.139473999081823  0.103718919745517
-   10  ( 24) -0.228943772617007  0.607904766836796  0.190620042163283  0.232958068554443  0.097307404392685 -0.308161168894475  0.021743402571297 -0.163623966328651 -0.316399909940952
-   11  ( 25)  0.113574180450176  0.174427793696739 -0.418995996797932 -0.308337203773489  0.075443225258948 -0.339087151000572  0.159463644175662  0.028413073183974  0.098871219135018
-   12  ( 26)  0.037424667627758  0.021650461815628 -0.117304488555654  0.051902638516337 -0.180454397204301 -0.010740660446775 -0.081519307958206  0.155893098286787 -0.070546741513103
-   13  ( 27) -0.017280094917641  0.067254948202109 -0.031223412783479  0.363810241712273 -0.387221887172221 -0.012090141232777 -0.015814975888526 -0.054980917535039  0.199339784826487
-   14  ( 28) -0.034098865606387 -0.073619427530260  0.020485113762460  0.085856422339691 -0.016811589994319  0.112843996612104  0.014113720302883 -0.178007823049380 -0.110352388592064
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  ( 14) -0.147079245976260  0.230634884327798 -0.118016008095876 -0.038157145434167  0.016510465499821  0.035555014241919
-    1  ( 15)  0.054535973951003 -0.607948556744402 -0.173873449665646 -0.021413077919509 -0.066607274428011  0.073358777560519
-    2  ( 16)  0.323553306716541 -0.191880318233455  0.420431580367675  0.118056258433329  0.032680374772067 -0.021063792737754
-    3  ( 17)  0.062647993136989 -0.233296910168052  0.309972235049851 -0.052767888000268 -0.365466873103625 -0.086191647721005
-    4  ( 18)  0.056463254581534 -0.097267541950806 -0.076718792428350  0.181006281426179  0.388581954607450  0.017033118173935
-    5  ( 19)  0.064619380352855  0.308870128837400  0.338018875040100  0.010262168024492  0.011437556053144 -0.112357517192840
-    6  ( 20)  0.155382617120808 -0.021349499069868 -0.159407311491110  0.081840985740344  0.016551112219655 -0.014159445447452
-    7  ( 21)  0.140537868365913  0.163950016139901 -0.028635642703436 -0.155664270522521  0.055628199070781  0.178154240957341
-    8  ( 22) -0.103340923981933  0.315438553715367 -0.098505861648548  0.070640699178892 -0.199194337948212  0.110183696150063
-    9  ( 23) -0.000686334523005  0.100169676705670  0.098205409926821 -0.175395135103276  0.218110756133058 -0.228152281729332
-   10  ( 24) -0.099945574901306  0.000096874523801 -0.318471840231024  0.225312239057313  0.500004280246570  0.463864297141458
-   11  ( 25) -0.099841601903911  0.317761699341874  0.000010561898700 -0.325597818757907  0.211905875429043  0.064803783303090
-   12  ( 26)  0.174935629969472 -0.225292248952868  0.325705390264674  0.000017197242562  0.212072627252549 -0.098012445880115
-   13  ( 27) -0.218628597779198 -0.499556536309007 -0.211864150049234 -0.212027765065009 -0.000008829414452  0.140826209095657
-   14  ( 28)  0.228628348644091 -0.463533897425291 -0.064881803408838  0.097950839605716 -0.140879063677935  0.000044304452715
-
-	DPD File2: L*_ZBAR_IA
-	DPD Parameters:
-	------------------
-	pnum = 0   qnum = 1   irrep = 0 
-	Irreps = 2
-
-	   Row and column dimensions for DPD Block:
-	   ----------------------------------------
-	   Irrep: 0 row =     4	col =    14
-	   Irrep: 1 row =     3	col =    15
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 0
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      (  0)              (  1)              (  2)              (  3)              (  4)              (  5)              (  6)              (  7)              (  8)    
-
-    0  (  0) -0.019783280962491  0.054735513036393 -0.001137513221933 -0.126035313397777 -0.202288257068162  0.093711193829816 -0.024984212293499 -0.040225532801761  0.083002910227929
-    1  (  1) -0.062354133456812  0.120130294655184  0.021767958501026  0.030544876872275 -0.074729404941111  0.202914227763797 -0.283260339857543 -0.110010624076740  0.075144553244755
-    2  (  2) -0.020071793451970  0.073560407589557  0.021169787012452  0.145854096701605  0.150911678978076  0.033300464776861 -0.073764758000912 -0.114546085873699  0.006653295400428
-    3  (  3)  0.203743026628905  0.061501992586247 -0.012053004875485 -0.096810295870523  0.111136074888818 -0.295383183736970  0.262971263836652 -0.383085480530365  0.093214804722179
-
-                         9                 10                 11                 12                 13     
-                      (  9)              ( 10)              ( 11)              ( 12)              ( 13)    
-
-    0  (  0)  0.009993046283887 -0.025513386596424  0.042737152836742  0.089318312648033 -0.047451575437880
-    1  (  1)  0.030039490649266  0.071945227885317  0.250267584137830 -0.142236308614906  0.184637048828095
-    2  (  2)  0.082997800944815 -0.054871782095115  0.094796172305804  0.401103667111563  0.092927166183836
-    3  (  3)  0.430981237821724  0.170811685089178 -0.282618320770360 -0.039486333217088  0.208093566455086
-
-	File 101 DPD File2: L*_ZBAR_IA
-	Matrix for Irrep 1
-	----------------------------------------
-
-                         0                  1                  2                  3                  4                  5                  6                  7                  8     
-                      ( 14)              ( 15)              ( 16)              ( 17)              ( 18)              ( 19)              ( 20)              ( 21)              ( 22)    
-
-    0  (  4) -0.010424640140636 -0.070076236901647  0.057204661229737  0.211582690126517 -0.193468115965468  0.043909115261545 -0.178375291288102 -0.011291008781060 -0.006135050116210
-    1  (  5)  0.063097232722725 -0.334472526495555  0.025536894990807 -0.078253601702773 -0.050626850793128 -0.056751425430030 -0.294768356957907 -0.157483239712855  0.310569420319987
-    2  (  6) -0.095244048403721  0.044264153982762  0.212560989611836 -0.091390108488898 -0.149038965211255 -0.211765484415775 -0.210419446695478 -0.121083327494802 -0.309642081940379
-
-                         9                 10                 11                 12                 13                 14     
-                      ( 23)              ( 24)              ( 25)              ( 26)              ( 27)              ( 28)    
-
-    0  (  4)  0.068004773266362  0.092578615344634  0.065573414828925  0.010233554140998 -0.030163257404408  0.003064448161750
-    1  (  5)  0.053600127227434 -0.069934324462776  0.342538882666169 -0.056907034018328 -0.186630072086963 -0.106323576616076
-    2  (  6)  0.072821378093083 -0.126275999821165  0.117600524675145  0.149377060058828  0.309029921623329 -0.046031657791552
-
 	Computing Mu_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.194769257179
-	   1         5.234145791667    3.287e-01
-	   2         6.407097563020    2.124e-01
-	   3         6.488759815991    7.102e-02
-	   4         6.556272178680    3.544e-02
-	   5         6.566960164058    1.658e-02
-	   6         6.567840819252    8.008e-03
-	   7         6.570224496540    4.762e-03
-	   8         6.569439074938    2.617e-03
-	   9         6.569607474211    1.435e-03
-	  10         6.569715133622    5.714e-04
-	  11         6.569657378403    1.584e-04
-	  12         6.569580994898    7.027e-05
-	  13         6.569558256690    3.206e-05
-	  14         6.569576338046    1.541e-05
-	  15         6.569587541671    5.994e-06
-	  16         6.569590098453    2.428e-06
-	  17         6.569589491889    1.218e-06
-	  18         6.569588955068    4.639e-07
-	  19         6.569588790158    2.247e-07
-	  20         6.569588743445    1.105e-07
-	  21         6.569588705890    5.894e-08
-	  22         6.569588706747    1.625e-08
-	  23         6.569588709010    5.960e-09
-	  24         6.569588714424    2.617e-09
-	  25         6.569588716520    1.038e-09
-	  26         6.569588717515    4.120e-10
-	  27         6.569588717795    1.624e-10
+	   0         4.194769250266
+	   1         5.234145781640    3.287e-01
+	   2         6.407097549025    2.124e-01
+	   3         6.488759802182    7.102e-02
+	   4         6.556272165274    3.544e-02
+	   5         6.566960150429    1.658e-02
+	   6         6.567840805665    8.008e-03
+	   7         6.570224482897    4.762e-03
+	   8         6.569439061284    2.617e-03
+	   9         6.569607460560    1.435e-03
+	  10         6.569715119968    5.714e-04
+	  11         6.569657364749    1.584e-04
+	  12         6.569580981243    7.027e-05
+	  13         6.569558243035    3.206e-05
+	  14         6.569576324391    1.541e-05
+	  15         6.569587528017    5.994e-06
+	  16         6.569590084799    2.428e-06
+	  17         6.569589478235    1.218e-06
+	  18         6.569588941414    4.639e-07
+	  19         6.569588776504    2.247e-07
+	  20         6.569588729791    1.105e-07
+	  21         6.569588692236    5.894e-08
+	  22         6.569588693093    1.625e-08
+	  23         6.569588695356    5.960e-09
+	  24         6.569588700770    2.617e-09
+	  25         6.569588702867    1.038e-09
+	  26         6.569588703861    4.120e-10
+	  27         6.569588704141    1.624e-10
 	-----------------------------------------
 	Converged Mu_X-Perturbed Wfn to 4.529e-11
 
 	Computing P*_X-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.567077994117
-	   1         9.794811576534    2.555e-01
-	   2        10.533472618795    1.469e-01
-	   3        10.609568110643    6.924e-02
-	   4        10.649172672397    3.372e-02
-	   5        10.659558655819    1.729e-02
-	   6        10.664568900336    9.710e-03
-	   7        10.666738513696    5.260e-03
-	   8        10.666626317502    2.726e-03
-	   9        10.667123425150    1.240e-03
-	  10        10.667283701875    5.306e-04
-	  11        10.667179393481    1.373e-04
-	  12        10.667092980783    4.910e-05
-	  13        10.667075040286    2.031e-05
-	  14        10.667078011873    1.099e-05
-	  15        10.667080488008    4.814e-06
-	  16        10.667080094760    2.178e-06
-	  17        10.667078880021    1.228e-06
-	  18        10.667078030981    7.815e-07
-	  19        10.667077746544    3.625e-07
-	  20        10.667077562146    1.451e-07
-	  21        10.667077504632    5.020e-08
-	  22        10.667077487128    1.653e-08
-	  23        10.667077483975    8.860e-09
-	  24        10.667077480072    4.099e-09
-	  25        10.667077478345    1.654e-09
-	  26        10.667077477801    5.493e-10
-	  27        10.667077477811    1.993e-10
+	   0         8.567078016154
+	   1         9.794811600721    2.555e-01
+	   2        10.533472645707    1.469e-01
+	   3        10.609568138185    6.924e-02
+	   4        10.649172700311    3.372e-02
+	   5        10.659558683633    1.729e-02
+	   6        10.664568928119    9.710e-03
+	   7        10.666738541381    5.260e-03
+	   8        10.666626345168    2.726e-03
+	   9        10.667123452805    1.240e-03
+	  10        10.667283729526    5.306e-04
+	  11        10.667179421133    1.373e-04
+	  12        10.667093008437    4.910e-05
+	  13        10.667075067940    2.031e-05
+	  14        10.667078039528    1.099e-05
+	  15        10.667080515663    4.814e-06
+	  16        10.667080122415    2.178e-06
+	  17        10.667078907676    1.228e-06
+	  18        10.667078058636    7.815e-07
+	  19        10.667077774199    3.625e-07
+	  20        10.667077589801    1.451e-07
+	  21        10.667077532286    5.020e-08
+	  22        10.667077514782    1.653e-08
+	  23        10.667077511630    8.860e-09
+	  24        10.667077507727    4.099e-09
+	  25        10.667077506000    1.654e-09
+	  26        10.667077505455    5.493e-10
+	  27        10.667077505466    1.993e-10
 	-----------------------------------------
 	Converged P*_X-Perturbed Wfn to 7.814e-11
 
 	Computing L*_X-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         4.196236851167
-	   1         5.174523918216    2.469e-01
-	   2         5.926983959628    1.286e-01
-	   3         5.941306919916    2.623e-02
-	   4         5.952209193192    9.565e-03
-	   5         5.952557756760    2.698e-03
-	   6         5.952729245112    1.070e-03
-	   7         5.952897890094    3.838e-04
-	   8         5.952863434294    1.241e-04
-	   9         5.952860203209    3.217e-05
-	  10         5.952860253428    9.417e-06
-	  11         5.952862510572    2.575e-06
-	  12         5.952862915817    6.419e-07
-	  13         5.952862793108    1.705e-07
-	  14         5.952862729182    6.011e-08
-	  15         5.952862701785    2.073e-08
-	  16         5.952862695453    6.519e-09
-	  17         5.952862693430    2.077e-09
-	  18         5.952862692369    6.831e-10
-	  19         5.952862692188    1.963e-10
+	   0         4.196236822918
+	   1         5.174523882784    2.469e-01
+	   2         5.926983915035    1.286e-01
+	   3         5.941306874533    2.623e-02
+	   4         5.952209147435    9.565e-03
+	   5         5.952557710944    2.698e-03
+	   6         5.952729199281    1.070e-03
+	   7         5.952897844254    3.838e-04
+	   8         5.952863388456    1.241e-04
+	   9         5.952860157371    3.217e-05
+	  10         5.952860207590    9.417e-06
+	  11         5.952862464734    2.575e-06
+	  12         5.952862869979    6.419e-07
+	  13         5.952862747270    1.705e-07
+	  14         5.952862683344    6.011e-08
+	  15         5.952862655947    2.073e-08
+	  16         5.952862649615    6.519e-09
+	  17         5.952862647592    2.077e-09
+	  18         5.952862646531    6.831e-10
+	  19         5.952862646350    1.963e-10
 	-----------------------------------------
 	Converged L*_X-Perturbed Wfn to 6.916e-11
 
 	Computing Mu_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.157202385923
-	   1        12.069043331404    5.825e-01
-	   2        15.999588988690    3.672e-01
-	   3        16.135886527613    8.688e-02
-	   4        16.292227330165    5.246e-02
-	   5        16.319486436890    2.064e-02
-	   6        16.319169069633    9.993e-03
-	   7        16.322965256520    6.672e-03
-	   8        16.324608498328    3.808e-03
-	   9        16.323765905856    1.509e-03
-	  10        16.323899734903    6.735e-04
-	  11        16.324542373436    3.463e-04
-	  12        16.324962833753    1.211e-04
-	  13        16.324915715963    4.347e-05
-	  14        16.324825391971    2.242e-05
-	  15        16.324773662132    1.168e-05
-	  16        16.324762357372    4.566e-06
-	  17        16.324763773128    1.472e-06
-	  18        16.324763210360    9.617e-07
-	  19        16.324763141703    5.336e-07
-	  20        16.324763021201    2.138e-07
-	  21        16.324763072166    1.333e-07
-	  22        16.324763036830    5.886e-08
-	  23        16.324763002227    2.557e-08
-	  24        16.324762994301    1.224e-08
-	  25        16.324762994918    5.522e-09
-	  26        16.324762995163    2.946e-09
-	  27        16.324762994114    9.203e-10
-	  28        16.324762994033    3.939e-10
-	  29        16.324762994312    2.052e-10
+	   0         9.157202315451
+	   1        12.069043235932    5.825e-01
+	   2        15.999588842134    3.672e-01
+	   3        16.135886374471    8.688e-02
+	   4        16.292227174485    5.246e-02
+	   5        16.319486280309    2.064e-02
+	   6        16.319168913082    9.993e-03
+	   7        16.322965099741    6.672e-03
+	   8        16.324608341447    3.808e-03
+	   9        16.323765749017    1.509e-03
+	  10        16.323899578060    6.735e-04
+	  11        16.324542216583    3.463e-04
+	  12        16.324962676881    1.211e-04
+	  13        16.324915559092    4.347e-05
+	  14        16.324825235104    2.242e-05
+	  15        16.324773505266    1.168e-05
+	  16        16.324762200507    4.566e-06
+	  17        16.324763616263    1.472e-06
+	  18        16.324763053495    9.617e-07
+	  19        16.324762984838    5.336e-07
+	  20        16.324762864336    2.138e-07
+	  21        16.324762915301    1.333e-07
+	  22        16.324762879965    5.886e-08
+	  23        16.324762845362    2.557e-08
+	  24        16.324762837437    1.224e-08
+	  25        16.324762838053    5.522e-09
+	  26        16.324762838298    2.946e-09
+	  27        16.324762837250    9.203e-10
+	  28        16.324762837168    3.939e-10
+	  29        16.324762837447    2.052e-10
 	-----------------------------------------
 	Converged Mu_Y-Perturbed Wfn to 6.624e-11
 
 	Computing P*_Y-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         8.865002725070
-	   1        10.590728201932    3.416e-01
-	   2        11.937977852421    1.917e-01
-	   3        12.025923495843    5.504e-02
-	   4        12.062077054269    2.825e-02
-	   5        12.068076852960    9.482e-03
-	   6        12.068396888868    3.756e-03
-	   7        12.069112283279    1.498e-03
-	   8        12.069015230180    9.372e-04
-	   9        12.068904299986    5.785e-04
-	  10        12.069010884546    3.190e-04
-	  11        12.069079927874    1.516e-04
-	  12        12.069092752894    7.608e-05
-	  13        12.069055259105    2.714e-05
-	  14        12.069042685829    9.819e-06
-	  15        12.069038843547    4.279e-06
-	  16        12.069037545197    1.892e-06
-	  17        12.069036400012    8.568e-07
-	  18        12.069036313051    3.327e-07
-	  19        12.069036459066    1.652e-07
-	  20        12.069036520777    1.017e-07
-	  21        12.069036526982    5.993e-08
-	  22        12.069036502397    2.576e-08
-	  23        12.069036493808    1.630e-08
-	  24        12.069036493190    6.925e-09
-	  25        12.069036495088    2.848e-09
-	  26        12.069036496281    1.072e-09
-	  27        12.069036496852    4.955e-10
-	  28        12.069036496851    2.282e-10
+	   0         8.865002743143
+	   1        10.590728226708    3.416e-01
+	   2        11.937977881990    1.917e-01
+	   3        12.025923523419    5.504e-02
+	   4        12.062077081691    2.825e-02
+	   5        12.068076880260    9.482e-03
+	   6        12.068396916176    3.756e-03
+	   7        12.069112310564    1.498e-03
+	   8        12.069015257460    9.372e-04
+	   9        12.068904327267    5.785e-04
+	  10        12.069010911825    3.190e-04
+	  11        12.069079955154    1.516e-04
+	  12        12.069092780172    7.608e-05
+	  13        12.069055286384    2.714e-05
+	  14        12.069042713108    9.819e-06
+	  15        12.069038870825    4.279e-06
+	  16        12.069037572475    1.892e-06
+	  17        12.069036427290    8.568e-07
+	  18        12.069036340329    3.327e-07
+	  19        12.069036486344    1.652e-07
+	  20        12.069036548055    1.017e-07
+	  21        12.069036554260    5.993e-08
+	  22        12.069036529675    2.576e-08
+	  23        12.069036521086    1.630e-08
+	  24        12.069036520468    6.925e-09
+	  25        12.069036522366    2.848e-09
+	  26        12.069036523559    1.072e-09
+	  27        12.069036524130    4.955e-10
+	  28        12.069036524129    2.282e-10
 	-----------------------------------------
 	Converged P*_Y-Perturbed Wfn to 9.977e-11
 
 	Computing L*_Y-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         0.230584978898
-	   1         0.300347832255    6.826e-02
-	   2         0.357993914351    3.670e-02
-	   3         0.359786604708    7.881e-03
-	   4         0.360365721590    1.735e-03
-	   5         0.360304359653    4.071e-04
-	   6         0.360299394753    1.139e-04
-	   7         0.360304977577    4.272e-05
-	   8         0.360303003365    1.821e-05
-	   9         0.360303653558    4.966e-06
-	  10         0.360303795221    1.417e-06
-	  11         0.360303732200    3.699e-07
-	  12         0.360303655998    1.154e-07
-	  13         0.360303648088    2.174e-08
-	  14         0.360303650648    6.804e-09
-	  15         0.360303651917    2.127e-09
-	  16         0.360303652257    5.959e-10
-	  17         0.360303652264    1.839e-10
+	   0         0.230584975278
+	   1         0.300347827146    6.826e-02
+	   2         0.357993907298    3.670e-02
+	   3         0.359786597554    7.881e-03
+	   4         0.360365714403    1.735e-03
+	   5         0.360304352469    4.071e-04
+	   6         0.360299387570    1.139e-04
+	   7         0.360304970393    4.272e-05
+	   8         0.360302996181    1.821e-05
+	   9         0.360303646374    4.966e-06
+	  10         0.360303788038    1.417e-06
+	  11         0.360303725016    3.699e-07
+	  12         0.360303648814    1.154e-07
+	  13         0.360303640905    2.174e-08
+	  14         0.360303643464    6.804e-09
+	  15         0.360303644733    2.127e-09
+	  16         0.360303645074    5.959e-10
+	  17         0.360303645080    1.839e-10
 	-----------------------------------------
 	Converged L*_Y-Perturbed Wfn to 4.893e-11
 
 	Computing Mu_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         6.515692783712
-	   1         8.318755914702    4.415e-01
-	   2        10.402192980401    2.645e-01
-	   3        10.443322378310    6.468e-02
-	   4        10.509134933677    3.527e-02
-	   5        10.520755187139    1.316e-02
-	   6        10.520775802835    5.741e-03
-	   7        10.521932038493    3.215e-03
-	   8        10.521951624536    1.306e-03
-	   9        10.521762758980    4.749e-04
-	  10        10.521821129282    1.886e-04
-	  11        10.521897897015    9.992e-05
-	  12        10.521960024216    5.220e-05
-	  13        10.521945903788    2.883e-05
-	  14        10.521921159327    1.518e-05
-	  15        10.521909138956    7.526e-06
-	  16        10.521909357425    3.140e-06
-	  17        10.521910652313    1.312e-06
-	  18        10.521911187100    6.234e-07
-	  19        10.521911350694    2.888e-07
-	  20        10.521911357556    1.072e-07
-	  21        10.521911314271    5.868e-08
-	  22        10.521911288983    2.704e-08
-	  23        10.521911273371    9.960e-09
-	  24        10.521911267423    4.600e-09
-	  25        10.521911265145    1.672e-09
-	  26        10.521911264654    5.382e-10
-	  27        10.521911264613    1.808e-10
+	   0         6.515692741927
+	   1         8.318755856522    4.415e-01
+	   2        10.402192896656    2.645e-01
+	   3        10.443322294219    6.468e-02
+	   4        10.509134848970    3.527e-02
+	   5        10.520755102218    1.316e-02
+	   6        10.520775717902    5.741e-03
+	   7        10.521931953542    3.215e-03
+	   8        10.521951539576    1.306e-03
+	   9        10.521762674031    4.749e-04
+	  10        10.521821044336    1.886e-04
+	  11        10.521897812071    9.992e-05
+	  12        10.521959939277    5.220e-05
+	  13        10.521945818845    2.883e-05
+	  14        10.521921074381    1.518e-05
+	  15        10.521909054009    7.526e-06
+	  16        10.521909272478    3.140e-06
+	  17        10.521910567366    1.312e-06
+	  18        10.521911102152    6.234e-07
+	  19        10.521911265746    2.888e-07
+	  20        10.521911272608    1.072e-07
+	  21        10.521911229323    5.868e-08
+	  22        10.521911204035    2.704e-08
+	  23        10.521911188423    9.960e-09
+	  24        10.521911182475    4.600e-09
+	  25        10.521911180197    1.672e-09
+	  26        10.521911179706    5.382e-10
+	  27        10.521911179665    1.808e-10
 	-----------------------------------------
 	Converged Mu_Z-Perturbed Wfn to 8.207e-11
 
 	Computing P*_Z-Perturbed Wave Function (0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         9.244833682572
-	   1        10.697250323238    3.055e-01
-	   2        11.752575585201    1.645e-01
-	   3        11.789787721942    5.134e-02
-	   4        11.812180413601    2.587e-02
-	   5        11.818050716920    1.014e-02
-	   6        11.819107756674    4.791e-03
-	   7        11.819954598894    2.551e-03
-	   8        11.819932452213    1.220e-03
-	   9        11.819919470515    4.580e-04
-	  10        11.819987250791    2.147e-04
-	  11        11.820008594150    1.231e-04
-	  12        11.819996828480    6.937e-05
-	  13        11.819973883253    3.011e-05
-	  14        11.819968615663    1.327e-05
-	  15        11.819967265087    6.206e-06
-	  16        11.819966415299    2.530e-06
-	  17        11.819965325179    1.082e-06
-	  18        11.819965042481    5.607e-07
-	  19        11.819965029940    2.297e-07
-	  20        11.819965030321    7.826e-08
-	  21        11.819964981103    4.059e-08
-	  22        11.819964956087    1.464e-08
-	  23        11.819964947204    5.578e-09
-	  24        11.819964944727    2.629e-09
-	  25        11.819964944670    1.113e-09
-	  26        11.819964944648    4.908e-10
-	  27        11.819964944745    1.930e-10
+	   0         9.244833704971
+	   1        10.697250348169    3.055e-01
+	   2        11.752575610470    1.645e-01
+	   3        11.789787747130    5.134e-02
+	   4        11.812180438878    2.587e-02
+	   5        11.818050742144    1.014e-02
+	   6        11.819107781885    4.791e-03
+	   7        11.819954624097    2.551e-03
+	   8        11.819932477414    1.220e-03
+	   9        11.819919495719    4.580e-04
+	  10        11.819987275998    2.147e-04
+	  11        11.820008619359    1.231e-04
+	  12        11.819996853687    6.937e-05
+	  13        11.819973908459    3.011e-05
+	  14        11.819968640868    1.327e-05
+	  15        11.819967290292    6.206e-06
+	  16        11.819966440504    2.530e-06
+	  17        11.819965350385    1.082e-06
+	  18        11.819965067686    5.607e-07
+	  19        11.819965055145    2.297e-07
+	  20        11.819965055526    7.826e-08
+	  21        11.819965006308    4.059e-08
+	  22        11.819964981292    1.464e-08
+	  23        11.819964972409    5.578e-09
+	  24        11.819964969932    2.629e-09
+	  25        11.819964969875    1.113e-09
+	  26        11.819964969853    4.908e-10
+	  27        11.819964969950    1.930e-10
 	-----------------------------------------
 	Converged P*_Z-Perturbed Wfn to 8.575e-11
 
 	Computing L*_Z-Perturbed Wave Function (-0.128 E_h).
 	Iter   Pseudopolarizability       RMS 
 	----   --------------------   -----------
-	   0         3.767770288215
-	   1         4.563532536038    2.151e-01
-	   2         5.153334006106    1.198e-01
-	   3         5.184426371039    3.270e-02
-	   4         5.197264590575    8.990e-03
-	   5         5.196483147822    2.257e-03
-	   6         5.196637546289    7.071e-04
-	   7         5.196727166176    2.123e-04
-	   8         5.196698658662    7.458e-05
-	   9         5.196703185912    1.972e-05
-	  10         5.196703905424    6.251e-06
-	  11         5.196704312321    1.959e-06
-	  12         5.196703892912    7.478e-07
-	  13         5.196703860311    2.229e-07
-	  14         5.196703949007    7.279e-08
-	  15         5.196703989147    2.244e-08
-	  16         5.196704001220    6.373e-09
-	  17         5.196704003337    1.692e-09
-	  18         5.196704003662    5.365e-10
-	  19         5.196704003861    1.625e-10
+	   0         3.767770261761
+	   1         4.563532503386    2.151e-01
+	   2         5.153333965821    1.198e-01
+	   3         5.184426329345    3.270e-02
+	   4         5.197264548381    8.990e-03
+	   5         5.196483105619    2.257e-03
+	   6         5.196637504074    7.071e-04
+	   7         5.196727123955    2.123e-04
+	   8         5.196698616442    7.458e-05
+	   9         5.196703143691    1.972e-05
+	  10         5.196703863203    6.251e-06
+	  11         5.196704270100    1.959e-06
+	  12         5.196703850691    7.478e-07
+	  13         5.196703818090    2.229e-07
+	  14         5.196703906786    7.279e-08
+	  15         5.196703946926    2.244e-08
+	  16         5.196703958999    6.373e-09
+	  17         5.196703961116    1.692e-09
+	  18         5.196703961441    5.365e-10
+	  19         5.196703961640    1.625e-10
 	-----------------------------------------
 	Converged L*_Z-Perturbed Wfn to 5.865e-11
 
@@ -11411,9 +1974,9 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.247980570429615    -0.130332715357560     0.000000000000000
-    1     -0.485840586780009    -0.000172988287553     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.221409966802105
+    0      0.247980568634529    -0.130332714336036     0.000000000000000
+    1     -0.485840586162693    -0.000172987701478     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.221409962770563
 
    Specific rotation using length-gauge electric-dipole Rosenfeld tensor.
 	[alpha]_(0.128) = -214.73273 deg/[dm (g/cm^3)]
@@ -11425,12 +1988,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.399349644680690    -0.398490098672511     0.000000000000000
-    1     -0.184609678704297     0.013642793674983     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.419065224393867
+    0      0.399349642666539    -0.398490095264482     0.000000000000000
+    1     -0.184609678444966     0.013642793858624     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.419065221878491
 
    Specific rotation using velocity-gauge electric-dipole Rosenfeld tensor.
-	[alpha]_(0.128) =  384.88786 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) =  384.88776 deg/[dm (g/cm^3)]
 
         CCSD Optical Rotation Tensor (Modified Velocity Gauge):
   -------------------------------------------------------------------------
@@ -11439,12 +2002,12 @@ Total time:
 
                    0                     1                     2        
 
-    0      0.035646850238411    -0.035735208871057     0.000000000000000
-    1     -0.068288754589601     0.001564304619152     0.000000000000000
-    2      0.000000000000000     0.000000000000000    -0.027043020427084
+    0      0.035646850206740    -0.035735208829790     0.000000000000000
+    1     -0.068288755470338     0.001564304738917     0.000000000000000
+    2      0.000000000000000     0.000000000000000    -0.027043020202826
 
    Specific rotation using modified velocity-gauge Rosenfeld tensor.
-	[alpha]_(0.128) = -644.44746 deg/[dm (g/cm^3)]
+	[alpha]_(0.128) = -644.44739 deg/[dm (g/cm^3)]
 
    Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.
      Delta_x =   0.00   Delta_y =   0.00   Delta_z = -72.34
@@ -11457,7 +2020,7 @@ Total time:
    -----   ------ ------------------  ----------------------------------
                                           x           y           z      
    0.077   589.00       -76.93388       0.00000     0.00000   -19.64800
-   0.128   355.00      -214.73273       0.00000     0.00000   -72.33679
+   0.128   355.00      -214.73273       0.00000     0.00000   -72.33678
 
    ------------------------------------------------------
             CCSD Velocity-Gauge Optical Rotation
@@ -11466,17 +2029,22 @@ Total time:
 
     E_h      nm   Velocity-Gauge  Modified Velocity-Gauge
    -----   ------ --------------  -----------------------
-   0.077   589.00    850.24712          -179.08820
-   0.128   355.00    384.88786          -644.44746
+   0.077   589.00    850.24697          -179.08818
+   0.128   355.00    384.88776          -644.44739
+    CCSD rotation @ 589nm in length gauge.................................................PASSED
+    CCSD rotation @ 589nm in velocity gauge...............................................PASSED
+    CCSD rotation @ 589nm in modified velocity gauge......................................PASSED
+    CCSD rotation @ 355nm in length gauge.................................................PASSED
+    CCSD rotation @ 355nm in velocity gauge...............................................PASSED
+    CCSD rotation @ 355nm in modified velocity gauge......................................PASSED
+    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
+    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
+    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
+    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
+    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
+    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:54 2017
-Module time:
-	user time   =      10.78 seconds =       0.18 minutes
-	system time =      10.19 seconds =       0.17 minutes
-	total time  =         21 seconds =       0.35 minutes
-Total time:
-	user time   =      12.09 seconds =       0.20 minutes
-	system time =      10.93 seconds =       0.18 minutes
-	total time  =         23 seconds =       0.38 minutes
+    Psi4 stopped on: Friday, 18 February 2022 02:08PM
+    Psi4 wall time for execution: 0:00:30.18
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This PR fixes a docs fail caused by the previous PR in the series and also adapts a few more tests. Test `cc29` needs another adaptation, but as that will require a new psivar, I'm saving that for the next PR.

This is PR 5 in an ongoing series to make `ccdensity` compatible with the standard `Matrix` and `Wavefunction` machinery used elsewhere in Psi. Obligatory @lothian ping for `cc` and obligatory @loriab ping for fixing the docs.

## Status
- [x] Ready for review
- [x] Ready for merge
