### PR TITLE
Add Spec. Rot. Origin Dependence Psivar

### DIFF
--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -230,6 +230,11 @@ PSI Variables by Alpha
    The specific rotation [deg/(dm (g/cm^3))] calculated at the CC2 level in the
    modified velocity gauge for a given (x) wavelength, (x) rounded to nearest integer.
 
+.. psivar:: CC2 ROTATION (LEN) ORIGIN-DEPENDENCE @ xNM
+
+   The origin-dependence of the CC2 specific rotation in deg/[dm (g/cm^3)]/bohr and the
+   length gauge, computed at (x) wavelength, (x) rounded to nearest integer.
+
 .. psivar:: CC QUADRUPOLE XX
    CC QUADRUPOLE XY
    CC QUADRUPOLE XZ
@@ -350,6 +355,11 @@ PSI Variables by Alpha
 
    The specific rotation [deg/(dm (g/cm^3))] calculated at the CCSD level in the
    modified velocity gauge for a given (x) wavelength, (x) rounded to nearest integer.
+
+.. psivar:: CCSD ROTATION (LEN) ORIGIN-DEPENDENCE @ xNM
+
+   The origin-dependence of the CCSD specific rotation in deg/[dm (g/cm^3)]/bohr and the
+   length gauge, computed at (x) wavelength, (x) rounded to nearest integer.
 
 .. psivar:: CEPA(0) DIPOLE
 

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -103,7 +103,7 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
     char **cartcomp, pert[32], pert_x[32], pert_y[32];
     int alpha, beta, i, j, k;
     double TrG_rl, TrG_pl, M, nu, bohr2a4, m2a, hbar, prefactor;
-    double *rotation_rl, *rotation_pl, *rotation_rp, *rotation_mod, **delta;
+    double *rotation_rl, *rotation_pl, *rotation_rp, *rotation_mod;
     char lbl1[32], lbl2[32], lbl3[32];
     int compute_rl = 0, compute_pl = 0;
     auto molecule = ref_wfn->molecule();
@@ -134,7 +134,7 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
     rotation_pl = init_array(params.nomega);
     rotation_rp = init_array(params.nomega);
     rotation_mod = init_array(params.nomega);
