### PR TITLE
Add missing doi, fix doi syntax

### DIFF
--- a/psi4/src/psi4/dfmp2/README.txt
+++ b/psi4/src/psi4/dfmp2/README.txt
@@ -1,13 +1,13 @@
 General Notes About the Code
 
 1. There are several references to previous gradient papers in the comments.
-  DiStasio : DOI 10.1002/jcc; J. Comput. Chem. 28, 839–856, (2007)
+  DiStasio : doi:10.1002/jcc.20604, J. Comput. Chem. 28, 839–856, (2007)
     "An Improved Algorithm for Analytical Gradient
     Evaluation in Resolution-of-the-Identity Second-Order
     Møller-Plesset Perturbation Theory: Application to
     Alanine Tetrapeptide Conformational Analysis"
       Most of our equations come from here.
-  Wang : DOI 10.1063/1.5100175; J. Chem. Phys. 151, 044118 (2019)
+  Wang : doi:10.1063/1.5100175; J. Chem. Phys. 151, 044118 (2019)
     "Analytic gradients for the single-reference
     driven similarity renormalization group
     second-order perturbation theory"
@@ -15,7 +15,7 @@ General Notes About the Code
       another parameter to MP2, so these formulas apply to MP2 as well.
       Table II of this paper will be crucial in explaining a trick that
       does not appear in DiStasio. (See Sec. 3 here.)
-  Aikens : DOI 10.1007/s00214-003-0453-3; Theor. Chem. Acc. 110, 233-253 (2003)
+  Aikens : doi:10.1007/s00214-003-0453-3; Theor. Chem. Acc. 110, 233-253 (2003)
     "A derivation of the frozen-orbital unrestricted open-shell
     and restricted closed-shell second-order perturbation theory
     analytic gradient expressions"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Adds a missing doi in a source tree README file, also standardizes the use of doi syntax (it is doi:foo not DOI foo)

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
