### PR TITLE
docs fix

### DIFF
--- a/doc/sphinxman/source/prog_integrals.rst
+++ b/doc/sphinxman/source/prog_integrals.rst
@@ -278,9 +278,9 @@ thread.  Moreover, if integral objects are created only in the initialization
 of each code that uses them, and stored persistently, the cost of integral
 object creation is further reduced.
 
-===================================
+
 One Electron Integrals in |PSIfour|
-===================================
+-----------------------------------
 
 After version 1.5, we started transitioning the one electron integral code over to
 use Libint2 instead of the old handwritten Obara-Saika code.  There are a


### PR DESCRIPTION
## Description
I think this will overcome the latest warnings. will have to take a look at the built docs to see if headings levels still ok.

```
/home/runner/work/psi4/psi4/code/objdir/doc/sphinxman/source/prog_integrals.rst:298: CRITICAL: Title level inconsistent:

Calling ``compute_shell(int P, int Q)``
.......................................

... 4 more ...

/home/runner/work/psi4/psi4/code/objdir/doc/sphinxman/source/prog_integrals.rst:383: CRITICAL: Title level inconsistent:

Shell Pairs
...........
```

## Status
- [x] Ready for review
- [x] Ready for merge
