### PR TITLE
ExternalPotential in Bohr

### DIFF
--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -955,7 +955,7 @@ computations, |PSIfour| can perform more rudimentary QM/MM procedures via the
 
     gradient('scf', external_potentials=external_potentials)
 
-The ``external_potentials`` array has three rows for thee separate
+The ``external_potentials`` array has three rows for three separate
 particles, and it is passed to the SCF code on the last line. The
 rows are composed of the atomic charge, x coordinate, y coordinate,
 and z coordinate in that order. The atomic charge and coordinates are

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -973,10 +973,17 @@ needed to describe the full MM region.
 
     gradient('scf')
 
-   The main differences are the specification of charge locations in
-   units of the active molecule, rather than always in Bohr, and in
-   the use of the :py:class:`psi4.driver.QMMM` class, which is now
-   discouraged from being used directly.
+   The main differences are that (1) the specification of
+   charge locations in the old way used the units of the active
+   molecule, whereas the new way always uses Bohr and (2) the
+   specification of the charge and locations in the old way used the
+   :py:class:`psi4.driver.QMMM` class directly and added one charge
+   per command, whereas the new way consolidates all into an array and
+   passes it by keyword argument to the calculation.
+
+   The successor to the :py:class:`psi4.driver.QMMM` class,
+   :py:class:`psi4.driver.QMMMbohr`, is operable, but it is discouraged
+   from being used directly.
 
 To run a computation in a constant dipole field, the |scf__perturb_h|,
 |scf__perturb_with| and |scf__perturb_dipole| keywords can be used.  As an

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -947,19 +947,36 @@ computations, |PSIfour| can perform more rudimentary QM/MM procedures via the
 |scf__extern| keyword.  The following snippet, extracted from the
 :srcsample:`extern1` test case, demonstrates its use for a TIP3P external potential::
 
+    import numpy as np
+    external_potentials = [
+        [-0.834, np.array([1.649232019048,0.0,-2.356023604706]) / psi_bohr2angstroms],
+        [ 0.417, np.array([0.544757019107,0.0,-3.799961446760]) / psi_bohr2angstroms],
+        [ 0.417, np.array([0.544757019107,0.0,-0.912085762652]) / psi_bohr2angstroms]]
+
+    gradient('scf', external_potentials=external_potentials)
+
+The ``external_potentials`` array has three rows for thee separate
+particles, and it is passed to the SCF code on the last line. The
+rows are composed of the atomic charge, x coordinate, y coordinate,
+and z coordinate in that order. The atomic charge and coordinates are
+specified in atomic units, [e] and [a0]. Add as many particle rows as
+needed to describe the full MM region.
+
+.. caution:: In |PSIfour| previous to Spring 2022 and v1.6, setting an
+   external potential like the above looked like ::
+
     Chrgfield = QMMM()
     Chrgfield.extern.addCharge(-0.834, 1.649232019048, 0.0, -2.356023604706)
     Chrgfield.extern.addCharge( 0.417, 0.544757019107, 0.0, -3.799961446760)
     Chrgfield.extern.addCharge( 0.417, 0.544757019107, 0.0, -0.912085762652)
     psi4.set_global_option_python('EXTERN', Chrgfield.extern)
 
-First a QMMM object is created, then three separate particles are added to this
-object before the SCF code is told about its existence on the last line.  The
-calls to ``addCharge`` take the atomic charge, x coordinate, y coordinate, and
-z coordinate in that order.  The atomic charge is specified in atomic units,
-and the coordinates always use the same units as the geometry specification in
-the regular QM region.  Additional MM molecules may be specified by adding
-extra calls to ``addCharge`` to describe the full MM region.
+    gradient('scf')
+
+   The main differences are the specification of charge locations in
+   units of the active molecule, rather than always in Bohr, and in
+   the use of the :py:class:`psi4.driver.QMMM` class, which is now
+   discouraged from being used directly.
 
 To run a computation in a constant dipole field, the |scf__perturb_h|,
 |scf__perturb_with| and |scf__perturb_dipole| keywords can be used.  As an

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -41,7 +41,7 @@ from psi4.driver.p4util.testing import *
 from psi4.driver.p4util.fcidump import *
 from psi4.driver.p4util.fchk import *
 from psi4.driver.p4util.text import *
-from psi4.driver.qmmm import QMMM
+from psi4.driver.qmmm import QMMM, QMMMbohr
 from psi4.driver.pluginutil import *
 
 from psi4.driver import gaussian_n

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -554,6 +554,10 @@ def energy(name, **kwargs):
     #for precallback in hooks['energy']['pre']:
     #    precallback(lowername, **kwargs)
 
+    ep = kwargs.get('external_potentials', None)
+    if ep is not None and not isinstance(ep, dict):
+        electrostatic_embedding(kwargs['external_potentials'])
+
     optstash = driver_util._set_convergence_criterion('energy', lowername, 6, 8, 6, 8, 6)
     optstash2 = p4util.OptionsState(['SCF', 'GUESS'])
 
@@ -733,6 +737,10 @@ def gradient(name, **kwargs):
     molecule = kwargs.pop('molecule', core.get_active_molecule())
     molecule.update_geometry()
 
+    ep = kwargs.get('external_potentials', None)
+    if ep is not None and not isinstance(ep, dict):
+        electrostatic_embedding(kwargs['external_potentials'])
+
     # Does dertype indicate an analytic procedure both exists and is wanted?
     if dertype == 1:
         core.print_out("""gradient() will perform analytic gradient computation.\n""")
