### PR TITLE
Fix corner case in the C++ implementation of Molecule::atom_at_position

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -924,10 +924,10 @@ void export_mints(py::module& m) {
              "Gets the multiplicity of each fragment")
         .def("atom_at_position", &Molecule::atom_at_position1,
              "Returns the index of the atom inside *tol* radius around *coord*. Returns -1 for no atoms, "
-             "returns the index of the closest atom if more than one is found.", "coord"_a, "tol"_a)
+             "throws an exception if more than one is found.", "coord"_a, "tol"_a)
         .def("atom_at_position", &Molecule::atom_at_position3,
              "Returns the index of the atom inside *tol* radius around *coord*. Returns -1 for no atoms, "
-             "returns the index of the closest atom if more than one is found.", "coord"_a, "tol"_a)
+             "throws an exception if more than one is found.", "coord"_a, "tol"_a)
         .def("print_out", &Molecule::print, "Prints the molecule in Cartesians in input units to output file")
         .def("print_out_in_bohr", &Molecule::print_in_bohr, "Prints the molecule in Cartesians in Bohr to output file")
         .def("print_out_in_angstrom", &Molecule::print_in_angstrom,

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -923,9 +923,11 @@ void export_mints(py::module& m) {
         .def("get_fragment_multiplicities", &Molecule::get_fragment_multiplicities,
              "Gets the multiplicity of each fragment")
         .def("atom_at_position", &Molecule::atom_at_position1,
-             "Tests to see if an atom is at the position *coord* with a given tolerance *tol*", "coord"_a, "tol"_a)
+             "Returns the index of the atom inside *tol* radius around *coord*. Returns -1 for no atoms, "
+             "returns the index of the closest atom if more than one is found.", "coord"_a, "tol"_a)
         .def("atom_at_position", &Molecule::atom_at_position3,
-             "Tests to see if an atom is at the position *coord* with a given tolerance *tol*", "coord"_a, "tol"_a)
+             "Returns the index of the atom inside *tol* radius around *coord*. Returns -1 for no atoms, "
+             "returns the index of the closest atom if more than one is found.", "coord"_a, "tol"_a)
         .def("print_out", &Molecule::print, "Prints the molecule in Cartesians in input units to output file")
         .def("print_out_in_bohr", &Molecule::print_in_bohr, "Prints the molecule in Cartesians in Bohr to output file")
         .def("print_out_in_angstrom", &Molecule::print_in_angstrom,

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -375,8 +375,9 @@ int Molecule::atom_at_position2(const Vector3 &b, const double tol) const {
     }
     if (num_near > 1){
         throw PSIEXCEPTION(
-          "More than one atom within tolerance distance! The geometry is either near nuclear fusion "
-          "or symmetry detection tolerance has been set too large.");
+          "More than one atom within tolerance distance! The geometry is either near nuclear fusion or symmetry "
+          "detection tolerance has been set too large. If you want to bypass this error please open an issue at "
+		  "https://github.com/psi4/psi4/issues");
     }
     return std::min_element(dists.cbegin(), dists.cend()) - dists.cbegin();
 }

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -364,11 +364,21 @@ int Molecule::atom_at_position1(double *const coord, const double tol) const {
 }
 
 int Molecule::atom_at_position2(const Vector3 &b, const double tol) const {
+    std::vector<double> dists(natom());
     for (int i = 0; i < natom(); ++i) {
-        Vector3 a = xyz(i);
-        if (b.distance(a) < tol) return i;
+        const Vector3 a = xyz(i);
+        dists[i] = b.distance(a);
     }
-    return -1;
+    const int num_near = std::count_if(dists.cbegin(), dists.cend(), [tol](double dist){return dist < tol;});
+    if (num_near == 0){
+        return -1;
+    }
+    if (num_near > 1){
+        outfile->Printf("WARNING: More than one atom within tolerance distance. Symmetry assignment may be "
+        "incorrect!\n"
+        "Please check your results carefully!\n");
+    }
+    return std::min_element(dists.cbegin(), dists.cend()) - dists.cbegin();
 }
 
 int Molecule::atom_at_position3(const std::array<double, 3> &coord, const double tol) const {

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -374,9 +374,9 @@ int Molecule::atom_at_position2(const Vector3 &b, const double tol) const {
         return -1;
     }
     if (num_near > 1){
-        outfile->Printf("WARNING: More than one atom within tolerance distance. Symmetry assignment may be "
-        "incorrect!\n"
-        "Please check your results carefully!\n");
+        throw PSIEXCEPTION(
+          "More than one atom within tolerance distance! The geometry is either near nuclear fusion "
+          "or symmetry detection tolerance has been set too large.");
     }
     return std::min_element(dists.cbegin(), dists.cend()) - dists.cbegin();
 }

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -375,9 +375,8 @@ int Molecule::atom_at_position2(const Vector3 &b, const double tol) const {
     }
     if (num_near > 1){
         throw PSIEXCEPTION(
-          "More than one atom within tolerance distance! The geometry is either near nuclear fusion or symmetry "
-          "detection tolerance has been set too large. If you want to bypass this error please open an issue at "
-		  "https://github.com/psi4/psi4/issues");
+          "More than one atom within tolerance distance! The geometry either has one or more atoms extremely close "
+          "to each other, or the tolerance distance has been set too large.");
     }
     return std::min_element(dists.cbegin(), dists.cend()) - dists.cbegin();
 }

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -316,7 +316,8 @@ class PSI_API Molecule {
     void set_shell_by_label(const std::string& label, const std::string& name, const std::string& type = "BASIS");
 
     /// @{
-    /// Tests to see of an atom is at the passed position with a given tolerance
+    /// Returns the index of the atom inside the tolerance radius around a specific point.
+    /// Returns -1 if no atom is found, returns the closest atom if multiple atoms are found.
     int atom_at_position1(double*const, const double tol = 0.05) const;
     int atom_at_position2(const Vector3&, const double tol = 0.05) const;
     int atom_at_position3(const std::array<double, 3>&, const double tol = 0.05) const;

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -317,7 +317,7 @@ class PSI_API Molecule {
 
     /// @{
     /// Returns the index of the atom inside the tolerance radius around a specific point.
-    /// Returns -1 if no atom is found, returns the closest atom if multiple atoms are found.
+    /// Returns -1 if no atom is found, throws an exception if multiple atoms are found.
     int atom_at_position1(double*const, const double tol = 0.05) const;
     int atom_at_position2(const Vector3&, const double tol = 0.05) const;
     int atom_at_position3(const std::array<double, 3>&, const double tol = 0.05) const;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

`Molecule::atom_at_position` is supposed to return the index of the atom found in a specified radius of a specified point in 3D space, or -1 if no atom is found in the radius. The current implementation assumes there is never more than one atom within the given radius, and returns the index of the first atom found to be within the tolerance.
This can hypothetically happen in two ways: the atoms are either extremely close, or the tolerance is set to a large value.

The new implementation behaves more like one would expect it to behave: under the aforementioned extreme circumstances it throws an exception and informs the user with an error message.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Detect corner case and throw error if encountered
- [x] Update docstrings to better describe implementation

## Questions
- [x] Apparently, `qcdb.Molecule` has its own independent Python implementation of `atom_at_position`. As is, this PR means that calling `qcdb.Molecule.atom_at_position` and `psi4.core.Molecule.atom_at_position` from a Python program may return different results for the same geometry, if the aforementioned corner case happens.
Not sure what to do about this, at first glance it would be neater if both `qcdb.Molecule.atom_at_position` and `psi4.core.Molecule.atom_at_position` ended up calling the same C++ implementation, but I am not sure how feasible that would be.
Thoughts?

## Checklist
- [x] No new features
- [x] `ctest -j24` and `make pytest` both passed locally

## Status
- [x] Ready for review
- [x] Ready for merge
