### PR TITLE
Retire n-pole components

### DIFF
--- a/doc/sphinxman/source/cfour.rst
+++ b/doc/sphinxman/source/cfour.rst
@@ -547,7 +547,7 @@ following could be used. ::
 
 .. caution:: Some features are not yet implemented. Buy a developer a coffee.
 
-   - No PSI Variables for properties: *e.g.*, :psivar:`SCF DIPOLE X`
+   - No PSI Variables for properties: *e.g.*, :psivar:`SCF DIPOLE`
 
    - No PSI Variables for excited state energies
 

--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -68,28 +68,9 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the averaged coupled-pair functional level of theory, (3,).
 
-.. psivar:: ACPF DIPOLE X
-   ACPF DIPOLE Y
-   ACPF DIPOLE Z
-
-   The three components of the dipole [Debye] for the
-   averaged coupled-pair functional level of theory.
-   Deprecated in favor of :psivar:`ACPF DIPOLE`.
-
 .. psivar:: ACPF QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the averaged coupled-pair functional level of theory, (3, 3).
-
-.. psivar:: ACPF QUADRUPOLE XX
-   ACPF QUADRUPOLE XY
-   ACPF QUADRUPOLE XZ
-   ACPF QUADRUPOLE YY
-   ACPF QUADRUPOLE YZ
-   ACPF QUADRUPOLE ZZ
-
-   The six components of the quadrupole [Debye Ang] for the
-   averaged coupled-pair functional level of theory.
-   Deprecated in favor of :psivar:`ACPF QUADRUPOLE`.
 
 .. psivar:: ACPF TOTAL ENERGY
    ACPF CORRELATION ENERGY
@@ -114,28 +95,9 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the averaged quadratic coupled-cluster level of theory, (3,).
 
-.. psivar:: AQCC DIPOLE X
-   AQCC DIPOLE Y
-   AQCC DIPOLE Z
-
-   The three components of the dipole [Debye] for the
-   averaged quadratic coupled-cluster level of theory.
-   Deprecated in favor of :psivar:`AQCC DIPOLE`.
-
 .. psivar:: AQCC QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the averaged quadratic coupled-cluster level of theory, (3, 3).
-
-.. psivar:: AQCC QUADRUPOLE XX
-   AQCC QUADRUPOLE XY
-   AQCC QUADRUPOLE XZ
-   AQCC QUADRUPOLE YY
-   AQCC QUADRUPOLE YZ
-   AQCC QUADRUPOLE ZZ
-
-   The six components of the quadrupole [Debye Ang] for the
-   averaged quadratic coupled-cluster level of theory.
-   Deprecated in favor of :psivar:`AQCC QUADRUPOLE`.
 
 .. psivar:: AQCC TOTAL ENERGY
    AQCC CORRELATION ENERGY
@@ -158,28 +120,9 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the requested coupled cluster level of theory and root *n* (number starts at GS = 0), (3,).
 
-.. psivar:: CC ROOT n DIPOLE X
-   CC ROOT n DIPOLE Y
-   CC ROOT n DIPOLE Z
-
-   The three components of the dipole [Debye] for the requested
-   coupled cluster level of theory and root *n* (number starts at GS = 0).
-   Deprecated in favor of :psivar:`CC ROOT n DIPOLE`.
-
 .. psivar:: CC ROOT n QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the requested coupled cluster level of theory and root *n* (number starts at GS = 0), (3, 3).
-
-.. psivar:: CC ROOT n QUADRUPOLE XX
-   CC ROOT n QUADRUPOLE XY
-   CC ROOT n QUADRUPOLE XZ
-   CC ROOT n QUADRUPOLE YY
-   CC ROOT n QUADRUPOLE YZ
-   CC ROOT n QUADRUPOLE ZZ
-
-   The six components of the quadrupole [Debye Ang] for the requested
-   coupled cluster level of theory and root *n* (numbering starts at GS = 0).
-   Deprecated in favor of :psivar:`CC ROOT n QUADRUPOLE`.
 
 .. psivar:: CC ROOT n TOTAL ENERGY
    CC ROOT n CORRELATION ENERGY
@@ -215,14 +158,6 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the requested coupled cluster level of theory and root, (3,).
 
-.. psivar:: CC DIPOLE X
-   CC DIPOLE Y
-   CC DIPOLE Z
-
-   The three components of the dipole [Debye] for the requested
-   coupled cluster level of theory and root.
-   Deprecated in favor of :psivar:`CC DIPOLE`.
-
 .. psivar:: CC2 DIPOLE POLARIZABILITY @ xNM
 
    The dipole polarizability [au] calculated at the CC2 level
@@ -247,16 +182,6 @@ PSI Variables by Alpha
 
    The origin-dependence of the CC2 specific rotation in deg/[dm (g/cm^3)]/bohr and the
    length gauge, computed at (x) wavelength, (x) rounded to nearest integer.
-
-.. psivar:: CC QUADRUPOLE XX
-   CC QUADRUPOLE XY
-   CC QUADRUPOLE XZ
-   CC QUADRUPOLE YY
-   CC QUADRUPOLE YZ
-   CC QUADRUPOLE ZZ
-
-   The six components of the quadrupole [Debye Ang] for the requested
-   coupled cluster level of theory and root.
 
 .. psivar:: CCD TOTAL ENERGY
    CCD CORRELATION ENERGY
@@ -397,28 +322,9 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the coupled electron pair approximation variant 0 level of theory, (3,).
 
-.. psivar:: CEPA(0) DIPOLE X
-   CEPA(0) DIPOLE Y
-   CEPA(0) DIPOLE Z
-
-   The three components of the dipole [Debye] for the
-   coupled electron pair approximation variant 0 level of theory.
-   Deprecated in favor of :psivar:`CEPA(0) DIPOLE`.
-
 .. psivar:: CEPA(0) QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the coupled electron pair approximation variant 0 level of theory, (3, 3).
-
-.. psivar:: CEPA(0) QUADRUPOLE XX
-   CEPA(0) QUADRUPOLE XY
-   CEPA(0) QUADRUPOLE XZ
-   CEPA(0) QUADRUPOLE YY
-   CEPA(0) QUADRUPOLE YZ
-   CEPA(0) QUADRUPOLE ZZ
-
-   The six components of the quadrupole [Debye Ang] for the
-   coupled electron pair approximation variant 0 level of theory.
-   Deprecated in favor of :psivar:`CEPA(0) QUADRUPOLE`.
 
 .. psivar:: CEPA(0) TOTAL ENERGY
    CEPA(0) CORRELATION ENERGY
@@ -440,83 +346,25 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the requested configuration interaction level of theory, (3,).
 
-.. psivar:: CI DIPOLE X
-   CI DIPOLE Y
-   CI DIPOLE Z
-
-   The three components of the dipole [Debye] for the requested
-   configuration interaction level of theory and root.
-   Deprecated in favor of :psivar:`CI DIPOLE`.
-
 .. psivar:: CI QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the requested configuration interaction level of theory, (3, 3).
-
-.. psivar:: CI QUADRUPOLE XX
-   CI QUADRUPOLE XY
-   CI QUADRUPOLE XZ
-   CI QUADRUPOLE YY
-   CI QUADRUPOLE YZ
-   CI QUADRUPOLE ZZ
-
-   The six components of the quadrupole [Debye Ang] for the requested
-   configuration interaction level of theory and root.
-   Deprecated in favor of :psivar:`CI QUADRUPOLE`.
 
 .. psivar:: CI ROOT n -> ROOT m DIPOLE
 
    Transition dipole array [e a0] between roots *n* and *m* for the requested configuration interaction level of theory, (3,).
 
-.. psivar:: CI ROOT n -> ROOT m DIPOLE X
-   CI ROOT n -> ROOT m DIPOLE Y
-   CI ROOT n -> ROOT m DIPOLE Z
-
-   The three components of the transition dipole [Debye] between roots *n*
-   and *m* for the requested configuration interaction level of theory.
-   Deprecated in favor of :psivar:`CI ROOT n -> ROOT m DIPOLE`.
-
 .. psivar:: CI ROOT n -> ROOT m QUADRUPOLE
 
    Redundant transition quadrupole array [e a0^2] between roots *n* and *m* for the requested configuration interaction level of theory, (3, 3).
