### PR TITLE
EOMCC Psivar Cleanup [1/2]

### DIFF
--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -374,6 +374,25 @@ PSI Variables by Alpha
    The origin-dependence of the CCSD specific rotation in deg/[dm (g/cm^3)]/bohr and the
    length gauge, computed at (x) wavelength, (x) rounded to nearest integer.
 
+.. psivar:: CCname ROOT m CORRELATION ENERGY
+   CCname ROOT m (h) CORRELATION ENERGY
+   CCname ROOT m CORRELATION ENERGY - h TRANSITION
+
+   The correlation energy of given method from ground state to root m in h symmetry.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :ref:`sec:psivarnotes`.
+
+.. psivar:: CCname ROOT m TOTAL ENERGY
+   CCname ROOT m (h) TOTAL ENERGY
+   CCname ROOT m TOTAL ENERGY - h TRANSITION
+   TD-fctl ROOT m TOTAL ENERGY
+   TD-fctl ROOT m (h) TOTAL ENERGY
+   TD-fctl ROOT m TOTAL ENERGY - h TRANSITION
+
+   The total energy of given method from ground state to root m in h symmetry.
+   Conventions for root indexing and whether h refers to transition or root
+   irrep are as in :ref:`sec:psivarnotes`.
+
 .. psivar:: CEPA(0) DIPOLE
 
    Dipole array [e a0] for the coupled electron pair approximation variant 0 level of theory, (3,).
@@ -1704,13 +1723,6 @@ PSI Variables by Alpha
    Conventions for root indexing and whether h refers to transition or root
    irrep are as in :ref:`sec:psivarnotes`.
 
-.. psivar:: TD-fctl ROOT m TOTAL ENERGY
-   TD-fctl ROOT m (h) TOTAL ENERGY
-   TD-fctl ROOT m TOTAL ENERGY - h TRANSITION
-
-   The total energy of given method from ground state to root m in h symmetry.
-   Conventions for root indexing and whether h refers to transition or root
-   irrep are as in :ref:`sec:psivarnotes`.
 
 .. psivar:: TD-fctl ROOT 0 -> ROOT m ELECTRIC TRANSITION DIPOLE MOMENT (LEN)
    TD-fctl ROOT 0 (h) -> ROOT m (i) ELECTRIC TRANSITION DIPOLE MOMENT (LEN)

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -1078,12 +1078,15 @@ void diag() {
         auto target_irrep = moinfo.irr_labs[moinfo.sym ^ std::get<1>(tuple)];
         auto corr_energy = std::get<2>(tuple);
         auto irrep_idx = irrep_counts[target_irrep];
-        Process::environment.globals[short_name + " ROOT " + std::to_string(i + 1) + " TOTAL ENERGY"] = total_energy;
-        Process::environment.globals[short_name + " ROOT " + std::to_string(i + 1) + " CORRELATION ENERGY"] = corr_energy;
-        Process::environment.globals[short_name + " ROOT " + std::to_string(i + 1) + " TOTAL ENERGY - " + trans_irrep + " TRANSITION"] = total_energy;
-        Process::environment.globals[short_name + " ROOT " + std::to_string(i + 1) + " CORRELATION ENERGY - " + trans_irrep + " TRANSITION"] = corr_energy;
-        Process::environment.globals[short_name + " ROOT " + std::to_string(irrep_idx) + " (" + target_irrep + ") TOTAL ENERGY"] = total_energy;
-        Process::environment.globals[short_name + " ROOT " + std::to_string(irrep_idx) + " (" + target_irrep + ") CORRELATION ENERGY"] = corr_energy;
+        const std::vector<std::string> names {"CC", short_name};
+        for (const auto& name : names) {
+            Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " TOTAL ENERGY"] = total_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " CORRELATION ENERGY"] = corr_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " TOTAL ENERGY - " + trans_irrep + " TRANSITION"] = total_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " CORRELATION ENERGY - " + trans_irrep + " TRANSITION"] = corr_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(irrep_idx) + " (" + target_irrep + ") TOTAL ENERGY"] = total_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(irrep_idx) + " (" + target_irrep + ") CORRELATION ENERGY"] = corr_energy;
+        }
         irrep_counts[target_irrep]++;
     }
 

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -35,6 +35,7 @@
  *    right-hand eigenvector and eigenvalue
  */
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <string>

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -40,6 +40,7 @@
 #include <string>
 #include <sstream>
 #include <cmath>