-    delta = block_matrix(params.nomega, 3);
+    std::vector<SharedMatrix> deltas;
 
     if (compute_pl) {
         /* compute the zero-frequency Rosenfeld tensor for Koch's modified
@@ -552,15 +552,19 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
         }
 
         if (params.gauge == "BOTH") {
-            delta[i][0] = prefactor * (tensor_rp[i][1][2] - tensor_rp[i][2][1]) * nu * nu / M;
-            delta[i][1] = prefactor * (tensor_rp[i][2][0] - tensor_rp[i][0][2]) * nu * nu / M;
-            delta[i][2] = prefactor * (tensor_rp[i][0][1] - tensor_rp[i][1][0]) * nu * nu / M;
-            delta[i][0] /= 6.0 * params.omega[i];
-            delta[i][1] /= 6.0 * params.omega[i];
-            delta[i][2] /= 6.0 * params.omega[i];
+            long om_nm = std::lround((pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]));
+            auto delta = std::make_shared<Matrix>(1, 3);
+            delta->set(0, 0, prefactor * (tensor_rp[i][1][2] - tensor_rp[i][2][1]) * nu * nu / M);
+            delta->set(0, 1, prefactor * (tensor_rp[i][2][0] - tensor_rp[i][0][2]) * nu * nu / M);
+            delta->set(0, 2, prefactor * (tensor_rp[i][0][1] - tensor_rp[i][1][0]) * nu * nu / M);
+            delta->scale(1 / (params.omega[i] * 6.0));
             outfile->Printf("\n   Origin-dependence vector for length-gauge rotation deg/[dm (g/cm^3)]/bohr.\n");
-            outfile->Printf("     Delta_x = %6.2f   Delta_y = %6.2f   Delta_z = %6.2f\n", delta[i][0], delta[i][1],
-                            delta[i][2]);
+            outfile->Printf("     Delta_x = %6.2f   Delta_y = %6.2f   Delta_z = %6.2f\n", delta->get(0, 0), delta->get(0, 1),
+                            delta->get(0, 2));
+            std::stringstream temp;
+            temp << params.wfn << " ROTATION (LEN) ORIGIN-DEPENDENCE @ " << om_nm << "NM";
+            ref_wfn->set_array_variable(temp.str(), delta);
+            deltas.push_back(delta);
         }
     } /* loop i over nomega */
 
@@ -579,10 +583,11 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("    E_h      nm   deg/[dm (g/cm^3)]        deg/[dm (g/cm^3)]/bohr\n");
                 outfile->Printf("   -----   ------ ------------------  ----------------------------------\n");
                 outfile->Printf("                                          x           y           z      \n");
-                for (i = 0; i < params.nomega; i++)
+                for (i = 0; i < params.nomega; i++) {
                     outfile->Printf("   %5.3f   %6.2f      %10.5f    %10.5f  %10.5f  %10.5f\n", params.omega[i],
-                                    (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), rotation_rl[i], delta[i][0],
-                                    delta[i][1], delta[i][2]);
+                                    (pc_c * pc_h * 1e9) / (pc_hartree2J * params.omega[i]), rotation_rl[i], deltas[i]->get(0, 0),
+                                    deltas[i]->get(0, 1), deltas[i]->get(0, 2));
+                }
             } else {
                 outfile->Printf("       Omega           alpha\n");
                 outfile->Printf("    E_h      nm   deg/[dm (g/cm^3)]\n");
@@ -614,7 +619,6 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
     free(rotation_pl);
     free(rotation_rp);
     free(rotation_mod);
-    free_block(delta);
 
     for (i = 0; i < params.nomega; i++) {
         free_block(tensor_rl[i]);
@@ -640,9 +644,11 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
 /*- Process::environment.globals["CC2 SPECIFIC ROTATION (LEN) @ xNM"] -*/
 /*- Process::environment.globals["CC2 SPECIFIC ROTATION (VEL) @ xNM"] -*/
 /*- Process::environment.globals["CC2 SPECIFIC ROTATION (MVG) @ xNM"] -*/
+/*- Process::environment.globals["CC2 ROTATION (LEN) ORIGIN-DEPENDENCE @ xNM"] -*/
 /*- Process::environment.globals["CCSD SPECIFIC ROTATION (LEN) @ xNM"] -*/
 /*- Process::environment.globals["CCSD SPECIFIC ROTATION (VEL) @ xNM"] -*/
 /*- Process::environment.globals["CCSD SPECIFIC ROTATION (MVG) @ xNM"] -*/
+/*- Process::environment.globals["CCSD ROTATION (LEN) ORIGIN-DEPENDENCE @ xNM"] -*/
 
 }  // namespace ccresponse
 }  // namespace psi

