### PR TITLE
Restore `psio_tocprint`

### DIFF
--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -55,7 +55,7 @@ psio_address psio_get_entry_end(size_t unit, const char *key);
 
 int psio_tocwrite(size_t unit);
 int psio_tocread(size_t unit);
-void psio_tocprint(size_t unit, FILE *output);
+void psio_tocprint(size_t unit);
 psio_tocentry *psio_tocscan(size_t unit, const char *key);
 bool psio_tocentry_exists(size_t unit, const char *key);
 psio_tocentry *psio_toclast(size_t unit);


### PR DESCRIPTION
## Description
Fixes an incorrect header for a PSIO debug function.

## Status
- [x] Ready for review
- [x] Ready for merge
