### PR TITLE
Refactor `PseudospectralInts` using Libint2

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1511,6 +1511,8 @@ void export_mints(py::module& m) {
         .def("electrostatic_potential_value", &MintsHelper::electrostatic_potential_value,
              "Electrostatic potential values at given sites with associated charge, specified as an (n_sites, 4) matrix.",
              "charges"_a, "coords"_a, "D"_a)
+        .def("ao_pseudospectral", &MintsHelper::ao_pseudospectral, "AO Pseudospectral Integrals",
+        "origin"_a = std::vector<double>{0, 0, 0}, "omega"_a = 0.0, "deriv"_a = 0)
 
         // Two-electron AO
         .def("ao_eri", normal_eri_factory(&MintsHelper::ao_eri), "AO ERI integrals", "factory"_a = nullptr)

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -56,6 +56,7 @@
 #include "psi4/libmints/eri.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/3coverlap.h"
+#include "psi4/libmints/potential_erf.h"
 #include "psi4/libmints/oeprop.h"
 #include "psi4/libmints/nabla.h"
 #include "psi4/libmints/electrostatic.h"
@@ -1511,7 +1512,9 @@ void export_mints(py::module& m) {
         .def("electrostatic_potential_value", &MintsHelper::electrostatic_potential_value,
              "Electrostatic potential values at given sites with associated charge, specified as an (n_sites, 4) matrix.",
              "charges"_a, "coords"_a, "D"_a)
-        .def("ao_pseudospectral", &MintsHelper::ao_pseudospectral, "AO Pseudospectral Integrals",
+        .def("ao_potential_erf", &MintsHelper::ao_potential_erf, "AO Erf-attenuated Coulomb potential on a given point",
+        "origin"_a = std::vector<double>{0, 0, 0}, "omega"_a = 0.0, "deriv"_a = 0)
+        .def("ao_potential_erf_complement", &MintsHelper::ao_potential_erf_complement, "AO Erfc-attenuated Coulomb potential on a given point",
         "origin"_a = std::vector<double>{0, 0, 0}, "omega"_a = 0.0, "deriv"_a = 0)
 
         // Two-electron AO

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -68,6 +68,7 @@ onebody.cc
 overlap.cc
 potential.cc
 potentialint.cc
+pseudospectral.cc
 quadrupole.cc
 rel_potential.cc
 tracelessquadrupole.cc

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -68,7 +68,7 @@ onebody.cc
 overlap.cc
 potential.cc
 potentialint.cc
-pseudospectral.cc
+potential_erf.cc
 quadrupole.cc
 rel_potential.cc
 tracelessquadrupole.cc

--- a/psi4/src/psi4/libmints/electricfield.cc
+++ b/psi4/src/psi4/libmints/electricfield.cc
@@ -35,8 +35,6 @@
 
 #include <libint2/engine.h>
 
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 using namespace psi;
 
 ElectricFieldInt::ElectricFieldInt(std::vector<SphericalTransform>& spherical_transforms, std::shared_ptr<BasisSet> bs1,

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -147,11 +147,11 @@ std::unique_ptr<OneBodyAOInt> IntegralFactory::electrostatic() { return std::mak
 std::unique_ptr<OneBodyAOInt> IntegralFactory::pcm_potentialint() { return  std::make_unique<PCMPotentialInt>(spherical_transforms_, bs1_, bs2_, 0); }
 
 std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_potential_erf(double omega, int deriv) {
-    return new PotentialErfInt(spherical_transforms_, bs1_, bs2_, omega, deriv);
+    return std::make_unique<PotentialErfInt>(spherical_transforms_, bs1_, bs2_, omega, deriv);
 }
 
 std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_potential_erf_complement(double omega, int deriv) {
-    return new PotentialErfComplementInt(spherical_transforms_, bs1_, bs2_, omega, deriv);
+    return std::make_unique<PotentialErfComplementInt>(spherical_transforms_, bs1_, bs2_, omega, deriv);
 }
 
 std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_dipole(int deriv) { return  std::make_unique<DipoleInt>(spherical_transforms_, bs1_, bs2_, deriv); }

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -145,6 +145,15 @@ std::unique_ptr<OneBodyAOInt> IntegralFactory::electrostatic() { return std::mak
 
 std::unique_ptr<OneBodyAOInt> IntegralFactory::pcm_potentialint() { return  std::make_unique<PCMPotentialInt>(spherical_transforms_, bs1_, bs2_, 0); }
 
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_pseudospectral(double omega, int deriv) {
+    return new PseudospectralInt(spherical_transforms_, bs1_, bs2_, omega, deriv);
+}
+
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_pseudospectral(double omega, int deriv) {
+    std::shared_ptr<OneBodyAOInt> ao_int(ao_pseudospectral(omega, deriv));
+    return new OneBodySOInt(ao_int, this);
+}
+
 std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_dipole(int deriv) { return  std::make_unique<DipoleInt>(spherical_transforms_, bs1_, bs2_, deriv); }
 
 std::unique_ptr<OneBodySOInt> IntegralFactory::so_dipole(int deriv) {

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -39,6 +39,7 @@
 #include "psi4/libmints/nabla.h"
 #include "psi4/libmints/dipole.h"
 #include "psi4/libmints/electrostatic.h"
+#include "psi4/libmints/potential_erf.h"
 #include "psi4/libmints/kinetic.h"
 #include "psi4/libmints/3coverlap.h"
 #include "psi4/libmints/overlap.h"
@@ -145,13 +146,12 @@ std::unique_ptr<OneBodyAOInt> IntegralFactory::electrostatic() { return std::mak
 
 std::unique_ptr<OneBodyAOInt> IntegralFactory::pcm_potentialint() { return  std::make_unique<PCMPotentialInt>(spherical_transforms_, bs1_, bs2_, 0); }
 
-std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_pseudospectral(double omega, int deriv) {
-    return new PseudospectralInt(spherical_transforms_, bs1_, bs2_, omega, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_potential_erf(double omega, int deriv) {
+    return new PotentialErfInt(spherical_transforms_, bs1_, bs2_, omega, deriv);
 }
 
-std::unique_ptr<OneBodySOInt> IntegralFactory::so_pseudospectral(double omega, int deriv) {
-    std::shared_ptr<OneBodyAOInt> ao_int(ao_pseudospectral(omega, deriv));
-    return new OneBodySOInt(ao_int, this);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_potential_erf_complement(double omega, int deriv) {
+    return new PotentialErfComplementInt(spherical_transforms_, bs1_, bs2_, omega, deriv);
 }
 
 std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_dipole(int deriv) { return  std::make_unique<DipoleInt>(spherical_transforms_, bs1_, bs2_, deriv); }

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -450,6 +450,10 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<OneBodyAOInt> ao_rel_potential(int deriv = 0);
     virtual std::unique_ptr<OneBodySOInt> so_rel_potential(int deriv = 0);
 
+    /// Returns the OneBodyInt that computes the pseudospectral grid integrals
+    virtual std::unique_ptr<OneBodyAOInt> ao_pseudospectral(double omega = 0.0, int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_pseudospectral(double omega = 0.0, int deriv = 0);
+
     /// Returns an OneBodyInt that computes the dipole integral.
     virtual std::unique_ptr<OneBodyAOInt> ao_dipole(int deriv = 0);
     virtual std::unique_ptr<OneBodySOInt> so_dipole(int deriv = 0);

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -450,9 +450,9 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<OneBodyAOInt> ao_rel_potential(int deriv = 0);
     virtual std::unique_ptr<OneBodySOInt> so_rel_potential(int deriv = 0);
 
-    /// Returns the OneBodyInt that computes the pseudospectral grid integrals
-    virtual std::unique_ptr<OneBodyAOInt> ao_pseudospectral(double omega = 0.0, int deriv = 0);
-    virtual std::unique_ptr<OneBodySOInt> so_pseudospectral(double omega = 0.0, int deriv = 0);
+    /// Returns the OneBodyInt that computes the erf/erfc-attenuated Coulomb potential on a given origin
+    virtual std::unique_ptr<OneBodyAOInt> ao_potential_erf(double omega = 0.0, int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_potential_erf_complement(double omega = 0.0, int deriv = 0);
 
     /// Returns an OneBodyInt that computes the dipole integral.
     virtual std::unique_ptr<OneBodyAOInt> ao_dipole(int deriv = 0);

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -70,9 +70,6 @@ extern int str_to_int(const std::string &s);
 
 extern double str_to_double(const std::string &s);
 
-#define MIN(x, y) ((x) < (y) ? (x) : (y))
-#define MAX(x, y) ((x) > (y) ? (x) : (y))
-
 Matrix::Matrix() {
     matrix_ = nullptr;
     nirrep_ = 0;
@@ -1045,7 +1042,7 @@ void Matrix::identity() {
 
         if (size) {
             memset(&(matrix_[h][0][0]), 0, size);
-            for (int i = 0; i < MIN(rowspi_[h], colspi_[h]); ++i) matrix_[h][i][i] = 1.0;
+            for (int i = 0; i < std::min(rowspi_[h], colspi_[h]); ++i) matrix_[h][i][i] = 1.0;
         }
     }
 }
@@ -1068,7 +1065,7 @@ void Matrix::zero_diagonal() {
     int h, i;
 
     for (h = 0; h < nirrep_; ++h) {
-        for (i = 0; i < MIN(rowspi_[h], colspi_[h]); ++i) {
+        for (i = 0; i < std::min(rowspi_[h], colspi_[h]); ++i) {
             matrix_[h][i][i] = 0.0;
         }
     }
@@ -1081,7 +1078,7 @@ double Matrix::trace() {
     double val = (double)0.0;
 
     for (h = 0; h < nirrep_; ++h) {
-        for (i = 0; i < MIN(rowspi_[h], colspi_[h]); ++i) {
+        for (i = 0; i < std::min(rowspi_[h], colspi_[h]); ++i) {
             val += matrix_[h][i][i];
         }
     }

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1753,13 +1753,22 @@ SharedMatrix MintsHelper::electric_field_value(SharedMatrix coords, SharedMatrix
     return efields;
 }
 
-SharedMatrix MintsHelper::ao_pseudospectral(const std::vector<double> &origin, double omega, int deriv) {
-    SharedMatrix pseudo = std::make_shared<Matrix>("AO Pseudo", basisset_->nbf(), basisset_->nbf());
+SharedMatrix MintsHelper::ao_potential_erf(const std::vector<double> &origin, double omega, int deriv) {
+    SharedMatrix int_erf = std::make_shared<Matrix>("AO Potential Erf", basisset_->nbf(), basisset_->nbf());
     Vector3 v3origin(origin[0], origin[1], origin[2]);
-    std::shared_ptr<OneBodyAOInt> ints(integral_->ao_pseudospectral(omega, deriv)); 
+    std::shared_ptr<OneBodyAOInt> ints(integral_->ao_potential_erf(omega, deriv)); 
     ints->set_origin(v3origin);
-    ints->compute(pseudo);
-    return pseudo;
+    ints->compute(int_erf);
+    return int_erf;
+}
+
+SharedMatrix MintsHelper::ao_potential_erf_complement(const std::vector<double> &origin, double omega, int deriv) {
+    SharedMatrix int_erfc = std::make_shared<Matrix>("AO Potential Erf Complement", basisset_->nbf(), basisset_->nbf());
+    Vector3 v3origin(origin[0], origin[1], origin[2]);
+    std::shared_ptr<OneBodyAOInt> ints(integral_->ao_potential_erf_complement(omega, deriv)); 
+    ints->set_origin(v3origin);
+    ints->compute(int_erfc);
+    return int_erfc;
 }
 
 std::vector<SharedMatrix> MintsHelper::ao_nabla() {

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1753,6 +1753,15 @@ SharedMatrix MintsHelper::electric_field_value(SharedMatrix coords, SharedMatrix
     return efields;
 }
 
+SharedMatrix MintsHelper::ao_pseudospectral(const std::vector<double> &origin, double omega, int deriv) {
+    SharedMatrix pseudo = std::make_shared<Matrix>("AO Pseudo", basisset_->nbf(), basisset_->nbf());
+    Vector3 v3origin(origin[0], origin[1], origin[2]);
+    std::shared_ptr<OneBodyAOInt> ints(integral_->ao_pseudospectral(omega, deriv)); 
+    ints->set_origin(v3origin);
+    ints->compute(pseudo);
+    return pseudo;
+}
+
 std::vector<SharedMatrix> MintsHelper::ao_nabla() {
     // Create a vector of matrices with the proper symmetry
     std::vector<SharedMatrix> nabla;

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1756,7 +1756,7 @@ SharedMatrix MintsHelper::electric_field_value(SharedMatrix coords, SharedMatrix
 SharedMatrix MintsHelper::ao_potential_erf(const std::vector<double> &origin, double omega, int deriv) {
     SharedMatrix int_erf = std::make_shared<Matrix>("AO Potential Erf", basisset_->nbf(), basisset_->nbf());
     Vector3 v3origin(origin[0], origin[1], origin[2]);
-    std::shared_ptr<OneBodyAOInt> ints(integral_->ao_potential_erf(omega, deriv)); 
+    std::shared_ptr<OneBodyAOInt> ints(integral_->ao_potential_erf(omega, deriv));
     ints->set_origin(v3origin);
     ints->compute(int_erf);
     return int_erf;
@@ -1765,7 +1765,7 @@ SharedMatrix MintsHelper::ao_potential_erf(const std::vector<double> &origin, do
 SharedMatrix MintsHelper::ao_potential_erf_complement(const std::vector<double> &origin, double omega, int deriv) {
     SharedMatrix int_erfc = std::make_shared<Matrix>("AO Potential Erf Complement", basisset_->nbf(), basisset_->nbf());
     Vector3 v3origin(origin[0], origin[1], origin[2]);
-    std::shared_ptr<OneBodyAOInt> ints(integral_->ao_potential_erf_complement(omega, deriv)); 
+    std::shared_ptr<OneBodyAOInt> ints(integral_->ao_potential_erf_complement(omega, deriv));
     ints->set_origin(v3origin);
     ints->compute(int_erfc);
     return int_erfc;

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -248,6 +248,8 @@ class PSI_API MintsHelper {
     SharedMatrix ao_3coverlap();
     SharedMatrix ao_3coverlap(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
                               std::shared_ptr<BasisSet> bs3);
+    
+    SharedMatrix ao_pseudospectral(const std::vector<double> &origin, double omega = 0.0, int deriv = 0);
 
     /// Symmetric MO ERI Integrals, (ov|ov) type  (Full matrix, N^5, not recommended for large systems)
     /// Pass C_ C_ for (aa|aa) type, Cocc_, Cocc_ for (oo|oo) type, or Cvir_, Cvir_ for (vv|vv) type

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -248,7 +248,7 @@ class PSI_API MintsHelper {
     SharedMatrix ao_3coverlap();
     SharedMatrix ao_3coverlap(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
                               std::shared_ptr<BasisSet> bs3);
-    
+
     /// Erf-attenuated Coulomb potential on origin
     SharedMatrix ao_potential_erf(const std::vector<double> &origin, double omega = 0.0, int deriv = 0);
     /// Erfc-attenuated Coulomb potential on origin

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -249,7 +249,10 @@ class PSI_API MintsHelper {
     SharedMatrix ao_3coverlap(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
                               std::shared_ptr<BasisSet> bs3);
     
-    SharedMatrix ao_pseudospectral(const std::vector<double> &origin, double omega = 0.0, int deriv = 0);
+    /// Erf-attenuated Coulomb potential on origin
+    SharedMatrix ao_potential_erf(const std::vector<double> &origin, double omega = 0.0, int deriv = 0);
+    /// Erfc-attenuated Coulomb potential on origin
+    SharedMatrix ao_potential_erf_complement(const std::vector<double> &origin, double omega = 0.0, int deriv = 0);
 
     /// Symmetric MO ERI Integrals, (ov|ov) type  (Full matrix, N^5, not recommended for large systems)
     /// Pass C_ C_ for (aa|aa) type, Cocc_, Cocc_ for (oo|oo) type, or Cvir_, Cvir_ for (vv|vv) type

--- a/psi4/src/psi4/libmints/potential.cc
+++ b/psi4/src/psi4/libmints/potential.cc
@@ -39,13 +39,8 @@
 
 #include <libint2/engine.h>
 
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
-#define VDEBUG 1
-
 using namespace psi;
 
-// Initialize potential_recur_ to +1 basis set angular momentum
 PotentialInt::PotentialInt(std::vector<SphericalTransform> &st, std::shared_ptr<BasisSet> bs1,
                            std::shared_ptr<BasisSet> bs2, int deriv)
     : OneBodyAOInt(st, bs1, bs2, deriv) {

--- a/psi4/src/psi4/libmints/potential_erf.cc
+++ b/psi4/src/psi4/libmints/potential_erf.cc
@@ -3,7 +3,7 @@
  *
  * Psi4: an open-source quantum chemistry software package
  *
- * Copyright (c) 2007-2022 The Psi4 Developers.
+ * Copyright (c) 2007-2024 The Psi4 Developers.
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/psi4/src/psi4/libmints/potential_erf.cc
+++ b/psi4/src/psi4/libmints/potential_erf.cc
@@ -35,9 +35,8 @@ using namespace psi;
 using Zxyz_vector = std::vector<std::pair<double, std::array<double, 3>>>;
 
 PotentialErfInt::PotentialErfInt(std::vector<SphericalTransform>& st, std::shared_ptr<BasisSet> bs1,
-                                     std::shared_ptr<BasisSet> bs2, double omega, int deriv)
+                                 std::shared_ptr<BasisSet> bs2, double omega, int deriv)
     : OneBodyAOInt(st, bs1, bs2, deriv), omega_(omega) {
-
     if (deriv > 0) {
         throw PSIEXCEPTION("PotentialErfInt does not support derivatives.");
     }
@@ -66,9 +65,8 @@ void PotentialErfInt::set_origin(const Vector3& _origin) {
 }
 
 PotentialErfComplementInt::PotentialErfComplementInt(std::vector<SphericalTransform>& st, std::shared_ptr<BasisSet> bs1,
-                                     std::shared_ptr<BasisSet> bs2, double omega, int deriv)
+                                                     std::shared_ptr<BasisSet> bs2, double omega, int deriv)
     : OneBodyAOInt(st, bs1, bs2, deriv), omega_(omega) {
-
     if (deriv > 0) {
         throw PSIEXCEPTION("PotentialErfComplementInt does not support derivatives.");
     }

--- a/psi4/src/psi4/libmints/potential_erf.cc
+++ b/psi4/src/psi4/libmints/potential_erf.cc
@@ -1,0 +1,97 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2022 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+#include "psi4/libmints/potential_erf.h"
+#include "psi4/libmints/integral.h"
+#include "psi4/libmints/basisset.h"
+#include "psi4/libmints/molecule.h"
+#include <libint2/engine.h>
+
+using namespace psi;
+using Zxyz_vector = std::vector<std::pair<double, std::array<double, 3>>>;
+
+PotentialErfInt::PotentialErfInt(std::vector<SphericalTransform>& st, std::shared_ptr<BasisSet> bs1,
+                                     std::shared_ptr<BasisSet> bs2, double omega, int deriv)
+    : OneBodyAOInt(st, bs1, bs2, deriv), omega_(omega) {
+
+    if (deriv > 0) {
+        throw PSIEXCEPTION("PotentialErfInt does not support derivatives.");
+    }
+
+    int max_am = std::max(basis1()->max_am(), basis2()->max_am());
+    int max_nprim = std::max(basis1()->max_nprimitive(), basis2()->max_nprimitive());
+
+    engine0_ = std::make_unique<libint2::Engine>(libint2::Operator::erf_nuclear, max_nprim, max_am, 0);
+
+    // set engine parameters
+    set_origin(Vector3(0, 0, 0));
+
+    buffer_ = nullptr;
+    buffers_.resize(nchunk_);
+}
+
+void PotentialErfInt::set_origin(const Vector3& _origin) {
+    origin_ = _origin;
+    std::cout << "(set origin) erf using omega = " << omega_ << std::endl;
+    Zxyz_vector pcs;
+    // l2 includes the electron charge, legacy psi4 code does not, so
+    // we adopt this behavior here with -1.0
+    pcs.push_back({-1.0, {origin_[0], origin_[1], origin_[2]}});
+    std::tuple<double, Zxyz_vector> params{omega_, pcs};
+    engine0_->set_params(params);
+}
+
+PotentialErfComplementInt::PotentialErfComplementInt(std::vector<SphericalTransform>& st, std::shared_ptr<BasisSet> bs1,
+                                     std::shared_ptr<BasisSet> bs2, double omega, int deriv)
+    : OneBodyAOInt(st, bs1, bs2, deriv), omega_(omega) {
+
+    if (deriv > 0) {
+        throw PSIEXCEPTION("PotentialErfComplementInt does not support derivatives.");
+    }
+
+    int max_am = std::max(basis1()->max_am(), basis2()->max_am());
+    int max_nprim = std::max(basis1()->max_nprimitive(), basis2()->max_nprimitive());
+
+    engine0_ = std::make_unique<libint2::Engine>(libint2::Operator::erfc_nuclear, max_nprim, max_am, 0);
+
+    // set engine parameters
+    set_origin(Vector3(0, 0, 0));
+
+    buffer_ = nullptr;
+    buffers_.resize(nchunk_);
+}
+
+void PotentialErfComplementInt::set_origin(const Vector3& _origin) {
+    origin_ = _origin;
+    std::cout << "(set origin) erfc using omega = " << omega_ << std::endl;
+    Zxyz_vector pcs;
+    // l2 includes the electron charge, legacy psi4 code does not, so
+    // we adopt this behavior here with -1.0
+    pcs.push_back({-1.0, {origin_[0], origin_[1], origin_[2]}});
+    std::tuple<double, Zxyz_vector> params{omega_, pcs};
+    engine0_->set_params(params);
+}

--- a/psi4/src/psi4/libmints/potential_erf.h
+++ b/psi4/src/psi4/libmints/potential_erf.h
@@ -47,7 +47,6 @@ class SphericalTransform;
  * Use an IntegralFactory to create this object.
  */
 class PotentialErfInt : public OneBodyAOInt {
-
    protected:
     /// The range-separation parameter. Defaults to 1.0
     double omega_;
@@ -55,8 +54,8 @@ class PotentialErfInt : public OneBodyAOInt {
    public:
     /// Constructor
     PotentialErfInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
-                      double omega = 1.0, int deriv = 0);
-    ~PotentialErfInt() override {};
+                    double omega = 1.0, int deriv = 0);
+    ~PotentialErfInt() override{};
 
     void set_origin(const Vector3& _origin) override;
 };
@@ -68,7 +67,6 @@ class PotentialErfInt : public OneBodyAOInt {
  */
 
 class PotentialErfComplementInt : public OneBodyAOInt {
-
    protected:
     /// The range-separation parameter. Defaults to 1.0
     double omega_;
@@ -76,8 +74,8 @@ class PotentialErfComplementInt : public OneBodyAOInt {
    public:
     /// Constructor
     PotentialErfComplementInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
-                      double omega = 1.0, int deriv = 0);
-    ~PotentialErfComplementInt() override {};
+                              double omega = 1.0, int deriv = 0);
+    ~PotentialErfComplementInt() override{};
 
     void set_origin(const Vector3& _origin) override;
 };

--- a/psi4/src/psi4/libmints/potential_erf.h
+++ b/psi4/src/psi4/libmints/potential_erf.h
@@ -1,0 +1,85 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2022 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
+
+#include <vector>
+#include "psi4/pragma.h"
+PRAGMA_WARNING_PUSH
+PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
+#include <memory>
+PRAGMA_WARNING_POP
+#include "psi4/libmints/onebody.h"
+
+namespace psi {
+
+class BasisSet;
+class SphericalTransform;
+
+/*! \ingroup MINTS
+ *  \class PotentialErfInt
+ *  \brief Computes the erf-attenuated Coulomb integrals on a given origin.
+ * Use an IntegralFactory to create this object.
+ */
+class PotentialErfInt : public OneBodyAOInt {
+
+   protected:
+    /// The range-separation parameter. Defaults to 1.0
+    double omega_;
+
+   public:
+    /// Constructor
+    PotentialErfInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
+                      double omega = 1.0, int deriv = 0);
+    ~PotentialErfInt() override {};
+
+    void set_origin(const Vector3& _origin) override;
+};
+
+/*! \ingroup MINTS
+ *  \class PotentialErfComplementInt
+ *  \brief Computes the complementary erf-attenuated Coulomb integrals on a given origin.
+ * Use an IntegralFactory to create this object.
+ */
+
+class PotentialErfComplementInt : public OneBodyAOInt {
+
+   protected:
+    /// The range-separation parameter. Defaults to 1.0
+    double omega_;
+
+   public:
+    /// Constructor
+    PotentialErfComplementInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
+                      double omega = 1.0, int deriv = 0);
+    ~PotentialErfComplementInt() override {};
+
+    void set_origin(const Vector3& _origin) override;
+};
+
+}  // namespace psi

--- a/psi4/src/psi4/libmints/potential_erf.h
+++ b/psi4/src/psi4/libmints/potential_erf.h
@@ -3,7 +3,7 @@
  *
  * Psi4: an open-source quantum chemistry software package
  *
- * Copyright (c) 2007-2022 The Psi4 Developers.
+ * Copyright (c) 2007-2024 The Psi4 Developers.
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/psi4/src/psi4/libmints/rel_potential.cc
+++ b/psi4/src/psi4/libmints/rel_potential.cc
@@ -35,9 +35,7 @@
 
 #include <libint2/engine.h>
 
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
-#define RELVDEBUG 0
+#include <algorithm>
 
 using namespace psi;
 

--- a/psi4/src/psi4/libmints/tracelessquadrupole.cc
+++ b/psi4/src/psi4/libmints/tracelessquadrupole.cc
@@ -33,8 +33,6 @@
 
 #include <libint2/engine.h>
 
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 using namespace psi;
 
 // Initialize overlap_recur_ to +2 basis set angular momentum

--- a/tests/pytests/test_potential_erf.py
+++ b/tests/pytests/test_potential_erf.py
@@ -26,12 +26,12 @@ def test_potential_erf_integrals():
     # corner cases
     # erf(inf) = 1
     x = mints.ao_potential_erf(C, omega=1e20).np
-    y = mints.ao_multipole_potential(C, max_k=0)[0].np
+    y = mints.ao_multipole_potential(origin=C, order=0)[0].np
     np.testing.assert_allclose(x, y, atol=1e-14)
 
     # erfc(0) = 1
     x = mints.ao_potential_erf_complement(C, omega=0.0).np
-    y = mints.ao_multipole_potential(C, max_k=0)[0].np
+    y = mints.ao_multipole_potential(origin=C, order=0)[0].np
     np.testing.assert_allclose(x, y, atol=1e-14)
 
     # 1/R - erf(R)/R - erfc(R)/R = 0

--- a/tests/pytests/test_potential_erf.py
+++ b/tests/pytests/test_potential_erf.py
@@ -1,6 +1,5 @@
 """
-This file tests the ao_multipole_potential integrals
-using finite differences
+This file tests the ao_potential_erf/ao_potential_erf_complement integrals
 """
 import numpy as np
 import pytest
@@ -23,20 +22,20 @@ def test_potential_erf_integrals():
     """)
     basis_obj = psi4.core.BasisSet.build(mol, 'ORBITAL', "cc-pvtz")
     mints = psi4.core.MintsHelper(basis_obj)
-    
+    C = [1, 2, 3]
     # corner cases
     # erf(inf) = 1
-    x = mints.ao_potential_erf([1, 2, 3], omega=1e20).np
-    y = mints.ao_multipole_potential([1, 2, 3], max_k=0)[0].np
+    x = mints.ao_potential_erf(C, omega=1e20).np
+    y = mints.ao_multipole_potential(C, max_k=0)[0].np
     np.testing.assert_allclose(x, y, atol=1e-14)
 
     # erfc(0) = 1
-    x = mints.ao_potential_erf_complement([1, 2, 3], omega=0.0).np
-    y = mints.ao_multipole_potential([1, 2, 3], max_k=0)[0].np
+    x = mints.ao_potential_erf_complement(C, omega=0.0).np
+    y = mints.ao_multipole_potential(C, max_k=0)[0].np
     np.testing.assert_allclose(x, y, atol=1e-14)
 
     # 1/R - erf(R)/R - erfc(R)/R = 0
-    erf = mints.ao_potential_erf([1, 2, 3], omega=1.5).np
-    erfc = mints.ao_potential_erf_complement([1, 2, 3], omega=1.5).np
+    erf = mints.ao_potential_erf(C, omega=1.5).np
+    erfc = mints.ao_potential_erf_complement(C, omega=1.5).np
     diff = y - erf - erfc
     np.testing.assert_allclose(diff, np.zeros_like(diff), atol=1e-14)

--- a/tests/pytests/test_potential_erf.py
+++ b/tests/pytests/test_potential_erf.py
@@ -1,0 +1,42 @@
+"""
+This file tests the ao_multipole_potential integrals
+using finite differences
+"""
+import numpy as np
+import pytest
+import psi4
+
+
+pytestmark = pytest.mark.quick
+
+
+def test_potential_erf_integrals():
+    mol = psi4.geometry("""
+    units bohr
+    0 1
+    O1     0.000000000000     0.000000000000     0.224348285559
+    H2    -1.423528800232     0.000000000000    -0.897393142237
+    H3     1.423528800232     0.000000000000    -0.897393142237
+    symmetry c1
+    no_com
+    no_reorient
+    """)
+    basis_obj = psi4.core.BasisSet.build(mol, 'ORBITAL', "cc-pvtz")
+    mints = psi4.core.MintsHelper(basis_obj)
+    
+    # corner cases
+    # erf(inf) = 1
+    x = mints.ao_potential_erf([1, 2, 3], omega=1e20).np
+    y = mints.ao_multipole_potential([1, 2, 3], max_k=0)[0].np
+    np.testing.assert_allclose(x, y, atol=1e-14)
+
+    # erfc(0) = 1
+    x = mints.ao_potential_erf_complement([1, 2, 3], omega=0.0).np
+    y = mints.ao_multipole_potential([1, 2, 3], max_k=0)[0].np
+    np.testing.assert_allclose(x, y, atol=1e-14)
+
+    # 1/R - erf(R)/R - erfc(R)/R = 0
+    erf = mints.ao_potential_erf([1, 2, 3], omega=1.5).np
+    erfc = mints.ao_potential_erf_complement([1, 2, 3], omega=1.5).np
+    diff = y - erf - erfc
+    np.testing.assert_allclose(diff, np.zeros_like(diff), atol=1e-14)


### PR DESCRIPTION
## Description
This PR refactors the existing `PseudospectralInts` (untested, unused, but maybe needed at some point, see #2414)
with some refactoring: The "old" `PseudospectralInts` did compute `<p| 1/R |q>` *or* `<p| erf(omega*R)/R |q>` with `R = |r -r_c|` for some given point/origin `r_c`. 

- The class `PseudospectralInts` is removed. To compute the "normal" Coulomb potential at a given origin, one can use either `MultipolePotentialInt` (with `max_k=0`) *OR* `ElectrostaticInt`.
- To compute the erf-attenuated Coulomb potential, I created a new class named `PotentialErfInt` to better reflect the actual "property integral" being computed. For testing purposes, I also added the erfc-attenuated Coulomb potential (`PotentialErfComplementInt`), maybe they're also useful at some point. Both use L2 under the hood.
- The point `r_c` is canonically set with `set_origin`.
- I've added the new integrals to `MintsHelper` and the Python API.
- Tests are added. (`erf(infinity*R)/R = 1/R`, `erfc(0*R)/R = 1/R`, and `1/R - erf(R)/R - erfc(R)/R = 0`).

This is a preparation to get rid of most of the remaining OS86 code as discussed in #2414.
Ping @loriab @zachglick @andysim 

## Questions
- [ ] Question1

## Checklist
- [x] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