@@ -895,6 +903,10 @@ def properties(*args, **kwargs):
 
     if "/" in lowername:
         return driver_cbs._cbs_gufunc(properties, lowername, ptype='properties', **kwargs)
+
+    ep = kwargs.get('external_potentials', None)
+    if ep is not None and not isinstance(ep, dict):
+        electrostatic_embedding(kwargs['external_potentials'])
 
     return_wfn = kwargs.pop('return_wfn', False)
     props = kwargs.get('properties', ['dipole', 'quadrupole'])
@@ -1540,6 +1552,10 @@ def hessian(name, **kwargs):
             core.print_out(
                 """hessian() switching to finite difference by gradients for partial Hessian calculation.\n""")
             dertype = 1
+
+    ep = kwargs.get('external_potentials', None)
+    if ep is not None and not isinstance(ep, dict):
+        electrostatic_embedding(kwargs['external_potentials'])
 
     # At stationary point?
     if 'ref_gradient' in kwargs:
@@ -2217,6 +2233,31 @@ def molden(wfn, filename=None, density_a=None, density_b=None, dovirtual=None):
 
 def tdscf(wfn, **kwargs):
     return proc.run_tdscf_excitations(wfn,**kwargs)
+
+
+def electrostatic_embedding(external_potential):
+    """Initialize :py:class:`psi4.core.ExternalPotential` object from charges and locations.
+
+    Parameters
+    ----------
+    external_potential
+        List-like structure where each row corresponds to a charge. Lines can be composed of ``q, [x, y, z]`` or
+        ``q, x, y, z``. Locations are in [a0].
+
+    """
+    from psi4.driver import qmmm
+
+    # Add embedding point charges
+    Chrgfield = qmmm.QMMMbohr()
+    for qxyz in external_potential:
+        if len(qxyz) == 2:
+            Chrgfield.extern.addCharge(qxyz[0], qxyz[1][0], qxyz[1][1], qxyz[1][2])
+        elif len(qxyz) == 4:
+            Chrgfield.extern.addCharge(qxyz[0], qxyz[1], qxyz[2], qxyz[3])
+        else:
+            raise ValidationError(f"Point charge '{qxyz}' not mapping into 'chg, [x, y, z]' or 'chg, x, y, z'")
+    core.set_global_option_python('EXTERN', Chrgfield.extern)
+
 
 # Aliases
 opt = optimize

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -47,6 +47,7 @@ from psi4.driver import driver_nbody
 from psi4.driver import driver_findif
 from psi4.driver import p4util
 from psi4.driver import qcdb
+from psi4.driver import qmmm
 from psi4.driver.procrouting import *
 from psi4.driver.p4util.exceptions import *
 from psi4.driver.mdi_engine import mdi_run
@@ -556,7 +557,7 @@ def energy(name, **kwargs):
 
     ep = kwargs.get('external_potentials', None)
     if ep is not None and not isinstance(ep, dict):
-        electrostatic_embedding(kwargs['external_potentials'])
+        set_external_potential(kwargs['external_potentials'])
 
     optstash = driver_util._set_convergence_criterion('energy', lowername, 6, 8, 6, 8, 6)
     optstash2 = p4util.OptionsState(['SCF', 'GUESS'])
@@ -739,7 +740,7 @@ def gradient(name, **kwargs):
 
     ep = kwargs.get('external_potentials', None)
     if ep is not None and not isinstance(ep, dict):
-        electrostatic_embedding(kwargs['external_potentials'])
+        set_external_potential(kwargs['external_potentials'])
 
     # Does dertype indicate an analytic procedure both exists and is wanted?
     if dertype == 1:
@@ -906,7 +907,7 @@ def properties(*args, **kwargs):
 
     ep = kwargs.get('external_potentials', None)
     if ep is not None and not isinstance(ep, dict):
-        electrostatic_embedding(kwargs['external_potentials'])
+        set_external_potential(kwargs['external_potentials'])
 
     return_wfn = kwargs.pop('return_wfn', False)
     props = kwargs.get('properties', ['dipole', 'quadrupole'])
@@ -1555,7 +1556,7 @@ def hessian(name, **kwargs):
 
     ep = kwargs.get('external_potentials', None)
     if ep is not None and not isinstance(ep, dict):
-        electrostatic_embedding(kwargs['external_potentials'])
+        set_external_potential(kwargs['external_potentials'])
 
     # At stationary point?
     if 'ref_gradient' in kwargs:
@@ -2235,7 +2236,7 @@ def tdscf(wfn, **kwargs):
     return proc.run_tdscf_excitations(wfn,**kwargs)
 
 
-def electrostatic_embedding(external_potential):
+def set_external_potential(external_potential):
     """Initialize :py:class:`psi4.core.ExternalPotential` object from charges and locations.
 
     Parameters
@@ -2245,9 +2246,6 @@ def electrostatic_embedding(external_potential):
         ``q, x, y, z``. Locations are in [a0].
 
     """
-    from psi4.driver import qmmm
-
-    # Add embedding point charges
     Chrgfield = qmmm.QMMMbohr()
     for qxyz in external_potential:
         if len(qxyz) == 2:

--- a/psi4/driver/driver_nbody_helper.py
+++ b/psi4/driver/driver_nbody_helper.py
@@ -190,13 +190,11 @@ def electrostatic_embedding(metadata, pair):
     if not metadata['return_total_data']:
         raise Exception('Cannot return interaction data when using embedding scheme.')
     # Add embedding point charges
