### PR TITLE
Change TDSCF Variable Names

### DIFF
--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -1697,7 +1697,7 @@ PSI Variables by Alpha
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY
    TD-fctl ROOT 0 (h) -> ROOT m (i) EXCITATION ENERGY
-   TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY - h TRANSITION
 
    The excitation energy of a given method from ground state to root m.
    DFT functional labeled if canonical.
@@ -1708,7 +1708,7 @@ PSI Variables by Alpha
 
 .. psivar:: TD-fctl ROOT m TOTAL ENERGY
    TD-fctl ROOT m (h) TOTAL ENERGY
-   TD-fctl ROOT m TOTAL ENERGY - h SYMMETRY
+   TD-fctl ROOT m TOTAL ENERGY - h TRANSITION
 
    The total energy of given method from ground state to root m in h symmetry.
    Conventions for root indexing and whether h refers to transition or root
@@ -1716,10 +1716,10 @@ PSI Variables by Alpha
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN)
    TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (LEN)
-   TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - h TRANSITION
    TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL)
    TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (VEL)
-   TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - h TRANSITION
 
    The electric transition dipole moment in length or velocity gauge of named method
    from ground state to root m in h symmetry (if available). DFT
@@ -1729,16 +1729,16 @@ PSI Variables by Alpha
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA
    TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR ALPHA
-   TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA - h TRANSITION
    TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA
    TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR BETA
-   TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA - h TRANSITION
    TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA
    TD-fctl ROOT 0 (h) -> ROOT m (i) RIGHT EIGENVECTOR ALPHA
-   TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA - h TRANSITION
    TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA
    TD-fctl ROOT 0 (h) -> ROOT m (i) RIGHT EIGENVECTOR BETA
-   TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA - h TRANSITION
 
    The left and right alpha and beta spin eigenvectors of the named method
    from ground state to root m in h symmetry (if available). DFT
@@ -1748,7 +1748,7 @@ PSI Variables by Alpha
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT
    TD-fctl ROOT 0 (h) -> ROOT m (i) MAGNETIC TRANSITION DIPOLE MOMENT
-   TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT - h TRANSITION
 
    The magnetic transition dipole moment in length or velocity gauge of named method
    from ground state to root m in h symmetry (if available). DFT
@@ -1758,10 +1758,10 @@ PSI Variables by Alpha
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN)
    TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (LEN)
-   TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN) - h TRANSITION
    TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL)
    TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (VEL)
-   TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL) - h TRANSITION
 
    The oscillator strength in length or velocity gauge of named method
    from ground state to root m in h symmetry (if available). DFT
@@ -1771,10 +1771,10 @@ PSI Variables by Alpha
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (LEN)
    TD-fctl ROOT 0 (h) -> ROOT m (i) ROTARY STRENGTH (LEN)
-   TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (LEN) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (LEN) - h TRANSITION
    TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (VEL)
    TD-fctl ROOT 0 (h) -> ROOT m (i) ROTARY STRENGTH (VEL)
-   TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (VEL) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (VEL) - h TRANSITION
 
    The rotary strength in length or velocity gauge of named method
    from ground state to root m in h symmetry (if available). DFT

--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -100,7 +100,7 @@ PSI Variables by Alpha
 .. psivar:: ADC ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY
 
    The excitation energy of given method from ground state to root m
-   in h symmetry (if available). DFT functional labeled if canonical.
+   in h symmetry (if available).
    
 .. psivar:: ADC ROOT n TOTAL ENERGY - h SYMMETRY
 
@@ -1701,10 +1701,8 @@ PSI Variables by Alpha
 
    The excitation energy of a given method from ground state to root m.
    DFT functional labeled if canonical.
-   m in the first and third variables is the index of the root among all roots.
-   m in the second variable is the index of the root among all roots of irrep i.
-   h, i in the second variable are the irreps of the roots.
-   h in the third variable is the irrep of the transition between roots.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :ref:`sec:psivarnotes`.
 
 .. psivar:: TD-fctl ROOT m TOTAL ENERGY
    TD-fctl ROOT m (h) TOTAL ENERGY
@@ -1712,7 +1710,7 @@ PSI Variables by Alpha
 
    The total energy of given method from ground state to root m in h symmetry.
    Conventions for root indexing and whether h refers to transition or root
-   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
+   irrep are as in :ref:`sec:psivarnotes`.
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN)
    TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (LEN)
@@ -1725,7 +1723,7 @@ PSI Variables by Alpha
    from ground state to root m in h symmetry (if available). DFT
    functional labeled if canonical.
    Conventions for root indexing and whether h refers to transition or root
-   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
+   irrep are as in :ref:`sec:psivarnotes`.
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA
    TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR ALPHA
@@ -1744,7 +1742,7 @@ PSI Variables by Alpha
    from ground state to root m in h symmetry (if available). DFT
    functional labeled if canonical.
    Conventions for root indexing and whether h refers to transition or root
-   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
+   irrep are as in :ref:`sec:psivarnotes`.
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT
    TD-fctl ROOT 0 (h) -> ROOT m (i) MAGNETIC TRANSITION DIPOLE MOMENT
@@ -1754,7 +1752,7 @@ PSI Variables by Alpha
    from ground state to root m in h symmetry (if available). DFT
    functional labeled if canonical.
    Conventions for root indexing and whether h refers to transition or root
-   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
+   irrep are as in :ref:`sec:psivarnotes`.
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN)
    TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (LEN)
@@ -1767,7 +1765,7 @@ PSI Variables by Alpha
    from ground state to root m in h symmetry (if available). DFT
    functional labeled if canonical.
    Conventions for root indexing and whether h refers to transition or root
-   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
+   irrep are as in :ref:`sec:psivarnotes`.
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (LEN)
    TD-fctl ROOT 0 (h) -> ROOT m (i) ROTARY STRENGTH (LEN)
@@ -1780,7 +1778,7 @@ PSI Variables by Alpha
    from ground state to root m in h symmetry (if available). DFT
    functional labeled if canonical.
    Conventions for root indexing and whether h refers to transition or root
-   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
+   irrep are as in :ref:`sec:psivarnotes`.
 
 .. psivar:: THERMAL ENERGY
 

--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -97,6 +97,19 @@ PSI Variables by Alpha
    The total electronic energy [Eh] and correlation energy component [Eh]
    for the averaged coupled-pair functional level of theory.
 
+.. psivar:: ADC ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY
+
+   The excitation energy of given method from ground state to root m
+   in h symmetry (if available). DFT functional labeled if canonical.
+   
+.. psivar:: ADC ROOT n TOTAL ENERGY - h SYMMETRY
+
+   The total energy of given method from ground state to root m in h symmetry.
+
+.. psivar:: ADC ROOT 0 -> ROOT m CORRELATION ENERGY - h SYMMETRY
+
+   The correlation energy of given method from ground state reference energy to root m in h symmetry.
+
 .. psivar:: AQCC DIPOLE
 
    Dipole array [e a0] for the averaged quadratic coupled-cluster level of theory, (3,).
@@ -1682,39 +1695,92 @@ PSI Variables by Alpha
    by 1.4 opposite-spin and 0 same-spin contributions, with
    any singles carried along.
 
-.. psivar:: TDDFT ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY
+.. psivar:: TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY
+   TD-fctl ROOT 0 (h) -> ROOT m (i) EXCITATION ENERGY
    TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY
-   ADC ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY
-   EOM-CCSD ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY
 
-   The excitation energy of given method from ground state to root m
-   in h symmetry (if available). DFT functional labeled if canonical.
+   The excitation energy of a given method from ground state to root m.
+   DFT functional labeled if canonical.
+   m in the first and third variables is the index of the root among all roots.
+   m in the second variable is the index of the root among all roots of irrep i.
+   h, i in the second variable are the irreps of the roots.
+   h in the third variable is the irrep of the transition between roots.
 
-.. psivar:: TDDFT ROOT n TOTAL ENERGY - h SYMMETRY
-   TD-fctl ROOT n TOTAL ENERGY - h SYMMETRY
-   ADC ROOT n TOTAL ENERGY - h SYMMETRY
-   EOM-CCSD ROOT n TOTAL ENERGY - h SYMMETRY
+.. psivar:: TD-fctl ROOT m TOTAL ENERGY
+   TD-fctl ROOT m (h) TOTAL ENERGY
+   TD-fctl ROOT m TOTAL ENERGY - h SYMMETRY
 
    The total energy of given method from ground state to root m in h symmetry.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
 
-.. psivar:: ADC ROOT 0 -> ROOT m CORRELATION ENERGY - h SYMMETRY
-   EOM-CCSD ROOT 0 -> ROOT m CORRELATION ENERGY - h SYMMETRY
+.. psivar:: TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN)
+   TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (LEN)
+   TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL)
+   TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (VEL)
+   TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - h SYMMETRY
 
-   The correlation energy of given method from ground state reference energy to root m in h symmetry.
+   The electric transition dipole moment in length or velocity gauge of named method
+   from ground state to root m in h symmetry (if available). DFT
+   functional labeled if canonical.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
 
-.. psivar:: TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN) - h SYMMETRY
+.. psivar:: TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA
+   TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR ALPHA
+   TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA
+   TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR BETA
+   TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA
+   TD-fctl ROOT 0 (h) -> ROOT m (i) RIGHT EIGENVECTOR ALPHA
+   TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA
+   TD-fctl ROOT 0 (h) -> ROOT m (i) RIGHT EIGENVECTOR BETA
+   TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA - h SYMMETRY
+
+   The left and right alpha and beta spin eigenvectors of the named method
+   from ground state to root m in h symmetry (if available). DFT
+   functional labeled if canonical.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
+
+.. psivar:: TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT
+   TD-fctl ROOT 0 (h) -> ROOT m (i) MAGNETIC TRANSITION DIPOLE MOMENT
+   TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT - h SYMMETRY
+
+   The magnetic transition dipole moment in length or velocity gauge of named method
+   from ground state to root m in h symmetry (if available). DFT
+   functional labeled if canonical.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
+
+.. psivar:: TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN)
+   TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (LEN)
+   TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL)
+   TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (VEL)
    TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL) - h SYMMETRY
 
    The oscillator strength in length or velocity gauge of named method
    from ground state to root m in h symmetry (if available). DFT
    functional labeled if canonical.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
 
-.. psivar:: TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (LEN) - h SYMMETRY
-   TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (VEL) - h SYMMETRY
+.. psivar:: TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (LEN)
+   TD-fctl ROOT 0 (h) -> ROOT m (i) ROTARY STRENGTH (LEN)
+   TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (LEN) - h SYMMETRY
+   TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (VEL)
+   TD-fctl ROOT 0 (h) -> ROOT m (i) ROTARY STRENGTH (VEL)
+   TD-fctl ROOT 0 -> ROOT m ROTARY STRENGTH (VEL) - h SYMMETRY
 
-   The rotatory strength in length or velocity gauge of named method
+   The rotary strength in length or velocity gauge of named method
    from ground state to root m in h symmetry (if available). DFT
    functional labeled if canonical.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :psivar:`TD-fctl ROOT m TOTAL ENERGY`.
 
 .. psivar:: THERMAL ENERGY
 

--- a/doc/sphinxman/source/notes_c.rst
+++ b/doc/sphinxman/source/notes_c.rst
@@ -54,6 +54,20 @@ Notes on Options
    as energy converged to :math:`10^{-6} E_h`, the user may set the ``e_convergence``
    keyword to ``0.000001``, ``1.0e-6``, or ``6``.
 
+Notes on Psivars
+================
+
+.. note:: Starting in 1.6, there are three standard ways to access an excited state
+    property. We give examples below, but the method name and property name may change.
+    * ``method ROOT 0 -> ROOT m property`` to get root m.
+    * ``method ROOT 0 -> ROOT m property - h TRANSITION`` to get root m and
+      independently specify that the total transition symmetry is A2.
+    * ``method ROOT 0 (h) -> ROOT m (i) property`` to get the transition
+      between two roots, specifying the symmetry of both states and the index of the target
+      roots among states of their own symmetry.
+    For example, to target the second excited-state, which is also the lowest energy state
+    of its irrep, the first two calls will take m = 2, while the last takes m = 0.
+    Methods that use this interface are: TD-fctl.
 
 Alternate Implementations
 =========================

--- a/doc/sphinxman/source/notes_c.rst
+++ b/doc/sphinxman/source/notes_c.rst
@@ -54,6 +54,8 @@ Notes on Options
    as energy converged to :math:`10^{-6} E_h`, the user may set the ``e_convergence``
    keyword to ``0.000001``, ``1.0e-6``, or ``6``.
 
+.. _`sec:psivarnotes`:
+
 Notes on Psivars
 ================
 

--- a/doc/sphinxman/source/notes_c.rst
+++ b/doc/sphinxman/source/notes_c.rst
@@ -68,6 +68,10 @@ Notes on Psivars
     For example, to target the second excited-state, which is also the lowest energy state
     of its irrep, the first two calls will take m = 2, while the last takes m = 0.
     Methods that use this interface are: TD-fctl.
+    Note that numberings are associated with the calculation much more strongly than 
+    with the molecular system. Changing the number of roots sought, the symmetry 
+    subspace or the symmetry apportionment or roots under which the computation is run, 
+    or the excited state method are all likely to scramble root numberings.
 
 Alternate Implementations
 =========================

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -26,6 +26,7 @@
 # @END LICENSE
 #
 
+from collections import Counter
 from typing import Union, List
 try:
     from dataclasses import dataclass
@@ -39,6 +40,9 @@ from psi4.driver import constants
 from psi4.driver.p4util import solvers
 from psi4.driver.p4util.exceptions import *
 from psi4.driver.procrouting.response.scf_products import (TDRSCFEngine, TDUSCFEngine)
+
+# TODO: Split this file into a CPSCF file (frequency-independent case) and TD-SCF file (frequency-dependent case).
+# Neither "half" of the file uses any function from the other "half". The danger is what could happen to import paths...
 
 dipole = {
     'name': 'Dipole polarizabilities',
@@ -723,6 +727,8 @@ def tdscf_excitations(wfn,
 
     # collect results
     solver_results = []
+    root_count = Counter()
+    root_count[_results[0].irrep_GS] += 1
     for i, x in enumerate(_results):
         sym_descr = f"{x.irrep_GS}->{x.irrep_ES} ({1 if x.spin_mult== 'singlet' else 3} {x.irrep_trans})"
 
@@ -748,45 +754,135 @@ def tdscf_excitations(wfn,
             "LEFT EIGENVECTOR BETA": x.L_eigvec if restricted else x.L_eigvec[1],
         })
 
-        # stash in psivars/wfnvars
+        # All TDSCF variables sare saved to the wavefunction here. The driver pushes them to globals.
         ssuper_name = wfn.functional().name()
-        # wfn.set_variable("TD-fctl ROOT n TOTAL ENERGY - h SYMMETRY")  # P::e SCF
+        target_h_count = root_count[x.irrep_ES]
+
+        # wfn.set_variable("TD-fctl ROOT m TOTAL ENERGY")               # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT m (h) TOTAL ENERGY")           # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT m TOTAL ENERGY - h SYMMETRY")  # P::e SCF
+        wfn.set_variable(f"TD-{ssuper_name} ROOT {i+1} TOTAL ENERGY", E_tot_au)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT {target_h_count} ({x.irrep_ES}) TOTAL ENERGY", E_tot_au)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT {i+1} TOTAL ENERGY - {x.irrep_trans} SYMMETRY", E_tot_au)
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY")               # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) EXCITATION ENERGY")       # P::e SCF
         # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY")  # P::e SCF
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} EXCITATION ENERGY", x.E_ex_au)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) EXCITATION ENERGY", x.E_ex_au)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} EXCITATION ENERGY - {x.irrep_trans} SYMMETRY", x.E_ex_au)
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN)")               # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (LEN)")       # P::e SCF
         # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN) - h SYMMETRY")  # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL) - h SYMMETRY")  # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (LEN) - h SYMMETRY")  # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (VEL) - h SYMMETRY")  # P::e SCF
-        wfn.set_variable(f"TD-{ssuper_name} ROOT {i+1} TOTAL ENERGY - {x.irrep_ES} SYMMETRY", E_tot_au)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} EXCITATION ENERGY - {x.irrep_ES} SYMMETRY", x.E_ex_au)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (LEN) - {x.irrep_ES} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (LEN) ",
                          x.f_length)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (VEL) - {x.irrep_ES} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) OSCILLATOR STRENGTH (LEN)",
