### PR TITLE
Remove Reference to Unimplemented Method

### DIFF
--- a/psi4/src/psi4/cc/cceom/Local.h
+++ b/psi4/src/psi4/cc/cceom/Local.h
@@ -51,7 +51,6 @@ struct Local {
     int *pairdom_len;
     int *pairdom_nrlen;
     int *weak_pairs;
-    int ghost;
     int do_singles;
     double ***V;
     double ***W;

--- a/psi4/src/psi4/cc/cceom/get_params.cc
+++ b/psi4/src/psi4/cc/cceom/get_params.cc
@@ -118,7 +118,6 @@ void get_params(Options &options) {
         local.method = options.get_str("LOCAL_METHOD");
         local.weakp = options.get_str("LOCAL_WEAKP");
         local.precon = options.get_str("LOCAL_PRECONDITIONER");
-        local.ghost = options.get_int("LOCAL_GHOST");
         local.do_singles = options["LOCAL_DO_SINGLES"].to_integer();
         local.filter_singles = options["LOCAL_FILTER_SINGLES"].to_integer();
     }
@@ -148,7 +147,6 @@ void get_params(Options &options) {
         outfile->Printf("\tLocal Method    =    %s\n", local.method.c_str());
         outfile->Printf("\tWeak pairs      =    %s\n", local.weakp.c_str());
         outfile->Printf("\tLocal precon.   =    %s\n", local.precon.c_str());
-        outfile->Printf("\tGhost atom      =    %d\n", local.ghost);
         outfile->Printf("\tLocal guess     =    %s\n", local.do_singles ? "HBAR_SS" : "UNIT VECTORS");
         outfile->Printf("\tFilter singles  =    %s\n", local.filter_singles ? "Yes" : "No");
     }

--- a/psi4/src/psi4/libqt/cc_excited.cc
+++ b/psi4/src/psi4/libqt/cc_excited.cc
@@ -56,8 +56,7 @@ int cc_excited(const char *wfn) {
     if (!strcmp(wfn, "CCSD") || !strcmp(wfn, "CCSD_T") || !strcmp(wfn, "BCCD") || !strcmp(wfn, "BCCD_T") ||
         !strcmp(wfn, "CC2") || !strcmp(wfn, "CC3") || !strcmp(wfn, "CCSD_MVD") || !strcmp(wfn, "CCSD_AT")) {
         return 0;
-    } else if (!strcmp(wfn, "EOM_CCSD") || !strcmp(wfn, "LEOM_CCSD") || !strcmp(wfn, "EOM_CC2") ||
-               !strcmp(wfn, "EOM_CC3")) {
+    } else if (!strcmp(wfn, "EOM_CCSD") || !strcmp(wfn, "EOM_CC2") || !strcmp(wfn, "EOM_CC3")) {
         return 1;
     } else {
         std::string str = "Invalid value of input keyword WFN: ";

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2249,7 +2249,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
         /*- Wavefunction type !expert -*/
         options.add_str("WFN", "NONE",
-                        "CCSD CCSD_T CCSD_AT EOM_CCSD LEOM_CCSD BCCD BCCD_T CC2 CC3 EOM_CC2 EOM_CC3 CCSD_MVD");
+                        "CCSD CCSD_T CCSD_AT EOM_CCSD BCCD BCCD_T CC2 CC3 EOM_CC2 EOM_CC3 CCSD_MVD");
         /*- Reference wavefunction type -*/
         options.add_str("REFERENCE", "RHF", "RHF ROHF UHF");
         /*- Do use new triples? -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2015,9 +2015,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("LOCAL_WEAKP", "NONE", "NONE MP2 NEGLECT");
         /*- Preconditioner will be used in local CC computations -*/
         options.add_str("LOCAL_PRECONDITIONER", "HBAR", "HBAR FOCK");
-        /*- Permit ghost atoms to hold projected atomic orbitals to include in the virtual space in local-EOM-CCSD
-           calculations -*/
-        options.add_int("LOCAL_GHOST", -1);
         /*- -*/
         options.add_bool("LOCAL_DO_SINGLES", true);
         /*- Do apply local filtering to singles amplitudes? -*/


### PR DESCRIPTION
## Description
`LEOM_CCSD` is included in the list of EOM methods, but I can find no evidence that this method exists in Psi, other than as an option. This PR removes the option entirely.

This brings the EOM methods to create variables for down to EOMCCSD, EOMCC2, and EOMCC3.

Per Lori observation, the `LOCAL_GHOST` option is removed as unused.

## Status
- [x] Ready for review
- [ ] Ready for merge
