### PR TITLE
Cleanup to find_occupation and more sanity checks

### DIFF
--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -462,12 +462,9 @@ void HF::find_occupation() {
             for (int i = 0; i < nbeta_; ++i) nbetapi_[pairs_b[i].second]++;
         }
 
-        int old_socc[nirrep_];
-        int old_docc[nirrep_];
-        for (int h = 0; h < nirrep_; ++h) {
-            old_socc[h] = soccpi_[h];
-            old_docc[h] = doccpi_[h];
-        }
+        // Copies of socc and docc
+        Dimension old_socc = soccpi_;
+        Dimension old_docc = doccpi_;
 
         if (!input_docc_ && !input_socc_) {
             int alphacount = 0;
@@ -492,13 +489,7 @@ void HF::find_occupation() {
             }
         }
 
-        bool occ_changed = false;
-        for (int h = 0; h < nirrep_; ++h) {
-            if (old_socc[h] != soccpi_[h] || old_docc[h] != doccpi_[h]) {
-                occ_changed = true;
-                break;
-            }
-        }
+        bool occ_changed = (soccpi_ != old_socc) || (doccpi_ != old_docc);
 
         // If print > 2 (diagnostics), print always
         if ((print_ > 2 || (print_ && occ_changed)) && iteration_ > 0) {

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -464,9 +464,25 @@ void HF::find_occupation() {
         }
 
         if (!input_docc_ && !input_socc_) {
+            int alphacount = 0;
+            int betacount = 0;
             for (int h = 0; h < nirrep_; ++h) {
                 soccpi_[h] = std::abs(nalphapi_[h] - nbetapi_[h]);
                 doccpi_[h] = std::min(nalphapi_[h], nbetapi_[h]);
+                alphacount += doccpi_[h] + soccpi_[h];
+                betacount += doccpi_[h];
+            }
+            if (alphacount != nalpha_) {
+                std::ostringstream oss;
+                oss << "Count " << alphacount << " alpha electrons, expected " << nalpha_ << ".\n";
+                oss << "This is a bug. Please file a report.";
+                throw PSIEXCEPTION(oss.str());
+            }
+            if (betacount != nbeta_) {
+                std::ostringstream oss;
+                oss << "Count " << betacount << " beta electrons, expected " << nbeta_ << ".\n";
+                oss << "This is a bug. Please file a report.";
+                throw PSIEXCEPTION(oss.str());
             }
         }
 

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -425,11 +425,14 @@ void HF::find_occupation() {
         MOM();
     } else {
         if (!input_docc_ && !input_socc_) {
+            assert(nirrep_ == epsilon_a_->nirrep());
+            assert(nirrep_ == epsilon_b_->nirrep());
+
             // The occupations are determined by the Aufbau
             // principle. We first collect all the orbital energies and
             // sort them in increasing order
             std::vector<std::pair<double, int> > pairs_a;
-            for (int h = 0; h < epsilon_a_->nirrep(); ++h) {
+            for (int h = 0; h < nirrep_; ++h) {
                 for (int i = 0; i < epsilon_a_->dimpi()[h]; ++i) {
                     pairs_a.push_back(std::make_pair(epsilon_a_->get(h, i), h));
                 }
@@ -437,7 +440,7 @@ void HF::find_occupation() {
             sort(pairs_a.begin(), pairs_a.end());
             // Same for beta electrons
             std::vector<std::pair<double, int> > pairs_b;
-            for (int h = 0; h < epsilon_b_->nirrep(); ++h) {
+            for (int h = 0; h < nirrep_; ++h) {
                 for (int i = 0; i < epsilon_b_->dimpi()[h]; ++i) {
                     pairs_b.push_back(std::make_pair(epsilon_b_->get(h, i), h));
                 }
@@ -448,11 +451,14 @@ void HF::find_occupation() {
             if ((size_t)std::max(nalpha_, nbeta_) > pairs_a.size())
                 throw PSIEXCEPTION("Not enough basis functions to satisfy requested occupancies");
 
+            // Reset occupations
+            for (int h = 0; h < nirrep_; ++h) {
+                nalphapi_[h] = 0;
+                nbetapi_[h] = 0;
+            }
             // Occupy the lowest nalpha orbitals
-            memset(nalphapi_, 0, sizeof(int) * nirrep_);
             for (int i = 0; i < nalpha_; ++i) nalphapi_[pairs_a[i].second]++;
             // Occupy the lowest nbeta electrons
-            memset(nbetapi_, 0, sizeof(int) * nirrep_);
             for (int i = 0; i < nbeta_; ++i) nbetapi_[pairs_b[i].second]++;
         }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Minor cleanups to `find_occupation` as well as the introduction of sanity checks for #2476 to prevent sudden changes of the spin state during the calculation.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
