### PR TITLE
pin L2 for l2-oei

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -86,7 +86,7 @@ jobs:
         -n p4env \
         python=$PYTHON_VER \
         psi4/label/dev::gau2grid \
-        psi4/label/testing::libint2=2.6.0=h2fe1556_13 \
+        psi4/label/dev::libint2=2.6.0=h2fe1556_13 \
         psi4/label/dev::libxc=5 \
         psi4/label/dev::ambit \
         psi4/label/dev::chemps2 \

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -129,7 +129,7 @@ jobs:
                         psi4/label/dev::dftd3 ^
                         psi4/label/dev::gcp ^
                         conda-forge::gau2grid ^
-                        psi4/label/testing::libint2=2.6.0=h2e52968_3 ^
+                        psi4/label/dev::libint2=2.6.0=h2e52968_5 ^
                         conda-forge::libxc ^
                         conda-forge::mpfr ^
                         conda-forge::mpmath ^


### PR DESCRIPTION
## Description
The L2 after Friday's merge of l2-oei wasn't working consistently for Mac or Win. Replacements have been built that are stable, so resetting where they appear in repo itself. No change in Linux, as it was working fine. 

```
       # c. l2-oei Mar 2022
     - h2fe1556_13    [linux]
-    - h879752b_4     [osx]
-    - h2e52968_3     [win]
+    - h879752b_6     [osx]
+    - h2e52968_5     [win]
```

## Status
- [x] Ready for review
- [x] Ready for merge