+                         x.f_length)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (LEN) - {x.irrep_trans} SYMMETRY",
+                         x.f_length)
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL)")               # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (VEL)")       # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL) - h SYMMETRY")  # P::e SCF
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (VEL)",
                          x.f_velocity)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (LEN) - {x.irrep_ES} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} OSCILLATOR STRENGTH (VEL) - {x.irrep_ES} SYMMETRY",
+                         x.f_velocity)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (VEL) - {x.irrep_trans} SYMMETRY",
+                         x.f_velocity)
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (LEN)")               # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) ROTATORY STRENGTH (LEN)")       # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (LEN) - h SYMMETRY")  # P::e SCF
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (LEN) ",
                          x.R_length)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (VEL) - {x.irrep_ES} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) ROTATORY STRENGTH (LEN)",
+                         x.R_length)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (LEN) - {x.irrep_trans} SYMMETRY",
+                         x.R_length)
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (VEL)")               # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) ROTATORY STRENGTH (VEL)")       # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (VEL) - h SYMMETRY")  # P::e SCF
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (VEL)",
                          x.R_velocity)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) ROTATORY STRENGTH (VEL)",
+                         x.R_velocity)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (VEL) - {x.irrep_trans} SYMMETRY",
+                         x.R_velocity)
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN")                # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (LEN")        # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - h SYMMETRY")  # P::e SCF
         wfn.set_array_variable(
-            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - {x.irrep_ES} SYMMETRY",
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (LEN)",
             core.Matrix.from_array(x.edtm_length.reshape((1, 3))))
         wfn.set_array_variable(
-            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - {x.irrep_ES} SYMMETRY",
+            f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) ELECTRIC TRANSITION DIPOLE MOMENT (LEN)",
+            core.Matrix.from_array(x.edtm_length.reshape((1, 3))))
+        wfn.set_array_variable(
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - {x.irrep_trans} SYMMETRY",
+            core.Matrix.from_array(x.edtm_length.reshape((1, 3))))
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL)")               # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (VEL)")       # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - h SYMMETRY")  # P::e SCF
+        wfn.set_array_variable(
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (VEL)",
             core.Matrix.from_array(x.edtm_velocity.reshape((1, 3))))
         wfn.set_array_variable(
-            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} MAGNETIC TRANSITION DIPOLE MOMENT - {x.irrep_ES} SYMMETRY",
+            f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) ELECTRIC TRANSITION DIPOLE MOMENT (VEL)",
+            core.Matrix.from_array(x.edtm_velocity.reshape((1, 3))))
+        wfn.set_array_variable(
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - {x.irrep_trans} SYMMETRY",
+            core.Matrix.from_array(x.edtm_velocity.reshape((1, 3))))
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT")               # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) MAGNETIC TRANSITION DIPOLE MOMENT")       # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT - h SYMMETRY")  # P::e SCF
+        wfn.set_array_variable(
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} MAGNETIC TRANSITION DIPOLE MOMENT",
             core.Matrix.from_array(x.mdtm.reshape((1, 3))))
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR ALPHA - {x.irrep_ES} SYMMETRY",
+        wfn.set_array_variable(
+            f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) MAGNETIC TRANSITION DIPOLE MOMENT",
+            core.Matrix.from_array(x.mdtm.reshape((1, 3))))
+        wfn.set_array_variable(
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} MAGNETIC TRANSITION DIPOLE MOMENT - {x.irrep_trans} SYMMETRY",
+            core.Matrix.from_array(x.mdtm.reshape((1, 3))))
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA")               # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) RIGHT EIGENVECTOR ALPHA")       # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA - h SYMMETRY")  # P::e SCF
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR ALPHA",
                                x.R_eigvec if restricted else x.R_eigvec[0])
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR ALPHA - {x.irrep_ES} SYMMETRY",
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) RIGHT EIGENVECTOR ALPHA",
+                               x.R_eigvec if restricted else x.R_eigvec[0])
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR ALPHA - {x.irrep_trans} SYMMETRY",
+                               x.R_eigvec if restricted else x.R_eigvec[0])
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA")               # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR ALPHA")       # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA - h SYMMETRY")  # P::e SCF
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR ALPHA",
                                x.L_eigvec if restricted else x.L_eigvec[0])
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR BETA - {x.irrep_ES} SYMMETRY",
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) LEFT EIGENVECTOR ALPHA",
+                               x.L_eigvec if restricted else x.L_eigvec[0])
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR ALPHA - {x.irrep_trans} SYMMETRY",
+                               x.L_eigvec if restricted else x.L_eigvec[0])
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA")               # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) RIGHT EIGENVECTOR BETA")       # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA - h SYMMETRY")  # P::e SCF
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR BETA",
                                x.R_eigvec if restricted else x.R_eigvec[1])
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR BETA - {x.irrep_ES} SYMMETRY",
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) RIGHT EIGENVECTOR BETA",
+                               x.R_eigvec if restricted else x.R_eigvec[1])
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR BETA - {x.irrep_trans} SYMMETRY",
+                               x.R_eigvec if restricted else x.R_eigvec[1])
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA")               # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR BETA")       # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA - h SYMMETRY")  # P::e SCF
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR BETA",
+                               x.L_eigvec if restricted else x.L_eigvec[1])
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) LEFT EIGENVECTOR BETA",
+                               x.L_eigvec if restricted else x.L_eigvec[1])
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR BETA - {x.irrep_trans} SYMMETRY",
                                x.L_eigvec if restricted else x.L_eigvec[1])
 
         core.print_out(
             f"    {i+1:^4} {sym_descr:^20} {x.E_ex_au:< 15.5f} {E_ex_ev:< 15.5f} {E_tot_au:< 15.5f} {x.f_length:< 15.4f} {x.f_velocity:< 15.4f} {x.R_length:< 15.4f} {x.R_velocity:< 15.4f}\n"
         )
+        root_count[x.irrep_ES] += 1
 
     core.print_out("\n")
     

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -223,7 +223,19 @@ def _print_output(complete_dict, output):
             _print_matrix(directions, output[i], var_name)
 
 
+def _print_tdscf_warning():
+    core.print_out("\n{}\n".format("*"*90) +
+                   "{}{:^70}{}\n".format("*"*10, "WARNING", "*"*10) +
+                   "{}{:^70}{}\n".format("*"*10, "The names of excited state variables changed between 1.5", "*"*10) +
+                   "{}{:^70}{}\n".format("*"*10, "and 1.6. For a quick solution, remove the symmetry specifier", "*"*10) +
+                   "{}{:^70}{}\n".format("*"*10, "from the variable name. For full details, see 'Notes on Psivars'", "*"*10) +
+                   "{}{:^70}{}\n".format("*"*10, "in the documentation.", "*"*10) +
+                   "{}\n\n".format("*"*90)) #yapf: disable
+
+
+
 def _print_tdscf_header(*, r_convergence: float, guess_type: str, restricted: bool, ptype: str):
+    _print_tdscf_warning()
     core.print_out("\n\n         ---------------------------------------------------------\n"
                    f"         {'TDSCF excitation energies':^57}\n" +
                    f"         {'by Andrew M. James and Daniel G. A. Smith':^57}\n" +
@@ -760,55 +772,55 @@ def tdscf_excitations(wfn,
 
         # wfn.set_variable("TD-fctl ROOT m TOTAL ENERGY")               # P::e SCF
         # wfn.set_variable("TD-fctl ROOT m (h) TOTAL ENERGY")           # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT m TOTAL ENERGY - h SYMMETRY")  # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT m TOTAL ENERGY - h TRANSITION")  # P::e SCF
         wfn.set_variable(f"TD-{ssuper_name} ROOT {i+1} TOTAL ENERGY", E_tot_au)
         wfn.set_variable(f"TD-{ssuper_name} ROOT {target_h_count} ({x.irrep_ES}) TOTAL ENERGY", E_tot_au)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT {i+1} TOTAL ENERGY - {x.irrep_trans} SYMMETRY", E_tot_au)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT {i+1} TOTAL ENERGY - {x.irrep_trans} TRANSITION", E_tot_au)
         # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY")               # P::e SCF
         # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) EXCITATION ENERGY")       # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY - h SYMMETRY")  # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m EXCITATION ENERGY - h TRANSITION")  # P::e SCF
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} EXCITATION ENERGY", x.E_ex_au)
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) EXCITATION ENERGY", x.E_ex_au)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} EXCITATION ENERGY - {x.irrep_trans} SYMMETRY", x.E_ex_au)
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} EXCITATION ENERGY - {x.irrep_trans} TRANSITION", x.E_ex_au)
         # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN)")               # P::e SCF
         # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (LEN)")       # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN) - h SYMMETRY")  # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN) - h TRANSITION")  # P::e SCF
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (LEN) ",
                          x.f_length)
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) OSCILLATOR STRENGTH (LEN)",
                          x.f_length)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (LEN) - {x.irrep_trans} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (LEN) - {x.irrep_trans} TRANSITION",
                          x.f_length)
         # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL)")               # P::e SCF
         # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (VEL)")       # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL) - h SYMMETRY")  # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL) - h TRANSITION")  # P::e SCF
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (VEL)",
                          x.f_velocity)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} OSCILLATOR STRENGTH (VEL) - {x.irrep_ES} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} OSCILLATOR STRENGTH (VEL) - {x.irrep_ES} TRANSITION",
                          x.f_velocity)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (VEL) - {x.irrep_trans} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (VEL) - {x.irrep_trans} TRANSITION",
                          x.f_velocity)
         # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (LEN)")               # P::e SCF
         # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) ROTATORY STRENGTH (LEN)")       # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (LEN) - h SYMMETRY")  # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (LEN) - h TRANSITION")  # P::e SCF
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (LEN) ",
                          x.R_length)
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) ROTATORY STRENGTH (LEN)",
                          x.R_length)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (LEN) - {x.irrep_trans} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (LEN) - {x.irrep_trans} TRANSITION",
                          x.R_length)
         # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (VEL)")               # P::e SCF
         # wfn.set_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) ROTATORY STRENGTH (VEL)")       # P::e SCF
-        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (VEL) - h SYMMETRY")  # P::e SCF
+        # wfn.set_variable("TD-fctl ROOT 0 -> ROOT m ROTATORY STRENGTH (VEL) - h TRANSITION")  # P::e SCF
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (VEL)",
                          x.R_velocity)
         wfn.set_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) ROTATORY STRENGTH (VEL)",
                          x.R_velocity)
-        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (VEL) - {x.irrep_trans} SYMMETRY",
+        wfn.set_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ROTATORY STRENGTH (VEL) - {x.irrep_trans} TRANSITION",
                          x.R_velocity)
         # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN")                # P::e SCF
         # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (LEN")        # P::e SCF
-        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - h SYMMETRY")  # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - h TRANSITION")  # P::e SCF
         wfn.set_array_variable(
             f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (LEN)",
             core.Matrix.from_array(x.edtm_length.reshape((1, 3))))
@@ -816,11 +828,11 @@ def tdscf_excitations(wfn,
             f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) ELECTRIC TRANSITION DIPOLE MOMENT (LEN)",
             core.Matrix.from_array(x.edtm_length.reshape((1, 3))))
         wfn.set_array_variable(
-            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - {x.irrep_trans} SYMMETRY",
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (LEN) - {x.irrep_trans} TRANSITION",
             core.Matrix.from_array(x.edtm_length.reshape((1, 3))))
         # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL)")               # P::e SCF
         # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (VEL)")       # P::e SCF
-        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - h SYMMETRY")  # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - h TRANSITION")  # P::e SCF
         wfn.set_array_variable(
             f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (VEL)",
             core.Matrix.from_array(x.edtm_velocity.reshape((1, 3))))
@@ -828,11 +840,11 @@ def tdscf_excitations(wfn,
             f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) ELECTRIC TRANSITION DIPOLE MOMENT (VEL)",
             core.Matrix.from_array(x.edtm_velocity.reshape((1, 3))))
         wfn.set_array_variable(
-            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - {x.irrep_trans} SYMMETRY",
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} ELECTRIC TRANSITION DIPOLE MOMENT (VEL) - {x.irrep_trans} TRANSITION",
             core.Matrix.from_array(x.edtm_velocity.reshape((1, 3))))
         # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT")               # P::e SCF
         # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) MAGNETIC TRANSITION DIPOLE MOMENT")       # P::e SCF
-        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT - h SYMMETRY")  # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m MAGNETIC TRANSITION DIPOLE MOMENT - h TRANSITION")  # P::e SCF
         wfn.set_array_variable(
             f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} MAGNETIC TRANSITION DIPOLE MOMENT",
             core.Matrix.from_array(x.mdtm.reshape((1, 3))))
@@ -840,43 +852,43 @@ def tdscf_excitations(wfn,
             f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) MAGNETIC TRANSITION DIPOLE MOMENT",
             core.Matrix.from_array(x.mdtm.reshape((1, 3))))
         wfn.set_array_variable(
-            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} MAGNETIC TRANSITION DIPOLE MOMENT - {x.irrep_trans} SYMMETRY",
+            f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} MAGNETIC TRANSITION DIPOLE MOMENT - {x.irrep_trans} TRANSITION",
             core.Matrix.from_array(x.mdtm.reshape((1, 3))))
         # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA")               # P::e SCF
         # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) RIGHT EIGENVECTOR ALPHA")       # P::e SCF
-        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA - h SYMMETRY")  # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR ALPHA - h TRANSITION")  # P::e SCF
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR ALPHA",
                                x.R_eigvec if restricted else x.R_eigvec[0])
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) RIGHT EIGENVECTOR ALPHA",
                                x.R_eigvec if restricted else x.R_eigvec[0])
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR ALPHA - {x.irrep_trans} SYMMETRY",
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR ALPHA - {x.irrep_trans} TRANSITION",
                                x.R_eigvec if restricted else x.R_eigvec[0])
         # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA")               # P::e SCF
         # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR ALPHA")       # P::e SCF
-        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA - h SYMMETRY")  # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR ALPHA - h TRANSITION")  # P::e SCF
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR ALPHA",
                                x.L_eigvec if restricted else x.L_eigvec[0])
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) LEFT EIGENVECTOR ALPHA",
                                x.L_eigvec if restricted else x.L_eigvec[0])
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR ALPHA - {x.irrep_trans} SYMMETRY",
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR ALPHA - {x.irrep_trans} TRANSITION",
                                x.L_eigvec if restricted else x.L_eigvec[0])
         # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA")               # P::e SCF
         # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) RIGHT EIGENVECTOR BETA")       # P::e SCF
-        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA - h SYMMETRY")  # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m RIGHT EIGENVECTOR BETA - h TRANSITION")  # P::e SCF
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR BETA",
                                x.R_eigvec if restricted else x.R_eigvec[1])
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) RIGHT EIGENVECTOR BETA",
                                x.R_eigvec if restricted else x.R_eigvec[1])
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR BETA - {x.irrep_trans} SYMMETRY",
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} RIGHT EIGENVECTOR BETA - {x.irrep_trans} TRANSITION",
                                x.R_eigvec if restricted else x.R_eigvec[1])
         # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA")               # P::e SCF
         # wfn.set_array_variable("TD-fctl ROOT 0 (h) -> ROOT m (i) LEFT EIGENVECTOR BETA")       # P::e SCF
-        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA - h SYMMETRY")  # P::e SCF
+        # wfn.set_array_variable("TD-fctl ROOT 0 -> ROOT m LEFT EIGENVECTOR BETA - h TRANSITION")  # P::e SCF
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR BETA",
                                x.L_eigvec if restricted else x.L_eigvec[1])
         wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 ({x.irrep_GS}) -> ROOT {target_h_count} ({x.irrep_ES}) LEFT EIGENVECTOR BETA",
                                x.L_eigvec if restricted else x.L_eigvec[1])