-    Chrgfield = qmmm.QMMM()
+    Chrgfield = qmmm.QMMMbohr()
     for p in metadata['embedding_charges']:
         if p in pair[1]: continue
         mol = metadata['molecule'].extract_subsets([p])
         for i in range(mol.natom()):
             geom = np.array([mol.x(i), mol.y(i), mol.z(i)])
-            if mol.units() == 'Angstrom':
-                geom *= constants.bohr2angstroms
             Chrgfield.extern.addCharge(metadata['embedding_charges'][p][i], geom[0], geom[1], geom[2])
     core.set_global_option_python('EXTERN', Chrgfield.extern)

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -76,7 +76,7 @@ class MDIEngine():
         self.nlattice = 0  # number of lattice point charges
         self.clattice = []  # list of lattice coordinates
         self.lattice = []  # list of lattice charges
-        self.lattice_field = psi4.QMMM()  # Psi4 chargefield
+        self.lattice_field = psi4.QMMMbohr()  # Psi4 chargefield
 
         # MPI variables
         self.mpi_world = None
@@ -281,12 +281,11 @@ class MDIEngine():
     def set_lattice_field(self):
         """ Set a field of lattice point charges using information received through MDI
         """
-        self.lattice_field = psi4.QMMM()
-        unit_conv = self.length_conversion()
+        self.lattice_field = psi4.QMMMbohr()
         for ilat in range(self.nlattice):
-            latx = self.clattice[3 * ilat + 0] * unit_conv
-            laty = self.clattice[3 * ilat + 1] * unit_conv
-            latz = self.clattice[3 * ilat + 2] * unit_conv
+            latx = self.clattice[3 * ilat + 0]
+            laty = self.clattice[3 * ilat + 1]
+            latz = self.clattice[3 * ilat + 2]
             self.lattice_field.extern.addCharge(self.lattice[ilat], latx, laty, latz)
         psi4.core.set_global_option_python('EXTERN', self.lattice_field.extern)
         self.set_lattice = True

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1249,12 +1249,23 @@ def scf_wavefunction_factory(name, ref_wfn, reference, **kwargs):
         # For the dimer SAPT calculation, we need to account for the external potential
         # in all of the subsystems A, B, C. So we add them all in total_external_potential
         # and set the external potential to the dimer wave function
+        from psi4.driver.qmmm import QMMMbohr
+
         total_external_potential = core.ExternalPotential()
 
         for frag in kwargs['external_potentials']:
             if frag.upper() in "ABC":
-                wfn.set_potential_variable(frag.upper(), kwargs['external_potentials'][frag].extern)
-                total_external_potential.appendCharges(kwargs['external_potentials'][frag].extern.getCharges())
+                chrgfield = QMMMbohr()
+                for qxyz in kwargs['external_potentials'][frag]:
+                    if len(qxyz) == 2:
+                        chrgfield.extern.addCharge(qxyz[0], qxyz[1][0], qxyz[1][1], qxyz[1][2])
+                    elif len(qxyz) == 4:
+                        chrgfield.extern.addCharge(qxyz[0], qxyz[1], qxyz[2], qxyz[3])
+                    else:
+                        raise ValidationError(f"Point charge '{qxyz}' not mapping into 'chg, [x, y, z]' or 'chg, x, y, z'")
+
+                wfn.set_potential_variable(frag.upper(), chrgfield.extern)
+                total_external_potential.appendCharges(chrgfield.extern.getCharges())
 
             else:
                 core.print_out("\n  Warning! Unknown key for the external_potentials argument: %s" % frag)

--- a/psi4/driver/procrouting/sapt/fisapt_proc.py
+++ b/psi4/driver/procrouting/sapt/fisapt_proc.py
@@ -141,14 +141,18 @@ def fisapt_fdrop(self, external_potentials=None):
         fh.write(xyz)
 
     # write external potential geometries
-    if external_potentials is not None:
+    if external_potentials is not None and isinstance(external_potentials, dict):
         for frag in "ABC":
             potential = external_potentials.get(frag, None)
             if potential is not None:
-                charges = potential.extern.getCharges()
-                xyz = str(len(charges)) + "\n\n"
-                for charge in charges:
-                    xyz += "Ch %f %f %f\n" % (charge[1], charge[2], charge[3])
+                xyz = str(len(potential)) + "\n\n"
+                for qxyz in potential:
+                    if len(qxyz) == 2:
+                        xyz += "Ch %f %f %f\n" % (qxyz[1][0], qxyz[1][1], qxyz[1][2])
+                    elif len(qxyz) == 4:
+                        xyz += "Ch %f %f %f\n" % (qxyz[1], qxyz[2], qxyz[3])
+                    else:
+                        raise ValidationError(f"Point charge '{qxyz}' not mapping into 'chg, [x, y, z]' or 'chg, x, y, z'")
 
                 with open(filepath + os.sep + "Extern_%s.xyz" % frag, "w") as fh:
                     fh.write(xyz)

--- a/psi4/driver/qmmm.py
+++ b/psi4/driver/qmmm.py
@@ -121,12 +121,15 @@ class Diffuse(object):
 
 
 class QMMM():
+    """Hold charges and :py:class:`psi4.core.ExternalPotential`. Use :py:class:`psi4.driver.QMMMbohr` instead."""
 
     def __init__(self):
         raise UpgradeHelper(self.__class__.__name__, "QMMMbohr", 1.6, ' Replace object with a list of charges and locations in Bohr passed as keyword argument, e.g., `energy(..., embedding_charges=[[0.5, [0, 0, 1]], [-0.5, [0, 0, -1]]])`.')
 
 
 class QMMMbohr():
