### PR TITLE
Three-center overlap integrals using Libint2

### DIFF
--- a/psi4/src/psi4/libmints/3coverlap.cc
+++ b/psi4/src/psi4/libmints/3coverlap.cc
@@ -35,11 +35,17 @@
 
 using namespace psi;
 
-ThreeCenterOverlapInt::ThreeCenterOverlapInt(std::vector<SphericalTransform> st, std::shared_ptr<BasisSet> bs1,
-                                             std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3)
-    : bs1_(bs1), bs2_(bs2), bs3_(bs3), st_(st) {
-    int max_am = std::max({basis1()->max_am(), basis2()->max_am(), basis3()->max_am()});
+ThreeCenterOverlapInt::ThreeCenterOverlapInt(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
+                                             std::shared_ptr<BasisSet> bs3)
+    : bs1_(bs1), bs2_(bs2), bs3_(bs3) {
+    int maxam1 = bs1_->max_am();
+    int maxam2 = bs2_->max_am();
+    int maxam3 = bs3_->max_am();
+    int max_am = std::max({maxam1, maxam2, maxam3});
     int max_nprim = std::max({basis1()->max_nprimitive(), basis2()->max_nprimitive(), basis3()->max_nprimitive()});
+
+    int max_nao = INT_NCART(maxam1) * INT_NCART(maxam2) * INT_NCART(maxam3);
+    zero_vec_ = std::vector<double>(max_nao, 0.0);
 
     libint2::initialize();
     // set engine precision to 0.0 to disable primitive screening
@@ -62,4 +68,9 @@ void ThreeCenterOverlapInt::compute_shell(int sh1, int sh2, int sh3) {
 void ThreeCenterOverlapInt::compute_pair(const libint2::Shell& s1, const libint2::Shell& s2, const libint2::Shell& s3) {
     engine0_->compute(s1, s2, s3, libint2::Shell::unit());
     buffers_[0] = engine0_->results()[0];
+    // in case l2 gives us a nullptr, point to a zero vector
+    // to avoid undefined behavior in the calling code
+    if (buffers_[0] == nullptr) {
+        buffers_[0] = zero_vec_.data();
+    }
 }

--- a/psi4/src/psi4/libmints/3coverlap.cc
+++ b/psi4/src/psi4/libmints/3coverlap.cc
@@ -26,44 +26,28 @@
  * @END LICENSE
  */
 #include "psi4/libmints/3coverlap.h"
-#include "psi4/libqt/qt.h"
 #include "psi4/libmints/basisset.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
 
 #include <memory>
 #include <stdexcept>
+
+#include <libint2/engine.h>
 
 using namespace psi;
 
 ThreeCenterOverlapInt::ThreeCenterOverlapInt(std::vector<SphericalTransform> st, std::shared_ptr<BasisSet> bs1,
                                              std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3)
-    : overlap_recur_(bs1->max_am(), bs2->max_am(), bs3->max_am()), bs1_(bs1), bs2_(bs2), bs3_(bs3), st_(st) {
-    size_t size = INT_NCART(bs1->max_am()) * INT_NCART(bs2->max_am()) * INT_NCART(bs3->max_am());
+    : bs1_(bs1), bs2_(bs2), bs3_(bs3), st_(st) {
+    int max_am = std::max({basis1()->max_am(), basis2()->max_am(), basis3()->max_am()});
+    int max_nprim = std::max({basis1()->max_nprimitive(), basis2()->max_nprimitive(), basis3()->max_nprimitive()});
 
-    // Allocate memory for buffer_ storage
-    try {
-        buffer_ = new double[size];
-    } catch (std::bad_alloc& e) {
-        outfile->Printf("Error allocating memory for buffer_\n");
-        exit(EXIT_FAILURE);
-    }
-    ::memset(buffer_, 0, sizeof(double) * size);
-
-    try {
-        temp_ = new double[size];
-    } catch (std::bad_alloc& e) {
-        outfile->Printf("Error allocating memory for temp_\n");
-        exit(EXIT_FAILURE);
-    }
-    ::memset(temp_, 0, sizeof(double) * size);
+    libint2::initialize();
+    // set engine precision to 0.0 to disable primitive screening
+    engine0_ = std::make_unique<libint2::Engine>(libint2::Operator::delta, max_nprim, max_am, 0, 0.0);
+    buffers_.resize(1);
 }
 
-ThreeCenterOverlapInt::~ThreeCenterOverlapInt() {
-    delete[] buffer_;
-    delete[] temp_;
-}
-
-std::shared_ptr<BasisSet> ThreeCenterOverlapInt::basis() { return bs1_; }
+ThreeCenterOverlapInt::~ThreeCenterOverlapInt() {}
 
 std::shared_ptr<BasisSet> ThreeCenterOverlapInt::basis1() { return bs1_; }
 
@@ -72,235 +56,10 @@ std::shared_ptr<BasisSet> ThreeCenterOverlapInt::basis2() { return bs2_; }
 std::shared_ptr<BasisSet> ThreeCenterOverlapInt::basis3() { return bs3_; }
 
 void ThreeCenterOverlapInt::compute_shell(int sh1, int sh2, int sh3) {
-    compute_pair(bs1_->shell(sh1), bs2_->shell(sh2), bs3_->shell(sh3));
+    compute_pair(bs1_->l2_shell(sh1), bs2_->l2_shell(sh2), bs3_->l2_shell(sh3));
 }
 
-void ThreeCenterOverlapInt::compute_pair(const GaussianShell& sA, const GaussianShell& sB, const GaussianShell& sC) {
-    size_t ao123;
-    int amA = sA.am();
-    int amB = sB.am();
-    int amC = sC.am();
-    int nprimA = sA.nprimitive();
-    int nprimB = sB.nprimitive();
-    int nprimC = sC.nprimitive();
-    double A[3], B[3], C[3], P[3], G[3], GA[3], GB[3], GC[3];
-    A[0] = sA.center()[0];
-    A[1] = sA.center()[1];
-    A[2] = sA.center()[2];
-    B[0] = sB.center()[0];
-    B[1] = sB.center()[1];
-    B[2] = sB.center()[2];
-    C[0] = sC.center()[0];
-    C[1] = sC.center()[1];
-    C[2] = sC.center()[2];
-
-    double AB2 = 0.0;
-    AB2 += (A[0] - B[0]) * (A[0] - B[0]);
-    AB2 += (A[1] - B[1]) * (A[1] - B[1]);
-    AB2 += (A[2] - B[2]) * (A[2] - B[2]);
-
-    memset(buffer_, 0, sA.ncartesian() * sC.ncartesian() * sB.ncartesian() * sizeof(double));
-
-    double*** x = overlap_recur_.x();
-    double*** y = overlap_recur_.y();
-    double*** z = overlap_recur_.z();
-
-    for (int pA = 0; pA < nprimA; ++pA) {
-        double aA = sA.exp(pA);
-        double cA = sA.coef(pA);
-
-        for (int pB = 0; pB < nprimB; ++pB) {
-            double aB = sB.exp(pB);
-            double cB = sB.coef(pB);
-
-            double gamma = aA + aB;
-            double oog = 1.0 / gamma;
-
-            P[0] = (aA * A[0] + aB * B[0]) * oog;
-            P[1] = (aA * A[1] + aB * B[1]) * oog;
-            P[2] = (aA * A[2] + aB * B[2]) * oog;
-
-            double overlap_AB = exp(-aA * aB * AB2 * oog) * sqrt(M_PI * oog) * M_PI * oog * cA * cB;
-
-            for (int pC = 0; pC < nprimC; ++pC) {
-                double aC = sC.exp(pC);
-                double cC = sC.coef(pC);
-
-                double PC2 = 0.0;
-                PC2 += (P[0] - C[0]) * (P[0] - C[0]);
-                PC2 += (P[1] - C[1]) * (P[1] - C[1]);
-                PC2 += (P[2] - C[2]) * (P[2] - C[2]);
-
-                double gammac = gamma + aC;
-                double oogc = 1.0 / (gammac);
-
-                G[0] = (gamma * P[0] + aC * C[0]) * oogc;
-                G[1] = (gamma * P[1] + aC * C[1]) * oogc;
-                G[2] = (gamma * P[2] + aC * C[2]) * oogc;
-
-                GA[0] = G[0] - A[0];
-                GA[1] = G[1] - A[1];
-                GA[2] = G[2] - A[2];
-                GB[0] = G[0] - B[0];
-                GB[1] = G[1] - B[1];
-                GB[2] = G[2] - B[2];
-                GC[0] = G[0] - C[0];
-                GC[1] = G[1] - C[1];
-                GC[2] = G[2] - C[2];
-
-                double overlap_ACB =
-                    exp(-gamma * aC * oogc * PC2) * sqrt(gamma * oogc) * (gamma * oogc) * overlap_AB * cC;
-
-                // Computes (ACB) overlap
-                overlap_recur_.compute(GA, GB, GC, gammac, amA, amB, amC);
-
-                // We're going to be reordering the result of the above line.
-                // The result of above B is the fast running index, but I'm going to be make it C instead.
-                ao123 = 0;
-                for (int ii = 0; ii <= amA; ii++) {
-                    int lA = amA - ii;
-                    for (int jj = 0; jj <= ii; jj++) {
-                        int mA = ii - jj;
-                        int nA = jj;
-
-                        for (int mm = 0; mm <= amB; mm++) {
-                            int lB = amB - mm;
-                            for (int nn = 0; nn <= mm; nn++) {
-                                int mB = mm - nn;
-                                int nB = nn;
-
-                                for (int kk = 0; kk <= amC; kk++) {
-                                    int lC = amC - kk;
-                                    for (int ll = 0; ll <= kk; ll++) {
-                                        int mC = kk - ll;
-                                        int nC = ll;
-
-                                        // These are ordered (ACB) -> B fast running
-                                        double x0 = x[lA][lC][lB];
-                                        double y0 = y[mA][mC][mB];
-                                        double z0 = z[nA][nC][nB];
-
-                                        // But we're going to store then like (ABC) -> C fast running
-                                        buffer_[ao123++] += overlap_ACB * x0 * y0 * z0;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // normalize_am(sA, sB, sC);
-    pure_transform(sA, sB, sC);
-}
-
-void ThreeCenterOverlapInt::normalize_am(const GaussianShell& /*sA*/, const GaussianShell& /*sB*/,
-                                         const GaussianShell& /*sC*/) {
-    /// ACS commented this out.  The normalize:: function just returns 1.0, so this is not needed.
-    //    // Assume integrals are done. Normalize for angular momentum
-    //    int amA = sA.am();
-    //    int amB = sB.am();
-    //    int amC = sC.am();
-
-    //    size_t ao123 = 0;
-    //    for(int ii = 0; ii <= amA; ii++) {
-    //        int lA = amA - ii;
-    //        for(int jj = 0; jj <= ii; jj++) {
-    //            int mA = ii - jj;
-    //            int nA = jj;
-
-    //            double normA = GaussianShell::normalize(lA, mA, nA);
-
-    //            for(int mm = 0; mm <= amB; mm++) {
-    //                int lB = amB - mm;
-    //                for(int nn = 0; nn <= mm; nn++) {
-    //                    int mB = mm - nn;
-    //                    int nB = nn;
-
-    //                    double normB = GaussianShell::normalize(lB, mB, nB);
-
-    //                    for(int kk = 0; kk <= amC; kk++) {
-    //                        int lC = amC - kk;
-    //                        for(int ll = 0; ll <= kk; ll++) {
-    //                            int mC = kk - ll;
-    //                            int nC = ll;
-
-    //                            buffer_[ao123] *= normA * normB * GaussianShell::normalize(lC, mC, nC);
-    //                            ao123++;
-    //                        }
-    //                    }
-    //                }
-    //            }
-    //        }
-    //    }
-}
-
-void ThreeCenterOverlapInt::pure_transform(const GaussianShell& s1, const GaussianShell& s2, const GaussianShell& s3) {
-    // Get the transforms from the basis set
-    SphericalTransformIter trans1(st_[s1.am()]);
-    SphericalTransformIter trans2(st_[s2.am()]);
-    SphericalTransformIter trans3(st_[s3.am()]);
-
-    // Get number of Cartesian functions for each shell
-    int nao1 = s1.ncartesian();
-    int nao2 = s2.ncartesian();
-    int nao3 = s3.ncartesian();
-
-    // Get number of Basis functions for each shell
-    int nso1 = s1.nfunction();
-    int nso2 = s2.nfunction();
-    int nso3 = s3.nfunction();
-
-    // Get if each shell has pure functions
-    bool is_pure1 = s1.is_pure();
-    bool is_pure2 = s2.is_pure();
-    bool is_pure3 = s3.is_pure();
-
-    // ABC -> ABc
-    if (is_pure3) {
-        ::memset(temp_, '\0', sizeof(double) * nao1 * nao2 * nso3);
-
-        for (trans3.first(); !trans3.is_done(); trans3.next()) {
-            double* sptr = buffer_ + trans3.cartindex();
-            double* tptr = temp_ + trans3.pureindex();
-            double coef = trans3.coef();
-            C_DAXPY(nao1 * nao2, coef, sptr, nao3, tptr, nso3);
-        }
-
-        ::memcpy((void*)buffer_, (void*)temp_, sizeof(double) * nao1 * nao2 * nso3);
-    }
-
-    // ABc -> Abc
-    if (is_pure2) {
-        ::memset(temp_, '\0', sizeof(double) * nao1 * nso2 * nso3);
-
-        for (trans2.first(); !trans2.is_done(); trans2.next()) {
-            double coef = trans2.coef();
-            double* sptr = buffer_ + trans2.cartindex() * nso3;
-            double* tptr = temp_ + trans2.pureindex() * nso3;
-            for (int a = 0; a < nao1; ++a) {
-                C_DAXPY(nso3, coef, sptr, 1, tptr, 1);
-                sptr += nao2 * nso3;
-                tptr += nso2 * nso3;
-            }
-        }
-
-        ::memcpy((void*)buffer_, (void*)temp_, sizeof(double) * nao1 * nso2 * nso3);
-    }
-
-    // Abc -> abc
-    if (is_pure1) {
-        ::memset(temp_, '\0', sizeof(double) * nso1 * nso2 * nso3);
-
-        for (trans1.first(); !trans1.is_done(); trans1.next()) {
-            double* sptr = buffer_ + trans1.cartindex() * nso2 * nso3;
-            double* tptr = temp_ + trans1.pureindex() * nso2 * nso3;
-            double coef = trans1.coef();
-            C_DAXPY(nso2 * nso3, coef, sptr, 1, tptr, 1);
-        }
-
-        ::memcpy((void*)buffer_, (void*)temp_, sizeof(double) * nso1 * nso2 * nso3);
-    }
+void ThreeCenterOverlapInt::compute_pair(const libint2::Shell& s1, const libint2::Shell& s2, const libint2::Shell& s3) {
+    engine0_->compute(s1, s2, s3, libint2::Shell::unit());
+    buffers_[0] = engine0_->results()[0];
 }

--- a/psi4/src/psi4/libmints/3coverlap.h
+++ b/psi4/src/psi4/libmints/3coverlap.h
@@ -25,18 +25,18 @@
  *
  * @END LICENSE
  */
+#pragma once
 
-#ifndef _psi_src_lib_libmints_3coverlap_h
-#define _psi_src_lib_libmints_3coverlap_h
-
-#include "psi4/libmints/osrecur.h"
 #include "psi4/libmints/integral.h"
-#include "psi4/libpsi4util/exception.h"
+
+namespace libint2 {
+class Engine;
+class Shell;
+}  // namespace libint2
 
 namespace psi {
 
 class BasisSet;
-class GaussianShell;
 
 /** \ingroup MINTS
     \class ThreeCenterOverlapInt
@@ -44,33 +44,26 @@ class GaussianShell;
  */
 class ThreeCenterOverlapInt {
    protected:
-    ObaraSaikaThreeCenterRecursion overlap_recur_;
-
     std::shared_ptr<BasisSet> bs1_;
     std::shared_ptr<BasisSet> bs2_;
     std::shared_ptr<BasisSet> bs3_;
 
-    /// Buffer to hold the source integrals.
-    double* buffer_;
+    std::unique_ptr<libint2::Engine> engine0_;
 
-    /// Buffer for spherical harmonics
-    double* temp_;
+    /// Buffer to hold the source integrals.
+    std::vector<const double*> buffers_;
 
     /// Vector of Sphericaltransforms
     std::vector<SphericalTransform> st_;
 
-    void compute_pair(const GaussianShell& s1, const GaussianShell& s2, const GaussianShell& s3);
+    void compute_pair(const libint2::Shell& s1, const libint2::Shell& s2, const libint2::Shell& s3);
 
    public:
     ThreeCenterOverlapInt(std::vector<SphericalTransform> st, std::shared_ptr<BasisSet> bs1,
                           std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3);
 
-    ThreeCenterOverlapInt(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3);
+    ~ThreeCenterOverlapInt();
 
-    virtual ~ThreeCenterOverlapInt();
-
-    /// Basis set on center one.
-    std::shared_ptr<BasisSet> basis();
     /// Basis set on center one.
     std::shared_ptr<BasisSet> basis1();
     /// Basis set on center two.
@@ -78,19 +71,11 @@ class ThreeCenterOverlapInt {
     /// Basis set on center three.
     std::shared_ptr<BasisSet> basis3();
 
-    /// Buffer where the integrals are placed.
-    const double* buffer() const { return buffer_; }
-
     /// Compute the integrals of the form (a|c|b).
     virtual void compute_shell(int, int, int);
 
-    /// Normalize Cartesian functions based on angular momentum
-    void normalize_am(const GaussianShell&, const GaussianShell&, const GaussianShell&);
-
-    /// Perform pure (spherical) transform.
-    void pure_transform(const GaussianShell&, const GaussianShell&, const GaussianShell&);
+    /// Buffer where each chunk of integrals is placed
+    const std::vector<const double*>& buffers() const { return buffers_; }
 };
 
 }  // namespace psi
-
-#endif

--- a/psi4/src/psi4/libmints/3coverlap.h
+++ b/psi4/src/psi4/libmints/3coverlap.h
@@ -53,15 +53,13 @@ class ThreeCenterOverlapInt {
     /// Buffer to hold the source integrals.
     std::vector<const double*> buffers_;
 
-    /// Vector of Sphericaltransforms
-    std::vector<SphericalTransform> st_;
+    /// A vector of zeros that we can point to if libint2 gives us back a nullptr
+    std::vector<double> zero_vec_;
 
     void compute_pair(const libint2::Shell& s1, const libint2::Shell& s2, const libint2::Shell& s3);
 
    public:
-    ThreeCenterOverlapInt(std::vector<SphericalTransform> st, std::shared_ptr<BasisSet> bs1,
-                          std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3);
-
+    ThreeCenterOverlapInt(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3);
     ~ThreeCenterOverlapInt();
 
     /// Basis set on center one.

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -26,7 +26,6 @@ list(APPEND sources
   symop.cc
   benchmark.cc
   get_writer_file_prefix.cc
-  3coverlap.cc
   petitelist.cc
   solidharmonics.cc
   multipoles.cc
@@ -73,7 +72,8 @@ potential.cc
 potentialint.cc
 quadrupole.cc
 rel_potential.cc
-tracelessquadrupole.cc)
+tracelessquadrupole.cc
+3coverlap.cc)
 set_property(TARGET l2intf PROPERTY CXX_STANDARD 14)
 set_property(TARGET l2intf PROPERTY POSITION_INDEPENDENT_CODE ON)
 # below are what l2intf files would ordinarily have gotten from psi4_add_module.

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -95,7 +95,7 @@ OneBodySOInt* IntegralFactory::so_overlap(int deriv) {
 }
 
 ThreeCenterOverlapInt* IntegralFactory::overlap_3c() {
-    return new ThreeCenterOverlapInt(spherical_transforms_, bs1_, bs2_, bs3_);
+    return new ThreeCenterOverlapInt(bs1_, bs2_, bs3_);
 }
 
 OneBodyAOInt* IntegralFactory::ao_kinetic(int deriv) {

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -944,7 +944,7 @@ SharedMatrix MintsHelper::ao_3coverlap_helper(const std::string &label, std::sha
         for (int N = 0; N < bs2->nshell(); N++) {
             for (int P = 0; P < bs3->nshell(); P++) {
                 ints->compute_shell(M, N, P);
-                const double *buffer = ints->buffer();
+                const double *buffer = ints->buffers()[0];
                 int Mfi = bs1->shell(M).function_index();
                 int Nfi = bs2->shell(N).function_index();
                 int Pfi = bs3->shell(P).function_index();

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -967,23 +967,14 @@ SharedMatrix MintsHelper::ao_3coverlap_helper(const std::string &label, std::sha
     return I;
 }
 SharedMatrix MintsHelper::ao_3coverlap() {
-    std::vector<SphericalTransform> trans;
-    for (int i = 0; i <= basisset_->max_am(); i++) {
-        trans.push_back(SphericalTransform(i));
-    }
     std::shared_ptr<ThreeCenterOverlapInt> ints =
-        std::make_shared<ThreeCenterOverlapInt>(trans, basisset_, basisset_, basisset_);
+        std::make_shared<ThreeCenterOverlapInt>(basisset_, basisset_, basisset_);
     return ao_3coverlap_helper("AO 3-Center Overlap Tensor", ints);
 }
 
 SharedMatrix MintsHelper::ao_3coverlap(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
                                        std::shared_ptr<BasisSet> bs3) {
-    int max_am = std::max(std::max(bs1->max_am(), bs2->max_am()), bs3->max_am());
-    std::vector<SphericalTransform> trans;
-    for (int i = 0; i <= max_am; i++) {
-        trans.push_back(SphericalTransform(i));
-    }
-    auto ints = std::make_shared<ThreeCenterOverlapInt>(trans, bs1, bs2, bs3);
+    auto ints = std::make_shared<ThreeCenterOverlapInt>(bs1, bs2, bs3);
     return ao_3coverlap_helper("AO 3-Center Overlap Tensor", ints);
 }
 

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.cc
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.cc
@@ -354,16 +354,12 @@ std::vector<SharedMatrix> FDDS_Dispersion::project_densities(std::vector<SharedM
     }
 
     // ==> Contract (PQS) S -> PQ <== //
-    std::vector<SphericalTransform> trans;
-    for (size_t i = 0; i <= auxiliary_->max_am(); i++) {
-        trans.push_back(SphericalTransform(i));
-    }
     std::vector<std::shared_ptr<ThreeCenterOverlapInt>> aux_ints(nthread);
     std::vector<const double*> aux_buff(nthread);
 
     for (size_t i = 0; i < nthread; i++) {
         aux_ints[i] = std::shared_ptr<ThreeCenterOverlapInt>(
-            new ThreeCenterOverlapInt(trans, auxiliary_, auxiliary_, auxiliary_));
+            new ThreeCenterOverlapInt(auxiliary_, auxiliary_, auxiliary_));
         aux_buff[i] = aux_ints[i]->buffers()[0];
     }
 

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.cc
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.cc
@@ -364,7 +364,7 @@ std::vector<SharedMatrix> FDDS_Dispersion::project_densities(std::vector<SharedM
     for (size_t i = 0; i < nthread; i++) {
         aux_ints[i] = std::shared_ptr<ThreeCenterOverlapInt>(
             new ThreeCenterOverlapInt(trans, auxiliary_, auxiliary_, auxiliary_));
-        aux_buff[i] = aux_ints[i]->buffer();
+        aux_buff[i] = aux_ints[i]->buffers()[0];
     }
 
     // Pack the Aux pairs
@@ -410,7 +410,7 @@ std::vector<SharedMatrix> FDDS_Dispersion::project_densities(std::vector<SharedM
             size_t index_r = auxiliary_->shell(Rshell).function_index();
 
             aux_ints[thread]->compute_shell(Pshell, Qshell, Rshell);
-            aux_buff[thread] = aux_ints[thread]->buffer();
+            aux_buff[thread] = aux_ints[thread]->buffers()[0];
 
             size_t index = 0;
             for (size_t p = 0; p < num_p; p++) {


### PR DESCRIPTION
## Description
This PR refactors `ThreeCenterOverlapInt` using Libint2. Even though one cannot compute these integrals directly, it's possible to obtain them through the delta function: `<phi(r_1) phi(r_1)| delta(r_1 - r_2) | phi(r_2) 1>`.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] 3-center overlap integrals with L2

## Checklist
- [x] Tests added for any new features (SAPT-DFT still working, Python API via `MintsHelper` tested locally 👍)
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
