### PR TITLE
Miscellaneous JK Improvements

### DIFF
--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -74,6 +74,8 @@ void export_fock(py::module &m) {
         .def("get_omega_alpha", &JK::get_omega_alpha, "Weight for HF exchange term in range-separated DFT")
         .def("set_omega_beta", &JK::set_omega_beta, "Weight for dampened exchange term in range-separated DFT", "beta"_a)
         .def("get_omega_beta", &JK::get_omega_beta, "Weight for dampened exchange term in range-separated DFT")
+        .def("set_early_screening", &JK::set_early_screening, "Use severe screening techniques? Useful in early SCF iterations.", "early_screening"_a)
+        .def("get_early_screening", &JK::get_early_screening, "Use severe screening techniques? Useful in early SCF iterations.")
         .def("compute", &JK::compute)
         .def("finalize", &JK::finalize)
         .def("C_clear",

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -217,6 +217,10 @@ void DirectJK::incfock_postiter() {
 }
 
 void DirectJK::compute_JK() {
+
+    // zero out J, K, and wK matrices
+    zero();
+
 #ifdef USING_BrianQC
     if (brianEnable) {
         brianBool computeCoulomb = (do_J_ ? BRIAN_TRUE : BRIAN_FALSE);

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -435,6 +435,10 @@ void DiskDFJK::preiterations() {
 }
 
 void DiskDFJK::compute_JK() {
+
+    // zero out J, K, and wK matrices
+    zero();
+
     max_nocc_ = max_nocc();
     max_rows_ = max_rows();
 

--- a/psi4/src/psi4/libfock/DiskJK.cc
+++ b/psi4/src/psi4/libfock/DiskJK.cc
@@ -89,6 +89,10 @@ void DiskJK::preiterations() {
     mints.reset();
 }
 void DiskJK::compute_JK() {
+
+    // zero out J, K, and wK matrices
+    zero();
+
     auto psio = std::make_shared<PSIO>();
     IWL* iwl = new IWL(psio.get(), PSIF_SO_TEI, cutoff_, 1, 1);
     Label* lblptr = iwl->labels();

--- a/psi4/src/psi4/libfock/GTFockJK.cc
+++ b/psi4/src/psi4/libfock/GTFockJK.cc
@@ -47,6 +47,10 @@ size_t GTFockJK::estimate_memory() {
     return 0; // Effectively
 }
 void GTFockJK::compute_JK() {
+
+    // zero out J, K, and wK matrices
+    zero();
+
     NMats_ = C_left_.size();
     Impl_->create_pfock(NMats_, lr_symmetric_);
     Impl_->SetP(D_ao_);

--- a/psi4/src/psi4/libfock/MemDFJK.cc
+++ b/psi4/src/psi4/libfock/MemDFJK.cc
@@ -94,6 +94,10 @@ void MemDFJK::preiterations() {
     dfh_->initialize();
 }
 void MemDFJK::compute_JK() {
+
+    // zero out J, K, and wK matrices
+    zero();
+
     dfh_->build_JK(C_left_ao_, C_right_ao_, D_ao_, J_ao_, K_ao_, wK_ao_, max_nocc(), do_J_, do_K_, do_wK_,
                    lr_symmetric_);
     if (lr_symmetric_) {

--- a/psi4/src/psi4/libfock/PKJK.cc
+++ b/psi4/src/psi4/libfock/PKJK.cc
@@ -114,6 +114,10 @@ void PKJK::preiterations() {
 }
 
 void PKJK::compute_JK() {
+
+    // zero out J, K, and wK matrices
+    zero();
+
     timer_on("PK computes JK");
     // We form the vector containing the density matrix triangular elements
     PKmanager_->prepare_JK(D_ao_, C_left_ao_, C_right_ao_);

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -330,12 +330,6 @@ void JK::allocate_JK() {
         }
     }
 
-    // Zero out J/K for compute_JK()
-    for (size_t N = 0; N < D_.size(); ++N) {
-        if (do_J_) J_[N]->zero();
-        if (do_K_) K_[N]->zero();
-        if (do_wK_) wK_[N]->zero();
-    }
 }
 void JK::USO2AO() {
     allocate_JK();
@@ -481,11 +475,6 @@ void JK::USO2AO() {
         }
     }
 
-    for (size_t N = 0; N < D_.size(); ++N) {
-        if (do_J_) J_ao_[N]->zero();
-        if (do_K_) K_ao_[N]->zero();
-        if (do_wK_) wK_ao_[N]->zero();
-    }
 }
 void JK::AO2USO() {
     // If already C1, J/K are J_ao/K_ao, pointers are already aliased
@@ -634,11 +623,28 @@ void JK::compute() {
         C_right_.clear();
     }
 }
+
 void JK::set_wcombine(bool wcombine) {
     wcombine_ = wcombine;
     if (wcombine) {
         throw PSIEXCEPTION("To combine exchange terms, use MemDFJK\n");
     }
 }
+
+void JK::zero() {
+    if (do_J_) {
+        for(auto J : J_) J->zero();
+        for(auto J : J_ao_) J->zero();
+    }
+    if (do_K_) {
+        for(auto K : K_) K->zero();
+        for(auto K : K_ao_) K->zero();
+    }
+    if (do_wK_) {
+        for(auto wK : wK_) wK->zero();
+        for(auto wK : wK_ao_) wK->zero();
+    }
+}
+
 void JK::finalize() { postiterations(); }
 }  // namespace psi

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -212,6 +212,7 @@ void JK::common_init() {
     omega_ = 0.0;
     omega_alpha_ = 1.0;
     omega_beta_ = 0.0;
+    early_screening_ = false;
 
     std::shared_ptr<IntegralFactory> integral =
         std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -340,6 +340,8 @@ class PSI_API JK {
 
     /// Memory (doubles) used to hold J/K/wK/C/D and ao versions, at current moment
     size_t memory_overhead() const;
+    /// Zero out all J, K, and wK matrices
+    void zero();
 
    public:
     // => Constructors <= //

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -245,6 +245,8 @@ class PSI_API JK {
     double do_csam_;
     /// Whether to all desymmetrization, for cases when it's already been performed elsewhere
     std::vector<bool> input_symmetry_cast_map_;
+    /// Use severe screening techniques? Useful in early SCF iterations (defaults to false)
+    bool early_screening_;
 
     // => Tasks <= //
 
@@ -466,11 +468,19 @@ class PSI_API JK {
     double get_omega_alpha() {return omega_alpha_; }
 
     /**
-    * Set the alpha value for w exchange: weight for dampened Term                
+    * Set the beta value for w exchange: weight for dampened Term                
     * @param omega_beta Dampened Exchange weight
     */
     virtual void set_omega_beta(double beta) { omega_beta_ = beta; }
     double get_omega_beta() { return omega_beta_; }
+
+    /**
+    * Enable severe screening techniques, which can be useful in early 
+    *       SCF iterations.
+    * @param early_screening early screening status (defaults to false)
+    */
+    void set_early_screening(bool early_screening) { early_screening_ = early_screening; }
+    bool get_early_screening() { return early_screening_; }
 
     // => Computers <= //
 


### PR DESCRIPTION
## Description
This PR makes two small improvements to the `JK` class and SCF code. These improvements simplify the addition of new JK algorithms to Psi4, particularly an upcoming semi-numerical exchange.

The first change is transferring the responsibility of zeroing out the `J`, `K`, and `wK` matrices from the parent `JK` class to each derived `JK` class. This makes it easier to implement JK algorithms which build the fock matrix incrementally. (i.e. use the difference in density between SCF iterations to compute differences in J/K). With this change, much of the incremental fock code in the `DirectJK` class can be simplified.

The second change is the addition of an `early_screening_` member variable to the `JK`. The idea is that some future JK algorithms will increase performance by using looser screening procedures/thresholds in early SCF iterations. Screening is then tightened as the SCF approaches convergence. This logic was added to the SCF driver. The `early_screening_` variable defaults to false for all existing JK classes, so there is currently. no change in behavior.

## Todos
- [x] Derived `JK` classes are responsible for zeroing their matrices
- [x] JK screening is SCF iteration dependent

## Questions

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