+    """Hold charges and :py:class:`psi4.core.ExternalPotential`. To add external charges to a calculation, prefer
+    passing the array of charges with kwarg ``external_potentials``, as in extern2 example."""
 
     def __init__(self):
         self.charges = []

--- a/psi4/driver/qmmm.py
+++ b/psi4/driver/qmmm.py
@@ -120,7 +120,13 @@ class Diffuse(object):
             extern.addCharge(self.molecule.Z(A), self.molecule.x(A), self.molecule.y(A), self.molecule.z(A))
 
 
-class QMMM(object):
+class QMMM():
+
+    def __init__(self):
+        raise UpgradeHelper(self.__class__.__name__, "QMMMbohr", 1.6, ' Replace object with a list of charges and locations in Bohr passed as keyword argument, e.g., `energy(..., embedding_charges=[[0.5, [0, 0, 1]], [-0.5, [0, 0, -1]]])`.')
+
+
+class QMMMbohr():
 
     def __init__(self):
         self.charges = []

--- a/psi4/src/psi4/fisapt/fisapt.cc
+++ b/psi4/src/psi4/fisapt/fisapt.cc
@@ -721,12 +721,7 @@ void FISAPT::nuclear() {
         for (int p1 = 0; p1 < pot_list.size(); p1++) {
             for (int p2 = p1+1; p2 < pot_list.size(); p2++) {
 
-                bool in_angstrom = false;
-                if (mol->units() == Molecule::Angstrom) {
-                    in_angstrom = true;
-                }
-
-                double IE = pot_list[p1]->computeExternExternInteraction(pot_list[p2], in_angstrom);
+                double IE = pot_list[p1]->computeExternExternInteraction(pot_list[p2]);
                 // store half the interaction so that Eij + Eji = Etotal
                 extern_extern_IE_matp[pot_ids[p1]][pot_ids[p2]] = IE * 0.5;
                 extern_extern_IE_matp[pot_ids[p2]][pot_ids[p1]] = IE * 0.5;

--- a/psi4/src/psi4/libmints/extern.h
+++ b/psi4/src/psi4/libmints/extern.h
@@ -72,6 +72,7 @@ class PSI_API ExternalPotential {
     void setName(const std::string& name) { name_ = name; }
 
     /// Add a charge Z at (x,y,z)
+    /// Apr 2022: now always [a0] rather than units of Molecule
     void addCharge(double Z, double x, double y, double z);
 
     /// get the vector of charges
@@ -98,7 +99,7 @@ class PSI_API ExternalPotential {
     double computeNuclearEnergy(std::shared_ptr<Molecule> mol);
 
     // Compute the interaction of this potential with an external potential
-    double computeExternExternInteraction(std::shared_ptr<ExternalPotential> other_extern, bool in_angstrom=false);
+    double computeExternExternInteraction(std::shared_ptr<ExternalPotential> other_extern);
 
     /// Print a trace of the external potential
     void print(std::string out_fname = "outfile") const;

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,7 +32,7 @@ markers =
     df: "tests that employ density-fitting"
     dft
     dipole
-    extern: "tests the use ExternalPotential object"
+    extern: "tests that use the ExternalPotential object"
     fcidump
     freq
     fsapt

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,7 @@ markers =
     df: "tests that employ density-fitting"
     dft
     dipole
+    extern: "tests the use ExternalPotential object"
     fcidump
     freq
     fsapt

--- a/tests/extern1/CMakeLists.txt
+++ b/tests/extern1/CMakeLists.txt
@@ -1,3 +1,4 @@
 include(TestingMacros)
 
-add_regression_test(extern1 "psi;quicktests;scf")
+add_regression_test(extern1 "psi;quicktests;scf;extern")
+

--- a/tests/extern1/input.dat
+++ b/tests/extern1/input.dat
@@ -20,11 +20,24 @@ H 1 1.0
 }
 
 # Define a TIP3P water as the external potential
-Chrgfield = QMMM()
-Chrgfield.extern.addCharge(-0.834,1.649232019048,0.0,-2.356023604706)
-Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-3.799961446760)
-Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-0.912085762652)
-psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+# Apr 2022: QMMM object directly is outdated -- instead pass list in Bohr as kwarg
+upgrade_helper_raised = False
+try:
+    Chrgfield = QMMM()
+    Chrgfield.extern.addCharge(-0.834,1.649232019048,0.0,-2.356023604706)
+    Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-3.799961446760)
+    Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-0.912085762652)
+    psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+except UpgradeHelper as e:
+    if "QMMMbohr" in str(e):
+        upgrade_helper_raised = True
+compare(True, upgrade_helper_raised, "avert old QMMM syntax")
+
+import numpy as np
+external_potentials = [
+    [-0.834, np.array([1.649232019048,0.0,-2.356023604706]) / psi_bohr2angstroms],
+    [ 0.417, np.array([0.544757019107,0.0,-3.799961446760]) / psi_bohr2angstroms],
+    [ 0.417, np.array([0.544757019107,0.0,-0.912085762652]) / psi_bohr2angstroms]]
 
 set {
     scf_type df
@@ -32,9 +45,9 @@ set {
     basis 6-31G*
 }
 
-fd_grad = gradient('scf', molecule=water, dertype=0)
+fd_grad = gradient('scf', molecule=water, dertype=0, external_potentials=external_potentials)
 fd_ener = psi4.variable('CURRENT ENERGY')
-an_grad = gradient('scf', molecule=water)
+an_grad = gradient('scf', molecule=water, external_potentials=external_potentials)
 an_ener = psi4.variable('CURRENT ENERGY')
 
 compare_matrices(an_grad, fd_grad, 5, "Finite difference (3-pt.) vs. analytic gradient to 10^-5") #TEST

--- a/tests/extern1/test_input.py
+++ b/tests/extern1/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;scf;extern")
+def test_extern1():
+    ctest_runner(__file__)
+

--- a/tests/extern2/CMakeLists.txt
+++ b/tests/extern2/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(extern2 "psi;mp2;cart")
+add_regression_test(extern2 "psi;mp2;cart;extern")

--- a/tests/extern2/input.dat
+++ b/tests/extern2/input.dat
@@ -12,11 +12,20 @@ molecule water {
 }
 
 # Define a TIP3P water as the external potential
-Chrgfield = QMMM()
-Chrgfield.extern.addCharge(-0.834,1.649232019048,0.0,-2.356023604706)
-Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-3.799961446760)
-Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-0.912085762652)
-psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+# Apr 2022: QMMM object directly is outdated -- instead pass list in Bohr as kwarg
+#Chrgfield = QMMM()
+#Chrgfield.extern.addCharge(-0.834,1.649232019048,0.0,-2.356023604706)
+#Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-3.799961446760)
+#Chrgfield.extern.addCharge(0.417,0.544757019107,0.0,-0.912085762652)
+#psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+
+external_potentials = np.array([
+-0.834,1.649232019048,0.0,-2.356023604706,
+0.417,0.544757019107,0.0,-3.799961446760,
+0.417,0.544757019107,0.0,-0.912085762652]).reshape((-1, 4))
+# convert coordinates columns to bohr
+external_potentials[:,[1,2,3]] /= psi_bohr2angstroms
+
 
 set {
     scf_type df
@@ -24,9 +33,9 @@ set {
     basis 6-31G*
 }
 
-fd_grad = gradient('mp2', molecule=water, dertype=0)
+fd_grad = gradient('mp2', molecule=water, dertype=0, external_potentials=external_potentials)
 fd_ener = psi4.variable('CURRENT ENERGY')
-an_grad = gradient('mp2', molecule=water)
+an_grad = gradient('mp2', molecule=water, external_potentials=external_potentials)
 an_ener = psi4.variable('CURRENT ENERGY')
 
 compare_matrices(an_grad, fd_grad, 5, "Finite difference (3-pt.) vs. analytic gradient to 10^-5") #TEST

--- a/tests/extern2/test_input.py
+++ b/tests/extern2/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("mp2;cart;extern")
+def test_extern2():
+    ctest_runner(__file__)
+

--- a/tests/extern3/CMakeLists.txt
+++ b/tests/extern3/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(extern3 "psi;mp2;cart")
+add_regression_test(extern3 "psi;mp2;cart;extern")

--- a/tests/extern3/input.dat
+++ b/tests/extern3/input.dat
@@ -10,11 +10,15 @@ molecule mol {
 }
 
 # Define point charge on top of first Ghost atom
-Chrgfield = QMMM()
-Chrgfield.extern.addCharge(7.05, 0., 0., 1.)
-psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+# Apr 2022: QMMM object directly is outdated -- instead pass list in Bohr as kwarg
+#Chrgfield = QMMM()
+#Chrgfield.extern.addCharge(7.05, 0., 0., 1.)
+#psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+
+external_potentials = np.array([7.05, 0., 0., 1.]).reshape((-1, 4))
+external_potentials[:,[1,2,3]] /= psi_bohr2angstroms
 
 set basis 6-31G
 set reference rhf
-e = energy('pbe')
+e = energy('pbe', external_potentials=external_potentials)
 compare_values(-110.2168666458496773, e, 6, 'Total energy') #TEST

--- a/tests/extern3/test_input.py
+++ b/tests/extern3/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("mp2;cart;extern")
+def test_extern3():
+    ctest_runner(__file__)
+

--- a/tests/fsapt-ext-abc-au/CMakeLists.txt
+++ b/tests/fsapt-ext-abc-au/CMakeLists.txt
@@ -1,4 +1,4 @@
 include(TestingMacros)
 
-add_regression_test(fsapt-ext-abc-au "psi;quicktests;sapt;cart")
+add_regression_test(fsapt-ext-abc-au "psi;quicktests;sapt;cart;extern")
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../psi4/share/psi4/fsapt/fsapt.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/fsapt-ext-abc-au/input.dat
+++ b/tests/fsapt-ext-abc-au/input.dat
@@ -24,27 +24,21 @@ mol = psi4.core.Molecule.from_arrays(
     units="Bohr")
 activate(mol)
 
-Chrgfield_A = QMMM()
-Chrgfield_A.extern.addCharge( 0.417, -0.5496 / psi_bohr2angstroms, -0.6026 / psi_bohr2angstroms,  1.5720 / psi_bohr2angstroms)
-Chrgfield_A.extern.addCharge(-0.834, -1.4545 / psi_bohr2angstroms, -0.1932 / psi_bohr2angstroms,  1.4677 / psi_bohr2angstroms)
-Chrgfield_A.extern.addCharge( 0.417, -1.9361 / psi_bohr2angstroms, -0.4028 / psi_bohr2angstroms,  2.2769 / psi_bohr2angstroms)
-
-Chrgfield_B = QMMM()
-Chrgfield_B.extern.addCharge( 0.417, -2.5628 / psi_bohr2angstroms, -0.8269 / psi_bohr2angstroms, -1.6696 / psi_bohr2angstroms)
-Chrgfield_B.extern.addCharge(-0.834, -1.7899 / psi_bohr2angstroms, -0.4027 / psi_bohr2angstroms, -1.2768 / psi_bohr2angstroms)
-Chrgfield_B.extern.addCharge( 0.417, -1.8988 / psi_bohr2angstroms, -0.4993 / psi_bohr2angstroms, -0.3072 / psi_bohr2angstroms)
-
-Chrgfield_C = QMMM()
-Chrgfield_C.extern.addCharge( 0.417,  1.1270 / psi_bohr2angstroms,  1.5527 / psi_bohr2angstroms, -0.1658 / psi_bohr2angstroms)
-Chrgfield_C.extern.addCharge(-0.834,  1.9896 / psi_bohr2angstroms,  1.0738 / psi_bohr2angstroms, -0.1673 / psi_bohr2angstroms)
-Chrgfield_C.extern.addCharge( 0.417,  2.6619 / psi_bohr2angstroms,  1.7546 / psi_bohr2angstroms, -0.2910 / psi_bohr2angstroms)
-
-
 external_potentials = {
-                       'A': Chrgfield_A,
-                       'B': Chrgfield_B,
-                       'C': Chrgfield_C,
-                      }
+    "A": [
+        [ 0.417, np.array([-0.5496, -0.6026,  1.5720]) / psi_bohr2angstroms],
+        [-0.834, np.array([-1.4545, -0.1932,  1.4677]) / psi_bohr2angstroms],
+        [ 0.417, np.array([-1.9361, -0.4028,  2.2769]) / psi_bohr2angstroms]],
+    "B": [
+        [ 0.417, np.array([-2.5628, -0.8269, -1.6696]) / psi_bohr2angstroms],
+        [-0.834, np.array([-1.7899, -0.4027, -1.2768]) / psi_bohr2angstroms],
+        [ 0.417, np.array([-1.8988, -0.4993, -0.3072]) / psi_bohr2angstroms]],
+    "C": [
+        [ 0.417, np.array([ 1.1270,  1.5527, -0.1658]) / psi_bohr2angstroms],
+        [-0.834, np.array([ 1.9896,  1.0738, -0.1673]) / psi_bohr2angstroms],
+        [ 0.417, np.array([ 2.6619,  1.7546, -0.2910]) / psi_bohr2angstroms]],
+}
+
 
 set {
 basis jun-cc-pvdz
@@ -108,4 +102,3 @@ fEref = {               #TEST
 
 for key in fkeys:                                      #TEST
     compare_values(fEref[key], fEnergies[key], 2, key) #TEST
-

--- a/tests/fsapt-ext-abc-au/test_input.py
+++ b/tests/fsapt-ext-abc-au/test_input.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import psi4
+from addons import *
+
+@ctest_labeler("quick;sapt;cart;extern")
+def test_fsapt_ext_abc_au():
+    fsaptpy_installed = (Path(psi4.executable) / ".." / ".." / "share" / "psi4" / "fsapt" / "fsapt.py").resolve()
+
+    ctest_runner(__file__, [
+        fsaptpy_installed,
+    ])
+

--- a/tests/fsapt-ext-abc/CMakeLists.txt
+++ b/tests/fsapt-ext-abc/CMakeLists.txt
@@ -1,4 +1,4 @@
 include(TestingMacros)
 
-add_regression_test(fsapt-ext-abc "psi;quicktests;sapt;cart;fsapt")
+add_regression_test(fsapt-ext-abc "psi;quicktests;sapt;cart;fsapt;extern")
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../psi4/share/psi4/fsapt/fsapt.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/fsapt-ext-abc/input.dat
+++ b/tests/fsapt-ext-abc/input.dat
@@ -21,26 +21,21 @@ no_reorient
 no_com
 }
 
-Chrgfield_A = QMMM()
-Chrgfield_A.extern.addCharge(0.417, -0.5496, -0.6026, 1.5720)
-Chrgfield_A.extern.addCharge(-0.834, -1.4545, -0.1932, 1.4677)
-Chrgfield_A.extern.addCharge(0.417, -1.9361, -0.4028, 2.2769)
-
-Chrgfield_B = QMMM()
-Chrgfield_B.extern.addCharge(0.417, -2.5628, -0.8269, -1.6696)
-Chrgfield_B.extern.addCharge(-0.834, -1.7899, -0.4027, -1.2768)
-Chrgfield_B.extern.addCharge(0.417, -1.8988, -0.4993, -0.3072)
-
-Chrgfield_C = QMMM()
-Chrgfield_C.extern.addCharge(0.417, 1.1270, 1.5527, -0.1658)
-Chrgfield_C.extern.addCharge(-0.834, 1.9896, 1.0738, -0.1673)
-Chrgfield_C.extern.addCharge(0.417, 2.6619, 1.7546, -0.2910)
-
 external_potentials = {
-                       'A': Chrgfield_A,
-                       'B': Chrgfield_B,
-                       'C': Chrgfield_C,
-                      }
+    "A": [
+        [ 0.417, np.array([-0.5496, -0.6026,  1.5720]) / psi_bohr2angstroms],
+        [-0.834, np.array([-1.4545, -0.1932,  1.4677]) / psi_bohr2angstroms],
+        [ 0.417, np.array([-1.9361, -0.4028,  2.2769]) / psi_bohr2angstroms]],
+    "B": [
+        [ 0.417, np.array([-2.5628, -0.8269, -1.6696]) / psi_bohr2angstroms],
+        [-0.834, np.array([-1.7899, -0.4027, -1.2768]) / psi_bohr2angstroms],
+        [ 0.417, np.array([-1.8988, -0.4993, -0.3072]) / psi_bohr2angstroms]],
+    "C": [
+        [ 0.417, np.array([ 1.1270,  1.5527, -0.1658]) / psi_bohr2angstroms],
+        [-0.834, np.array([ 1.9896,  1.0738, -0.1673]) / psi_bohr2angstroms],
+        [ 0.417, np.array([ 2.6619,  1.7546, -0.2910]) / psi_bohr2angstroms]],
+}
+
 
 set {
 basis jun-cc-pvdz

--- a/tests/fsapt-ext-abc/test_input.py
+++ b/tests/fsapt-ext-abc/test_input.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import psi4
+from addons import *
+
+@ctest_labeler("quick;sapt;cart;fsapt;extern")
+def test_fsapt_ext_abc():
+    fsaptpy_installed = (Path(psi4.executable) / ".." / ".." / "share" / "psi4" / "fsapt" / "fsapt.py").resolve()
+
+    ctest_runner(__file__, [
+        fsaptpy_installed,
+    ])
+

--- a/tests/fsapt-ext-abc2/CMakeLists.txt
+++ b/tests/fsapt-ext-abc2/CMakeLists.txt
@@ -1,4 +1,4 @@
 include(TestingMacros)
 
-add_regression_test(fsapt-ext-abc2 "psi;quicktests;sapt;cart;fsapt")
+add_regression_test(fsapt-ext-abc2 "psi;quicktests;sapt;cart;fsapt;extern")
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../psi4/share/psi4/fsapt/fsapt.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/fsapt-ext-abc2/input.dat
+++ b/tests/fsapt-ext-abc2/input.dat
@@ -20,20 +20,20 @@ no_reorient
 no_com
 }
 
