### PR TITLE
Fixed export of left eigenvector beta in scf_response.py

### DIFF
--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -782,7 +782,7 @@ def tdscf_excitations(wfn,
                                x.L_eigvec if restricted else x.L_eigvec[0])
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR BETA - {x.irrep_ES} SYMMETRY",
                                x.R_eigvec if restricted else x.R_eigvec[1])
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR ALPHA - {x.irrep_ES} SYMMETRY",
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR BETA - {x.irrep_ES} SYMMETRY",
                                x.L_eigvec if restricted else x.L_eigvec[1])
 
         core.print_out(

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -775,9 +775,8 @@ def tdscf_excitations(wfn,
         wfn.set_array_variable(
             f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} MAGNETIC TRANSITION DIPOLE MOMENT - {x.irrep_ES} SYMMETRY",
             core.Matrix.from_array(x.mdtm.reshape((1, 3))))
-        wfn.set_array_variable(
-            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR ALPHA - {x.irrep_ES} SYMMETRY",
-            x.R_eigvec if restricted else x.R_eigvec[0])
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR ALPHA - {x.irrep_ES} SYMMETRY",
+                               x.R_eigvec if restricted else x.R_eigvec[0])
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR ALPHA - {x.irrep_ES} SYMMETRY",
                                x.L_eigvec if restricted else x.L_eigvec[0])
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR BETA - {x.irrep_ES} SYMMETRY",


### PR DESCRIPTION
## Description
This fixes #2452. I export the correct value TD-LEFT EIGENVECTOR BETA and do not overwrite TD-LEFT EIGENVECTOR ALPHA anymore.

## Checklist
I did not rerun the tests, as the fix is trivial. I did not find pre-existing unittests referencing TD-LEFT EIGENVECTOR ALPHA or TD-LEFT EIGENVECTOR BETA

## Status
- [X] Ready for review
- [ ] Ready for merge