-        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR BETA - {x.irrep_trans} SYMMETRY",
+        wfn.set_array_variable(f"TD-{ssuper_name} ROOT 0 -> ROOT {i+1} LEFT EIGENVECTOR BETA - {x.irrep_trans} TRANSITION",
                                x.L_eigvec if restricted else x.L_eigvec[1])
 
         core.print_out(
@@ -887,5 +899,7 @@ def tdscf_excitations(wfn,
     core.print_out("\n")
     
     _analyze_tdscf_excitations(_results, wfn, tda, coeff_cutoff, tdm_print)
+
+    _print_tdscf_warning()
 
     return solver_results

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,7 +101,7 @@ foreach(test_name adc1 adc2 aediis-1 aediis-2
                   options1 cubeprop-esp dft-smoke scf-hess1 scf-hess2 scf-hess3 scf-hess4 scf-hess5 scf-freq1 dft-jk scf-coverage
                   dft-custom-dhdf dft-custom-hybrid dft-custom-mgga dft-custom-gga
                   pywrap-bfs pywrap-align pywrap-align-chiral mints12 cc-module
-                  tdscf-1 tdscf-2 tdscf-3 tdscf-4 tdscf-5 tdscf-6
+                  tdscf-1 tdscf-2 tdscf-3 tdscf-4 tdscf-5 tdscf-6 tdscf-7
                   basis-ecp dft-pruning freq-masses sapt9 sapt10 sapt11 scf-uhf-grad-nobeta
 )
     add_subdirectory(${test_name})

--- a/tests/pytests/test_cppe.py
+++ b/tests/pytests/test_cppe.py
@@ -299,8 +299,8 @@ def _base_tdscf_test(molecule, ref_scf_energy, ref_pe_energy, exc_energies, osc_
     e_calc = []
     r_calc = []
     for i in range(len(exc_energies)):
-        e_calc.append(wfn.variable(f'TD-HF ROOT 0 -> ROOT {i+1} EXCITATION ENERGY - A SYMMETRY'))
-        r_calc.append(wfn.variable(f'TD-HF ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (LEN) - A SYMMETRY'))
+        e_calc.append(wfn.variable(f'TD-HF ROOT 0 -> ROOT {i+1} EXCITATION ENERGY - A TRANSITION'))
+        r_calc.append(wfn.variable(f'TD-HF ROOT 0 -> ROOT {i+1} OSCILLATOR STRENGTH (LEN) - A TRANSITION'))
     assert compare_arrays(exc_energies, e_calc, 4, f'PE EXCITATION ENERGY')
     assert compare_arrays(osc_strengths, r_calc, 4, f'PE OSCILLATOR STRENGTH')
 

--- a/tests/tdscf-1/input.dat
+++ b/tests/tdscf-1/input.dat
@@ -31,5 +31,5 @@ set scf tdscf_states [9]
 energy('td-hf/cc-pvdz')
 
 for n, ref in enumerate(UHF_RPA_cc_pvdz):
-    ex_en = psi4.variable(f"TD-HF ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
-    compare_values(ref,ex_en, 4, f"TD-UHF/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
+    ex_en = psi4.variable(f"TD-HF ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-UHF/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")

--- a/tests/tdscf-1/output.ref
+++ b/tests/tdscf-1/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.4a2.dev670 
+                               Psi4 undefined 
 
-                         Git: Rev {document-tddft} ba91f9e dirty
+                         Git: Rev {tdscf_var} c8200ee dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -19,7 +19,7 @@
                             Additional Code Authors
     E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
     J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
-    P. Verma, and M. H. Lechner
+    P. Verma, M. H. Lechner, and A. Jiang
 
              Previous Authors, Complete List of Code Contributors,
                        and Citations for Specific Modules
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 11 June 2020 03:33PM
+    Psi4 started on: Tuesday, 08 March 2022 09:38AM
 
-    Process ID: 18990
-    Host:       minazo
-    PSIDATADIR: /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4
+    Process ID: 4294
+    Host:       dhcp189-161.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -74,24 +74,24 @@ set scf tdscf_states [9]
 energy('td-hf/cc-pvdz')
 
 for n, ref in enumerate(UHF_RPA_cc_pvdz):
-    ex_en = psi4.variable(f"TD-HF ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
-    compare_values(ref,ex_en, 4, f"TD-UHF/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
+    ex_en = psi4.variable(f"TD-HF ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-UHF/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
 Scratch directory: /tmp/
 
-*** tstart() called on minazo
-*** at Thu Jun 11 15:33:46 2020
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Tue Mar  8 09:38:24 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry C          line   138 file /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -136,14 +136,14 @@ Scratch directory: /tmp/
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
@@ -196,18 +196,18 @@ Scratch directory: /tmp/
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter SAD:   -38.17324753824925   -3.81732e+01   0.00000e+00 
-   @UHF iter   1:   -38.90234371202389   -7.29096e-01   5.27401e-03 DIIS
-   @UHF iter   2:   -38.91513876275200   -1.27951e-02   1.70345e-03 DIIS
-   @UHF iter   3:   -38.91704711158790   -1.90835e-03   5.19120e-04 DIIS
-   @UHF iter   4:   -38.91728869118322   -2.41580e-04   2.55109e-04 DIIS
-   @UHF iter   5:   -38.91736733351760   -7.86423e-05   8.96531e-05 DIIS
-   @UHF iter   6:   -38.91737802879636   -1.06953e-05   2.28836e-05 DIIS
-   @UHF iter   7:   -38.91737868822741   -6.59431e-07   5.16337e-06 DIIS
-   @UHF iter   8:   -38.91737871259063   -2.43632e-08   9.98195e-07 DIIS
-   @UHF iter   9:   -38.91737871345225   -8.61618e-10   2.36900e-07 DIIS
-   @UHF iter  10:   -38.91737871350318   -5.09246e-11   3.58717e-08 DIIS
-   @UHF iter  11:   -38.91737871350435   -1.17240e-12   7.95232e-09 DIIS
+   @UHF iter SAD:   -38.17324753824924   -3.81732e+01   0.00000e+00 
+   @UHF iter   1:   -38.90234371202389   -7.29096e-01   5.27401e-03 DIIS/ADIIS
+   @UHF iter   2:   -38.91513876275199   -1.27951e-02   1.70345e-03 DIIS/ADIIS
+   @UHF iter   3:   -38.91704423443393   -1.90547e-03   5.21791e-04 DIIS/ADIIS
+   @UHF iter   4:   -38.91728854267783   -2.44308e-04   2.55301e-04 DIIS/ADIIS
+   @UHF iter   5:   -38.91736728514920   -7.87425e-05   8.98095e-05 DIIS
+   @UHF iter   6:   -38.91737802885026   -1.07437e-05   2.28830e-05 DIIS
+   @UHF iter   7:   -38.91737868823718   -6.59387e-07   5.16256e-06 DIIS
+   @UHF iter   8:   -38.91737871259110   -2.43539e-08   9.97946e-07 DIIS
+   @UHF iter   9:   -38.91737871345227   -8.61164e-10   2.36834e-07 DIIS
+   @UHF iter  10:   -38.91737871350313   -5.08606e-11   3.58628e-08 DIIS
+   @UHF iter  11:   -38.91737871350434   -1.21503e-12   7.95207e-09 DIIS
   Energy and wave function converged.
 
 
@@ -256,14 +256,14 @@ Scratch directory: /tmp/
     DOCC [     3 ]
     SOCC [     2 ]
 
-  @UHF Final Energy:   -38.91737871350435
+  @UHF Final Energy:   -38.91737871350434
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              6.0682991182693025
-    One-Electron Energy =                 -63.7147379959455549
-    Two-Electron Energy =                  18.7290601641719050
-    Total Energy =                        -38.9173787135043483
+    One-Electron Energy =                 -63.7147379959311451
+    Two-Electron Energy =                  18.7290601641575023
+    Total Energy =                        -38.9173787135043412
 
   UHF NO Occupations:
   HONO-2 :    3  A 1.9967234
@@ -286,24 +286,33 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -1.0254
 
   Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:     0.0000      Z:     0.7742
+     X:     0.0000      Y:    -0.0000      Z:     0.7742
 
   Dipole Moment: [e a0]
-     X:    -0.0000      Y:     0.0000      Z:    -0.2512     Total:     0.2512
+     X:     0.0000      Y:    -0.0000      Z:    -0.2512     Total:     0.2512
 
   Dipole Moment: [D]
-     X:    -0.0000      Y:     0.0000      Z:    -0.6386     Total:     0.6386
+     X:     0.0000      Y:    -0.0000      Z:    -0.6386     Total:     0.6386
 
 
-*** tstop() called on minazo at Thu Jun 11 15:33:47 2020
+*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:25 2022
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
 
 
          ---------------------------------------------------------
@@ -311,27 +320,29 @@ Total time:
                  by Andrew M. James and Daniel G. A. Smith        
          ---------------------------------------------------------
 
+  ==> Options <==
+
+     Residual threshold  : 1.0000e-06
+     Initial guess       : denominators
+     Reference           : UHF
+     Solver type         : RPA (Hamiltonian)
+
+
   ==> Requested Excitations <==
 
       9 singlet states with A symmetry
 
-  ==> Options <==
 
-     r_convergence:              1e-06
-     guess_type:              DENOMINATORS
-     restricted:              False
-     ptype     :              rpa
-
-
+  ==> Seeking the lowest 9 singlet states with A symmetry
 
                         Generalized Hamiltonian Solver                       
                               By Andrew M. James                             
 
   ==> Options <==
 
-    Maxiter                         = 60   
-    Eigenvector tolerance           = 1.00000e-06
-    Max number of expansion vectors = 1350 
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-06
+    Max number of expansion vectors = 2700 
 
   => Iterations <=
                               Max[D[value]]     Max[|R|]   # vectors
@@ -341,8 +352,8 @@ Total time:
   HamiltonianSolver iter   4:   1.77790e-05  1.84521e-03     90      
   HamiltonianSolver iter   5:   1.80632e-07  1.62254e-04    108      
   HamiltonianSolver iter   6:   1.44464e-09  1.70693e-05    118      
-  HamiltonianSolver iter   7:   2.01171e-11  1.69677e-06    124      
-  HamiltonianSolver iter   8:   1.47937e-13  4.27528e-07    128      Converged
+  HamiltonianSolver iter   7:   2.00971e-11  1.69677e-06    124      
+  HamiltonianSolver iter   8:   1.72973e-13  4.27528e-07    128      Converged
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -352,27 +363,131 @@ Total time:
                                     Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
-     1        A->A (1 A)       0.24455         6.65443        -38.67283        0.0007          0.0021         -0.0000          0.0000        
+     1        A->A (1 A)       0.24455         6.65443        -38.67283        0.0007          0.0021         -0.0000         -0.0000        
      2        A->A (1 A)       0.28784         7.83264        -38.62953        0.0000          0.0000         -0.0000         -0.0000        
-     3        A->A (1 A)       0.31787         8.64972        -38.59951        0.0181          0.0176          0.0000          0.0000        
-     4        A->A (1 A)       0.35472         9.65236        -38.56266        0.0000          0.0000          0.0000          0.0000        
-     5        A->A (1 A)       0.38788         10.55483       -38.52950        0.0235          0.0223          0.0000          0.0000        
-     6        A->A (1 A)       0.40378         10.98736       -38.51360        0.0059          0.0056         -0.0000          0.0000        
+     3        A->A (1 A)       0.31787         8.64972        -38.59951        0.0181          0.0176         -0.0000         -0.0000        
+     4        A->A (1 A)       0.35472         9.65236        -38.56266        0.0000          0.0000          0.0000         -0.0000        
+     5        A->A (1 A)       0.38788         10.55483       -38.52950        0.0235          0.0223         -0.0000         -0.0000        
+     6        A->A (1 A)       0.40378         10.98736       -38.51360        0.0059          0.0056         -0.0000         -0.0000        
      7        A->A (1 A)       0.43527         11.84437       -38.48211        0.1141          0.1200          0.0000          0.0000        
      8        A->A (1 A)       0.45079         12.26650       -38.46659        0.1839          0.1864          0.0000          0.0000        
      9        A->A (1 A)       0.48344         13.15512       -38.43394        0.3899          0.4128          0.0000          0.0000        
 
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A SYMMETRY........................PASSED
 
-    Psi4 stopped on: Thursday, 11 June 2020 03:33PM
-    Psi4 wall time for execution: 0:00:02.69
+
+Contributing excitations and de-excitations
+Only contributions with coefficients > 1.00e-01 will be printed:
+
+Excited State    1 (1 A):   0.24455 au   186.32 nm f = 0.0007
+Alpha orbitals:
+  Sums of squares: Xssq =  9.328429e-03; Yssq =  2.548749e-03; Xssq - Yssq =  6.779679e-03
+Beta orbitals:
+  Sums of squares: Xssq =  9.947973e-01; Yssq =  1.577004e-03; Xssq - Yssq =  9.932203e-01
+     3B->  4B  -0.983428 (96.713%)
+
+Excited State    2 (1 A):   0.28784 au   158.29 nm f = 0.0000
+Alpha orbitals:
+  Sums of squares: Xssq =  2.283312e-02; Yssq =  8.597404e-04; Xssq - Yssq =  2.197338e-02
+     5 ->  7    0.141137 ( 1.992%)
+Beta orbitals:
+  Sums of squares: Xssq =  9.784668e-01; Yssq =  4.401742e-04; Xssq - Yssq =  9.780266e-01
+     3B->  5B  -0.976655 (95.386%)
+     3B-> 10B  -0.148948 ( 2.219%)
+
+Excited State    3 (1 A):   0.31787 au   143.34 nm f = 0.0181
+Alpha orbitals:
+  Sums of squares: Xssq =  9.890945e-01; Yssq =  1.206152e-03; Xssq - Yssq =  9.878883e-01
+     5 ->  6   -0.981007 (96.238%)
+     5 -> 11   -0.110087 ( 1.212%)
+     5 -> 13    0.113362 ( 1.285%)
+Beta orbitals:
+  Sums of squares: Xssq =  1.323955e-02; Yssq =  1.127871e-03; Xssq - Yssq =  1.211168e-02
+     2B->  5B   0.106199 ( 1.128%)
+
+Excited State    4 (1 A):   0.35472 au   128.45 nm f = 0.0000
+Alpha orbitals:
+  Sums of squares: Xssq =  9.804419e-01; Yssq =  1.914675e-03; Xssq - Yssq =  9.785272e-01
+     5 ->  7    0.966771 (93.465%)
+     5 -> 12    0.201884 ( 4.076%)
+Beta orbitals:
+  Sums of squares: Xssq =  2.171951e-02; Yssq =  2.467586e-04; Xssq - Yssq =  2.147275e-02
+     3B->  5B   0.146877 ( 2.157%)
+
+Excited State    5 (1 A):   0.38788 au   117.47 nm f = 0.0235
+Alpha orbitals:
+  Sums of squares: Xssq =  8.341528e-01; Yssq =  3.699185e-03; Xssq - Yssq =  8.304536e-01
+     3 ->  7   -0.292514 ( 8.556%)
+     4 ->  6   -0.841837 (70.869%)
+     4 -> 11   -0.108092 ( 1.168%)
+Beta orbitals:
+  Sums of squares: Xssq =  1.741692e-01; Yssq =  4.622860e-03; Xssq - Yssq =  1.695464e-01
+     2B->  4B   0.189634 ( 3.596%)
+     2B->  6B   0.128143 ( 1.642%)
+     3B->  7B   0.323280 (10.451%)
+     3B-> 12B   0.106790 ( 1.140%)
+
+Excited State    6 (1 A):   0.40378 au   112.84 nm f = 0.0059
+Alpha orbitals:
+  Sums of squares: Xssq =  5.332611e-01; Yssq =  3.945240e-03; Xssq - Yssq =  5.293158e-01
+     3 ->  6   -0.513920 (26.411%)
+     4 ->  7   -0.483284 (23.356%)
+     4 -> 12   -0.101206 ( 1.024%)
+Beta orbitals:
+  Sums of squares: Xssq =  4.742126e-01; Yssq =  3.528427e-03; Xssq - Yssq =  4.706842e-01
+     2B->  7B   0.124901 ( 1.560%)
+     3B->  6B   0.656205 (43.060%)
+     3B-> 11B   0.123273 ( 1.520%)
+
+Excited State    7 (1 A):   0.43527 au   104.68 nm f = 0.1141
+Alpha orbitals:
+  Sums of squares: Xssq =  4.885897e-01; Yssq =  5.698129e-03; Xssq - Yssq =  4.828916e-01
+     3 ->  7   -0.444051 (19.718%)
+     3 -> 12   -0.142765 ( 2.038%)
+     4 ->  6    0.492742 (24.279%)
+Beta orbitals:
+  Sums of squares: Xssq =  5.198062e-01; Yssq =  2.697795e-03; Xssq - Yssq =  5.171084e-01
+     2B->  4B   0.525870 (27.654%)
+     3B->  7B   0.456964 (20.882%)
+     3B-> 12B   0.134310 ( 1.804%)
+
+Excited State    8 (1 A):   0.45079 au   101.08 nm f = 0.1839
+Alpha orbitals:
+  Sums of squares: Xssq =  7.951684e-01; Yssq =  1.525832e-03; Xssq - Yssq =  7.936425e-01
+     3 ->  6   -0.214145 ( 4.586%)
+     4 ->  7    0.845574 (71.500%)
+     4 -> 12    0.161500 ( 2.608%)
+Beta orbitals:
+  Sums of squares: Xssq =  2.069012e-01; Yssq =  5.437353e-04; Xssq - Yssq =  2.063575e-01
+     3B->  6B   0.442574 (19.587%)
+
+Excited State    9 (1 A):   0.48344 au   94.25 nm f = 0.3899
+Alpha orbitals:
+  Sums of squares: Xssq =  6.672618e-01; Yssq =  3.682473e-04; Xssq - Yssq =  6.668935e-01
+     3 ->  6   -0.801067 (64.171%)
+Beta orbitals:
+  Sums of squares: Xssq =  3.337961e-01; Yssq =  6.896392e-04; Xssq - Yssq =  3.331065e-01
+     3B->  6B  -0.567551 (32.211%)
+
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION......................PASSED
+
+    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
+    Psi4 wall time for execution: 0:00:01.94
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-2/input.dat
+++ b/tests/tdscf-2/input.dat
@@ -32,5 +32,5 @@ e, wfn = energy('hf/cc-pvdz', return_wfn=True)
 tdscf(wfn)
 
 for n, ref in enumerate(UHF_TDA_cc_pvdz):
-    ex_en = wfn.variable(f"TD-HF ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
-    compare_values(ref,ex_en, 4, f"TD-UHF/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
+    ex_en = wfn.variable(f"TD-HF ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-UHF/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")

--- a/tests/tdscf-2/output.ref
+++ b/tests/tdscf-2/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.4a2.dev670 
+                               Psi4 undefined 
 
-                         Git: Rev {document-tddft} ba91f9e dirty
+                         Git: Rev {tdscf_var} c8200ee dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -19,7 +19,7 @@
                             Additional Code Authors
     E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
     J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
-    P. Verma, and M. H. Lechner
+    P. Verma, M. H. Lechner, and A. Jiang
 
              Previous Authors, Complete List of Code Contributors,
                        and Citations for Specific Modules
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 11 June 2020 03:33PM
+    Psi4 started on: Tuesday, 08 March 2022 09:38AM
 
-    Process ID: 18996
-    Host:       minazo
-    PSIDATADIR: /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4
+    Process ID: 4296
+    Host:       dhcp189-161.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -75,24 +75,24 @@ e, wfn = energy('hf/cc-pvdz', return_wfn=True)
 tdscf(wfn)
 
 for n, ref in enumerate(UHF_TDA_cc_pvdz):
-    ex_en = wfn.variable(f"TD-HF ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
-    compare_values(ref,ex_en, 4, f"TD-UHF/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
+    ex_en = wfn.variable(f"TD-HF ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-UHF/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
 Scratch directory: /tmp/
 
-*** tstart() called on minazo
-*** at Thu Jun 11 15:33:50 2020
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Tue Mar  8 09:38:27 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry C          line   138 file /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -137,14 +137,14 @@ Scratch directory: /tmp/
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
@@ -197,18 +197,18 @@ Scratch directory: /tmp/
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter SAD:   -38.17324753824925   -3.81732e+01   0.00000e+00 
-   @UHF iter   1:   -38.90234371202389   -7.29096e-01   5.27401e-03 DIIS
-   @UHF iter   2:   -38.91513876275200   -1.27951e-02   1.70345e-03 DIIS
-   @UHF iter   3:   -38.91704711158790   -1.90835e-03   5.19120e-04 DIIS
-   @UHF iter   4:   -38.91728869118322   -2.41580e-04   2.55109e-04 DIIS
-   @UHF iter   5:   -38.91736733351760   -7.86423e-05   8.96531e-05 DIIS
-   @UHF iter   6:   -38.91737802879636   -1.06953e-05   2.28836e-05 DIIS
-   @UHF iter   7:   -38.91737868822741   -6.59431e-07   5.16337e-06 DIIS
-   @UHF iter   8:   -38.91737871259063   -2.43632e-08   9.98195e-07 DIIS
-   @UHF iter   9:   -38.91737871345225   -8.61618e-10   2.36900e-07 DIIS
-   @UHF iter  10:   -38.91737871350318   -5.09246e-11   3.58717e-08 DIIS
-   @UHF iter  11:   -38.91737871350435   -1.17240e-12   7.95232e-09 DIIS
+   @UHF iter SAD:   -38.17324753824924   -3.81732e+01   0.00000e+00 
+   @UHF iter   1:   -38.90234371202389   -7.29096e-01   5.27401e-03 ADIIS/DIIS
+   @UHF iter   2:   -38.91513876275199   -1.27951e-02   1.70345e-03 ADIIS/DIIS
+   @UHF iter   3:   -38.91704423443393   -1.90547e-03   5.21791e-04 ADIIS/DIIS
+   @UHF iter   4:   -38.91728854267783   -2.44308e-04   2.55301e-04 ADIIS/DIIS
+   @UHF iter   5:   -38.91736728514920   -7.87425e-05   8.98095e-05 DIIS
+   @UHF iter   6:   -38.91737802885026   -1.07437e-05   2.28830e-05 DIIS
+   @UHF iter   7:   -38.91737868823718   -6.59387e-07   5.16256e-06 DIIS
+   @UHF iter   8:   -38.91737871259110   -2.43539e-08   9.97946e-07 DIIS
+   @UHF iter   9:   -38.91737871345227   -8.61164e-10   2.36834e-07 DIIS
+   @UHF iter  10:   -38.91737871350313   -5.08606e-11   3.58628e-08 DIIS
+   @UHF iter  11:   -38.91737871350434   -1.21503e-12   7.95207e-09 DIIS
   Energy and wave function converged.
 
 
@@ -257,14 +257,14 @@ Scratch directory: /tmp/
     DOCC [     3 ]
     SOCC [     2 ]
 
-  @UHF Final Energy:   -38.91737871350435
+  @UHF Final Energy:   -38.91737871350434
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              6.0682991182693025
-    One-Electron Energy =                 -63.7147379959455549
-    Two-Electron Energy =                  18.7290601641719050
-    Total Energy =                        -38.9173787135043483
+    One-Electron Energy =                 -63.7147379959311451
+    Two-Electron Energy =                  18.7290601641575023
+    Total Energy =                        -38.9173787135043412
 
   UHF NO Occupations:
   HONO-2 :    3  A 1.9967234
@@ -287,24 +287,33 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -1.0254
 
   Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:     0.0000      Z:     0.7742
+     X:     0.0000      Y:    -0.0000      Z:     0.7742
 
   Dipole Moment: [e a0]
-     X:    -0.0000      Y:     0.0000      Z:    -0.2512     Total:     0.2512
+     X:     0.0000      Y:    -0.0000      Z:    -0.2512     Total:     0.2512
 
   Dipole Moment: [D]
-     X:    -0.0000      Y:     0.0000      Z:    -0.6386     Total:     0.6386
+     X:     0.0000      Y:    -0.0000      Z:    -0.6386     Total:     0.6386
 
 
-*** tstop() called on minazo at Thu Jun 11 15:33:50 2020
+*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:28 2022
 Module time:
-	user time   =       0.41 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.41 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
 
 
          ---------------------------------------------------------
@@ -312,27 +321,29 @@ Total time:
                  by Andrew M. James and Daniel G. A. Smith        
          ---------------------------------------------------------
 
+  ==> Options <==
+
+     Residual threshold  : 1.0000e-06
+     Initial guess       : denominators
+     Reference           : UHF
+     Solver type         : TDA (Davidson)
+
+
   ==> Requested Excitations <==
 
       9 singlet states with A symmetry
 
-  ==> Options <==
 
-     r_convergence:              1e-06
-     guess_type:              DENOMINATORS
-     restricted:              False
-     ptype     :              tda
-
-
+  ==> Seeking the lowest 9 singlet states with A symmetry
 
                          Generalized Davidson Solver                         
                                By Ruhee Dcunha                               
 
   ==> Options <==
 
-    Maxiter                         = 60   
-    Eigenvector tolerance           = 1.00000e-06
-    Max number of expansion vectors = 1350 
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-06
+    Max number of expansion vectors = 2700 
 
   => Iterations <=
                            Max[D[value]]     Max[|R|]   # vectors
@@ -342,8 +353,8 @@ Total time:
   DavidsonSolver iter   4:   1.46308e-05  9.09692e-04     63      
   DavidsonSolver iter   5:   1.74360e-07  9.62295e-05     72      
   DavidsonSolver iter   6:   2.12837e-09  9.99771e-06     81      
-  DavidsonSolver iter   7:   2.74170e-11  1.31154e-06     84      
-  DavidsonSolver iter   8:   3.79585e-13  7.60128e-07     86      Converged
+  DavidsonSolver iter   7:   2.74178e-11  1.31154e-06     84      
+  DavidsonSolver iter   8:   3.79086e-13  7.60128e-07     86      Converged
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -356,24 +367,126 @@ Total time:
      1        A->A (1 A)       0.24879         6.76994        -38.66859        0.0006          0.0040         -0.0000         -0.0000        
      2        A->A (1 A)       0.28968         7.88267        -38.62770        0.0000          0.0000         -0.0000         -0.0000        
      3        A->A (1 A)       0.32054         8.72234        -38.59684        0.0150          0.0291          0.0000          0.0000        
-     4        A->A (1 A)       0.35741         9.72562        -38.55997        0.0000          0.0000         -0.0000         -0.0000        
+     4        A->A (1 A)       0.35741         9.72562        -38.55997        0.0000          0.0000          0.0000          0.0000        
      5        A->A (1 A)       0.39501         10.74870       -38.52237        0.0356          0.0332          0.0000          0.0000        
      6        A->A (1 A)       0.41142         11.19542       -38.50595        0.0061          0.0021          0.0000          0.0000        
      7        A->A (1 A)       0.44454         12.09643       -38.47284        0.1042          0.0870          0.0000          0.0000        
      8        A->A (1 A)       0.45358         12.34258       -38.46380        0.1997          0.1607         -0.0000         -0.0000        
      9        A->A (1 A)       0.48481         13.19234       -38.43257        0.4129          0.3788          0.0000          0.0000        
 
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A SYMMETRY........................PASSED
-    TD-UHF/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A SYMMETRY........................PASSED
 
-    Psi4 stopped on: Thursday, 11 June 2020 03:33PM
-    Psi4 wall time for execution: 0:00:01.55
+
+Contributing excitations
+Only contributions with coefficients > 1.00e-01 will be printed:
+
+Excited State    1 (1 A):   0.24879 au   183.14 nm f = 0.0006
+Alpha orbitals:
+  Sums of squares: Xssq =  7.426208e-03
+Beta orbitals:
+  Sums of squares: Xssq =  9.925738e-01
+     3B->  4B  -0.982608 (96.552%)
+
+Excited State    2 (1 A):   0.28968 au   157.29 nm f = 0.0000
+Alpha orbitals:
+  Sums of squares: Xssq =  2.026403e-02
+     5 ->  7   -0.132771 ( 1.763%)
+Beta orbitals:
+  Sums of squares: Xssq =  9.797360e-01
+     3B->  5B   0.977538 (95.558%)
+     3B-> 10B   0.147970 ( 2.190%)
+
+Excited State    3 (1 A):   0.32054 au   142.15 nm f = 0.0150
+Alpha orbitals:
+  Sums of squares: Xssq =  9.877030e-01
+     5 ->  6    0.981275 (96.290%)
+     5 -> 11    0.103828 ( 1.078%)
+     5 -> 13   -0.111456 ( 1.242%)
+Beta orbitals:
+  Sums of squares: Xssq =  1.229700e-02
+     2B->  5B  -0.102339 ( 1.047%)
+
+Excited State    4 (1 A):   0.35741 au   127.48 nm f = 0.0000
+Alpha orbitals:
+  Sums of squares: Xssq =  9.806620e-01
+     5 ->  7   -0.967800 (93.664%)
+     5 -> 12   -0.197509 ( 3.901%)
+Beta orbitals:
+  Sums of squares: Xssq =  1.933797e-02
+     3B->  5B  -0.138606 ( 1.921%)
+
+Excited State    5 (1 A):   0.39501 au   115.35 nm f = 0.0356
+Alpha orbitals:
+  Sums of squares: Xssq =  8.852916e-01
+     3 ->  7   -0.229917 ( 5.286%)
+     4 ->  6   -0.895219 (80.142%)
+     4 -> 13    0.100344 ( 1.007%)
+Beta orbitals:
+  Sums of squares: Xssq =  1.147084e-01
+     2B->  4B   0.142221 ( 2.023%)
+     2B->  6B   0.110517 ( 1.221%)
+     3B->  7B   0.268023 ( 7.184%)
+
+Excited State    6 (1 A):   0.41142 au   110.75 nm f = 0.0061
+Alpha orbitals:
+  Sums of squares: Xssq =  5.242575e-01
+     3 ->  6   -0.501572 (25.157%)
+     4 ->  7   -0.491952 (24.202%)
+Beta orbitals:
+  Sums of squares: Xssq =  4.757425e-01
+     2B->  7B   0.117682 ( 1.385%)
+     3B->  6B   0.660893 (43.678%)
+     3B-> 11B   0.116402 ( 1.355%)
+
+Excited State    7 (1 A):   0.44454 au   102.50 nm f = 0.1042
+Alpha orbitals:
+  Sums of squares: Xssq =  4.323560e-01
+     3 ->  7    0.480286 (23.067%)
+     3 -> 12    0.143547 ( 2.061%)
+     4 ->  6   -0.391102 (15.296%)
+Beta orbitals:
+  Sums of squares: Xssq =  5.676440e-01
+     2B->  4B  -0.547450 (29.970%)
+     3B->  7B  -0.483990 (23.425%)
+     3B-> 12B  -0.130742 ( 1.709%)
+
+Excited State    8 (1 A):   0.45358 au   100.45 nm f = 0.1997
+Alpha orbitals:
+  Sums of squares: Xssq =  7.838693e-01
+     3 ->  6    0.212919 ( 4.533%)
+     4 ->  7   -0.840382 (70.624%)
+     4 -> 12   -0.156598 ( 2.452%)
+Beta orbitals:
+  Sums of squares: Xssq =  2.161307e-01
+     3B->  6B  -0.452833 (20.506%)
+
+Excited State    9 (1 A):   0.48481 au   93.98 nm f = 0.4129
+Alpha orbitals:
+  Sums of squares: Xssq =  6.824258e-01
+     3 ->  6    0.810667 (65.718%)
+Beta orbitals:
+  Sums of squares: Xssq =  3.175742e-01
+     3B->  6B   0.553505 (30.637%)
+
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A TRANSITION......................PASSED
+    TD-UHF/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION......................PASSED
+
+    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
+    Psi4 wall time for execution: 0:00:01.51
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-3/input.dat
+++ b/tests/tdscf-3/input.dat
@@ -36,5 +36,5 @@ e, wfn = energy('wb97x/cc-pvdz', return_wfn=True)
 tdscf(wfn)
 
 for n, ref in enumerate(rhf_wB97X_RPA_cc_pvdz):
-    ex_en = wfn.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
-    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
+    ex_en = wfn.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")

--- a/tests/tdscf-3/output.ref
+++ b/tests/tdscf-3/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.4a2.dev670 
+                               Psi4 undefined 
 
-                         Git: Rev {document-tddft} ba91f9e dirty
+                         Git: Rev {tdscf_var} c8200ee dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -19,7 +19,7 @@
                             Additional Code Authors
     E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
     J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
-    P. Verma, and M. H. Lechner
+    P. Verma, M. H. Lechner, and A. Jiang
 
              Previous Authors, Complete List of Code Contributors,
                        and Citations for Specific Modules
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 11 June 2020 03:33PM
+    Psi4 started on: Tuesday, 08 March 2022 09:38AM
 
-    Process ID: 19004
-    Host:       minazo
-    PSIDATADIR: /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4
+    Process ID: 4299
+    Host:       dhcp189-161.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -79,24 +79,24 @@ e, wfn = energy('wb97x/cc-pvdz', return_wfn=True)
 tdscf(wfn)
 
 for n, ref in enumerate(rhf_wB97X_RPA_cc_pvdz):
-    ex_en = wfn.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
-    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
+    ex_en = wfn.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
 Scratch directory: /tmp/
 
-*** tstart() called on minazo
-*** at Thu Jun 11 15:33:52 2020
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Tue Mar  8 09:38:31 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -141,25 +141,30 @@ Scratch directory: /tmp/
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
 
   ==> DFT Potential <==
 
+   => LibXC <=
+
+    Version 5.1.5
+    S. Lehtola, C. Steigemann, M. J. Oliveira, and M. A. Marques, SoftwareX 7, 1 (2018) (10.1016/j.softx.2017.11.002)
+
    => Composite Functional: WB97X <= 
 
     wB97X Hyb-GGA Exchange-Correlation Functional
 
-    J.-D. Chai and M. Head-Gordon, J. Chem. Phys. 128, 084106 (2008)
+    J.-D. Chai and M. Head-Gordon, J. Chem. Phys. 128, 084106 (2008) (10.1063/1.2834918)
 
     Deriv               =              1
     GGA                 =           TRUE
@@ -177,12 +182,17 @@ Scratch directory: /tmp/
     0.8423            HF,LR [omega = 0.3000]
     0.1577               HF 
 
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_WB97X:  1.00E-14 
+
    => Molecular Quadrature <=
 
     Radial Scheme          =       TREUTLER
     Pruning Scheme         =           NONE
     Nuclear Scheme         =       TREUTLER
 
+    Blocking Scheme        =         OCTREE
     BS radius alpha        =              1
     Pruning alpha          =              1
     Radial Points          =             75
@@ -248,21 +258,24 @@ Scratch directory: /tmp/
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RKS iter SAD:   -75.82538727182803   -7.58254e+01   0.00000e+00 
-   @RKS iter   1:   -76.24870831810121   -4.23321e-01   2.28250e-02 DIIS
-   @RKS iter   2:   -76.24436550816512    4.34281e-03   2.48492e-02 DIIS
-   @RKS iter   3:   -76.37349533694226   -1.29130e-01   7.85221e-04 DIIS
-   @RKS iter   4:   -76.37369157088349   -1.96234e-04   2.76872e-04 DIIS
-   @RKS iter   5:   -76.37371552281103   -2.39519e-05   3.94776e-05 DIIS
-   @RKS iter   6:   -76.37371627474715   -7.51936e-07   6.41685e-06 DIIS
-   @RKS iter   7:   -76.37371632339109   -4.86439e-08   1.44046e-06 DIIS
-   @RKS iter   8:   -76.37371632570031   -2.30922e-09   1.37516e-07 DIIS
-   @RKS iter   9:   -76.37371632571869   -1.83746e-11   1.77274e-08 DIIS
-   @RKS iter  10:   -76.37371632571880   -1.13687e-13   1.26998e-09 DIIS
+   @RKS iter SAD:   -75.82538727182798   -7.58254e+01   0.00000e+00 
+   @RKS iter   1:   -76.24870831810148   -4.23321e-01   2.28250e-02 ADIIS/DIIS
+   @RKS iter   2:   -76.24436550816516    4.34281e-03   2.48492e-02 ADIIS/DIIS
+   @RKS iter   3:   -76.37349855046513   -1.29133e-01   7.45202e-04 ADIIS/DIIS
+   @RKS iter   4:   -76.37369202322047   -1.93473e-04   2.73557e-04 ADIIS/DIIS
+   @RKS iter   5:   -76.37371552037376   -2.34972e-05   3.96467e-05 DIIS
+   @RKS iter   6:   -76.37371627547660   -7.55103e-07   6.37382e-06 DIIS
+   @RKS iter   7:   -76.37371632343006   -4.79535e-08   1.42622e-06 DIIS
+   @RKS iter   8:   -76.37371632570053   -2.27047e-09   1.37058e-07 DIIS
+   @RKS iter   9:   -76.37371632571876   -1.82325e-11   1.76597e-08 DIIS
+   @RKS iter  10:   -76.37371632571880   -4.26326e-14   1.27570e-09 DIIS
   Energy and wave function converged.
 
 
   ==> Post-Iterations <==
+
+   Electrons on quadrature grid:
+      Ntotal   =   10.0000000519 ; deviation = 5.190e-08 
 
     Orbital Energies [Eh]
     ---------------------
@@ -291,9 +304,9 @@ Scratch directory: /tmp/
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.0023638541353055
-    One-Electron Energy =                -121.0198712300129387
-    Two-Electron Energy =                  43.1406036034156841
-    DFT Exchange-Correlation Energy =      -6.4968125532568575
+    One-Electron Energy =                -121.0198712309101268
+    Two-Electron Energy =                  43.1406036044107140
+    DFT Exchange-Correlation Energy =      -6.4968125533546965
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
     Total Energy =                        -76.3737163257188030
@@ -318,15 +331,24 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:    -0.0000      Z:    -2.0208     Total:     2.0208
 
 
-*** tstop() called on minazo at Thu Jun 11 15:33:54 2020
+*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:33 2022
 Module time:
-	user time   =       2.00 seconds =       0.03 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       2.25 seconds =       0.04 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       2.00 seconds =       0.03 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       2.25 seconds =       0.04 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
 
 
          ---------------------------------------------------------
@@ -334,27 +356,29 @@ Total time:
                  by Andrew M. James and Daniel G. A. Smith        
          ---------------------------------------------------------
 
+  ==> Options <==
+
+     Residual threshold  : 1.0000e-06
+     Initial guess       : denominators
+     Reference           : RHF
+     Solver type         : RPA (Hamiltonian)
+
+
   ==> Requested Excitations <==
 
       10 singlet states with A symmetry
 
-  ==> Options <==
 
-     r_convergence:              1e-06
-     guess_type:              DENOMINATORS
-     restricted:              True
-     ptype     :              rpa
-
-
+  ==> Seeking the lowest 10 singlet states with A symmetry
 
                         Generalized Hamiltonian Solver                       
                               By Andrew M. James                             
 
   ==> Options <==
 
-    Maxiter                         = 60   
-    Eigenvector tolerance           = 1.00000e-06
-    Max number of expansion vectors = 1500 
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-06
+    Max number of expansion vectors = 3000 
 
   => Iterations <=
                               Max[D[value]]     Max[|R|]   # vectors
@@ -362,7 +386,7 @@ Total time:
   HamiltonianSolver iter   2:   2.65603e-03  7.34528e-03     60      
   HamiltonianSolver iter   3:   3.75488e-06  8.07100e-04     80      
   HamiltonianSolver iter   4:   1.26255e-08  5.90177e-05     92      
-  HamiltonianSolver iter   5:   4.91479e-11  3.58939e-12     95      Converged
+  HamiltonianSolver iter   5:   4.91595e-11  2.27018e-12     95      Converged
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -372,29 +396,92 @@ Total time:
                                     Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
-     1        A->A (1 A)       0.24719         6.72642        -76.12652        0.0121          0.0794         -0.0000          0.0000        
+     1        A->A (1 A)       0.24719         6.72642        -76.12652        0.0121          0.0794          0.0000          0.0000        
      2        A->A (1 A)       0.31320         8.52260        -76.06052        0.0000          0.0000          0.0000          0.0000        
      3        A->A (1 A)       0.34444         9.37279        -76.02927        0.0884          0.1765         -0.0000         -0.0000        
      4        A->A (1 A)       0.41036         11.16660       -75.96335        0.0477          0.0536          0.0000          0.0000        
-     5        A->A (1 A)       0.45277         12.32056       -75.92094        0.4396          0.4587         -0.0000         -0.0000        
+     5        A->A (1 A)       0.45277         12.32056       -75.92094        0.4396          0.4587          0.0000          0.0000        
      6        A->A (1 A)       0.56744         15.44078       -75.80628        0.2021          0.2217         -0.0000         -0.0000        
-     7        A->A (1 A)       0.71910         19.56767       -75.65462        0.0000          0.0000          0.0000         -0.0000        
-     8        A->A (1 A)       0.75183         20.45836       -75.62189        0.0688          0.0749          0.0000          0.0000        
-     9        A->A (1 A)       0.82955         22.57317       -75.54417        0.0685          0.0645         -0.0000         -0.0000        
-     10       A->A (1 A)       0.84004         22.85867       -75.53368        0.0014          0.0062          0.0000          0.0000        
+     7        A->A (1 A)       0.71910         19.56767       -75.65462        0.0000          0.0000          0.0000          0.0000        
+     8        A->A (1 A)       0.75183         20.45836       -75.62189        0.0688          0.0749         -0.0000         -0.0000        
+     9        A->A (1 A)       0.82955         22.57317       -75.54417        0.0685          0.0645          0.0000         -0.0000        
+     10       A->A (1 A)       0.84004         22.85867       -75.53368        0.0014          0.0062         -0.0000         -0.0000        
 
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 10 EXCITATION ENERGY - A SYMMETRY.....................PASSED
 
-    Psi4 stopped on: Thursday, 11 June 2020 03:34PM
-    Psi4 wall time for execution: 0:00:07.68
+
+Contributing excitations and de-excitations
+Only contributions with coefficients > 1.00e-01 will be printed:
+
+Excited State    1 (1 A):   0.24719 au   184.32 nm f = 0.0121
+  Sums of squares: Xssq =  1.001414e+00; Yssq =  1.414379e-03; Xssq - Yssq =  1.000000e+00
+     5 ->  6   -0.999040 (99.808%)
+
+Excited State    2 (1 A):   0.31320 au   145.48 nm f = 0.0000
+  Sums of squares: Xssq =  1.000365e+00; Yssq =  3.646789e-04; Xssq - Yssq =  1.000000e+00
+     5 ->  7    0.995324 (99.067%)
+
+Excited State    3 (1 A):   0.34444 au   132.28 nm f = 0.0884
+  Sums of squares: Xssq =  1.003331e+00; Yssq =  3.330699e-03; Xssq - Yssq =  1.000000e+00
+     3 ->  7    0.152682 ( 2.331%)
+     4 ->  6    0.986843 (97.386%)
+
+Excited State    4 (1 A):   0.41036 au   111.03 nm f = 0.0477
+  Sums of squares: Xssq =  1.001633e+00; Yssq =  1.632695e-03; Xssq - Yssq =  1.000000e+00
+     3 ->  6   -0.297362 ( 8.842%)
+     4 ->  7   -0.951947 (90.620%)
+
+Excited State    5 (1 A):   0.45277 au   100.63 nm f = 0.4396
+  Sums of squares: Xssq =  1.002596e+00; Yssq =  2.595737e-03; Xssq - Yssq =  1.000000e+00
+     3 ->  6   -0.952405 (90.708%)
+     4 ->  7    0.298174 ( 8.891%)
+
+Excited State    6 (1 A):   0.56744 au   80.30 nm f = 0.2021
+  Sums of squares: Xssq =  1.009159e+00; Yssq =  9.158933e-03; Xssq - Yssq =  1.000000e+00
+     3 ->  7   -0.974139 (94.895%)
+     4 ->  6    0.148797 ( 2.214%)
+     4 ->  9    0.110131 ( 1.213%)
+     5 -> 11    0.112746 ( 1.271%)
+
+Excited State    7 (1 A):   0.71910 au   63.36 nm f = 0.0000
+  Sums of squares: Xssq =  1.000076e+00; Yssq =  7.630217e-05; Xssq - Yssq =  1.000000e+00
+     5 ->  8    0.995433 (99.089%)
+
+Excited State    8 (1 A):   0.75183 au   60.60 nm f = 0.0688
+  Sums of squares: Xssq =  1.000582e+00; Yssq =  5.822575e-04; Xssq - Yssq =  1.000000e+00
+     5 ->  9    0.997371 (99.475%)
+
+Excited State    9 (1 A):   0.82955 au   54.93 nm f = 0.0685
+  Sums of squares: Xssq =  1.001533e+00; Yssq =  1.533186e-03; Xssq - Yssq =  1.000000e+00
+     3 ->  9    0.238210 ( 5.674%)
+     4 ->  8   -0.965791 (93.275%)
+
+Excited State   10 (1 A):   0.84004 au   54.24 nm f = 0.0014
+  Sums of squares: Xssq =  1.000950e+00; Yssq =  9.497346e-04; Xssq - Yssq =  1.000000e+00
+     2 ->  6    0.166260 ( 2.764%)
+     3 ->  8    0.159010 ( 2.528%)
+     4 ->  9   -0.965396 (93.199%)
+
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 10 EXCITATION ENERGY - A TRANSITION...................PASSED
+
+    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
+    Psi4 wall time for execution: 0:00:07.13
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-4/input.dat
+++ b/tests/tdscf-4/input.dat
@@ -34,5 +34,5 @@ set TDSCF_TDA true
 energy('td-wB97X/cc-pvdz')
 
 for n, ref in enumerate(rhf_wB97X_TDA_cc_pvdz):
-    ex_en = psi4.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
-    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
+    ex_en = psi4.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")

--- a/tests/tdscf-4/output.ref
+++ b/tests/tdscf-4/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.4a2.dev670 
+                               Psi4 undefined 
 
-                         Git: Rev {document-tddft} ba91f9e dirty
+                         Git: Rev {tdscf_var} c8200ee dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -19,7 +19,7 @@
                             Additional Code Authors
     E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
     J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
-    P. Verma, and M. H. Lechner
+    P. Verma, M. H. Lechner, and A. Jiang
 
              Previous Authors, Complete List of Code Contributors,
                        and Citations for Specific Modules
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 11 June 2020 03:34PM
+    Psi4 started on: Tuesday, 08 March 2022 09:38AM
 
-    Process ID: 19012
-    Host:       minazo
-    PSIDATADIR: /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4
+    Process ID: 4305
+    Host:       dhcp189-161.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -77,24 +77,24 @@ set TDSCF_TDA true
 energy('td-wB97X/cc-pvdz')
 
 for n, ref in enumerate(rhf_wB97X_TDA_cc_pvdz):
-    ex_en = psi4.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
-    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A SYMMETRY")
+    ex_en = psi4.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
 Scratch directory: /tmp/
 
-*** tstart() called on minazo
-*** at Thu Jun 11 15:34:00 2020
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Tue Mar  8 09:38:39 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /home/roberto/Workspace/robertodr/psi4/build_document-tddft/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -139,25 +139,30 @@ Scratch directory: /tmp/
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
 
   ==> DFT Potential <==
 
+   => LibXC <=
+
+    Version 5.1.5
+    S. Lehtola, C. Steigemann, M. J. Oliveira, and M. A. Marques, SoftwareX 7, 1 (2018) (10.1016/j.softx.2017.11.002)
+
    => Composite Functional: WB97X <= 
 
     wB97X Hyb-GGA Exchange-Correlation Functional
 
-    J.-D. Chai and M. Head-Gordon, J. Chem. Phys. 128, 084106 (2008)
+    J.-D. Chai and M. Head-Gordon, J. Chem. Phys. 128, 084106 (2008) (10.1063/1.2834918)
 
     Deriv               =              1
     GGA                 =           TRUE
@@ -175,12 +180,17 @@ Scratch directory: /tmp/
     0.8423            HF,LR [omega = 0.3000]
     0.1577               HF 
 
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_WB97X:  1.00E-14 
+
    => Molecular Quadrature <=
 
     Radial Scheme          =       TREUTLER
     Pruning Scheme         =           NONE
     Nuclear Scheme         =       TREUTLER
 
+    Blocking Scheme        =         OCTREE
     BS radius alpha        =              1
     Pruning alpha          =              1
     Radial Points          =             75
@@ -246,21 +256,24 @@ Scratch directory: /tmp/
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RKS iter SAD:   -75.82538727182803   -7.58254e+01   0.00000e+00 
-   @RKS iter   1:   -76.24870831810121   -4.23321e-01   2.28250e-02 DIIS
-   @RKS iter   2:   -76.24436550816512    4.34281e-03   2.48492e-02 DIIS
-   @RKS iter   3:   -76.37349533694226   -1.29130e-01   7.85221e-04 DIIS
-   @RKS iter   4:   -76.37369157088349   -1.96234e-04   2.76872e-04 DIIS
-   @RKS iter   5:   -76.37371552281103   -2.39519e-05   3.94776e-05 DIIS
-   @RKS iter   6:   -76.37371627474715   -7.51936e-07   6.41685e-06 DIIS
-   @RKS iter   7:   -76.37371632339109   -4.86439e-08   1.44046e-06 DIIS
-   @RKS iter   8:   -76.37371632570031   -2.30922e-09   1.37516e-07 DIIS
-   @RKS iter   9:   -76.37371632571869   -1.83746e-11   1.77274e-08 DIIS
-   @RKS iter  10:   -76.37371632571880   -1.13687e-13   1.26998e-09 DIIS
+   @RKS iter SAD:   -75.82538727182798   -7.58254e+01   0.00000e+00 
+   @RKS iter   1:   -76.24870831810148   -4.23321e-01   2.28250e-02 ADIIS/DIIS
+   @RKS iter   2:   -76.24436550816516    4.34281e-03   2.48492e-02 ADIIS/DIIS
+   @RKS iter   3:   -76.37349855046513   -1.29133e-01   7.45202e-04 ADIIS/DIIS
+   @RKS iter   4:   -76.37369202322047   -1.93473e-04   2.73557e-04 ADIIS/DIIS
+   @RKS iter   5:   -76.37371552037376   -2.34972e-05   3.96467e-05 DIIS
+   @RKS iter   6:   -76.37371627547660   -7.55103e-07   6.37382e-06 DIIS
+   @RKS iter   7:   -76.37371632343006   -4.79535e-08   1.42622e-06 DIIS
+   @RKS iter   8:   -76.37371632570053   -2.27047e-09   1.37058e-07 DIIS
+   @RKS iter   9:   -76.37371632571876   -1.82325e-11   1.76597e-08 DIIS
+   @RKS iter  10:   -76.37371632571880   -4.26326e-14   1.27570e-09 DIIS
   Energy and wave function converged.
 
 
   ==> Post-Iterations <==
+
+   Electrons on quadrature grid:
+      Ntotal   =   10.0000000519 ; deviation = 5.190e-08 
 
     Orbital Energies [Eh]
     ---------------------
@@ -289,9 +302,9 @@ Scratch directory: /tmp/
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.0023638541353055
-    One-Electron Energy =                -121.0198712300129387
-    Two-Electron Energy =                  43.1406036034156841
-    DFT Exchange-Correlation Energy =      -6.4968125532568575
+    One-Electron Energy =                -121.0198712309101268
+    Two-Electron Energy =                  43.1406036044107140
+    DFT Exchange-Correlation Energy =      -6.4968125533546965
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
     Total Energy =                        -76.3737163257188030
@@ -316,15 +329,24 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:    -0.0000      Z:    -2.0208     Total:     2.0208
 
 
-*** tstop() called on minazo at Thu Jun 11 15:34:02 2020
+*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:41 2022
 Module time:
-	user time   =       2.01 seconds =       0.03 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       1.85 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       2.01 seconds =       0.03 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       1.85 seconds =       0.03 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
 
 
          ---------------------------------------------------------
@@ -332,27 +354,29 @@ Total time:
                  by Andrew M. James and Daniel G. A. Smith        
          ---------------------------------------------------------
 
+  ==> Options <==
+
+     Residual threshold  : 1.0000e-06
+     Initial guess       : denominators
+     Reference           : RHF
+     Solver type         : TDA (Davidson)
+
+
   ==> Requested Excitations <==
 
       10 singlet states with A symmetry
 
-  ==> Options <==
 
-     r_convergence:              1e-06
-     guess_type:              DENOMINATORS
-     restricted:              True
-     ptype     :              tda
-
-
+  ==> Seeking the lowest 10 singlet states with A symmetry
 
                          Generalized Davidson Solver                         
                                By Ruhee Dcunha                               
 
   ==> Options <==
 
-    Maxiter                         = 60   
-    Eigenvector tolerance           = 1.00000e-06
-    Max number of expansion vectors = 1500 
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-06
+    Max number of expansion vectors = 3000 
 
   => Iterations <=
                            Max[D[value]]     Max[|R|]   # vectors
@@ -360,7 +384,7 @@ Total time:
   DavidsonSolver iter   2:   2.70401e-03  2.42998e-03     50      
   DavidsonSolver iter   3:   1.71329e-06  1.97103e-04     60      
   DavidsonSolver iter   4:   2.99649e-09  1.04489e-05     70      
-  DavidsonSolver iter   5:   1.13910e-11  7.16840e-07     77      Converged
+  DavidsonSolver iter   5:   1.13888e-11  7.16840e-07     77      Converged
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -370,29 +394,93 @@ Total time:
                                     Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
-     1        A->A (1 A)       0.24888         6.77226        -76.12484        0.0115          0.1095         -0.0000          0.0000        
+     1        A->A (1 A)       0.24888         6.77226        -76.12484        0.0115          0.1095          0.0000          0.0000        
      2        A->A (1 A)       0.31363         8.53423        -76.06009        0.0000          0.0000          0.0000          0.0000        
      3        A->A (1 A)       0.34848         9.48266        -76.02524        0.0959          0.1190         -0.0000         -0.0000        
-     4        A->A (1 A)       0.41300         11.23824       -75.96072        0.0470          0.0137          0.0000          0.0000        
+     4        A->A (1 A)       0.41300         11.23824       -75.96072        0.0470          0.0137         -0.0000         -0.0000        
      5        A->A (1 A)       0.45629         12.41639       -75.91742        0.5107          0.3505          0.0000          0.0000        
      6        A->A (1 A)       0.58222         15.84290       -75.79150        0.2592          0.1462          0.0000          0.0000        
      7        A->A (1 A)       0.71925         19.57181       -75.65447        0.0000          0.0000         -0.0000         -0.0000        
-     8        A->A (1 A)       0.75329         20.49815       -75.62042        0.0760          0.0527         -0.0000         -0.0000        
-     9        A->A (1 A)       0.83260         22.65611       -75.54112        0.0890          0.0321         -0.0000          0.0000        
-     10       A->A (1 A)       0.84182         22.90705       -75.53190        0.0004          0.0108          0.0000          0.0000        
+     8        A->A (1 A)       0.75329         20.49815       -75.62042        0.0760          0.0527          0.0000          0.0000        
+     9        A->A (1 A)       0.83260         22.65611       -75.54112        0.0890          0.0321         -0.0000         -0.0000        
+     10       A->A (1 A)       0.84182         22.90705       -75.53190        0.0004          0.0108         -0.0000         -0.0000        
 
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A SYMMETRY......................PASSED
-    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 10 EXCITATION ENERGY - A SYMMETRY.....................PASSED
 
-    Psi4 stopped on: Thursday, 11 June 2020 03:34PM
-    Psi4 wall time for execution: 0:00:06.79
+
+Contributing excitations
+Only contributions with coefficients > 1.00e-01 will be printed:
+
+Excited State    1 (1 A):   0.24888 au   183.08 nm f = 0.0115
+  Sums of squares: Xssq =  1.000000e+00
+     5 ->  6    0.998415 (99.683%)
+
+Excited State    2 (1 A):   0.31363 au   145.28 nm f = 0.0000
+  Sums of squares: Xssq =  1.000000e+00
+     5 ->  7   -0.995202 (99.043%)
+
+Excited State    3 (1 A):   0.34848 au   130.75 nm f = 0.0959
+  Sums of squares: Xssq =  1.000000e+00
+     3 ->  7    0.191057 ( 3.650%)
+     4 ->  6    0.977183 (95.489%)
+
+Excited State    4 (1 A):   0.41300 au   110.32 nm f = 0.0470
+  Sums of squares: Xssq =  1.000000e+00
+     3 ->  6    0.334350 (11.179%)
+     4 ->  7    0.938417 (88.063%)
+
+Excited State    5 (1 A):   0.45629 au   99.86 nm f = 0.5107
+  Sums of squares: Xssq =  1.000000e+00
+     3 ->  6   -0.938371 (88.054%)
+     4 ->  7    0.332320 (11.044%)
+
+Excited State    6 (1 A):   0.58222 au   78.26 nm f = 0.2592
+  Sums of squares: Xssq =  1.000000e+00
+     3 ->  7    0.951590 (90.552%)
+     4 ->  6   -0.170897 ( 2.921%)
+     4 ->  9   -0.139849 ( 1.956%)
+     4 -> 10    0.105797 ( 1.119%)
+     5 -> 11   -0.143840 ( 2.069%)
+
+Excited State    7 (1 A):   0.71925 au   63.35 nm f = 0.0000
+  Sums of squares: Xssq =  1.000000e+00
+     5 ->  8   -0.995436 (99.089%)
+
+Excited State    8 (1 A):   0.75329 au   60.49 nm f = 0.0760
+  Sums of squares: Xssq =  1.000000e+00
+     5 ->  9   -0.996902 (99.381%)
+
+Excited State    9 (1 A):   0.83260 au   54.72 nm f = 0.0890
+  Sums of squares: Xssq =  1.000000e+00
+     3 ->  9    0.268963 ( 7.234%)
+     4 ->  8   -0.955637 (91.324%)
+
+Excited State   10 (1 A):   0.84182 au   54.12 nm f = 0.0004
+  Sums of squares: Xssq =  1.000000e+00
+     2 ->  6   -0.185480 ( 3.440%)
+     3 ->  8   -0.184067 ( 3.388%)
+     4 ->  9    0.954674 (91.140%)
+
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 10 EXCITATION ENERGY - A TRANSITION...................PASSED
+
+    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
+    Psi4 wall time for execution: 0:00:05.55
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-5/output.ref
+++ b/tests/tdscf-5/output.ref
@@ -1,0 +1,441 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {tdscf_var} c8200ee dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 08 March 2022 09:38AM
+
+    Process ID: 4307
+    Host:       dhcp189-161.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! td-camb3lyp with DiskDF and method/basis specification
+from psi4.driver.procrouting.response.scf_response import tdscf_excitations
+
+memory 280 mb
+
+molecule h2o {
+O
+H 1 r
+H 1 r 2 a
+
+r=0.958
+a=104.5
+
+symmetry c1
+}
+
+set {
+    scf_type disk_df
+    save_jk true
+    df_ints_io save
+    e_convergence 8
+    d_convergence 8
+}
+e, wfn = psi4.energy("cam-b3lyp/aug-cc-pvtz", return_wfn=True, molecule=h2o)
+res = tdscf_excitations(wfn, states=1, tda=True)
+--------------------------------------------------------------------------
+
+  Memory set to 267.029 MiB by Python driver.
+
+Scratch directory: /tmp/
+
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Tue Mar  8 09:38:45 2022
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   331 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    40 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        1 Threads,    267 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065638538108    15.994914619570
+         H            0.000000000000    -0.757480611647     0.520865616165     1.007825032230
+         H            0.000000000000     0.757480611647     0.520865616165     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.37692  B =     14.57600  C =      9.51176 [cm^-1]
+  Rotational constants: A = 820739.39651  B = 436977.44416  C = 285155.28473 [MHz]
+  Nuclear repulsion =    9.187333574704981
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVTZ
+    Blend: AUG-CC-PVTZ
+    Number of shells: 32
+    Number of basis functions: 92
+    Number of Cartesian functions: 105
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFT Potential <==
+
+   => LibXC <=
+
+    Version 5.1.5
+    S. Lehtola, C. Steigemann, M. J. Oliveira, and M. A. Marques, SoftwareX 7, 1 (2018) (10.1016/j.softx.2017.11.002)
+
+   => Composite Functional: CAM-B3LYP <= 
+
+    CAM-B3LYP Hyb-GGA Exchange-Correlation Functional
+
+    T. Yanai, D. P. Tew, and N. C. Handy, Chem. Phys. Lett. 393, 51 (2004) (10.1016/j.cplett.2004.06.011)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange Functionals <=
+
+    0.3500         Becke 88 [omega = 0.3300]
+    0.4600   Short-range recipe for B88 functional - erf [omega = 0.3300]
+
+   => Exact (HF) Exchange <=
+
+    0.4600            HF,LR [omega = 0.3300]
+    0.1900               HF 
+
+   => Correlation Functionals <=
+
+    0.1900   Vosko, Wilk & Nusair (VWN5)
+    0.8100   Lee, Yang & Parr
+
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_CAM_B3LYP:  1.00E-14 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           NONE
+    Nuclear Scheme         =       TREUTLER
+
+    Blocking Scheme        =         OCTREE
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             75
+    Spherical Points       =            302
+    Total Points           =          66706
+    Total Blocks           =            559
+    Max Points             =            256
+    Max Functions          =             92
+    Weights Tolerance      =       1.00E-15
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   286 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.300E-01
+    OpenMP threads:              1
+    Integrals threads:           1
+    Memory [MiB]:               19
+    Algorithm:                Disk
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVTZ AUX)
+    Blend: AUG-CC-PVTZ-JKFIT
+    Number of shells: 58
+    Number of basis functions: 196
+    Number of Cartesian functions: 241
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Cached 100.0% of DFT collocation blocks in 0.176 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 3.8522020800E-04.
+  Reciprocal condition number of the overlap matrix is 5.6317587608E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         92      92 
+   -------------------------
+    Total      92      92
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RKS iter SAD:   -75.99649856945162   -7.59965e+01   0.00000e+00 
+   @DF-RKS iter   1:   -76.27848037838424   -2.81982e-01   7.43710e-03 ADIIS/DIIS
+   @DF-RKS iter   2:   -76.13846395305951    1.40016e-01   1.00918e-02 ADIIS/DIIS
+   @DF-RKS iter   3:   -76.43792342004775   -2.99459e-01   1.44390e-04 ADIIS/DIIS
+   @DF-RKS iter   4:   -76.43802433927998   -1.00919e-04   5.53433e-05 DIIS
+   @DF-RKS iter   5:   -76.43803373954702   -9.40027e-06   7.62052e-06 DIIS
+   @DF-RKS iter   6:   -76.43803397919825   -2.39651e-07   1.01649e-06 DIIS
+   @DF-RKS iter   7:   -76.43803398667335   -7.47509e-09   1.11109e-07 DIIS
+   @DF-RKS iter   8:   -76.43803398687703   -2.03684e-10   1.90677e-08 DIIS
+   @DF-RKS iter   9:   -76.43803398688198   -4.94538e-12   1.72436e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   Electrons on quadrature grid:
+      Ntotal   =    9.9999999133 ; deviation = -8.666e-08 
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -19.211098     2A     -1.101387     3A     -0.608836  
+       4A     -0.468184     5A     -0.393185  
+
+    Virtual:                                                              
+
+       6A      0.001190     7A      0.033940     8A      0.099363  
+       9A      0.123045    10A      0.130869    11A      0.144240  
+      12A      0.179754    13A      0.200818    14A      0.221920  
+      15A      0.251649    16A      0.257670    17A      0.332034  
+      18A      0.366091    19A      0.387448    20A      0.513133  
+      21A      0.567610    22A      0.616687    23A      0.636746  
+      24A      0.639544    25A      0.732605    26A      0.756680  
+      27A      0.778861    28A      0.812680    29A      0.815467  
+      30A      0.835185    31A      0.849666    32A      0.865714  
+      33A      0.924016    34A      0.933083    35A      0.965705  
+      36A      1.028767    37A      1.087235    38A      1.092807  
+      39A      1.152508    40A      1.382505    41A      1.409139  
+      42A      1.446136    43A      1.631586    44A      1.677796  
+      45A      1.805816    46A      1.928884    47A      2.060676  
+      48A      2.116438    49A      2.127673    50A      2.196492  
+      51A      2.232294    52A      2.240661    53A      2.278919  
+      54A      2.479606    55A      2.496869    56A      2.554994  
+      57A      2.631682    58A      2.681890    59A      3.397881  
+      60A      3.487986    61A      3.725621    62A      3.790191  
+      63A      3.943377    64A      4.022017    65A      4.061703  
+      66A      4.141940    67A      4.149755    68A      4.158231  
+      69A      4.232583    70A      4.381368    71A      4.529549  
+      72A      4.884380    73A      4.893204    74A      4.971530  
+      75A      5.010077    76A      5.200016    77A      5.354628  
+      78A      5.803420    79A      6.128888    80A      6.323490  
+      81A      6.512822    82A      6.729803    83A      6.817558  
+      84A      6.875485    85A      6.900618    86A      6.914855  
+      87A      6.931551    88A      7.117039    89A      7.474043  
+      90A      7.505558    91A      8.362220    92A     15.088895  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RKS Final Energy:   -76.43803398688198
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873335747049811
+    One-Electron Energy =                -123.0232657260598614
+    Two-Electron Energy =                  44.2113887867615816
+    DFT Exchange-Correlation Energy =      -6.8134906222886888
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                        -76.4380339868819902
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9763
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2317
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.7446     Total:     0.7446
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     1.8926     Total:     1.8926
+
+
+*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:50 2022
+Module time:
+	user time   =       4.10 seconds =       0.07 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+Total time:
+	user time   =       4.10 seconds =       0.07 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
+
+
+         ---------------------------------------------------------
+                         TDSCF excitation energies                
+                 by Andrew M. James and Daniel G. A. Smith        
+         ---------------------------------------------------------
+
+  ==> Options <==
+
+     Residual threshold  : 1.0000e-04
+     Initial guess       : denominators
+     Reference           : RHF
+     Solver type         : TDA (Davidson)
+
+
+  ==> Requested Excitations <==
+
+      1 singlet states with A symmetry
+
+
+  ==> Seeking the lowest 1 singlet states with A symmetry
+
+                         Generalized Davidson Solver                         
+                               By Ruhee Dcunha                               
+
+  ==> Options <==
+
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-04
+    Max number of expansion vectors = 200  
+
+  => Iterations <=
+                           Max[D[value]]     Max[|R|]   # vectors
+  DavidsonSolver iter   1:   2.67528e-01  4.62608e-02      4      
+  DavidsonSolver iter   2:   4.50424e-03  1.96073e-02      5      
+  DavidsonSolver iter   3:   1.70641e-04  4.49505e-03      6      
+  DavidsonSolver iter   4:   1.19113e-05  6.30581e-04      7      
+  DavidsonSolver iter   5:   3.87062e-07  1.18658e-04      8      
+  DavidsonSolver iter   6:   1.03900e-08  2.15383e-05      9      Converged
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********  Length-gauge rotatory strengths are **NOT** gauge-origin invariant  **********
+******************************************************************************************
+
+                                    Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
+     #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
+    ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
+     1        A->A (1 A)       0.26284         7.15226        -76.17519        0.0504          0.0604         -0.0000         -0.0000        
+
+
+
+Contributing excitations
+Only contributions with coefficients > 1.00e-01 will be printed:
+
+Excited State    1 (1 A):   0.26284 au   173.35 nm f = 0.0504
+  Sums of squares: Xssq =  1.000000e+00
+     5 ->  6    0.950891 (90.419%)
+     5 ->  8    0.261758 ( 6.852%)
+     5 -> 10    0.151293 ( 2.289%)
+
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
+
+    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
+    Psi4 wall time for execution: 0:00:08.85
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-6/input.dat
+++ b/tests/tdscf-6/input.dat
@@ -23,7 +23,7 @@ set {
 }
 
 ref = 0.283463
-string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
+string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION"
 
 wfn = psi4.energy("cam-b3lyp", return_wfn=True, molecule=h2o)[1]
 res = tdscf_excitations(wfn, states=1, tda=True)

--- a/tests/tdscf-6/output.ref
+++ b/tests/tdscf-6/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev45 
+                               Psi4 undefined 
 
-                         Git: Rev {master} 2e3b0f2 dirty
+                         Git: Rev {tdscf_var} c8200ee dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 10 February 2022 03:39PM
+    Psi4 started on: Tuesday, 08 March 2022 09:38AM
 
-    Process ID: 31647
-    Host:       dhcp189-153.emerson.emory.edu
+    Process ID: 4309
+    Host:       dhcp189-161.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -66,7 +66,7 @@ set {
 }
 
 ref = 0.283463
-string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY"
+string = "TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION"
 
 wfn = psi4.energy("cam-b3lyp", return_wfn=True, molecule=h2o)[1]
 res = tdscf_excitations(wfn, states=1, tda=True)
@@ -86,8 +86,8 @@ compare_values(ref, wfn.variable(string), 4, string)
 
 Scratch directory: /tmp/
 
-*** tstart() called on dhcp189-153.emerson.emory.edu
-*** at Thu Feb 10 15:39:02 2022
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Tue Mar  8 09:38:55 2022
 
    => Loading Basis Set <=
 
@@ -265,15 +265,15 @@ Scratch directory: /tmp/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-RKS iter SAD:   -75.96686470860365   -7.59669e+01   0.00000e+00 
-   @DF-RKS iter   1:   -76.20148342915417   -2.34619e-01   2.43937e-02 DIIS
-   @DF-RKS iter   2:   -76.17589780043996    2.55856e-02   2.74605e-02 DIIS
-   @DF-RKS iter   3:   -76.32971418457153   -1.53816e-01   4.95859e-04 DIIS
-   @DF-RKS iter   4:   -76.32977996490725   -6.57803e-05   1.40139e-04 DIIS
-   @DF-RKS iter   5:   -76.32978482532044   -4.86041e-06   2.18588e-05 DIIS
-   @DF-RKS iter   6:   -76.32978496172510   -1.36405e-07   1.46511e-06 DIIS
-   @DF-RKS iter   7:   -76.32978496393514   -2.21004e-09   2.68910e-07 DIIS
-   @DF-RKS iter   8:   -76.32978496400901   -7.38680e-11   2.37192e-08 DIIS
-   @DF-RKS iter   9:   -76.32978496400946   -4.54747e-13   1.62146e-09 DIIS
+   @DF-RKS iter   1:   -76.20148342915417   -2.34619e-01   2.43937e-02 DIIS/ADIIS
+   @DF-RKS iter   2:   -76.17589780043996    2.55856e-02   2.74605e-02 DIIS/ADIIS
+   @DF-RKS iter   3:   -76.32970494934206   -1.53807e-01   5.70032e-04 DIIS/ADIIS
+   @DF-RKS iter   4:   -76.32977981408435   -7.48647e-05   1.42003e-04 DIIS/ADIIS
+   @DF-RKS iter   5:   -76.32978482197544   -5.00789e-06   2.20692e-05 DIIS
+   @DF-RKS iter   6:   -76.32978496157291   -1.39597e-07   1.50265e-06 DIIS
+   @DF-RKS iter   7:   -76.32978496392973   -2.35681e-09   2.80977e-07 DIIS
+   @DF-RKS iter   8:   -76.32978496400891   -7.91829e-11   2.39853e-08 DIIS
+   @DF-RKS iter   9:   -76.32978496400948   -5.68434e-13   1.68862e-09 DIIS
   Energy and wave function converged.
 
 
@@ -304,17 +304,17 @@ Scratch directory: /tmp/
               A 
     DOCC [     5 ]
 
-  @DF-RKS Final Energy:   -76.32978496400946
+  @DF-RKS Final Energy:   -76.32978496400948
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1873335747049811
-    One-Electron Energy =                -123.1023942421548156
-    Two-Electron Energy =                  44.4154516829815691
-    DFT Exchange-Correlation Energy =      -6.8301759795411927
+    One-Electron Energy =                -123.1023942495666432
+    Two-Electron Energy =                  44.4154516912874300
+    DFT Exchange-Correlation Energy =      -6.8301759804352375
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
-    Total Energy =                        -76.3297849640094626
+    Total Energy =                        -76.3297849640094768
 
 Computation Completed
 
@@ -336,15 +336,24 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:     2.0151     Total:     2.0151
 
 
-*** tstop() called on dhcp189-153.emerson.emory.edu at Thu Feb 10 15:39:05 2022
+*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:58 2022
 Module time:
-	user time   =       2.29 seconds =       0.04 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       2.65 seconds =       0.04 minutes
+	system time =       0.22 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       2.29 seconds =       0.04 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       2.65 seconds =       0.04 minutes
+	system time =       0.22 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
 
 
          ---------------------------------------------------------
@@ -402,12 +411,21 @@ Excited State    1 (1 A):   0.28346 au   160.74 nm f = 0.0179
   Sums of squares: Xssq =  1.000000e+00
      5 ->  6    0.998965 (99.793%)
 
-    TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY..........................PASSED
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
+    TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION........................PASSED
 
 Scratch directory: /tmp/
 
-*** tstart() called on dhcp189-153.emerson.emory.edu
-*** at Thu Feb 10 15:39:07 2022
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Tue Mar  8 09:39:00 2022
 
    => Loading Basis Set <=
 
@@ -586,15 +604,15 @@ Scratch directory: /tmp/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-RKS iter SAD:   -75.96686470860524   -7.59669e+01   0.00000e+00 
-   @DF-RKS iter   1:   -76.20148342915220   -2.34619e-01   2.43937e-02 DIIS
-   @DF-RKS iter   2:   -76.17589780043848    2.55856e-02   2.74605e-02 DIIS
-   @DF-RKS iter   3:   -76.32971418456872   -1.53816e-01   4.95859e-04 DIIS
-   @DF-RKS iter   4:   -76.32977996490450   -6.57803e-05   1.40139e-04 DIIS
-   @DF-RKS iter   5:   -76.32978482531766   -4.86041e-06   2.18588e-05 DIIS
-   @DF-RKS iter   6:   -76.32978496172220   -1.36405e-07   1.46511e-06 DIIS
-   @DF-RKS iter   7:   -76.32978496393233   -2.21013e-09   2.68910e-07 DIIS
-   @DF-RKS iter   8:   -76.32978496400614   -7.38112e-11   2.37192e-08 DIIS
-   @DF-RKS iter   9:   -76.32978496400669   -5.54223e-13   1.62146e-09 DIIS
+   @DF-RKS iter   1:   -76.20148342915220   -2.34619e-01   2.43937e-02 DIIS/ADIIS
+   @DF-RKS iter   2:   -76.17589780043848    2.55856e-02   2.74605e-02 DIIS/ADIIS
+   @DF-RKS iter   3:   -76.32970494933926   -1.53807e-01   5.70032e-04 DIIS/ADIIS
+   @DF-RKS iter   4:   -76.32977981408150   -7.48647e-05   1.42003e-04 DIIS/ADIIS
+   @DF-RKS iter   5:   -76.32978482197259   -5.00789e-06   2.20692e-05 DIIS
+   @DF-RKS iter   6:   -76.32978496157017   -1.39598e-07   1.50265e-06 DIIS
+   @DF-RKS iter   7:   -76.32978496392698   -2.35681e-09   2.80977e-07 DIIS
+   @DF-RKS iter   8:   -76.32978496400614   -7.91545e-11   2.39853e-08 DIIS
+   @DF-RKS iter   9:   -76.32978496400666   -5.25802e-13   1.68862e-09 DIIS
   Energy and wave function converged.
 
 
@@ -625,17 +643,17 @@ Scratch directory: /tmp/
               A 
     DOCC [     5 ]
 
-  @DF-RKS Final Energy:   -76.32978496400669
+  @DF-RKS Final Energy:   -76.32978496400666
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1873335747049811
-    One-Electron Energy =                -123.1023942421458059
-    Two-Electron Energy =                  44.4154516829742008
-    DFT Exchange-Correlation Energy =      -6.8301759795400541
+    One-Electron Energy =                -123.1023942495575909
+    Two-Electron Energy =                  44.4154516912800474
+    DFT Exchange-Correlation Energy =      -6.8301759804340980
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
-    Total Energy =                        -76.3297849640066772
+    Total Energy =                        -76.3297849640066488
 
 Computation Completed
 
@@ -657,15 +675,24 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:    -0.0000      Z:     2.0151     Total:     2.0151
 
 
-*** tstop() called on dhcp189-153.emerson.emory.edu at Thu Feb 10 15:39:09 2022
+*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:39:02 2022
 Module time:
-	user time   =       2.20 seconds =       0.04 minutes
-	system time =       0.08 seconds =       0.00 minutes
+	user time   =       2.12 seconds =       0.04 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       6.10 seconds =       0.10 minutes
-	system time =       0.24 seconds =       0.00 minutes
+	user time   =       6.28 seconds =       0.10 minutes
+	system time =       0.34 seconds =       0.01 minutes
 	total time  =          7 seconds =       0.12 minutes
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
 
 
          ---------------------------------------------------------
@@ -723,9 +750,18 @@ Excited State    1 (1 A):   0.28346 au   160.74 nm f = 0.0179
   Sums of squares: Xssq =  1.000000e+00
      5 ->  6    0.998965 (99.793%)
 
-    TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A SYMMETRY..........................PASSED
 
-    Psi4 stopped on: Thursday, 10 February 2022 03:39PM
-    Psi4 wall time for execution: 0:00:08.85
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
+    TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION........................PASSED
+
+    Psi4 stopped on: Tuesday, 08 March 2022 09:39AM
+    Psi4 wall time for execution: 0:00:07.99
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-7/CMakeLists.txt
+++ b/tests/tdscf-7/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(tdscf-7 "psi;tdscf")

--- a/tests/tdscf-7/input.dat
+++ b/tests/tdscf-7/input.dat
@@ -1,0 +1,32 @@
+molecule h2o {
+  1 2 
+  O
+  H 1 0.9 
+  H 1 0.9 2 104.0
+}
+
+set {
+  reference uhf 
+  basis cc-pVDZ
+  tdscf_states [1, 1, 1, 1]
+}
+
+wfn = energy('td-hf', return_wfn=True)[1]
+
+exc_1 = 0.09302 # TEST
+exc_2 = 0.27347 # TEST
+exc_3 = 0.57815 # TEST
+exc_4 = 0.63789 # TEST
+
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A1) EXCITATION ENERGY"), 5, "First Excitation Energy")      # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")     # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 1 (B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")      # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")     # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY"), 5, "First Excitation Energy")                # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY"), 5, "Second Excitation Energy")               # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY"), 5, "Third Excitation Energy")                # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY"), 5, "Fourth Excitation Energy")               # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY - B1 SYMMETRY"), 5, "First Excitation Energy")  # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY - A2 SYMMETRY"), 5, "Second Excitation Energy") # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY - A1 SYMMETRY"), 5, "Third Excitation Energy")  # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY - B2 SYMMETRY"), 5, "Fourth Excitation Energy") # TEST

--- a/tests/tdscf-7/input.dat
+++ b/tests/tdscf-7/input.dat
@@ -18,15 +18,15 @@ exc_2 = 0.27347 # TEST
 exc_3 = 0.57815 # TEST
 exc_4 = 0.63789 # TEST
 
-compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A1) EXCITATION ENERGY"), 5, "First Excitation Energy")      # TEST
-compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")     # TEST
-compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 1 (B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")      # TEST
-compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")     # TEST
-compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY"), 5, "First Excitation Energy")                # TEST
-compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY"), 5, "Second Excitation Energy")               # TEST
-compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY"), 5, "Third Excitation Energy")                # TEST
-compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY"), 5, "Fourth Excitation Energy")               # TEST
-compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY - B1 SYMMETRY"), 5, "First Excitation Energy")  # TEST
-compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY - A2 SYMMETRY"), 5, "Second Excitation Energy") # TEST
-compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY - A1 SYMMETRY"), 5, "Third Excitation Energy")  # TEST
-compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY - B2 SYMMETRY"), 5, "Fourth Excitation Energy") # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A1) EXCITATION ENERGY"), 5, "First Excitation Energy")        # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")       # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 1 (B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")        # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")       # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY"), 5, "First Excitation Energy")                  # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY"), 5, "Second Excitation Energy")                 # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY"), 5, "Third Excitation Energy")                  # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY"), 5, "Fourth Excitation Energy")                 # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY - B1 TRANSITION"), 5, "First Excitation Energy")  # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY - A2 TRANSITION"), 5, "Second Excitation Energy") # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY - A1 TRANSITION"), 5, "Third Excitation Energy")  # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY - B2 TRANSITION"), 5, "Fourth Excitation Energy") # TEST

--- a/tests/tdscf-7/output.ref
+++ b/tests/tdscf-7/output.ref
@@ -1,0 +1,451 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {tdscf_var} 4c81d8b dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Saturday, 05 March 2022 08:55PM
+
+    Process ID: 20847
+    Host:       Jonathons-MacBook-Pro.local
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+molecule h2o {
+  1 2 
+  O
+  H 1 0.9 
+  H 1 0.9 2 104.0
+}
+
+set {
+  reference uhf 
+  basis cc-pVDZ
+  tdscf_states [1, 1, 1, 1]
+}
+
+wfn = energy('td-hf', return_wfn=True)[1]
+
+exc_1 = 0.09302 # TEST
+exc_2 = 0.27347 # TEST
+exc_3 = 0.57815 # TEST
+exc_4 = 0.63789 # TEST
+
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A1) EXCITATION ENERGY"), 5, "First Excitation Energy")      # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")     # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 1 (B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")      # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")     # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY"), 5, "First Excitation Energy")                # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY"), 5, "Second Excitation Energy")               # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY"), 5, "Third Excitation Energy")                # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY"), 5, "Fourth Excitation Energy")               # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY - B1 SYMMETRY"), 5, "First Excitation Energy")  # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY - A2 SYMMETRY"), 5, "Second Excitation Energy") # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY - A1 SYMMETRY"), 5, "Third Excitation Energy")  # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY - B2 SYMMETRY"), 5, "Fourth Excitation Energy") # TEST
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+
+*** tstart() called on Jonathons-MacBook-Pro.local
+*** at Sat Mar  5 20:55:23 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.062011508399    15.994914619570
+         H            0.000000000000    -0.709209678246     0.492083819394     1.007825032230
+         H            0.000000000000     0.709209678246     0.492083819394     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     30.67311  B =     16.62770  C =     10.78255 [cm^-1]
+  Rotational constants: A = 919556.65020  B = 498485.75869  C = 323252.59919 [MHz]
+  Nuclear repulsion =    9.780670144878627
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis functions: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.8509508519E-02.
+  Reciprocal condition number of the overlap matrix is 8.8848532316E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -75.58765897087146   -7.55877e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.57843545735250    9.22351e-03   1.98316e-02 DIIS/ADIIS
+   @DF-UHF iter   2:   -75.61445301952274   -3.60176e-02   5.18490e-03 DIIS/ADIIS
+   @DF-UHF iter   3:   -75.61660995565767   -2.15694e-03   1.73720e-03 DIIS/ADIIS
+   @DF-UHF iter   4:   -75.61692032828329   -3.10373e-04   5.44294e-04 DIIS/ADIIS
+   @DF-UHF iter   5:   -75.61697259988762   -5.22716e-05   2.21843e-04 DIIS/ADIIS
+   @DF-UHF iter   6:   -75.61698427055263   -1.16707e-05   6.14164e-05 DIIS
+   @DF-UHF iter   7:   -75.61698524513895   -9.74586e-07   1.02000e-05 DIIS
+   @DF-UHF iter   8:   -75.61698526830453   -2.31656e-08   1.60396e-06 DIIS
+   @DF-UHF iter   9:   -75.61698526874258   -4.38050e-10   2.81746e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   5.210098139E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.552100981E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -21.145639     2A1    -1.954253     1B2    -1.260794  
+       1B1    -1.145521     3A1    -1.120497  
+
+    Alpha Virtual:                                                        
+
+       4A1    -0.130271     2B2    -0.044379     3B2     0.421481  
+       5A1     0.493377     2B1     0.664513     6A1     0.706828  
+       4B2     0.823537     7A1     1.005754     1A2     1.045891  
+       3B1     1.236546     8A1     1.368714     5B2     1.594580  
+       6B2     2.124195     9A1     2.142693     4B1     2.772418  
+       2A2     2.824155    10A1     3.071358    11A1     3.387600  
+       7B2     3.714767  
+
+    Beta Occupied:                                                        
+
+       1A1   -21.101111     2A1    -1.802440     1B2    -1.223097  
+       3A1    -1.067520  
+
+    Beta Virtual:                                                         
+
+       1B1    -0.327019     4A1    -0.117295     2B2    -0.037355  
+       3B2     0.421754     5A1     0.512937     6A1     0.729486  
+       4B2     0.839788     2B1     0.858361     7A1     1.017203  
+       1A2     1.081569     3B1     1.273960     8A1     1.420876  
+       5B2     1.591957     6B2     2.136631     9A1     2.204837  
+       4B1     2.873116     2A2     2.925434    10A1     3.102985  
+      11A1     3.457194     7B2     3.731637  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    0,    1 ]
+    SOCC [     0,    0,    1,    0 ]
+
+  @DF-UHF Final Energy:   -75.61698526874258
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.7806701448786271
+    One-Electron Energy =                -118.9744363721655986
+    Two-Electron Energy =                  33.5767809585443970
+    Total Energy =                        -75.6169852687425816
+
+  UHF NO Occupations:
+  HONO-2 :    1 B2 1.9994184
+  HONO-1 :    3 A1 1.9982056
+  HONO-0 :    1 B1 1.0000000
+  LUNO+0 :    4 A1 0.0017944
+  LUNO+1 :    2 B2 0.0005816
+  LUNO+2 :    5 A1 0.0002306
+  LUNO+3 :    6 A1 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9223
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0027
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9250     Total:     0.9250
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.3511     Total:     2.3511
+
+
+*** tstop() called on Jonathons-MacBook-Pro.local at Sat Mar  5 20:55:24 2022
+Module time:
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+
+         ---------------------------------------------------------
+                         TDSCF excitation energies                
+                 by Andrew M. James and Daniel G. A. Smith        
+         ---------------------------------------------------------
+
+  ==> Options <==
+
+     Residual threshold  : 1.0000e-04
+     Initial guess       : denominators
+     Reference           : UHF
+     Solver type         : RPA (Hamiltonian)
+
+
+  ==> Requested Excitations <==
+
+      1 singlet states with A1 symmetry
+      1 singlet states with A2 symmetry
+      1 singlet states with B1 symmetry
+      1 singlet states with B2 symmetry
+
+
+  ==> Seeking the lowest 1 singlet states with A1 symmetry
+
+                        Generalized Hamiltonian Solver                       
+                              By Andrew M. James                             
+
+  ==> Options <==
+
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-04
+    Max number of expansion vectors = 200  
+
+  => Iterations <=
+                              Max[D[value]]     Max[|R|]   # vectors
+  HamiltonianSolver iter   1:   1.26337e-01  4.41825e-01      4      
+  HamiltonianSolver iter   2:   3.30520e-02  4.13028e-02      6      
+  HamiltonianSolver iter   3:   2.58736e-04  7.65967e-03      8      
+  HamiltonianSolver iter   4:   5.65574e-06  6.96226e-04     10      
+  HamiltonianSolver iter   5:   2.22752e-08  7.55270e-05     12      Converged
+
+
+  ==> Seeking the lowest 1 singlet states with A2 symmetry
+
+                        Generalized Hamiltonian Solver                       
+                              By Andrew M. James                             
+
+  ==> Options <==
+
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-04
+    Max number of expansion vectors = 200  
+
+  => Iterations <=
+                              Max[D[value]]     Max[|R|]   # vectors
+  HamiltonianSolver iter   1:   6.99437e-01  3.61771e-01      4      
+  HamiltonianSolver iter   2:   5.70396e-02  1.40978e-01      6      
+  HamiltonianSolver iter   3:   4.03646e-03  5.18922e-02      8      
+  HamiltonianSolver iter   4:   4.32270e-04  1.70791e-02     10      
+  HamiltonianSolver iter   5:   4.00777e-05  6.19018e-03     12      
+  HamiltonianSolver iter   6:   3.01081e-06  1.95184e-03     14      
+  HamiltonianSolver iter   7:   1.49613e-07  2.89779e-04     16      
+  HamiltonianSolver iter   8:   5.21947e-09  3.99349e-05     18      Converged
+
+
+  ==> Seeking the lowest 1 singlet states with B1 symmetry
+
+                        Generalized Hamiltonian Solver                       
+                              By Andrew M. James                             
+
+  ==> Options <==
+
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-04
+    Max number of expansion vectors = 200  
+
+  => Iterations <=
+                              Max[D[value]]     Max[|R|]   # vectors
+  HamiltonianSolver iter   1:   6.13403e-01  3.14373e-01      4      
+  HamiltonianSolver iter   2:   3.14428e-02  1.22412e-01      6      
+  HamiltonianSolver iter   3:   3.28588e-03  5.20293e-02      8      
+  HamiltonianSolver iter   4:   4.95798e-04  1.73050e-02     10      
+  HamiltonianSolver iter   5:   2.80193e-05  3.88639e-03     12      
+  HamiltonianSolver iter   6:   1.02152e-06  1.18978e-03     14      
+  HamiltonianSolver iter   7:   5.57744e-08  1.43980e-04     16      
+  HamiltonianSolver iter   8:   1.36573e-09  1.85486e-05     18      Converged
+
+
+  ==> Seeking the lowest 1 singlet states with B2 symmetry
+
+                        Generalized Hamiltonian Solver                       
+                              By Andrew M. James                             
+
+  ==> Options <==
+
+    Max number of iterations        = 60   
+    Eigenvector tolerance           = 1.0000e-04
+    Max number of expansion vectors = 200  
+
+  => Iterations <=
+                              Max[D[value]]     Max[|R|]   # vectors
+  HamiltonianSolver iter   1:   2.99428e-01  3.89053e-01      4      
+  HamiltonianSolver iter   2:   2.59214e-02  1.87424e-02      6      
+  HamiltonianSolver iter   3:   3.86124e-05  2.51975e-03      8      
+  HamiltonianSolver iter   4:   3.74065e-07  3.45287e-04     10      
+  HamiltonianSolver iter   5:   2.37651e-09  1.13459e-05     12      Converged
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********  Length-gauge rotatory strengths are **NOT** gauge-origin invariant  **********
+******************************************************************************************
+
+                                    Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
+     #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
+    ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
+     1      B1->A1 (1 B1)      0.09302         2.53122        -75.52396        0.0017          0.0043          0.0000         -0.0000        
+     2      B1->B2 (1 A2)      0.27347         7.44145        -75.34352        0.0000          0.0000          0.0000         -0.0000        
+     3      B1->B1 (1 A1)      0.57815         15.73224       -75.03884        0.0078          0.0103          0.0000         -0.0000        
+     4      B1->A2 (1 B2)      0.63789         17.35774       -74.97910        0.0075          0.0070          0.0000         -0.0000        
+
+
+
+Contributing excitations and de-excitations...only curently available with C1 symmetry
+
+    First Excitation Energy...............................................................PASSED
+    Second Excitation Energy..............................................................PASSED
+    Third Excitation Energy...............................................................PASSED
+    Fourth Excitation Energy..............................................................PASSED
+    First Excitation Energy...............................................................PASSED
+    Second Excitation Energy..............................................................PASSED
+    Third Excitation Energy...............................................................PASSED
+    Fourth Excitation Energy..............................................................PASSED
+    First Excitation Energy...............................................................PASSED
+    Second Excitation Energy..............................................................PASSED
+    Third Excitation Energy...............................................................PASSED
+    Fourth Excitation Energy..............................................................PASSED
+
+    Psi4 stopped on: Saturday, 05 March 2022 08:55PM
+    Psi4 wall time for execution: 0:00:00.99
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-7/output.ref
+++ b/tests/tdscf-7/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {tdscf_var} 4c81d8b dirty
+                         Git: Rev {tdscf_var} c8200ee dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 05 March 2022 08:55PM
+    Psi4 started on: Tuesday, 08 March 2022 09:39AM
 
-    Process ID: 20847
-    Host:       Jonathons-MacBook-Pro.local
+    Process ID: 4311
+    Host:       dhcp189-161.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -61,24 +61,24 @@ exc_2 = 0.27347 # TEST
 exc_3 = 0.57815 # TEST
 exc_4 = 0.63789 # TEST
 
-compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A1) EXCITATION ENERGY"), 5, "First Excitation Energy")      # TEST
-compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")     # TEST
-compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 1 (B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")      # TEST
-compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")     # TEST
-compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY"), 5, "First Excitation Energy")                # TEST
-compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY"), 5, "Second Excitation Energy")               # TEST
-compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY"), 5, "Third Excitation Energy")                # TEST
-compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY"), 5, "Fourth Excitation Energy")               # TEST
-compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY - B1 SYMMETRY"), 5, "First Excitation Energy")  # TEST
-compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY - A2 SYMMETRY"), 5, "Second Excitation Energy") # TEST
-compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY - A1 SYMMETRY"), 5, "Third Excitation Energy")  # TEST
-compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY - B2 SYMMETRY"), 5, "Fourth Excitation Energy") # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A1) EXCITATION ENERGY"), 5, "First Excitation Energy")        # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")       # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 1 (B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")        # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")       # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY"), 5, "First Excitation Energy")                  # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY"), 5, "Second Excitation Energy")                 # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY"), 5, "Third Excitation Energy")                  # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY"), 5, "Fourth Excitation Energy")                 # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY - B1 TRANSITION"), 5, "First Excitation Energy")  # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY - A2 TRANSITION"), 5, "Second Excitation Energy") # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY - A1 TRANSITION"), 5, "Third Excitation Energy")  # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY - B2 TRANSITION"), 5, "Fourth Excitation Energy") # TEST
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
-*** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Mar  5 20:55:23 2022
+*** tstart() called on dhcp189-161.emerson.emory.edu
+*** at Tue Mar  8 09:39:04 2022
 
    => Loading Basis Set <=
 
@@ -298,15 +298,24 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.3511     Total:     2.3511
 
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Mar  5 20:55:24 2022
+*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:39:05 2022
 Module time:
-	user time   =       0.50 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.50 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
+	user time   =       0.47 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
 
 
          ---------------------------------------------------------
@@ -432,6 +441,15 @@ Total time:
 
 Contributing excitations and de-excitations...only curently available with C1 symmetry
 
+
+******************************************************************************************
+**********                               WARNING                                **********
+**********       The names of excited state variables changed between 1.5       **********
+**********     and 1.6. For a quick solution, remove the symmetry specifier     **********
+**********   from the variable name. For full details, see 'Notes on Psivars'   **********
+**********                        in the documentation.                         **********
+******************************************************************************************
+
     First Excitation Energy...............................................................PASSED
     Second Excitation Energy..............................................................PASSED
     Third Excitation Energy...............................................................PASSED
@@ -445,7 +463,7 @@ Contributing excitations and de-excitations...only curently available with C1 sy
     Third Excitation Energy...............................................................PASSED
     Fourth Excitation Energy..............................................................PASSED
 
-    Psi4 stopped on: Saturday, 05 March 2022 08:55PM
-    Psi4 wall time for execution: 0:00:00.99
+    Psi4 stopped on: Tuesday, 08 March 2022 09:39AM
+    Psi4 wall time for execution: 0:00:00.91
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
TDSCF/ADC and EOM can't agree on how to name variables for excitation energies. Per discussion between Lori and I, this moves the TDSCF variable names to the new standard, as I see it. This PR is not complete and is submitted for feedback from the excited-state gurus, who are likely to have strong opinions: @loriab @robertodr @lothian @maxscheurer 

To demonstrate the changes, consider the example file I added. Old code would write the second transition as "TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY - B2 SYMMETRY". The new code replaces that with three new psivars:

- TD-HF ROOT 0 (B1) -> ROOT 0 (B2) EXCITATION ENERGY
- TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY
- TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY - A2 SYMMETRY

We have one access call that requires the symmetries of initial and target states and the indices of both _within their irreps_. We have one access call that requires no symmetry information and just requires the index of the states _among all irreps_. The last access call is like the second, but adds on the symmetry of the _transition_. **This is a breaking change** because old code instead used the symmetry of the final state.

After coding this all up, I'm inclined to remove the last access call. The original reason for keeping it up was consistency with the current way TDSCF operates, but it's still inconsistent, per the last paragraph.

I'll add docs once we're settled about the new naming conventions. Once this PR is in, the other modules will need to update to the new style.

## Questions
- [x] Opinions on the new variable names?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