-Chrgfield_B = QMMM()
-Chrgfield_B.extern.addCharge(0.417, -2.5628, -0.8269, -1.6696)
-Chrgfield_B.extern.addCharge(-0.834, -1.7899, -0.4027, -1.2768)
-Chrgfield_B.extern.addCharge(0.417, -1.8988, -0.4993, -0.3072)
+Chrgfield_B = np.array([
+ 0.417, -2.5628, -0.8269, -1.6696,
+-0.834, -1.7899, -0.4027, -1.2768,
+ 0.417, -1.8988, -0.4993, -0.3072]).reshape((-1, 4))
+Chrgfield_B[:,[1,2,3]] /= psi_bohr2angstroms
 
-Chrgfield_C = QMMM()
-Chrgfield_C.extern.addCharge(0.417, 1.1270, 1.5527, -0.1658)
-Chrgfield_C.extern.addCharge(-0.834, 1.9896, 1.0738, -0.1673)
-Chrgfield_C.extern.addCharge(0.417, 2.6619, 1.7546, -0.2910)
-Chrgfield_C.extern.addCharge(0.417, -1.0231, 1.6243, -0.8743)
-Chrgfield_C.extern.addCharge(-0.834, -0.5806, 2.0297, -0.1111)
-Chrgfield_C.extern.addCharge(0.417, -0.9480, 1.5096, 0.6281)
-
-
+Chrgfield_C = np.array([
+ 0.417,  1.1270, 1.5527, -0.1658,
+-0.834,  1.9896, 1.0738, -0.1673,
+ 0.417,  2.6619, 1.7546, -0.2910,
+ 0.417, -1.0231, 1.6243, -0.8743,
+-0.834, -0.5806, 2.0297, -0.1111,
+ 0.417, -0.9480, 1.5096,  0.6281]).reshape((-1, 4))
+Chrgfield_C[:,[1,2,3]] /= psi_bohr2angstroms
 
 external_potentials = {
                        'B': Chrgfield_B,

--- a/tests/fsapt-ext-abc2/test_input.py
+++ b/tests/fsapt-ext-abc2/test_input.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import psi4
+from addons import *
+
+@ctest_labeler("quick;sapt;cart;fsapt;extern")
+def test_fsapt_ext_abc2():
+    fsaptpy_installed = (Path(psi4.executable) / ".." / ".." / "share" / "psi4" / "fsapt" / "fsapt.py").resolve()
+
+    ctest_runner(__file__, [
+        fsaptpy_installed,
+    ])
+

--- a/tests/fsapt-ext/CMakeLists.txt
+++ b/tests/fsapt-ext/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(fsapt-ext "psi;quicktests;sapt;cart;fsapt")
+add_regression_test(fsapt-ext "psi;quicktests;sapt;cart;fsapt;extern")

--- a/tests/fsapt-ext/input.dat
+++ b/tests/fsapt-ext/input.dat
@@ -19,11 +19,12 @@ no_com
 }
 
 # External potential containing the third water from the trimer with TIP3P charges
