### PR TITLE
EOMCC Oscillator Strengths

### DIFF
--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -1529,7 +1529,8 @@ PSI Variables by Alpha
    Conventions for root indexing and whether h refers to transition or root
    irrep are as in :ref:`sec:psivarnotes`.
 
-.. psivar:: TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN)
+.. psivar:: CC ROOT n (h) -> ROOT m (i) OSCILLATOR STRENGTH (LEN)
+   TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN)
    TD-fctl ROOT 0 (h) -> ROOT m (i) OSCILLATOR STRENGTH (LEN)
    TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (LEN) - h TRANSITION
    TD-fctl ROOT 0 -> ROOT m OSCILLATOR STRENGTH (VEL)

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -319,7 +319,7 @@ def _solve_loop(wfn,
         # ret = {"eigvals": ee, "eigvecs": (rvecs, rvecs), "stats": stats} (TDA)
         # ret = {"eigvals": ee, "eigvecs": (rvecs, lvecs), "stats": stats} (RPA)
         # N.B.: Eigvecs and eigvals are of the reduced, non-Hermitian eigenvalue problem, not the
-        # original Hermitian pseudo-eigenvalue problem. To convert to quantiites of original probe:
+        # original Hermitian pseudo-eigenvalue problem. To convert to quantities of original problem:
         # ee = omega^2
         # rvecs = X + Y
         # lvecs = X - Y

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -318,6 +318,11 @@ def _solve_loop(wfn,
 
         # ret = {"eigvals": ee, "eigvecs": (rvecs, rvecs), "stats": stats} (TDA)
         # ret = {"eigvals": ee, "eigvecs": (rvecs, lvecs), "stats": stats} (RPA)
+        # N.B.: Eigvecs and eigvals are of the reduced, non-Hermitian eigenvalue problem, not the
+        # original Hermitian pseudo-eigenvalue problem. To convert to quantiites of original probe:
+        # ee = omega^2
+        # rvecs = X + Y
+        # lvecs = X - Y
         ret = solve_function(engine, nstates, guess_, maxiter)
 
         # check whether all roots converged

--- a/psi4/src/psi4/cc/ccdensity/Params.h
+++ b/psi4/src/psi4/cc/ccdensity/Params.h
@@ -116,9 +116,14 @@ struct RHO_Params {
     char opdm_b_lbl[32];
 };
 
+// TODO: Refactor TD_Params and XTD_Params into Root_Params and Transition_Params.
+// Map pairs of state identifiers to Transition_Params, and be able to grab the EOM
+// from Root_Params. All ex_* files that duplicate another file can be then made obsolete.
+
+// Describes both an excited state and the transition to it, from the ground state.
 struct TD_Params {
-    int irrep;
-    int root;
+    int irrep;           // Irrep index of the transition between states.
+    int root;            // Index of the target root within irrep, excluding the ground state.
     double R0;
     double cceom_energy;
     char L1A_lbl[32];
@@ -138,6 +143,7 @@ struct TD_Params {
     double einstein_b;
 };
 
+// Describes a transition between excited states.
 struct XTD_Params {
     int irrep1;
     int irrep2;

--- a/psi4/src/psi4/cc/ccdensity/get_td_params.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_td_params.cc
@@ -45,7 +45,6 @@ namespace psi {
 namespace ccdensity {
 
 void get_td_params(Options& options) {
-    int i, j, k, l;
     char lbl[32];
 
     params.nstates = 0;
@@ -58,12 +57,11 @@ void get_td_params(Options& options) {
         params.prop_root -= 1;
         params.nstates = 1;
     } else if (options["ROOTS_PER_IRREP"].has_changed()) {
-        i = options["ROOTS_PER_IRREP"].size();
-        if (i != moinfo.nirreps) {
+        if (options["ROOTS_PER_IRREP"].size() != moinfo.nirreps) {
             outfile->Printf("Dim. of states_per_irrep vector must be %d\n", moinfo.nirreps);
             throw PsiException("ccdensity: error", __FILE__, __LINE__);
         }
-        for (i = 0; i < moinfo.nirreps; ++i) {
+        for (int i = 0; i < moinfo.nirreps; ++i) {
             params.nstates += options["ROOTS_PER_IRREP"][i].to_integer();
         }
     } else {
@@ -76,12 +74,12 @@ void get_td_params(Options& options) {
 
     */
 
-    td_params = (struct TD_Params*)malloc(params.nstates * sizeof(struct TD_Params));
+    td_params.resize(params.nstates);
 
-    l = 0;
+    int l = 0;
     if (options["PROP_SYM"].has_changed() && options["PROP_ROOT"].has_changed()) {
         td_params[0].irrep = params.prop_sym ^ moinfo.sym;
-        k = td_params[0].root = params.prop_root;
+        auto k = td_params[0].root = params.prop_root;
 
         if (params.wfn == "CC2" || params.wfn == "EOM_CC2") {
             sprintf(lbl, "EOM CC2 Energy for root %d %d", td_params[0].irrep, k);
@@ -111,9 +109,9 @@ void get_td_params(Options& options) {
         sprintf(td_params[l].R2BB_lbl, "Rijab %d %d", td_params[0].irrep, k);
         sprintf(td_params[l].R2AB_lbl, "RIjAb %d %d", td_params[0].irrep, k);
     } else if (options["ROOTS_PER_IRREP"].has_changed()) {
-        for (i = 0; i < moinfo.nirreps; ++i) {
-            j = options["ROOTS_PER_IRREP"][i].to_integer();
-            for (k = 0; k < j; ++k) {
+        for (int i = 0; i < moinfo.nirreps; ++i) {
+            auto j = options["ROOTS_PER_IRREP"][i].to_integer();
+            for (int k = 0; k < j; ++k) {
                 td_params[l].irrep = i ^ moinfo.sym;
                 td_params[l].root = k;
 

--- a/psi4/src/psi4/cc/ccdensity/globals.h
+++ b/psi4/src/psi4/cc/ccdensity/globals.h
@@ -38,6 +38,7 @@
 #include "psi4/libpsio/psio.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "Params.h"
 
 namespace psi {
 
@@ -57,7 +58,7 @@ EXTERN struct MOInfo moinfo;
 EXTERN struct Frozen frozen;
 EXTERN struct Params params;
 EXTERN struct RHO_Params *rho_params;
-EXTERN struct TD_Params *td_params;
+EXTERN std::vector<TD_Params> td_params;
 // EXTERN std::vector<struct XTD_Params> xtd_params;
 }
 }  // namespace psi

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -317,8 +317,8 @@ double CCLambdaWavefunction::compute_energy() {
             /*- Process::environment.globals["LEFT-RIGHT CC2 EIGENVECTOR OVERLAP"] -*/
             /*- Process::environment.globals["LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"] -*/
             /*- Process::environment.globals["LEFT-RIGHT CCSD(T) EIGENVECTOR OVERLAP"] -*/
-            auto varname = "LEFT-RIGHT " + gs_name + " EIGENVECTOR OVERLAP";
-            reference_wavefunction_->set_scalar_variable(varname, LR_overlap);
+            auto lambda_varname = "LEFT-RIGHT " + gs_name + " EIGENVECTOR OVERLAP";
+            reference_wavefunction_->set_scalar_variable(lambda_varname, LR_overlap);
         }
     }
 

--- a/tests/cc47/input.dat
+++ b/tests/cc47/input.dat
@@ -14,4 +14,53 @@ set {
   roots_per_irrep [2, 2]
 }
 
-properties('eom-ccsd', properties=['oscillator_strength'])
+wfn = properties('eom-ccsd', properties=['oscillator_strength'], return_wfn=True)[1]
+
+### ccdensity checks
+
+refnre     =   38.2539685310425384 # TEST
+refscf     = -150.7791838721300337 # TEST
+refccsd    = -151.173863088601593  # TEST
+refoverlap =    0.89177313450      # TEST
+
+compare_values(refnre, h2o2.nuclear_repulsion_energy(), 6, "Nuclear Repulsion Energy") # TEST
+compare_values(refscf, wfn.variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(refccsd, wfn.variable("CCSD TOTAL ENERGY"), 6, "CCSD Energy") # TEST
+compare_values(refoverlap, wfn.variable("LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"), 5, "Left-Right CCSD Overlap") # TEST
+
+### Excitation energy checks
+
+ref1A = -150.917014087692 # TEST
+ref2A = -150.839749395623 # TEST
+ref0B = -150.920333329231 # TEST
+ref1B = -150.839220324206 # TEST
+
+compare_values(ref1A, core.variable("CCSD ROOT 1 (A) TOTAL ENERGY"), 6, "Root 1 (A) Energy") # TEST
+compare_values(ref2A, core.variable("CCSD ROOT 2 (A) TOTAL ENERGY"), 6, "Root 2 (A) Energy") # TEST
+compare_values(ref0B, core.variable("CCSD ROOT 0 (B) TOTAL ENERGY"), 6, "Root 0 (B) Energy") # TEST
+compare_values(ref1B, core.variable("CCSD ROOT 1 (B) TOTAL ENERGY"), 6, "Root 1 (B) Energy") # TEST
+
+### Oscillator strength checks
+
+os0A1A = 0.00000959 # TEST
+os0A2A = 0.00791943 # TEST
+os0A0B = 0.00193778 # TEST
+os0A1B = 0.01015988 # TEST
+os1A2A = 0.00001783 # TEST
+os0B1A = 0.00152626 # TEST
+os0B2A = 0.01290715 # TEST
+os1A1B = 0.01441595 # TEST
+os2A1B = 0.00019032 # TEST
+os0B1B = 0.00682565 # TEST
+
+compare_values(os0A1A, wfn.variable("CC ROOT 0 (A) -> ROOT 1 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 1 (A) Oscillator Strength") # TEST
+compare_values(os0A2A, wfn.variable("CC ROOT 0 (A) -> ROOT 2 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 2 (A) Oscillator Strength") # TEST
+compare_values(os0A0B, wfn.variable("CC ROOT 0 (A) -> ROOT 0 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 0 (B) Oscillator Strength") # TEST
+compare_values(os0A1B, wfn.variable("CC ROOT 0 (A) -> ROOT 1 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 1 (B) Oscillator Strength") # TEST
+compare_values(os1A2A, wfn.variable("CC ROOT 1 (A) -> ROOT 2 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 1 (A) -> Root 2 (A) Oscillator Strength") # TEST
+compare_values(os0B1A, wfn.variable("CC ROOT 0 (B) -> ROOT 1 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 0 (B) -> Root 1 (A) Oscillator Strength") # TEST
+compare_values(os0B2A, wfn.variable("CC ROOT 0 (B) -> ROOT 2 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 0 (B) -> Root 2 (A) Oscillator Strength") # TEST
+compare_values(os1A1B, wfn.variable("CC ROOT 1 (A) -> ROOT 1 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 1 (A) -> Root 1 (B) Oscillator Strength") # TEST
+compare_values(os2A1B, wfn.variable("CC ROOT 2 (A) -> ROOT 1 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 2 (A) -> Root 1 (B) Oscillator Strength") # TEST
+compare_values(os0B1B, wfn.variable("CC ROOT 0 (B) -> ROOT 1 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 0 (B) -> Root 1 (B) Oscillator Strength") # TEST
+

--- a/tests/cc47/output.ref
+++ b/tests/cc47/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.6a1.dev51 
+                               Psi4 undefined 
 
-                         Git: Rev {ccdensity_fix} 4732348 dirty
+                         Git: Rev {master} 946cdd7 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Saturday, 12 February 2022 03:25PM
+    Psi4 started on: Tuesday, 29 March 2022 06:25PM
 
-    Process ID: 65748
+    Process ID: 22229
     Host:       Jonathons-MacBook-Pro.local
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
@@ -57,11 +57,60 @@ set {
   roots_per_irrep [2, 2]
 }
 
-properties('eom-ccsd', properties=['oscillator_strength'])
+wfn = properties('eom-ccsd', properties=['oscillator_strength'], return_wfn=True)[1]
+
+### ccdensity checks
+
+refnre     =   38.2539685310425384 # TEST
+refscf     = -150.7791838721300337 # TEST
+refccsd    = -151.173863088601593  # TEST
+refoverlap =    0.89177313450      # TEST
+
+compare_values(refnre, h2o2.nuclear_repulsion_energy(), 6, "Nuclear Repulsion Energy") # TEST
+compare_values(refscf, wfn.variable("SCF TOTAL ENERGY"), 6, "SCF Energy") # TEST
+compare_values(refccsd, wfn.variable("CCSD TOTAL ENERGY"), 6, "CCSD Energy") # TEST
+compare_values(refoverlap, wfn.variable("LEFT-RIGHT CCSD EIGENVECTOR OVERLAP"), 5, "Left-Right CCSD Overlap") # TEST
+
+### Excitation energy checks
+
+ref1A = -150.917014087692 # TEST
+ref2A = -150.839749395623 # TEST
+ref0B = -150.920333329231 # TEST
+ref1B = -150.839220324206 # TEST
+
+compare_values(ref1A, core.variable("CCSD ROOT 1 (A) TOTAL ENERGY"), 6, "Root 1 (A) Energy") # TEST
+compare_values(ref2A, core.variable("CCSD ROOT 2 (A) TOTAL ENERGY"), 6, "Root 2 (A) Energy") # TEST
+compare_values(ref0B, core.variable("CCSD ROOT 0 (B) TOTAL ENERGY"), 6, "Root 0 (B) Energy") # TEST
+compare_values(ref1B, core.variable("CCSD ROOT 1 (B) TOTAL ENERGY"), 6, "Root 1 (B) Energy") # TEST
+
+### Oscillator strength checks
+
+os0A1A = 0.00000959 # TEST
+os0A2A = 0.00791943 # TEST
+os0A0B = 0.00193778 # TEST
+os0A1B = 0.01015988 # TEST
+os1A2A = 0.00001783 # TEST
+os0B1A = 0.00152626 # TEST
+os0B2A = 0.01290715 # TEST
+os1A1B = 0.01441595 # TEST
+os2A1B = 0.00019032 # TEST
+os0B1B = 0.00682565 # TEST
+
+compare_values(os0A1A, wfn.variable("CC ROOT 0 (A) -> ROOT 1 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 1 (A) Oscillator Strength") # TEST
+compare_values(os0A2A, wfn.variable("CC ROOT 0 (A) -> ROOT 2 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 2 (A) Oscillator Strength") # TEST
+compare_values(os0A0B, wfn.variable("CC ROOT 0 (A) -> ROOT 0 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 0 (B) Oscillator Strength") # TEST
+compare_values(os0A1B, wfn.variable("CC ROOT 0 (A) -> ROOT 1 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 1 (B) Oscillator Strength") # TEST
+compare_values(os1A2A, wfn.variable("CC ROOT 1 (A) -> ROOT 2 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 1 (A) -> Root 2 (A) Oscillator Strength") # TEST
+compare_values(os0B1A, wfn.variable("CC ROOT 0 (B) -> ROOT 1 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 0 (B) -> Root 1 (A) Oscillator Strength") # TEST
+compare_values(os0B2A, wfn.variable("CC ROOT 0 (B) -> ROOT 2 (A) OSCILLATOR STRENGTH (LEN)"), 6, "Root 0 (B) -> Root 2 (A) Oscillator Strength") # TEST
+compare_values(os1A1B, wfn.variable("CC ROOT 1 (A) -> ROOT 1 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 1 (A) -> Root 1 (B) Oscillator Strength") # TEST
+compare_values(os2A1B, wfn.variable("CC ROOT 2 (A) -> ROOT 1 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 2 (A) -> Root 1 (B) Oscillator Strength") # TEST
+compare_values(os0B1B, wfn.variable("CC ROOT 0 (B) -> ROOT 1 (B) OSCILLATOR STRENGTH (LEN)"), 6, "Root 0 (B) -> Root 1 (B) Oscillator Strength") # TEST
+
 --------------------------------------------------------------------------
 
 *** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:25:26 2022
+*** at Tue Mar 29 18:25:14 2022
 
    => Loading Basis Set <=
 
@@ -176,21 +225,21 @@ properties('eom-ccsd', properties=['oscillator_strength'])
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:  -150.13109142562024   -1.50131e+02   0.00000e+00 
-   @RHF iter   1:  -150.72994418505689   -5.98853e-01   1.20798e-02 ADIIS/DIIS
-   @RHF iter   2:  -150.77474437542560   -4.48002e-02   3.93712e-03 ADIIS/DIIS
-   @RHF iter   3:  -150.77872862263547   -3.98425e-03   9.99210e-04 ADIIS/DIIS
-   @RHF iter   4:  -150.77914039140384   -4.11769e-04   2.79341e-04 ADIIS/DIIS
-   @RHF iter   5:  -150.77918120837066   -4.08170e-05   4.89524e-05 DIIS
-   @RHF iter   6:  -150.77918362626531   -2.41789e-06   1.25560e-05 DIIS
-   @RHF iter   7:  -150.77918384927895   -2.23014e-07   3.89300e-06 DIIS
-   @RHF iter   8:  -150.77918387131706   -2.20381e-08   8.16055e-07 DIIS
-   @RHF iter   9:  -150.77918387210650   -7.89441e-10   1.49865e-07 DIIS
-   @RHF iter  10:  -150.77918387212898   -2.24816e-11   3.10868e-08 DIIS
-   @RHF iter  11:  -150.77918387213006   -1.08002e-12   6.61624e-09 DIIS
-   @RHF iter  12:  -150.77918387213001    5.68434e-14   1.38474e-09 DIIS
-   @RHF iter  13:  -150.77918387213003   -2.84217e-14   3.05202e-10 DIIS
-   @RHF iter  14:  -150.77918387213003    0.00000e+00   6.31844e-11 DIIS
+   @RHF iter SAD:  -150.13109142562013   -1.50131e+02   0.00000e+00 
+   @RHF iter   1:  -150.72994418505670   -5.98853e-01   1.20798e-02 DIIS/ADIIS
+   @RHF iter   2:  -150.77474437542543   -4.48002e-02   3.93712e-03 DIIS/ADIIS
+   @RHF iter   3:  -150.77872862263519   -3.98425e-03   9.99210e-04 DIIS/ADIIS
+   @RHF iter   4:  -150.77914039140370   -4.11769e-04   2.79341e-04 DIIS/ADIIS
+   @RHF iter   5:  -150.77918120037543   -4.08090e-05   4.90416e-05 DIIS
+   @RHF iter   6:  -150.77918362626571   -2.42589e-06   1.25561e-05 DIIS
+   @RHF iter   7:  -150.77918384927833   -2.23013e-07   3.89306e-06 DIIS
+   @RHF iter   8:  -150.77918387131695   -2.20386e-08   8.16021e-07 DIIS
+   @RHF iter   9:  -150.77918387210659   -7.89640e-10   1.49862e-07 DIIS
+   @RHF iter  10:  -150.77918387212858   -2.19984e-11   3.10838e-08 DIIS
+   @RHF iter  11:  -150.77918387212992   -1.33582e-12   6.61314e-09 DIIS
+   @RHF iter  12:  -150.77918387212981    1.13687e-13   1.38427e-09 DIIS
+   @RHF iter  13:  -150.77918387212972    8.52651e-14   3.04978e-10 DIIS
+   @RHF iter  14:  -150.77918387212989   -1.70530e-13   6.31113e-11 DIIS
   Energy and wave function converged.
 
 
@@ -222,14 +271,14 @@ properties('eom-ccsd', properties=['oscillator_strength'])
               A     B 
     DOCC [     5,    4 ]
 
-  @RHF Final Energy:  -150.77918387213003
+  @RHF Final Energy:  -150.77918387212989
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             38.2539685310425384
-    One-Electron Energy =                -284.0698924306753952
-    Two-Electron Energy =                  95.0367400275028018
-    Total Energy =                       -150.7791838721300337
+    One-Electron Energy =                -284.0698924306771005
+    Two-Electron Energy =                  95.0367400275046776
+    Total Energy =                       -150.7791838721298632
 
 Computation Completed
 
@@ -238,28 +287,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     1.4677
 
-  Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.2602
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     1.2074     Total:     1.2074
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     3.0690     Total:     3.0690
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.2602411            1.4676695            1.2074284
+ Magnitude           :                                                    1.2074284
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:28 2022
+*** tstop() called on Jonathons-MacBook-Pro.local at Tue Mar 29 18:25:15 2022
 Module time:
-	user time   =       1.19 seconds =       0.02 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.76 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.19 seconds =       0.02 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.76 seconds =       0.01 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -285,7 +336,7 @@ Total time:
 
 
 *** tstart() called on Jonathons-MacBook-Pro.local
-*** at Sat Feb 12 15:25:28 2022
+*** at Tue Mar 29 18:25:15 2022
 
 
 	Wfn Parameters:
@@ -344,7 +395,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =   -132.27484829822760
+	Frozen core energy     =   -132.27484829822714
 
 	Size of irrep 0 of <ab|cd> integrals:      0.177 (MW) /      1.418 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.176 (MW) /      1.411 (MB)
@@ -359,20 +410,20 @@ Total time:
 	Total:                                     0.021 (MW) /      0.165 (MB)
 
 	Nuclear Rep. energy          =     38.25396853104254
-	SCF energy                   =   -150.77918387213003
-	One-electron energy          =   -101.99691974243427
-	Two-electron energy          =     45.23861563748924
-	Reference energy             =   -150.77918387213009
+	SCF energy                   =   -150.77918387212989
+	One-electron energy          =   -101.99691974243702
+	Two-electron energy          =     45.23861563749188
+	Reference energy             =   -150.77918387212975
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Sat Feb 12 15:25:28 2022
+*** tstop() called on Jonathons-MacBook-Pro.local at Tue Mar 29 18:25:15 2022
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.21 seconds =       0.00 minutes
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.44 seconds =       0.02 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.94 seconds =       0.02 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -380,8 +431,8 @@ Total time:
             **************************
 
     Nuclear Rep. energy (wfn)     =   38.253968531042538
-    SCF energy          (wfn)     = -150.779183872130034
-    Reference energy    (file100) = -150.779183872130091
+    SCF energy          (wfn)     = -150.779183872129892
+    Reference energy    (file100) = -150.779183872129749
 
     Input parameters:
     -----------------
@@ -409,26 +460,26 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.3802563047354116
+MP2 correlation energy -0.3802563047354557
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.380256304735412    0.000e+00    0.000000    0.000000    0.000000    0.143419
-     1        -0.384252699668223    4.172e-02    0.006281    0.014957    0.014957    0.146642
-     2        -0.393202764097124    1.580e-02    0.007156    0.016728    0.016728    0.156356
-     3        -0.394603277393149    5.260e-03    0.008061    0.018516    0.018516    0.160181
-     4        -0.394657649472679    1.398e-03    0.008198    0.018646    0.018646    0.161027
-     5        -0.394690572111229    5.030e-04    0.008266    0.018685    0.018685    0.161216
-     6        -0.394682676918496    1.898e-04    0.008293    0.018687    0.018687    0.161210
-     7        -0.394679308421909    5.979e-05    0.008301    0.018685    0.018685    0.161200
-     8        -0.394679268023979    2.095e-05    0.008303    0.018684    0.018684    0.161198
-     9        -0.394678918998321    7.909e-06    0.008304    0.018684    0.018684    0.161197
-    10        -0.394679205282325    3.344e-06    0.008304    0.018684    0.018684    0.161197
-    11        -0.394679179930230    1.110e-06    0.008304    0.018684    0.018684    0.161197
-    12        -0.394679217846231    3.658e-07    0.008304    0.018684    0.018684    0.161197
-    13        -0.394679216147637    1.105e-07    0.008304    0.018684    0.018684    0.161197
-    14        -0.394679216471492    3.761e-08    0.008304    0.018684    0.018684    0.161197
+     0        -0.380256304735456    0.000e+00    0.000000    0.000000    0.000000    0.143419
+     1        -0.384252699668260    4.172e-02    0.006281    0.014957    0.014957    0.146642
+     2        -0.393202764097170    1.580e-02    0.007156    0.016728    0.016728    0.156356
+     3        -0.394603277393201    5.260e-03    0.008061    0.018516    0.018516    0.160181
+     4        -0.394657649472730    1.398e-03    0.008198    0.018646    0.018646    0.161027
+     5        -0.394690572111280    5.030e-04    0.008266    0.018685    0.018685    0.161216
+     6        -0.394682676918545    1.898e-04    0.008293    0.018687    0.018687    0.161210
+     7        -0.394679308421960    5.979e-05    0.008301    0.018685    0.018685    0.161200
+     8        -0.394679268024030    2.095e-05    0.008303    0.018684    0.018684    0.161198
+     9        -0.394678918998370    7.909e-06    0.008304    0.018684    0.018684    0.161197
+    10        -0.394679205282375    3.344e-06    0.008304    0.018684    0.018684    0.161197
+    11        -0.394679179930281    1.110e-06    0.008304    0.018684    0.018684    0.161197
+    12        -0.394679217846279    3.658e-07    0.008304    0.018684    0.018684    0.161197
+    13        -0.394679216147687    1.105e-07    0.008304    0.018684    0.018684    0.161197
+    14        -0.394679216471542    3.761e-08    0.008304    0.018684    0.018684    0.161197
 
     Iterations converged.
 
@@ -457,20 +508,20 @@ MP2 correlation energy -0.3802563047354116
       1   1   1   1        -0.0213098148
       2   2  14  14        -0.0200419741
 
-    SCF energy       (wfn)                    = -150.779183872130034
-    Reference energy (file100)                = -150.779183872130091
+    SCF energy       (wfn)                    = -150.779183872129892
+    Reference energy (file100)                = -150.779183872129749
 
-    Opposite-spin MP2 correlation energy      =   -0.282698986958674
-    Same-spin MP2 correlation energy          =   -0.097557317776737
+    Opposite-spin MP2 correlation energy      =   -0.282698986958717
+    Same-spin MP2 correlation energy          =   -0.097557317776739
     Singles MP2 correlation energy            =   -0.000000000000000
-    MP2 correlation energy                    =   -0.380256304735412
-      * MP2 total energy                      = -151.159440176865502
+    MP2 correlation energy                    =   -0.380256304735456
+      * MP2 total energy                      = -151.159440176865218
 
-    Opposite-spin CCSD correlation energy     =   -0.309012024407253
+    Opposite-spin CCSD correlation energy     =   -0.309012024407304
     Same-spin CCSD correlation energy         =   -0.085667192064238
     Singles CCSD correlation energy           =    0.000000000000000
-    CCSD correlation energy                   =   -0.394679216471492
-      * CCSD total energy                     = -151.173863088601593
+    CCSD correlation energy                   =   -0.394679216471542
+      * CCSD total energy                     = -151.173863088601280
 
 
 			**************************
@@ -485,9 +536,9 @@ MP2 correlation energy -0.3802563047354116
 	**********************************************************
 
 	Nuclear Rep. energy (wfn)     =   38.253968531042538
-	SCF energy          (wfn)     = -150.779183872130034
-	Reference energy    (file100) = -150.779183872130091
-	CCSD energy         (file100) =   -0.394679216471492
+	SCF energy          (wfn)     = -150.779183872129892
+	Reference energy    (file100) = -150.779183872129749
+	CCSD energy         (file100) =   -0.394679216471542
 
 	Input parameters:
 	-----------------
@@ -521,8 +572,8 @@ MP2 correlation energy -0.3802563047354116
 
 
 
-Fae   dot Fae   total  161.9913829038
-Fmi   dot Fmi   total    6.2814463882
+Fae   dot Fae   total  161.9913829037
+Fmi   dot Fmi   total    6.2814463883
 Fme   dot Fme   total    0.0000103500
 WMBIJ dot WMBIJ total    0.0000000000
 Wmbij dot Wmbij total    0.0000000000
@@ -573,27 +624,27 @@ Iter=12   L=22    Root    EOM Energy     Delta E   Res. Norm    Conv?
 Collapsing to only 2 vector(s).
 
 Procedure converged for 2 root(s).
-EOM CCSD R0 for root 0 =  -0.00300763378
+EOM CCSD R0 for root 0 =   0.00300763378
 EOM CCSD R0 for root 1 =   0.01181206651
 
 Final Energetic Summary for Converged Roots of Irrep A
                      Excitation Energy              Total Energy
                 (eV)     (cm^-1)     (au)             (au)
-EOM State 1      6.989    56371.8   0.2568490009  -150.917014087692
+EOM State 1      6.989    56371.8   0.2568490009  -150.917014087691
 
 Largest components of excited wave function #1:
  RIA (libdpd indices) : (cscf notation)
-         3 >   0      :        5a >     6a :    0.6760837560
-         3 >   1      :        5a >     7a :   -0.0627193427
-         2 >   0      :        4b >     5b :    0.0421614061
-         1 >   0      :        3b >     5b :   -0.0393688502
-         2 >   0      :        4a >     6a :    0.0330840179
+         3 >   0      :        5a >     6a :   -0.6760837560
+         3 >   1      :        5a >     7a :    0.0627193427
+         2 >   0      :        4b >     5b :   -0.0421614061
+         1 >   0      :        3b >     5b :    0.0393688502
+         2 >   0      :        4a >     6a :   -0.0330840179
  RIjAb (libdpd indices)     : (cscf notation)
-        2   1 >   1   0     :     4a     3b >     6b     6a :    0.0461657036
-        1   2 >   0   1     :     3b     4a >     6a     6b :    0.0461657036
-        1   3 >   0   0     :     3a     5a >     6a     6a :    0.0387839600
-        3   1 >   0   0     :     5a     3a >     6a     6a :    0.0387839600
-        2   2 >   1   0     :     4a     4b >     6b     6a :   -0.0277131706
+        2   1 >   1   0     :     4a     3b >     6b     6a :   -0.0461657036
+        1   2 >   0   1     :     3b     4a >     6a     6b :   -0.0461657036
+        1   3 >   0   0     :     3a     5a >     6a     6a :   -0.0387839600
+        3   1 >   0   0     :     5a     3a >     6a     6a :   -0.0387839600
+        2   2 >   1   0     :     4a     4b >     6b     6a :    0.0277131706
 EOM State 2      9.092    73329.5   0.3341136930  -150.839749395623
 
 Largest components of excited wave function #2:
@@ -652,13 +703,13 @@ Iter=12   L=23    Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.2535297642   1.15e-08    2.68e-05      Y
                      2   0.3346431862  -3.07e-06    4.38e-04      N
 Iter=13   L=24  
-Sum of complex part of HBar eigenvalues    0.000423842411345,   1.00e-12
+Sum of complex part of HBar eigenvalues    0.000423842411152,   1.00e-12
   Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.2535297652   9.53e-10    2.45e-05      Y
                      2   0.3346427464  -4.40e-07    2.18e-04      N
 Iter=14   L=4     Root    EOM Energy     Delta E   Res. Norm    Conv?
-                     1   0.2535297652  -1.04e-14    2.45e-05      Y
-                     2   0.3346427464   2.16e-15    2.18e-04      N
+                     1   0.2535297652   9.99e-16    2.45e-05      Y
+                     2   0.3346427464   1.47e-14    2.18e-04      N
 Iter=15   L=5     Root    EOM Energy     Delta E   Res. Norm    Conv?
                      1   0.2535297594  -5.81e-09    2.41e-05      Y
                      2   0.3346427644   1.80e-08    9.17e-05      Y
@@ -716,10 +767,10 @@ Largest components of excited wave function #4:
 
 	Nuclear Rep. energy (wfn)     =   38.253968531042538
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     = -150.779183872130034
-	Reference energy    (CC_INFO) = -150.779183872130091
-	CCSD energy         (CC_INFO) =   -0.394679216471492
-	Total CCSD energy   (CC_INFO) = -151.173863088601593
+	SCF energy          (wfn)     = -150.779183872129892
+	Reference energy    (CC_INFO) = -150.779183872129749
+	CCSD energy         (CC_INFO) =   -0.394679216471542
+	Total CCSD energy   (CC_INFO) = -151.173863088601280
 
 	Input parameters:
 	-----------------
@@ -735,7 +786,7 @@ Largest components of excited wave function #4:
 	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
-	  2   0     1         No       0.2568490009  -0.0030076338
+	  2   0     1         No       0.2568490009   0.0030076338
 	  3   0     2         No       0.3341136930   0.0118120665
 	  4   1     1         No       0.2535297594   0.0000000000
 	  5   1     2         No       0.3346427644   0.0000000000
@@ -757,12 +808,12 @@ Largest components of excited wave function #4:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.394689327699558    0.000e+00
-	   1        -0.387343314762134    8.725e-03
-	   2        -0.386499939344902    2.080e-03
-	   3        -0.386317947916533    6.944e-04
-	   4        -0.386312992662775    2.285e-04
-	   5        -0.386314886176575    9.110e-05
+	   0        -0.394689327699609    0.000e+00
+	   1        -0.387343314762170    8.725e-03
+	   2        -0.386499939344935    2.080e-03
+	   3        -0.386317947916568    6.944e-04
+	   4        -0.386312992662811    2.285e-04
+	   5        -0.386314886176611    9.110e-05
 
 	Largest LIA Amplitudes:
 	          5  14        -0.0082327683
@@ -800,47 +851,47 @@ Largest components of excited wave function #4:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         0.000306122337813    9.110e-05
-	   1        -0.000392059897956    5.148e-02
-	   2        -0.000402796125736    1.320e-02
-	   3        -0.000414436162919    2.780e-03
-	   4        -0.000409594311917    1.309e-03
-	   5        -0.000403682975676    6.251e-04
-	   6        -0.000402420950387    3.342e-04
-	   7        -0.000404094364455    1.427e-04
-	   8        -0.000404386098083    6.007e-05
+	   0        -0.000306122337822    9.110e-05
+	   1         0.000392059897977    5.148e-02
+	   2         0.000402796125755    1.320e-02
+	   3         0.000414436162939    2.780e-03
+	   4         0.000409594311937    1.309e-03
+	   5         0.000403682975696    6.251e-04
+	   6         0.000402420950407    3.342e-04
+	   7         0.000404094364475    1.427e-04
+	   8         0.000404386098103    6.007e-05
 
 	Initial  <L|R>  =        0.9742430736
 	Normalizing L...
-	L0 * R0 =       -0.0000000000
+	L0 * R0 =        0.0000000000
 	L1 * R1 =        0.9289315282
 	L2 * R2 =        0.0710684718
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =   -0.000415077211259
+	Pseudoenergy or Norm of normalized L =    0.000415077211279
 
 	Largest LIA Amplitudes:
-	          3   0         0.6694371291
-	          3   1        -0.0598299592
-	          6  14         0.0427964857
-	          5  14        -0.0409680065
-	          2   0         0.0339087752
-	          5  15        -0.0323994000
-	          6  15         0.0266839610
-	          3   2         0.0191562934
-	          3   5        -0.0155159513
-	          1   0         0.0154280519
+	          3   0        -0.6694371291
+	          3   1         0.0598299592
+	          6  14        -0.0427964857
+	          5  14         0.0409680065
+	          2   0        -0.0339087752
+	          5  15         0.0323994000
+	          6  15        -0.0266839610
+	          3   2        -0.0191562934
+	          3   5         0.0155159513
+	          1   0        -0.0154280519
 
 	Largest LIjAb Amplitudes:
-	  2   5  15   0         0.0565917123
-	  5   2   0  15         0.0565917123
-	  1   3   0   0         0.0414071744
-	  3   1   0   0         0.0414071744
-	  2   6  15   0        -0.0349700246
-	  6   2   0  15        -0.0349700246
-	  1   5  15   0        -0.0312823800
-	  5   1   0  15        -0.0312823800
-	  3   3   0   4        -0.0282415876
-	  3   3   4   0        -0.0282415876
+	  2   5  15   0        -0.0565917123
+	  5   2   0  15        -0.0565917123
+	  1   3   0   0        -0.0414071744
+	  3   1   0   0        -0.0414071744
+	  2   6  15   0         0.0349700246
+	  6   2   0  15         0.0349700246
+	  1   5  15   0         0.0312823800
+	  5   1   0  15         0.0312823800
+	  3   3   0   4         0.0282415876
+	  3   3   4   0         0.0282415876
 
 	Iterations converged.
 
@@ -853,16 +904,16 @@ Largest components of excited wave function #4:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.000362074140726    6.007e-05
-	   1         0.002780463439076    3.558e-02
-	   2         0.002713114272152    8.772e-03
-	   3         0.002791741460138    3.352e-03
-	   4         0.002782939559508    1.991e-03
-	   5         0.002764803286576    1.265e-03
-	   6         0.002764249869335    8.096e-04
-	   7         0.002763680893531    4.009e-04
-	   8         0.002764376770778    1.659e-04
-	   9         0.002764441650095    7.287e-05
+	   0        -0.000362074140741    6.007e-05
+	   1         0.002780463439114    3.558e-02
+	   2         0.002713114272188    8.772e-03
+	   3         0.002791741460177    3.352e-03
+	   4         0.002782939559547    1.991e-03
+	   5         0.002764803286615    1.265e-03
+	   6         0.002764249869374    8.096e-04
+	   7         0.002763680893570    4.009e-04
+	   8         0.002764376770817    1.659e-04
+	   9         0.002764441650134    7.287e-05
 
 	Initial  <L|R>  =        0.9848106991
 	Normalizing L...
@@ -870,7 +921,7 @@ Largest components of excited wave function #4:
 	L1 * R1 =        0.9287966896
 	L2 * R2 =        0.0712033104
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    0.002807079221145
+	Pseudoenergy or Norm of normalized L =    0.002807079221185
 
 	Largest LIA Amplitudes:
 	          6  14         0.5247537236
@@ -908,15 +959,15 @@ Largest components of excited wave function #4:
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
 	   0         1.000000000000000    7.287e-05
-	   1         0.981916992432146    3.500e-02
-	   2         0.984667624844179    8.595e-03
-	   3         0.984826101420597    3.006e-03
-	   4         0.985072552088514    1.768e-03
-	   5         0.985364276831351    1.124e-03
-	   6         0.985597038847825    7.321e-04
-	   7         0.985752873507787    3.420e-04
-	   8         0.985807709440838    1.305e-04
-	   9         0.985812447336846    4.997e-05
+	   1         0.981916992434863    3.500e-02
+	   2         0.984667624846862    8.595e-03
+	   3         0.984826101424223    3.006e-03
+	   4         0.985072552092869    1.768e-03
+	   5         0.985364276837329    1.124e-03
+	   6         0.985597038855276    7.321e-04
+	   7         0.985752873515689    3.420e-04
+	   8         0.985807709448631    1.305e-04
+	   9         0.985812447344602    4.997e-05
 
 	Initial  <L|R>  =        0.9848616766
 	Normalizing L...
@@ -924,7 +975,7 @@ Largest components of excited wave function #4:
 	L1 * R1 =        0.9388629860
 	L2 * R2 =        0.0611370140
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.000965385025876
+	Pseudoenergy or Norm of normalized L =    1.000965385026383
 
 	Largest LIA Amplitudes:
 	          3  14        -0.5381614901
@@ -961,18 +1012,18 @@ Largest components of excited wave function #4:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0         1.000000000000000    4.997e-05
-	   1         0.976211587973123    4.248e-02
-	   2         0.979985998183435    1.011e-02
-	   3         0.980087718625270    2.932e-03
-	   4         0.980284264710606    1.394e-03
-	   5         0.980390431412276    6.927e-04
-	   6         0.980435042218616    5.343e-04
-	   7         0.980491961431606    4.330e-04
-	   8         0.980560981972800    3.621e-04
-	   9         0.980641502043312    2.762e-04
-	  10         0.980754380338436    1.982e-04
-	  11         0.980759067264219    9.848e-05
+	   0         1.000000000000001    4.997e-05
+	   1         0.976211587973140    4.248e-02
+	   2         0.979985998183426    1.011e-02
+	   3         0.980087718625230    2.932e-03
+	   4         0.980284264710541    1.394e-03
+	   5         0.980390431412191    6.927e-04
+	   6         0.980435042218513    5.343e-04
+	   7         0.980491961431486    4.330e-04
+	   8         0.980560981972652    3.621e-04
+	   9         0.980641502043078    2.762e-04
+	  10         0.980754380338112    1.982e-04
+	  11         0.980759067263879    9.848e-05
 
 	Initial  <L|R>  =        0.9796718365
 	Normalizing L...
@@ -980,7 +1031,7 @@ Largest components of excited wave function #4:
 	L1 * R1 =        0.9371868088
 	L2 * R2 =        0.0628131912
 	 <L|R>  =        1.0000000000
-	Pseudoenergy or Norm of normalized L =    1.001109790793320
+	Pseudoenergy or Norm of normalized L =    1.001109790793383
 
 	Largest LIA Amplitudes:
 	          6   0         0.5705123073
@@ -1012,9 +1063,9 @@ Largest components of excited wave function #4:
 
                  1            2            3            4            5
 
-    1    1.0000000   -0.0000000    0.0000000  -99.0000000  -99.0000000
-    2    0.0000000    1.0000000   -0.0000001  -99.0000000  -99.0000000
-    3    0.0000000   -0.0000000    1.0000000  -99.0000000  -99.0000000
+    1    1.0000000    0.0000000    0.0000000  -99.0000000  -99.0000000
+    2    0.0000000    1.0000000    0.0000001  -99.0000000  -99.0000000
+    3    0.0000000    0.0000000    1.0000000  -99.0000000  -99.0000000
     4  -99.0000000  -99.0000000  -99.0000000    1.0000000    0.0000000
     5  -99.0000000  -99.0000000  -99.0000000    0.0000001    1.0000000
 
@@ -1023,11 +1074,11 @@ Largest components of excited wave function #4:
 
                  1            2            3            4            5
 
-    1    1.0000000    0.0000000   -0.0000000  -99.0000000  -99.0000000
-    2    0.0000000    1.0000000    0.0000000  -99.0000000  -99.0000000
-    3    0.0000000   -0.0000000    1.0000000  -99.0000000  -99.0000000
+    1    1.0000000   -0.0000000    0.0000000  -99.0000000  -99.0000000
+    2    0.0000000    1.0000000   -0.0000000  -99.0000000  -99.0000000
+    3    0.0000000    0.0000000    1.0000000  -99.0000000  -99.0000000
     4  -99.0000000  -99.0000000  -99.0000000    1.0000000   -0.0000000
-    5  -99.0000000  -99.0000000  -99.0000000    0.0000000    1.0000000
+    5  -99.0000000  -99.0000000  -99.0000000   -0.0000000    1.0000000
 
 
 
@@ -1082,15 +1133,15 @@ Largest components of excited wave function #4:
 	Compute NO       = No
 
 	Nuclear Rep. energy (wfn)     =   38.253968531042538
-	SCF energy          (wfn)     = -150.779183872130034
-	Reference energy    (file100) = -150.779183872130091
-	CCSD energy         (CC_INFO) =   -0.394679216471492
-	Total CCSD energy   (CC_INFO) = -151.173863088601593
+	SCF energy          (wfn)     = -150.779183872129892
+	Reference energy    (file100) = -150.779183872129749
+	CCSD energy         (CC_INFO) =   -0.394679216471542
+	Total CCSD energy   (CC_INFO) = -151.173863088601280
 	Number of States = 5
 
 	Ground?  State     EOM Energy       R0
 	  Yes     0  A    0.0000000000   1.00000000
-	   No     1  A    0.2568490009  -0.00300763
+	   No     1  A    0.2568490009   0.00300763
 	   No     2  A    0.3341136930   0.01181207
 	   No     1  B    0.2535297594   0.00000000
 	   No     2  B    0.3346427644   0.00000000
@@ -1098,8 +1149,8 @@ Doing transition
 
 	Oscillator Strength for 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.00802796
-	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.00697813
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.00802796
+	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.00697813
 	Dipole Strength          0.00005602 
 	Oscillator Strength      0.00000959 
 	Einstein A Coefficient   2.03327968e+04 
@@ -1108,20 +1159,20 @@ Doing transition
 
 	Length-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.00802796
-	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.31729650
-	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.31136481
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.00697813
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.00802796
+	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.31729650
+	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.31136481
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.00697813
 
 	Rotational Strength (au)                 -0.00235999
 	Rotational Strength (10^-40 esu^2 cm^2)  -1.11260334
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.01578728
-	<n|mu_m|0>               0.00000000 	  0.00000000 	 -0.31729650
-	<0|mu_m|n>*              0.00000000 	  0.00000000 	 -0.31136481
-	<n|mu_e|0>*              0.00000000 	  0.00000000 	  0.01454886
+	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.01578728
+	<n|mu_m|0>               0.00000000 	  0.00000000 	  0.31729650
+	<0|mu_m|n>*              0.00000000 	  0.00000000 	  0.31136481
+	<n|mu_e|0>*              0.00000000 	  0.00000000 	 -0.01454886
 
 	Rotational Strength (au)                 -0.01856976
 	Rotational Strength (10^-40 esu^2 cm^2)  -8.75459439
@@ -1260,8 +1311,8 @@ Doing transition
 
 	Oscillator Strength for 1  A to 2  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.00000000 	  0.00000000 	 -0.01539035
-	<n|mu_e|0>               0.00000000 	  0.00000000 	 -0.02249264
+	<0|mu_e|n>               0.00000000 	  0.00000000 	  0.01539035
+	<n|mu_e|0>               0.00000000 	  0.00000000 	  0.02249264
 	Dipole Strength          0.00034617 
 	Oscillator Strength      0.00001783 
 	Einstein A Coefficient   3.42020116e+03 
@@ -1269,20 +1320,20 @@ Doing transition
 
 	Length-Gauge Rotational Strength for 1  A to 2  A Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.01539035
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00997871
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.01218772
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.02249264
+	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.01539035
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00997871
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.01218772
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.02249264
 
 	Rotational Strength (au)                 -0.00021385
 	Rotational Strength (10^-40 esu^2 cm^2)  -0.10082049
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.00000000 	  0.00000000 	 -0.00505700
-	<q|mu_m|p>               0.00000000 	  0.00000000 	  0.00997871
-	<p|mu_m|q>*              0.00000000 	  0.00000000 	  0.01218772
-	<q|mu_e|p>*              0.00000000 	  0.00000000 	 -0.00083996
+	<p|mu_e|q>               0.00000000 	  0.00000000 	  0.00505700
+	<q|mu_m|p>               0.00000000 	  0.00000000 	 -0.00997871
+	<p|mu_m|q>*              0.00000000 	  0.00000000 	 -0.01218772
+	<q|mu_e|p>*              0.00000000 	  0.00000000 	  0.00083996
 
 	Rotational Strength (au)                 -0.00039280
 	Rotational Strength (10^-40 esu^2 cm^2)  -0.18518426
@@ -1303,8 +1354,8 @@ Doing transition
 
 	Oscillator Strength for 1  B to 1  A
 	                              X    	       Y    	       Z
-	<0|mu_e|n>               0.38044180 	 -0.75054662 	  0.00000000
-	<n|mu_e|0>               0.37309014 	 -0.72986017 	  0.00000000
+	<0|mu_e|n>              -0.38044180 	  0.75054662 	  0.00000000
+	<n|mu_e|0>              -0.37309014 	  0.72986017 	  0.00000000
 	Dipole Strength          0.68973316 
 	Oscillator Strength      0.00152626 
 	Einstein A Coefficient   5.40278023e+02 
@@ -1312,23 +1363,23 @@ Doing transition
 
 	Length-Gauge Rotational Strength for 1  B to 1  A Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>               0.38044180 	 -0.75054662 	  0.00000000
-	<q|mu_m|p>              -0.05157700 	 -0.03267411 	  0.00000000
-	<p|mu_m|q>*             -0.05536850 	 -0.03275400 	  0.00000000
-	<q|mu_e|p>*              0.37309014 	 -0.72986017 	  0.00000000
+	<p|mu_e|q>              -0.38044180 	  0.75054662 	  0.00000000
+	<q|mu_m|p>               0.05157700 	  0.03267411 	  0.00000000
+	<p|mu_m|q>*              0.05536850 	  0.03275400 	  0.00000000
+	<q|mu_e|p>*             -0.37309014 	  0.72986017 	  0.00000000
 
 	Rotational Strength (au)                  0.00407490
 	Rotational Strength (10^-40 esu^2 cm^2)   1.92108440
 
 	Velocity-Gauge Rotational Strength for 1  B
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.00646845 	 -0.05368007 	  0.00000000
-	<q|mu_m|p>              -0.05157700 	 -0.03267411 	  0.00000000
-	<p|mu_m|q>*             -0.05536850 	 -0.03275400 	  0.00000000
-	<q|mu_e|p>*             -0.01030609 	 -0.06004936 	  0.00000000
+	<p|mu_e|q>               0.00646845 	  0.05368007 	  0.00000000
+	<q|mu_m|p>               0.05157700 	  0.03267411 	  0.00000000
+	<p|mu_m|q>*              0.05536850 	  0.03275400 	  0.00000000
+	<q|mu_e|p>*              0.01030609 	  0.06004936 	  0.00000000
 
 	Rotational Strength (au)                  0.69670461
-	Rotational Strength (10^-40 esu^2 cm^2)  328.45688725
+	Rotational Strength (10^-40 esu^2 cm^2)  328.45688717
 
 	*** Computing <1 B|X{pq}}|2 A> (LEFT) Transition Density ***
 
@@ -1389,8 +1440,8 @@ Doing transition
 
 	Oscillator Strength for 1  A to 2  B
 	                              X    	       Y    	       Z
-	<0|mu_e|n>              -0.38497996 	  0.36360336 	  0.00000000
-	<n|mu_e|0>              -0.37997920 	  0.36215392 	  0.00000000
+	<0|mu_e|n>               0.38497996 	 -0.36360336 	  0.00000000
+	<n|mu_e|0>               0.37997920 	 -0.36215392 	  0.00000000
 	Dipole Strength          0.27796476 
 	Oscillator Strength      0.01441595 
 	Einstein A Coefficient   2.80313304e+06 
@@ -1398,20 +1449,20 @@ Doing transition
 
 	Length-Gauge Rotational Strength for 1  A to 2  B Transition
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.38497996 	  0.36360336 	  0.00000000
-	<q|mu_m|p>              -0.01536333 	 -0.32343426 	  0.00000000
-	<p|mu_m|q>*             -0.01701146 	 -0.32547704 	  0.00000000
-	<q|mu_e|p>*             -0.37997920 	  0.36215392 	  0.00000000
+	<p|mu_e|q>               0.38497996 	 -0.36360336 	  0.00000000
+	<q|mu_m|p>               0.01536333 	  0.32343426 	  0.00000000
+	<p|mu_m|q>*              0.01701146 	  0.32547704 	  0.00000000
+	<q|mu_e|p>*              0.37997920 	 -0.36215392 	  0.00000000
 
 	Rotational Strength (au)                 -0.11154800
-	Rotational Strength (10^-40 esu^2 cm^2)  -52.58858270
+	Rotational Strength (10^-40 esu^2 cm^2)  -52.58858271
 
 	Velocity-Gauge Rotational Strength for 1  A
 	                              X    	       Y    	       Z
-	<p|mu_e|q>              -0.00850035 	  0.01051941 	  0.00000000
-	<q|mu_m|p>              -0.01536333 	 -0.32343426 	  0.00000000
-	<p|mu_m|q>*             -0.01701146 	 -0.32547704 	  0.00000000
-	<q|mu_e|p>*             -0.00582108 	  0.06175903 	  0.00000000
+	<p|mu_e|q>               0.00850035 	 -0.01051941 	  0.00000000
+	<q|mu_m|p>               0.01536333 	  0.32343426 	  0.00000000
+	<p|mu_m|q>*              0.01701146 	  0.32547704 	  0.00000000
+	<q|mu_e|p>*              0.00582108 	 -0.06175903 	  0.00000000
 
 	Rotational Strength (au)                 -0.14958696
 	Rotational Strength (10^-40 esu^2 cm^2)  -70.52180571
@@ -1456,8 +1507,8 @@ Doing transition
 	<p|mu_m|q>*              0.03021866 	  0.02723917 	  0.00000000
 	<q|mu_e|p>*              0.00763547 	  0.05046870 	  0.00000000
 
-	Rotational Strength (au)                  2.69517365
-	Rotational Strength (10^-40 esu^2 cm^2)  1270.62220198
+	Rotational Strength (au)                  2.69517364
+	Rotational Strength (10^-40 esu^2 cm^2)  1270.62220010
 
 	*** Computing <1 B|X{pq}}|2 B> (LEFT) Transition Density ***
 
@@ -1523,8 +1574,26 @@ Doing transition
 	  2A->2B   0.014     116.1 86119.5   0.000529   0.0002   0.0087   2.6952  1.711659E+00
 	  1B->2B   2.207   17802.2   561.7   0.081113   0.0068   0.0017   0.0012  1.442900E+06
 
+    Nuclear Repulsion Energy..............................................................PASSED
+    SCF Energy............................................................................PASSED
+    CCSD Energy...........................................................................PASSED
+    Left-Right CCSD Overlap...............................................................PASSED
+    Root 1 (A) Energy.....................................................................PASSED
+    Root 2 (A) Energy.....................................................................PASSED
+    Root 0 (B) Energy.....................................................................PASSED
+    Root 1 (B) Energy.....................................................................PASSED
+    Root 1 (A) Oscillator Strength........................................................PASSED
+    Root 2 (A) Oscillator Strength........................................................PASSED
+    Root 0 (B) Oscillator Strength........................................................PASSED
+    Root 1 (B) Oscillator Strength........................................................PASSED
+    Root 1 (A) -> Root 2 (A) Oscillator Strength..........................................PASSED
+    Root 0 (B) -> Root 1 (A) Oscillator Strength..........................................PASSED
+    Root 0 (B) -> Root 2 (A) Oscillator Strength..........................................PASSED
+    Root 1 (A) -> Root 1 (B) Oscillator Strength..........................................PASSED
+    Root 2 (A) -> Root 1 (B) Oscillator Strength..........................................PASSED
+    Root 0 (B) -> Root 1 (B) Oscillator Strength..........................................PASSED
 
-    Psi4 stopped on: Saturday, 12 February 2022 03:25PM
-    Psi4 wall time for execution: 0:00:08.82
+    Psi4 stopped on: Tuesday, 29 March 2022 06:25PM
+    Psi4 wall time for execution: 0:00:08.73
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc52/input.dat
+++ b/tests/cc52/input.dat
@@ -63,8 +63,3 @@ compare_values(ref589vel, wfn.variable("CCSD OPTICAL ROTATION TENSOR (VEL) @ 589
 compare_values(ref589mvg, wfn.variable("CCSD OPTICAL ROTATION TENSOR (MVG) @ 589NM"),  3, "CCSD rotation tensor @ 589nm in modified velocity gauge") # TEST    
 compare_values(ref589quadpol, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR @ 589NM"), 3, "CCSD quadrupole polarizability @ 589nm") # TEST 
 
-
-#compare_values(ref589quadpol0, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 0 @ 589NM"), 3, "CCSD quadrupole polarizability component 0 @ 589nm") # TEST 
-#compare_values(ref589quadpol1, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 1 @ 589NM"), 3, "CCSD quadrupole polarizability component 1 @ 589nm") # TEST 
-#compare_values(ref589quadpol2, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 2 @ 589NM"), 3, "CCSD quadrupole polarizability component 2 @ 589nm") # TEST 
-

--- a/tests/cc52/output.ref
+++ b/tests/cc52/output.ref
@@ -107,10 +107,6 @@ compare_values(ref589mvg, wfn.variable("CCSD OPTICAL ROTATION TENSOR (MVG) @ 589
 compare_values(ref589quadpol, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR @ 589NM"), 3, "CCSD quadrupole polarizability @ 589nm") # TEST 
 
 
-#compare_values(ref589quadpol0, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 0 @ 589NM"), 3, "CCSD quadrupole polarizability component 0 @ 589nm") # TEST 
-#compare_values(ref589quadpol1, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 1 @ 589NM"), 3, "CCSD quadrupole polarizability component 1 @ 589nm") # TEST 
-#compare_values(ref589quadpol2, wfn.variable("CCSD QUADRUPOLE POLARIZABILITY TENSOR COMPONENT 2 @ 589NM"), 3, "CCSD quadrupole polarizability component 2 @ 589nm") # TEST 
-
 --------------------------------------------------------------------------
 
 *** tstart() called on Jonathons-MacBook-Pro.local


### PR DESCRIPTION
This PR exposes EOMCC oscillator strengths to psivars and makes other miscellaneous changes:

- Adds a comment to the TD-DFT code to disambiguate between eigenvectors of two different matrices.
- Renames a variable created earlier in the `cc` cleanup series.
- Makes the `oscillator_strength.cc` and `ex_oscillator_strength.cc` files more similar
- Begins changing `cc47` to newstyle.
- Adds refactor TODOs

**That said**, the EOMCC code currently only supports irrep-separated indexing. The irrep-combined indexing isn't easily obtainable due to the awkward way `cceom` passes information to `ccdensity`. While I could fix this, I'll save that until after `ccdensity` has a wavefunction, so the task becomes easier. I'm happy to make an issue so we don't forget.

## Checklist
- [x] Modified `cc47` passes

## Status
- [x] Ready for review
- [x] Ready for merge