-
-.. psivar:: CI ROOT n -> ROOT m QUADRUPOLE XX
-   CI ROOT n -> ROOT m QUADRUPOLE XY
-   CI ROOT n -> ROOT m QUADRUPOLE XZ
-   CI ROOT n -> ROOT m QUADRUPOLE YY
-   CI ROOT n -> ROOT m QUADRUPOLE YZ
-   CI ROOT n -> ROOT m QUADRUPOLE ZZ
-
-   The three components of the transition quadrupole [Debye Ang] between
-   roots *n* and *m* for the requested configuration interaction level of
-   theory.
-   Deprecated in favor of :psivar:`CI ROOT n -> ROOT m QUADRUPOLE`.
 
 .. psivar:: CI ROOT n DIPOLE
 
    Dipole array [e a0] for the requested configuration interaction level of theory and root *n*, (3,).
 
-.. psivar:: CI ROOT n DIPOLE X
-   CI ROOT n DIPOLE Y
-   CI ROOT n DIPOLE Z
-
-   The three components of the dipole [Debye] for the requested
-   configuration interaction level of theory and root *n*.
-   Deprecated in favor of :psivar:`CI ROOT n DIPOLE`.
-
 .. psivar:: CI ROOT n QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the requested configuration interaction level of theory and root *n*, (3, 3).
-
-.. psivar:: CI ROOT n QUADRUPOLE XX
-   CI ROOT n QUADRUPOLE XY
-   CI ROOT n QUADRUPOLE XZ
-   CI ROOT n QUADRUPOLE YY
-   CI ROOT n QUADRUPOLE YZ
-   CI ROOT n QUADRUPOLE ZZ
-
-   The six components of the quadrupole [Debye Ang] for the requested
-   configuration interaction level of theory and root *n*.
-   Deprecated in favor of :psivar:`CI ROOT n QUADRUPOLE`.
 
 .. psivar:: CI ROOT n TOTAL ENERGY
    CI ROOT n CORRELATION ENERGY
@@ -541,28 +389,9 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the configuration interaction singles and doubles level of theory, (3,).
 
-.. psivar:: CISD DIPOLE X
-   CISD DIPOLE Y
-   CISD DIPOLE Z
-
-   The three components of the dipole [Debye] for the
-   configuration interaction singles and doubles level of theory and root.
-   Deprecated in favor of :psivar:`CISD DIPOLE`.
-
 .. psivar:: CISD QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the configuration interaction singles and doubles level of theory, (3, 3).
-
-.. psivar:: CISD QUADRUPOLE XX
-   CISD QUADRUPOLE XY
-   CISD QUADRUPOLE XZ
-   CISD QUADRUPOLE YY
-   CISD QUADRUPOLE YZ
-   CISD QUADRUPOLE ZZ
-
-   The six components of the quadrupole [Debye Ang] for the
-   configuration interaction singles and doubles level of theory and root.
-   Deprecated in favor of :psivar:`CISD QUADRUPOLE`.
 
 .. psivar:: CISD TOTAL ENERGY
    CISD CORRELATION ENERGY
@@ -944,88 +773,29 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the named method, (3,).
 
-.. psivar:: mtd DIPOLE X
-   mtd DIPOLE Y
-   mtd DIPOLE Z
-
-   The three components of the named method dipole [Debye].
-   Deprecated in favor of :psivar:`mtd DIPOLE`.
-
 .. psivar:: mtd QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the named method, (3, 3).
-
-.. psivar:: mtd QUADRUPOLE XX
-   mtd QUADRUPOLE XY
-   mtd QUADRUPOLE XZ
-   mtd QUADRUPOLE YY
-   mtd QUADRUPOLE YZ
-   mtd QUADRUPOLE ZZ
-
-   The six components of the named method quadrupole [Debye Ang].
-   Deprecated in favor of :psivar:`mtd QUADRUPOLE`.
 
 .. psivar:: mtd OCTUPOLE
 
    Redundant octupole array [e a0^3] for the named method, (3, 3, 3).
 
-.. psivar:: mtd OCTUPOLE XXX
-   mtd OCTUPOLE XXY
-   mtd OCTUPOLE XXZ
-   mtd OCTUPOLE XYY
-   mtd OCTUPOLE XYZ
-   mtd OCTUPOLE XZZ
-   mtd OCTUPOLE YYY
-   mtd OCTUPOLE YYZ
-   mtd OCTUPOLE YZZ
-   mtd OCTUPOLE ZZZ
-
-   The ten components of the named method octupole [Debye Ang^2].
-   Deprecated in favor of :psivar:`mtd OCTUPOLE`.
-
 .. psivar:: mtd HEXADECAPOLE
 
    Redundant hexadecapole array [e a0^4] for the named method, (3, 3, 3, 3).
-
-.. psivar:: mtd HEXADECAPOLE XXXX
-   mtd HEXADECAPOLE XXXY
-   mtd HEXADECAPOLE ZZZZ
-
-   The 15 components of the named method hexadecapole [Debye Ang^3].
-   Deprecated in favor of :psivar:`mtd HEXADECAPOLE`.
 
 .. psivar:: mtd 32-POLE
 
    Redundant 32-pole array [e a0^5] for the named method, (3, 3, 3, 3, 3).
 
-.. psivar:: mtd 32-POLE XXXXX
-   mtd 32-POLE XXXXY
-   mtd 32-POLE ZZZZZ
-
-   The 21 components of the named method 32-pole [Debye Ang^4].
-   Deprecated in favor of :psivar:`mtd 32-POLE`.
-
 .. psivar:: mtd 64-POLE
 
    Redundant 64-pole array [e a0^6] for the named method, (3, 3, 3, 3, 3, 3).
 
-.. psivar:: mtd 64-POLE XXXXXX
-   mtd 64-POLE XXXXXY
-   mtd 64-POLE ZZZZZZ
-
-   The 28 components of the named method 64-pole [Debye Ang^5].
-   Deprecated in favor of :psivar:`mtd 64-POLE`.
-
 .. psivar:: mtd 128-POLE
 
    Redundant 128-pole array [e a0^7] for the named method, (3, 3, 3, 3, 3, 3, 3).
-
-.. psivar:: mtd 128-POLE XXXXXXX
-   mtd 128-POLE XXXXXXY
-   mtd 128-POLE ZZZZZZZ
-
-   The 36 components of the named method 128-pole [Debye Ang^6].
-   Deprecated in favor of :psivar:`mtd 128-POLE`.
 
 .. psivar:: MP2 TOTAL ENERGY
    MP2 CORRELATION ENERGY
@@ -1556,26 +1326,9 @@ PSI Variables by Alpha
 
    Dipole array [e a0] for the SCF stage, (3,).
 
-.. psivar:: SCF DIPOLE X
-   SCF DIPOLE Y
-   SCF DIPOLE Z
-
-   The three components of the SCF dipole [Debye].
-   Deprecated in favor of :psivar:`SCF DIPOLE`.
-
 .. psivar:: SCF QUADRUPOLE
 
    Redundant quadrupole array [e a0^2] for the SCF stage, (3, 3).
-
-.. psivar:: SCF QUADRUPOLE XX
-   SCF QUADRUPOLE XY
-   SCF QUADRUPOLE XZ
-   SCF QUADRUPOLE YY
-   SCF QUADRUPOLE YZ
-   SCF QUADRUPOLE ZZ
-
-   The six components of the SCF quadrupole [Debye Ang].
-   Deprecated in favor of :psivar:`SCF QUADRUPOLE`.
 
 .. psivar:: SCF TOTAL ENERGY
 

--- a/doc/sphinxman/source/oeprop.rst
+++ b/doc/sphinxman/source/oeprop.rst
@@ -58,7 +58,7 @@ summarized in the table below.
    +------------------------------------+-----------------------+-----------------------------------------------------------------------------------+
    | Electric quadrupole moment         | QUADRUPOLE            | Raw (traced) moments and traceless multipoles                                     |
    +------------------------------------+-----------------------+-----------------------------------------------------------------------------------+