-Chrgfield = QMMM()
-Chrgfield.extern.addCharge(-0.834, 0.179217, 2.438389, -1.484606)
-Chrgfield.extern.addCharge(0.417, -0.194107, 1.702697, -0.966751)
-Chrgfield.extern.addCharge(0.417, -0.426657, 2.563754, -2.222683)
-psi4.set_global_option_python('EXTERN', Chrgfield.extern)
+external_potentials = np.array([
+-0.834, 0.179217, 2.438389, -1.484606,
+0.417, -0.194107, 1.702697, -0.966751,
+0.417, -0.426657, 2.563754, -2.222683]).reshape((-1, 4))
+# convert coordinates columns to bohr
+external_potentials[:,[1,2,3]] /= psi_bohr2angstroms
 
 set {
 basis         jun-cc-pvdz
@@ -32,7 +33,7 @@ guess sad
 freeze_core true
 }
 
-energy('fisapt0')
+energy('fisapt0', external_potentials=external_potentials)
 
 keys = ['Enuc', 'Eelst', 'Eexch', 'Eind', 'Edisp', 'Etot']  #TEST
 

--- a/tests/fsapt-ext/test_input.py
+++ b/tests/fsapt-ext/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;sapt;cart;fsapt;extern")
+def test_fsapt_ext():
+    ctest_runner(__file__)
+