+#include "psi4/libmints/matrix.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsio/psio.h"
@@ -139,10 +140,10 @@ void diag() {
     int num_converged, num_converged_index = 0, keep_going, already_sigma;
     int irrep, numCs, iter, lwork, info, vectors_per_root, nsigma_evaluations = 0;
     int get_right_ev = 1, get_left_ev = 0, first_irrep = 1;
-    int L, h, i, j, k, a, nirreps, errcod, C_irr;
-    double norm, tval, **G, *work, *evals_complex, **alpha, **evectors_left;
-    double *lambda, *lambda_old, totalE, **G_old, **alpha_old;
-    int num_vecs, cc3_index, num_cc3_restarts = 0, ignore_G_old = 0;
+    int L, h, j, k, a, nirreps, errcod, C_irr;
+    double norm, tval, *work, *evals_complex, **alpha, **evectors_left;
+    double *lambda, *lambda_old, totalE, **alpha_old;
+    int num_vecs, cc3_index, num_cc3_restarts = 0;
     double ra, rb, r2aa, r2bb, r2ab, cc3_eval, cc3_last_converged_eval = 0.0, C0, S0, R0;
     int cc3_stage; /* 0=eom_ccsd; 1=eom_cc3 (reuse sigmas), 2=recompute sigma */
     int L_start_iter, L_old;
@@ -162,9 +163,11 @@ void diag() {
     if (params.wfn == "EOM_CC3") cc3_stage = 0; /* do EOM_CCSD first */
 
     outfile->Printf("Symmetry of ground state: %s\n", moinfo.irr_labs[moinfo.sym].c_str());
-    /* loop over symmetry of C's */
+    // Master Loop over transition symmetries
     for (C_irr = 0; C_irr < moinfo.nirreps; ++C_irr) {
-        ignore_G_old = 1;
+        bool ignore_G_old = true;
+        SharedMatrix G;
+        auto G_old = std::make_shared<Matrix>(0, 0);
         already_sigma = 0;
         iter = 0;
         keep_going = 1;
@@ -182,7 +185,7 @@ void diag() {
             global_dpd_->file4_cache_close();
             global_dpd_->file4_cache_init();
         }
-        for (i = PSIF_EOM_D; i <= PSIF_EOM_R; ++i) {
+        for (int i = PSIF_EOM_D; i <= PSIF_EOM_R; ++i) {
             if (eom_params.restart_eom_cc3 && (i >= PSIF_EOM_CME) && (i <= PSIF_EOM_CMnEf)) continue;
             psio_close(i, 0);
             psio_open(i, 0);
@@ -221,7 +224,7 @@ void diag() {
                     global_dpd_->file2_scm(&CME, 1.0 / norm);
                     global_dpd_->file2_close(&CME);
                     /* reorthoganalize and normalize other guesses */
-                    for (i = 1; i < eom_params.cs_per_irrep[C_irr]; i++) {
+                    for (int i = 1; i < eom_params.cs_per_irrep[C_irr]; i++) {
                         sprintf(lbl, "%s %d", "CME", i);
                         global_dpd_->file2_init(&CME, PSIF_EOM_CME, C_irr, 0, 1, lbl);
                         for (j = 0; j < i; j++) {
@@ -238,7 +241,7 @@ void diag() {
 #ifdef EOM_DEBUG
                     /* check initial guesses - overlap matrix */
                     outfile->Printf("Checking overlap of orthogonalized initial guesses\n");
-                    for (i = 0; i < eom_params.cs_per_irrep[C_irr]; i++) {
+                    for (int i = 0; i < eom_params.cs_per_irrep[C_irr]; i++) {
                         sprintf(lbl, "%s %d", "CME", i);
                         global_dpd_->file2_init(&CME, PSIF_EOM_CME, C_irr, 0, 1, lbl);
                         for (j = 0; j < eom_params.cs_per_irrep[C_irr]; j++) {
@@ -261,7 +264,7 @@ void diag() {
 
 #ifdef EOM_DEBUG
         /* printout initial guesses */
-        for (i = 0; i < eom_params.cs_per_irrep[C_irr]; ++i) {
+        for (int i = 0; i < eom_params.cs_per_irrep[C_irr]; ++i) {
             sprintf(lbl, "%s %d", "CME", i);
             global_dpd_->file2_init(&CME, PSIF_EOM_CME, C_irr, 0, 1, lbl);
             global_dpd_->file2_print(&CME, "outfile");
@@ -282,7 +285,7 @@ void diag() {
 #endif
 
         /* Setup and zero initial C2 and S2 vector to go with Hbar_SS */
-        for (i = 0; i < eom_params.cs_per_irrep[C_irr]; ++i) {
+        for (int i = 0; i < eom_params.cs_per_irrep[C_irr]; ++i) {
             /* init_S1(i, C_irr); gets done at first iteration anyway */
             init_S1(i, C_irr);
             if (!eom_params.restart_eom_cc3) init_C2(i, C_irr);
@@ -299,10 +302,8 @@ void diag() {
 
         std::vector<bool> converged(eom_params.cs_per_irrep[C_irr], false);
         lambda_old = init_array(eom_params.cs_per_irrep[C_irr]);
+        // L := Current number of multiroot Davidson vectors. Changes during loop.
         L = eom_params.cs_per_irrep[C_irr];
-        /* allocate G_old just once */
-        i = (eom_params.vectors_per_root + 1) * eom_params.cs_per_irrep[C_irr];
-        G_old = block_matrix(i, i);
 
         vectors_per_root = eom_params.vectors_per_root; /* used for CCSD */
 
@@ -312,7 +313,7 @@ void diag() {
             numCs = L_start_iter = L;
             num_converged = 0;
 
-            for (i = already_sigma; i < L; ++i) {
+            for (int i = already_sigma; i < L; ++i) {
                 /* Form a zeroed S vector for each C vector
                    SIA and Sia do get overwritten by sigmaSS
                    so this may only be necessary for debugging */
@@ -404,15 +405,16 @@ void diag() {
 
             timer_on("BUILD G");
             /* Form G = C'*S matrix */
-            G = block_matrix(L, L);
+            G = std::make_shared<Matrix>(L, L);
 
-            /* reuse values from old G matrix */
-            /* if last step was restart, sigma is OK but recompute full G matrix */
-            if (ignore_G_old) already_sigma = 0;
-            for (i = 0; i < already_sigma; ++i)
-                for (j = 0; j < already_sigma; ++j) G[i][j] = G_old[i][j];
+            /* Populate G matrix elements to be reused. We may not be able to reuse any. */
+            if (ignore_G_old) {
+                already_sigma = 0;
+            }
+            auto temp_slice = Slice(Dimension(std::vector<int> {0}), Dimension(std::vector<int> {already_sigma}));
+            G->set_block(temp_slice, *G_old->get_block(temp_slice));
 
-            for (i = 0; i < L; ++i) {
+            for (int i = 0; i < L; ++i) {
                 if (params.eom_ref == 0) {
                     /* Spin-adapt C */
                     sprintf(lbl, "%s %d", "CME", i);
@@ -464,7 +466,6 @@ void diag() {
                 /* Dot C's and sigma vectors together to form G matrix */
                 for (j = 0; j < L; ++j) {
                     if (i < already_sigma && j < already_sigma) continue;
-                    /* outfile->Printf("Computing G[%d][%d].\n",i,j); */
 
                     if (params.eom_ref == 0) {
                         sprintf(lbl, "%s %d", "SIA", j);
@@ -524,7 +525,7 @@ void diag() {
                         tval += global_dpd_->buf4_dot(&CMnEf, &SIjAb);
                         global_dpd_->buf4_close(&SIjAb);
                     }
-                    G[i][j] = tval;
+                    G->set(i, j, tval);
                 }
 
                 global_dpd_->file2_close(&CME);
@@ -536,25 +537,22 @@ void diag() {
                 }
             } /* end build of G */
 
-            ignore_G_old = 0;
+            ignore_G_old = false;
             already_sigma = L;
 
             timer_off("BUILD G");
 #ifdef EOM_DEBUG
             outfile->Printf("The G Matrix\n");
-            print_mat(G, L, L, "outfile");
+            G->print_out();
 #endif
-            for (i = 0; i < L; ++i) {
-                for (j = 0; j < L; ++j) G_old[i][j] = G[i][j];
-            }
+            G_old = G->clone();
 
             /* Diagonalize G Matrix */
             lambda = init_array(L);     /* holds real part of eigenvalues of G */
             alpha = block_matrix(L, L); /* will hold eigenvectors of G */
-            dgeev_eom(L, G, lambda, alpha);
+            dgeev_eom(L, G->pointer(), lambda, alpha);
             eigsort(lambda, alpha, L);
             /* eivout(alpha, lambda, L, L, outfile);*/
-            free_block(G);
 
             /* Open up residual vector files */
             if (params.eom_ref == 0) {
@@ -599,7 +597,7 @@ void diag() {
                 }
 
                 converged[k] = false;
-                for (i = 0; i < L; ++i) {
+                for (int i = 0; i < L; ++i) {
                     if (params.eom_ref == 0) { /* RHF residual */
                         sprintf(lbl, "%s %d", "SIA", i);
                         global_dpd_->file2_init(&SIA, PSIF_EOM_SIA, C_irr, 0, 1, lbl);
@@ -812,7 +810,7 @@ void diag() {
                 global_dpd_->buf4_close(&Rijab);
             }
 
-            for (i = 0; i < eom_params.cs_per_irrep[C_irr]; ++i) lambda_old[i] = lambda[i];
+            for (int i = 0; i < eom_params.cs_per_irrep[C_irr]; ++i) lambda_old[i] = lambda[i];
             free(lambda);
             if ((params.wfn == "EOM_CC3") && (cc3_stage > 0)) {
                 lambda_old[cc3_index] = cc3_eval; /* a hack to make Delta E work next iteration */
@@ -827,7 +825,7 @@ void diag() {
                     if (eom_params.collapse_with_last_cc3) L *= 2;
                     outfile->Printf("Collapsing to %d vector(s).\n", L);
                     already_sigma = 0;
-                    ignore_G_old = 1;
+                    ignore_G_old = true;
                 } else {
                     restart(alpha, L, eom_params.cs_per_irrep[C_irr], C_irr, 1, alpha_old, L_old,
                             eom_params.collapse_with_last);
@@ -837,7 +835,7 @@ void diag() {
                     else
                         L = eom_params.cs_per_irrep[C_irr];
                     already_sigma = L;
-                    ignore_G_old = 1;
+                    ignore_G_old = true;
                 }
                 keep_going = 1;
                 /* keep track of number of triples restarts */
@@ -880,7 +878,7 @@ void diag() {
                     eom_params.cs_per_irrep[C_irr] = 1; /* only get 1 CC3 solution */
                     keep_going = 1;
                     already_sigma = 0;
-                    ignore_G_old = 1;
+                    ignore_G_old = true;
                     iter = 0;
                     cc3_stage = 1;
                     vectors_per_root = eom_params.vectors_cc3;
@@ -903,7 +901,7 @@ void diag() {
                     outfile->Printf("Setting old CC3 eigenvalue to %15.10lf\n", cc3_eval);
                     keep_going = 1;
                     already_sigma = 0;
-                    ignore_G_old = 1;
+                    ignore_G_old = true;
                     L_old = L;
                     L = cc3_index + 1;
                     cc3_stage = 2;
@@ -923,10 +921,9 @@ void diag() {
             }
             alpha_old = block_matrix(L_start_iter, L_start_iter);
             for (k = 0; k < L_start_iter; ++k)
-                for (i = 0; i < L_start_iter; ++i) alpha_old[i][k] = alpha[i][k];
+                for (int i = 0; i < L_start_iter; ++i) alpha_old[i][k] = alpha[i][k];
             free_block(alpha);
         }
-        free_block(G_old);
 
         outfile->Printf("\nProcedure converged for %d root(s).\n", num_converged);
         if (num_converged == eom_params.cs_per_irrep[C_irr]) {
@@ -954,7 +951,7 @@ void diag() {
                             moinfo.irr_labs[moinfo.sym ^ C_irr].c_str());
             outfile->Printf("                     Excitation Energy              Total Energy\n");
             outfile->Printf("                (eV)     (cm^-1)     (au)             (au)\n");
-            for (i = 0; i < eom_params.cs_per_irrep[C_irr]; ++i) {
+            for (int i = 0; i < eom_params.cs_per_irrep[C_irr]; ++i) {
                 if (converged[i]) {
                     if (!params.full_matrix)
                         totalE = lambda_old[i] + moinfo.eref + moinfo.ecc;
@@ -1053,7 +1050,7 @@ void diag() {
 
         free(lambda_old);
         free_block(alpha_old);
-    }
+    } // End Master Loop
 
     outfile->Printf("\tTotal # of sigma evaluations: %d\n", nsigma_evaluations);
     return;

--- a/psi4/src/psi4/cc/cceom/rzero.cc
+++ b/psi4/src/psi4/cc/cceom/rzero.cc
@@ -52,7 +52,7 @@ extern void scm_C(dpdfile2 *CME, dpdfile2 *Cme, dpdbuf4 *CMNEF, dpdbuf4 *Cmnef, 
  * with the ground state left eigenvector (1+lambda) */
 
 /* for ROHF and UHF */
-void rzero(int C_irr, int *converged) {
+void rzero(int C_irr, const std::vector<bool>& converged) {
     double rzero = 0.0, energy, norm, dotval;
     double dot_IA, dot_ia, dot_IJAB, dot_ijab, dot_IjAb;
     dpdfile2 RIA, Ria, RIA2, Ria2, FIA, Fia, LIA, Lia;
@@ -286,7 +286,7 @@ void rzero(int C_irr, int *converged) {
 /* normalizes R and produces copies of R that are ROHF-like */
 /* sort_amps then produces the others sorted versions of R */
 
-void rzero_rhf(int C_irr, int *converged) {
+void rzero_rhf(int C_irr, const std::vector<bool>& converged) {
     double r1, r2, rzero = 0.0, energy, norm, dotval;
     double dot_IA, dot_ia, dot_IJAB, dot_ijab, dot_IjAb;
     dpdfile2 RIA, FIA, LIA, Lia, Ria;

--- a/psi4/src/psi4/cc/cceom/write_Rs.cc
+++ b/psi4/src/psi4/cc/cceom/write_Rs.cc
@@ -47,7 +47,7 @@
 namespace psi {
 namespace cceom {
 
-void write_Rs(int C_irr, double *evals, const std::vector<bool>& converged) {
+void write_Rs(int C_irr, const std::vector<double>& evals, const std::vector<bool>& converged) {
     int i;
     dpdfile2 CME, Cme;
     dpdbuf4 CMNEF, Cmnef, CMnEf;

--- a/psi4/src/psi4/cc/cceom/write_Rs.cc
+++ b/psi4/src/psi4/cc/cceom/write_Rs.cc
@@ -47,7 +47,7 @@
 namespace psi {
 namespace cceom {
 
-void write_Rs(int C_irr, double *evals, int *converged) {
+void write_Rs(int C_irr, double *evals, const std::vector<bool>& converged) {
     int i;
     dpdfile2 CME, Cme;
     dpdbuf4 CMNEF, Cmnef, CMnEf;

--- a/tests/cc12/CMakeLists.txt
+++ b/tests/cc12/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc12 "psi;cc;noc1")
+add_regression_test(cc12 "psi;cc;noc1;eom")

--- a/tests/cc12/input.dat
+++ b/tests/cc12/input.dat
@@ -2,8 +2,9 @@
 
 scf_0       =   -76.021709716552  #TEST
 ccsd_0      =   -76.231133524444  #TEST
-eomccsd_ref = [ -75.814603692260, -75.539103963086, -75.831943898862, -75.396306147194,  #TEST
-                -75.909915072934, -75.311455726994, -75.734249213528, -75.649833933279 ] #TEST
+eomccsd_ref = [ (-75.814603692260, "A1", 1), (-75.539103963086, "A1", 2), (-75.831943898862, "A2", 0), (-75.396306147194, "A2", 1),  #TEST
+                (-75.909915072934, "B1", 0), (-75.311455726994, "B1", 1), (-75.734249213528, "B2", 0), (-75.649833933279, "B2", 1) ] #TEST
+eomccsd_ref.sort()
 
 molecule h2o {
   O
@@ -20,7 +21,6 @@ energy('eom-ccsd')
 
 compare_values(scf_0, variable("SCF TOTAL ENERGY"), 6, "SCF energy")                 #TEST
 compare_values(ccsd_0, variable("CCSD TOTAL ENERGY"), 6, "CCSD energy")              #TEST
-for root in range(1,9):                                                                  #TEST
-    ref = eomccsd_ref[root-1]                                                            #TEST
-    val = variable("CC ROOT %d TOTAL ENERGY" % root)                                 #TEST
-    compare_values(ref, val, 6, "EOM-CCSD root %d" %root)                                #TEST
+for (ref, h, i) in eomccsd_ref: # TEST
+    val = variable(f"CCSD ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CCSD root {i} ({h})")                                #TEST

--- a/tests/cc12/output.ref
+++ b/tests/cc12/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 undefined 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {eom_var} 5b439ed dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 March 2022 01:18PM
 
-    Process ID:  12371
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 23944
+    Host:       dhcp189-157.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -32,8 +45,9 @@
 
 scf_0       =   -76.021709716552  #TEST
 ccsd_0      =   -76.231133524444  #TEST
-eomccsd_ref = [ -75.814603692260, -75.539103963086, -75.831943898862, -75.396306147194,  #TEST
-                -75.909915072934, -75.311455726994, -75.734249213528, -75.649833933279 ] #TEST
+eomccsd_ref = [ (-75.814603692260, "A1", 1), (-75.539103963086, "A1", 2), (-75.831943898862, "A2", 0), (-75.396306147194, "A2", 1),  #TEST
+                (-75.909915072934, "B1", 0), (-75.311455726994, "B1", 1), (-75.734249213528, "B2", 0), (-75.649833933279, "B2", 1) ] #TEST
+eomccsd_ref.sort()
 
 molecule h2o {
   O
@@ -48,32 +62,31 @@ set {
 
 energy('eom-ccsd')
 
-compare_values(scf_0, get_variable("SCF TOTAL ENERGY"), 6, "SCF energy")                 #TEST
-compare_values(ccsd_0, get_variable("CCSD TOTAL ENERGY"), 6, "CCSD energy")              #TEST
-for root in range(1,9):                                                                  #TEST
-    ref = eomccsd_ref[root-1]                                                            #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root)                                 #TEST
-    compare_values(ref, val, 6, "EOM-CCSD root %d" %root)                                #TEST
+compare_values(scf_0, variable("SCF TOTAL ENERGY"), 6, "SCF energy")                 #TEST
+compare_values(ccsd_0, variable("CCSD TOTAL ENERGY"), 6, "CCSD energy")              #TEST
+for (ref, h, i) in eomccsd_ref: # TEST
+    val = variable(f"CCSD ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CCSD root {i} ({h})")                                #TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:09 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:18:10 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -87,15 +100,15 @@ for root in range(1,9):                                                         
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.062011508391    15.994914619560
-           H          0.000000000000    -0.709209678246     0.492083819402     1.007825032070
-           H          0.000000000000     0.709209678246     0.492083819402     1.007825032070
+         O            0.000000000000     0.000000000000    -0.062011508399    15.994914619570
+         H            0.000000000000    -0.709209678246     0.492083819394     1.007825032230
+         H            0.000000000000     0.709209678246     0.492083819394     1.007825032230
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     30.67311  B =     16.62769  C =     10.78255 [cm^-1]
-  Rotational constants: A = 919556.64332  B = 498485.75497  C = 323252.59678 [MHz]
-  Nuclear repulsion =    9.780670106434430
+  Rotational constants: A =     30.67311  B =     16.62770  C =     10.78255 [cm^-1]
+  Rotational constants: A = 919556.65020  B = 498485.75869  C = 323252.59919 [MHz]
+  Nuclear repulsion =    9.780670144878627
 
   Charge       = 0
   Multiplicity = 1
@@ -112,30 +125,17 @@ for root in range(1,9):                                                         
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      24      24       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -154,40 +154,58 @@ for root in range(1,9):                                                         
   Using 90300 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.0308209013E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.8509508519E-02.
+  Reciprocal condition number of the overlap matrix is 8.8848532316E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -76.00036552232700   -7.60004e+01   1.37083e-01 
-   @RHF iter   1:   -75.99396440566998    6.40112e-03   1.95487e-02 
-   @RHF iter   2:   -76.01606760481947   -2.21032e-02   9.21675e-03 DIIS
-   @RHF iter   3:   -76.02154111671648   -5.47351e-03   1.16914e-03 DIIS
-   @RHF iter   4:   -76.02169606567813   -1.54949e-04   2.55438e-04 DIIS
-   @RHF iter   5:   -76.02170884188928   -1.27762e-05   5.64894e-05 DIIS
-   @RHF iter   6:   -76.02170970347760   -8.61588e-07   1.09505e-05 DIIS
-   @RHF iter   7:   -76.02170973305272   -2.95751e-08   7.96894e-07 DIIS
-   @RHF iter   8:   -76.02170973316740   -1.14682e-10   8.72934e-08 DIIS
-   @RHF iter   9:   -76.02170973316872   -1.32161e-12   1.39744e-08 DIIS
-   @RHF iter  10:   -76.02170973316879   -7.10543e-14   1.76714e-09 DIIS
+   @RHF iter SAD:   -75.58766968018563   -7.55877e+01   0.00000e+00 
+   @RHF iter   1:   -75.95133166138200   -3.63662e-01   3.06155e-02 DIIS/ADIIS
+   @RHF iter   2:   -76.00457684631773   -5.32452e-02   1.64039e-02 DIIS/ADIIS
+   @RHF iter   3:   -76.02124204957340   -1.66652e-02   2.11696e-03 DIIS/ADIIS
+   @RHF iter   4:   -76.02169761562715   -4.55566e-04   2.96855e-04 DIIS/ADIIS
+   @RHF iter   5:   -76.02170914705820   -1.15314e-05   5.41322e-05 DIIS
+   @RHF iter   6:   -76.02170971449411   -5.67436e-07   8.85428e-06 DIIS
+   @RHF iter   7:   -76.02170973207299   -1.75789e-08   1.05807e-06 DIIS
+   @RHF iter   8:   -76.02170973230233   -2.29335e-10   2.11146e-07 DIIS
+   @RHF iter   9:   -76.02170973231311   -1.07860e-11   4.20609e-08 DIIS
+   @RHF iter  10:   -76.02170973231350   -3.83693e-13   3.49770e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -208,49 +226,44 @@ for root in range(1,9):                                                         
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.02170973316879
+  @RHF Final Energy:   -76.02170973231350
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.7806701064344299
-    One-Electron Energy =                -124.1736229796359936
-    Two-Electron Energy =                  38.3712431400327674
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0217097331687910
+    Nuclear Repulsion Energy =              9.7806701448786271
+    One-Electron Energy =                -124.1736230653224453
+    Two-Electron Energy =                  38.3712431881303146
+    Total Energy =                        -76.0217097323134965
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.9223
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.1331
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.7892     Total:     0.7892
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     2.0059     Total:     2.0059
 
 
-*** tstop() called on psinet at Mon May 15 15:34:09 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:18:11 2022
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.82 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.82 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -264,19 +277,19 @@ Total time:
       Number of basis functions:        24
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  11    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 11683 non-zero two-electron integrals.
+      Computed 11412 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:09 2017
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:18:11 2022
 
 
 	Wfn Parameters:
@@ -301,7 +314,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -357,34 +370,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.005 (MB)
 	Total:                                     0.002 (MW) /      0.020 (MB)
 
-	Nuclear Rep. energy          =      9.78067010643443
-	SCF energy                   =    -76.02170973316879
-	One-electron energy          =   -124.17362294055455
-	Two-electron energy          =     38.37124310095135
-	Reference energy             =    -76.02170973316876
+	Nuclear Rep. energy          =      9.78067014487863
+	SCF energy                   =    -76.02170973231350
+	One-electron energy          =   -124.17362300671449
+	Two-electron energy          =     38.37124312952228
+	Reference energy             =    -76.02170973231358
 
-*** tstop() called on psinet at Mon May 15 15:34:09 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:18:11 2022
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:09 2017
-
+	user time   =       0.89 seconds =       0.01 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.780670106434430
-    SCF energy          (wfn)     =  -76.021709733168791
-    Reference energy    (file100) =  -76.021709733168763
+    Nuclear Rep. energy (wfn)     =    9.780670144878627
+    SCF energy          (wfn)     =  -76.021709732313496
+    Reference energy    (file100) =  -76.021709732313582
 
     Input parameters:
     -----------------
@@ -412,76 +421,64 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2001371966492304
+MP2 correlation energy -0.2001371963480357
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.200137196649230    0.000e+00    0.000000    0.000000    0.000000    0.104241
-     1        -0.205628513947910    2.428e-02    0.003581    0.007890    0.007890    0.110659
-     2        -0.209096507331447    8.092e-03    0.004200    0.009013    0.009013    0.115070
-     3        -0.209408132011952    1.924e-03    0.004521    0.009669    0.009669    0.115934
-     4        -0.209416210309087    4.168e-04    0.004541    0.009691    0.009691    0.116074
-     5        -0.209424600373444    9.956e-05    0.004551    0.009697    0.009697    0.116098
-     6        -0.209423962026443    2.973e-05    0.004553    0.009695    0.009695    0.116096
-     7        -0.209423888310255    9.448e-06    0.004555    0.009694    0.009694    0.116095
-     8        -0.209423840213295    1.850e-06    0.004555    0.009694    0.009694    0.116095
-     9        -0.209423803772429    4.092e-07    0.004555    0.009694    0.009694    0.116095
-    10        -0.209423812464128    7.837e-08    0.004555    0.009694    0.009694    0.116095
+     0        -0.200137196348036    0.000e+00    0.000000    0.000000    0.000000    0.104241
+     1        -0.205628513737322    2.428e-02    0.003581    0.007890    0.007890    0.110659
+     2        -0.209096507122634    8.092e-03    0.004200    0.009013    0.009013    0.115070
+     3        -0.209408131742269    1.924e-03    0.004521    0.009669    0.009669    0.115934
+     4        -0.209416210062414    4.168e-04    0.004541    0.009691    0.009691    0.116074
+     5        -0.209424600126034    9.956e-05    0.004551    0.009697    0.009697    0.116098
+     6        -0.209423961781267    2.973e-05    0.004553    0.009695    0.009695    0.116096
+     7        -0.209423888065604    9.448e-06    0.004555    0.009694    0.009694    0.116095
+     8        -0.209423839968698    1.850e-06    0.004555    0.009694    0.009694    0.116095
+     9        -0.209423803527841    4.092e-07    0.004555    0.009694    0.009694    0.116095
+    10        -0.209423812219539    7.837e-08    0.004555    0.009694    0.009694    0.116095
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              4  17         0.0065183019
-              4  13        -0.0061936413
-              2   0         0.0049958708
-              1   0        -0.0045267339
-              2   5         0.0042337213
-              1   2         0.0036328144
-              4  15         0.0032291132
-              3  11        -0.0029349477
-              2   3        -0.0027916445
+              4  17         0.0065183024
+              4  13        -0.0061936384
+              2   0         0.0049958640
+              1   0        -0.0045267340
+              2   5         0.0042337215
+              1   2         0.0036328147
+              4  15         0.0032291152
+              3  11        -0.0029349483
+              2   3        -0.0027916442
               1   5        -0.0024943478
 
     Largest TIjAb Amplitudes:
-      3   3  10  10        -0.0507376219
-      4   4  14  14        -0.0344275544
+      3   3  10  10        -0.0507376220
+      4   4  14  14        -0.0344275542
       2   2   2   2        -0.0341934388
       2   3   2  10         0.0279179871
       3   2  10   2         0.0279179871
-      4   4   1   1        -0.0265452373
-      2   2  14  14        -0.0252781368
-      4   4  13  13        -0.0241114962
+      4   4   1   1        -0.0265452370
+      2   2  14  14        -0.0252781367
+      4   4  13  13        -0.0241114956
       3   4  10  15        -0.0230396641
       4   3  15  10        -0.0230396641
 
-    SCF energy       (wfn)                    =  -76.021709733168791
-    Reference energy (file100)                =  -76.021709733168763
+    SCF energy       (wfn)                    =  -76.021709732313496
+    Reference energy (file100)                =  -76.021709732313582
 
-    Opposite-spin MP2 correlation energy      =   -0.149220599289343
-    Same-spin MP2 correlation energy          =   -0.050916597359887
-    MP2 correlation energy                    =   -0.200137196649230
-      * MP2 total energy                      =  -76.221846929818000
+    Opposite-spin MP2 correlation energy      =   -0.149220599037016
+    Same-spin MP2 correlation energy          =   -0.050916597311020
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.200137196348036
+      * MP2 total energy                      =  -76.221846928661620
 
-    Opposite-spin CCSD correlation energy     =   -0.163377863825318
-    Same-spin CCSD correlation energy         =   -0.046045948645861
-    CCSD correlation energy                   =   -0.209423812464128
-      * CCSD total energy                     =  -76.231133545632886
-
-
-*** tstop() called on psinet at Mon May 15 15:34:09 2017
-Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.53 seconds =       0.01 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:09 2017
+    Opposite-spin CCSD correlation energy     =   -0.163377863568495
+    Same-spin CCSD correlation energy         =   -0.046045948651044
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.209423812219539
+      * CCSD total energy                     =  -76.231133544533122
 
 
 			**************************
@@ -491,28 +488,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:09 2017
-Module time:
-	user time   =       0.00 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.53 seconds =       0.01 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:09 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    9.780670106434430
-	SCF energy          (wfn)     =  -76.021709733168791
-	Reference energy    (file100) =  -76.021709733168763
-	CCSD energy         (file100) =   -0.209423812464128
+	Nuclear Rep. energy (wfn)     =    9.780670144878627
+	SCF energy          (wfn)     =  -76.021709732313496
+	Reference energy    (file100) =  -76.021709732313582
+	CCSD energy         (file100) =   -0.209423812219539
 
 	Input parameters:
 	-----------------
@@ -545,6 +528,14 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total  103.6666402803
+Fmi   dot Fmi   total  425.4217447003
+Fme   dot Fme   total    0.0000086181
+WMBIJ dot WMBIJ total    0.0000000000
+Wmbij dot Wmbij total    0.0000000000
+WMbIj dot WMbIj total    1.5397252604
+WmBiJ dot WmBiJ total    0.0000000000
 Symmetry of ground state: A1
 Symmetry of excited state: A1
 Symmetry of right eigenvector: A1
@@ -552,80 +543,80 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5255165378   5.26e-01    4.93e-01      N
-                     2   0.7812227340   7.81e-01    4.51e-01      N
+                     1   0.5255165367   5.26e-01    4.93e-01      N
+                     2   0.7812227362   7.81e-01    4.51e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4188204688  -1.07e-01    7.50e-02      N
-                     2   0.6936846068  -8.75e-02    6.51e-02      N
+                     1   0.4188204672  -1.07e-01    7.50e-02      N
+                     2   0.6936846085  -8.75e-02    6.51e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4167526840  -2.07e-03    2.50e-02      N
-                     2   0.6921786846  -1.51e-03    2.05e-02      N
+                     1   0.4167526825  -2.07e-03    2.50e-02      N
+                     2   0.6921786862  -1.51e-03    2.05e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165501721  -2.03e-04    5.88e-03      N
-                     2   0.6920792803  -9.94e-05    7.02e-03      N
+                     1   0.4165501705  -2.03e-04    5.88e-03      N
+                     2   0.6920792820  -9.94e-05    7.02e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165287158  -2.15e-05    1.32e-03      N
-                     2   0.6920292641  -5.00e-05    2.59e-03      N
+                     1   0.4165287142  -2.15e-05    1.32e-03      N
+                     2   0.6920292657  -5.00e-05    2.59e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165292272   5.11e-07    3.58e-04      N
-                     2   0.6920273910  -1.87e-06    9.24e-04      N
+                     1   0.4165292256   5.11e-07    3.58e-04      N
+                     2   0.6920273927  -1.87e-06    9.24e-04      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165296639   4.37e-07    9.32e-05      N
-                     2   0.6920296970   2.31e-06    2.83e-04      N
+                     1   0.4165296624   4.37e-07    9.32e-05      N
+                     2   0.6920296986   2.31e-06    2.83e-04      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165298483   1.84e-07    2.11e-05      N
-                     2   0.6920295936  -1.03e-07    8.60e-05      N
+                     1   0.4165298467   1.84e-07    2.11e-05      N
+                     2   0.6920295953  -1.03e-07    8.60e-05      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165298023  -4.60e-08    5.05e-06      N
-                     2   0.6920294459  -1.48e-07    2.44e-05      N
+                     1   0.4165298008  -4.60e-08    5.05e-06      N
+                     2   0.6920294475  -1.48e-07    2.44e-05      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165298115   9.18e-09    1.20e-06      N
-                     2   0.6920295189   7.30e-08    6.81e-06      N
+                     1   0.4165298099   9.18e-09    1.20e-06      N
+                     2   0.6920295205   7.30e-08    6.81e-06      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165298110  -4.82e-10    3.06e-07      Y
-                     2   0.6920295225   3.68e-09    1.96e-06      N
+                     1   0.4165298095  -4.82e-10    3.06e-07      Y
+                     2   0.6920295242   3.68e-09    1.96e-06      N
 Iter=12   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4165298111   1.11e-10    2.79e-07      Y
-                     2   0.6920295198  -2.72e-09    4.74e-07      Y
+                     1   0.4165298096   1.11e-10    2.79e-07      Y
+                     2   0.6920295215  -2.72e-09    4.74e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-EOM CCSD R0 for root 0 =   0.00810729799
-EOM CCSD R0 for root 1 =  -0.01288018870
+EOM CCSD R0 for root 0 =  -0.00810728868
+EOM CCSD R0 for root 1 =   0.01288018390
 
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1     11.334    91417.7   0.4165298111   -75.814603734506
+EOM State 1     11.334    91417.7   0.4165298096   -75.814603734957
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    4a1 :   -0.6856664510
-         2 >   1      :       3a1 >    5a1 :    0.0549040275
-         0 >   0      :       1b2 >    2b2 :   -0.0313496504
-         1 >   0      :       2a1 >    4a1 :   -0.0273081726
-         2 >   4      :       3a1 >    8a1 :    0.0211149360
+         2 >   0      :       3a1 >    4a1 :    0.6856664514
+         2 >   1      :       3a1 >    5a1 :   -0.0549040274
+         0 >   0      :       1b2 >    2b2 :    0.0313496474
+         1 >   0      :       2a1 >    4a1 :    0.0273081720
+         2 >   4      :       3a1 >    8a1 :   -0.0211149357
  RIjAb (libdpd indices)     : (cscf notation)
-        2   2 >   0   0     :    3a1    3a1 >    4a1    4a1 :    0.0578470160
-        2   2 >   0   2     :    3a1    3a1 >    4a1    6a1 :    0.0498524342
-        2   2 >   2   0     :    3a1    3a1 >    6a1    4a1 :    0.0498524342
-        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :   -0.0494854532
-        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :   -0.0494854532
-EOM State 2     18.831   151882.9   0.6920295198   -75.539104025807
+        2   2 >   0   0     :    3a1    3a1 >    4a1    4a1 :   -0.0578470104
+        2   2 >   0   2     :    3a1    3a1 >    4a1    6a1 :   -0.0498524344
+        2   2 >   2   0     :    3a1    3a1 >    6a1    4a1 :   -0.0498524344
+        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :    0.0494854530
+        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :    0.0494854530
+EOM State 2     18.831   151882.9   0.6920295215   -75.539104023069
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    2b2 :   -0.6818003063
-         0 >   0      :       1b1 >    2b1 :    0.0733385741
-         2 >   2      :       3a1 >    6a1 :   -0.0557368665
-         2 >   1      :       3a1 >    5a1 :    0.0436851200
-         0 >   1      :       1b2 >    3b2 :   -0.0399738494
+         0 >   0      :       1b2 >    2b2 :    0.6818003067
+         0 >   0      :       1b1 >    2b1 :   -0.0733385737
+         2 >   2      :       3a1 >    6a1 :    0.0557368660
+         2 >   1      :       3a1 >    5a1 :   -0.0436851203
+         0 >   1      :       1b2 >    3b2 :    0.0399738492
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b2    1b2 >    2b2    2b2 :   -0.1002494666
-        0   0 >   0   0     :    1b2    1b2 >    4a1    4a1 :   -0.0368564319
-        0   0 >   0   0     :    1b1    1b2 >    2b1    2b2 :   -0.0317802605
-        0   0 >   0   0     :    1b2    1b1 >    2b2    2b1 :   -0.0317802605
-        0   0 >   0   0     :    1b1    1b1 >    2b2    2b2 :   -0.0271534267
+        0   0 >   0   0     :    1b2    1b2 >    2b2    2b2 :    0.1002494663
+        0   0 >   0   0     :    1b2    1b2 >    4a1    4a1 :    0.0368564311
+        0   0 >   0   0     :    1b1    1b2 >    2b1    2b2 :    0.0317802613
+        0   0 >   0   0     :    1b2    1b1 >    2b2    2b1 :    0.0317802613
+        0   0 >   0   0     :    1b1    1b1 >    2b2    2b2 :    0.0271534265
 
 Symmetry of excited state: A2
 Symmetry of right eigenvector: A2
@@ -633,44 +624,44 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5011905303   5.01e-01    4.91e-01      N
-                     2   0.9493360242   9.49e-01    5.15e-01      N
+                     1   0.5011905278   5.01e-01    4.91e-01      N
+                     2   0.9493360230   9.49e-01    5.15e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4007386002  -1.00e-01    6.33e-02      N
-                     2   0.8379056391  -1.11e-01    8.95e-02      N
+                     1   0.4007385978  -1.00e-01    6.33e-02      N
+                     2   0.8379056385  -1.11e-01    8.95e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3992909915  -1.45e-03    1.80e-02      N
-                     2   0.8350950952  -2.81e-03    2.56e-02      N
+                     1   0.3992909891  -1.45e-03    1.80e-02      N
+                     2   0.8350950946  -2.81e-03    2.56e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991960214  -9.50e-05    3.84e-03      N
-                     2   0.8350063847  -8.87e-05    1.37e-02      N
+                     1   0.3991960189  -9.50e-05    3.84e-03      N
+                     2   0.8350063840  -8.87e-05    1.37e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991892934  -6.73e-06    6.79e-04      N
-                     2   0.8349095710  -9.68e-05    1.37e-02      N
+                     1   0.3991892910  -6.73e-06    6.79e-04      N
+                     2   0.8349095705  -9.68e-05    1.37e-02      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991895876   2.94e-07    1.50e-04      N
-                     2   0.8348511569  -5.84e-05    6.06e-03      N
+                     1   0.3991895851   2.94e-07    1.50e-04      N
+                     2   0.8348511563  -5.84e-05    6.06e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991896540   6.64e-08    3.63e-05      N
-                     2   0.8348310926  -2.01e-05    2.34e-03      N
+                     1   0.3991896515   6.64e-08    3.63e-05      N
+                     2   0.8348310920  -2.01e-05    2.34e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991896027  -5.13e-08    7.31e-06      N
-                     2   0.8348275039  -3.59e-06    7.40e-04      N
+                     1   0.3991896003  -5.13e-08    7.31e-06      N
+                     2   0.8348275033  -3.59e-06    7.40e-04      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991895991  -3.59e-09    1.43e-06      N
-                     2   0.8348274706  -3.33e-08    1.81e-04      N
+                     1   0.3991895967  -3.59e-09    1.43e-06      N
+                     2   0.8348274700  -3.33e-08    1.81e-04      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991896018   2.76e-09    2.86e-07      Y
-                     2   0.8348272738  -1.97e-07    4.39e-05      N
+                     1   0.3991895994   2.76e-09    2.86e-07      Y
+                     2   0.8348272732  -1.97e-07    4.39e-05      N
 Iter=11   L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991896019   6.22e-11    2.64e-07      Y
-                     2   0.8348273114   3.76e-08    1.25e-05      N
+                     1   0.3991895995   6.22e-11    2.64e-07      Y
+                     2   0.8348273108   3.76e-08    1.25e-05      N
 Iter=12   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991896020   6.53e-11    2.59e-07      Y
-                     2   0.8348273273   1.59e-08    3.13e-06      N
+                     1   0.3991895996   6.53e-11    2.59e-07      Y
+                     2   0.8348273267   1.59e-08    3.13e-06      N
 Iter=13   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3991896020   4.74e-11    2.53e-07      Y
-                     2   0.8348273262  -1.12e-09    7.92e-07      Y
+                     1   0.3991895996   4.74e-11    2.53e-07      Y
+                     2   0.8348273256  -1.12e-09    7.92e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
@@ -680,36 +671,36 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep A2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 3     10.862    87612.0   0.3991896020   -75.831943943621
+EOM State 3     10.863    87612.0   0.3991895996   -75.831943944935
 
 Largest components of excited wave function #3:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    2b2 :   -0.6829187066
-         0 >   1      :       1b1 >    3b2 :   -0.0908684584
-         0 >   2      :       1b1 >    4b2 :   -0.0605425561
-         0 >   4      :       1b1 >    6b2 :   -0.0096650555
-         1 >   0      :       2a1 >    1a2 :   -0.0034571227
+         0 >   0      :       1b1 >    2b2 :   -0.6829187070
+         0 >   1      :       1b1 >    3b2 :   -0.0908684573
+         0 >   2      :       1b1 >    4b2 :   -0.0605425566
+         0 >   4      :       1b1 >    6b2 :   -0.0096650554
+         1 >   0      :       2a1 >    1a2 :   -0.0034571226
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :   -0.0585813908
-        0   0 >   0   0     :    1b2    1b1 >    2b2    2b2 :   -0.0585813908
-        0   0 >   0   0     :    1b1    1b1 >    2b1    2b2 :   -0.0535993557
-        0   0 >   0   0     :    1b1    1b1 >    2b2    2b1 :   -0.0535993557
-        2   0 >   2   0     :    3a1    1b1 >    6a1    2b2 :    0.0332500021
-EOM State 4     22.717   183223.4   0.8348273262   -75.396306219412
+        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :   -0.0585813901
+        0   0 >   0   0     :    1b2    1b1 >    2b2    2b2 :   -0.0585813901
+        0   0 >   0   0     :    1b1    1b1 >    2b1    2b2 :   -0.0535993559
+        0   0 >   0   0     :    1b1    1b1 >    2b2    2b1 :   -0.0535993559
+        2   0 >   2   0     :    3a1    1b1 >    6a1    2b2 :    0.0332500022
+EOM State 4     22.717   183223.4   0.8348273256   -75.396306218911
 
 Largest components of excited wave function #4:
  RIA (libdpd indices) : (cscf notation)
-         0 >   1      :       1b1 >    3b2 :    0.6819980775
-         0 >   0      :       1b1 >    2b2 :   -0.0864962696
+         0 >   1      :       1b1 >    3b2 :    0.6819980779
+         0 >   0      :       1b1 >    2b2 :   -0.0864962686
          0 >   4      :       1b1 >    6b2 :    0.0299450395
-         0 >   2      :       1b1 >    4b2 :    0.0224214185
-         0 >   0      :       1b2 >    2b1 :   -0.0071948983
+         0 >   2      :       1b1 >    4b2 :    0.0224214203
+         0 >   0      :       1b2 >    2b1 :   -0.0071948984
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   1   1     :    1b1    1b2 >    3b2    3b2 :    0.0552359037
-        0   0 >   1   1     :    1b2    1b1 >    3b2    3b2 :    0.0552359037
-        0   0 >   0   1     :    1b1    1b1 >    2b1    3b2 :    0.0472466157
-        0   0 >   1   0     :    1b1    1b1 >    3b2    2b1 :    0.0472466157
-        0   0 >   1   0     :    1b1    1b2 >    3b2    2b2 :    0.0347189663
+        0   0 >   1   1     :    1b1    1b2 >    3b2    3b2 :    0.0552359034
+        0   0 >   1   1     :    1b2    1b1 >    3b2    3b2 :    0.0552359034
+        0   0 >   0   1     :    1b1    1b1 >    2b1    3b2 :    0.0472466155
+        0   0 >   1   0     :    1b1    1b1 >    3b2    2b1 :    0.0472466155
+        0   0 >   1   0     :    1b1    1b2 >    3b2    2b2 :    0.0347189657
 
 Symmetry of excited state: B1
 Symmetry of right eigenvector: B1
@@ -717,44 +708,44 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4277832883   4.28e-01    4.89e-01      N
-                     2   1.0375034013   1.04e+00    5.20e-01      N
+                     1   0.4277832865   4.28e-01    4.89e-01      N
+                     2   1.0375034009   1.04e+00    5.20e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3226103398  -1.05e-01    6.52e-02      N
-                     2   0.9258311555  -1.12e-01    9.58e-02      N
+                     1   0.3226103378  -1.05e-01    6.52e-02      N
+                     2   0.9258311559  -1.12e-01    9.58e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212761062  -1.33e-03    1.71e-02      N
-                     2   0.9210734511  -4.76e-03    4.22e-02      N
+                     1   0.3212761043  -1.33e-03    1.71e-02      N
+                     2   0.9210734516  -4.76e-03    4.22e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212160238  -6.01e-05    3.81e-03      N
-                     2   0.9199759490  -1.10e-03    1.94e-02      N
+                     1   0.3212160219  -6.01e-05    3.81e-03      N
+                     2   0.9199759494  -1.10e-03    1.94e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212174588   1.44e-06    7.60e-04      N
-                     2   0.9197143756  -2.62e-04    7.24e-03      N
+                     1   0.3212174569   1.44e-06    7.60e-04      N
+                     2   0.9197143760  -2.62e-04    7.24e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212183888   9.30e-07    1.69e-04      N
-                     2   0.9196843022  -3.01e-05    2.38e-03      N
+                     1   0.3212183868   9.30e-07    1.69e-04      N
+                     2   0.9196843026  -3.01e-05    2.38e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212184561   6.73e-08    3.89e-05      N
-                     2   0.9196775572  -6.75e-06    7.42e-04      N
+                     1   0.3212184542   6.73e-08    3.89e-05      N
+                     2   0.9196775576  -6.75e-06    7.42e-04      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212184405  -1.57e-08    6.85e-06      N
-                     2   0.9196778553   2.98e-07    2.23e-04      N
+                     1   0.3212184385  -1.57e-08    6.85e-06      N
+                     2   0.9196778557   2.98e-07    2.23e-04      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212184304  -1.00e-08    1.37e-06      N
-                     2   0.9196777149  -1.40e-07    5.94e-05      N
+                     1   0.3212184285  -1.00e-08    1.37e-06      N
+                     2   0.9196777153  -1.40e-07    5.94e-05      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212184297  -7.07e-10    3.14e-07      Y
-                     2   0.9196777339   1.91e-08    1.91e-05      N
+                     1   0.3212184278  -7.07e-10    3.14e-07      Y
+                     2   0.9196777343   1.91e-08    1.91e-05      N
 Iter=11   L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212184299   1.37e-10    2.73e-07      Y
-                     2   0.9196777339  -8.97e-12    6.78e-06      N
+                     1   0.3212184279   1.37e-10    2.73e-07      Y
+                     2   0.9196777343  -8.97e-12    6.78e-06      N
 Iter=12   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212184299  -4.57e-12    2.72e-07      Y
-                     2   0.9196777260  -7.95e-09    2.00e-06      N
+                     1   0.3212184279  -4.57e-12    2.72e-07      Y
+                     2   0.9196777264  -7.95e-09    2.00e-06      N
 Iter=13   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3212184299   1.95e-12    2.72e-07      Y
-                     2   0.9196777284   2.45e-09    6.07e-07      Y
+                     1   0.3212184279   1.95e-12    2.72e-07      Y
+                     2   0.9196777288   2.45e-09    6.07e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
@@ -764,36 +755,36 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 5      8.741    70499.3   0.3212184299   -75.909915115756
+EOM State 5      8.741    70499.3   0.3212184279   -75.909915116587
 
 Largest components of excited wave function #5:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    4a1 :   -0.6870151946
-         0 >   1      :       1b1 >    5a1 :    0.0651280998
-         0 >   2      :       1b1 >    6a1 :   -0.0202531240
-         0 >   4      :       1b1 >    8a1 :    0.0200157289
-         0 >   3      :       1b1 >    7a1 :    0.0139613990
+         0 >   0      :       1b1 >    4a1 :    0.6870151948
+         0 >   1      :       1b1 >    5a1 :   -0.0651280992
+         0 >   2      :       1b1 >    6a1 :    0.0202531241
+         0 >   4      :       1b1 >    8a1 :   -0.0200157288
+         0 >   3      :       1b1 >    7a1 :   -0.0139613991
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :   -0.0578461349
-        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :   -0.0578461349
-        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :   -0.0509886957
-        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :   -0.0509886957
-        1   0 >   0   0     :    2a1    1b1 >    4a1    4a1 :   -0.0414754616
-EOM State 6     25.026   201845.9   0.9196777284   -75.311455817208
+        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :    0.0578461352
+        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :    0.0578461352
+        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :    0.0509886950
+        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :    0.0509886950
+        1   0 >   0   0     :    2a1    1b1 >    4a1    4a1 :    0.0414754617
+EOM State 6     25.026   201845.9   0.9196777288   -75.311455815697
 
 Largest components of excited wave function #6:
  RIA (libdpd indices) : (cscf notation)
-         0 >   1      :       1b1 >    5a1 :    0.6800713651
-         0 >   0      :       1b1 >    4a1 :    0.0596632102
-         0 >   2      :       1b1 >    6a1 :   -0.0572406879
-         0 >   0      :       1b2 >    1a2 :   -0.0224852490
-         0 >   5      :       1b1 >    9a1 :    0.0217659331
+         0 >   1      :       1b1 >    5a1 :   -0.6800713656
+         0 >   0      :       1b1 >    4a1 :   -0.0596632097
+         0 >   2      :       1b1 >    6a1 :    0.0572406880
+         0 >   0      :       1b2 >    1a2 :    0.0224852489
+         0 >   5      :       1b1 >    9a1 :   -0.0217659329
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   1   1     :    1b1    1b2 >    5a1    3b2 :    0.0533454745
-        0   0 >   1   1     :    1b2    1b1 >    3b2    5a1 :    0.0533454745
-        0   0 >   1   1     :    1b1    1b2 >    3b2    5a1 :    0.0484354551
-        0   0 >   1   1     :    1b2    1b1 >    5a1    3b2 :    0.0484354551
-        0   0 >   1   0     :    1b1    1b2 >    5a1    2b2 :    0.0425015220
+        0   0 >   1   1     :    1b1    1b2 >    5a1    3b2 :   -0.0533454742
+        0   0 >   1   1     :    1b2    1b1 >    3b2    5a1 :   -0.0533454742
+        0   0 >   1   1     :    1b1    1b2 >    3b2    5a1 :   -0.0484354547
+        0   0 >   1   1     :    1b2    1b1 >    5a1    3b2 :   -0.0484354547
+        0   0 >   1   0     :    1b1    1b2 >    5a1    2b2 :   -0.0425015213
 
 Symmetry of excited state: B2
 Symmetry of right eigenvector: B2
@@ -801,42 +792,42 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5993214651   5.99e-01    4.86e-01      N
-                     2   0.6674359098   6.67e-01    4.49e-01      N
+                     1   0.5993214638   5.99e-01    4.86e-01      N
+                     2   0.6674359133   6.67e-01    4.49e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4991346958  -1.00e-01    7.20e-02      N
-                     2   0.5826605688  -8.48e-02    6.28e-02      N
+                     1   0.4991346942  -1.00e-01    7.20e-02      N
+                     2   0.5826605716  -8.48e-02    6.28e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4971354828  -2.00e-03    2.45e-02      N
-                     2   0.5814105746  -1.25e-03    1.84e-02      N
+                     1   0.4971354812  -2.00e-03    2.45e-02      N
+                     2   0.5814105774  -1.25e-03    1.84e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4969096314  -2.26e-04    5.87e-03      N
-                     2   0.5813337200  -7.69e-05    5.12e-03      N
+                     1   0.4969096298  -2.26e-04    5.87e-03      N
+                     2   0.5813337229  -7.69e-05    5.12e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4968862383  -2.34e-05    1.25e-03      N
-                     2   0.5813015854  -3.21e-05    1.33e-03      N
+                     1   0.4968862367  -2.34e-05    1.25e-03      N
+                     2   0.5813015882  -3.21e-05    1.33e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4968839051  -2.33e-06    3.23e-04      N
-                     2   0.5812991596  -2.43e-06    3.94e-04      N
+                     1   0.4968839035  -2.33e-06    3.23e-04      N
+                     2   0.5812991624  -2.43e-06    3.94e-04      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4968842810   3.76e-07    8.01e-05      N
-                     2   0.5812995489   3.89e-07    1.09e-04      N
+                     1   0.4968842793   3.76e-07    8.01e-05      N
+                     2   0.5812995517   3.89e-07    1.09e-04      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4968842981   1.71e-08    1.77e-05      N
-                     2   0.5812996232   7.43e-08    3.23e-05      N
+                     1   0.4968842965   1.71e-08    1.77e-05      N
+                     2   0.5812996260   7.43e-08    3.23e-05      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4968842813  -1.68e-08    3.64e-06      N
-                     2   0.5812995426  -8.06e-08    8.03e-06      N
+                     1   0.4968842797  -1.68e-08    3.64e-06      N
+                     2   0.5812995454  -8.06e-08    8.03e-06      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4968842872   5.92e-09    7.17e-07      Y
-                     2   0.5812995454   2.85e-09    1.69e-06      N
+                     1   0.4968842856   5.92e-09    7.17e-07      Y
+                     2   0.5812995482   2.85e-09    1.69e-06      N
 Iter=11   L=21    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4968842872   1.89e-11    7.16e-07      Y
-                     2   0.5812995457   3.31e-10    4.05e-07      Y
+                     1   0.4968842856   1.89e-11    7.16e-07      Y
+                     2   0.5812995486   3.31e-10    4.05e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-Energy written to CC_INFO:Etot  -75.6498339999
+Energy written to CC_INFO:Etot  -75.6498339960
 States per irrep written to CC_INFO.
 EOM CCSD R0 for root 0 =   0.00000000000
 EOM CCSD R0 for root 1 =   0.00000000000
@@ -844,60 +835,53 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 7     13.521   109053.5   0.4968842872   -75.734249258429
+EOM State 7     13.521   109053.5   0.4968842856   -75.734249258938
 
 Largest components of excited wave function #7:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    2b2 :    0.6850724073
-         2 >   1      :       3a1 >    3b2 :    0.0612947863
-         2 >   2      :       3a1 >    4b2 :    0.0612347444
-         0 >   1      :       1b2 >    5a1 :   -0.0191755093
-         0 >   0      :       1b2 >    4a1 :    0.0114159063
+         2 >   0      :       3a1 >    2b2 :   -0.6850724075
+         2 >   1      :       3a1 >    3b2 :   -0.0612947860
+         2 >   2      :       3a1 >    4b2 :   -0.0612347450
+         0 >   1      :       1b2 >    5a1 :    0.0191755083
+         0 >   0      :       1b2 >    4a1 :   -0.0114159030
  RIjAb (libdpd indices)     : (cscf notation)
-        2   0 >   0   0     :    3a1    1b2 >    2b2    2b2 :    0.0573234396
-        0   2 >   0   0     :    1b2    3a1 >    2b2    2b2 :    0.0573234396
-        2   2 >   0   0     :    3a1    3a1 >    4a1    2b2 :   -0.0440195487
-        2   2 >   0   0     :    3a1    3a1 >    2b2    4a1 :   -0.0440195487
-        2   2 >   2   0     :    3a1    3a1 >    6a1    2b2 :   -0.0429862607
-EOM State 8     15.818   127580.5   0.5812995457   -75.649833999886
+        2   0 >   0   0     :    3a1    1b2 >    2b2    2b2 :   -0.0573234394
+        0   2 >   0   0     :    1b2    3a1 >    2b2    2b2 :   -0.0573234394
+        2   2 >   0   0     :    3a1    3a1 >    4a1    2b2 :    0.0440195450
+        2   2 >   0   0     :    3a1    3a1 >    2b2    4a1 :    0.0440195450
+        2   2 >   2   0     :    3a1    3a1 >    6a1    2b2 :    0.0429862609
+EOM State 8     15.818   127580.5   0.5812995486   -75.649833995966
 
 Largest components of excited wave function #8:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    4a1 :    0.6899805566
-         0 >   1      :       1b2 >    5a1 :   -0.0550931424
-         0 >   2      :       1b2 >    6a1 :    0.0234221377
-         2 >   1      :       3a1 >    3b2 :    0.0183535732
-         1 >   0      :       2a1 >    2b2 :    0.0179189446
+         0 >   0      :       1b2 >    4a1 :   -0.6899805566
+         0 >   1      :       1b2 >    5a1 :    0.0550931424
+         0 >   2      :       1b2 >    6a1 :   -0.0234221377
+         2 >   1      :       3a1 >    3b2 :   -0.0183535729
+         1 >   0      :       2a1 >    2b2 :   -0.0179189449
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b2    1b2 >    4a1    2b2 :    0.0665526024
-        0   0 >   0   0     :    1b2    1b2 >    2b2    4a1 :    0.0665526024
-        0   0 >   0   0     :    1b1    1b2 >    2b1    4a1 :    0.0349310134
-        0   0 >   0   0     :    1b2    1b1 >    4a1    2b1 :    0.0349310134
-        2   0 >   2   0     :    3a1    1b2 >    6a1    4a1 :   -0.0312518511
+        0   0 >   0   0     :    1b2    1b2 >    4a1    2b2 :   -0.0665526020
+        0   0 >   0   0     :    1b2    1b2 >    2b2    4a1 :   -0.0665526020
+        0   0 >   0   0     :    1b1    1b2 >    2b1    4a1 :   -0.0349310141
+        0   0 >   0   0     :    1b2    1b1 >    4a1    2b1 :   -0.0349310141
+        2   0 >   2   0     :    3a1    1b2 >    6a1    4a1 :    0.0312518515
 
 	Putting into environment energy for root of R irrep 4 and root 2.
-	Putting into environment CURRENT ENERGY:              -75.6498339999
+	Putting into environment CURRENT ENERGY:              -75.6498339960
 
 	Total # of sigma evaluations: 90
+    SCF energy............................................................................PASSED
+    CCSD energy...........................................................................PASSED
+    EOM-CCSD root 0 (B1)..................................................................PASSED
+    EOM-CCSD root 0 (A2)..................................................................PASSED
+    EOM-CCSD root 1 (A1)..................................................................PASSED
+    EOM-CCSD root 0 (B2)..................................................................PASSED
+    EOM-CCSD root 1 (B2)..................................................................PASSED
+    EOM-CCSD root 2 (A1)..................................................................PASSED
+    EOM-CCSD root 1 (A2)..................................................................PASSED
+    EOM-CCSD root 1 (B1)..................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:10 2017
-Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.90 seconds =       0.02 minutes
-	system time =       0.44 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-	SCF energy........................................................PASSED
-	CCSD energy.......................................................PASSED
-	EOM-CCSD root 1...................................................PASSED
-	EOM-CCSD root 2...................................................PASSED
-	EOM-CCSD root 3...................................................PASSED
-	EOM-CCSD root 4...................................................PASSED
-	EOM-CCSD root 5...................................................PASSED
-	EOM-CCSD root 6...................................................PASSED
-	EOM-CCSD root 7...................................................PASSED
-	EOM-CCSD root 8...................................................PASSED
+    Psi4 stopped on: Monday, 14 March 2022 01:18PM
+    Psi4 wall time for execution: 0:00:04.60
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc17/CMakeLists.txt
+++ b/tests/cc17/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc17 "psi;quicktests;cc;noc1")
+add_regression_test(cc17 "psi;quicktests;cc;noc1;eom")

--- a/tests/cc17/input.dat
+++ b/tests/cc17/input.dat
@@ -19,11 +19,10 @@ energy('eom-ccsd')
 
 escf = -38.917378694797                                                        #TEST
 eccsd = -39.03274757226                                                        #TEST
-eeom_ccsd = [-38.6664604477, -38.6032901417, -38.7702711146, -38.6989011688,   #TEST
-             -38.7458590086, -38.5424940735, -38.8224374840, -38.6232036004 ]  #TEST
+eeom_ccsd = [(-38.6664604477, "B1", 1), (-38.6032901417, "B1", 2), (-38.7702711146, "B2", 0), (-38.6989011688, "B2", 1),   #TEST
+             (-38.7458590086, "A1", 0), (-38.5424940735, "A1", 1), (-38.8224374840, "A2", 0), (-38.6232036004, "A2", 1) ]  #TEST
 compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy")        #TEST
 compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy")     #TEST
-for root in range(1,9):                                                        #TEST
-    ref = eeom_ccsd[root-1]                                                    #TEST
-    val = variable("CC ROOT %d TOTAL ENERGY" % root)                       #TEST
-    compare_values(ref, val, 7, "EOM-CCSD root %d" % root)                     #TEST
+for (ref, h, i) in eeom_ccsd: # TEST
+    val = variable(f"CCSD ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CCSD root {i} ({h})")                                #TEST

--- a/tests/cc17/output.ref
+++ b/tests/cc17/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 undefined 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {eom_var} 5b439ed dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 March 2022 01:16PM
 
-    Process ID:  12521
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 23864
+    Host:       dhcp189-157.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -49,31 +62,33 @@ energy('eom-ccsd')
 
 escf = -38.917378694797                                                        #TEST
 eccsd = -39.03274757226                                                        #TEST
-eeom_ccsd = [-38.6664604477, -38.6032901417, -38.7702711146, -38.6989011688,   #TEST
-             -38.7458590086, -38.5424940735, -38.8224374840, -38.6232036004 ]  #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy")        #TEST
-compare_values(eccsd, get_variable("CCSD TOTAL ENERGY"), 7, "CCSD energy")     #TEST
-for root in range(1,9):                                                        #TEST
-    ref = eeom_ccsd[root-1]                                                    #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root)                       #TEST
-    compare_values(ref, val, 7, "EOM-CCSD root %d" % root)                     #TEST
+eeom_ccsd = [(-38.6664604477, "B1", 1), (-38.6032901417, "B1", 2), (-38.7702711146, "B2", 0), (-38.6989011688, "B2", 1),   #TEST
+             (-38.7458590086, "A1", 0), (-38.5424940735, "A1", 1), (-38.8224374840, "A2", 0), (-38.6232036004, "A2", 1) ]  #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy")        #TEST
+compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy")     #TEST
+for (ref, h, i) in eeom_ccsd: # TEST
+    val = variable(f"CCSD ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CCSD root {i} ({h})")                                #TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:15 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:16:17 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry C          line   130 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -87,15 +102,15 @@ for root in range(1,9):                                                        #
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.091864689759    12.000000000000
-           H          0.000000000000    -0.895527070192     0.546908561523     1.007825032070
-           H          0.000000000000     0.895527070192     0.546908561523     1.007825032070
+         C            0.000000000000     0.000000000000    -0.091864689772    12.000000000000
+         H            0.000000000000    -0.895527070192     0.546908561510     1.007825032230
+         H            0.000000000000     0.895527070192     0.546908561510     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     23.93977  B =     10.42855  C =      7.26416 [cm^-1]
-  Rotational constants: A = 717696.14844  B = 312640.05804  C = 217774.12469 [MHz]
-  Nuclear repulsion =    6.068298005568229
+  Rotational constants: A = 717696.15382  B = 312640.06037  C = 217774.12632 [MHz]
+  Nuclear repulsion =    6.068298029420463
 
   Charge       = 0
   Multiplicity = 3
@@ -109,33 +124,20 @@ for root in range(1,9):                                                        #
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      24      24       5       3       3       2
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -154,48 +156,66 @@ for root in range(1,9):                                                        #
   Using 90300 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.9429630952E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 2.6725919994E-02.
+  Reciprocal condition number of the overlap matrix is 8.2894136923E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter   1:   -38.31961105999222   -3.83196e+01   7.93567e-02 
-   @UHF iter   2:   -38.88101600456738   -5.61405e-01   1.58957e-02 DIIS
-   @UHF iter   3:   -38.91270296738569   -3.16870e-02   3.91910e-03 DIIS
-   @UHF iter   4:   -38.91662354907332   -3.92058e-03   1.48823e-03 DIIS
-   @UHF iter   5:   -38.91730228395674   -6.78735e-04   4.44253e-04 DIIS
-   @UHF iter   6:   -38.91737258063893   -7.02967e-05   1.17907e-04 DIIS
-   @UHF iter   7:   -38.91737754549431   -4.96486e-06   4.91546e-05 DIIS
-   @UHF iter   8:   -38.91737856026896   -1.01477e-06   1.75671e-05 DIIS
-   @UHF iter   9:   -38.91737868936091   -1.29092e-07   2.94888e-06 DIIS
-   @UHF iter  10:   -38.91737869216925   -2.80834e-09   5.22485e-07 DIIS
-   @UHF iter  11:   -38.91737869225074   -8.14921e-11   6.46134e-08 DIIS
-   @UHF iter  12:   -38.91737869225197   -1.22924e-12   1.63998e-08 DIIS
-   @UHF iter  13:   -38.91737869225208   -1.06581e-13   2.84225e-09 DIIS
+   @UHF iter SAD:   -38.17324740294818   -3.81732e+01   0.00000e+00 
+   @UHF iter   1:   -38.90234369081279   -7.29096e-01   9.18281e-03 DIIS/ADIIS
+   @UHF iter   2:   -38.91513874101256   -1.27951e-02   2.96594e-03 DIIS/ADIIS
+   @UHF iter   3:   -38.91704192221886   -1.90318e-03   9.12227e-04 DIIS/ADIIS
+   @UHF iter   4:   -38.91728837837267   -2.46456e-04   4.44838e-04 DIIS/ADIIS
+   @UHF iter   5:   -38.91736720436321   -7.88260e-05   1.56708e-04 DIIS/ADIIS
+   @UHF iter   6:   -38.91737800485830   -1.08005e-05   3.98991e-05 DIIS
+   @UHF iter   7:   -38.91737866712213   -6.62264e-07   8.98792e-06 DIIS
+   @UHF iter   8:   -38.91737869147015   -2.43480e-08   1.73727e-06 DIIS
+   @UHF iter   9:   -38.91737869233101   -8.60865e-10   4.12327e-07 DIIS
+   @UHF iter  10:   -38.91737869238192   -5.09033e-11   6.24424e-08 DIIS
+   @UHF iter  11:   -38.91737869238311   -1.19371e-12   1.38529e-08 DIIS
+   @UHF iter  12:   -38.91737869238315   -4.26326e-14   2.42356e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   1.210199601E-02
+   @Spin Contamination Metric:   1.210199554E-02
    @S^2 Expected:                2.000000000E+00
    @S^2 Observed:                2.012101996E+00
    @S   Expected:                1.000000000E+00
    @S   Observed:                1.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
@@ -221,7 +241,7 @@ for root in range(1,9):                                                        #
        3A1     0.105281     1B1     0.159004     4A1     0.221021  
        2B2     0.285269     3B2     0.620941     5A1     0.737973  
        2B1     0.822031     6A1     0.832333     4B2     0.906448  
-       7A1     1.062088     1A2     1.257736     8A1     1.303650  
+       7A1     1.062089     1A2     1.257736     8A1     1.303650  
        3B1     1.383571     5B2     1.732543     9A1     1.810140  
        6B2     1.988311     4B1     2.039560     2A2     2.087798  
       10A1     2.350790    11A1     2.720420     7B2     2.769588  
@@ -231,21 +251,14 @@ for root in range(1,9):                                                        #
     DOCC [     2,    0,    0,    1 ]
     SOCC [     1,    0,    1,    0 ]
 
-  Energy converged.
-
-  @UHF Final Energy:   -38.91737869225208
+  @UHF Final Energy:   -38.91737869238315
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              6.0682980055682290
-    One-Electron Energy =                 -63.7147359432526912
-    Two-Electron Energy =                  18.7290592454323814
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -38.9173786922520790
-
+    Nuclear Repulsion Energy =              6.0682980294204629
+    One-Electron Energy =                 -63.7147359963744790
+    Two-Electron Energy =                  18.7290592745708651
+    Total Energy =                        -38.9173786923831528
 
   UHF NO Occupations:
   HONO-2 :    2 A1 1.9967234
@@ -254,36 +267,38 @@ for root in range(1,9):                                                        #
   LUNO+0 :    4 A1 0.0032766
   LUNO+1 :    2 B2 0.0027828
   LUNO+2 :    5 A1 0.0000008
-  LUNO+3 :    2 B1 0.0000000
+  LUNO+3 :    6 A1 0.0000000
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.0254
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.7742
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.2512     Total:     0.2512
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     0.6386     Total:     0.6386
 
 
-*** tstop() called on psinet at Mon May 15 15:34:15 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:16:18 2022
 Module time:
-	user time   =       0.19 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.87 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.19 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.87 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -297,19 +312,19 @@ Total time:
       Number of basis functions:        24
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  11    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 11581 non-zero two-electron integrals.
+      Computed 11412 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:15 2017
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:16:18 2022
 
 
 	Wfn Parameters:
@@ -334,7 +349,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -444,37 +459,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.001 (MW) /      0.005 (MB)
 	Total:                                     0.002 (MW) /      0.014 (MB)
 
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -38.91737869225208
-	One-electron energy          =    -63.71473595479578
-	Two-electron (AA) energy     =      5.37013793621956
-	Two-electron (BB) energy     =      1.64169186800055
-	Two-electron (AB) energy     =     11.71722945275536
-	Two-electron energy          =     18.72905925697547
-	Reference energy             =    -38.91737869225208
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -38.91737869238315
+	One-electron energy          =    -63.71473599658705
+	Two-electron (AA) energy     =      5.37013793966768
+	Two-electron (BB) energy     =      1.64169187144937
+	Two-electron (AB) energy     =     11.71722946366638
+	Two-electron energy          =     18.72905927478342
+	Reference energy             =    -38.91737869238316
 
-*** tstop() called on psinet at Mon May 15 15:34:15 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:16:18 2022
 Module time:
-	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.08 seconds =       0.00 minutes
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.18 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.27 seconds =       0.00 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:15 2017
-
+	user time   =       0.96 seconds =       0.02 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    6.068298005568229
-    SCF energy          (wfn)     =  -38.917378692252079
-    Reference energy    (file100) =  -38.917378692252079
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -38.917378692383153
+    Reference energy    (file100) =  -38.917378692383160
 
     Input parameters:
     -----------------
@@ -502,114 +513,102 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.0953539827620370
+MP2 correlation energy -0.0953539827361329
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.095353982762037    0.000e+00    0.000000    0.000000    0.000000    0.000000
-     1        -0.110266543973313    3.737e-02    0.005013    0.000000    0.000000    0.000000
-     2        -0.114891353194010    1.453e-02    0.008836    0.000000    0.000000    0.000000
-     3        -0.115324840326396    5.355e-03    0.010951    0.000000    0.000000    0.000000
-     4        -0.115365473610362    1.590e-03    0.011467    0.000000    0.000000    0.000000
-     5        -0.115363321481896    4.133e-04    0.011469    0.000000    0.000000    0.000000
-     6        -0.115368451269937    1.485e-04    0.011447    0.000000    0.000000    0.000000
-     7        -0.115368914325626    5.418e-05    0.011431    0.000000    0.000000    0.000000
-     8        -0.115368689413904    1.449e-05    0.011427    0.000000    0.000000    0.000000
-     9        -0.115368893814819    3.829e-06    0.011426    0.000000    0.000000    0.000000
-    10        -0.115368895730993    1.230e-06    0.011426    0.000000    0.000000    0.000000
-    11        -0.115368877652505    2.944e-07    0.011426    0.000000    0.000000    0.000000
-    12        -0.115368880312994    7.396e-08    0.011426    0.000000    0.000000    0.000000
+     0        -0.095353982736133    0.000e+00    0.000000    0.000000    0.000000    0.000000
+     1        -0.110266544002532    3.737e-02    0.005013    0.000000    0.000000    0.000000
+     2        -0.114891353388513    1.453e-02    0.008836    0.000000    0.000000    0.000000
+     3        -0.115324840558529    5.355e-03    0.010951    0.000000    0.000000    0.000000
+     4        -0.115365473827952    1.590e-03    0.011467    0.000000    0.000000    0.000000
+     5        -0.115363321698194    4.133e-04    0.011469    0.000000    0.000000    0.000000
+     6        -0.115368451486811    1.485e-04    0.011447    0.000000    0.000000    0.000000
+     7        -0.115368914542807    5.418e-05    0.011431    0.000000    0.000000    0.000000
+     8        -0.115368689631151    1.449e-05    0.011427    0.000000    0.000000    0.000000
+     9        -0.115368894032097    3.829e-06    0.011426    0.000000    0.000000    0.000000
+    10        -0.115368895948265    1.230e-06    0.011426    0.000000    0.000000    0.000000
+    11        -0.115368877869773    2.944e-07    0.011426    0.000000    0.000000    0.000000
+    12        -0.115368880530262    7.396e-08    0.011426    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              1   0        -0.0061202810
-              4  13        -0.0055757554
-              1   2        -0.0053728888
-              1   1         0.0045269836
-              3  10        -0.0044643475
-              4  17         0.0042945261
-              3  11        -0.0042615603
-              4  14         0.0041869329
-              2   1        -0.0034574791
-              2   4        -0.0033930086
+              1   0        -0.0061202785
+              4  13        -0.0055757566
+              1   2        -0.0053728913
+              1   1         0.0045269854
+              3  10        -0.0044643224
+              4  17         0.0042945245
+              3  11        -0.0042615577
+              4  14         0.0041869453
+              2   1        -0.0034574946
+              2   4        -0.0033930100
 
     Largest Tia Amplitudes:
-              1   0         0.0201527600
-              1   2         0.0108376266
-              2  17         0.0099808157
-              2  15         0.0066459910
-              2  19         0.0061259548
-              1   6        -0.0055673816
-              1   4        -0.0049145442
-              1   5        -0.0037649771
+              1   0         0.0201527711
+              1   2         0.0108376317
+              2  17         0.0099808161
+              2  15         0.0066459891
+              2  19         0.0061259551
+              1   6        -0.0055673805
+              1   4        -0.0049145440
+              1   5        -0.0037649772
               2  20         0.0032881320
-              1   1         0.0032013180
+              1   1         0.0032013172
 
     Largest TIJAB Amplitudes:
-      3   2  10   1        -0.0308037376
-      4   3   8   2         0.0236253263
-      3   2  11   4        -0.0219460053
-      4   3  15  10        -0.0209042529
-      4   3  13  10        -0.0206618946
-      4   2  13   1        -0.0197290054
+      3   2  10   1        -0.0308037373
+      4   3   8   2         0.0236253260
+      3   2  11   4        -0.0219460051
+      4   3  15  10        -0.0209042527
+      4   3  13  10        -0.0206618943
+      4   2  13   1        -0.0197290057
       4   2  15   1        -0.0196745294
-      3   2  10   2        -0.0173927194
-      4   2  14   4         0.0154691821
-      4   2  14   2        -0.0154634278
+      3   2  10   2        -0.0173927190
+      4   2  14   4         0.0154691818
+      4   2  14   2        -0.0154634274
 
     Largest Tijab Amplitudes:
-      2   1  11   9        -0.0103227604
-      2   1  16   1        -0.0077371145
-      2   1  16   0         0.0077090178
-      2   1  16   3        -0.0072993206
-      2   1  15   0        -0.0068600087
-      2   1  17   0        -0.0067733794
-      2   1  15   1        -0.0066037841
+      2   1  11   9        -0.0103227606
+      2   1  16   1        -0.0077371146
+      2   1  16   0         0.0077090182
+      2   1  16   3        -0.0072993207
+      2   1  15   0        -0.0068600089
+      2   1  17   0        -0.0067733795
+      2   1  15   1        -0.0066037842
       2   1  17   4         0.0063165633
-      2   1  15   4         0.0061108818
-      2   1  12   9        -0.0045929582
+      2   1  15   4         0.0061108819
+      2   1  12   9        -0.0045929583
 
     Largest TIjAb Amplitudes:
-      4   2  15  17        -0.0339373940
-      4   2  13  15        -0.0325022870
-      3   1   2  11        -0.0318051316
-      4   2  13  17        -0.0297797883
-      4   2   2   2        -0.0291206477
-      4   2  14  16        -0.0279412314
-      3   2  10  17        -0.0258275154
-      2   1   4   0        -0.0257444543
-      4   2  15  15        -0.0257199817
-      3   2  10  15        -0.0255216164
+      4   2  15  17        -0.0339373939
+      4   2  13  15        -0.0325022868
+      3   1   2  11        -0.0318051315
+      4   2  13  17        -0.0297797880
+      4   2   2   2        -0.0291206474
+      4   2  14  16        -0.0279412313
+      3   2  10  17        -0.0258275152
+      2   1   4   0        -0.0257444550
+      4   2  15  15        -0.0257199816
+      3   2  10  15        -0.0255216161
 
-    SCF energy       (wfn)                    =  -38.917378692252079
-    Reference energy (file100)                =  -38.917378692252079
+    SCF energy       (wfn)                    =  -38.917378692383153
+    Reference energy (file100)                =  -38.917378692383160
 
-    Opposite-spin MP2 correlation energy      =   -0.073704210981818
-    Same-spin MP2 correlation energy          =   -0.021649771780218
-    MP2 correlation energy                    =   -0.095353982762037
-      * MP2 total energy                      =  -39.012732675014114
+    Opposite-spin MP2 correlation energy      =   -0.073704210977524
+    Same-spin MP2 correlation energy          =   -0.021649771758609
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.095353982736133
+      * MP2 total energy                      =  -39.012732675119295
 
-    Opposite-spin CCSD correlation energy     =   -0.092056134520519
-    Same-spin CCSD correlation energy         =   -0.023312745904051
-    CCSD correlation energy                   =   -0.115368880312994
-      * CCSD total energy                     =  -39.032747572565071
-
-
-*** tstop() called on psinet at Mon May 15 15:34:16 2017
-Module time:
-	user time   =       0.16 seconds =       0.00 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.43 seconds =       0.01 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:16 2017
+    Opposite-spin CCSD correlation energy     =   -0.092056134750395
+    Same-spin CCSD correlation energy         =   -0.023312745779868
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.115368880530262
+      * CCSD total energy                     =  -39.032747572913422
 
 
 			**************************
@@ -619,28 +618,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:16 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.45 seconds =       0.01 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:16 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    6.068298005568229
-	SCF energy          (wfn)     =  -38.917378692252079
-	Reference energy    (file100) =  -38.917378692252079
-	CCSD energy         (file100) =   -0.115368880312994
+	Nuclear Rep. energy (wfn)     =    6.068298029420463
+	SCF energy          (wfn)     =  -38.917378692383153
+	Reference energy    (file100) =  -38.917378692383160
+	CCSD energy         (file100) =   -0.115368880530262
 
 	Input parameters:
 	-----------------
@@ -673,216 +658,220 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total   95.2864130276
+Fmi   dot Fmi   total  256.0985730320
+WmBeJ and WMbEj dots    0.4826991318
 Symmetry of ground state: B1
 Symmetry of excited state: B1
 Symmetry of right eigenvector: A1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4350097566   4.35e-01    2.93e-01      N
-                     2   0.4934922877   4.93e-01    3.01e-01      N
+                     1   0.4350097501   4.35e-01    2.93e-01      N
+                     2   0.4934922872   4.93e-01    3.01e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3738719143  -6.11e-02    7.67e-02      N
-                     2   0.4424785918  -5.10e-02    6.73e-02      N
+                     1   0.3738719068  -6.11e-02    7.67e-02      N
+                     2   0.4424785910  -5.10e-02    6.73e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3685281474  -5.34e-03    4.64e-02      N
-                     2   0.4372887664  -5.19e-03    5.77e-02      N
+                     1   0.3685281396  -5.34e-03    4.64e-02      N
+                     2   0.4372887656  -5.19e-03    5.77e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3670630576  -1.47e-03    2.52e-02      N
-                     2   0.4332428919  -4.05e-03    4.87e-02      N
+                     1   0.3670630496  -1.47e-03    2.52e-02      N
+                     2   0.4332428906  -4.05e-03    4.87e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3666073368  -4.56e-04    1.57e-02      N
-                     2   0.4313400266  -1.90e-03    2.78e-02      N
+                     1   0.3666073287  -4.56e-04    1.57e-02      N
+                     2   0.4313400250  -1.90e-03    2.78e-02      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3664110793  -1.96e-04    1.41e-02      N
-                     2   0.4304721355  -8.68e-04    3.14e-02      N
+                     1   0.3664110711  -1.96e-04    1.41e-02      N
+                     2   0.4304721333  -8.68e-04    3.14e-02      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3663153543  -9.57e-05    7.19e-03      N
-                     2   0.4297289295  -7.43e-04    2.21e-02      N
+                     1   0.3663153461  -9.57e-05    7.19e-03      N
+                     2   0.4297289270  -7.43e-04    2.21e-02      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662955339  -1.98e-05    3.03e-03      N
-                     2   0.4295252834  -2.04e-04    1.18e-02      N
+                     1   0.3662955256  -1.98e-05    3.03e-03      N
+                     2   0.4295252807  -2.04e-04    1.18e-02      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662892973  -6.24e-06    1.43e-03      N
-                     2   0.4294705300  -5.48e-05    6.60e-03      N
+                     1   0.3662892891  -6.24e-06    1.43e-03      N
+                     2   0.4294705273  -5.48e-05    6.60e-03      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662873768  -1.92e-06    7.11e-04      N
-                     2   0.4294590025  -1.15e-05    3.69e-03      N
+                     1   0.3662873686  -1.92e-06    7.11e-04      N
+                     2   0.4294589998  -1.15e-05    3.69e-03      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662872825  -9.42e-08    2.89e-04      N
-                     2   0.4294581848  -8.18e-07    1.69e-03      N
+                     1   0.3662872743  -9.42e-08    2.89e-04      N
+                     2   0.4294581821  -8.18e-07    1.69e-03      N
 Iter=12   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662870659  -2.17e-07    1.09e-04      N
-                     2   0.4294566159  -1.57e-06    7.15e-04      N
+                     1   0.3662870577  -2.17e-07    1.09e-04      N
+                     2   0.4294566132  -1.57e-06    7.15e-04      N
 Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662870659   1.11e-15    1.09e-04      N
-                     2   0.4294566159  -1.28e-15    7.15e-04      N
+                     1   0.3662870577  -2.16e-15    1.09e-04      N
+                     2   0.4294566132   2.22e-16    7.15e-04      N
 Iter=14   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871282   6.23e-08    4.03e-05      N
-                     2   0.4294570971   4.81e-07    3.02e-04      N
+                     1   0.3662871200   6.23e-08    4.03e-05      N
+                     2   0.4294570944   4.81e-07    3.02e-04      N
 Iter=15   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871313   3.09e-09    1.27e-05      N
-                     2   0.4294574464   3.49e-07    1.10e-04      N
+                     1   0.3662871231   3.09e-09    1.27e-05      N
+                     2   0.4294574437   3.49e-07    1.10e-04      N
 Iter=16   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871187  -1.26e-08    4.27e-06      N
-                     2   0.4294573862  -6.02e-08    4.04e-05      N
+                     1   0.3662871105  -1.26e-08    4.27e-06      N
+                     2   0.4294573835  -6.02e-08    4.04e-05      N
 Iter=17   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871147  -4.04e-09    1.53e-06      N
-                     2   0.4294574050   1.88e-08    1.52e-05      N
+                     1   0.3662871065  -4.04e-09    1.53e-06      N
+                     2   0.4294574023   1.88e-08    1.52e-05      N
 Iter=18   L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871125  -2.17e-09    5.66e-07      Y
-                     2   0.4294574040  -1.08e-09    6.47e-06      N
+                     1   0.3662871043  -2.17e-09    5.66e-07      Y
+                     2   0.4294574012  -1.08e-09    6.47e-06      N
 Iter=19   L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871123  -2.23e-10    2.68e-07      Y
-                     2   0.4294574066   2.61e-09    3.44e-06      N
+                     1   0.3662871041  -2.23e-10    2.68e-07      Y
+                     2   0.4294574039   2.61e-09    3.44e-06      N
 Iter=20   L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871123   8.29e-12    2.11e-07      Y
-                     2   0.4294574085   1.91e-09    2.11e-06      N
+                     1   0.3662871041   8.29e-12    2.11e-07      Y
+                     2   0.4294574058   1.91e-09    2.11e-06      N
 Iter=21   L=17    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871123   1.20e-11    2.19e-07      Y
-                     2   0.4294574075  -1.00e-09    1.81e-06      N
+                     1   0.3662871041   1.20e-11    2.19e-07      Y
+                     2   0.4294574048  -1.00e-09    1.81e-06      N
 Iter=22   L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871123  -3.59e-11    2.04e-07      Y
-                     2   0.4294574066  -9.21e-10    1.52e-06      N
+                     1   0.3662871041  -3.59e-11    2.04e-07      Y
+                     2   0.4294574038  -9.21e-10    1.52e-06      N
 Iter=23   L=19    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871123  -1.65e-11    1.90e-07      Y
-                     2   0.4294574039  -2.66e-09    1.12e-06      N
+                     1   0.3662871041  -1.65e-11    1.90e-07      Y
+                     2   0.4294574012  -2.66e-09    1.12e-06      N
 Iter=24   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3662871123   8.93e-12    1.88e-07      Y
-                     2   0.4294574018  -2.13e-09    6.98e-07      Y
+                     1   0.3662871041   8.93e-12    1.88e-07      Y
+                     2   0.4294573991  -2.13e-09    6.98e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-<R|R> =   0.9999999999999998
-EOM CCSD R0 for root 0 =  -0.00267446344
-<R|R> =   0.9999999999999998
-EOM CCSD R0 for root 1 =   0.03155817485
+<R|R> =   1.0000000000000004
+EOM CCSD R0 for root 0 =  -0.00267448921
+<R|R> =   1.0000000000000002
+EOM CCSD R0 for root 1 =   0.03155818123
 
 Final Energetic Summary for Converged Roots of Irrep B1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      9.967    80390.7   0.3662871123   -38.666460460276
+EOM State 1      9.967    80390.7   0.3662871041   -38.666460468830
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    4a1 :   -0.9425966848
-         2 >   3      :       3a1 >    7a1 :    0.0925607854
-         2 >   2      :       3a1 >    6a1 :   -0.0899831627
-         0 >   0      :       1b2 >    2b2 :   -0.0429588605
-         0 >   0      :       1b1 >    2b1 :    0.0253285243
+         2 >   0      :       3a1 >    4a1 :   -0.9425966843
+         2 >   3      :       3a1 >    7a1 :    0.0925607859
+         2 >   2      :       3a1 >    6a1 :   -0.0899831586
+         0 >   0      :       1b2 >    2b2 :   -0.0429588563
+         0 >   0      :       1b1 >    2b1 :    0.0253285231
  Ria (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    2b2 :    0.0944759715
-         1 >   1      :       2a1 >    4a1 :    0.0507113362
-         1 >   0      :       2a1 >    3a1 :    0.0484833535
-         0 >   2      :       1b2 >    4b2 :    0.0304947081
-         1 >   3      :       2a1 >    6a1 :    0.0235049171
+         0 >   0      :       1b2 >    2b2 :    0.0944759683
+         1 >   1      :       2a1 >    4a1 :    0.0507113307
+         1 >   0      :       2a1 >    3a1 :    0.0484833697
+         0 >   2      :       1b2 >    4b2 :    0.0304947060
+         1 >   3      :       2a1 >    6a1 :    0.0235049131
  RIjAb (libdpd indices)     : (cscf notation)
-        2   1 >   0   0     :    3a1    2a1 >    4a1    3a1 :   -0.1272600478
-        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :   -0.0805671347
-        1   1 >   0   0     :    2a1    2a1 >    4a1    3a1 :    0.0780327584
-        2   0 >   0   0     :    3a1    1b2 >    2b2    3a1 :   -0.0696468079
-        0   0 >   0   0     :    1b2    1b2 >    4a1    3a1 :    0.0601536244
+        2   1 >   0   0     :    3a1    2a1 >    4a1    3a1 :   -0.1272600509
+        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :   -0.0805671328
+        1   1 >   0   0     :    2a1    2a1 >    4a1    3a1 :    0.0780327603
+        2   0 >   0   0     :    3a1    1b2 >    2b2    3a1 :   -0.0696468159
+        0   0 >   0   0     :    1b2    1b2 >    4a1    3a1 :    0.0601536235
  RIJAB (libdpd indices)     : (cscf notation)
-        0   2 >   0   0     :    1b1    3a1 >    2b1    4a1 :   -0.0632913466
-        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :   -0.0408683654
-        0   2 >   2   0     :    1b2    3a1 >    4b2    4a1 :   -0.0388942087
-        2   1 >   3   0     :    3a1    2a1 >    7a1    4a1 :   -0.0318221258
-        0   2 >   0   2     :    1b2    3a1 >    2b2    6a1 :    0.0211331704
+        0   2 >   0   0     :    1b1    3a1 >    2b1    4a1 :   -0.0632913437
+        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :   -0.0408683647
+        0   2 >   2   0     :    1b2    3a1 >    4b2    4a1 :   -0.0388942080
+        2   1 >   3   0     :    3a1    2a1 >    7a1    4a1 :   -0.0318221257
+        0   2 >   0   2     :    1b2    3a1 >    2b2    6a1 :    0.0211331706
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   0   1     :    1b2    2a1 >    2b2    4a1 :    0.0048231702
-        0   1 >   0   0     :    1b2    2a1 >    2b2    3a1 :    0.0038988213
-        0   1 >   0   3     :    1b2    2a1 >    2b2    6a1 :    0.0021698130
-        0   1 >   2   0     :    1b2    2a1 >    4b2    3a1 :    0.0016861419
-        0   1 >   0   4     :    1b2    2a1 >    2b2    7a1 :   -0.0015081549
-EOM State 2     11.686    94255.0   0.4294574018   -38.603290170795
+        0   1 >   0   1     :    1b2    2a1 >    2b2    4a1 :    0.0048231700
+        0   1 >   0   0     :    1b2    2a1 >    2b2    3a1 :    0.0038988210
+        0   1 >   0   3     :    1b2    2a1 >    2b2    6a1 :    0.0021698131
+        0   1 >   2   0     :    1b2    2a1 >    4b2    3a1 :    0.0016861417
+        0   1 >   0   4     :    1b2    2a1 >    2b2    7a1 :   -0.0015081548
+EOM State 2     11.686    94255.0   0.4294573991   -38.603290173853
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    2b2 :    0.3215844213
-         0 >   2      :       1b2 >    4b2 :    0.1044477951
-         0 >   1      :       1b2 >    3b2 :   -0.0880744552
-         2 >   0      :       3a1 >    4a1 :   -0.0864393906
-         2 >   4      :       3a1 >    8a1 :    0.0494839844
+         0 >   0      :       1b2 >    2b2 :    0.3215843355
+         0 >   2      :       1b2 >    4b2 :    0.1044477796
+         0 >   1      :       1b2 >    3b2 :   -0.0880744527
+         2 >   0      :       3a1 >    4a1 :   -0.0864394091
+         2 >   4      :       3a1 >    8a1 :    0.0494839882
  Ria (libdpd indices) : (cscf notation)
-         1 >   0      :       2a1 >    3a1 :   -0.8384719742
-         0 >   0      :       1b2 >    2b2 :   -0.2567027085
-         1 >   2      :       2a1 >    5a1 :   -0.0918535958
-         1 >   3      :       2a1 >    6a1 :    0.0897411611
-         0 >   2      :       1b2 >    4b2 :   -0.0741613307
+         1 >   0      :       2a1 >    3a1 :   -0.8384720222
+         0 >   0      :       1b2 >    2b2 :   -0.2567026389
+         1 >   2      :       2a1 >    5a1 :   -0.0918535977
+         1 >   3      :       2a1 >    6a1 :    0.0897411778
+         0 >   2      :       1b2 >    4b2 :   -0.0741613092
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   2   0     :    1b2    1b2 >    6a1    3a1 :    0.0840104401
-        2   0 >   1   0     :    3a1    1b2 >    3b2    3a1 :   -0.0659219130
-        2   1 >   4   0     :    3a1    2a1 >    8a1    3a1 :    0.0657149472
-        2   0 >   0   0     :    3a1    1b2 >    2b2    3a1 :    0.0648387972
-        0   1 >   1   0     :    1b1    2a1 >    3b1    3a1 :    0.0574634961
+        0   0 >   2   0     :    1b2    1b2 >    6a1    3a1 :    0.0840104436
+        2   0 >   1   0     :    3a1    1b2 >    3b2    3a1 :   -0.0659219232
+        2   1 >   4   0     :    3a1    2a1 >    8a1    3a1 :    0.0657149513
+        2   0 >   0   0     :    3a1    1b2 >    2b2    3a1 :    0.0648388533
+        0   1 >   1   0     :    1b1    2a1 >    3b1    3a1 :    0.0574634987
  RIJAB (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b2    1b1 >    2b2    2b1 :    0.0137633057
-        0   1 >   0   0     :    1b2    2a1 >    2b2    4a1 :    0.0136218526
-        0   1 >   0   2     :    1b2    2a1 >    2b2    6a1 :    0.0111631499
-        0   1 >   0   0     :    1b1    2a1 >    2b2    1a2 :    0.0095167949
-        0   2 >   2   1     :    1b2    3a1 >    4b2    5a1 :   -0.0085454779
+        0   0 >   0   0     :    1b2    1b1 >    2b2    2b1 :    0.0137633016
+        0   1 >   0   0     :    1b2    2a1 >    2b2    4a1 :    0.0136218495
+        0   1 >   0   2     :    1b2    2a1 >    2b2    6a1 :    0.0111631479
+        0   1 >   0   0     :    1b1    2a1 >    2b2    1a2 :    0.0095167923
+        0   2 >   2   1     :    1b2    3a1 >    4b2    5a1 :   -0.0085454763
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   1   0     :    1b2    2a1 >    3b2    3a1 :   -0.0194740667
-        0   1 >   0   0     :    1b2    2a1 >    2b2    3a1 :    0.0155446721
-        0   1 >   2   0     :    1b2    2a1 >    4b2    3a1 :    0.0129019814
-        0   1 >   0   3     :    1b2    2a1 >    2b2    6a1 :   -0.0128964558
-        0   1 >   2   2     :    1b2    2a1 >    4b2    5a1 :    0.0125924181
+        0   1 >   1   0     :    1b2    2a1 >    3b2    3a1 :   -0.0194740671
+        0   1 >   0   0     :    1b2    2a1 >    2b2    3a1 :    0.0155446730
+        0   1 >   2   0     :    1b2    2a1 >    4b2    3a1 :    0.0129019812
+        0   1 >   0   3     :    1b2    2a1 >    2b2    6a1 :   -0.0128964547
+        0   1 >   2   2     :    1b2    2a1 >    4b2    5a1 :    0.0125924191
 
 Symmetry of excited state: B2
 Symmetry of right eigenvector: A2
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3419798651   3.42e-01    3.71e-01      N
-                     2   0.3980134634   3.98e-01    3.16e-01      N
+                     1   0.3419798597   3.42e-01    3.71e-01      N
+                     2   0.3980134724   3.98e-01    3.16e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2667551683  -7.52e-02    7.78e-02      N
-                     2   0.3376516973  -6.04e-02    6.72e-02      N
+                     1   0.2667551626  -7.52e-02    7.78e-02      N
+                     2   0.3376517060  -6.04e-02    6.72e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2628427627  -3.91e-03    2.47e-02      N
-                     2   0.3344499332  -3.20e-03    2.63e-02      N
+                     1   0.2628427570  -3.91e-03    2.47e-02      N
+                     2   0.3344499417  -3.20e-03    2.63e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2625053803  -3.37e-04    6.74e-03      N
-                     2   0.3340304458  -4.19e-04    1.42e-02      N
+                     1   0.2625053745  -3.37e-04    6.74e-03      N
+                     2   0.3340304541  -4.19e-04    1.42e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624787069  -2.67e-05    2.26e-03      N
-                     2   0.3338640297  -1.66e-04    8.74e-03      N
+                     1   0.2624787012  -2.67e-05    2.26e-03      N
+                     2   0.3338640379  -1.66e-04    8.74e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624770506  -1.66e-06    7.68e-04      N
-                     2   0.3338488413  -1.52e-05    3.81e-03      N
+                     1   0.2624770448  -1.66e-06    7.68e-04      N
+                     2   0.3338488496  -1.52e-05    3.81e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624764094  -6.41e-07    2.18e-04      N
-                     2   0.3338467387  -2.10e-06    1.12e-03      N
+                     1   0.2624764036  -6.41e-07    2.18e-04      N
+                     2   0.3338467470  -2.10e-06    1.12e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624763780  -3.14e-08    6.59e-05      N
-                     2   0.3338463345  -4.04e-07    3.43e-04      N
+                     1   0.2624763723  -3.14e-08    6.59e-05      N
+                     2   0.3338463428  -4.04e-07    3.43e-04      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624764342   5.62e-08    2.35e-05      N
-                     2   0.3338463449   1.03e-08    9.76e-05      N
+                     1   0.2624764285   5.62e-08    2.35e-05      N
+                     2   0.3338463531   1.03e-08    9.76e-05      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624764494   1.52e-08    8.00e-06      N
-                     2   0.3338463593   1.44e-08    3.09e-05      N
+                     1   0.2624764437   1.52e-08    8.00e-06      N
+                     2   0.3338463676   1.44e-08    3.09e-05      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624764506   1.23e-09    2.33e-06      N
-                     2   0.3338463827   2.34e-08    1.07e-05      N
+                     1   0.2624764449   1.23e-09    2.33e-06      N
+                     2   0.3338463910   2.34e-08    1.07e-05      N
 Iter=12   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624764501  -5.66e-10    5.54e-07      Y
-                     2   0.3338463711  -1.16e-08    3.28e-06      N
+                     1   0.2624764443  -5.66e-10    5.54e-07      Y
+                     2   0.3338463794  -1.16e-08    3.28e-06      N
 Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624764501  -2.15e-14    5.54e-07      Y
-                     2   0.3338463711  -5.75e-14    3.28e-06      N
+                     1   0.2624764443   4.24e-14    5.54e-07      Y
+                     2   0.3338463794  -9.41e-14    3.28e-06      N
 Iter=14   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624764500  -4.49e-11    5.39e-07      Y
-                     2   0.3338463706  -5.30e-10    1.03e-06      N
+                     1   0.2624764443  -4.49e-11    5.39e-07      Y
+                     2   0.3338463788  -5.30e-10    1.03e-06      N
 Iter=15   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2624764500   7.40e-12    5.43e-07      Y
-                     2   0.3338463715   9.84e-10    2.85e-07      Y
+                     1   0.2624764443   7.39e-12    5.43e-07      Y
+                     2   0.3338463798   9.84e-10    2.85e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-Energy written to CC_INFO:Etot  -38.6989012010
+Energy written to CC_INFO:Etot  -38.6989011931
 States per irrep written to CC_INFO.
-<R|R> =   1.0000000000000004
+<R|R> =   1.0000000000000002
 EOM CCSD R0 for root 0 =   0.00000000000
 <R|R> =   1.0000000000000002
 EOM CCSD R0 for root 1 =   0.00000000000
@@ -890,380 +879,373 @@ EOM CCSD R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 3      7.142    57606.9   0.2624764500   -38.770271122523
+EOM State 3      7.142    57606.9   0.2624764443   -38.770271128632
 
 Largest components of excited wave function #3:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    2b2 :    0.1255155556
-         0 >   2      :       1b1 >    4b2 :    0.0322765678
-         0 >   1      :       1b1 >    3b2 :   -0.0244052771
-         1 >   0      :       2a1 >    1a2 :   -0.0208647538
-         2 >   1      :       3a1 >    2a2 :    0.0100491576
+         0 >   0      :       1b1 >    2b2 :   -0.1255155306
+         0 >   2      :       1b1 >    4b2 :   -0.0322765642
+         0 >   1      :       1b1 >    3b2 :    0.0244052749
+         1 >   0      :       2a1 >    1a2 :    0.0208647537
+         2 >   1      :       3a1 >    2a2 :   -0.0100491579
  Ria (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    1b1 :   -0.9495539008
-         0 >   1      :       1b2 >    2b1 :   -0.1788797537
-         1 >   0      :       2a1 >    1a2 :    0.0265218468
-         0 >   3      :       1b2 >    4b1 :   -0.0062522520
-         1 >   1      :       2a1 >    2a2 :    0.0054746360
+         0 >   0      :       1b2 >    1b1 :    0.9495539055
+         0 >   1      :       1b2 >    2b1 :    0.1788797497
+         1 >   0      :       2a1 >    1a2 :   -0.0265218465
+         0 >   3      :       1b2 >    4b1 :    0.0062522521
+         1 >   1      :       2a1 >    2a2 :   -0.0054746358
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   1     :    1b1    1b2 >    2b1    2b1 :    0.0656336434
-        0   1 >   2   0     :    1b2    2a1 >    6a1    1b1 :    0.0538953722
-        2   1 >   1   0     :    3a1    2a1 >    3b2    1b1 :   -0.0470659880
-        0   0 >   1   0     :    1b2    1b2 >    3b2    1b1 :   -0.0468318313
-        0   1 >   0   0     :    1b1    2a1 >    1a2    1b1 :    0.0455415697
+        0   0 >   0   1     :    1b1    1b2 >    2b1    2b1 :   -0.0656336432
+        0   1 >   2   0     :    1b2    2a1 >    6a1    1b1 :   -0.0538953711
+        2   1 >   1   0     :    3a1    2a1 >    3b2    1b1 :    0.0470659882
+        0   0 >   1   0     :    1b2    1b2 >    3b2    1b1 :    0.0468318304
+        0   1 >   0   0     :    1b1    2a1 >    1a2    1b1 :   -0.0455415692
  RIJAB (libdpd indices)     : (cscf notation)
-        0   0 >   2   0     :    1b2    1b1 >    4b2    2b2 :    0.0051120501
-        0   2 >   2   1     :    1b1    3a1 >    4b2    5a1 :   -0.0036024537
-        0   2 >   0   2     :    1b1    3a1 >    2b2    6a1 :    0.0035357978
-        0   2 >   0   1     :    1b1    3a1 >    2b2    5a1 :    0.0032080906
-        0   0 >   5   2     :    1b2    1b1 >    9a1    6a1 :   -0.0028604177
+        0   0 >   2   0     :    1b2    1b1 >    4b2    2b2 :   -0.0051120490
+        0   2 >   2   1     :    1b1    3a1 >    4b2    5a1 :    0.0036024531
+        0   2 >   0   2     :    1b1    3a1 >    2b2    6a1 :   -0.0035357974
+        0   2 >   0   1     :    1b1    3a1 >    2b2    5a1 :   -0.0032080898
+        0   0 >   5   2     :    1b2    1b1 >    9a1    6a1 :    0.0028604174
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   0   2     :    1b2    2a1 >    1b1    5a1 :   -0.0306516241
-        0   1 >   0   3     :    1b2    2a1 >    1b1    6a1 :   -0.0244203363
-        0   1 >   0   1     :    1b2    2a1 >    1b1    4a1 :   -0.0171231334
-        0   1 >   2   0     :    1b2    2a1 >    3b1    3a1 :    0.0136651612
-        0   1 >   1   4     :    1b2    2a1 >    2b1    7a1 :   -0.0128181304
-EOM State 4      9.084    73270.8   0.3338463715   -38.698901201029
+        0   1 >   0   2     :    1b2    2a1 >    1b1    5a1 :    0.0306516242
+        0   1 >   0   3     :    1b2    2a1 >    1b1    6a1 :    0.0244203367
+        0   1 >   0   1     :    1b2    2a1 >    1b1    4a1 :    0.0171231337
+        0   1 >   2   0     :    1b2    2a1 >    3b1    3a1 :   -0.0136651615
+        0   1 >   1   4     :    1b2    2a1 >    2b1    7a1 :    0.0128181305
+EOM State 4      9.084    73270.8   0.3338463798   -38.698901193093
 
 Largest components of excited wave function #4:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    2b2 :   -0.9491250975
-         0 >   2      :       1b1 >    4b2 :   -0.1641926549
-         0 >   1      :       1b1 >    3b2 :    0.0544498488
-         0 >   5      :       1b1 >    7b2 :   -0.0091584784
-         1 >   1      :       2a1 >    2a2 :    0.0088399561
+         0 >   0      :       1b1 >    2b2 :    0.9491250992
+         0 >   2      :       1b1 >    4b2 :    0.1641926604
+         0 >   1      :       1b1 >    3b2 :   -0.0544498499
+         0 >   5      :       1b1 >    7b2 :    0.0091584795
+         1 >   1      :       2a1 >    2a2 :   -0.0088399562
  Ria (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    1b1 :   -0.1340790983
-         0 >   1      :       1b2 >    2b1 :   -0.0121828520
-         1 >   1      :       2a1 >    2a2 :   -0.0058899746
-         1 >   0      :       2a1 >    1a2 :   -0.0052000322
-         0 >   2      :       1b2 >    3b1 :    0.0031128150
+         0 >   0      :       1b2 >    1b1 :    0.1340790718
+         0 >   1      :       1b2 >    2b1 :    0.0121828458
+         1 >   1      :       2a1 >    2a2 :    0.0058899749
+         1 >   0      :       2a1 >    1a2 :    0.0052000333
+         0 >   2      :       1b2 >    3b1 :   -0.0031128149
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :   -0.0711589485
-        0   0 >   0   0     :    1b1    1b2 >    4a1    3a1 :   -0.0668599624
-        1   1 >   0   0     :    2a1    2a1 >    2b2    1b1 :   -0.0663814985
-        0   1 >   0   0     :    1b1    2a1 >    2b2    3a1 :   -0.0612059116
-        0   1 >   0   1     :    1b1    2a1 >    2b2    4a1 :   -0.0576082221
+        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :    0.0711589506
+        0   0 >   0   0     :    1b1    1b2 >    4a1    3a1 :    0.0668599676
+        1   1 >   0   0     :    2a1    2a1 >    2b2    1b1 :    0.0663814995
+        0   1 >   0   0     :    1b1    2a1 >    2b2    3a1 :    0.0612059129
+        0   1 >   0   1     :    1b1    2a1 >    2b2    4a1 :    0.0576082228
  RIJAB (libdpd indices)     : (cscf notation)
-        0   0 >   2   0     :    1b2    1b1 >    4b2    2b2 :   -0.0448324424
-        0   2 >   0   1     :    1b1    3a1 >    2b2    5a1 :   -0.0387837646
-        0   1 >   0   3     :    1b1    2a1 >    2b2    7a1 :    0.0259245283
-        0   2 >   0   2     :    1b1    3a1 >    2b2    6a1 :   -0.0252450816
-        0   1 >   0   0     :    1b1    2a1 >    2b2    4a1 :   -0.0233872888
+        0   0 >   2   0     :    1b2    1b1 >    4b2    2b2 :    0.0448324429
+        0   2 >   0   1     :    1b1    3a1 >    2b2    5a1 :    0.0387837662
+        0   1 >   0   3     :    1b1    2a1 >    2b2    7a1 :   -0.0259245284
+        0   2 >   0   2     :    1b1    3a1 >    2b2    6a1 :    0.0252450824
+        0   1 >   0   0     :    1b1    2a1 >    2b2    4a1 :    0.0233872891
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   0   2     :    1b2    2a1 >    1b1    5a1 :   -0.0055081940
-        0   1 >   0   0     :    1b2    2a1 >    1b1    3a1 :   -0.0052466192
-        0   1 >   0   1     :    1b2    2a1 >    1b1    4a1 :   -0.0034860894
-        0   1 >   0   3     :    1b2    2a1 >    1b1    6a1 :   -0.0033686577
-        0   1 >   2   0     :    1b2    2a1 >    3b1    3a1 :    0.0025005026
+        0   1 >   0   2     :    1b2    2a1 >    1b1    5a1 :    0.0055081932
+        0   1 >   0   0     :    1b2    2a1 >    1b1    3a1 :    0.0052466196
+        0   1 >   0   1     :    1b2    2a1 >    1b1    4a1 :    0.0034860889
+        0   1 >   0   3     :    1b2    2a1 >    1b1    6a1 :    0.0033686569
+        0   1 >   2   0     :    1b2    2a1 >    3b1    3a1 :   -0.0025005023
 
 	Putting into environment energy for root of R irrep 2 and root 2.
-	Putting into environment CURRENT ENERGY:              -38.6989012010
+	Putting into environment CURRENT ENERGY:              -38.6989011931
 
 Symmetry of excited state: A1
 Symmetry of right eigenvector: B1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3563872218   3.56e-01    3.07e-01      N
-                     2   0.5792368150   5.79e-01    3.68e-01      N
+                     1   0.3563872326   3.56e-01    3.07e-01      N
+                     2   0.5792368140   5.79e-01    3.68e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2910146920  -6.54e-02    7.13e-02      N
-                     2   0.4989453546  -8.03e-02    9.42e-02      N
+                     1   0.2910147025  -6.54e-02    7.13e-02      N
+                     2   0.4989453537  -8.03e-02    9.42e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2874134596  -3.60e-03    2.80e-02      N
-                     2   0.4921689968  -6.78e-03    4.07e-02      N
+                     1   0.2874134699  -3.60e-03    2.80e-02      N
+                     2   0.4921689958  -6.78e-03    4.07e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2869813373  -4.32e-04    1.30e-02      N
-                     2   0.4909521193  -1.22e-03    2.54e-02      N
+                     1   0.2869813474  -4.32e-04    1.30e-02      N
+                     2   0.4909521181  -1.22e-03    2.54e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868900475  -9.13e-05    5.40e-03      N
-                     2   0.4904818574  -4.70e-04    1.64e-02      N
+                     1   0.2868900575  -9.13e-05    5.40e-03      N
+                     2   0.4904818561  -4.70e-04    1.64e-02      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868890881  -9.59e-07    2.21e-03      N
-                     2   0.4903323874  -1.49e-04    9.28e-03      N
+                     1   0.2868890982  -9.59e-07    2.21e-03      N
+                     2   0.4903323860  -1.49e-04    9.28e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868883564  -7.32e-07    7.49e-04      N
-                     2   0.4902724314  -6.00e-05    4.86e-03      N
+                     1   0.2868883664  -7.32e-07    7.49e-04      N
+                     2   0.4902724300  -6.00e-05    4.86e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868883658   9.39e-09    2.19e-04      N
-                     2   0.4902569811  -1.55e-05    2.21e-03      N
+                     1   0.2868883758   9.39e-09    2.19e-04      N
+                     2   0.4902569798  -1.55e-05    2.21e-03      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868884748   1.09e-07    6.22e-05      N
-                     2   0.4902541362  -2.84e-06    8.95e-04      N
+                     1   0.2868884849   1.09e-07    6.22e-05      N
+                     2   0.4902541348  -2.84e-06    8.95e-04      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868885232   4.83e-08    1.89e-05      N
-                     2   0.4902535264  -6.10e-07    3.12e-04      N
+                     1   0.2868885332   4.83e-08    1.89e-05      N
+                     2   0.4902535250  -6.10e-07    3.12e-04      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868885372   1.40e-08    5.78e-06      N
-                     2   0.4902534898  -3.66e-08    1.06e-04      N
+                     1   0.2868885473   1.40e-08    5.78e-06      N
+                     2   0.4902534884  -3.66e-08    1.06e-04      N
 Iter=12   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868885349  -2.34e-09    1.39e-06      N
-                     2   0.4902534924   2.64e-09    3.34e-05      N
+                     1   0.2868885449  -2.34e-09    1.39e-06      N
+                     2   0.4902534911   2.64e-09    3.34e-05      N
 Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868885349  -2.05e-15    1.39e-06      N
-                     2   0.4902534924  -1.22e-15    3.34e-05      N
+                     1   0.2868885449   2.00e-15    1.39e-06      N
+                     2   0.4902534911   6.16e-15    3.34e-05      N
 Iter=14   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868885350   9.41e-11    3.67e-07      Y
-                     2   0.4902534810  -1.14e-08    1.42e-05      N
+                     1   0.2868885450   9.41e-11    3.67e-07      Y
+                     2   0.4902534797  -1.14e-08    1.42e-05      N
 Iter=15   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868885348  -1.74e-10    2.93e-07      Y
-                     2   0.4902534778  -3.28e-09    5.36e-06      N
+                     1   0.2868885449  -1.74e-10    2.93e-07      Y
+                     2   0.4902534764  -3.28e-09    5.36e-06      N
 Iter=16   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868885349   1.58e-10    2.94e-07      Y
-                     2   0.4902534803   2.52e-09    2.01e-06      N
+                     1   0.2868885450   1.58e-10    2.94e-07      Y
+                     2   0.4902534789   2.52e-09    2.01e-06      N
 Iter=17   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2868885349   1.10e-11    2.88e-07      Y
-                     2   0.4902534790  -1.26e-09    7.60e-07      Y
+                     1   0.2868885450   1.10e-11    2.88e-07      Y
+                     2   0.4902534777  -1.26e-09    7.60e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
 <R|R> =   1.0000000000000000
 EOM CCSD R0 for root 0 =   0.00000000000
-<R|R> =   1.0000000000000002
+<R|R> =   1.0000000000000004
 EOM CCSD R0 for root 1 =   0.00000000000
 
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 5      7.807    62964.7   0.2868885349   -38.745859037619
+EOM State 5      7.807    62964.8   0.2868885450   -38.745859027892
 
 Largest components of excited wave function #5:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    4a1 :   -0.9548481879
-         0 >   2      :       1b1 >    6a1 :   -0.0991185800
-         0 >   3      :       1b1 >    7a1 :    0.0958188555
-         0 >   1      :       1b1 >    5a1 :   -0.0183798083
-         1 >   0      :       2a1 >    2b1 :   -0.0156470053
+         0 >   0      :       1b1 >    4a1 :   -0.9548481862
+         0 >   2      :       1b1 >    6a1 :   -0.0991185781
+         0 >   3      :       1b1 >    7a1 :    0.0958188578
+         0 >   1      :       1b1 >    5a1 :   -0.0183798037
+         1 >   0      :       2a1 >    2b1 :   -0.0156470056
  Ria (libdpd indices) : (cscf notation)
-         1 >   0      :       2a1 >    1b1 :    0.0978484788
-         1 >   1      :       2a1 >    2b1 :    0.0386607819
-         0 >   0      :       1b2 >    1a2 :   -0.0128543943
-         0 >   1      :       1b2 >    2a2 :   -0.0061981238
-         1 >   3      :       2a1 >    4b1 :    0.0059846432
+         1 >   0      :       2a1 >    1b1 :    0.0978484859
+         1 >   1      :       2a1 >    2b1 :    0.0386607835
+         0 >   0      :       1b2 >    1a2 :   -0.0128543948
+         0 >   1      :       1b2 >    2a2 :   -0.0061981239
+         1 >   3      :       2a1 >    4b1 :    0.0059846433
  RIjAb (libdpd indices)     : (cscf notation)
-        0   1 >   0   0     :    1b1    2a1 >    4a1    3a1 :   -0.0885803591
-        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :   -0.0865303984
-        1   1 >   0   0     :    2a1    2a1 >    4a1    1b1 :   -0.0633762114
-        0   0 >   0   2     :    1b1    1b2 >    4a1    4b2 :   -0.0579813972
-        0   0 >   0   0     :    1b1    1b2 >    2b2    3a1 :   -0.0537343222
+        0   1 >   0   0     :    1b1    2a1 >    4a1    3a1 :   -0.0885803602
+        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :   -0.0865303997
+        1   1 >   0   0     :    2a1    2a1 >    4a1    1b1 :   -0.0633762123
+        0   0 >   0   2     :    1b1    1b2 >    4a1    4b2 :   -0.0579813981
+        0   0 >   0   0     :    1b1    1b2 >    2b2    3a1 :   -0.0537343250
  RIJAB (libdpd indices)     : (cscf notation)
-        0   2 >   1   0     :    1b1    3a1 >    5a1    4a1 :    0.0471347196
-        0   0 >   2   0     :    1b2    1b1 >    4b2    4a1 :   -0.0355791434
-        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :   -0.0341496034
-        0   1 >   3   0     :    1b1    2a1 >    7a1    4a1 :   -0.0328298501
-        0   2 >   2   0     :    1b1    3a1 >    6a1    4a1 :    0.0326945649
+        0   2 >   1   0     :    1b1    3a1 >    5a1    4a1 :    0.0471347208
+        0   0 >   2   0     :    1b2    1b1 >    4b2    4a1 :   -0.0355791442
+        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :   -0.0341496048
+        0   1 >   3   0     :    1b1    2a1 >    7a1    4a1 :   -0.0328298499
+        0   2 >   2   0     :    1b1    3a1 >    6a1    4a1 :    0.0326945655
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   0   2     :    1b2    2a1 >    1a2    5a1 :    0.0020879784
-        0   1 >   2   1     :    1b2    2a1 >    4b2    2b1 :   -0.0014525343
-        0   1 >   0   6     :    1b2    2a1 >    1a2    9a1 :   -0.0012852070
-        0   1 >   0   3     :    1b2    2a1 >    1a2    6a1 :    0.0011579807
-        0   1 >   1   2     :    1b2    2a1 >    3b2    3b1 :    0.0010960820
-EOM State 6     13.340   107598.2   0.4902534790   -38.542494093545
+        0   1 >   0   2     :    1b2    2a1 >    1a2    5a1 :    0.0020879786
+        0   1 >   2   1     :    1b2    2a1 >    4b2    2b1 :   -0.0014525344
+        0   1 >   0   6     :    1b2    2a1 >    1a2    9a1 :   -0.0012852071
+        0   1 >   0   3     :    1b2    2a1 >    1a2    6a1 :    0.0011579808
+        0   1 >   1   2     :    1b2    2a1 >    3b2    3b1 :    0.0010960821
+EOM State 6     13.340   107598.2   0.4902534777   -38.542494095244
 
 Largest components of excited wave function #6:
  RIA (libdpd indices) : (cscf notation)
-         0 >   2      :       1b1 >    6a1 :   -0.1333339907
-         0 >   0      :       1b1 >    4a1 :    0.1055910742
-         0 >   1      :       1b1 >    5a1 :    0.0982942107
-         2 >   1      :       3a1 >    3b1 :    0.0566089319
-         0 >   0      :       1b2 >    1a2 :    0.0527947723
+         0 >   2      :       1b1 >    6a1 :   -0.1333339830
+         0 >   0      :       1b1 >    4a1 :    0.1055910787
+         0 >   1      :       1b1 >    5a1 :    0.0982942113
+         2 >   1      :       3a1 >    3b1 :    0.0566089322
+         0 >   0      :       1b2 >    1a2 :    0.0527947721
  Ria (libdpd indices) : (cscf notation)
-         1 >   0      :       2a1 >    1b1 :    0.9146434632
-         1 >   1      :       2a1 >    2b1 :    0.1699579494
-         0 >   0      :       1b2 >    1a2 :   -0.0146526483
-         1 >   3      :       2a1 >    4b1 :    0.0067447471
-         0 >   1      :       1b2 >    2a2 :   -0.0025301226
+         1 >   0      :       2a1 >    1b1 :    0.9146434615
+         1 >   1      :       2a1 >    2b1 :    0.1699579448
+         0 >   0      :       1b2 >    1a2 :   -0.0146526471
+         1 >   3      :       2a1 >    4b1 :    0.0067447472
+         0 >   1      :       1b2 >    2a2 :   -0.0025301222
  RIjAb (libdpd indices)     : (cscf notation)
-        2   0 >   0   0     :    3a1    1b2 >    2b2    1b1 :   -0.1405966670
-        0   0 >   2   0     :    1b2    1b2 >    6a1    1b1 :   -0.0884482166
-        2   0 >   1   0     :    3a1    1b2 >    3b2    1b1 :    0.0878997177
-        2   0 >   2   0     :    3a1    1b2 >    4b2    1b1 :   -0.0735319039
-        0   0 >   0   0     :    1b1    1b2 >    1a2    1b1 :   -0.0609654665
+        2   0 >   0   0     :    3a1    1b2 >    2b2    1b1 :   -0.1405966810
+        0   0 >   2   0     :    1b2    1b2 >    6a1    1b1 :   -0.0884482142
+        2   0 >   1   0     :    3a1    1b2 >    3b2    1b1 :    0.0878997195
+        2   0 >   2   0     :    3a1    1b2 >    4b2    1b1 :   -0.0735319093
+        0   0 >   0   0     :    1b1    1b2 >    1a2    1b1 :   -0.0609654657
  RIJAB (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :    0.0114624014
-        0   0 >   2   0     :    1b2    1b1 >    4b2    4a1 :    0.0104189529
+        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :    0.0114624009
+        0   0 >   2   0     :    1b2    1b1 >    4b2    4a1 :    0.0104189526
         0   2 >   1   0     :    1b1    3a1 >    5a1    4a1 :   -0.0095851384
-        0   2 >   2   0     :    1b1    3a1 >    6a1    4a1 :   -0.0092236459
-        0   2 >   1   0     :    1b1    3a1 >    3b2    2b2 :    0.0057541070
+        0   2 >   2   0     :    1b1    3a1 >    6a1    4a1 :   -0.0092236460
+        0   2 >   1   0     :    1b1    3a1 >    3b2    2b2 :    0.0057541071
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   0   2     :    1b2    2a1 >    1a2    5a1 :    0.0199550222
+        0   1 >   0   2     :    1b2    2a1 >    1a2    5a1 :    0.0199550221
         0   1 >   0   1     :    1b2    2a1 >    2b2    2b1 :   -0.0184507639
-        0   1 >   2   1     :    1b2    2a1 >    4b2    2b1 :   -0.0153432909
-        0   1 >   0   3     :    1b2    2a1 >    1a2    6a1 :    0.0121714310
-        0   1 >   0   0     :    1b2    2a1 >    2b2    1b1 :   -0.0104801051
+        0   1 >   2   1     :    1b2    2a1 >    4b2    2b1 :   -0.0153432908
+        0   1 >   0   3     :    1b2    2a1 >    1a2    6a1 :    0.0121714312
+        0   1 >   0   0     :    1b2    2a1 >    2b2    1b1 :   -0.0104801049
 
 Symmetry of excited state: A2
 Symmetry of right eigenvector: B2
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2999912887   3.00e-01    3.91e-01      N
-                     2   0.4607903979   4.61e-01    2.72e-01      N
+                     1   0.2999912807   3.00e-01    3.91e-01      N
+                     2   0.4607903947   4.61e-01    2.72e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2162921662  -8.37e-02    8.81e-02      N
-                     2   0.4153372135  -4.55e-02    5.87e-02      N
+                     1   0.2162921571  -8.37e-02    8.81e-02      N
+                     2   0.4153372079  -4.55e-02    5.87e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2110767394  -5.22e-03    3.24e-02      N
-                     2   0.4120151763  -3.32e-03    3.73e-02      N
+                     1   0.2110767299  -5.22e-03    3.24e-02      N
+                     2   0.4120151705  -3.32e-03    3.73e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2104457347  -6.31e-04    1.09e-02      N
-                     2   0.4104979974  -1.52e-03    2.69e-02      N
+                     1   0.2104457251  -6.31e-04    1.09e-02      N
+                     2   0.4104979917  -1.52e-03    2.69e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103321295  -1.14e-04    5.83e-03      N
-                     2   0.4097979819  -7.00e-04    1.50e-02      N
+                     1   0.2103321198  -1.14e-04    5.83e-03      N
+                     2   0.4097979764  -7.00e-04    1.50e-02      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103122771  -1.99e-05    2.66e-03      N
-                     2   0.4096214504  -1.77e-04    8.90e-03      N
+                     1   0.2103122674  -1.99e-05    2.66e-03      N
+                     2   0.4096214450  -1.77e-04    8.90e-03      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103095005  -2.78e-06    9.22e-04      N
-                     2   0.4095715528  -4.99e-05    4.63e-03      N
+                     1   0.2103094908  -2.78e-06    9.22e-04      N
+                     2   0.4095715474  -4.99e-05    4.63e-03      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100081   5.08e-07    3.34e-04      N
-                     2   0.4095572628  -1.43e-05    2.90e-03      N
+                     1   0.2103099984   5.08e-07    3.34e-04      N
+                     2   0.4095572573  -1.43e-05    2.90e-03      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100668   5.88e-08    1.33e-04      N
-                     2   0.4095526229  -4.64e-06    1.97e-03      N
+                     1   0.2103100571   5.88e-08    1.33e-04      N
+                     2   0.4095526173  -4.64e-06    1.97e-03      N
 Iter=10   L=20    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100849   1.81e-08    5.00e-05      N
-                     2   0.4095492681  -3.35e-06    1.31e-03      N
+                     1   0.2103100752   1.81e-08    5.00e-05      N
+                     2   0.4095492626  -3.35e-06    1.31e-03      N
 Iter=11   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100827  -2.23e-09    1.66e-05      N
-                     2   0.4095462673  -3.00e-06    8.38e-04      N
+                     1   0.2103100730  -2.23e-09    1.66e-05      N
+                     2   0.4095462617  -3.00e-06    8.38e-04      N
 Iter=12   L=24    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100780  -4.71e-09    5.05e-06      N
-                     2   0.4095442123  -2.05e-06    3.88e-04      N
+                     1   0.2103100683  -4.71e-09    5.05e-06      N
+                     2   0.4095442067  -2.05e-06    3.88e-04      N
 Iter=13   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100780  -9.99e-16    5.05e-06      N
-                     2   0.4095442123  -3.00e-15    3.88e-04      N
+                     1   0.2103100683  -5.27e-16    5.05e-06      N
+                     2   0.4095442067   1.22e-15    3.88e-04      N
 Iter=14   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100789   9.27e-10    1.53e-06      N
-                     2   0.4095439137  -2.99e-07    1.48e-04      N
+                     1   0.2103100692   9.27e-10    1.53e-06      N
+                     2   0.4095439081  -2.99e-07    1.48e-04      N
 Iter=15   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100803   1.41e-09    4.66e-07      Y
-                     2   0.4095439692   5.56e-08    6.39e-05      N
+                     1   0.2103100706   1.41e-09    4.66e-07      Y
+                     2   0.4095439637   5.56e-08    6.39e-05      N
 Iter=16   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100808   4.54e-10    3.88e-07      Y
-                     2   0.4095439417  -2.75e-08    2.83e-05      N
+                     1   0.2103100710   4.54e-10    3.88e-07      Y
+                     2   0.4095439362  -2.75e-08    2.83e-05      N
 Iter=17   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100807  -4.70e-11    3.70e-07      Y
-                     2   0.4095439698   2.81e-08    1.82e-05      N
+                     1   0.2103100710  -4.70e-11    3.70e-07      Y
+                     2   0.4095439642   2.81e-08    1.82e-05      N
 Iter=18   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100805  -1.95e-10    3.38e-07      Y
-                     2   0.4095439701   2.69e-10    1.35e-05      N
+                     1   0.2103100708  -1.95e-10    3.38e-07      Y
+                     2   0.4095439645   2.69e-10    1.35e-05      N
 Iter=19   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100806   4.61e-11    3.07e-07      Y
-                     2   0.4095439601  -1.00e-08    1.04e-05      N
+                     1   0.2103100709   4.61e-11    3.07e-07      Y
+                     2   0.4095439545  -1.00e-08    1.04e-05      N
 Iter=20   L=13    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100806   2.70e-11    3.01e-07      Y
-                     2   0.4095439510  -9.10e-09    5.59e-06      N
+                     1   0.2103100709   2.70e-11    3.01e-07      Y
+                     2   0.4095439454  -9.10e-09    5.59e-06      N
 Iter=21   L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100806  -2.84e-12    3.05e-07      Y
-                     2   0.4095439414  -9.57e-09    3.47e-06      N
+                     1   0.2103100709  -2.84e-12    3.05e-07      Y
+                     2   0.4095439358  -9.57e-09    3.47e-06      N
 Iter=22   L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100805  -1.36e-10    2.85e-07      Y
-                     2   0.4095439441   2.66e-09    1.74e-06      N
+                     1   0.2103100707  -1.36e-10    2.85e-07      Y
+                     2   0.4095439385   2.66e-09    1.74e-06      N
 Iter=23   L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2103100804  -4.77e-12    2.85e-07      Y
-                     2   0.4095439460   1.93e-09    7.57e-07      Y
+                     1   0.2103100707  -4.77e-12    2.85e-07      Y
+                     2   0.4095439404   1.93e-09    7.57e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-<R|R> =   1.0000000000000000
+<R|R> =   1.0000000000000002
 EOM CCSD R0 for root 0 =   0.00000000000
-<R|R> =   1.0000000000000000
+<R|R> =   1.0000000000000002
 EOM CCSD R0 for root 1 =   0.00000000000
 
 Final Energetic Summary for Converged Roots of Irrep A2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 7      5.723    46157.7   0.2103100804   -38.822437492117
+EOM State 7      5.723    46157.7   0.2103100707   -38.822437502177
 
 Largest components of excited wave function #7:
  RIA (libdpd indices) : (cscf notation)
-         1 >   0      :       2a1 >    2b2 :   -0.0270497928
-         2 >   0      :       3a1 >    2b2 :    0.0258980720
-         0 >   0      :       1b2 >    4a1 :   -0.0252679355
-         1 >   2      :       2a1 >    4b2 :   -0.0231290017
-         1 >   1      :       2a1 >    3b2 :    0.0215582925
+         1 >   0      :       2a1 >    2b2 :    0.0270497910
+         2 >   0      :       3a1 >    2b2 :   -0.0258980687
+         0 >   0      :       1b2 >    4a1 :    0.0252679290
+         1 >   2      :       2a1 >    4b2 :    0.0231290010
+         1 >   1      :       2a1 >    3b2 :   -0.0215582923
  Ria (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    3a1 :    0.9522501321
-         0 >   3      :       1b2 >    6a1 :   -0.1210428990
-         0 >   2      :       1b2 >    5a1 :    0.0929279690
-         0 >   1      :       1b2 >    4a1 :   -0.0786138570
-         0 >   4      :       1b2 >    7a1 :   -0.0362270477
+         0 >   0      :       1b2 >    3a1 :   -0.9522501312
+         0 >   3      :       1b2 >    6a1 :    0.1210429038
+         0 >   2      :       1b2 >    5a1 :   -0.0929279681
+         0 >   1      :       1b2 >    4a1 :    0.0786138642
+         0 >   4      :       1b2 >    7a1 :    0.0362270460
  RIjAb (libdpd indices)     : (cscf notation)
-        2   0 >   4   0     :    3a1    1b2 >    8a1    3a1 :   -0.0585708467
-        0   0 >   1   0     :    1b2    1b2 >    3b2    3a1 :    0.0577149312
-        0   1 >   2   0     :    1b2    2a1 >    6a1    3a1 :   -0.0573874318
-        0   0 >   1   0     :    1b1    1b2 >    3b1    3a1 :   -0.0547692276
-        2   1 >   1   0     :    3a1    2a1 >    3b2    3a1 :    0.0466154692
+        2   0 >   4   0     :    3a1    1b2 >    8a1    3a1 :    0.0585708460
+        0   0 >   1   0     :    1b2    1b2 >    3b2    3a1 :   -0.0577149290
+        0   1 >   2   0     :    1b2    2a1 >    6a1    3a1 :    0.0573874301
+        0   0 >   1   0     :    1b1    1b2 >    3b1    3a1 :    0.0547692267
+        2   1 >   1   0     :    3a1    2a1 >    3b2    3a1 :   -0.0466154690
  RIJAB (libdpd indices)     : (cscf notation)
-        0   2 >   2   0     :    1b1    3a1 >    4b2    2b1 :    0.0013613572
-        0   2 >   2   1     :    1b2    3a1 >    4b2    3b2 :    0.0012018001
-        2   1 >   2   0     :    3a1    2a1 >    4b2    4a1 :   -0.0011935949
-        0   2 >   4   2     :    1b2    3a1 >    6b2    4b2 :    0.0011881424
-        2   1 >   2   1     :    3a1    2a1 >    4b2    5a1 :   -0.0011719228
+        0   2 >   2   0     :    1b1    3a1 >    4b2    2b1 :   -0.0013613571
+        0   2 >   2   1     :    1b2    3a1 >    4b2    3b2 :   -0.0012018001
+        2   1 >   2   0     :    3a1    2a1 >    4b2    4a1 :    0.0011935951
+        0   2 >   4   2     :    1b2    3a1 >    6b2    4b2 :   -0.0011881424
+        2   1 >   2   1     :    3a1    2a1 >    4b2    5a1 :    0.0011719228
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   5   0     :    1b2    2a1 >    8a1    3a1 :    0.0250649410
-        0   1 >   2   0     :    1b2    2a1 >    5a1    3a1 :   -0.0214818268
-        0   1 >   3   0     :    1b2    2a1 >    6a1    3a1 :   -0.0184735330
-        0   1 >   1   0     :    1b2    2a1 >    4a1    3a1 :   -0.0143986092
-        0   1 >   2   0     :    1b2    2a1 >    3b1    1b1 :   -0.0124644975
-EOM State 8     11.144    89884.5   0.4095439460   -38.623203626572
+        0   1 >   5   0     :    1b2    2a1 >    8a1    3a1 :   -0.0250649411
+        0   1 >   2   0     :    1b2    2a1 >    5a1    3a1 :    0.0214818266
+        0   1 >   3   0     :    1b2    2a1 >    6a1    3a1 :    0.0184735334
+        0   1 >   1   0     :    1b2    2a1 >    4a1    3a1 :    0.0143986095
+        0   1 >   2   0     :    1b2    2a1 >    3b1    1b1 :    0.0124644976
+EOM State 8     11.144    89884.5   0.4095439404   -38.623203632501
 
 Largest components of excited wave function #8:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    2b2 :    0.6886059811
-         0 >   0      :       1b2 >    4a1 :    0.3662962638
-         2 >   2      :       3a1 >    4b2 :    0.1152413503
-         0 >   3      :       1b2 >    7a1 :   -0.0507556834
-         1 >   0      :       2a1 >    2b2 :    0.0447434118
+         2 >   0      :       3a1 >    2b2 :   -0.6886062162
+         0 >   0      :       1b2 >    4a1 :   -0.3662960574
+         2 >   2      :       3a1 >    4b2 :   -0.1152413876
+         0 >   3      :       1b2 >    7a1 :    0.0507556616
+         1 >   0      :       2a1 >    2b2 :   -0.0447433761
  Ria (libdpd indices) : (cscf notation)
-         0 >   1      :       1b2 >    4a1 :   -0.5368555769
-         0 >   3      :       1b2 >    6a1 :   -0.1030590973
-         1 >   0      :       2a1 >    2b2 :   -0.0641013844
-         0 >   0      :       1b2 >    3a1 :   -0.0574243198
-         0 >   4      :       1b2 >    7a1 :    0.0571512067
+         0 >   1      :       1b2 >    4a1 :    0.5368554529
+         0 >   3      :       1b2 >    6a1 :    0.1030590812
+         1 >   0      :       2a1 >    2b2 :    0.0641013542
+         0 >   0      :       1b2 >    3a1 :    0.0574243241
+         0 >   4      :       1b2 >    7a1 :   -0.0571511906
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b2 >    4a1    1b1 :    0.1122339198
-        2   0 >   0   0     :    3a1    1b2 >    4a1    3a1 :   -0.0697829843
-        2   1 >   0   1     :    3a1    2a1 >    2b2    4a1 :    0.0508124206
-        0   0 >   0   0     :    1b2    1b2 >    2b2    3a1 :   -0.0458478468
-        1   1 >   0   0     :    2a1    2a1 >    2b2    3a1 :   -0.0433389834
+        0   0 >   0   0     :    1b1    1b2 >    4a1    1b1 :   -0.1122338345
+        2   0 >   0   0     :    3a1    1b2 >    4a1    3a1 :    0.0697828787
+        2   1 >   0   1     :    3a1    2a1 >    2b2    4a1 :   -0.0508124216
+        0   0 >   0   0     :    1b2    1b2 >    2b2    3a1 :    0.0458478630
+        1   1 >   0   0     :    2a1    2a1 >    2b2    3a1 :    0.0433390070
  RIJAB (libdpd indices)     : (cscf notation)
-        0   2 >   0   0     :    1b1    3a1 >    2b2    2b1 :   -0.0393495216
-        0   2 >   2   0     :    1b2    3a1 >    4b2    2b2 :    0.0337922113
-        0   0 >   0   0     :    1b2    1b1 >    2b1    4a1 :   -0.0225448526
-        0   2 >   1   0     :    1b2    3a1 >    5a1    4a1 :   -0.0217370336
-        2   1 >   2   0     :    3a1    2a1 >    4b2    4a1 :   -0.0181951623
+        0   2 >   0   0     :    1b1    3a1 >    2b2    2b1 :    0.0393495330
+        0   2 >   2   0     :    1b2    3a1 >    4b2    2b2 :   -0.0337922234
+        0   0 >   0   0     :    1b2    1b1 >    2b1    4a1 :    0.0225448402
+        0   2 >   1   0     :    1b2    3a1 >    5a1    4a1 :    0.0217370273
+        2   1 >   2   0     :    3a1    2a1 >    4b2    4a1 :    0.0181951609
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   3   1     :    1b2    2a1 >    6a1    4a1 :    0.0168912836
-        0   1 >   4   1     :    1b2    2a1 >    7a1    4a1 :   -0.0111351945
-        0   1 >   2   1     :    1b2    2a1 >    5a1    4a1 :    0.0108644328
-        0   1 >   1   0     :    1b2    2a1 >    2b1    1b1 :    0.0079983089
-        0   1 >   3   0     :    1b2    2a1 >    6a1    3a1 :   -0.0071044374
+        0   1 >   3   1     :    1b2    2a1 >    6a1    4a1 :   -0.0168912798
+        0   1 >   4   1     :    1b2    2a1 >    7a1    4a1 :    0.0111351922
+        0   1 >   2   1     :    1b2    2a1 >    5a1    4a1 :   -0.0108644302
+        0   1 >   1   0     :    1b2    2a1 >    2b1    1b1 :   -0.0079983064
+        0   1 >   3   0     :    1b2    2a1 >    6a1    3a1 :    0.0071044345
 
 	Total # of sigma evaluations: 131
+    SCF energy............................................................................PASSED
+    CCSD energy...........................................................................PASSED
+    EOM-CCSD root 1 (B1)..................................................................PASSED
+    EOM-CCSD root 2 (B1)..................................................................PASSED
+    EOM-CCSD root 0 (B2)..................................................................PASSED
+    EOM-CCSD root 1 (B2)..................................................................PASSED
+    EOM-CCSD root 0 (A1)..................................................................PASSED
+    EOM-CCSD root 1 (A1)..................................................................PASSED
+    EOM-CCSD root 0 (A2)..................................................................PASSED
+    EOM-CCSD root 1 (A2)..................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:18 2017
-Module time:
-	user time   =       1.19 seconds =       0.02 minutes
-	system time =       1.04 seconds =       0.02 minutes
-	total time  =          2 seconds =       0.03 minutes
-Total time:
-	user time   =       1.64 seconds =       0.03 minutes
-	system time =       1.43 seconds =       0.02 minutes
-	total time  =          3 seconds =       0.05 minutes
-	SCF energy........................................................PASSED
-	CCSD energy.......................................................PASSED
-	EOM-CCSD root 1...................................................PASSED
-	EOM-CCSD root 2...................................................PASSED
-	EOM-CCSD root 3...................................................PASSED
-	EOM-CCSD root 4...................................................PASSED
-	EOM-CCSD root 5...................................................PASSED
-	EOM-CCSD root 6...................................................PASSED
-	EOM-CCSD root 7...................................................PASSED
-	EOM-CCSD root 8...................................................PASSED
+    Psi4 stopped on: Monday, 14 March 2022 01:16PM
+    Psi4 wall time for execution: 0:00:12.28
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc21/CMakeLists.txt
+++ b/tests/cc21/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc21 "psi;cc;cart;noc1")
+add_regression_test(cc21 "psi;cc;cart;noc1;eom")

--- a/tests/cc22/CMakeLists.txt
+++ b/tests/cc22/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc22 "psi;cc;noc1")
+add_regression_test(cc22 "psi;cc;noc1;eom")

--- a/tests/cc22/input.dat
+++ b/tests/cc22/input.dat
@@ -19,10 +19,10 @@ energy('eom-ccsd')
 
 escf = -38.904170464925                                                    #TEST
 eccsd = -38.98782404003                                                    #TEST
-eeom_ccsd = [ -38.7169665265, -38.6330680540]                              #TEST
+eeom_ccsd = [ (-38.7169665265, "B2", 0), (-38.6330680540, "A1", 0)]                              #TEST
 compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy")        #TEST
 compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy")     #TEST
-for root in range(1,3):                                                    #TEST
-    ref = eeom_ccsd[root-1]                                                #TEST
-    val = variable("CC ROOT %d TOTAL ENERGY" % root)                       #TEST
-    compare_values(ref, val, 7, "EOM-CCSD root %d" % root)                 #TEST
+for (ref, h, i) in eeom_ccsd: # TEST
+    val = variable(f"CCSD ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CCSD root {i} ({h})")                                #TEST
+

--- a/tests/cc22/output.ref
+++ b/tests/cc22/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 undefined 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {eom_var} 5b439ed dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 March 2022 01:18PM
 
-    Process ID:  12585
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 23948
+    Host:       dhcp189-157.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -49,30 +62,33 @@ energy('eom-ccsd')
 
 escf = -38.904170464925                                                    #TEST
 eccsd = -38.98782404003                                                    #TEST
-eeom_ccsd = [ -38.7169665265, -38.6330680540]                              #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
-compare_values(eccsd, get_variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
-for root in range(1,3):                                                    #TEST
-    ref = eeom_ccsd[root-1]                                                #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root)                   #TEST
-    compare_values(ref, val, 7, "EOM-CCSD root %d" % root)                 #TEST
+eeom_ccsd = [ (-38.7169665265, "B2", 0), (-38.6330680540, "A1", 0)]                              #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy")        #TEST
+compare_values(eccsd, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy")     #TEST
+for (ref, h, i) in eeom_ccsd: # TEST
+    val = variable(f"CCSD ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CCSD root {i} ({h})")                                #TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:19 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:18:13 2022
 
    => Loading Basis Set <=
 
     Name: DZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry C          line    62 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/dz.gbs 
-    atoms 2-3 entry H          line    11 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/dz.gbs 
+    atoms 1   entry C          line    63 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/dz.gbs 
+    atoms 2-3 entry H          line    12 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/dz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              ROHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -86,15 +102,15 @@ for root in range(1,3):                                                    #TEST
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.091864689759    12.000000000000
-           H          0.000000000000    -0.895527070192     0.546908561523     1.007825032070
-           H          0.000000000000     0.895527070192     0.546908561523     1.007825032070
+         C            0.000000000000     0.000000000000    -0.091864689772    12.000000000000
+         H            0.000000000000    -0.895527070192     0.546908561510     1.007825032230
+         H            0.000000000000     0.895527070192     0.546908561510     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     23.93977  B =     10.42855  C =      7.26416 [cm^-1]
-  Rotational constants: A = 717696.14844  B = 312640.05804  C = 217774.12469 [MHz]
-  Nuclear repulsion =    6.068298005568229
+  Rotational constants: A = 717696.15382  B = 312640.06037  C = 217774.12632 [MHz]
+  Nuclear repulsion =    6.068298029420463
 
   Charge       = 0
   Multiplicity = 3
@@ -108,33 +124,20 @@ for root in range(1,3):                                                    #TEST
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: DZ
     Blend: DZ
     Number of shells: 10
-    Number of basis function: 14
+    Number of basis functions: 14
     Number of Cartesian functions: 14
     Spherical Harmonics?: false
     Max angular momentum: 1
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1         8       8       0       0       0       0
-     A2         0       0       0       0       0       0
-     B1         2       2       0       0       0       0
-     B2         4       4       0       0       0       0
-   -------------------------------------------------------
-    Total      14      14       5       3       3       2
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -153,40 +156,57 @@ for root in range(1,3):                                                    #TEST
   Using 11130 doubles for integral storage.
   We computed 1540 shell quartets total.
   Whereas there are 1540 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.0064706453E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 2.6849032766E-02.
+  Reciprocal condition number of the overlap matrix is 8.3055087158E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1         8       8 
+     A2         0       0 
+     B1         2       2 
+     B2         4       4 
+   -------------------------
+    Total      14      14
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @ROHF iter   1:   -38.61371387474159   -3.86137e+01   1.05696e-01 
-   @ROHF iter   2:   -38.87149268427513   -2.57779e-01   1.87542e-02 DIIS
-   @ROHF iter   3:   -38.90065488897006   -2.91622e-02   5.48786e-03 DIIS
-   @ROHF iter   4:   -38.90391234068094   -3.25745e-03   1.16416e-03 DIIS
-   @ROHF iter   5:   -38.90416648426562   -2.54144e-04   1.47430e-04 DIIS
-   @ROHF iter   6:   -38.90417036669442   -3.88243e-06   2.42874e-05 DIIS
-   @ROHF iter   7:   -38.90417045966353   -9.29691e-08   2.80202e-06 DIIS
-   @ROHF iter   8:   -38.90417046106608   -1.40255e-09   3.46349e-07 DIIS
-   @ROHF iter   9:   -38.90417046108047   -1.43885e-11   4.08294e-08 DIIS
-   @ROHF iter  10:   -38.90417046108076   -2.91323e-13   1.05546e-08 DIIS
-   @ROHF iter  11:   -38.90417046108078   -2.13163e-14   9.42136e-10 DIIS
+   @ROHF iter SAD:   -38.17476595904144   -3.81748e+01   0.00000e+00 
+   @ROHF iter   1:   -38.89577837591752   -7.21012e-01   7.88905e-03 DIIS
+   @ROHF iter   2:   -38.90381097251344   -8.03260e-03   1.48773e-03 DIIS
+   @ROHF iter   3:   -38.90415467597414   -3.43703e-04   2.75959e-04 DIIS
+   @ROHF iter   4:   -38.90416931006182   -1.46341e-05   8.96343e-05 DIIS
+   @ROHF iter   5:   -38.90417041792739   -1.10787e-06   1.68987e-05 DIIS
+   @ROHF iter   6:   -38.90417046032998   -4.24026e-08   2.25186e-06 DIIS
+   @ROHF iter   7:   -38.90417046126419   -9.34207e-10   2.65725e-07 DIIS
+   @ROHF iter   8:   -38.90417046127855   -1.43601e-11   3.35746e-08 DIIS
+   @ROHF iter   9:   -38.90417046127875   -2.06057e-13   5.70412e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -207,48 +227,43 @@ for root in range(1,3):                                                    #TEST
     DOCC [     2,    0,    0,    1 ]
     SOCC [     1,    0,    1,    0 ]
 
-  Energy converged.
-
-  @ROHF Final Energy:   -38.90417046108078
+  @ROHF Final Energy:   -38.90417046127875
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              6.0682980055682290
-    One-Electron Energy =                 -63.6729473764743901
-    Two-Electron Energy =                  18.7004789098253781
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -38.9041704610807813
+    Nuclear Repulsion Energy =              6.0682980294204629
+    One-Electron Energy =                 -63.6729473713914160
+    Two-Electron Energy =                  18.7004788806921987
+    Total Energy =                        -38.9041704612787527
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     1.0254
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.7367
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.2887     Total:     0.2887
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:     0.7338     Total:     0.7338
 
 
-*** tstop() called on psinet at Mon May 15 15:34:19 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:18:13 2022
 Module time:
-	user time   =       0.15 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.41 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.15 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.41 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -263,7 +278,7 @@ Total time:
       Number of basis functions:        14
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [   8    0    2    4 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
@@ -274,8 +289,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:19 2017
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:18:13 2022
 
 
 	Wfn Parameters:
@@ -300,7 +315,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -356,37 +371,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.002 (MB)
 	Total:                                     0.001 (MW) /      0.007 (MB)
 
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -38.90417046108078
-	One-electron energy          =    -63.67294737997355
-	Two-electron (AA) energy     =      5.29703917530608
-	Two-electron (BB) energy     =      1.68217078835154
-	Two-electron (AB) energy     =     11.72126894966686
-	Two-electron energy          =    -44.97246846664906
-	Reference energy             =    -38.90417046108083
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -38.90417046127875
+	One-electron energy          =    -63.67294742768424
+	Two-electron (AA) energy     =      5.29703918184860
+	Two-electron (BB) energy     =      1.68217079209002
+	Two-electron (AB) energy     =     11.72126896304644
+	Two-electron energy          =    -44.97246849069918
+	Reference energy             =    -38.90417046127872
 
-*** tstop() called on psinet at Mon May 15 15:34:20 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:18:14 2022
 Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:20 2017
-
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    6.068298005568229
-    SCF energy          (wfn)     =  -38.904170461080781
-    Reference energy    (file100) =  -38.904170461080831
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -38.904170461278753
+    Reference energy    (file100) =  -38.904170461278717
 
     Input parameters:
     -----------------
@@ -418,104 +429,91 @@ Total time:
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.065873755453066    0.000e+00    0.000270    0.000758    0.000758    0.000000
-     1        -0.078131347283700    4.045e-02    0.002891    0.003759    0.005316    0.000000
-     2        -0.083280713640721    1.690e-02    0.004908    0.006709    0.009488    0.000000
-     3        -0.083554838525495    4.737e-03    0.005374    0.007810    0.011044    0.000000
-     4        -0.083654810668411    1.661e-03    0.005450    0.008247    0.011663    0.000000
-     5        -0.083642547136538    4.698e-04    0.005446    0.008290    0.011724    0.000000
-     6        -0.083654719998586    1.170e-04    0.005445    0.008280    0.011710    0.000000
-     7        -0.083653519052742    3.225e-05    0.005442    0.008272    0.011698    0.000000
-     8        -0.083653476635563    9.467e-06    0.005442    0.008271    0.011696    0.000000
-     9        -0.083653578435206    2.409e-06    0.005442    0.008271    0.011696    0.000000
-    10        -0.083653598588872    7.748e-07    0.005442    0.008271    0.011696    0.000000
-    11        -0.083653579268708    2.287e-07    0.005442    0.008271    0.011697    0.000000
-    12        -0.083653580373768    6.053e-08    0.005442    0.008271    0.011697    0.000000
+     0        -0.065873755399058    0.000e+00    0.000270    0.000758    0.000758    0.000000
+     1        -0.078131347022983    4.045e-02    0.002891    0.003759    0.005316    0.000000
+     2        -0.083280713178429    1.690e-02    0.004908    0.006709    0.009488    0.000000
+     3        -0.083554838045047    4.737e-03    0.005374    0.007810    0.011044    0.000000
+     4        -0.083654810191373    1.661e-03    0.005450    0.008247    0.011663    0.000000
+     5        -0.083642546663858    4.698e-04    0.005446    0.008290    0.011724    0.000000
+     6        -0.083654719523155    1.170e-04    0.005445    0.008280    0.011710    0.000000
+     7        -0.083653518577526    3.225e-05    0.005442    0.008272    0.011698    0.000000
+     8        -0.083653476160436    9.467e-06    0.005442    0.008271    0.011696    0.000000
+     9        -0.083653577960053    2.409e-06    0.005442    0.008271    0.011696    0.000000
+    10        -0.083653598113708    7.748e-07    0.005442    0.008271    0.011696    0.000000
+    11        -0.083653578793548    2.287e-07    0.005442    0.008271    0.011696    0.000000
+    12        -0.083653579898608    6.053e-08    0.005442    0.008271    0.011697    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              4   9         0.0252900081
-              1   0         0.0243498376
-              4   8         0.0174030190
-              2   0        -0.0149389738
-              3   6        -0.0114688706
-              1   3         0.0098895239
-              4  10         0.0090861964
-              2   1         0.0059691312
-              1   2         0.0035883003
-              2   3        -0.0033869653
+              4   9         0.0252900248
+              1   0         0.0243498306
+              4   8         0.0174030299
+              2   0        -0.0149389508
+              3   6        -0.0114688607
+              1   3         0.0098895210
+              4  10         0.0090862003
+              2   1         0.0059691477
+              1   2         0.0035882968
+              2   3        -0.0033869622
 
     Largest Tia Amplitudes:
-              1   0        -0.0303883842
-              4   9        -0.0202359576
-              4   8        -0.0187763109
-              1   3        -0.0100085634
+              1   0        -0.0303883879
+              4   9        -0.0202359447
+              4   8        -0.0187763050
+              1   3        -0.0100085665
               4  10        -0.0092189533
-              1   2         0.0043019184
-              1   5         0.0020855795
-              1   1         0.0019966703
-              0   0         0.0004166232
-              1   4         0.0003819883
+              1   2         0.0043019130
+              1   5         0.0020855447
+              1   1         0.0019966667
+              0   0         0.0004166231
+              1   4         0.0003819882
 
     Largest TIJAB Amplitudes:
-      4   3   9   6        -0.0325575848
-      3   2   6   1         0.0325491326
-      4   2   9   1         0.0248576284
-      3   2   6   2        -0.0195504099
-      3   1   6   1        -0.0154641512
-      2   1   2   1        -0.0143894230
-      3   1   6   0        -0.0133008606
-      2   1   1   0         0.0118816686
-      4   1   9   1        -0.0111909138
-      3   1   6   2        -0.0111430856
+      4   3   9   6        -0.0325575844
+      3   2   6   1         0.0325491322
+      4   2   9   1         0.0248576288
+      3   2   6   2        -0.0195504101
+      3   1   6   1        -0.0154641514
+      2   1   2   1        -0.0143894232
+      3   1   6   0        -0.0133008605
+      2   1   1   0         0.0118816685
+      4   1   9   1        -0.0111909139
+      3   1   6   2        -0.0111430851
 
     Largest Tijab Amplitudes:
-      4   1   8   5        -0.0113661102
-      4   1   9   0        -0.0096234970
-      4   1   9   1        -0.0087835022
-      4   1   9   3        -0.0064833767
-      4   1  10   5        -0.0060494043
-      4   1   9   2        -0.0054449317
-      4   1   9   5        -0.0035740291
-      4   1   8   0         0.0032106817
-      4   1   8   2        -0.0020034670
-      4   1  10   2        -0.0019871982
+      4   1   8   5        -0.0113661092
+      4   1   9   0        -0.0096234964
+      4   1   9   1        -0.0087835028
+      4   1   9   3        -0.0064833762
+      4   1  10   5        -0.0060494039
+      4   1   9   2        -0.0054449315
+      4   1   9   5        -0.0035740283
+      4   1   8   0         0.0032106821
+      4   1   8   2        -0.0020034672
+      4   1  10   2        -0.0019871984
 
     Largest TIjAb Amplitudes:
-      4   4   9   9        -0.0489818135
-      3   1   0   7        -0.0445064490
-      3   4   6   9        -0.0404118908
-      2   4   1   9         0.0315749942
-      4   4   0   0        -0.0282307310
-      4   1   8   5        -0.0270361325
-      4   1   9   0        -0.0266466694
-      3   1   6   0        -0.0263754957
-      4   4   8   8        -0.0259655423
-      1   4   0   9        -0.0247841031
+      4   4   9   9        -0.0489818139
+      3   1   0   7        -0.0445064476
+      3   4   6   9        -0.0404118903
+      2   4   1   9         0.0315749944
+      4   4   0   0        -0.0282307287
+      4   1   8   5        -0.0270361305
+      4   1   9   0        -0.0266466692
+      3   1   6   0        -0.0263754950
+      4   4   8   8        -0.0259655420
+      1   4   0   9        -0.0247841028
 
-    SCF energy       (wfn)                    =  -38.904170461080781
-    Reference energy (file100)                =  -38.904170461080831
+    SCF energy       (wfn)                    =  -38.904170461278753
+    Reference energy (file100)                =  -38.904170461278717
 
-    Opposite-spin CCSD correlation energy     =   -0.070688993528840
-    Same-spin CCSD correlation energy         =   -0.010590940946784
-    CCSD correlation energy                   =   -0.083653580373768
-      * CCSD total energy                     =  -38.987824041454601
-
-
-*** tstop() called on psinet at Mon May 15 15:34:20 2017
-Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.31 seconds =       0.01 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:20 2017
+    Opposite-spin CCSD correlation energy     =   -0.070688993113373
+    Same-spin CCSD correlation energy         =   -0.010590940858701
+    Singles CCSD correlation energy           =   -0.002373645926534
+    CCSD correlation energy                   =   -0.083653579898608
+      * CCSD total energy                     =  -38.987824041177326
 
 
 			**************************
@@ -525,28 +523,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:20 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.32 seconds =       0.01 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:20 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    6.068298005568229
-	SCF energy          (wfn)     =  -38.904170461080781
-	Reference energy    (file100) =  -38.904170461080831
-	CCSD energy         (file100) =   -0.083653580373768
+	Nuclear Rep. energy (wfn)     =    6.068298029420463
+	SCF energy          (wfn)     =  -38.904170461278753
+	Reference energy    (file100) =  -38.904170461278717
+	CCSD energy         (file100) =   -0.083653579898608
 
 	Input parameters:
 	-----------------
@@ -579,47 +563,55 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total 1145.9367859715
+Fmi   dot Fmi   total  256.9060272187
+Fme   dot Fme   total    0.0026987997
+WMBIJ dot WMBIJ total    0.7283563709
+Wmbij dot Wmbij total    0.2629190557
+WMbIj dot WMbIj total    1.4618399539
+WmBiJ dot WmBiJ total    1.5692806626
 Symmetry of ground state: B1
 Symmetry of excited state: B2
 Symmetry of right eigenvector: A2
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=1     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3167121056   3.17e-01    2.46e-01      N
+                     1   0.3167121110   3.17e-01    2.46e-01      N
 Iter=2    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2723849772  -4.43e-02    5.84e-02      N
+                     1   0.2723849831  -4.43e-02    5.84e-02      N
 Iter=3    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2710159175  -1.37e-03    2.70e-02      N
+                     1   0.2710159237  -1.37e-03    2.70e-02      N
 Iter=4    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2709170530  -9.89e-05    1.23e-02      N
+                     1   0.2709170592  -9.89e-05    1.23e-02      N
 Iter=5    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708669242  -5.01e-05    3.62e-03      N
+                     1   0.2708669304  -5.01e-05    3.62e-03      N
 Iter=6    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708602521  -6.67e-06    1.46e-03      N
+                     1   0.2708602583  -6.67e-06    1.46e-03      N
 Iter=7    L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708592205  -1.03e-06    6.90e-04      N
+                     1   0.2708592267  -1.03e-06    6.90e-04      N
 Iter=8    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708576170  -1.60e-06    2.98e-04      N
+                     1   0.2708576231  -1.60e-06    2.98e-04      N
 Iter=9    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708571171  -5.00e-07    1.37e-04      N
+                     1   0.2708571233  -5.00e-07    1.37e-04      N
 Iter=10   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708573378   2.21e-07    5.55e-05      N
+                     1   0.2708573440   2.21e-07    5.55e-05      N
 Iter=11   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708574425   1.05e-07    2.37e-05      N
+                     1   0.2708574487   1.05e-07    2.37e-05      N
 Iter=12   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708574900   4.75e-08    1.10e-05      N
+                     1   0.2708574962   4.75e-08    1.10e-05      N
 Iter=13   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708574900  -1.04e-14    1.10e-05      N
+                     1   0.2708574962   2.69e-14    1.10e-05      N
 Iter=14   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708575099   1.99e-08    3.64e-06      N
+                     1   0.2708575161   1.99e-08    3.64e-06      N
 Iter=15   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708575038  -6.05e-09    1.52e-06      N
+                     1   0.2708575100  -6.05e-09    1.52e-06      N
 Iter=16   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2708574993  -4.56e-09    5.37e-07      Y
+                     1   0.2708575054  -4.56e-09    5.37e-07      Y
 Collapsing to only 1 vector(s).
 
 Procedure converged for 1 root(s).
-Energy written to CC_INFO:Etot  -38.7169665422
+Energy written to CC_INFO:Etot  -38.7169665357
 States per irrep written to CC_INFO.
 <R|R> =   1.0000000000000002
 EOM CCSD R0 for root 0 =   0.00000000000
@@ -627,77 +619,77 @@ EOM CCSD R0 for root 0 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      7.370    59446.3   0.2708574993   -38.716966542176
+EOM State 1      7.370    59446.4   0.2708575054   -38.716966535729
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    2b2 :   -0.0700516440
-         0 >   1      :       1b1 >    3b2 :   -0.0451382932
-         0 >   2      :       1b1 >    4b2 :   -0.0177370259
-         0 >   0      :       1b2 >    2b1 :   -0.0130477606
+         0 >   0      :       1b1 >    2b2 :   -0.0700516429
+         0 >   1      :       1b1 >    3b2 :   -0.0451382946
+         0 >   2      :       1b1 >    4b2 :   -0.0177370261
+         0 >   0      :       1b2 >    2b1 :   -0.0130477619
  Ria (libdpd indices) : (cscf notation)
          0 >   1      :       1b2 >    1b1 :    0.9672621999
-         0 >   0      :       1b2 >    2b1 :   -0.1099287684
+         0 >   0      :       1b2 >    2b1 :   -0.1099287715
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b2 >    2b1    2b1 :   -0.0719095807
-        0   0 >   0   1     :    1b2    1b2 >    2b2    1b1 :   -0.0605359866
-        2   1 >   0   1     :    3a1    2a1 >    2b2    1b1 :    0.0567642362
-        0   0 >   0   1     :    1b1    1b2 >    2b1    1b1 :   -0.0488377728
-        0   0 >   2   1     :    1b2    1b2 >    4b2    1b1 :   -0.0477219252
+        0   0 >   0   0     :    1b1    1b2 >    2b1    2b1 :   -0.0719095802
+        0   0 >   0   1     :    1b2    1b2 >    2b2    1b1 :   -0.0605359846
+        2   1 >   0   1     :    3a1    2a1 >    2b2    1b1 :    0.0567642377
+        0   0 >   0   1     :    1b1    1b2 >    2b1    1b1 :   -0.0488377700
+        0   0 >   2   1     :    1b2    1b2 >    4b2    1b1 :   -0.0477219238
  RIJAB (libdpd indices)     : (cscf notation)
-        0   0 >   1   0     :    1b2    1b1 >    3b2    2b2 :   -0.0030995245
-        0   2 >   0   1     :    1b1    3a1 >    2b2    5a1 :    0.0027008858
+        0   0 >   1   0     :    1b2    1b1 >    3b2    2b2 :   -0.0030995244
+        0   2 >   0   1     :    1b1    3a1 >    2b2    5a1 :    0.0027008860
         2   1 >   0   0     :    3a1    2a1 >    2b2    2b1 :   -0.0023758865
-        0   2 >   0   2     :    1b1    3a1 >    2b2    6a1 :   -0.0023013795
-        0   1 >   0   0     :    1b1    2a1 >    2b2    4a1 :   -0.0021040713
+        0   2 >   0   2     :    1b1    3a1 >    2b2    6a1 :   -0.0023013796
+        0   1 >   0   0     :    1b1    2a1 >    2b2    4a1 :   -0.0021040714
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   1   0     :    1b2    2a1 >    1b1    4a1 :    0.0397618497
-        0   1 >   1   2     :    1b2    2a1 >    1b1    6a1 :   -0.0238964463
-        0   1 >   1   3     :    1b2    2a1 >    1b1    7a1 :    0.0186633707
-        0   1 >   0   1     :    1b2    2a1 >    2b1    5a1 :   -0.0132258616
+        0   1 >   1   0     :    1b2    2a1 >    1b1    4a1 :    0.0397618483
+        0   1 >   1   2     :    1b2    2a1 >    1b1    6a1 :   -0.0238964462
+        0   1 >   1   3     :    1b2    2a1 >    1b1    7a1 :    0.0186633704
+        0   1 >   0   1     :    1b2    2a1 >    2b1    5a1 :   -0.0132258624
         0   1 >   0   0     :    1b2    2a1 >    2b1    4a1 :   -0.0132084534
 
 	Putting into environment energy for root of R irrep 2 and root 1.
-	Putting into environment CURRENT ENERGY:              -38.7169665422
+	Putting into environment CURRENT ENERGY:              -38.7169665357
 
 Symmetry of excited state: A1
 Symmetry of right eigenvector: B1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=1     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4071467023   4.07e-01    2.72e-01      N
+                     1   0.4071467131   4.07e-01    2.72e-01      N
 Iter=2    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3583322351  -4.88e-02    8.47e-02      N
+                     1   0.3583322471  -4.88e-02    8.47e-02      N
 Iter=3    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3553632582  -2.97e-03    4.11e-02      N
+                     1   0.3553632710  -2.97e-03    4.11e-02      N
 Iter=4    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3550348215  -3.28e-04    2.52e-02      N
+                     1   0.3550348347  -3.28e-04    2.52e-02      N
 Iter=5    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3548626578  -1.72e-04    1.26e-02      N
+                     1   0.3548626711  -1.72e-04    1.26e-02      N
 Iter=6    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547750059  -8.77e-05    4.85e-03      N
+                     1   0.3547750191  -8.77e-05    4.85e-03      N
 Iter=7    L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547576157  -1.74e-05    2.19e-03      N
+                     1   0.3547576290  -1.74e-05    2.19e-03      N
 Iter=8    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547553954  -2.22e-06    8.83e-04      N
+                     1   0.3547554086  -2.22e-06    8.83e-04      N
 Iter=9    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547547144  -6.81e-07    3.93e-04      N
+                     1   0.3547547277  -6.81e-07    3.93e-04      N
 Iter=10   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547556027   8.88e-07    1.85e-04      N
+                     1   0.3547556160   8.88e-07    1.85e-04      N
 Iter=11   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547558495   2.47e-07    5.98e-05      N
+                     1   0.3547558628   2.47e-07    5.98e-05      N
 Iter=12   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547558780   2.85e-08    2.08e-05      N
+                     1   0.3547558913   2.85e-08    2.08e-05      N
 Iter=13   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547558780   2.33e-15    2.08e-05      N
+                     1   0.3547558913   2.39e-15    2.08e-05      N
 Iter=14   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547559400   6.20e-08    7.93e-06      N
+                     1   0.3547559533   6.20e-08    7.93e-06      N
 Iter=15   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547559593   1.93e-08    3.19e-06      N
+                     1   0.3547559726   1.93e-08    3.19e-06      N
 Iter=16   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547559526  -6.71e-09    1.37e-06      N
+                     1   0.3547559659  -6.71e-09    1.37e-06      N
 Iter=17   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3547559485  -4.15e-09    6.01e-07      Y
+                     1   0.3547559617  -4.15e-09    6.01e-07      Y
 Collapsing to only 1 vector(s).
 
 Procedure converged for 1 root(s).
@@ -707,53 +699,46 @@ EOM CCSD R0 for root 0 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 2      9.653    77859.9   0.3547559485   -38.633068092986
+EOM State 2      9.653    77859.9   0.3547559617   -38.633068079434
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    4a1 :    0.9128835904
-         0 >   1      :       1b1 >    5a1 :    0.2314939083
-         0 >   3      :       1b1 >    7a1 :    0.0898595210
-         0 >   2      :       1b1 >    6a1 :    0.0359046035
-         2 >   0      :       3a1 >    2b1 :    0.0167383249
+         0 >   0      :       1b1 >    4a1 :    0.9128835977
+         0 >   1      :       1b1 >    5a1 :    0.2314938808
+         0 >   3      :       1b1 >    7a1 :    0.0898595176
+         0 >   2      :       1b1 >    6a1 :    0.0359046076
+         2 >   0      :       3a1 >    2b1 :    0.0167383272
  Ria (libdpd indices) : (cscf notation)
-         1 >   1      :       2a1 >    1b1 :   -0.2017390809
-         1 >   0      :       2a1 >    2b1 :   -0.0096057370
-         0 >   1      :       1a1 >    1b1 :    0.0008519092
+         1 >   1      :       2a1 >    1b1 :   -0.2017390898
+         1 >   0      :       2a1 >    2b1 :   -0.0096057354
+         0 >   1      :       1a1 >    1b1 :    0.0008519091
          0 >   0      :       1a1 >    2b1 :    0.0006005144
  RIjAb (libdpd indices)     : (cscf notation)
-        0   1 >   0   5     :    1b1    2a1 >    4a1    3a1 :    0.0981115315
-        0   0 >   0   1     :    1b1    1b2 >    4a1    3b2 :    0.0849924232
-        0   1 >   0   0     :    1b1    2a1 >    4a1    4a1 :    0.0717283806
-        0   1 >   1   5     :    1b1    2a1 >    5a1    3a1 :    0.0640970168
-        0   0 >   0   5     :    1b1    1b2 >    2b2    3a1 :    0.0615233351
+        0   1 >   0   5     :    1b1    2a1 >    4a1    3a1 :    0.0981115254
+        0   0 >   0   1     :    1b1    1b2 >    4a1    3b2 :    0.0849924244
+        0   1 >   0   0     :    1b1    2a1 >    4a1    4a1 :    0.0717283809
+        0   1 >   1   5     :    1b1    2a1 >    5a1    3a1 :    0.0640970103
+        0   0 >   0   5     :    1b1    1b2 >    2b2    3a1 :    0.0615233294
  RIJAB (libdpd indices)     : (cscf notation)
-        0   2 >   1   0     :    1b1    3a1 >    5a1    4a1 :    0.0416020513
-        0   2 >   1   0     :    1b1    3a1 >    3b2    2b2 :   -0.0296685511
-        0   0 >   1   3     :    1b2    1b1 >    3b2    7a1 :   -0.0267240614
-        0   2 >   2   0     :    1b1    3a1 >    6a1    4a1 :   -0.0262890317
-        0   1 >   1   0     :    1b1    2a1 >    5a1    4a1 :   -0.0253529544
+        0   2 >   1   0     :    1b1    3a1 >    5a1    4a1 :    0.0416020525
+        0   2 >   1   0     :    1b1    3a1 >    3b2    2b2 :   -0.0296685523
+        0   0 >   1   3     :    1b2    1b1 >    3b2    7a1 :   -0.0267240610
+        0   2 >   2   0     :    1b1    3a1 >    6a1    4a1 :   -0.0262890327
+        0   1 >   1   0     :    1b1    2a1 >    5a1    4a1 :   -0.0253529558
  Rijab (libdpd indices)     : (cscf notation)
-        0   1 >   1   0     :    1b2    2a1 >    3b2    2b1 :    0.0043095486
-        0   1 >   1   1     :    1b2    2a1 >    3b2    1b1 :    0.0014032530
-        0   1 >   0   1     :    1b2    2a1 >    2b2    1b1 :    0.0012615852
+        0   1 >   1   0     :    1b2    2a1 >    3b2    2b1 :    0.0043095489
+        0   1 >   1   1     :    1b2    2a1 >    3b2    1b1 :    0.0014032528
+        0   1 >   0   1     :    1b2    2a1 >    2b2    1b1 :    0.0012615853
         0   1 >   2   1     :    1b2    2a1 >    4b2    1b1 :    0.0006375636
-        0   1 >   2   0     :    1b2    2a1 >    4b2    2b1 :    0.0005925156
+        0   1 >   2   0     :    1b2    2a1 >    4b2    2b1 :    0.0005925157
 
 	Total # of sigma evaluations: 31
+    SCF energy............................................................................PASSED
+    CCSD energy...........................................................................PASSED
+    EOM-CCSD root 0 (B2)..................................................................PASSED
+    EOM-CCSD root 0 (A1)..................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:20 2017
-Module time:
-	user time   =       0.17 seconds =       0.00 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.45 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-	SCF energy........................................................PASSED
-	CCSD energy.......................................................PASSED
-	EOM-CCSD root 1...................................................PASSED
-	EOM-CCSD root 2...................................................PASSED
+    Psi4 stopped on: Monday, 14 March 2022 01:18PM
+    Psi4 wall time for execution: 0:00:02.93
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc23/CMakeLists.txt
+++ b/tests/cc23/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc23 "psi;cc;cart;noc1")
+add_regression_test(cc23 "psi;cc;cart;noc1;eom")

--- a/tests/cc24/CMakeLists.txt
+++ b/tests/cc24/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc24 "psi;cc;cart;noc1")
+add_regression_test(cc24 "psi;cc;cart;noc1;eom")

--- a/tests/cc25/CMakeLists.txt
+++ b/tests/cc25/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc25 "psi;cc;cart;noc1")
+add_regression_test(cc25 "psi;cc;cart;noc1;eom")

--- a/tests/cc26/CMakeLists.txt
+++ b/tests/cc26/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc26 "psi;cc;cart;noc1")
+add_regression_test(cc26 "psi;cc;cart;noc1;eom")

--- a/tests/cc27/CMakeLists.txt
+++ b/tests/cc27/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc27 "psi;cc;cart;noc1")
+add_regression_test(cc27 "psi;cc;cart;noc1;eom")

--- a/tests/cc44/CMakeLists.txt
+++ b/tests/cc44/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc44 "psi;cc;noc1")
+add_regression_test(cc44 "psi;cc;noc1;eom")

--- a/tests/cc44/input.dat
+++ b/tests/cc44/input.dat
@@ -25,11 +25,10 @@ energy('eom-ccsd')
 
 scf_0     =   -76.05675776144756                                            #TEST
 ccsd_0    =   -76.34161380738567                                            #TEST
-eomccsd_0 = [ -75.961272583411, -75.898190749064 ]                          #TEST
+eomccsd_0 = [ (-75.961272583411, "A1", 1), (-75.898190749064, "B2", 0) ]                          #TEST
 
 compare_values(scf_0, variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
 compare_values(ccsd_0, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
-for root in range(1,3):                                                     #TEST
-    ref = eomccsd_0[root-1]                                                 #TEST
-    val = variable("CC ROOT %d TOTAL ENERGY" % root)                    #TEST
-    compare_values(ref, val, 7, "EOM-CCSD root %d" %root)                   #TEST
+for (ref, h, i) in eomccsd_0: # TEST
+    val = variable(f"CCSD ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CCSD root {i} ({h})")                                #TEST

--- a/tests/cc44/output.ref
+++ b/tests/cc44/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 undefined 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {eom_var} 5b439ed dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 March 2022 01:17PM
 
-    Process ID:  12895
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 23903
+    Host:       dhcp189-157.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -55,33 +68,35 @@ energy('eom-ccsd')
 
 scf_0     =   -76.05675776144756                                            #TEST
 ccsd_0    =   -76.34161380738567                                            #TEST
-eomccsd_0 = [ -75.961272583411, -75.898190749064 ]                          #TEST
+eomccsd_0 = [ (-75.961272583411, "A1", 1), (-75.898190749064, "B2", 0) ]                          #TEST
 
-compare_values(scf_0, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
-compare_values(ccsd_0, get_variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
-for root in range(1,3):                                                     #TEST
-    ref = eomccsd_0[root-1]                                                 #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root)                    #TEST
-    compare_values(ref, val, 7, "EOM-CCSD root %d" %root)                   #TEST
+compare_values(scf_0, variable("SCF TOTAL ENERGY"), 7, "SCF energy")    #TEST
+compare_values(ccsd_0, variable("CCSD TOTAL ENERGY"), 7, "CCSD energy") #TEST
+for (ref, h, i) in eomccsd_0: # TEST
+    val = variable(f"CCSD ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CCSD root {i} ({h})")                                #TEST
 --------------------------------------------------------------------------
 
   Memory set to   1.907 MiB by Python driver.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:17:22 2022
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 3 entry H          line    34 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/aug-cc-pvtz.gbs 
-    atoms 2    entry O          line   313 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 1, 3 entry H          line    40 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2    entry O          line   331 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,      1 MiB Core
          ---------------------------------------------------------
@@ -95,15 +110,15 @@ for root in range(1,3):                                                     #TES
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           H          0.000000000000     0.709209678246    -0.492083819402     1.007825032070
-           O          0.000000000000     0.000000000000     0.062011508391    15.994914619560
-           H          0.000000000000    -0.709209678246    -0.492083819402     1.007825032070
+         H            0.000000000000     0.709209678246    -0.492083819394     1.007825032230
+         O            0.000000000000     0.000000000000     0.062011508399    15.994914619570
+         H            0.000000000000    -0.709209678246    -0.492083819394     1.007825032230
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     30.67311  B =     16.62769  C =     10.78255 [cm^-1]
-  Rotational constants: A = 919556.64332  B = 498485.75497  C = 323252.59678 [MHz]
-  Nuclear repulsion =    9.780670106434442
+  Rotational constants: A =     30.67311  B =     16.62770  C =     10.78255 [cm^-1]
+  Rotational constants: A = 919556.65020  B = 498485.75869  C = 323252.59919 [MHz]
+  Nuclear repulsion =    9.780670144878641
 
   Charge       = 0
   Multiplicity = 1
@@ -120,30 +135,17 @@ for root in range(1,3):                                                     #TES
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: AUG-CC-PVTZ
     Blend: AUG-CC-PVTZ
     Number of shells: 32
-    Number of basis function: 92
+    Number of basis functions: 92
     Number of Cartesian functions: 105
     Spherical Harmonics?: true
     Max angular momentum: 3
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        35      35       0       0       0       0
-     A2        12      12       0       0       0       0
-     B1        18      18       0       0       0       0
-     B2        27      27       0       0       0       0
-   -------------------------------------------------------
-    Total      92      92       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -152,34 +154,50 @@ for root in range(1,3):                                                     #TES
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):                 1
+    Memory [MiB]:                1
     Schwarz Cutoff:          1E-12
 
-  Minimum eigenvalue in the overlap matrix is 3.3431165402E-04.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 2.9105810740E-04.
+  Reciprocal condition number of the overlap matrix is 5.0305620792E-05.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        35      35 
+     A2        12      12 
+     B1        18      18 
+     B2        27      27 
+   -------------------------
+    Total      92      92
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -76.22585536387851   -7.62259e+01   3.97913e-02 
-   @RHF iter   1:   -76.00967614655097    2.16179e-01   6.87428e-03 
-   @RHF iter   2:   -76.04565885602342   -3.59827e-02   3.71071e-03 DIIS
-   @RHF iter   3:   -76.05603953920908   -1.03807e-02   6.47601e-04 DIIS
-   @RHF iter   4:   -76.05668688252321   -6.47343e-04   1.60678e-04 DIIS
-   @RHF iter   5:   -76.05675411610341   -6.72336e-05   3.38095e-05 DIIS
-   @RHF iter   6:   -76.05675770988353   -3.59378e-06   4.83021e-06 DIIS
-   @RHF iter   7:   -76.05675777532711   -6.54436e-08   6.29060e-07 DIIS
-   @RHF iter   8:   -76.05675777619763   -8.70514e-10   6.73703e-08 DIIS
-   @RHF iter   9:   -76.05675777621292   -1.52909e-11   1.54766e-08 DIIS
-   @RHF iter  10:   -76.05675777621370   -7.81597e-13   3.10347e-09 DIIS
+   @RHF iter SAD:   -75.54003984935071   -7.55400e+01   0.00000e+00 
+   @RHF iter   1:   -75.97376801263742   -4.33728e-01   9.70256e-03 ADIIS/DIIS
+   @RHF iter   2:   -76.02866362781872   -5.48956e-02   6.19156e-03 ADIIS/DIIS
+   @RHF iter   3:   -76.05639076426411   -2.77271e-02   4.62643e-04 ADIIS/DIIS
+   @RHF iter   4:   -76.05674255583966   -3.51792e-04   8.52766e-05 DIIS
+   @RHF iter   5:   -76.05675671688140   -1.41610e-05   1.80912e-05 DIIS
+   @RHF iter   6:   -76.05675772398821   -1.00711e-06   3.76178e-06 DIIS
+   @RHF iter   7:   -76.05675777367262   -4.96844e-08   7.33678e-07 DIIS
+   @RHF iter   8:   -76.05675777541785   -1.74524e-09   1.17308e-07 DIIS
+   @RHF iter   9:   -76.05675777545233   -3.44755e-11   2.56115e-08 DIIS
+   @RHF iter  10:   -76.05675777545365   -1.32161e-12   3.80551e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -222,52 +240,47 @@ for root in range(1,3):                                                     #TES
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.05675777621370
+  @RHF Final Energy:   -76.05675777545365
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.7806701064344423
-    One-Electron Energy =                -124.0655433641982768
-    Two-Electron Energy =                  38.2281154815501409
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0567577762136864
+    Nuclear Repulsion Energy =              9.7806701448786413
+    One-Electron Energy =                -124.0655434558905341
+    Two-Electron Energy =                  38.2281155355582456
+    Total Energy =                        -76.0567577754536472
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.9223
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.1584
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.7639     Total:     0.7639
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -1.9417     Total:     1.9417
 
 
-*** tstop() called on psinet at Mon May 15 15:34:44 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:17:26 2022
 Module time:
-	user time   =       1.72 seconds =       0.03 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.89 seconds =       0.05 minutes
+	system time =       0.49 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 Total time:
-	user time   =       1.72 seconds =       0.03 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.89 seconds =       0.05 minutes
+	system time =       0.49 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:44 2017
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:17:26 2022
 
 
 	Wfn Parameters:
@@ -292,7 +305,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 19
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -348,34 +361,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.012 (MW) /      0.099 (MB)
 	Total:                                     0.049 (MW) /      0.396 (MB)
 
-	Nuclear Rep. energy          =      9.78067010643444
-	SCF energy                   =    -76.05675777621370
-	One-electron energy          =   -124.06554312398551
-	Two-electron energy          =     38.22811524133731
-	Reference energy             =    -76.05675777621376
+	Nuclear Rep. energy          =      9.78067014487864
+	SCF energy                   =    -76.05675777545365
+	One-electron energy          =   -124.06554322117701
+	Two-electron energy          =     38.22811530084463
+	Reference energy             =    -76.05675777545373
 
-*** tstop() called on psinet at Mon May 15 15:35:02 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:17:54 2022
 Module time:
-	user time   =      15.20 seconds =       0.25 minutes
-	system time =       2.45 seconds =       0.04 minutes
-	total time  =         18 seconds =       0.30 minutes
+	user time   =      18.36 seconds =       0.31 minutes
+	system time =       5.43 seconds =       0.09 minutes
+	total time  =         28 seconds =       0.47 minutes
 Total time:
-	user time   =      16.92 seconds =       0.28 minutes
-	system time =       2.60 seconds =       0.04 minutes
-	total time  =         20 seconds =       0.33 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:35:02 2017
-
+	user time   =      21.25 seconds =       0.35 minutes
+	system time =       5.92 seconds =       0.10 minutes
+	total time  =         32 seconds =       0.53 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.780670106434442
-    SCF energy          (wfn)     =  -76.056757776213701
-    Reference energy    (file100) =  -76.056757776213757
+    Nuclear Rep. energy (wfn)     =    9.780670144878641
+    SCF energy          (wfn)     =  -76.056757775453647
+    Reference energy    (file100) =  -76.056757775453733
 
     Input parameters:
     -----------------
@@ -403,78 +412,66 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2796741299191189
+MP2 correlation energy -0.2796741288181929
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.279674129919109    0.000e+00    0.000000    0.000000    0.000000    0.112975
-     1        -0.279409493383623    3.234e-02    0.006916    0.015380    0.015380    0.114492
-     2        -0.283853549066708    1.083e-02    0.006811    0.015245    0.015245    0.118325
-     3        -0.284963176309784    4.144e-03    0.007831    0.017966    0.017966    0.119825
-     4        -0.284845264786383    8.605e-04    0.007970    0.018381    0.018381    0.119976
-     5        -0.284853922662929    3.048e-04    0.008041    0.018628    0.018628    0.120021
-     6        -0.284858122449349    7.414e-05    0.008058    0.018695    0.018695    0.120021
-     7        -0.284856405408508    2.369e-05    0.008061    0.018711    0.018711    0.120016
-     8        -0.284856099472249    6.223e-06    0.008062    0.018716    0.018716    0.120016
-     9        -0.284856157711081    1.813e-06    0.008062    0.018718    0.018718    0.120016
-    10        -0.284856044552551    6.021e-07    0.008062    0.018718    0.018718    0.120015
-    11        -0.284856051929005    1.425e-07    0.008062    0.018718    0.018718    0.120015
-    12        -0.284856047897318    5.004e-08    0.008062    0.018718    0.018718    0.120015
+     0        -0.279674128818193    0.000e+00    0.000000    0.000000    0.000000    0.112975
+     1        -0.279409493997117    3.234e-02    0.006916    0.015380    0.015380    0.114492
+     2        -0.283853550736234    1.083e-02    0.006812    0.015245    0.015245    0.118325
+     3        -0.284963178040770    4.144e-03    0.007831    0.017966    0.017966    0.119825
+     4        -0.284845266425054    8.605e-04    0.007970    0.018381    0.018381    0.119976
+     5        -0.284853924252351    3.048e-04    0.008041    0.018628    0.018628    0.120021
+     6        -0.284858124023768    7.414e-05    0.008058    0.018695    0.018695    0.120021
+     7        -0.284856406972560    2.369e-05    0.008061    0.018711    0.018711    0.120016
+     8        -0.284856101034776    6.223e-06    0.008062    0.018716    0.018716    0.120016
+     9        -0.284856159273349    1.813e-06    0.008062    0.018718    0.018718    0.120016
+    10        -0.284856046114797    6.021e-07    0.008062    0.018718    0.018718    0.120015
+    11        -0.284856053491197    1.425e-07    0.008062    0.018718    0.018718    0.120015
+    12        -0.284856049459439    5.004e-08    0.008062    0.018718    0.018718    0.120015
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              3  44         0.0128429815
-              3  45        -0.0116169512
-              2   1        -0.0077428715
-              2   4         0.0073408133
-              4  73        -0.0047997703
-              3  54         0.0039845198
-              3  47         0.0034300184
-              4  69        -0.0032757396
-              2  23        -0.0032700008
-              2   6        -0.0031145102
+              3  44         0.0128430372
+              3  45        -0.0116169949
+              2   1        -0.0077428255
+              2   4         0.0073407953
+              4  73        -0.0047997721
+              3  54         0.0039845169
+              3  47         0.0034300392
+              4  69        -0.0032757457
+              2  23        -0.0032700034
+              2   6        -0.0031145095
 
     Largest TIjAb Amplitudes:
-      2   2   9   9        -0.0181180978
-      4   4  65  65        -0.0169436208
-      4   4  66  66        -0.0150974209
-      4   4  69  69        -0.0147742734
-      2   2  66  66        -0.0143355680
-      4   4  65  69        -0.0143265185
-      4   4  69  65        -0.0143265185
-      3   3  49  49        -0.0134216445
-      2   2   4   9        -0.0117729189
-      2   2   9   4        -0.0117729189
+      2   2   9   9        -0.0181180972
+      4   4  65  65        -0.0169436203
+      4   4  66  66        -0.0150974208
+      4   4  69  69        -0.0147742736
+      2   2  66  66        -0.0143355661
+      4   4  65  69        -0.0143265184
+      4   4  69  65        -0.0143265184
+      3   3  49  49        -0.0134216451
+      2   2   4   9        -0.0117729178
+      2   2   9   4        -0.0117729178
 
-    SCF energy       (wfn)                    =  -76.056757776213701
-    Reference energy (file100)                =  -76.056757776213757
+    SCF energy       (wfn)                    =  -76.056757775453647
+    Reference energy (file100)                =  -76.056757775453733
 
-    Opposite-spin MP2 correlation energy      =   -0.212326063003239
-    Same-spin MP2 correlation energy          =   -0.067348066915871
-    MP2 correlation energy                    =   -0.279674129919119
-      * MP2 total energy                      =  -76.336431906132873
+    Opposite-spin MP2 correlation energy      =   -0.212326062182611
+    Same-spin MP2 correlation energy          =   -0.067348066635582
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.279674128818193
+      * MP2 total energy                      =  -76.336431904271919
 
-    Opposite-spin CCSD correlation energy     =   -0.224130700285727
-    Same-spin CCSD correlation energy         =   -0.060725348662330
-    CCSD correlation energy                   =   -0.284856047897318
-      * CCSD total energy                     =  -76.341613824111079
-
-
-*** tstop() called on psinet at Mon May 15 15:35:05 2017
-Module time:
-	user time   =       0.65 seconds =       0.01 minutes
-	system time =       0.88 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-Total time:
-	user time   =      17.57 seconds =       0.29 minutes
-	system time =       3.48 seconds =       0.06 minutes
-	total time  =         23 seconds =       0.38 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:35:05 2017
+    Opposite-spin CCSD correlation energy     =   -0.224130700469010
+    Same-spin CCSD correlation energy         =   -0.060725348990429
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.284856049459439
+      * CCSD total energy                     =  -76.341613824913168
 
 
 			**************************
@@ -484,28 +481,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:35:05 2017
-Module time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =      17.78 seconds =       0.30 minutes
-	system time =       3.66 seconds =       0.06 minutes
-	total time  =         23 seconds =       0.38 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:35:05 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    9.780670106434442
-	SCF energy          (wfn)     =  -76.056757776213701
-	Reference energy    (file100) =  -76.056757776213757
-	CCSD energy         (file100) =   -0.284856047897318
+	Nuclear Rep. energy (wfn)     =    9.780670144878641
+	SCF energy          (wfn)     =  -76.056757775453647
+	Reference energy    (file100) =  -76.056757775453733
+	CCSD energy         (file100) =   -0.284856049459439
 
 	Input parameters:
 	-----------------
@@ -538,6 +521,14 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total 1640.7070072926
+Fmi   dot Fmi   total  426.6134466086
+Fme   dot Fme   total    0.0000247732
+WMBIJ dot WMBIJ total    0.0000000000
+Wmbij dot Wmbij total    0.0000000000
+WMbIj dot WMbIj total    3.2169780877
+WmBiJ dot WmBiJ total    0.0000000000
 Symmetry of ground state: A1
 Symmetry of excited state: A1
 Symmetry of right eigenvector: A1
@@ -545,68 +536,68 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=1     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5026852316   5.03e-01    5.28e-01      N
+                     1   0.5026852689   5.03e-01    5.28e-01      N
 Iter=2    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3842310978  -1.18e-01    9.34e-02      N
+                     1   0.3842311283  -1.18e-01    9.34e-02      N
 Iter=3    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3808140664  -3.42e-03    2.83e-02      N
+                     1   0.3808140963  -3.42e-03    2.83e-02      N
 Iter=4    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3805428253  -2.71e-04    1.30e-02      N
+                     1   0.3805428545  -2.71e-04    1.30e-02      N
 Iter=5    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3804673950  -7.54e-05    7.53e-03      N
+                     1   0.3804674240  -7.54e-05    7.53e-03      N
 Iter=6    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803790682  -8.83e-05    6.68e-03      N
+                     1   0.3803790968  -8.83e-05    6.68e-03      N
 Iter=7    L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803520166  -2.71e-05    3.58e-03      N
+                     1   0.3803520450  -2.71e-05    3.58e-03      N
 Iter=8    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803546980   2.68e-06    2.50e-03      N
+                     1   0.3803547264   2.68e-06    2.50e-03      N
 Iter=9    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803472381  -7.46e-06    1.93e-03      N
+                     1   0.3803472665  -7.46e-06    1.93e-03      N
 Iter=10   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803408066  -6.43e-06    8.74e-04      N
+                     1   0.3803408349  -6.43e-06    8.74e-04      N
 Iter=11   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803408120   5.40e-09    3.83e-04      N
+                     1   0.3803408403   5.41e-09    3.83e-04      N
 Iter=12   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803413427   5.31e-07    1.79e-04      N
+                     1   0.3803413710   5.31e-07    1.79e-04      N
 Iter=13   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803413427   1.67e-16    1.79e-04      N
+                     1   0.3803413710  -1.11e-16    1.79e-04      N
 Iter=14   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803410131  -3.30e-07    9.73e-05      N
+                     1   0.3803410415  -3.30e-07    9.73e-05      N
 Iter=15   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803410358   2.27e-08    5.00e-05      N
+                     1   0.3803410642   2.27e-08    5.00e-05      N
 Iter=16   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803412001   1.64e-07    2.01e-05      N
+                     1   0.3803412285   1.64e-07    2.01e-05      N
 Iter=17   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803411825  -1.76e-08    8.78e-06      N
+                     1   0.3803412109  -1.76e-08    8.78e-06      N
 Iter=18   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803411906   8.12e-09    3.96e-06      N
+                     1   0.3803412190   8.12e-09    3.96e-06      N
 Iter=19   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803411833  -7.32e-09    1.70e-06      N
+                     1   0.3803412117  -7.32e-09    1.70e-06      N
 Iter=20   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3803411851   1.83e-09    9.52e-07      Y
+                     1   0.3803412135   1.83e-09    9.52e-07      Y
 Collapsing to only 1 vector(s).
 
 Procedure converged for 1 root(s).
-EOM CCSD R0 for root 0 =   0.00104986034
+EOM CCSD R0 for root 0 =   0.00104973306
 
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1     10.350    83475.2   0.3803411851   -75.961272639002
+EOM State 1     10.350    83475.2   0.3803412135   -75.961272611429
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    4a1 :   -0.5689218954
-         2 >   2      :       3a1 >    6a1 :   -0.2633887367
-         2 >   1      :       3a1 >    5a1 :    0.2204456584
-         0 >   0      :       1b1 >    2b1 :    0.1189434266
-         2 >   5      :       3a1 >    9a1 :   -0.1093549172
+         2 >   0      :       3a1 >    4a1 :   -0.5689218623
+         2 >   2      :       3a1 >    6a1 :   -0.2633887204
+         2 >   1      :       3a1 >    5a1 :    0.2204457054
+         0 >   0      :       1b1 >    2b1 :    0.1189435039
+         2 >   5      :       3a1 >    9a1 :   -0.1093549328
  RIjAb (libdpd indices)     : (cscf notation)
-        2   2 >   0   9     :    3a1    3a1 >    4a1   13a1 :    0.0382368696
-        2   2 >   9   0     :    3a1    3a1 >   13a1    4a1 :    0.0382368696
-        2   2 >   0   1     :    3a1    3a1 >    4a1    5a1 :   -0.0355828666
-        2   2 >   1   0     :    3a1    3a1 >    5a1    4a1 :   -0.0355828666
-        2   2 >   0   4     :    3a1    3a1 >    4a1    8a1 :    0.0354767290
+        2   2 >   0   9     :    3a1    3a1 >    4a1   13a1 :    0.0382368671
+        2   2 >   9   0     :    3a1    3a1 >   13a1    4a1 :    0.0382368671
+        2   2 >   0   1     :    3a1    3a1 >    4a1    5a1 :   -0.0355828504
+        2   2 >   1   0     :    3a1    3a1 >    5a1    4a1 :   -0.0355828504
+        2   2 >   0   4     :    3a1    3a1 >    4a1    8a1 :    0.0354767241
 
 Symmetry of excited state: B2
 Symmetry of right eigenvector: B2
@@ -614,88 +605,81 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=1     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5625361036   5.63e-01    5.14e-01      N
+                     1   0.5625361479   5.63e-01    5.14e-01      N
 Iter=2    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4467391822  -1.16e-01    8.83e-02      N
+                     1   0.4467392188  -1.16e-01    8.83e-02      N
 Iter=3    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4436875542  -3.05e-03    2.53e-02      N
+                     1   0.4436875899  -3.05e-03    2.53e-02      N
 Iter=4    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434963909  -1.91e-04    9.77e-03      N
+                     1   0.4434964261  -1.91e-04    9.77e-03      N
 Iter=5    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434588295  -3.76e-05    3.90e-03      N
+                     1   0.4434588647  -3.76e-05    3.90e-03      N
 Iter=6    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434261455  -3.27e-05    3.02e-03      N
+                     1   0.4434261807  -3.27e-05    3.02e-03      N
 Iter=7    L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434169498  -9.20e-06    1.74e-03      N
+                     1   0.4434169850  -9.20e-06    1.74e-03      N
 Iter=8    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434222695   5.32e-06    7.17e-04      N
+                     1   0.4434223047   5.32e-06    7.17e-04      N
 Iter=9    L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434233437   1.07e-06    3.06e-04      N
+                     1   0.4434233789   1.07e-06    3.06e-04      N
 Iter=10   L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434229148  -4.29e-07    1.41e-04      N
+                     1   0.4434229501  -4.29e-07    1.41e-04      N
 Iter=11   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434229383   2.35e-08    8.99e-05      N
+                     1   0.4434229736   2.35e-08    8.99e-05      N
 Iter=12   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434231511   2.13e-07    5.74e-05      N
+                     1   0.4434231864   2.13e-07    5.74e-05      N
 Iter=13   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434231511  -2.22e-15    5.74e-05      N
+                     1   0.4434231864   5.94e-15    5.74e-05      N
 Iter=14   L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434230838  -6.73e-08    3.43e-05      N
+                     1   0.4434231191  -6.73e-08    3.43e-05      N
 Iter=15   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434230289  -5.49e-08    1.97e-05      N
+                     1   0.4434230641  -5.49e-08    1.97e-05      N
 Iter=16   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434230178  -1.11e-08    1.15e-05      N
+                     1   0.4434230531  -1.11e-08    1.15e-05      N
 Iter=17   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434230257   7.90e-09    7.29e-06      N
+                     1   0.4434230610   7.90e-09    7.29e-06      N
 Iter=18   L=7     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434230217  -4.06e-09    3.35e-06      N
+                     1   0.4434230569  -4.06e-09    3.35e-06      N
 Iter=19   L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434230059  -1.58e-08    1.18e-06      N
+                     1   0.4434230412  -1.58e-08    1.18e-06      N
 Iter=20   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4434230152   9.26e-09    4.56e-07      Y
+                     1   0.4434230504   9.26e-09    4.56e-07      Y
 Collapsing to only 1 vector(s).
 
 Procedure converged for 1 root(s).
-Energy written to CC_INFO:Etot  -75.8981908089
+Energy written to CC_INFO:Etot  -75.8981907745
 States per irrep written to CC_INFO.
 EOM CCSD R0 for root 0 =   0.00000000000
 
 Final Energetic Summary for Converged Roots of Irrep B2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 2     12.066    97320.1   0.4434230152   -75.898190808930
+EOM State 2     12.066    97320.1   0.4434230504   -75.898190774496
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    2b2 :   -0.5911868697
-         2 >   1      :       3a1 >    3b2 :   -0.3098887445
-         2 >   2      :       3a1 >    4b2 :    0.1121670410
-         2 >   4      :       3a1 >    6b2 :    0.1023758069
-         0 >   0      :       1b1 >    1a2 :    0.0384558453
+         2 >   0      :       3a1 >    2b2 :   -0.5911868528
+         2 >   1      :       3a1 >    3b2 :   -0.3098887535
+         2 >   2      :       3a1 >    4b2 :    0.1121670699
+         2 >   4      :       3a1 >    6b2 :    0.1023758189
+         0 >   0      :       1b1 >    1a2 :    0.0384558793
  RIjAb (libdpd indices)     : (cscf notation)
-        2   2 >   9   0     :    3a1    3a1 >   13a1    2b2 :    0.0399184159
-        2   2 >   0   9     :    3a1    3a1 >    2b2   13a1 :    0.0399184159
-        2   2 >   4   0     :    3a1    3a1 >    8a1    2b2 :    0.0357753788
-        2   2 >   0   4     :    3a1    3a1 >    2b2    8a1 :    0.0357753788
-        2   2 >   1   0     :    3a1    3a1 >    5a1    2b2 :   -0.0332148884
+        2   2 >   9   0     :    3a1    3a1 >   13a1    2b2 :    0.0399184146
+        2   2 >   0   9     :    3a1    3a1 >    2b2   13a1 :    0.0399184146
+        2   2 >   4   0     :    3a1    3a1 >    8a1    2b2 :    0.0357753746
+        2   2 >   0   4     :    3a1    3a1 >    2b2    8a1 :    0.0357753746
+        2   2 >   1   0     :    3a1    3a1 >    5a1    2b2 :   -0.0332148761
 
 	Putting into environment energy for root of R irrep 4 and root 1.
-	Putting into environment CURRENT ENERGY:              -75.8981908089
+	Putting into environment CURRENT ENERGY:              -75.8981907745
 
 	Total # of sigma evaluations: 38
+    SCF energy............................................................................PASSED
+    CCSD energy...........................................................................PASSED
+    EOM-CCSD root 1 (A1)..................................................................PASSED
+    EOM-CCSD root 0 (B2)..................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:35:12 2017
-Module time:
-	user time   =       1.81 seconds =       0.03 minutes
-	system time =       2.12 seconds =       0.04 minutes
-	total time  =          7 seconds =       0.12 minutes
-Total time:
-	user time   =      19.59 seconds =       0.33 minutes
-	system time =       5.78 seconds =       0.10 minutes
-	total time  =         30 seconds =       0.50 minutes
-	SCF energy........................................................PASSED
-	CCSD energy.......................................................PASSED
-	EOM-CCSD root 1...................................................PASSED
-	EOM-CCSD root 2...................................................PASSED
+    Psi4 stopped on: Monday, 14 March 2022 01:18PM
+    Psi4 wall time for execution: 0:00:44.97
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc45/CMakeLists.txt
+++ b/tests/cc45/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc45 "psi;cc;noc1")
+add_regression_test(cc45 "psi;cc;noc1;eom")

--- a/tests/cc45/input.dat
+++ b/tests/cc45/input.dat
@@ -16,13 +16,13 @@ energy('eom-cc2')
 
 scf_0   =   -76.02170971655195                                                        #TEST
 cc2_0   =   -76.22253325763003                                                        #TEST
-eomcc_0 = [ -75.809233678819, -75.534141615619, -75.826553933384, -75.381447128586,   #TEST
-            -75.904202214316, -75.295956806957, -75.729129680049, -75.642857468928 ]  #TEST
+eomcc_0 = [ (-75.809233678819, "A1", 1), (-75.534141615619, "A1", 2), (-75.826553933384, "A2", 0), (-75.381447128586, "A2", 1),   #TEST
+            (-75.904202214316, "B1", 0), (-75.295956806957, "B1", 1), (-75.729129680049, "B2", 0), (-75.642857468928, "B2", 1) ]  #TEST
 
 compare_values(scf_0, variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
 compare_values(cc2_0, variable("CC2 TOTAL ENERGY"), 6, "CC2 energy") #TEST
 
-for root in range(1,9):                                  #TEST
-    ref = eomcc_0[root-1]                                #TEST
-    val = variable("CC ROOT %d TOTAL ENERGY" % root) #TEST
-    compare_values(ref, val, 6, "EOM-CC2 root %d" %root) #TEST
+for (ref, h, i) in eomcc_0: # TEST
+    val = variable(f"CC2 ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CC2 root {i} ({h})")                                #TEST
+

--- a/tests/cc45/input.dat
+++ b/tests/cc45/input.dat
@@ -23,6 +23,8 @@ compare_values(scf_0, variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
 compare_values(cc2_0, variable("CC2 TOTAL ENERGY"), 6, "CC2 energy") #TEST
 
 for (ref, h, i) in eomcc_0: # TEST
-    val = variable(f"CC2 ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    val = variable(f"CC2 ROOT {i} ({h}) TOTAL ENERGY")                                    #TEST
+    compare_values(ref, val, 6, f"EOM-CC2 root {i} ({h})")                                #TEST
+    val = variable(f"CC ROOT {i} ({h}) TOTAL ENERGY")                                     #TEST
     compare_values(ref, val, 6, f"EOM-CC2 root {i} ({h})")                                #TEST
 

--- a/tests/cc45/output.ref
+++ b/tests/cc45/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 undefined 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {eom_var} 5b439ed dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 14 March 2022 01:18PM
 
-    Process ID:  12894
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 23946
+    Host:       dhcp189-157.emerson.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -46,33 +59,36 @@ energy('eom-cc2')
 
 scf_0   =   -76.02170971655195                                                        #TEST
 cc2_0   =   -76.22253325763003                                                        #TEST
-eomcc_0 = [ -75.809233678819, -75.534141615619, -75.826553933384, -75.381447128586,   #TEST
-            -75.904202214316, -75.295956806957, -75.729129680049, -75.642857468928 ]  #TEST
+eomcc_0 = [ (-75.809233678819, "A1", 1), (-75.534141615619, "A1", 2), (-75.826553933384, "A2", 0), (-75.381447128586, "A2", 1),   #TEST
+            (-75.904202214316, "B1", 0), (-75.295956806957, "B1", 1), (-75.729129680049, "B2", 0), (-75.642857468928, "B2", 1) ]  #TEST
 
-compare_values(scf_0, get_variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
-compare_values(cc2_0, get_variable("CC2 TOTAL ENERGY"), 6, "CC2 energy") #TEST
+compare_values(scf_0, variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
+compare_values(cc2_0, variable("CC2 TOTAL ENERGY"), 6, "CC2 energy") #TEST
 
-for root in range(1,9):                                  #TEST
-    ref = eomcc_0[root-1]                                #TEST
-    val = get_variable("CC ROOT %d TOTAL ENERGY" % root) #TEST
-    compare_values(ref, val, 6, "EOM-CC2 root %d" %root) #TEST
+for (ref, h, i) in eomcc_0: # TEST
+    val = variable(f"CC2 ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    compare_values(ref, val, 6, f"EOM-CC2 root {i} ({h})")                                #TEST
+
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:42 2017
+Scratch directory: /tmp/
+
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:18:13 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1, 3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2    entry O          line   190 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1, 3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2    entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -86,15 +102,15 @@ for root in range(1,9):                                  #TEST
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           H          0.000000000000     0.709209678246    -0.492083819402     1.007825032070
-           O          0.000000000000     0.000000000000     0.062011508391    15.994914619560
-           H          0.000000000000    -0.709209678246    -0.492083819402     1.007825032070
+         H            0.000000000000     0.709209678246    -0.492083819394     1.007825032230
+         O            0.000000000000     0.000000000000     0.062011508399    15.994914619570
+         H            0.000000000000    -0.709209678246    -0.492083819394     1.007825032230
 
   Running in c2v symmetry.
 
-  Rotational constants: A =     30.67311  B =     16.62769  C =     10.78255 [cm^-1]
-  Rotational constants: A = 919556.64332  B = 498485.75497  C = 323252.59678 [MHz]
-  Nuclear repulsion =    9.780670106434442
+  Rotational constants: A =     30.67311  B =     16.62770  C =     10.78255 [cm^-1]
+  Rotational constants: A = 919556.65020  B = 498485.75869  C = 323252.59919 [MHz]
+  Nuclear repulsion =    9.780670144878641
 
   Charge       = 0
   Multiplicity = 1
@@ -111,30 +127,17 @@ for root in range(1,9):                                  #TEST
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      24      24       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -153,40 +156,58 @@ for root in range(1,9):                                  #TEST
   Using 90300 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 3.0308209013E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.8509508519E-02.
+  Reciprocal condition number of the overlap matrix is 8.8848532316E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -76.00036552232697   -7.60004e+01   1.37083e-01 
-   @RHF iter   1:   -75.99396440566989    6.40112e-03   1.95487e-02 
-   @RHF iter   2:   -76.01606760481933   -2.21032e-02   9.21675e-03 DIIS
-   @RHF iter   3:   -76.02154111671629   -5.47351e-03   1.16914e-03 DIIS
-   @RHF iter   4:   -76.02169606567804   -1.54949e-04   2.55438e-04 DIIS
-   @RHF iter   5:   -76.02170884188914   -1.27762e-05   5.64894e-05 DIIS
-   @RHF iter   6:   -76.02170970347746   -8.61588e-07   1.09505e-05 DIIS
-   @RHF iter   7:   -76.02170973305257   -2.95751e-08   7.96894e-07 DIIS
-   @RHF iter   8:   -76.02170973316721   -1.14639e-10   8.72934e-08 DIIS
-   @RHF iter   9:   -76.02170973316871   -1.49214e-12   1.39744e-08 DIIS
-   @RHF iter  10:   -76.02170973316869    1.42109e-14   1.76714e-09 DIIS
+   @RHF iter SAD:   -75.58766968018561   -7.55877e+01   0.00000e+00 
+   @RHF iter   1:   -75.95133166138166   -3.63662e-01   3.06155e-02 ADIIS/DIIS
+   @RHF iter   2:   -76.00457684631751   -5.32452e-02   1.64039e-02 ADIIS/DIIS
+   @RHF iter   3:   -76.02124204957298   -1.66652e-02   2.11696e-03 ADIIS/DIIS
+   @RHF iter   4:   -76.02169761562679   -4.55566e-04   2.96855e-04 ADIIS/DIIS
+   @RHF iter   5:   -76.02170914705776   -1.15314e-05   5.41322e-05 DIIS
+   @RHF iter   6:   -76.02170971449380   -5.67436e-07   8.85428e-06 DIIS
+   @RHF iter   7:   -76.02170973207276   -1.75790e-08   1.05807e-06 DIIS
+   @RHF iter   8:   -76.02170973230204   -2.29278e-10   2.11146e-07 DIIS
+   @RHF iter   9:   -76.02170973231284   -1.08002e-11   4.20609e-08 DIIS
+   @RHF iter  10:   -76.02170973231328   -4.40536e-13   3.49770e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -207,48 +228,43 @@ for root in range(1,9):                                  #TEST
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.02170973316869
+  @RHF Final Energy:   -76.02170973231328
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.7806701064344423
-    One-Electron Energy =                -124.1736229796358373
-    Two-Electron Energy =                  38.3712431400327105
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0217097331686773
+    Nuclear Repulsion Energy =              9.7806701448786413
+    One-Electron Energy =                -124.1736230653221327
+    Two-Electron Energy =                  38.3712431881302152
+    Total Energy =                        -76.0217097323132691
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.9223
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.1331
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:    -0.7892     Total:     0.7892
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0000      Y:     0.0000      Z:    -2.0059     Total:     2.0059
 
 
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:18:14 2022
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -263,19 +279,19 @@ Total time:
       Number of basis functions:        24
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  11    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 11649 non-zero two-electron integrals.
+      Computed 11412 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:18:14 2022
 
 
 	Wfn Parameters:
@@ -300,7 +316,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -356,34 +372,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.005 (MB)
 	Total:                                     0.002 (MW) /      0.020 (MB)
 
-	Nuclear Rep. energy          =      9.78067010643444
-	SCF energy                   =    -76.02170973316869
-	One-electron energy          =   -124.17362294055454
-	Two-electron energy          =     38.37124310095140
-	Reference energy             =    -76.02170973316869
+	Nuclear Rep. energy          =      9.78067014487864
+	SCF energy                   =    -76.02170973231328
+	One-electron energy          =   -124.17362300671405
+	Two-electron energy          =     38.37124312952215
+	Reference energy             =    -76.02170973231325
 
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:18:14 2022
 Module time:
 	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.43 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       0.86 seconds =       0.01 minutes
+	system time =       0.24 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
-
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.780670106434442
-    SCF energy          (wfn)     =  -76.021709733168692
-    Reference energy    (file100) =  -76.021709733168692
+    Nuclear Rep. energy (wfn)     =    9.780670144878641
+    SCF energy          (wfn)     =  -76.021709732313283
+    Reference energy    (file100) =  -76.021709732313255
 
     Input parameters:
     -----------------
@@ -411,73 +423,60 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2001371966492295
+MP2 correlation energy -0.2001371963480349
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.200137196649229    0.000e+00    0.000000    0.000000    0.000000    0.104241
-     1        -0.200129980659726    1.132e-02    0.003581    0.007890    0.007890    0.104241
-     2        -0.200769725482735    2.835e-03    0.004279    0.009388    0.009388    0.104993
-     3        -0.200833650837341    9.064e-04    0.004575    0.009962    0.009962    0.105066
-     4        -0.200822329134536    2.564e-04    0.004611    0.009977    0.009977    0.105061
-     5        -0.200823086741689    8.748e-05    0.004628    0.009980    0.009980    0.105061
-     6        -0.200823556771038    1.593e-05    0.004628    0.009972    0.009972    0.105062
-     7        -0.200823544383077    2.987e-06    0.004629    0.009971    0.009971    0.105062
-     8        -0.200823544206318    6.376e-07    0.004628    0.009971    0.009971    0.105061
-     9        -0.200823545437442    1.052e-07    0.004628    0.009971    0.009971    0.105061
-    10        -0.200823545766196    2.014e-08    0.004628    0.009971    0.009971    0.105061
+     0        -0.200137196348035    0.000e+00    0.000000    0.000000    0.000000    0.104241
+     1        -0.200129980418991    1.132e-02    0.003581    0.007890    0.007890    0.104241
+     2        -0.200769725246132    2.835e-03    0.004279    0.009388    0.009388    0.104993
+     3        -0.200833650577223    9.064e-04    0.004575    0.009962    0.009962    0.105066
+     4        -0.200822328890850    2.564e-04    0.004611    0.009977    0.009977    0.105061
+     5        -0.200823086496605    8.748e-05    0.004628    0.009980    0.009980    0.105061
+     6        -0.200823556525552    1.593e-05    0.004628    0.009972    0.009972    0.105062
+     7        -0.200823544137589    2.987e-06    0.004629    0.009971    0.009971    0.105062
+     8        -0.200823543960819    6.376e-07    0.004628    0.009971    0.009971    0.105061
+     9        -0.200823545191942    1.052e-07    0.004628    0.009971    0.009971    0.105061
+    10        -0.200823545520695    2.014e-08    0.004628    0.009971    0.009971    0.105061
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              4  13         0.0066725211
-              4  17        -0.0065339313
-              2   0         0.0059782751
-              2   5        -0.0043114707
-              1   0         0.0036088625
-              4  15         0.0034033835
-              1   2         0.0033053491
-              3  11         0.0030153675
-              3  10        -0.0028450472
-              2   3         0.0026848386
+              4  13         0.0066725182
+              4  17        -0.0065339319
+              2   0         0.0059782681
+              2   5        -0.0043114709
+              1   0         0.0036088626
+              4  15         0.0034033855
+              1   2         0.0033053494
+              3  11         0.0030153680
+              3  10        -0.0028450495
+              2   3         0.0026848383
 
     Largest TIjAb Amplitudes:
       3   3  10  10        -0.0463827520
       2   2   2   2        -0.0315831481
-      4   4  14  14        -0.0290398866
-      2   3   2  10        -0.0284154741
-      3   2  10   2        -0.0284154741
-      3   4  10  15        -0.0234083882
-      4   3  15  10        -0.0234083882
-      4   4  13  13        -0.0228449330
-      4   4   1   1        -0.0222532990
+      4   4  14  14        -0.0290398865
+      2   3   2  10        -0.0284154742
+      3   2  10   2        -0.0284154742
+      3   4  10  15        -0.0234083883
+      4   3  15  10        -0.0234083883
+      4   4  13  13        -0.0228449324
+      4   4   1   1        -0.0222532988
       2   2  14  14        -0.0219525172
 
-    SCF energy       (wfn)                    =  -76.021709733168692
-    Reference energy (file100)                =  -76.021709733168692
+    SCF energy       (wfn)                    =  -76.021709732313283
+    Reference energy (file100)                =  -76.021709732313255
 
-    Opposite-spin MP2 correlation energy      =   -0.149220599289343
-    Same-spin MP2 correlation energy          =   -0.050916597359887
-    MP2 correlation energy                    =   -0.200137196649229
-      * MP2 total energy                      =  -76.221846929817914
-    CC2 correlation energy                    =   -0.200823545766196
-      * CC2 total energy                      =  -76.222533278934890
-
-
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
-Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
+    Opposite-spin MP2 correlation energy      =   -0.149220599037016
+    Same-spin MP2 correlation energy          =   -0.050916597311019
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.200137196348035
+      * MP2 total energy                      =  -76.221846928661293
+    CC2 correlation energy                    =   -0.200823545520695
+      * CC2 total energy                      =  -76.222533277833946
 
 
 			**************************
@@ -487,28 +486,14 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:34:43 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.50 seconds =       0.01 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:43 2017
-
-
 	**********************************************************
 	*  CCEOM: An Equation of Motion Coupled Cluster Program  *
 	**********************************************************
 
-	Nuclear Rep. energy (wfn)     =    9.780670106434442
-	SCF energy          (wfn)     =  -76.021709733168692
-	Reference energy    (file100) =  -76.021709733168692
-	CC2 energy          (file100) =   -0.200823545766196
+	Nuclear Rep. energy (wfn)     =    9.780670144878641
+	SCF energy          (wfn)     =  -76.021709732313283
+	Reference energy    (file100) =  -76.021709732313255
+	CC2 energy          (file100) =   -0.200823545520695
 
 	Input parameters:
 	-----------------
@@ -541,6 +526,14 @@ Total time:
 	Collapse with last vector   = YES
 
 
+
+Fae   dot Fae   total  103.6327461187
+Fmi   dot Fmi   total  425.3964700975
+Fme   dot Fme   total    0.0000070512
+WMBIJ dot WMBIJ total    0.0000000000
+Wmbij dot Wmbij total    0.0000000000
+WMbIj dot WMbIj total    0.0000000000
+WmBiJ dot WmBiJ total    0.0000000000
 Symmetry of ground state: A1
 Symmetry of excited state: A1
 Symmetry of right eigenvector: A1
@@ -548,74 +541,74 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5222774641   5.22e-01    5.48e-01      N
-                     2   0.7780395032   7.78e-01    4.97e-01      N
+                     1   0.5222774630   5.22e-01    5.48e-01      N
+                     2   0.7780395055   7.78e-01    4.97e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4143079529  -1.08e-01    3.09e-02      N
-                     2   0.6889967113  -8.90e-02    2.12e-02      N
+                     1   0.4143079514  -1.08e-01    3.09e-02      N
+                     2   0.6889967130  -8.90e-02    2.12e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4134064971  -9.01e-04    1.70e-02      N
-                     2   0.6884605140  -5.36e-04    1.38e-02      N
+                     1   0.4134064956  -9.01e-04    1.70e-02      N
+                     2   0.6884605157  -5.36e-04    1.38e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4133008697  -1.06e-04    2.23e-03      N
-                     2   0.6883932919  -6.72e-05    2.40e-03      N
+                     1   0.4133008682  -1.06e-04    2.23e-03      N
+                     2   0.6883932936  -6.72e-05    2.40e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4132998725  -9.97e-07    4.96e-04      N
-                     2   0.6883913000  -1.99e-06    7.65e-04      N
+                     1   0.4132998710  -9.97e-07    4.96e-04      N
+                     2   0.6883913017  -1.99e-06    7.65e-04      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4132995719  -3.01e-07    6.78e-05      N
-                     2   0.6883917021   4.02e-07    1.78e-04      N
+                     1   0.4132995704  -3.01e-07    6.78e-05      N
+                     2   0.6883917038   4.02e-07    1.78e-04      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4132995736   1.70e-09    1.86e-05      N
-                     2   0.6883915824  -1.20e-07    4.50e-05      N
+                     1   0.4132995721   1.70e-09    1.86e-05      N
+                     2   0.6883915841  -1.20e-07    4.50e-05      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4132995588  -1.48e-08    3.63e-06      N
-                     2   0.6883915996   1.72e-08    1.42e-05      N
+                     1   0.4132995573  -1.48e-08    3.63e-06      N
+                     2   0.6883916013   1.72e-08    1.42e-05      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4132995578  -9.50e-10    6.64e-07      Y
-                     2   0.6883916013   1.70e-09    3.65e-06      N
+                     1   0.4132995563  -9.50e-10    6.64e-07      Y
+                     2   0.6883916030   1.70e-09    3.65e-06      N
 Iter=10   L=19    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4132995578  -6.72e-12    3.24e-07      Y
-                     2   0.6883916010  -3.21e-10    5.34e-07      Y
+                     1   0.4132995563  -6.72e-12    3.24e-07      Y
+                     2   0.6883916027  -3.21e-10    5.34e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-EOM CC2 R0 for root 0 =  -0.01101415911
-EOM CC2 R0 for root 1 =  -0.01559960104
+EOM CC2 R0 for root 0 =   0.01101414937
+EOM CC2 R0 for root 1 =   0.01559959619
 
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1     11.246    90708.8   0.4132995578   -75.809233721096
+EOM State 1     11.246    90708.8   0.4132995563   -75.809233721517
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    4a1 :    0.6865230914
-         2 >   1      :       3a1 >    5a1 :    0.0493551708
-         0 >   0      :       1b2 >    2b2 :   -0.0304160988
-         1 >   0      :       2a1 >    4a1 :   -0.0251599872
-         0 >   0      :       1b1 >    2b1 :    0.0206125101
+         2 >   0      :       3a1 >    4a1 :   -0.6865230919
+         2 >   1      :       3a1 >    5a1 :   -0.0493551708
+         0 >   0      :       1b2 >    2b2 :    0.0304160960
+         1 >   0      :       2a1 >    4a1 :    0.0251599866
+         0 >   0      :       1b1 >    2b1 :   -0.0206125092
  RIjAb (libdpd indices)     : (cscf notation)
-        2   2 >   0   0     :    3a1    3a1 >    4a1    4a1 :   -0.0568208278
-        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :   -0.0493741172
-        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :   -0.0493741172
-        2   2 >   0   2     :    3a1    3a1 >    4a1    6a1 :    0.0477025940
-        2   2 >   2   0     :    3a1    3a1 >    6a1    4a1 :    0.0477025940
-EOM State 2     18.732   151084.5   0.6883916010   -75.534141677980
+        2   2 >   0   0     :    3a1    3a1 >    4a1    4a1 :    0.0568208222
+        2   0 >   0   0     :    3a1    1b2 >    4a1    2b2 :    0.0493741171
+        0   2 >   0   0     :    1b2    3a1 >    2b2    4a1 :    0.0493741171
+        2   2 >   0   2     :    3a1    3a1 >    4a1    6a1 :   -0.0477025942
+        2   2 >   2   0     :    3a1    3a1 >    6a1    4a1 :   -0.0477025942
+EOM State 2     18.732   151084.5   0.6883916027   -75.534141675178
 
 Largest components of excited wave function #2:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b2 >    2b2 :    0.6831351690
-         0 >   0      :       1b1 >    2b1 :    0.0710256365
-         2 >   2      :       3a1 >    6a1 :    0.0539491008
-         2 >   1      :       3a1 >    5a1 :   -0.0425218402
-         0 >   1      :       1b2 >    3b2 :    0.0346180167
+         0 >   0      :       1b2 >    2b2 :   -0.6831351693
+         0 >   0      :       1b1 >    2b1 :   -0.0710256362
+         2 >   2      :       3a1 >    6a1 :   -0.0539491003
+         2 >   1      :       3a1 >    5a1 :    0.0425218404
+         0 >   1      :       1b2 >    3b2 :   -0.0346180167
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b2    1b2 >    2b2    2b2 :   -0.1003209542
-        0   0 >   0   0     :    1b1    1b2 >    2b1    2b2 :    0.0380946747
-        0   0 >   0   0     :    1b2    1b1 >    2b2    2b1 :    0.0380946747
-        2   0 >   2   0     :    3a1    1b2 >    6a1    2b2 :    0.0308016918
-        0   2 >   0   2     :    1b2    3a1 >    2b2    6a1 :    0.0308016918
+        0   0 >   0   0     :    1b2    1b2 >    2b2    2b2 :    0.1003209537
+        0   0 >   0   0     :    1b1    1b2 >    2b1    2b2 :   -0.0380946753
+        0   0 >   0   0     :    1b2    1b1 >    2b2    2b1 :   -0.0380946753
+        2   0 >   2   0     :    3a1    1b2 >    6a1    2b2 :   -0.0308016922
+        0   2 >   0   2     :    1b2    3a1 >    2b2    6a1 :   -0.0308016922
 
 Symmetry of excited state: A2
 Symmetry of right eigenvector: A2
@@ -623,32 +616,32 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4987945539   4.99e-01    5.44e-01      N
-                     2   0.9459775370   9.46e-01    5.59e-01      N
+                     1   0.4987945514   4.99e-01    5.44e-01      N
+                     2   0.9459775357   9.46e-01    5.59e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3965697271  -1.02e-01    2.50e-02      N
-                     2   0.8416306373  -1.04e-01    2.80e-02      N
+                     1   0.3965697246  -1.02e-01    2.50e-02      N
+                     2   0.8416306368  -1.04e-01    2.80e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3960054134  -5.64e-04    9.62e-03      N
-                     2   0.8411209004  -5.10e-04    1.05e-02      N
+                     1   0.3960054109  -5.64e-04    9.62e-03      N
+                     2   0.8411208998  -5.10e-04    1.05e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3959795299  -2.59e-05    6.99e-04      N
-                     2   0.8410866461  -3.43e-05    1.72e-03      N
+                     1   0.3959795275  -2.59e-05    6.99e-04      N
+                     2   0.8410866455  -3.43e-05    1.72e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3959792777  -2.52e-07    9.40e-05      N
-                     2   0.8410860878  -5.58e-07    1.84e-04      N
+                     1   0.3959792752  -2.52e-07    9.40e-05      N
+                     2   0.8410860873  -5.58e-07    1.84e-04      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3959792994   2.17e-08    1.30e-05      N
-                     2   0.8410860830  -4.77e-09    4.62e-05      N
+                     1   0.3959792969   2.17e-08    1.30e-05      N
+                     2   0.8410860825  -4.77e-09    4.62e-05      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3959793017   2.33e-09    1.27e-06      N
-                     2   0.8410860782  -4.81e-09    6.74e-06      N
+                     1   0.3959792992   2.33e-09    1.27e-06      N
+                     2   0.8410860777  -4.81e-09    6.74e-06      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3959793012  -5.06e-10    1.03e-07      Y
-                     2   0.8410860772  -1.03e-09    1.50e-06      N
+                     1   0.3959792987  -5.06e-10    1.03e-07      Y
+                     2   0.8410860766  -1.03e-09    1.50e-06      N
 Iter=9    L=17    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3959793012   4.06e-14    9.79e-08      Y
-                     2   0.8410860772   4.31e-11    1.64e-07      Y
+                     1   0.3959792987   3.75e-14    9.79e-08      Y
+                     2   0.8410860767   4.30e-11    1.64e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
@@ -658,36 +651,36 @@ EOM CC2 R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep A2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 3     10.775    86907.4   0.3959793012   -75.826553977720
+EOM State 3     10.775    86907.4   0.3959792987   -75.826553979097
 
 Largest components of excited wave function #3:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    2b2 :    0.6842456136
-         0 >   1      :       1b1 >    3b2 :    0.0833407444
-         0 >   2      :       1b1 >    4b2 :   -0.0578521386
-         0 >   4      :       1b1 >    6b2 :    0.0098134638
+         0 >   0      :       1b1 >    2b2 :    0.6842456139
+         0 >   1      :       1b1 >    3b2 :    0.0833407434
+         0 >   2      :       1b1 >    4b2 :   -0.0578521390
+         0 >   4      :       1b1 >    6b2 :    0.0098134637
          1 >   0      :       2a1 >    1a2 :    0.0032330023
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :   -0.0552000457
-        0   0 >   0   0     :    1b2    1b1 >    2b2    2b2 :   -0.0552000457
-        0   0 >   0   0     :    1b1    1b1 >    2b1    2b2 :    0.0528674012
-        0   0 >   0   0     :    1b1    1b1 >    2b2    2b1 :    0.0528674012
-        2   0 >   2   0     :    3a1    1b1 >    6a1    2b2 :    0.0374006823
-EOM State 4     22.887   184597.0   0.8410860772   -75.381447201697
+        0   0 >   0   0     :    1b1    1b2 >    2b2    2b2 :   -0.0552000451
+        0   0 >   0   0     :    1b2    1b1 >    2b2    2b2 :   -0.0552000451
+        0   0 >   0   0     :    1b1    1b1 >    2b1    2b2 :    0.0528674013
+        0   0 >   0   0     :    1b1    1b1 >    2b2    2b1 :    0.0528674013
+        2   0 >   2   0     :    3a1    1b1 >    6a1    2b2 :    0.0374006824
+EOM State 4     22.887   184597.1   0.8410860767   -75.381447201160
 
 Largest components of excited wave function #4:
  RIA (libdpd indices) : (cscf notation)
-         0 >   1      :       1b1 >    3b2 :    0.6871275225
-         0 >   0      :       1b1 >    2b2 :   -0.0748276195
+         0 >   1      :       1b1 >    3b2 :    0.6871275228
+         0 >   0      :       1b1 >    2b2 :   -0.0748276188
          0 >   4      :       1b1 >    6b2 :    0.0308136341
-         0 >   2      :       1b1 >    4b2 :   -0.0271412421
-         0 >   0      :       1b2 >    2b1 :    0.0066255648
+         0 >   2      :       1b1 >    4b2 :   -0.0271412437
+         0 >   0      :       1b2 >    2b1 :    0.0066255650
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   1     :    1b1    1b1 >    2b1    3b2 :    0.0423138430
-        0   0 >   1   0     :    1b1    1b1 >    3b2    2b1 :    0.0423138430
-        0   0 >   1   1     :    1b1    1b2 >    3b2    3b2 :   -0.0395731969
-        0   0 >   1   1     :    1b2    1b1 >    3b2    3b2 :   -0.0395731969
-        0   0 >   1   0     :    1b1    1b2 >    3b2    2b2 :   -0.0318278329
+        0   0 >   0   1     :    1b1    1b1 >    2b1    3b2 :    0.0423138426
+        0   0 >   1   0     :    1b1    1b1 >    3b2    2b1 :    0.0423138426
+        0   0 >   1   1     :    1b1    1b2 >    3b2    3b2 :   -0.0395731967
+        0   0 >   1   1     :    1b2    1b1 >    3b2    3b2 :   -0.0395731967
+        0   0 >   1   0     :    1b1    1b2 >    3b2    2b2 :   -0.0318278323
 
 Symmetry of excited state: B1
 Symmetry of right eigenvector: B1
@@ -695,38 +688,38 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4251090839   4.25e-01    5.45e-01      N
-                     2   1.0342568217   1.03e+00    5.65e-01      N
+                     1   0.4251090820   4.25e-01    5.45e-01      N
+                     2   1.0342568213   1.03e+00    5.65e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3186156390  -1.06e-01    2.17e-02      N
-                     2   0.9293810571  -1.05e-01    3.68e-02      N
+                     1   0.3186156370  -1.06e-01    2.17e-02      N
+                     2   0.9293810575  -1.05e-01    3.68e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183403776  -2.75e-04    5.33e-03      N
-                     2   0.9271904365  -2.19e-03    3.17e-02      N
+                     1   0.3183403756  -2.75e-04    5.33e-03      N
+                     2   0.9271904369  -2.19e-03    3.17e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183314229  -8.95e-06    7.57e-04      N
-                     2   0.9266613799  -5.29e-04    1.26e-02      N
+                     1   0.3183314208  -8.95e-06    7.57e-04      N
+                     2   0.9266613803  -5.29e-04    1.26e-02      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183309847  -4.38e-07    1.04e-04      N
-                     2   0.9265778168  -8.36e-05    2.11e-03      N
+                     1   0.3183309827  -4.38e-07    1.04e-04      N
+                     2   0.9265778172  -8.36e-05    2.11e-03      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183310254   4.06e-08    1.26e-05      N
-                     2   0.9265767015  -1.12e-06    4.83e-04      N
+                     1   0.3183310233   4.06e-08    1.26e-05      N
+                     2   0.9265767019  -1.12e-06    4.83e-04      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183310223  -3.07e-09    1.44e-06      N
-                     2   0.9265764725  -2.29e-07    1.37e-04      N
+                     1   0.3183310203  -3.07e-09    1.44e-06      N
+                     2   0.9265764729  -2.29e-07    1.37e-04      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183310220  -2.58e-10    1.50e-07      Y
-                     2   0.9265763822  -9.03e-08    3.11e-05      N
+                     1   0.3183310200  -2.58e-10    1.50e-07      Y
+                     2   0.9265763826  -9.03e-08    3.11e-05      N
 Iter=9    L=17    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183310220  -6.41e-14    1.50e-07      Y
-                     2   0.9265763801  -2.04e-09    7.22e-06      N
+                     1   0.3183310200  -6.16e-14    1.50e-07      Y
+                     2   0.9265763805  -2.04e-09    7.22e-06      N
 Iter=10   L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183310220  -1.42e-12    1.48e-07      Y
-                     2   0.9265763818   1.70e-09    1.09e-06      N
+                     1   0.3183310200  -1.42e-12    1.48e-07      Y
+                     2   0.9265763822   1.70e-09    1.09e-06      N
 Iter=11   L=19    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.3183310220  -1.59e-12    1.49e-07      Y
-                     2   0.9265763817  -1.56e-10    2.16e-07      Y
+                     1   0.3183310200  -1.59e-12    1.49e-07      Y
+                     2   0.9265763821  -1.56e-10    2.16e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
@@ -736,36 +729,36 @@ EOM CC2 R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 5      8.662    69865.6   0.3183310220   -75.904202256911
+EOM State 5      8.662    69865.6   0.3183310200   -75.904202257837
 
 Largest components of excited wave function #5:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    4a1 :    0.6877768713
-         0 >   1      :       1b1 >    5a1 :    0.0599176473
+         0 >   0      :       1b1 >    4a1 :    0.6877768715
+         0 >   1      :       1b1 >    5a1 :    0.0599176467
          0 >   2      :       1b1 >    6a1 :   -0.0203437679
-         0 >   4      :       1b1 >    8a1 :   -0.0192517499
-         0 >   3      :       1b1 >    7a1 :    0.0127205644
+         0 >   4      :       1b1 >    8a1 :   -0.0192517498
+         0 >   3      :       1b1 >    7a1 :    0.0127205645
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :    0.0553402492
-        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :    0.0553402492
-        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :   -0.0511727615
-        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :   -0.0511727615
-        2   0 >   2   0     :    3a1    1b1 >    6a1    4a1 :    0.0409052844
-EOM State 6     25.213   203360.0   0.9265763817   -75.295956897250
+        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :    0.0553402493
+        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :    0.0553402493
+        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :   -0.0511727610
+        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :   -0.0511727610
+        2   0 >   2   0     :    3a1    1b1 >    6a1    4a1 :    0.0409052845
+EOM State 6     25.213   203360.0   0.9265763821   -75.295956895741
 
 Largest components of excited wave function #6:
  RIA (libdpd indices) : (cscf notation)
-         0 >   1      :       1b1 >    5a1 :    0.6852269995
-         0 >   2      :       1b1 >    6a1 :   -0.0641363794
-         0 >   0      :       1b1 >    4a1 :   -0.0499616442
-         0 >   5      :       1b1 >    9a1 :    0.0220003602
-         0 >   0      :       1b2 >    1a2 :    0.0218311784
+         0 >   1      :       1b1 >    5a1 :    0.6852269999
+         0 >   2      :       1b1 >    6a1 :   -0.0641363795
+         0 >   0      :       1b1 >    4a1 :   -0.0499616439
+         0 >   5      :       1b1 >    9a1 :    0.0220003600
+         0 >   0      :       1b2 >    1a2 :    0.0218311783
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   1   1     :    1b1    1b2 >    5a1    3b2 :   -0.0413164680
-        0   0 >   1   1     :    1b2    1b1 >    3b2    5a1 :   -0.0413164680
-        0   0 >   1   0     :    1b1    1b2 >    5a1    2b2 :   -0.0351594072
-        0   0 >   0   1     :    1b2    1b1 >    2b2    5a1 :   -0.0351594072
-        0   0 >   1   0     :    1b1    1b1 >    5a1    2b1 :    0.0345892853
+        0   0 >   1   1     :    1b1    1b2 >    5a1    3b2 :   -0.0413164678
+        0   0 >   1   1     :    1b2    1b1 >    3b2    5a1 :   -0.0413164678
+        0   0 >   1   0     :    1b1    1b2 >    5a1    2b2 :   -0.0351594066
+        0   0 >   0   1     :    1b2    1b1 >    2b2    5a1 :   -0.0351594066
+        0   0 >   1   0     :    1b1    1b1 >    5a1    2b1 :    0.0345892849
 
 Symmetry of excited state: B2
 Symmetry of right eigenvector: B2
@@ -773,39 +766,39 @@ Seeking states with multiplicity of 1
 Obtaining initial guess from singles-singles block of Hbar...Done.
 
 Iter=1    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.5966765623   5.97e-01    5.39e-01      N
-                     2   0.6641275023   6.64e-01    4.91e-01      N
+                     1   0.5966765610   5.97e-01    5.39e-01      N
+                     2   0.6641275059   6.64e-01    4.91e-01      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4946597961  -1.02e-01    3.28e-02      N
-                     2   0.5800893564  -8.40e-02    2.00e-02      N
+                     1   0.4946597945  -1.02e-01    3.28e-02      N
+                     2   0.5800893593  -8.40e-02    2.00e-02      N
 Iter=3    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4935550830  -1.10e-03    1.92e-02      N
-                     2   0.5797147877  -3.75e-04    1.03e-02      N
+                     1   0.4935550814  -1.10e-03    1.92e-02      N
+                     2   0.5797147905  -3.75e-04    1.03e-02      N
 Iter=4    L=8     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4934098198  -1.45e-04    3.02e-03      N
-                     2   0.5796766454  -3.81e-05    1.66e-03      N
+                     1   0.4934098182  -1.45e-04    3.02e-03      N
+                     2   0.5796766483  -3.81e-05    1.66e-03      N
 Iter=5    L=10    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4934036049  -6.21e-06    9.01e-04      N
-                     2   0.5796755432  -1.10e-06    3.81e-04      N
+                     1   0.4934036033  -6.21e-06    9.01e-04      N
+                     2   0.5796755460  -1.10e-06    3.81e-04      N
 Iter=6    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4934034869  -1.18e-07    2.41e-04      N
-                     2   0.5796756935   1.50e-07    7.04e-05      N
+                     1   0.4934034854  -1.18e-07    2.41e-04      N
+                     2   0.5796756963   1.50e-07    7.04e-05      N
 Iter=7    L=14    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4934035805   9.36e-08    3.77e-05      N
-                     2   0.5796757368   4.33e-08    1.78e-05      N
+                     1   0.4934035789   9.36e-08    3.77e-05      N
+                     2   0.5796757396   4.33e-08    1.78e-05      N
 Iter=8    L=16    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4934035532  -2.73e-08    5.64e-06      N
-                     2   0.5796757418   5.08e-09    3.73e-06      N
+                     1   0.4934035516  -2.73e-08    5.64e-06      N
+                     2   0.5796757447   5.08e-09    3.73e-06      N
 Iter=9    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4934035535   3.10e-10    1.46e-06      N
-                     2   0.5796757435   1.70e-09    7.78e-07      Y
+                     1   0.4934035519   3.10e-10    1.46e-06      N
+                     2   0.5796757464   1.70e-09    7.78e-07      Y
 Iter=10   L=19    Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.4934035544   8.90e-10    2.22e-07      Y
-                     2   0.5796757437   1.08e-10    6.17e-07      Y
+                     1   0.4934035528   8.90e-10    2.22e-07      Y
+                     2   0.5796757465   1.08e-10    6.17e-07      Y
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-Energy written to CC_INFO:Etot  -75.6428575353
+Energy written to CC_INFO:Etot  -75.6428575313
 States per irrep written to CC_INFO.
 EOM CC2 R0 for root 0 =   0.00000000000
 EOM CC2 R0 for root 1 =   0.00000000000
@@ -813,60 +806,53 @@ EOM CC2 R0 for root 1 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B2
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 7     13.426   108289.5   0.4934035544   -75.729129724548
+EOM State 7     13.426   108289.6   0.4934035528   -75.729129725035
 
 Largest components of excited wave function #7:
  RIA (libdpd indices) : (cscf notation)
-         2 >   0      :       3a1 >    2b2 :    0.6862314267
-         2 >   2      :       3a1 >    4b2 :   -0.0579056472
-         2 >   1      :       3a1 >    3b2 :    0.0551717106
-         0 >   1      :       1b2 >    5a1 :   -0.0179859894
-         0 >   0      :       1b2 >    4a1 :   -0.0121127157
+         2 >   0      :       3a1 >    2b2 :   -0.6862314269
+         2 >   2      :       3a1 >    4b2 :    0.0579056478
+         2 >   1      :       3a1 >    3b2 :   -0.0551717103
+         0 >   1      :       1b2 >    5a1 :    0.0179859885
+         0 >   0      :       1b2 >    4a1 :    0.0121127127
  RIjAb (libdpd indices)     : (cscf notation)
-        2   0 >   0   0     :    3a1    1b2 >    2b2    2b2 :   -0.0535998891
-        0   2 >   0   0     :    1b2    3a1 >    2b2    2b2 :   -0.0535998891
-        2   0 >   0   0     :    3a1    1b1 >    2b2    2b1 :    0.0445219580
-        0   2 >   0   0     :    1b1    3a1 >    2b1    2b2 :    0.0445219580
-        2   2 >   2   0     :    3a1    3a1 >    6a1    2b2 :    0.0426370668
-EOM State 8     15.774   127224.1   0.5796757437   -75.642857535277
+        2   0 >   0   0     :    3a1    1b2 >    2b2    2b2 :    0.0535998889
+        0   2 >   0   0     :    1b2    3a1 >    2b2    2b2 :    0.0535998889
+        2   0 >   0   0     :    3a1    1b1 >    2b2    2b1 :   -0.0445219583
+        0   2 >   0   0     :    1b1    3a1 >    2b1    2b2 :   -0.0445219583
+        2   2 >   2   0     :    3a1    3a1 >    6a1    2b2 :   -0.0426370671
+EOM State 8     15.774   127224.1   0.5796757465   -75.642857531312
 
 Largest components of excited wave function #8:
  RIA (libdpd indices) : (cscf notation)
          0 >   0      :       1b2 >    4a1 :    0.6912700096
-         0 >   1      :       1b2 >    5a1 :    0.0512615495
+         0 >   1      :       1b2 >    5a1 :    0.0512615494
          0 >   2      :       1b2 >    6a1 :   -0.0228714707
-         1 >   0      :       2a1 >    2b2 :    0.0178075199
-         2 >   1      :       3a1 >    3b2 :   -0.0165803805
+         1 >   0      :       2a1 >    2b2 :    0.0178075202
+         2 >   1      :       3a1 >    3b2 :   -0.0165803803
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b2    1b2 >    4a1    2b2 :   -0.0599002445
-        0   0 >   0   0     :    1b2    1b2 >    2b2    4a1 :   -0.0599002445
-        0   0 >   0   0     :    1b1    1b2 >    2b1    4a1 :    0.0388947764
-        0   0 >   0   0     :    1b2    1b1 >    4a1    2b1 :    0.0388947764
-        2   0 >   2   0     :    3a1    1b2 >    6a1    4a1 :    0.0333808869
+        0   0 >   0   0     :    1b2    1b2 >    4a1    2b2 :   -0.0599002443
+        0   0 >   0   0     :    1b2    1b2 >    2b2    4a1 :   -0.0599002443
+        0   0 >   0   0     :    1b1    1b2 >    2b1    4a1 :    0.0388947771
+        0   0 >   0   0     :    1b2    1b1 >    4a1    2b1 :    0.0388947771
+        2   0 >   2   0     :    3a1    1b2 >    6a1    4a1 :    0.0333808873
 
 	Putting into environment energy for root of R irrep 4 and root 2.
-	Putting into environment CURRENT ENERGY:              -75.6428575353
+	Putting into environment CURRENT ENERGY:              -75.6428575313
 
 	Total # of sigma evaluations: 74
+    SCF energy............................................................................PASSED
+    CC2 energy............................................................................PASSED
+    EOM-CC2 root 1 (A1)...................................................................PASSED
+    EOM-CC2 root 2 (A1)...................................................................PASSED
+    EOM-CC2 root 0 (A2)...................................................................PASSED
+    EOM-CC2 root 1 (A2)...................................................................PASSED
+    EOM-CC2 root 0 (B1)...................................................................PASSED
+    EOM-CC2 root 1 (B1)...................................................................PASSED
+    EOM-CC2 root 0 (B2)...................................................................PASSED
+    EOM-CC2 root 1 (B2)...................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:44 2017
-Module time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.71 seconds =       0.01 minutes
-	system time =       0.46 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-	SCF energy........................................................PASSED
-	CC2 energy........................................................PASSED
-	EOM-CC2 root 1....................................................PASSED
-	EOM-CC2 root 2....................................................PASSED
-	EOM-CC2 root 3....................................................PASSED
-	EOM-CC2 root 4....................................................PASSED
-	EOM-CC2 root 5....................................................PASSED
-	EOM-CC2 root 6....................................................PASSED
-	EOM-CC2 root 7....................................................PASSED
-	EOM-CC2 root 8....................................................PASSED
+    Psi4 stopped on: Monday, 14 March 2022 01:18PM
+    Psi4 wall time for execution: 0:00:03.46
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc45/output.ref
+++ b/tests/cc45/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {eom_var} 5b439ed dirty
+                         Git: Rev {eom_var} c391178 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 14 March 2022 01:18PM
+    Psi4 started on: Monday, 14 March 2022 04:12PM
 
-    Process ID: 23946
+    Process ID: 33729
     Host:       dhcp189-157.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
@@ -66,7 +66,9 @@ compare_values(scf_0, variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
 compare_values(cc2_0, variable("CC2 TOTAL ENERGY"), 6, "CC2 energy") #TEST
 
 for (ref, h, i) in eomcc_0: # TEST
-    val = variable(f"CC2 ROOT {i} ({h}) TOTAL ENERGY")                                 #TEST
+    val = variable(f"CC2 ROOT {i} ({h}) TOTAL ENERGY")                                    #TEST
+    compare_values(ref, val, 6, f"EOM-CC2 root {i} ({h})")                                #TEST
+    val = variable(f"CC ROOT {i} ({h}) TOTAL ENERGY")                                     #TEST
     compare_values(ref, val, 6, f"EOM-CC2 root {i} ({h})")                                #TEST
 
 --------------------------------------------------------------------------
@@ -74,7 +76,7 @@ for (ref, h, i) in eomcc_0: # TEST
 Scratch directory: /tmp/
 
 *** tstart() called on dhcp189-157.emerson.emory.edu
-*** at Mon Mar 14 13:18:13 2022
+*** at Mon Mar 14 16:12:17 2022
 
    => Loading Basis Set <=
 
@@ -257,14 +259,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -2.0059     Total:     2.0059
 
 
-*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:18:14 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 16:12:18 2022
 Module time:
-	user time   =       0.80 seconds =       0.01 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.80 seconds =       0.01 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -291,7 +293,7 @@ Total time:
 
 
 *** tstart() called on dhcp189-157.emerson.emory.edu
-*** at Mon Mar 14 13:18:14 2022
+*** at Mon Mar 14 16:12:18 2022
 
 
 	Wfn Parameters:
@@ -378,14 +380,14 @@ Total time:
 	Two-electron energy          =     38.37124312952215
 	Reference energy             =    -76.02170973231325
 
-*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:18:14 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 16:12:18 2022
 Module time:
 	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.12 seconds =       0.00 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.86 seconds =       0.01 minutes
-	system time =       0.24 seconds =       0.00 minutes
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.17 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
@@ -844,15 +846,23 @@ Largest components of excited wave function #8:
     SCF energy............................................................................PASSED
     CC2 energy............................................................................PASSED
     EOM-CC2 root 1 (A1)...................................................................PASSED
+    EOM-CC2 root 1 (A1)...................................................................PASSED
+    EOM-CC2 root 2 (A1)...................................................................PASSED
     EOM-CC2 root 2 (A1)...................................................................PASSED
     EOM-CC2 root 0 (A2)...................................................................PASSED
+    EOM-CC2 root 0 (A2)...................................................................PASSED
+    EOM-CC2 root 1 (A2)...................................................................PASSED
     EOM-CC2 root 1 (A2)...................................................................PASSED
     EOM-CC2 root 0 (B1)...................................................................PASSED
+    EOM-CC2 root 0 (B1)...................................................................PASSED
+    EOM-CC2 root 1 (B1)...................................................................PASSED
     EOM-CC2 root 1 (B1)...................................................................PASSED
     EOM-CC2 root 0 (B2)...................................................................PASSED
+    EOM-CC2 root 0 (B2)...................................................................PASSED
+    EOM-CC2 root 1 (B2)...................................................................PASSED
     EOM-CC2 root 1 (B2)...................................................................PASSED
 
-    Psi4 stopped on: Monday, 14 March 2022 01:18PM
-    Psi4 wall time for execution: 0:00:03.46
+    Psi4 stopped on: Monday, 14 March 2022 04:12PM
+    Psi4 wall time for execution: 0:00:02.03
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc46/CMakeLists.txt
+++ b/tests/cc46/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc46 "psi;cc;autotest;noc1")
+add_regression_test(cc46 "psi;cc;autotest;noc1;eom")

--- a/tests/cc47/CMakeLists.txt
+++ b/tests/cc47/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc47 "psi;cc;autotest;noc1")
+add_regression_test(cc47 "psi;cc;autotest;noc1;eom")

--- a/tests/cc48/CMakeLists.txt
+++ b/tests/cc48/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc48 "psi;cc;autotest;noc1")
+add_regression_test(cc48 "psi;cc;autotest;noc1;eom")

--- a/tests/cc49/CMakeLists.txt
+++ b/tests/cc49/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc49 "psi;quicktests;cc;noc1")
+add_regression_test(cc49 "psi;quicktests;cc;noc1;eom")

--- a/tests/cc49/input.dat
+++ b/tests/cc49/input.dat
@@ -107,5 +107,5 @@ eom_ref = -38.221966233155 # TEST
 energy('eom-cc3')
 compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
 compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
-compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+compare_values(eom_ref, variable("CC3 ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")   #TEST
 

--- a/tests/cc49/output.ref
+++ b/tests/cc49/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev56 
+                               Psi4 undefined 
 
-                         Git: Rev {ccdensity_fix} 027e6dd dirty
+                         Git: Rev {eom_var} 5b439ed dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 14 February 2022 02:00PM
+    Psi4 started on: Monday, 14 March 2022 01:16PM
 
-    Process ID: 11736
-    Host:       dhcp189-242.emerson.emory.edu
+    Process ID: 23874
+    Host:       dhcp189-157.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -150,22 +150,22 @@ eom_ref = -38.221966233155 # TEST
 energy('eom-cc3')
 compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
 compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
-compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+compare_values(eom_ref, variable("CC3 ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")   #TEST
 
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
-*** tstart() called on dhcp189-242.emerson.emory.edu
-*** at Mon Feb 14 14:00:16 2022
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:16:38 2022
 
    => Loading Basis Set <=
 
-    Name: ANONYMOUSC1823E4E
+    Name: ANONYMOUS73F9E484
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line    22 inputblock anonymousc1823e4e 
-    atoms 2 entry H          line     5 inputblock anonymousc1823e4e 
+    atoms 1 entry C          line    22 inputblock anonymous73f9e484 
+    atoms 2 entry H          line     5 inputblock anonymous73f9e484 
 
 
          ---------------------------------------------------------
@@ -213,8 +213,8 @@ Scratch directory: /tmp/
 
   ==> Primary Basis <==
 
-  Basis Set: ANONYMOUSC1823E4E
-    Blend: ANONYMOUSC1823E4E
+  Basis Set: ANONYMOUS73F9E484
+    Blend: ANONYMOUS73F9E484
     Number of shells: 15
     Number of basis functions: 33
     Number of Cartesian functions: 35
@@ -273,24 +273,24 @@ Scratch directory: /tmp/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:   -37.45954292475091   -3.74595e+01   0.00000e+00 
-   @UHF iter   1:   -38.26453327391502   -8.04990e-01   5.71337e-03 ADIIS/DIIS
-   @UHF iter   2:   -38.27598667903774   -1.14534e-02   1.57889e-03 ADIIS/DIIS
-   @UHF iter   3:   -38.27709976752695   -1.11309e-03   5.28488e-04 ADIIS/DIIS
-   @UHF iter   4:   -38.27727669693479   -1.76929e-04   1.87711e-04 ADIIS/DIIS
-   @UHF iter   5:   -38.27730302381907   -2.63269e-05   6.21511e-05 DIIS
-   @UHF iter   6:   -38.27730628568217   -3.26186e-06   2.36022e-05 DIIS
-   @UHF iter   7:   -38.27730687486027   -5.89178e-07   9.31232e-06 DIIS
-   @UHF iter   8:   -38.27730697547304   -1.00613e-07   2.17470e-06 DIIS
-   @UHF iter   9:   -38.27730697939126   -3.91822e-09   5.18737e-07 DIIS
-   @UHF iter  10:   -38.27730697960749   -2.16239e-10   1.08043e-07 DIIS
-   @UHF iter  11:   -38.27730697961708   -9.58522e-12   1.75408e-08 DIIS
-   @UHF iter  12:   -38.27730697961735   -2.70006e-13   3.56930e-09 DIIS
+   @UHF iter   1:   -38.26453327391502   -8.04990e-01   5.71337e-03 DIIS/ADIIS
+   @UHF iter   2:   -38.27598667903774   -1.14534e-02   1.57889e-03 DIIS/ADIIS
+   @UHF iter   3:   -38.27709976752695   -1.11309e-03   5.28488e-04 DIIS/ADIIS
+   @UHF iter   4:   -38.27727653121834   -1.76764e-04   1.88230e-04 DIIS/ADIIS
+   @UHF iter   5:   -38.27730301874607   -2.64875e-05   6.21899e-05 DIIS
+   @UHF iter   6:   -38.27730628562913   -3.26688e-06   2.36032e-05 DIIS
+   @UHF iter   7:   -38.27730687484414   -5.89215e-07   9.31302e-06 DIIS
+   @UHF iter   8:   -38.27730697547243   -1.00628e-07   2.17485e-06 DIIS
+   @UHF iter   9:   -38.27730697939117   -3.91874e-09   5.18791e-07 DIIS
+   @UHF iter  10:   -38.27730697960752   -2.16353e-10   1.08062e-07 DIIS
+   @UHF iter  11:   -38.27730697961712   -9.59943e-12   1.75442e-08 DIIS
+   @UHF iter  12:   -38.27730697961736   -2.41585e-13   3.56927e-09 DIIS
   Energy and wave function converged.
 
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   9.241628135E-03
+   @Spin Contamination Metric:   9.241628134E-03
    @S^2 Expected:                7.500000000E-01
    @S^2 Observed:                7.592416281E-01
    @S   Expected:                5.000000000E-01
@@ -339,14 +339,14 @@ Scratch directory: /tmp/
     DOCC [     3,    0,    0,    0 ]
     SOCC [     0,    0,    1,    0 ]
 
-  @UHF Final Energy:   -38.27730697961735
+  @UHF Final Energy:   -38.27730697961736
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              2.8353842329165926
-    One-Electron Energy =                 -56.5869343457647034
-    Two-Electron Energy =                  15.4742431332307575
-    Total Energy =                        -38.2773069796173502
+    One-Electron Energy =                 -56.5869343457251901
+    Two-Electron Energy =                  15.4742431331912318
+    Total Energy =                        -38.2773069796173644
 
   UHF NO Occupations:
   HONO-2 :    2 A1 1.9995061
@@ -355,7 +355,7 @@ Scratch directory: /tmp/
   LUNO+0 :    4 A1 0.0041349
   LUNO+1 :    5 A1 0.0004939
   LUNO+2 :    6 A1 0.0000006
-  LUNO+3 :    7 A1 0.0000000
+  LUNO+3 :    2 B1 0.0000000
 
 
 Computation Completed
@@ -378,15 +378,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.5738     Total:     1.5738
 
 
-*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:00:16 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:16:39 2022
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.76 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.76 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -411,8 +411,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on dhcp189-242.emerson.emory.edu
-*** at Mon Feb 14 14:00:17 2022
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:16:40 2022
 
 
 	Wfn Parameters:
@@ -497,7 +497,7 @@ Total time:
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -33.30400349325223
+	Frozen core energy     =    -33.30400349325236
 
 	Size of irrep 0 of <AB|CD> integrals:      0.016 (MW) /      0.131 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.005 (MW) /      0.039 (MB)
@@ -548,23 +548,23 @@ Total time:
 	Total:                                     0.002 (MW) /      0.013 (MB)
 
 	Nuclear Rep. energy          =      2.83538423291659
-	SCF energy                   =    -38.27730697961735
-	One-electron energy          =    -12.61930518456482
-	Two-electron (AA) energy     =      1.28902381507314
-	Two-electron (BB) energy     =      0.38514919089554
-	Two-electron (AB) energy     =      3.13644445931440
-	Two-electron energy          =      4.81061746528307
-	Reference energy             =    -38.27730697961738
+	SCF energy                   =    -38.27730697961736
+	One-electron energy          =    -12.61930518457004
+	Two-electron (AA) energy     =      1.28902381507448
+	Two-electron (BB) energy     =      0.38514919089623
+	Two-electron (AB) energy     =      3.13644445931765
+	Two-electron energy          =      4.81061746528837
+	Reference energy             =    -38.27730697961744
 
-*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:00:17 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:16:40 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.14 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.25 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.57 seconds =       0.01 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.93 seconds =       0.02 minutes
+	system time =       0.39 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -572,8 +572,8 @@ Total time:
             **************************
 
     Nuclear Rep. energy (wfn)     =    2.835384232916593
-    SCF energy          (wfn)     =  -38.277306979617350
-    Reference energy    (file100) =  -38.277306979617379
+    SCF energy          (wfn)     =  -38.277306979617364
+    Reference energy    (file100) =  -38.277306979617443
 
     Input parameters:
     -----------------
@@ -602,27 +602,27 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.0814764554506603
+MP2 correlation energy -0.0814764554507952
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.081476455450660    0.000e+00    0.000000    0.000000    0.000000    0.000000
-     1        -0.100346437539435    5.672e-02    0.008161    0.000000    0.000000    0.000000
-     2        -0.109555883752014    2.715e-02    0.015638    0.000000    0.000000    0.000000
-     3        -0.110501035613285    9.720e-03    0.018561    0.000000    0.000000    0.000000
-     4        -0.110667164490028    3.256e-03    0.018723    0.000000    0.000000    0.000000
-     5        -0.110662428949275    1.394e-03    0.018601    0.000000    0.000000    0.000000
-     6        -0.110660986530976    6.048e-04    0.018487    0.000000    0.000000    0.000000
-     7        -0.110673861931800    1.639e-04    0.018479    0.000000    0.000000    0.000000
-     8        -0.110669651665970    4.988e-05    0.018476    0.000000    0.000000    0.000000
-     9        -0.110669471136449    1.884e-05    0.018477    0.000000    0.000000    0.000000
-    10        -0.110669328812437    7.575e-06    0.018478    0.000000    0.000000    0.000000
-    11        -0.110669493383145    2.779e-06    0.018478    0.000000    0.000000    0.000000
-    12        -0.110669433460538    1.046e-06    0.018478    0.000000    0.000000    0.000000
-    13        -0.110669398903257    3.340e-07    0.018478    0.000000    0.000000    0.000000
-    14        -0.110669398645605    1.268e-07    0.018478    0.000000    0.000000    0.000000
-    15        -0.110669401120191    4.838e-08    0.018478    0.000000    0.000000    0.000000
+     0        -0.081476455450795    0.000e+00    0.000000    0.000000    0.000000    0.000000
+     1        -0.100346437539658    5.672e-02    0.008161    0.000000    0.000000    0.000000
+     2        -0.109555883752333    2.715e-02    0.015638    0.000000    0.000000    0.000000
+     3        -0.110501035613630    9.720e-03    0.018561    0.000000    0.000000    0.000000
+     4        -0.110667164490382    3.256e-03    0.018723    0.000000    0.000000    0.000000
+     5        -0.110662428949629    1.394e-03    0.018601    0.000000    0.000000    0.000000
+     6        -0.110660986531329    6.048e-04    0.018487    0.000000    0.000000    0.000000
+     7        -0.110673861932154    1.639e-04    0.018479    0.000000    0.000000    0.000000
+     8        -0.110669651666324    4.988e-05    0.018476    0.000000    0.000000    0.000000
+     9        -0.110669471136803    1.884e-05    0.018477    0.000000    0.000000    0.000000
+    10        -0.110669328812790    7.575e-06    0.018478    0.000000    0.000000    0.000000
+    11        -0.110669493383499    2.779e-06    0.018478    0.000000    0.000000    0.000000
+    12        -0.110669433460892    1.046e-06    0.018478    0.000000    0.000000    0.000000
+    13        -0.110669398903611    3.340e-07    0.018478    0.000000    0.000000    0.000000
+    14        -0.110669398645959    1.268e-07    0.018478    0.000000    0.000000    0.000000
+    15        -0.110669401120545    4.838e-08    0.018478    0.000000    0.000000    0.000000
 
     Iterations converged.
 
@@ -687,16 +687,16 @@ MP2 correlation energy -0.0814764554506603
       0   0  23  23        -0.0294540187
       0   1  22  24        -0.0290773407
 
-    SCF energy       (wfn)                    =  -38.277306979617350
-    Reference energy (file100)                =  -38.277306979617379
+    SCF energy       (wfn)                    =  -38.277306979617364
+    Reference energy (file100)                =  -38.277306979617443
 
-    Opposite-spin MP2 correlation energy      =   -0.069193482559705
-    Same-spin MP2 correlation energy          =   -0.012282972890956
+    Opposite-spin MP2 correlation energy      =   -0.069193482559841
+    Same-spin MP2 correlation energy          =   -0.012282972890954
     Singles MP2 correlation energy            =   -0.000000000000000
-    MP2 correlation energy                    =   -0.081476455450660
-      * MP2 total energy                      =  -38.358783435068041
-    CC3 correlation energy                    =   -0.110669401120191
-      * CC3 total energy                      =  -38.387976380737570
+    MP2 correlation energy                    =   -0.081476455450795
+      * MP2 total energy                      =  -38.358783435068240
+    CC3 correlation energy                    =   -0.110669401120545
+      * CC3 total energy                      =  -38.387976380737989
 
 
 			**************************
@@ -751,9 +751,9 @@ Doing Wabei terms.
 	**********************************************************
 
 	Nuclear Rep. energy (wfn)     =    2.835384232916593
-	SCF energy          (wfn)     =  -38.277306979617350
-	Reference energy    (file100) =  -38.277306979617379
-	CC3 energy          (file100) =   -0.110669401120191
+	SCF energy          (wfn)     =  -38.277306979617364
+	Reference energy    (file100) =  -38.277306979617443
+	CC3 energy          (file100) =   -0.110669401120545
 
 	Input parameters:
 	-----------------
@@ -789,7 +789,7 @@ Doing Wabei terms.
 
 
 
-Fae   dot Fae   total 1048.9031837995
+Fae   dot Fae   total 1048.9031837972
 Fmi   dot Fmi   total    2.2574113079
 WmBeJ and WMbEj dots    0.3605429536
 Symmetry of ground state: B1
@@ -815,8 +815,8 @@ Iter=4    L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
                      3   0.3038564652  -1.19e-03    3.65e-02      N
 Iter=5    L=15    Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.1248811775  -2.02e-03    2.44e-02      N
-                     2   0.2265956732  -1.04e-02    1.48e-01      N
-                     3   0.2383630420  -6.55e-02    6.42e-02      N
+                     2   0.2265956731  -1.04e-02    1.48e-01      N
+                     3   0.2383630421  -6.55e-02    6.42e-02      N
 Iter=6    L=18    Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.1241141277  -7.67e-04    1.29e-02      N
                      2   0.2038930269  -2.27e-02    7.20e-02      N
@@ -846,9 +846,9 @@ Iter=12   L=36    Root    EOM Energy     Delta E   Res. Norm    Conv?
                      2   0.1970651347   1.17e-06    2.74e-04      N
                      3   0.2372438439  -2.68e-08    5.94e-05      N
 Iter=13   L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.1239050380  -2.05e-15    2.57e-05      N
-                     2   0.1970651347   3.11e-15    2.74e-04      N
-                     3   0.2372438439  -6.88e-15    5.94e-05      N
+                     1   0.1239050380  -1.19e-15    2.57e-05      N
+                     2   0.1970651347   2.78e-15    2.74e-04      N
+                     3   0.2372438439   2.53e-15    5.94e-05      N
 Iter=14   L=9     Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.1239050372  -7.54e-10    8.00e-06      N
                      2   0.1970650751  -5.96e-08    9.97e-05      N
@@ -887,7 +887,7 @@ Overlaps of Rs with EOM CCSD eigenvector:
 	 1      0.976518
 	 2      0.048593
 follow_root returning: 1
-                     2   0.1661693746  -3.09e-02    1.97e-02      N
+                     2   0.1661693745  -3.09e-02    1.97e-02      N
 Iter=2    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Overlaps of Rs with EOM CCSD eigenvector:
 	 0     -0.169538
@@ -1095,13 +1095,13 @@ Copying root 2 to start of PSIF_EOM_Cxxx files.
 Change in CC3 energy from last iterated value    0.0000000416
 
 Procedure converged for 1 root(s).
-<R|R> =   0.9999999999999999
+<R|R> =   1.0000000000000002
 EOM CC3 R0 for root 0 =   0.00000000000
 
 Final Energetic Summary for Converged Roots of Irrep A1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      4.517    36435.0   0.1660101476   -38.221966233155
+EOM State 1      4.517    36435.0   0.1660101476   -38.221966233160
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
@@ -1140,7 +1140,7 @@ Largest components of excited wave function #1:
     CC3 energy............................................................................PASSED
     EOM-CC3 energy........................................................................PASSED
 
-    Psi4 stopped on: Monday, 14 February 2022 02:00PM
-    Psi4 wall time for execution: 0:00:13.45
+    Psi4 stopped on: Monday, 14 March 2022 01:17PM
+    Psi4 wall time for execution: 0:00:23.45
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc50/CMakeLists.txt
+++ b/tests/cc50/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc50 "psi;cc;noc1")
+add_regression_test(cc50 "psi;cc;noc1;eom")

--- a/tests/cc50/input.dat
+++ b/tests/cc50/input.dat
@@ -105,7 +105,7 @@ cc3_ref = -38.387945828926 # TEST
 eom_ref = -38.223605162856 # TEST
 
 energy('eom-cc3')
-compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
-compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
-compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")               #TEST
+compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")               #TEST
+compare_values(eom_ref, variable("CC3 ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
 

--- a/tests/cc50/output.ref
+++ b/tests/cc50/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev56 
+                               Psi4 undefined 
 
-                         Git: Rev {ccdensity_fix} 027e6dd dirty
+                         Git: Rev {eom_var} 5b439ed dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 14 February 2022 02:01PM
+    Psi4 started on: Monday, 14 March 2022 01:16PM
 
-    Process ID: 12265
-    Host:       dhcp189-242.emerson.emory.edu
+    Process ID: 23880
+    Host:       dhcp189-157.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -148,24 +148,24 @@ cc3_ref = -38.387945828926 # TEST
 eom_ref = -38.223605162856 # TEST
 
 energy('eom-cc3')
-compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
-compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
-compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")               #TEST
+compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")               #TEST
+compare_values(eom_ref, variable("CC3 ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
 
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
-*** tstart() called on dhcp189-242.emerson.emory.edu
-*** at Mon Feb 14 14:01:58 2022
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:16:48 2022
 
    => Loading Basis Set <=
 
-    Name: ANONYMOUS80518D25
+    Name: ANONYMOUS6617F2ED
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line    22 inputblock anonymous80518d25 
-    atoms 2 entry H          line     5 inputblock anonymous80518d25 
+    atoms 1 entry C          line    22 inputblock anonymous6617f2ed 
+    atoms 2 entry H          line     5 inputblock anonymous6617f2ed 
 
 
          ---------------------------------------------------------
@@ -213,8 +213,8 @@ Scratch directory: /tmp/
 
   ==> Primary Basis <==
 
-  Basis Set: ANONYMOUS80518D25
-    Blend: ANONYMOUS80518D25
+  Basis Set: ANONYMOUS6617F2ED
+    Blend: ANONYMOUS6617F2ED
     Number of shells: 15
     Number of basis functions: 33
     Number of Cartesian functions: 35
@@ -346,14 +346,14 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     1.5663     Total:     1.5663
 
 
-*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:01:58 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:16:48 2022
 Module time:
-	user time   =       0.27 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.27 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
@@ -379,8 +379,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on dhcp189-242.emerson.emory.edu
-*** at Mon Feb 14 14:01:58 2022
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:16:49 2022
 
 
 	Wfn Parameters:
@@ -524,15 +524,15 @@ Total time:
 	Two-electron energy          =      4.81738194669782
 	Reference energy             =    -38.27301741921383
 
-*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:01:58 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:16:49 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.14 seconds =       0.00 minutes
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.24 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -1108,7 +1108,7 @@ Largest components of excited wave function #1:
     CC3 energy............................................................................PASSED
     EOM-CC3 energy........................................................................PASSED
 
-    Psi4 stopped on: Monday, 14 February 2022 02:02PM
-    Psi4 wall time for execution: 0:00:12.42
+    Psi4 stopped on: Monday, 14 March 2022 01:17PM
+    Psi4 wall time for execution: 0:00:23.98
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc51/CMakeLists.txt
+++ b/tests/cc51/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc51 "psi;cc;cart;noc1")
+add_regression_test(cc51 "psi;cc;cart;noc1;eom")

--- a/tests/cc51/input.dat
+++ b/tests/cc51/input.dat
@@ -21,5 +21,5 @@ eom_ref = -76.0519836445 # TEST
 energy('eom-cc3')
 compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
 compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
-compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+compare_values(eom_ref, variable("CC3 ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
 

--- a/tests/cc51/input.dat
+++ b/tests/cc51/input.dat
@@ -21,5 +21,5 @@ eom_ref = -76.0519836445 # TEST
 energy('eom-cc3')
 compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
 compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
-compare_values(eom_ref, variable("CC3 ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
 

--- a/tests/cc51/output.ref
+++ b/tests/cc51/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev56 
+                               Psi4 undefined 
 
-                         Git: Rev {ccdensity_fix} 027e6dd dirty
+                         Git: Rev {eom_var} 5b439ed dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,10 +30,10 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 14 February 2022 02:04PM
+    Psi4 started on: Monday, 14 March 2022 01:15PM
 
-    Process ID: 12886
-    Host:       dhcp189-242.emerson.emory.edu
+    Process ID: 23838
+    Host:       dhcp189-157.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
@@ -64,14 +64,14 @@ eom_ref = -76.0519836445 # TEST
 energy('eom-cc3')
 compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
 compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
-compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+compare_values(eom_ref, variable("CC3 ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
 
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
-*** tstart() called on dhcp189-242.emerson.emory.edu
-*** at Mon Feb 14 14:04:46 2022
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:15:16 2022
 
    => Loading Basis Set <=
 
@@ -188,16 +188,16 @@ Scratch directory: /tmp/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:   -75.47284908986008   -7.54728e+01   0.00000e+00 
-   @RHF iter   1:   -75.97599997288074   -5.03151e-01   1.43171e-02 DIIS/ADIIS
-   @RHF iter   2:   -76.02797054702684   -5.19706e-02   9.35047e-03 DIIS/ADIIS
-   @RHF iter   3:   -76.05394025202597   -2.59697e-02   7.99318e-04 DIIS/ADIIS
-   @RHF iter   4:   -76.05440637128751   -4.66119e-04   1.77588e-04 DIIS/ADIIS
-   @RHF iter   5:   -76.05443531057378   -2.89393e-05   3.75498e-05 DIIS
-   @RHF iter   6:   -76.05443722684294   -1.91627e-06   7.73184e-06 DIIS
-   @RHF iter   7:   -76.05443731105581   -8.42129e-08   1.36715e-06 DIIS
-   @RHF iter   8:   -76.05443731339022   -2.33442e-09   2.33822e-07 DIIS
-   @RHF iter   9:   -76.05443731345912   -6.88942e-11   5.98627e-08 DIIS
-   @RHF iter  10:   -76.05443731346327   -4.14957e-12   6.63712e-09 DIIS
+   @RHF iter   1:   -75.97599997288074   -5.03151e-01   1.43171e-02 ADIIS/DIIS
+   @RHF iter   2:   -76.02797054702684   -5.19706e-02   9.35047e-03 ADIIS/DIIS
+   @RHF iter   3:   -76.05394025187591   -2.59697e-02   7.99319e-04 ADIIS/DIIS
+   @RHF iter   4:   -76.05440637128768   -4.66119e-04   1.77588e-04 ADIIS/DIIS
+   @RHF iter   5:   -76.05443530591954   -2.89346e-05   3.76043e-05 DIIS
+   @RHF iter   6:   -76.05443722683471   -1.92092e-06   7.73253e-06 DIIS
+   @RHF iter   7:   -76.05443731105599   -8.42213e-08   1.36717e-06 DIIS
+   @RHF iter   8:   -76.05443731339020   -2.33420e-09   2.33768e-07 DIIS
+   @RHF iter   9:   -76.05443731345903   -6.88374e-11   5.98300e-08 DIIS
+   @RHF iter  10:   -76.05443731346313   -4.09273e-12   6.63438e-09 DIIS
   Energy and wave function converged.
 
 
@@ -236,14 +236,14 @@ Scratch directory: /tmp/
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @RHF Final Energy:   -76.05443731346327
+  @RHF Final Energy:   -76.05443731346313
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.0093542296626641
-    One-Electron Energy =                -122.8064784832630352
-    Two-Electron Energy =                  37.7426869401371050
-    Total Energy =                        -76.0544373134632679
+    One-Electron Energy =                -122.8064784831644261
+    Two-Electron Energy =                  37.7426869400386451
+    Total Energy =                        -76.0544373134631257
 
 Computation Completed
 
@@ -265,15 +265,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -1.9387     Total:     1.9387
 
 
-*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:04:47 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:15:18 2022
 Module time:
-	user time   =       0.75 seconds =       0.01 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.23 seconds =       0.02 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.75 seconds =       0.01 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.23 seconds =       0.02 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -298,8 +298,8 @@ Total time:
         Stored in file 33.
 
 
-*** tstart() called on dhcp189-242.emerson.emory.edu
-*** at Mon Feb 14 14:04:48 2022
+*** tstart() called on dhcp189-157.emerson.emory.edu
+*** at Mon Mar 14 13:15:18 2022
 
 
 	Wfn Parameters:
@@ -381,20 +381,20 @@ Total time:
 	Total:                                     0.018 (MW) /      0.148 (MB)
 
 	Nuclear Rep. energy          =      9.00935422966266
-	SCF energy                   =    -76.05443731346327
-	One-electron energy          =   -122.80647807769611
-	Two-electron energy          =     37.74268653457025
+	SCF energy                   =    -76.05443731346313
+	One-electron energy          =   -122.80647807761575
+	Two-electron energy          =     37.74268653448988
 	Reference energy             =    -76.05443731346320
 
-*** tstop() called on dhcp189-242.emerson.emory.edu at Mon Feb 14 14:04:48 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:15:19 2022
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.31 seconds =       0.01 minutes
+	system time =       0.43 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.02 seconds =       0.02 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.62 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -402,7 +402,7 @@ Total time:
             **************************
 
     Nuclear Rep. energy (wfn)     =    9.009354229662664
-    SCF energy          (wfn)     =  -76.054437313463268
+    SCF energy          (wfn)     =  -76.054437313463126
     Reference energy    (file100) =  -76.054437313463197
 
     Input parameters:
@@ -432,23 +432,23 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2758350525611515
+MP2 correlation energy -0.2758350525603985
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.275835052561152    0.000e+00    0.000000    0.000000    0.000000    0.117056
-     1        -0.284194341448798    2.916e-02    0.004406    0.008041    0.008041    0.125326
-     2        -0.289394064728986    1.031e-02    0.005096    0.009416    0.009416    0.130919
-     3        -0.289651483708352    2.694e-03    0.005531    0.010486    0.010486    0.132163
-     4        -0.289681267891566    7.302e-04    0.005595    0.010758    0.010758    0.132420
-     5        -0.289694265258202    2.079e-04    0.005617    0.010893    0.010893    0.132436
-     6        -0.289692049051451    7.001e-05    0.005624    0.010944    0.010944    0.132427
-     7        -0.289692054525358    2.234e-05    0.005628    0.010968    0.010968    0.132426
-     8        -0.289691637601027    4.124e-06    0.005629    0.010970    0.010970    0.132425
-     9        -0.289691584956895    1.121e-06    0.005629    0.010971    0.010971    0.132425
-    10        -0.289691607360151    2.606e-07    0.005629    0.010971    0.010971    0.132425
-    11        -0.289691605939266    6.247e-08    0.005629    0.010971    0.010971    0.132425
+     0        -0.275835052560399    0.000e+00    0.000000    0.000000    0.000000    0.117056
+     1        -0.284194341447941    2.916e-02    0.004406    0.008041    0.008041    0.125326
+     2        -0.289394064728079    1.031e-02    0.005096    0.009416    0.009416    0.130919
+     3        -0.289651483707443    2.694e-03    0.005531    0.010486    0.010486    0.132163
+     4        -0.289681267890656    7.302e-04    0.005595    0.010758    0.010758    0.132420
+     5        -0.289694265257292    2.079e-04    0.005617    0.010893    0.010893    0.132436
+     6        -0.289692049050541    7.001e-05    0.005624    0.010944    0.010944    0.132427
+     7        -0.289692054524449    2.234e-05    0.005628    0.010968    0.010968    0.132426
+     8        -0.289691637600118    4.124e-06    0.005629    0.010970    0.010970    0.132425
+     9        -0.289691584955985    1.121e-06    0.005629    0.010971    0.010971    0.132425
+    10        -0.289691607359241    2.606e-07    0.005629    0.010971    0.010971    0.132425
+    11        -0.289691605938355    6.247e-08    0.005629    0.010971    0.010971    0.132425
 
     Iterations converged.
 
@@ -477,16 +477,16 @@ MP2 correlation energy -0.2758350525611515
       4   3  39  27        -0.0232682915
       4   4  39  39        -0.0232373445
 
-    SCF energy       (wfn)                    =  -76.054437313463268
+    SCF energy       (wfn)                    =  -76.054437313463126
     Reference energy (file100)                =  -76.054437313463197
 
-    Opposite-spin MP2 correlation energy      =   -0.209130956357103
-    Same-spin MP2 correlation energy          =   -0.066704096204049
+    Opposite-spin MP2 correlation energy      =   -0.209130956356556
+    Same-spin MP2 correlation energy          =   -0.066704096203843
     Singles MP2 correlation energy            =   -0.000000000000000
-    MP2 correlation energy                    =   -0.275835052561152
-      * MP2 total energy                      =  -76.330272366024346
-    CC3 correlation energy                    =   -0.289691605939266
-      * CC3 total energy                      =  -76.344128919402465
+    MP2 correlation energy                    =   -0.275835052560399
+      * MP2 total energy                      =  -76.330272366023593
+    CC3 correlation energy                    =   -0.289691605938355
+      * CC3 total energy                      =  -76.344128919401555
 
 
 			**************************
@@ -502,7 +502,7 @@ Dots of (HeT1)c in names "CC3 Wxxx" in CC3_HET1
 <WMbIj (Ij,Mb) | WMbIj (Ij,Mb)> =    3.5598235797
 <WMbIj (Mb,Ij) | WMbIj (Mb,Ij)> =    3.5598235797
 <WMbEj (ME,jb) | WMbEj (ME,jb)> =    1.7094466770
-<WMbeJ (Me,Jb) | WMbeJ (Me,Jb)> =  113.7063702279
+<WMbeJ (Me,Jb) | WMbeJ (Me,Jb)> =  113.7063702278
 <WAbEi (Ie,bA) | WAbEi (Ie,bA)> =   11.5303140636
 
 	**********************************************************
@@ -510,9 +510,9 @@ Dots of (HeT1)c in names "CC3 Wxxx" in CC3_HET1
 	**********************************************************
 
 	Nuclear Rep. energy (wfn)     =    9.009354229662664
-	SCF energy          (wfn)     =  -76.054437313463268
+	SCF energy          (wfn)     =  -76.054437313463126
 	Reference energy    (file100) =  -76.054437313463197
-	CC3 energy          (file100) =   -0.289691605939266
+	CC3 energy          (file100) =   -0.289691605938355
 
 	Input parameters:
 	-----------------
@@ -547,8 +547,8 @@ Dots of (HeT1)c in names "CC3 Wxxx" in CC3_HET1
 
 
 
-Fae   dot Fae   total 1160.8867669857
-Fmi   dot Fmi   total  426.0220490632
+Fae   dot Fae   total 1160.8867669903
+Fmi   dot Fmi   total  426.0220490624
 Fme   dot Fme   total    0.0000221163
 WMBIJ dot WMBIJ total    0.0000000000
 Wmbij dot Wmbij total    0.0000000000
@@ -585,7 +585,7 @@ Iter=11   L=11    Root    EOM Energy     Delta E   Res. Norm    Conv?
 Iter=12   L=12    Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.2958541109   2.52e-09    3.56e-07      Y
 Iter=13   L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2958541109   3.01e-13    3.56e-07      Y
+                     1   0.2958541109  -2.69e-14    3.56e-07      Y
 Completed EOM_CCSD
 Collapsing to only 1 vector(s).
 Copying root 1 to CC3_MISC file.
@@ -597,7 +597,7 @@ Iter=2    L=2     Root    EOM Energy     Delta E   Res. Norm    Conv?
 Iter=3    L=3     Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.2921684914   5.39e-05    3.64e-03      N
 Iter=4    L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2921508018  -1.77e-05    1.14e-03      N
+                     1   0.2921508017  -1.77e-05    1.14e-03      N
 Iter=5    L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.2921471464  -3.66e-06    3.19e-04      N
 Iter=6    L=6     Root    EOM Energy     Delta E   Res. Norm    Conv?
@@ -639,21 +639,21 @@ EOM CC3 R0 for root 0 =   0.00000000000
 Final Energetic Summary for Converged Roots of Irrep B1
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      7.950    64118.5   0.2921452749   -76.051983644489
+EOM State 1      7.950    64118.5   0.2921452749   -76.051983644491
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         0 >   0      :       1b1 >    4a1 :   -0.6714703757
-         0 >   1      :       1b1 >    5a1 :    0.0981471713
-         0 >   2      :       1b1 >    6a1 :   -0.0587842764
-         0 >   3      :       1b1 >    7a1 :    0.0247616622
-         0 >   4      :       1b1 >    8a1 :    0.0246211037
+         0 >   0      :       1b1 >    4a1 :    0.6714703757
+         0 >   1      :       1b1 >    5a1 :   -0.0981471713
+         0 >   2      :       1b1 >    6a1 :    0.0587842764
+         0 >   3      :       1b1 >    7a1 :   -0.0247616622
+         0 >   4      :       1b1 >    8a1 :   -0.0246211037
  RIjAb (libdpd indices)     : (cscf notation)
-        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :   -0.0759932273
-        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :   -0.0759932273
-        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :   -0.0548457621
-        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :   -0.0548457621
-        2   0 >   2   0     :    3a1    1b1 >    6a1    4a1 :   -0.0513307135
+        0   0 >   0   0     :    1b1    1b1 >    4a1    2b1 :    0.0759932273
+        0   0 >   0   0     :    1b1    1b1 >    2b1    4a1 :    0.0759932273
+        0   0 >   0   0     :    1b1    1b2 >    4a1    2b2 :    0.0548457621
+        0   0 >   0   0     :    1b2    1b1 >    2b2    4a1 :    0.0548457621
+        2   0 >   2   0     :    3a1    1b1 >    6a1    4a1 :    0.0513307135
 
 	Putting into environment energy for root of R irrep 3 and root 1.
 	Putting into environment CURRENT ENERGY:              -76.0519836445
@@ -663,7 +663,7 @@ Largest components of excited wave function #1:
     CC3 energy............................................................................PASSED
     EOM-CC3 energy........................................................................PASSED
 
-    Psi4 stopped on: Monday, 14 February 2022 02:05PM
-    Psi4 wall time for execution: 0:00:41.97
+    Psi4 stopped on: Monday, 14 March 2022 01:15PM
+    Psi4 wall time for execution: 0:00:42.66
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc51/output.ref
+++ b/tests/cc51/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {eom_var} 5b439ed dirty
+                         Git: Rev {eom_var} c391178 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 14 March 2022 01:15PM
+    Psi4 started on: Monday, 14 March 2022 04:10PM
 
-    Process ID: 23838
+    Process ID: 33678
     Host:       dhcp189-157.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
@@ -64,14 +64,14 @@ eom_ref = -76.0519836445 # TEST
 energy('eom-cc3')
 compare_values(scf_ref, variable("SCF TOTAL ENERGY"), 6, "SCF energy")              #TEST
 compare_values(cc3_ref, variable("CC3 TOTAL ENERGY"), 6, "CC3 energy")              #TEST
-compare_values(eom_ref, variable("CC3 ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
+compare_values(eom_ref, variable("CC ROOT 1 TOTAL ENERGY"), 6, "EOM-CC3 energy")    #TEST
 
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
 *** tstart() called on dhcp189-157.emerson.emory.edu
-*** at Mon Mar 14 13:15:16 2022
+*** at Mon Mar 14 16:10:54 2022
 
    => Loading Basis Set <=
 
@@ -188,10 +188,10 @@ Scratch directory: /tmp/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:   -75.47284908986008   -7.54728e+01   0.00000e+00 
-   @RHF iter   1:   -75.97599997288074   -5.03151e-01   1.43171e-02 ADIIS/DIIS
-   @RHF iter   2:   -76.02797054702684   -5.19706e-02   9.35047e-03 ADIIS/DIIS
-   @RHF iter   3:   -76.05394025187591   -2.59697e-02   7.99319e-04 ADIIS/DIIS
-   @RHF iter   4:   -76.05440637128768   -4.66119e-04   1.77588e-04 ADIIS/DIIS
+   @RHF iter   1:   -75.97599997288074   -5.03151e-01   1.43171e-02 DIIS/ADIIS
+   @RHF iter   2:   -76.02797054702684   -5.19706e-02   9.35047e-03 DIIS/ADIIS
+   @RHF iter   3:   -76.05394025187591   -2.59697e-02   7.99319e-04 DIIS/ADIIS
+   @RHF iter   4:   -76.05440637128768   -4.66119e-04   1.77588e-04 DIIS/ADIIS
    @RHF iter   5:   -76.05443530591954   -2.89346e-05   3.76043e-05 DIIS
    @RHF iter   6:   -76.05443722683471   -1.92092e-06   7.73253e-06 DIIS
    @RHF iter   7:   -76.05443731105599   -8.42213e-08   1.36717e-06 DIIS
@@ -265,15 +265,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -1.9387     Total:     1.9387
 
 
-*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:15:18 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 16:10:55 2022
 Module time:
-	user time   =       1.23 seconds =       0.02 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.23 seconds =       0.02 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -299,7 +299,7 @@ Total time:
 
 
 *** tstart() called on dhcp189-157.emerson.emory.edu
-*** at Mon Mar 14 13:15:18 2022
+*** at Mon Mar 14 16:10:55 2022
 
 
 	Wfn Parameters:
@@ -386,15 +386,15 @@ Total time:
 	Two-electron energy          =     37.74268653448988
 	Reference energy             =    -76.05443731346320
 
-*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 13:15:19 2022
+*** tstop() called on dhcp189-157.emerson.emory.edu at Mon Mar 14 16:10:56 2022
 Module time:
-	user time   =       0.31 seconds =       0.01 minutes
-	system time =       0.43 seconds =       0.01 minutes
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.38 seconds =       0.01 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.71 seconds =       0.03 minutes
-	system time =       0.62 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.07 seconds =       0.02 minutes
+	system time =       0.53 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -663,7 +663,7 @@ Largest components of excited wave function #1:
     CC3 energy............................................................................PASSED
     EOM-CC3 energy........................................................................PASSED
 
-    Psi4 stopped on: Monday, 14 March 2022 01:15PM
-    Psi4 wall time for execution: 0:00:42.66
+    Psi4 stopped on: Monday, 14 March 2022 04:11PM
+    Psi4 wall time for execution: 0:00:39.63
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc55/CMakeLists.txt
+++ b/tests/cc55/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc55 "psi;cc;autotest;noc1")
+add_regression_test(cc55 "psi;cc;autotest;noc1;eom")


### PR DESCRIPTION
## Description
This PR is the _first part_ of migrating EOM variables to the new standard for variable names, introduced in #2462. Among other things, the new standard gets rid of a longstanding grievance of TDC's: you no longer need to mix up all the irreps. This PR is content to migrate energy variable names. Other EOM variables go through `oeprop`, which will be a follow-up PR. A comprehensive test of EOM naming conventions is deferred to Pt. 2.

This PR also contains misc. minor EOM cleanup I did while trying to understand the big picture of the code. More cleanup is possible, but you need to give EOM a wavefunction first, which is far outside the scope of this PR.

Obligatory pings to @loriab and @lothian.

## Todos
- [x] Improve cc docs
- [x] Rename EOMCC energy variables to new standard 
- [x] Creates new EOM tag for tests 

## Checklist
- [x] All cc tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