-   | All moments up order N             | MULTIPOLE(N)          | Only raw (traced) moments. Sets global variables e.g. "DIPOLE X", "32-POLE XYYZZ" |
+   | All moments up order N             | MULTIPOLE(N)          | Only raw (traced) moments. Sets global variables e.g. "DIPOLE", "32-POLE"         |
    +------------------------------------+-----------------------+-----------------------------------------------------------------------------------+
    | Electrostatic potential, at nuclei | ESP_AT_NUCLEI         | Sets global variables "ESP AT CENTER n", n = 1 to natoms                          |
    +------------------------------------+-----------------------+-----------------------------------------------------------------------------------+

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -651,16 +651,10 @@ _qcvar_cancellations = {
 
 def _qcvar_warnings(key: str) -> str:
     if any([key.upper().endswith(" DIPOLE " + cart) for cart in ["X", "Y", "Z"]]):
-        warnings.warn(
-            f"Using scalar QCVariable `{key.upper()}` [D] instead of array `{key.upper()[:-2]}` [e a0] is deprecated, and in 1.5 it will stop working\n",
-            category=FutureWarning,
-            stacklevel=3)
+        raise UpgradeHelper(key.upper(), key.upper()[:-2], 1.6, " Note the Debye -> a.u. units change.")
 
     if any([key.upper().endswith(" QUADRUPOLE " + cart) for cart in ["XX", "YY", "ZZ", "XY", "XZ", "YZ"]]):
-        warnings.warn(
-            f"Using scalar QCVariable `{key.upper()}` [D A] instead of array `{key.upper()[:-3]}` [e a0^2] is deprecated, and in 1.5 it will stop working\n",
-            category=FutureWarning,
-            stacklevel=3)
+        raise UpgradeHelper(key.upper(), key.upper()[:-2], 1.6, " Note the Debye -> a.u. units change.")
 
     if key.upper() in _qcvar_transitions:
         warnings.warn(

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -651,10 +651,10 @@ _qcvar_cancellations = {
 
 def _qcvar_warnings(key: str) -> str:
     if any([key.upper().endswith(" DIPOLE " + cart) for cart in ["X", "Y", "Z"]]):
-        raise UpgradeHelper(key.upper(), key.upper()[:-2], 1.6, " Note the Debye -> a.u. units change.")
+        raise UpgradeHelper(key.upper(), key.upper()[:-3], 1.6, " Note the Debye -> a.u. units change.")
 
     if any([key.upper().endswith(" QUADRUPOLE " + cart) for cart in ["XX", "YY", "ZZ", "XY", "XZ", "YZ"]]):
-        raise UpgradeHelper(key.upper(), key.upper()[:-2], 1.6, " Note the Debye -> a.u. units change.")
+        raise UpgradeHelper(key.upper(), key.upper()[:-3], 1.6, " Note the Debye -> a.u. units change.")
 
     if key.upper() in _qcvar_transitions:
         warnings.warn(

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -651,7 +651,7 @@ _qcvar_cancellations = {
 
 def _qcvar_warnings(key: str) -> str:
     if any([key.upper().endswith(" DIPOLE " + cart) for cart in ["X", "Y", "Z"]]):
-        raise UpgradeHelper(key.upper(), key.upper()[:-3], 1.6, " Note the Debye -> a.u. units change.")
+        raise UpgradeHelper(key.upper(), key.upper()[:-2], 1.6, " Note the Debye -> a.u. units change.")
 
     if any([key.upper().endswith(" QUADRUPOLE " + cart) for cart in ["XX", "YY", "ZZ", "XY", "XZ", "YZ"]]):
         raise UpgradeHelper(key.upper(), key.upper()[:-3], 1.6, " Note the Debye -> a.u. units change.")

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3172,20 +3172,6 @@ def run_cc_property(name, **kwargs):
         # call oe prop for each ES density
         if name.startswith('eom'):
             # copy GS CC DIP/QUAD ... to CC ROOT 0 DIP/QUAD ... if we are doing multiple roots
-            # retire components at v1.5
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                if 'dipole' in one:
-                    core.set_variable("CC ROOT 0 DIPOLE X", core.variable("CC DIPOLE X"))
-                    core.set_variable("CC ROOT 0 DIPOLE Y", core.variable("CC DIPOLE Y"))
-                    core.set_variable("CC ROOT 0 DIPOLE Z", core.variable("CC DIPOLE Z"))
-                if 'quadrupole' in one:
-                    core.set_variable("CC ROOT 0 QUADRUPOLE XX", core.variable("CC QUADRUPOLE XX"))
-                    core.set_variable("CC ROOT 0 QUADRUPOLE XY", core.variable("CC QUADRUPOLE XY"))
-                    core.set_variable("CC ROOT 0 QUADRUPOLE XZ", core.variable("CC QUADRUPOLE XZ"))
-                    core.set_variable("CC ROOT 0 QUADRUPOLE YY", core.variable("CC QUADRUPOLE YY"))
-                    core.set_variable("CC ROOT 0 QUADRUPOLE YZ", core.variable("CC QUADRUPOLE YZ"))
-                    core.set_variable("CC ROOT 0 QUADRUPOLE ZZ", core.variable("CC QUADRUPOLE ZZ"))
             if 'dipole' in one:
                 core.set_variable("CC ROOT 0 DIPOLE", core.variable("CC DIPOLE"))
                 # core.set_variable("CC ROOT n DIPOLE", core.variable("CC DIPOLE"))  # P::e CCENERGY
@@ -3910,12 +3896,6 @@ def run_detci(name, **kwargs):
         oeprop.add("DIPOLE")
         oeprop.compute()
         ciwfn.oeprop = oeprop
-        # retire components in v1.5
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            core.set_variable("CURRENT DIPOLE X", core.variable(name.upper() + " DIPOLE X"))
-            core.set_variable("CURRENT DIPOLE Y", core.variable(name.upper() + " DIPOLE Y"))
-            core.set_variable("CURRENT DIPOLE Z", core.variable(name.upper() + " DIPOLE Z"))
         core.set_variable("CURRENT DIPOLE", core.variable(name.upper() + " DIPOLE"))
 
     ciwfn.cleanup_ci()
@@ -5225,12 +5205,6 @@ def run_detcas(name, **kwargs):
     oeprop.add("DIPOLE")
     oeprop.compute()
     ciwfn.oeprop = oeprop
-    # retire components by v1.5
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        core.set_variable("CURRENT DIPOLE X", core.variable(name.upper() + " DIPOLE X"))
-        core.set_variable("CURRENT DIPOLE Y", core.variable(name.upper() + " DIPOLE Y"))
-        core.set_variable("CURRENT DIPOLE Z", core.variable(name.upper() + " DIPOLE Z"))
     core.set_variable("CURRENT DIPOLE", core.variable(name.upper() + " DIPOLE"))
 
     # Shove variables into global space

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1634,9 +1634,6 @@ def scf_helper(name, post_scf=True, **kwargs):
         for obj in [core, scf_wfn]:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                # component qcvars can be retired at v1.5
-                for xyz in 'XYZ':
-                    obj.set_variable('CURRENT DIPOLE ' + xyz, obj.variable('SCF DIPOLE ' + xyz))
             obj.set_variable("CURRENT DIPOLE", obj.variable("SCF DIPOLE"))  # P::e SCF
 
     # Write out MO's
@@ -3005,11 +3002,6 @@ def run_scf_property(name, **kwargs):
     oe.compute()
     scf_wfn.oeprop = oe
 
-    # Always must set SCF dipole (retire components at v1.5)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        for cart in ["X", "Y", "Z"]:
-            core.set_variable("SCF DIPOLE " + cart, core.variable(name + " DIPOLE " + cart))
     core.set_variable("SCF DIPOLE", core.variable(name + " DIPOLE"))  # P::e SCF
 
     # Run Linear Respsonse

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -646,18 +646,6 @@ def scf_finalize_energy(self):
         # Set callback function for CPSCF
         self.set_external_cpscf_perturbation("PE", lambda pert_dm : self.pe_state.get_pe_contribution(pert_dm, elec_only=True)[1])
 
-    # Properties
-    #  Comments so that autodoc utility will find these PSI variables
-    #  Process::environment.globals["SCF DIPOLE X"] =
-    #  Process::environment.globals["SCF DIPOLE Y"] =
-    #  Process::environment.globals["SCF DIPOLE Z"] =
-    #  Process::environment.globals["SCF QUADRUPOLE XX"] =
-    #  Process::environment.globals["SCF QUADRUPOLE XY"] =
-    #  Process::environment.globals["SCF QUADRUPOLE XZ"] =
-    #  Process::environment.globals["SCF QUADRUPOLE YY"] =
-    #  Process::environment.globals["SCF QUADRUPOLE YZ"] =
-    #  Process::environment.globals["SCF QUADRUPOLE ZZ"] =
-
     # Orbitals are always saved, in case an MO guess is requested later
     # save_orbitals()
 

--- a/psi4/driver/procrouting/wrappers_cfour.py
+++ b/psi4/driver/procrouting/wrappers_cfour.py
@@ -43,6 +43,7 @@ import subprocess
 
 from psi4.driver.p4util.exceptions import *
 
+# Not maintained: see #2478
 
 def run_cfour_module(xmod):
     # Find environment by merging PSIPATH and PATH environment variables

--- a/psi4/driver/procrouting/wrappers_cfour.py
+++ b/psi4/driver/procrouting/wrappers_cfour.py
@@ -43,7 +43,7 @@ import subprocess
 
 from psi4.driver.p4util.exceptions import *
 
-# Not maintained: see #2478
+# Not maintained: see https://github.com/psi4/psi4/issues/2478
 
 def run_cfour_module(xmod):
     # Find environment by merging PSIPATH and PATH environment variables

--- a/psi4/driver/qcdb/cfour.py
+++ b/psi4/driver/qcdb/cfour.py
@@ -42,7 +42,7 @@ from .options import conv_float2negexp
 from .hessparse import load_hessian
 from .align import B787
 
-# Not maintained: see #2478
+# Not maintained: see https://github.com/psi4/psi4/issues/2478
 
 def harvest_output(outtext):
     """Function to separate portions of a CFOUR output file *outtest*,

--- a/psi4/driver/qcdb/cfour.py
+++ b/psi4/driver/qcdb/cfour.py
@@ -42,6 +42,7 @@ from .options import conv_float2negexp
 from .hessparse import load_hessian
 from .align import B787
 
+# Not maintained: see #2478
 
 def harvest_output(outtext):
     """Function to separate portions of a CFOUR output file *outtest*,

--- a/psi4/driver/qcdb/orca.py
+++ b/psi4/driver/qcdb/orca.py
@@ -33,6 +33,7 @@ import qcelemental as qcel
 from .pdict import PreservingDict
 from .molecule import Molecule
 
+# Not maintained: see #2478
 
 def harvest(p4Mol, orca_out, **largs):
     """Harvest variables, gradient, and the molecule from the output and other

--- a/psi4/driver/qcdb/orca.py
+++ b/psi4/driver/qcdb/orca.py
@@ -33,7 +33,7 @@ import qcelemental as qcel
 from .pdict import PreservingDict
 from .molecule import Molecule
 
-# Not maintained: see #2478
+# Not maintained: see https://github.com/psi4/psi4/issues/2478
 
 def harvest(p4Mol, orca_out, **largs):
     """Harvest variables, gradient, and the molecule from the output and other

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -407,15 +407,6 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
 
         // Process::environment.globals["CC ROOT n DIPOLE"]
         // Process::environment.globals["CC ROOT n QUADRUPOLE"]
-        // Process::environment.globals["CC ROOT n DIPOLE X"]
-        // Process::environment.globals["CC ROOT n DIPOLE Y"]
-        // Process::environment.globals["CC ROOT n DIPOLE Z"]
-        // Process::environment.globals["CC ROOT n QUADRUPOLE XX"]
-        // Process::environment.globals["CC ROOT n QUADRUPOLE XY"]
-        // Process::environment.globals["CC ROOT n QUADRUPOLE XZ"]
-        // Process::environment.globals["CC ROOT n QUADRUPOLE YY"]
-        // Process::environment.globals["CC ROOT n QUADRUPOLE YZ"]
-        // Process::environment.globals["CC ROOT n QUADRUPOLE ZZ"]
 
         free_block(moinfo.opdm);
         free_block(moinfo.opdm_a);

--- a/psi4/src/psi4/detci/opdm.cc
+++ b/psi4/src/psi4/detci/opdm.cc
@@ -646,25 +646,9 @@ void CIWavefunction::ci_nat_orbs() {
 /*- Process::environment.globals["CIn CORRELATION ENERGY"] -*/
 /*- Process::environment.globals["CI ROOT n TOTAL ENERGY"] -*/
 /*- Process::environment.globals["CI ROOT n CORRELATION ENERGY"] -*/
-/*- Process::environment.globals["CI ROOT n DIPOLE X"] -*/
-/*- Process::environment.globals["CI ROOT n DIPOLE Y"] -*/
-/*- Process::environment.globals["CI ROOT n DIPOLE Z"] -*/
 /*- Process::environment.globals["CI ROOT n DIPOLE"] -*/
 /*- Process::environment.globals["CI ROOT n QUADRUPOLE"] -*/
-/*- Process::environment.globals["CI ROOT n QUADRUPOLE XX"] -*/
-/*- Process::environment.globals["CI ROOT n QUADRUPOLE XY"] -*/
-/*- Process::environment.globals["CI ROOT n QUADRUPOLE XZ"] -*/
-/*- Process::environment.globals["CI ROOT n QUADRUPOLE YY"] -*/
-/*- Process::environment.globals["CI ROOT n QUADRUPOLE YZ"] -*/
-/*- Process::environment.globals["CI ROOT n QUADRUPOLE ZZ"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m DIPOLE X"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m DIPOLE Y"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m DIPOLE Z"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m QUADRUPOLE XX"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m QUADRUPOLE XY"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m QUADRUPOLE XZ"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m QUADRUPOLE YY"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m QUADRUPOLE YZ"] -*/
-/*- Process::environment.globals["CI ROOT n -> ROOT m QUADRUPOLE ZZ"] -*/
+/*- Process::environment.globals["CI ROOT n -> ROOT m DIPOLE"] -*/
+/*- Process::environment.globals["CI ROOT n -> ROOT m QUADRUPOLE"] -*/
 }
 }  // namespace psi

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -837,7 +837,7 @@ void OEProp::compute() {
 }
 
 void OEProp::compute_multipoles(int order, bool transition) {
-    MultipolePropCalc::MultipoleOutputType mpoles = mpc_.compute_multipoles(order, transition, true, print_ > 4);
+    auto mpoles = mpc_.compute_multipoles(order, transition, true, print_ > 4);
 
     for (int l = 1; l <= order; ++l) {
         int component = 0;
@@ -858,6 +858,26 @@ void OEProp::compute_multipoles(int order, bool transition) {
         } else {
             int n = (1 << l);
             sstream << n << "-POLE";
+        }
+
+        for (auto it = mpoles->begin(); it != mpoles->end(); ++it) {
+            std::string name;
+            double total_mpole = 0.0;
+            int order_mpole;
+            // unpack the multipole, which is: name, nuc, elec, total, order, ignore nuc and elec:
+            std::tie(name, std::ignore, std::ignore, total_mpole, order_mpole) = *it;
+            /*- Process::environment.globals["mtd DIPOLE"] -*/
+            /*- Process::environment.globals["mtd QUADRUPOLE"] -*/
+            /*- Process::environment.globals["mtd OCTUPOLE"] -*/
+            /*- Process::environment.globals["mtd HEXADECAPOLE"] -*/
+            /*- Process::environment.globals["mtd 32-POLE"] -*/
+            /*- Process::environment.globals["mtd 64-POLE"] -*/
+            /*- Process::environment.globals["mtd 128-POLE"] -*/
+
+            if (order_mpole == l) {
+                multipole_array->set(0, component, total_mpole);
+                ++component;
+            }
         }
 
         Process::environment.arrays[sstream.str()] = multipole_array;

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -859,39 +859,7 @@ void OEProp::compute_multipoles(int order, bool transition) {
             int n = (1 << l);
             sstream << n << "-POLE";
         }
-        std::string mname = sstream.str();
 
-        for (auto it = mpoles->begin(); it != mpoles->end(); ++it) {
-            std::string name;
-            double total_mpole = 0.0;
-            int order_mpole;
-            // unpack the multipole, which is: name, nuc, elec, total, order, ignore nuc and elec:
-            std::tie(name, std::ignore, std::ignore, total_mpole, order_mpole) = *it;
-            /*- Process::environment.globals["mtd DIPOLE X"] -*/
-            /*- Process::environment.globals["mtd DIPOLE Y"] -*/
-            /*- Process::environment.globals["mtd DIPOLE Z"] -*/
-            /*- Process::environment.globals["mtd QUADRUPOLE XX"] -*/
-            /*- Process::environment.globals["mtd OCTUPOLE XXX"] -*/
-            /*- Process::environment.globals["mtd HEXADECAPOLE XXXX"] -*/
-            /*- Process::environment.globals["mtd 32-POLE XXXXX"] -*/
-            /*- Process::environment.globals["mtd 32-POLE XXXXY"] -*/
-            /*- Process::environment.globals["mtd 64-POLE XXXXXX"] -*/
-            /*- Process::environment.globals["mtd 128-POLE XXXXXXX"] -*/
-            /*- Process::environment.globals["mtd DIPOLE"] -*/
-            /*- Process::environment.globals["mtd QUADRUPOLE"] -*/
-            /*- Process::environment.globals["mtd OCTUPOLE"] -*/
-            /*- Process::environment.globals["mtd HEXADECAPOLE"] -*/
-            /*- Process::environment.globals["mtd 32-POLE"] -*/
-            /*- Process::environment.globals["mtd 64-POLE"] -*/
-            /*- Process::environment.globals["mtd 128-POLE"] -*/
-
-            if (order_mpole == l) {
-                Process::environment.globals[name] = total_mpole;
-                wfn_->set_scalar_variable(name, total_mpole);
-                multipole_array->set(0, component, total_mpole);
-                ++component;
-            }
-        }
         Process::environment.arrays[sstream.str()] = multipole_array;
         wfn_->set_array_variable(sstream.str(), multipole_array);
     }
@@ -1278,23 +1246,8 @@ std::shared_ptr<std::vector<double>> ESPPropCalc::compute_esp_at_nuclei(bool pri
 
 void OEProp::compute_dipole(bool transition) {
     SharedVector dipole = mpc_.compute_dipole(transition, true, print_ > 4);
-    // Dipole components in Debye
-    std::stringstream s;
-    s << title_ << " DIPOLE X";
-    Process::environment.globals[s.str()] = dipole->get(0);
-    wfn_->set_scalar_variable(s.str(), dipole->get(0));
-
-    s.str(std::string());
-    s << title_ << " DIPOLE Y";
-    Process::environment.globals[s.str()] = dipole->get(1);
-    wfn_->set_scalar_variable(s.str(), dipole->get(1));
-
-    s.str(std::string());
-    s << title_ << " DIPOLE Z";
-    Process::environment.globals[s.str()] = dipole->get(2);
-    wfn_->set_scalar_variable(s.str(), dipole->get(2));
-
     // Dipole array in au
+    std::stringstream s;
     auto dipole_array = std::make_shared<Matrix>(1, 3);
     dipole_array->set(0, 0, dipole->get(0) / pc_dipmom_au2debye);
     dipole_array->set(0, 1, dipole->get(1) / pc_dipmom_au2debye);
@@ -1401,36 +1354,8 @@ SharedVector MultipolePropCalc::compute_dipole(bool transition, bool print_outpu
 }
 
 void OEProp::compute_quadrupole(bool transition) {
-    SharedMatrix quadrupole = mpc_.compute_quadrupole(transition, true, print_ > 4);
+    auto quadrupole = mpc_.compute_quadrupole(transition, true, print_ > 4);
     std::stringstream s;
-    s << title_ << " QUADRUPOLE XX";
-    Process::environment.globals[s.str()] = quadrupole->get(0, 0);
-    wfn_->set_scalar_variable(s.str(), quadrupole->get(0, 0));
-
-    s.str(std::string());
-    s << title_ << " QUADRUPOLE YY";
-    Process::environment.globals[s.str()] = quadrupole->get(1, 1);
-    wfn_->set_scalar_variable(s.str(), quadrupole->get(1, 1));
-
-    s.str(std::string());
-    s << title_ << " QUADRUPOLE ZZ";
-    Process::environment.globals[s.str()] = quadrupole->get(2, 2);
-    wfn_->set_scalar_variable(s.str(), quadrupole->get(2, 2));
-
-    s.str(std::string());
-    s << title_ << " QUADRUPOLE XY";
-    Process::environment.globals[s.str()] = quadrupole->get(0, 1);
-    wfn_->set_scalar_variable(s.str(), quadrupole->get(0, 1));
-
-    s.str(std::string());
-    s << title_ << " QUADRUPOLE XZ";
-    Process::environment.globals[s.str()] = quadrupole->get(0, 2);
-    wfn_->set_scalar_variable(s.str(), quadrupole->get(0, 2));
-
-    s.str(std::string());
-    s << title_ << " QUADRUPOLE YZ";
-    Process::environment.globals[s.str()] = quadrupole->get(1, 2);
-    wfn_->set_scalar_variable(s.str(), quadrupole->get(1, 2));
 
     // Quadrupole array in au
     auto quadrupole_array = std::make_shared<Matrix>(1, 6);

--- a/tests/cc54/input.dat
+++ b/tests/cc54/input.dat
@@ -103,19 +103,6 @@ D 2 1.00
 
 ccsd_e, wfn = properties('ccsd',properties=['dipole'],return_wfn=True)
 oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="(OEPROP)CC")
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(psi4.variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
-    compare_values(psi4.variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
-    compare_values(psi4.variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
-    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
-    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
-    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
-    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
-    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
-    compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
-print_variables()
 
-# prefer array dipole/quadrupole over deprecated scalar variables in section above
-compare_values(ref_di_au, psi4.variable('(OEPROP)CC DIPOLE'), 4, "CC DIPOLE")  #TEST
-compare_values(ref_quad_au, psi4.variable('(OEPROP)CC QUADRUPOLE'), 4, "CC QUADRUPOLE")  #TEST
+psi4.compare_values(ref_di_au, psi4.variable('(OEPROP)CC DIPOLE'), 4, "CC DIPOLE")  #TEST
+psi4.compare_values(ref_quad_au, psi4.variable('(OEPROP)CC QUADRUPOLE'), 4, "CC QUADRUPOLE")  #TEST

--- a/tests/cc54/input.dat
+++ b/tests/cc54/input.dat
@@ -104,5 +104,5 @@ D 2 1.00
 ccsd_e, wfn = properties('ccsd',properties=['dipole'],return_wfn=True)
 oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="(OEPROP)CC")
 
-psi4.compare_values(ref_di_au, psi4.variable('(OEPROP)CC DIPOLE'), 4, "CC DIPOLE")  #TEST
-psi4.compare_values(ref_quad_au, psi4.variable('(OEPROP)CC QUADRUPOLE'), 4, "CC QUADRUPOLE")  #TEST
+compare_values(ref_di_au, psi4.variable('(OEPROP)CC DIPOLE'), 4, "CC DIPOLE")  #TEST
+compare_values(ref_quad_au, psi4.variable('(OEPROP)CC QUADRUPOLE'), 4, "CC QUADRUPOLE")  #TEST

--- a/tests/ci-property/input.dat
+++ b/tests/ci-property/input.dat
@@ -44,32 +44,6 @@ props = ['DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES',
 fci_energy = prop('FCI', properties=props)
 
 compare_values(fci_energy, -278.7924561878957, 6, 'FCI Energy')    #TEST
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(psi4.variable('CI DIPOLE Y'), 0.000000000000, 4, "FCI DIPOLE Y")    #TEST
-    compare_values(psi4.variable('CI DIPOLE Z'), 1.908946764853, 4, "FCI DIPOLE Z")    #TEST
-    compare_values(psi4.variable('CI QUADRUPOLE XX'), -22.395945512510, 4, "FCI QUADRUPOLE XX")    #TEST
-    compare_values(psi4.variable('CI QUADRUPOLE YY'), -27.774201286760, 4, "FCI QUADRUPOLE YY")    #TEST
-    compare_values(psi4.variable('CI QUADRUPOLE ZZ'), -29.166055634625, 4, "FCI QUADRUPOLE ZZ")    #TEST
-    compare_values(psi4.variable('CI QUADRUPOLE YZ'), 0.000000000000, 4, "FCI QUADRUPOLE YZ")    #TEST
-    compare_values(psi4.variable('CI ROOT 0 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 0 DIPOLE Y")    #TEST
-    compare_values(psi4.variable('CI ROOT 0 DIPOLE Z'), -0.483503167660, 4, "CI ROOT 0 DIPOLE Z")    #TEST
-    compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE XX'), -22.419106552690, 4, "CI ROOT 0 QUADRUPOLE XX")    #TEST
-    compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE YY'), -26.694665553619, 4, "CI ROOT 0 QUADRUPOLE YY")    #TEST
-    compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE ZZ'), -30.482314878839, 4, "CI ROOT 0 QUADRUPOLE ZZ")    #TEST
-    compare_values(psi4.variable('CI ROOT 0 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 0 QUADRUPOLE YZ")    #TEST
-    compare_values(psi4.variable('CI ROOT 1 DIPOLE Y'), 0.000000000000, 4, "CI ROOT 1 DIPOLE Y")    #TEST
-    compare_values(psi4.variable('CI ROOT 1 DIPOLE Z'), 4.301396697365, 4, "CI ROOT 1 DIPOLE Z")    #TEST
-    compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE XX'), -22.372784472330, 4, "CI ROOT 1 QUADRUPOLE XX")    #TEST
-    compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE YY'), -28.853737019899, 4, "CI ROOT 1 QUADRUPOLE YY")    #TEST
-    compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE ZZ'), -27.849796390412, 4, "CI ROOT 1 QUADRUPOLE ZZ")    #TEST
-    compare_values(psi4.variable('CI ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CI ROOT 1 QUADRUPOLE YZ")    #TEST
-    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 DIPOLE Y')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Y")  #TEST
-    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 DIPOLE Z')), 0.425513677544, 4, "CI ROOT 0 -> ROOT 1 DIPOLE Z")  #TEST
-    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE XX')), 0.016387859082, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE XX")  #TEST
-    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YY')), 0.573374390021, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YY")  #TEST
-    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ')), 0.677526505530, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE ZZ")  #TEST
-    compare_values(abs(psi4.variable('CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ')), 0.000000000000, 4, "CI ROOT 0 -> ROOT 1 QUADRUPOLE YZ")  #TEST
 compare_values(np.array([0, 0, 1.908946764853]) * d2au, variable("CI DIPOLE"), 4, "FCI DIPOLE")  #TEST
 compare_values(np.array([[-22.395945512510, 0, 0], [0, -27.774201286760, 0], [0, 0, -29.166055634625]]) * q2au, variable("CI QUADRUPOLE"), 4, "FCI QUADRUPOLE")  #TEST
 compare_values(np.array([0, 0, -0.483503167660]) * d2au, variable("CI ROOT 0 DIPOLE"), 4, "CI ROOT 0 DIPOLE")  #TEST
@@ -81,20 +55,6 @@ compare_values(np.array([[0.016387859082, 0, 0], [0, 0.573374390021, 0], [0, 0, 
 
 cas_energy = prop('CASSCF', properties=props)    #TEST
 compare_values(-278.778339189657800, cas_energy, 6, 'CASSCF Energy')    #TEST
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(psi4.variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
-    compare_values(psi4.variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
-    compare_values(psi4.variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
-    compare_values(psi4.variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
-    compare_values(psi4.variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
-    compare_values(psi4.variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
 compare_values(np.array([0, 0, 1.994979146421]) * d2au, variable('CASSCF DIPOLE'), 2, "CASSCF DIPOLE")  #TEST
 compare_values(np.array([[-22.404898239966, 0, 0], [0, -27.936106983618, 0], [0, 0, -28.338138881212]]) * q2au, variable("CASSCF QUADRUPOLE"), 2, "CASSCF QUADRUPOLE")  #TEST
 compare_values(np.array([0, 0, 4.462471853372]) * d2au, psi4.variable('CASSCF ROOT 1 DIPOLE'), 2, "CASSCF ROOT 1 DIPOLE")  #TEST
@@ -103,20 +63,6 @@ compare_values(np.array([[-22.295623175859, 0, 0], [0, -29.286904330283, 0], [0,
 set DETCI NAT_ORBS true
 cas_energy = prop('CASSCF', properties=props)    #TEST
 compare_values(-278.778339189657800, cas_energy, 6, 'CASSCF Energy')    #TEST
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(psi4.variable('CASSCF DIPOLE Y'), 0.000000000000, 2, "CASSCF DIPOLE Y")    #TEST
-    compare_values(psi4.variable('CASSCF DIPOLE Z'), 1.994979146421, 2, "CASSCF DIPOLE Z")    #TEST
-    compare_values(psi4.variable('CASSCF QUADRUPOLE XX'), -22.404898239966, 2, "CASSCF QUADRUPOLE XX")    #TEST
-    compare_values(psi4.variable('CASSCF QUADRUPOLE YY'), -27.936106983618, 2, "CASSCF QUADRUPOLE YY")    #TEST
-    compare_values(psi4.variable('CASSCF QUADRUPOLE ZZ'), -28.338138881212, 2, "CASSCF QUADRUPOLE ZZ")    #TEST
-    compare_values(psi4.variable('CASSCF QUADRUPOLE YZ'), 0.000000000000, 2, "CASSCF QUADRUPOLE YZ")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Y'), 0.000000000000, 2, "CASSCF ROOT 1 DIPOLE Y")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 DIPOLE Z'), 4.462471853372, 2, "CASSCF ROOT 1 DIPOLE Z")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE XX'), -22.295623175859, 2, "CASSCF ROOT 1 QUADRUPOLE XX")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YY'), -29.286904330283, 2, "CASSCF ROOT 1 QUADRUPOLE YY")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE ZZ'), -27.288580048926, 2, "CASSCF ROOT 1 QUADRUPOLE ZZ")    #TEST
-    compare_values(psi4.variable('CASSCF ROOT 1 QUADRUPOLE YZ'), 0.000000000000, 4, "CASSCF ROOT 1 QUADRUPOLE YZ")    #TEST
 compare_values(np.array([0, 0, 1.994979146421]) * d2au, psi4.variable('CASSCF DIPOLE'), 2, "CASSCF DIPOLE")  #TEST
 compare_values(np.array([[-22.404898239966, 0, 0], [0, -27.936106983618, 0], [0, 0, -28.338138881212]]) * q2au, psi4.variable('CASSCF QUADRUPOLE'), 2, "CASSCF QUADRUPOLE")  #TEST
 compare_values(np.array([0, 0, 4.462471853372]) * d2au, psi4.variable('CASSCF ROOT 1 DIPOLE'), 2, "CASSCF ROOT 1 DIPOLE")  #TEST

--- a/tests/fci-dipole/input.dat
+++ b/tests/fci-dipole/input.dat
@@ -27,11 +27,6 @@ compare_values(refnuc, h2o.nuclear_repulsion_energy(), 9, "Nuclear repulsion ene
 compare_values(refscf, variable("SCF TOTAL ENERGY"),     8, "SCF energy")                          #TEST
 compare_values(refci, thisenergy,                      7, "CI energy")                                 #TEST
 compare_values(refcorr, variable("CI CORRELATION ENERGY"), 7, "CI correlation energy")             #TEST
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")                 #TEST
-    compare_values(refDipCI, variable("CI DIPOLE Z"), 3, "CI Z Component of dipole")                   #TEST
-    compare_values(refQdpCI, variable("CI QUADRUPOLE ZZ"), 3, "CI ZZ Component of quadrupole")  #TEST
 compare_values(refDipHF, variable("SCF DIPOLE")[2] * constants.dipmom_au2debye, 3, "SCF Z Component of dipole")                 #TEST
 compare_values(refDipCI, variable("CI DIPOLE")[2] * constants.dipmom_au2debye, 3, "CI Z Component of dipole")                   #TEST
 compare_values(refQdpCI, variable("CI QUADRUPOLE")[2][2] * constants.dipmom_au2debye * constants.bohr2angstroms, 3, "CI ZZ Component of quadrupole")  #TEST

--- a/tests/fci-tdm-2/input.dat
+++ b/tests/fci-tdm-2/input.dat
@@ -42,12 +42,6 @@ compare_values(refci1, thisenergy,                      7, "CI ROOT 0 ENERGY") #
 compare_values(refci2,   variable("CI ROOT 1 TOTAL ENERGY"),       7, "CI ROOT 1 ENERGY") #TEST
 compare_values(refcorr1, variable("CI ROOT 0 CORRELATION ENERGY"), 7, "CI ROOT 0 correlation energy")  #TEST
 compare_values(refcorr2, variable("CI ROOT 1 CORRELATION ENERGY"), 7, "CI ROOT 1 correlation energy")  #TEST
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(refDipHF, variable("SCF DIPOLE Z"), 3, "SCF Z Component of dipole")      #TEST
-    compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 3, "CI ROOT 0 Z Component of dipole")        #TEST
-    compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 3, "CI ROOT 1 Z Component of dipole")        #TEST
-    compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 3, "CI ROOT 0 -> ROOT 1 Z Component of dipole")        #TEST
 compare_values(refDipHF * d2au, variable("SCF DIPOLE")[2], 3, "SCF Z Component of dipole")      #TEST
 compare_values(refDipCI1 * d2au, variable("CI ROOT 0 DIPOLE")[2], 3, "CI ROOT 0 Z Component of dipole")        #TEST
 compare_values(refDipCI2 * d2au, variable("CI ROOT 1 DIPOLE")[2], 3, "CI ROOT 1 Z Component of dipole")        #TEST

--- a/tests/fci-tdm/input.dat
+++ b/tests/fci-tdm/input.dat
@@ -36,12 +36,6 @@ compare_values(refci1, thisenergy,                      7, "CI ROOT 0 ENERGY") #
 compare_values(refci2,   variable("CI ROOT 1 TOTAL ENERGY"),       7, "CI ROOT 1 ENERGY") #TEST
 compare_values(refcorr1, variable("CI ROOT 0 CORRELATION ENERGY"), 7, "CI ROOT 0 correlation energy")  #TEST
 compare_values(refcorr2, variable("CI ROOT 1 CORRELATION ENERGY"), 7, "CI ROOT 1 correlation energy")  #TEST
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(refDipHF, variable("SCF DIPOLE Z"), 5, "SCF Z Component of dipole")      #TEST
-    compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE Z"), 5, "CI ROOT 0 Z Component of dipole")        #TEST
-    compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE Z"), 5, "CI ROOT 1 Z Component of dipole")        #TEST
-    compare_values(abs(refTDM), abs(variable("CI ROOT 0 -> ROOT 1 DIPOLE Z")), 5, "CI ROOT 0 -> ROOT 1 Z Component of dipole") #TEST
 compare_values(refDipHF, variable("SCF DIPOLE")[2], 5, "SCF Z Component of dipole")      #TEST
 compare_values(refDipCI1, variable("CI ROOT 0 DIPOLE")[2], 5, "CI ROOT 0 Z Component of dipole")        #TEST
 compare_values(refDipCI2, variable("CI ROOT 1 DIPOLE")[2], 5, "CI ROOT 1 Z Component of dipole")        #TEST

--- a/tests/mp2-property/input.dat
+++ b/tests/mp2-property/input.dat
@@ -23,19 +23,7 @@ props = ['DIPOLE', 'QUADRUPOLE', 'MULLIKEN_CHARGES', 'LOWDIN_CHARGES',
 
 mp2_e, mp2_wfn = prop('MP2', properties = props, return_wfn=True)
 
-import warnings
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(-184.1840201594929454, psi4.variable('CURRENT ENERGY'), 6, "MP2 Energy") #TEST
-    compare_values(0.000000000000, psi4.variable('MP2 DIPOLE X'), 4, "MP2 DIPOLE X") #TEST
-    compare_values(0.000000000000, psi4.variable('MP2 DIPOLE Y'), 4, "MP2 DIPOLE Y") #TEST
-    compare_values(0.234000203994, psi4.variable('MP2 DIPOLE Z'), 4, "MP2 DIPOLE Z") #TEST
-    compare_values(-14.731131601691, psi4.variable('MP2 QUADRUPOLE XX'), 4, "MP2 QUADRUPOLE XX") #TEST
-    compare_values(-14.731131601691, psi4.variable('MP2 QUADRUPOLE YY'), 4, "MP2 QUADRUPOLE YY") #TEST
-    compare_values(-19.287283345539, psi4.variable('MP2 QUADRUPOLE ZZ'), 4, "MP2 QUADRUPOLE ZZ") #TEST
-    compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XY'), 4, "MP2 QUADRUPOLE XY") #TEST
-    compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE XZ'), 4, "MP2 QUADRUPOLE XZ") #TEST
-    compare_values(0.000000000000, psi4.variable('MP2 QUADRUPOLE YZ'), 4, "MP2 QUADRUPOLE YZ") #TEST
+compare_values(-184.1840201594929454, psi4.variable('CURRENT ENERGY'), 6, "MP2 Energy") #TEST
 compare_values(np.array([0, 0, 0.234000203994]) / constants.dipmom_au2debye, variable("MP2 DIPOLE"), 4, "MP2 DIPOLE")  #TEST
 compare_values(np.array([[-14.731131601691, 0, 0], [0, -14.731131601691, 0], [0, 0, -19.287283345539]]) / (constants.dipmom_au2debye * constants.bohr2angstroms),  #TEST
     variable("MP2 QUADRUPOLE"), 4, "MP2 QUADRUPOLE")  #TEST

--- a/tests/props1/input.dat
+++ b/tests/props1/input.dat
@@ -39,7 +39,7 @@ set perturb_h false
 # Compute the analytic dipoles, for comparison
 e,wfn = energy('scf', return_wfn=True)
 oeprop(wfn, "MULTIPOLES(1)")
-analytic = variable("DIPOLE Z")
+analytic = variable("SCF DIPOLE")[2]
 
 # Tabulate the results of the energy computation
 for val in range(len(lambdas)):

--- a/tests/props2/input.dat
+++ b/tests/props2/input.dat
@@ -72,12 +72,6 @@ for R in Rvals:
     compare_values(refENuc[count], dimer.nuclear_repulsion_energy(),                                 #TEST
                       9, "Nuclear repulsion energy %d" % count)                                      #TEST
     compare_values(refESCF[count], eehf, 9, "Reference energy %d" % count)                           #TEST
-    with warnings.catch_warnings():  #TEST
-        warnings.simplefilter("ignore")  #TEST
-        compare_values(refDipY[count], variable("SCF DIPOLE Y"),                                     #TEST
-                          5, "Y Component of Dipole %d" % count)                                     #TEST
-        compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE YY"),                       #TEST
-                          5, "YY Component of Quadrupole %d" % count)                                #TEST
     compare_values(refDipY[count], variable("SCF DIPOLE")[1] * constants.dipmom_au2debye,     #TEST
                       5, "Y Component of Dipole %d" % count)                                         #TEST
     compare_values(refQuadYY[count], variable("BZH3O+ SCF QUADRUPOLE")[1][1] * constants.dipmom_au2debye * constants.bohr2angstroms,  #TEST
@@ -97,12 +91,6 @@ for R in Rvals:
     compare_values(refENuc[count], monoB.nuclear_repulsion_energy(),                                 #TEST
                       9, "Nuclear repulsion energy %d" % count)                                      #TEST
     compare_values(refESCF[count], eehf, 9, "Reference energy %d" % count)                           #TEST
-    with warnings.catch_warnings():  #TEST
-        warnings.simplefilter("ignore")  #TEST
-        compare_values(refDipY[count], variable("SCF DIPOLE Y"),                                     #TEST
-                          5, "Y Component of Dipole %d" % count)                                     #TEST
-        compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE YY"),                         #TEST
-                          5, "YY Component of Quadrupole %d" % count)                                #TEST
     compare_values(refDipY[count], variable("SCF DIPOLE")[1] * constants.dipmom_au2debye,     #TEST
                       5, "Y Component of Dipole %d" % count)                                         #TEST
     compare_values(refQuadYY[count], variable("H3O+ SCF QUADRUPOLE")[1][1] * constants.dipmom_au2debye * constants.bohr2angstroms,  #TEST

--- a/tests/props3/input.dat
+++ b/tests/props3/input.dat
@@ -56,9 +56,6 @@ oeprop(scf_wfn, "MULTIPOLES(7)", "ESP_AT_NUCLEI")
 
 subs = {"X": 0, "Y": 1, "Z": 2}  #TEST
 for mpole,val in reversed(sorted(refs.items())):        #TEST
-    compare_values(val, variable(mpole),  4, mpole) #TEST
-    compare_values(val, scf_wfn.variable(mpole),  4, mpole + " wfn") #TEST
-
     sorder, cart = mpole.split()  #TEST
     np_index = tuple([subs[x] for x in cart])  #TEST
     compare_values(val, variable(sorder)[np_index], 4, mpole + " array")  #TEST

--- a/tests/pytests/test_misc.py
+++ b/tests/pytests/test_misc.py
@@ -123,7 +123,7 @@ def test_deprecated_dcft_calls():
 
 def test_deprecated_component_dipole():
 
-    with pytest.raises(FutureWarning) as e:
+    with pytest.raises(psi4.UpgradeHelper) as e:
         psi4.variable("current dipole x")
 
 def test_deprecated_set_module_options():

--- a/tests/pytests/test_misc.py
+++ b/tests/pytests/test_misc.py
@@ -121,16 +121,6 @@ def test_deprecated_dcft_calls():
     assert err_substr in str(e.value)
 
 
-def test_deprecated_component_dipole():
-
-    #with pytest.warns(FutureWarning) as e:
-    psi4.set_variable("current dipole x", 5)
-
-    with pytest.warns(FutureWarning) as e:
-        ans = psi4.variable("current dipole x")
-
-    assert ans == 5
-
 def test_deprecated_set_module_options():
     err_substr = "instead of `psi4.set_options({<module>__<keys>: <vals>})`"
 

--- a/tests/pytests/test_misc.py
+++ b/tests/pytests/test_misc.py
@@ -121,6 +121,11 @@ def test_deprecated_dcft_calls():
     assert err_substr in str(e.value)
 
 
+def test_deprecated_component_dipole():
+
+    with pytest.raises(FutureWarning) as e:
+        psi4.variable("current dipole x")
+
 def test_deprecated_set_module_options():
     err_substr = "instead of `psi4.set_options({<module>__<keys>: <vals>})`"
 

--- a/tests/python/cc54/input.py
+++ b/tests/python/cc54/input.py
@@ -1,6 +1,9 @@
 #! CCSD dipole with user-specified basis set
 import psi4
 
+ref_di_au = [0.0, 0.0, -0.724043461736]  #TEST
+ref_quad_au = [[-5.84669623357, 0.0, 0.0], [0.0, -3.37343584714, 0.0], [0.0, 0.0, -4.70310405195]]  #TEST
+
 psi4.set_output_file("output.dat", False)
 
 h2o = psi4.geometry("""
@@ -101,16 +104,7 @@ D 2 1.00
 
 ccsd_e, wfn = psi4.properties('ccsd',properties=['dipole'],return_wfn=True)
 psi4.oeprop(wfn,"DIPOLE", "QUADRUPOLE", title="(OEPROP)CC")
-import warnings  #TEST
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE X"), 0.000000000000,6,"CC DIPOLE X")             #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE Y"), 0.000000000000,6,"CC DIPOLE Y")             #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC DIPOLE Z"),-1.840334899884,6,"CC DIPOLE Z")             #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XX"),-7.864006962064,6,"CC QUADRUPOLE XX")   #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XY"), 0.000000000000,6,"CC QUADRUPOLE XY")   #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE XZ"), 0.000000000000,6,"CC QUADRUPOLE XZ")   #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YY"),-4.537386915305,6,"CC QUADRUPOLE YY")   #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE YZ"), 0.000000000000,6,"CC QUADRUPOLE YZ")   #TEST
-    psi4.compare_values(psi4.variable("(OEPROP)CC QUADRUPOLE ZZ"),-6.325836255265,6,"CC QUADRUPOLE ZZ")   #TEST
-psi4.core.print_variables()
+
+psi4.compare_values(ref_di_au, psi4.variable('(OEPROP)CC DIPOLE'), 4, "CC DIPOLE")  #TEST
+psi4.compare_values(ref_quad_au, psi4.variable('(OEPROP)CC QUADRUPOLE'), 4, "CC QUADRUPOLE")  #TEST
+

--- a/tests/scf-property/input.dat
+++ b/tests/scf-property/input.dat
@@ -46,19 +46,6 @@ properties('scf', properties=props)
 compare_values(-38.91591819679808, psi4.variable("CURRENT ENERGY"), 6, "SCF energy")         #TEST
 compare_values(-38.91591819679808, psi4.variable("HF TOTAL ENERGY"), 6, "SCF energy")         #TEST
 
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(ref_hf_di_debye[0], psi4.variable('SCF DIPOLE X'), 4, "SCF DIPOLE X")    #TEST
-    compare_values(ref_hf_di_debye[1], psi4.variable('SCF DIPOLE Y'), 4, "SCF DIPOLE Y")    #TEST
-    compare_values(ref_hf_di_debye[2], psi4.variable('SCF DIPOLE Z'), 4, "SCF DIPOLE Z")    #TEST
-    compare_values(ref_hf_quad_debye[0][0], psi4.variable('SCF QUADRUPOLE XX'), 4, "SCF QUADRUPOLE XX")    #TEST
-    compare_values(ref_hf_quad_debye[1][1], psi4.variable('SCF QUADRUPOLE YY'), 4, "SCF QUADRUPOLE YY")    #TEST
-    compare_values(ref_hf_quad_debye[2][2], psi4.variable('SCF QUADRUPOLE ZZ'), 4, "SCF QUADRUPOLE ZZ")    #TEST
-    compare_values(ref_hf_quad_debye[0][1], psi4.variable('SCF QUADRUPOLE XY'), 4, "SCF QUADRUPOLE XY")    #TEST
-    compare_values(ref_hf_quad_debye[0][2], psi4.variable('SCF QUADRUPOLE XZ'), 4, "SCF QUADRUPOLE XZ")    #TEST
-    compare_values(ref_hf_quad_debye[1][2], psi4.variable('SCF QUADRUPOLE YZ'), 4, "SCF QUADRUPOLE YZ")    #TEST
-
-# prefer array dipole/quadrupole over deprecated scalar variables in section above
 compare_values(ref_hf_di_au, psi4.variable('SCF DIPOLE'), 4, "SCF DIPOLE")  #TEST
 compare_values(ref_hf_quad_au, psi4.variable('SCF QUADRUPOLE'), 4, "SCF QUADRUPOLE")  #TEST
 
@@ -67,18 +54,5 @@ properties('B3LYP', properties=props)
 compare_values(-39.14134740550916, variable('CURRENT ENERGY'), 6, "B3LYP energy")    #TEST
 #compare_values(-39.14134740550916, variable('B3LYP TOTaL ENERGY'), 6, "B3LYP energy")    #TEST  # waiting for dft fctl psivars
 
-with warnings.catch_warnings():  #TEST
-    warnings.simplefilter("ignore")  #TEST
-    compare_values(ref_b3lyp_di_debye[0], psi4.variable('B3LYP DIPOLE X'), 4, "B3LYP DIPOLE X")    #TEST
-    compare_values(ref_b3lyp_di_debye[1], psi4.variable('B3LYP DIPOLE Y'), 4, "B3LYP DIPOLE Y")    #TEST
-    compare_values(ref_b3lyp_di_debye[2], psi4.variable('B3LYP DIPOLE Z'), 4, "B3LYP DIPOLE Z")    #TEST
-    compare_values(ref_b3lyp_quad_debye[0][0], psi4.variable('B3LYP QUADRUPOLE XX'), 4, "B3LYP QUADRUPOLE XX")    #TEST
-    compare_values(ref_b3lyp_quad_debye[1][1], psi4.variable('B3LYP QUADRUPOLE YY'), 4, "B3LYP QUADRUPOLE YY")    #TEST
-    compare_values(ref_b3lyp_quad_debye[2][2], psi4.variable('B3LYP QUADRUPOLE ZZ'), 4, "B3LYP QUADRUPOLE ZZ")    #TEST
-    compare_values(ref_b3lyp_quad_debye[0][1], psi4.variable('B3LYP QUADRUPOLE XY'), 4, "B3LYP QUADRUPOLE XY")    #TEST
-    compare_values(ref_b3lyp_quad_debye[0][2], psi4.variable('B3LYP QUADRUPOLE XZ'), 4, "B3LYP QUADRUPOLE XZ")    #TEST
-    compare_values(ref_b3lyp_quad_debye[1][2], psi4.variable('B3LYP QUADRUPOLE YZ'), 4, "B3LYP QUADRUPOLE YZ")    #TEST
-
-# prefer array dipole/quadrupole over deprecated scalar variables in section above
 compare_values(ref_b3lyp_di_au, psi4.variable('B3LYP DIPOLE'), 4, "B3LYP DIPOLE")  #TEST
 compare_values(ref_b3lyp_quad_au, psi4.variable('B3LYP QUADRUPOLE'), 4, "B3LYP QUADRUPOLE")  #TEST

--- a/tests/scf-response1/CMakeLists.txt
+++ b/tests/scf-response1/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(scf-response1 "psi;quicktests;scf;prop;cart")
+add_regression_test(scf-response1 "psi;quicktests;scf;properties;cart")

--- a/tests/scf-response2/CMakeLists.txt
+++ b/tests/scf-response2/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(scf-response2 "psi;quicktests;scf;prop;cart")
+add_regression_test(scf-response2 "psi;quicktests;scf;properties;cart")

--- a/tests/scf-response3/CMakeLists.txt
+++ b/tests/scf-response3/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(scf-response3 "psi;quicktests;scf;uhf;prop")
+add_regression_test(scf-response3 "psi;quicktests;scf;uhf;properties")


### PR DESCRIPTION
## Description
Removes deprecated n-pole component psivars. Puts a warning in some QCDB files that they are not being properly maintained, per #2478.

## Status
- [x] Ready for review
- [x] Ready for merge