--- a/tests/nbody-multi-level/CMakeLists.txt
+++ b/tests/nbody-multi-level/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(nbody-multi-level "psi;nbody")
+add_regression_test(nbody-multi-level "psi;nbody;extern")

--- a/tests/nbody-multi-level/input.dat
+++ b/tests/nbody-multi-level/input.dat
@@ -52,3 +52,34 @@ clean()
 comparison_dict = {'1': -224.940138148882, '2': -224.943882712817}                                #TEST
 for n, v in comparison_dict.items():                                                              #TEST
     compare_values(v, wfn.variable(n), 6, 'Electrostatically embedded many-body expansion')   #TEST
+
+
+# units check
+h2o_trimer_ang = psi4.core.Molecule.from_arrays(
+    elez=[8, 1, 1, 8, 1, 1, 8, 1, 1],
+    fragment_separators=[3, 6],
+    geom=np.array([
+  -2.76373224,  -1.24377706,  -0.15444566,
+  -1.12357791,  -2.06227970,  -0.05243799,
+  -3.80792362,  -2.08705525,   1.06090407,
+   2.46924614,  -1.75437739,  -0.17092884,
+   3.76368260,  -2.21425403,   1.00846104,
+   2.30598330,   0.07098445,  -0.03942473,
+   0.29127930,   3.00875625,   0.20308515,
+  -1.21253048,   1.95820900,   0.10303324,
+   0.10002049,   4.24958115,  -1.10222079]) * psi_bohr2angstroms,
+    units="Angstrom")
+
+levels = {1: 'mp2/sto-3g', 'supersystem': 'scf/sto-3g'}
+e, wfn = energy('', molecule=h2o_trimer_ang, bsse_type='nocp', return_total_data=True, return_wfn=True, levels=levels)
+clean()
+comparison_dict = {'1': -224.998373505116, '3': -225.023509855159}                                #TEST
+for n, v in comparison_dict.items():                                                              #TEST
+    compare_values(v, wfn.variable(n+'nocp'), 6, 'Supersystem multi-level energy: Ang')           #TEST
+
+e, wfn = energy('scf/sto-3g', molecule=h2o_trimer_ang, bsse_type='vmfc', return_total_data=True, return_wfn=True,
+                max_nbody=2, embedding_charges=embedding_charges)
+clean()
+comparison_dict = {'1': -224.940138148882, '2': -224.943882712817}                                #TEST
+for n, v in comparison_dict.items():                                                              #TEST
+    compare_values(v, wfn.variable(n), 6, 'Electrostatically embedded many-body expansion: Ang')  #TEST

