### PR TITLE
try to fix docs build

### DIFF
--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -11,7 +11,7 @@ dependencies:
     # core
   - eigen
   - networkx
-  - psi4/label/dev::pybind11-headers
+  - pybind11
   - python=3.8.*
     # qc
   - psi4/label/dev::gau2grid

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -5,12 +5,11 @@ dependencies:
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
   - intel-openmp!=2019.5
     # build
-  - cmake >=3.15
+  - cmake>=3.15
   - doxygen
   - gxx_linux-64
     # core
   - eigen
-  - mpfr
   - networkx
   - psi4/label/dev::pybind11-headers
   - python=3.8.*
@@ -24,8 +23,8 @@ dependencies:
   - jupyter_client
   - nbsphinx
   - python-graphviz
-  - sphinx >=3.5
+  - sphinx>=3.5
   - sphinx-autodoc-typehints
   - sphinx-automodapi
   - psi4/label/dev::sphinx-psi-theme
-
+  - jinja2<3.0


### PR DESCRIPTION
## Description
cloud sphinx theme is importing `Markup` from `jinja2`, which is moved in the newly packaged jinja2 3.0 https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-0-0 . so let's try to use jinja2 2

## Status
- [ ] Ready for review
- [ ] Ready for merge