--- a/tests/cc29/input.dat
+++ b/tests/cc29/input.dat
@@ -18,19 +18,19 @@ set {
 
 wfn = properties('ccsd',properties=['rotation'], return_wfn=True)[1]
 
-reflen_589   =    -76.93388  #TEST
-refvel_589   =    850.24712  #TEST
-refmvg_589   =   -179.08820  #TEST
-reflen_355   =   -214.73273  #TEST
-refvel_355   =    384.88786  #TEST
-refmvg_355   =   -644.44746  #TEST
+reflen_589   =    -76.93388  # TEST
+refvel_589   =    850.24712  # TEST
+refmvg_589   =   -179.08820  # TEST
+reflen_355   =   -214.73273  # TEST
+refvel_355   =    384.88786  # TEST
+refmvg_355   =   -644.44746  # TEST
 
-compare_values(reflen_589,   variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") #TEST
-compare_values(refvel_589,   variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
-compare_values(refmvg_589,   variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
-compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
-compare_values(refvel_355,   variable("CCSD SPECIFIC ROTATION (VEL) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
-compare_values(refmvg_355,   variable("CCSD SPECIFIC ROTATION (MVG) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
+compare_values(reflen_589,   variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") # TEST
+compare_values(refvel_589,   variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") # TEST
+compare_values(refmvg_589,   variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") # TEST
+compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") # TEST
+compare_values(refvel_355,   variable("CCSD SPECIFIC ROTATION (VEL) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") # TEST
+compare_values(refmvg_355,   variable("CCSD SPECIFIC ROTATION (MVG) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") # TEST
 
 reflenT_589 = psi4.core.Matrix.from_list(        # TEST
    [[0.141679367454342, -0.070714074525053, 0],  # TEST
@@ -57,10 +57,15 @@ refmvgT_355 = psi4.core.Matrix.from_list(        # TEST
     [-0.068288754589601, 0.001564304619152, 0],  # TEST
     [0, 0, -0.027043020427084]])                 # TEST
 
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") # TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") # TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") # TEST
+compare_values(reflenT_355,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM"),  3, "CCSD rotation tensor @ 355nm in length gauge") # TEST
+compare_values(reflenT_355,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM"),  3, "CCSD rotation tensor @ 355nm in length gauge") # TEST
+compare_values(reflenT_355,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM"),  3, "CCSD rotation tensor @ 355nm in length gauge") # TEST
 
+refdep_589 = psi4.core.Matrix.from_list([[0, 0, -19.65]]) # TEST
+refdep_355 = psi4.core.Matrix.from_list([[0, 0, -72.34]]) # TEST
+
+compare_values(refdep_589, wfn.variable("CCSD ROTATION (LEN) ORIGIN-DEPENDENCE @ 589NM"), 2, "CCSD rotation origin-dependence @ 589nm in length gauge") # TEST
+compare_values(refdep_355, wfn.variable("CCSD ROTATION (LEN) ORIGIN-DEPENDENCE @ 355NM"), 2, "CCSD rotation origin-dependence @ 355nm in length gauge") # TEST

--- a/tests/cc29/output.ref
+++ b/tests/cc29/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {cctest} b401a9d dirty
+                         Git: Rev {master} fc65513 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Friday, 18 February 2022 02:08PM
+    Psi4 started on: Sunday, 20 February 2022 06:06PM
 
-    Process ID: 64299
-    Host:       dhcp189-242.emerson.emory.edu
+    Process ID: 18213
+    Host:       Jonathons-MacBook-Pro.local
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -61,19 +61,19 @@ set {
 
 wfn = properties('ccsd',properties=['rotation'], return_wfn=True)[1]
 
-reflen_589   =    -76.93388  #TEST
-refvel_589   =    850.24712  #TEST
-refmvg_589   =   -179.08820  #TEST
-reflen_355   =   -214.73273  #TEST
-refvel_355   =    384.88786  #TEST
-refmvg_355   =   -644.44746  #TEST
+reflen_589   =    -76.93388  # TEST
+refvel_589   =    850.24712  # TEST
+refmvg_589   =   -179.08820  # TEST
+reflen_355   =   -214.73273  # TEST
+refvel_355   =    384.88786  # TEST
+refmvg_355   =   -644.44746  # TEST
 
-compare_values(reflen_589,   variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") #TEST
-compare_values(refvel_589,   variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") #TEST
-compare_values(refmvg_589,   variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") #TEST
-compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") #TEST
-compare_values(refvel_355,   variable("CCSD SPECIFIC ROTATION (VEL) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") #TEST
-compare_values(refmvg_355,   variable("CCSD SPECIFIC ROTATION (MVG) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") #TEST
+compare_values(reflen_589,   variable("CCSD SPECIFIC ROTATION (LEN) @ 589NM"),  3, "CCSD rotation @ 589nm in length gauge") # TEST
+compare_values(refvel_589,   variable("CCSD SPECIFIC ROTATION (VEL) @ 589NM"),  3, "CCSD rotation @ 589nm in velocity gauge") # TEST
+compare_values(refmvg_589,   variable("CCSD SPECIFIC ROTATION (MVG) @ 589NM"),  3, "CCSD rotation @ 589nm in modified velocity gauge") # TEST
+compare_values(reflen_355,   variable("CCSD SPECIFIC ROTATION (LEN) @ 355NM"),  3, "CCSD rotation @ 355nm in length gauge") # TEST
+compare_values(refvel_355,   variable("CCSD SPECIFIC ROTATION (VEL) @ 355NM"),  3, "CCSD rotation @ 355nm in velocity gauge") # TEST
+compare_values(refmvg_355,   variable("CCSD SPECIFIC ROTATION (MVG) @ 355NM"),  3, "CCSD rotation @ 355nm in modified velocity gauge") # TEST
 
 reflenT_589 = psi4.core.Matrix.from_list(        # TEST
    [[0.141679367454342, -0.070714074525053, 0],  # TEST
@@ -100,17 +100,22 @@ refmvgT_355 = psi4.core.Matrix.from_list(        # TEST
     [-0.068288754589601, 0.001564304619152, 0],  # TEST
     [0, 0, -0.027043020427084]])                 # TEST
 
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
-compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") #TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") # TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") # TEST
+compare_values(reflenT_589,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in length gauge") # TEST
+compare_values(reflenT_355,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM"),  3, "CCSD rotation tensor @ 355nm in length gauge") # TEST
+compare_values(reflenT_355,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM"),  3, "CCSD rotation tensor @ 355nm in length gauge") # TEST
+compare_values(reflenT_355,   wfn.variable("CCSD OPTICAL ROTATION TENSOR (LEN) @ 355NM"),  3, "CCSD rotation tensor @ 355nm in length gauge") # TEST
 
+refdep_589 = psi4.core.Matrix.from_list([[0, 0, -19.65]]) # TEST
+refdep_355 = psi4.core.Matrix.from_list([[0, 0, -72.34]]) # TEST
+
+compare_values(refdep_589, wfn.variable("CCSD ROTATION (LEN) ORIGIN-DEPENDENCE @ 589NM"), 2, "CCSD rotation origin-dependence @ 589nm in length gauge") # TEST
+compare_values(refdep_355, wfn.variable("CCSD ROTATION (LEN) ORIGIN-DEPENDENCE @ 355NM"), 2, "CCSD rotation origin-dependence @ 355nm in length gauge") # TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on dhcp189-242.emerson.emory.edu
-*** at Fri Feb 18 14:08:10 2022
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sun Feb 20 18:06:11 2022
 
    => Loading Basis Set <=
 
@@ -300,14 +305,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
 
 
-*** tstop() called on dhcp189-242.emerson.emory.edu at Fri Feb 18 14:08:11 2022
+*** tstop() called on Jonathons-MacBook-Pro.local at Sun Feb 20 18:06:12 2022
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       1.04 seconds =       0.02 minutes
+	system time =       0.17 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       1.04 seconds =       0.02 minutes
+	system time =       0.17 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -333,8 +338,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on dhcp189-242.emerson.emory.edu
-*** at Fri Feb 18 14:08:11 2022
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sun Feb 20 18:06:13 2022
 
 
 	Wfn Parameters:
@@ -413,15 +418,15 @@ Total time:
 	Two-electron energy          =     45.23861563748702
 	Reference energy             =   -150.77918387213029
 
-*** tstop() called on dhcp189-242.emerson.emory.edu at Fri Feb 18 14:08:11 2022
+*** tstop() called on Jonathons-MacBook-Pro.local at Sun Feb 20 18:06:13 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.13 seconds =       0.00 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.21 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.81 seconds =       0.01 minutes
-	system time =       0.25 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.22 seconds =       0.02 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -2040,11 +2045,13 @@ MP2 correlation energy -0.3802563047354497
     CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
     CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
     CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
-    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
-    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
-    CCSD rotation tensor @ 589nm in length gauge..........................................PASSED
+    CCSD rotation tensor @ 355nm in length gauge..........................................PASSED
+    CCSD rotation tensor @ 355nm in length gauge..........................................PASSED
+    CCSD rotation tensor @ 355nm in length gauge..........................................PASSED
+    CCSD rotation origin-dependence @ 589nm in length gauge...............................PASSED
+    CCSD rotation origin-dependence @ 355nm in length gauge...............................PASSED
 
-    Psi4 stopped on: Friday, 18 February 2022 02:08PM
-    Psi4 wall time for execution: 0:00:30.18
+    Psi4 stopped on: Sunday, 20 February 2022 06:06PM
+    Psi4 wall time for execution: 0:00:31.14
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This PR adds a new psivar for the length gauge origin-dependence of the specific rotation, to aid in migration of the CC tests. `cc29` now tests this psivar. Once the psivar is accepted, I can resume porting tests over.

This is PR 6 in an ongoing series to make `ccdensity` compatible with the standard `Matrix` and `Wavefunction` machinery used elsewhere in Psi. Obligatory @lothian and @loriab ping for new `cc` psivars. For TDC's benefit, you can go to the "Files changed" tab, "Review changes", and then mark to approve if things look good to you.

## Checklist
- [x] Newly added psivar is tested

## Status
- [x] Ready for review
- [x] Ready for merge