--- a/tests/nbody-multi-level/test_input.py
+++ b/tests/nbody-multi-level/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;extern")
+def test_nbody_multi_level():
+    ctest_runner(__file__)
+


### PR DESCRIPTION
## Description
The `psi4.core.ExternalPotential` object has long stored its charge locations in the same units as its BasisSet's Molecule. Also, the usual way of initializing it is by creating a `psi4.driver.qmmm.QMMM()` object and then doing the unusual `psi4.set_global_option_python("EXTERN", qmmmobj.extern)` to a field of that object. That's the situation for "plain" external charges calcs, where there's only one potential and both charges and locations are specified.

Additionally, there's two related categories. F-SAPT can put _different_ external potentials on any of fragments A, B, C, which have been passed in as  `energy("fisapt", external_potentials={"A": extern, ...}, ...)`. Also nbody can take an array of charges (not locations) that replace fragments when the fragments are ghosted. These are passed as `energy(..., bsse_type=..., embedding_charges=[monoAchg, ...])`

Problems:
* formation of Python objects in the input file and special options setting doesn't translate to QCSchema, which is the sole means of communication for many calcs in DDD.
* the most common calc, the simple single extern has no kwarg-to-energy way to set
* the uncertainty in units of ExternalPotential can be confusing and has led to bugs. Also, in DDD, the spec order of mol and extern may not be so clear to set the units.

This is No. 2 of the DDD series, #1351.

## Todos
- [x] Replace `QMMM()` with `QMMMbohr()` and issue an update guide if the former is called.
- [x] For the common single-extern case, switch to `energy(..., external_potentials=array` instead of `QMMM()` object. This tests whether the `external_potentials` value is an array for a single extern, which gets processed and set immediately, or a dict of externs, which gets handled by the run_fsapt later on.
- [x] relaxed the array spec by which externs are initialized. instead of `q, [x, y, z]` also allow `q, x, y, z`, which makes for very easy numpy processing for units transofmation.
- [x] removed all the units handling around ExternalPotential
- [x] docs 

## Questions
- [ ] ok to use external_potentials kwarg for both simple and fsapt multi frags use cases?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
