### PR TITLE
Docs Fix Take 2

### DIFF
--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -317,7 +317,7 @@ double CCLambdaWavefunction::compute_energy() {
             /*- Process::environment.globals["LEFT-RIGHT CC2 EIGENVECTOR OVERLAP"] -*/
             /*- Process::environment.globals["LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"] -*/
             /*- Process::environment.globals["LEFT-RIGHT CCSD(T) EIGENVECTOR OVERLAP"] -*/
-            auto varname = "LEFT-RIGHT" + gs_name + " EIEGENVECTOR OVERLAP";
+            auto varname = "LEFT-RIGHT " + gs_name + " EIEGENVECTOR OVERLAP";
             reference_wavefunction_->set_scalar_variable(varname, LR_overlap);
         }
     }

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -317,7 +317,7 @@ double CCLambdaWavefunction::compute_energy() {
             /*- Process::environment.globals["LEFT-RIGHT CC2 EIGENVECTOR OVERLAP"] -*/
             /*- Process::environment.globals["LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"] -*/
             /*- Process::environment.globals["LEFT-RIGHT CCSD(T) EIGENVECTOR OVERLAP"] -*/
-            auto varname = "LEFT-RIGHT " + gs_name + " EIEGENVECTOR OVERLAP";
+            auto varname = "LEFT-RIGHT " + gs_name + " EIGENVECTOR OVERLAP";
             reference_wavefunction_->set_scalar_variable(varname, LR_overlap);
         }
     }

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -317,7 +317,8 @@ double CCLambdaWavefunction::compute_energy() {
             /*- Process::environment.globals["LEFT-RIGHT CC2 EIGENVECTOR OVERLAP"] -*/
             /*- Process::environment.globals["LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"] -*/
             /*- Process::environment.globals["LEFT-RIGHT CCSD(T) EIGENVECTOR OVERLAP"] -*/
-            reference_wavefunction_->set_scalar_variable("LEFT-RIGHT " + gs_name + " EIGENVECTOR OVERLAP", LR_overlap);
+            auto varname = "LEFT-RIGHT" + gs_name + " EIEGENVECTOR OVERLAP";
+            reference_wavefunction_->set_scalar_variable(varname, LR_overlap);
         }
     }
 


### PR DESCRIPTION
## Description
Docs still failed even after the last PR. My current suspicion is that the problem is [this line](https://github.com/psi4/psi4/runs/5253940040?check_suite_focus=true#step:9:248), which results when [an over-active Perl scraper thinks "LEFT-RIGHT" is a psivar](https://github.com/psi4/psi4/blob/master/doc/sphinxman/document_psivariables.pl#L213-L224). I don't particularly feel like learning enough Perl to implement the regex properly, so we're just going to avoid it.

## Status
- [x] Ready for review
- [x] Ready for merge
