### PR TITLE
various pieces from ddd

### DIFF
--- a/doc/sphinxman/source/build_faq.rst
+++ b/doc/sphinxman/source/build_faq.rst
@@ -131,6 +131,7 @@ Running |PSIfour|
 #. :ref:`faq:psi4PBS`
 #. :ref:`faq:psi4fileretention`
 #. :ref:`faq:logging`
+#. :ref:`faq:findexemod`
 
 Runtime Errors and Debugging
 ----------------------------

--- a/doc/sphinxman/source/build_planning.rst
+++ b/doc/sphinxman/source/build_planning.rst
@@ -1881,3 +1881,22 @@ To change the logging level to DEBUG in PsiAPI::
 
   >>> psi4.set_output_file(<filebase>, loglevel=10)
 
+
+.. _`faq:findexemod`:
+
+How to find the Psi4 module from the executable and vice versa
+--------------------------------------------------------------
+
+Because of the different conventions of C++/Linux and Python installation
+layouts, the |PSIfour| executable and the |PSIfour| Python module aren't
+at fixed locations relative to each other. Accessors have been added
+so that the executable can show where the module is, and the module
+can show where the executable is.
+
+  .. code-block:: bash
+
+    > /path/to/psi4/install/bin/psi4 --module
+    /path/to/psi4/install/lib//
+    > python -c "import psi4;print(psi4.executable)"
+    /path/to/psi4/install/bin/psi4
+

--- a/doc/sphinxman/source/external.rst
+++ b/doc/sphinxman/source/external.rst
@@ -507,6 +507,10 @@ Command-line arguments to |PSIfour| can be accessed through :option:`psi4 --help
 
    The amount of memory to use. Can be specified with units (e.g., '10MB') otherwise bytes is assumed.
 
+.. option:: --module
+
+   The location of the associated |PSIfour| Python module.
+
  .. option:: -n <threads>, --nthread <threads>
 
    Number of threads to use (overrides :envvar:`OMP_NUM_THREADS`).
@@ -524,7 +528,7 @@ Command-line arguments to |PSIfour| can be accessed through :option:`psi4 --help
 
    Generates a bash command to source correct Python interpreter and path for ``python -c "import psi4"``
 
-.. option:: --qcschema
+.. option:: --qcschema, --schema
 
    Runs input files as QCSchema. Can either be JSON or MessagePack input.
 

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -36,6 +36,10 @@ if pymod.startswith(os.path.sep + os.path.sep):
 pymod_dir_step = os.path.sep.join(['..'] * pymod.count(os.path.sep))
 data_dir = os.path.sep.join([psi4_module_loc, pymod_dir_step, '@CMAKE_INSTALL_DATADIR@', 'psi4'])
 executable = os.path.abspath(os.path.sep.join([psi4_module_loc, pymod_dir_step, '@CMAKE_INSTALL_BINDIR@', 'psi4']))
+from pathlib import Path
+if not Path(executable).exists():
+    # Win conda recipe moves psi4 executable unknown to CMake
+    executable = str((Path(psi4_module_loc) / ".." / ".." / ".." / "Scripts" / "psi4.exe").resolve())
 
 # from . import config
 # data_dir = config.psidatadir

--- a/psi4/extras.py
+++ b/psi4/extras.py
@@ -49,7 +49,6 @@ def register_numpy_file(filename):
 
 def clean_numpy_files():
     for nfile in numpy_files:
-        os.unlink(nfile)
         try:
             os.unlink(nfile)
         except OSError:

--- a/psi4/extras.py
+++ b/psi4/extras.py
@@ -50,6 +50,10 @@ def register_numpy_file(filename):
 def clean_numpy_files():
     for nfile in numpy_files:
         os.unlink(nfile)
+        try:
+            os.unlink(nfile)
+        except OSError:
+            pass
 
 
 atexit.register(clean_numpy_files)

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -64,6 +64,8 @@ parser.add_argument("-m", "--messy", action='store_true',
 parser.add_argument("--psiapi-path", action='store_true',
                     help="""Generates a bash command to source correct Python """
                          """interpreter and path for ``python -c "import psi4"``""")
+parser.add_argument("--module", action='store_true',
+                    help="""Generates the path to PsiAPI loading.""")
 parser.add_argument("-v", "--verbose", action='store_true', help="Prints Psithon to Python translation.")
 parser.add_argument("--inplace", action='store_true',
                     help="Runs Psi4 from the source directory. !Warning! expert option.")
@@ -72,7 +74,7 @@ parser.add_argument("-l", "--psidatadir",
 parser.add_argument("-k", "--skip-preprocessor", action='store_true',
                     help="Skips input preprocessing. !Warning! expert option.")
 parser.add_argument("--qcschema", "--schema", action='store_true',
-                    help="Runs input file as QCSchema. Can either be JSON or MessagePack input.")
+                    help="Runs input file as QCSchema. Can either be JSON or MessagePack input. Use `--output` to not overwrite schema input file.")
 parser.add_argument("--json", action='store_true',
                     help="Runs a JSON input file. !Warning! depcrated option in 1.4, use --qcschema instead.")
 parser.add_argument("-t", "--test", nargs='?', const='smoke', default=None,
@@ -162,6 +164,10 @@ if args['psiapi_path']:
     pyexe_dir = os.path.dirname("@Python_EXECUTABLE@")
     bin_dir = Path(cmake_install_prefix) / 'bin'
     print(f"""export PATH={pyexe_dir}:$PATH  # python interpreter\nexport PATH={bin_dir}:$PATH  # psi4 executable\nexport PYTHONPATH={lib_dir}:$PYTHONPATH  # psi4 pymodule""")
+    sys.exit()
+
+if args["module"]:
+    print(lib_dir)
     sys.exit()
 
 # Transmit any argument psidatadir through environ

--- a/psi4/src/psi4/libpsio/filemanager.cc
+++ b/psi4/src/psi4/libpsio/filemanager.cc
@@ -63,8 +63,22 @@ PSIOManager::~PSIOManager() {}
 
 std::shared_ptr<PSIOManager> PSIOManager::shared_object() { return _default_psio_manager_; }
 
-void PSIOManager::set_default_path(const std::string& path) { default_path_ = path + "/"; }
-void PSIOManager::set_specific_path(int fileno, const std::string& path) { specific_paths_[fileno] = path + "/"; }
+void PSIOManager::set_default_path(const std::string& path) {
+    if (path.size() && (path.back() == '/')) {
+        default_path_ = path;
+    } else {
+        default_path_ = path + "/";
+    }
+}
+
+void PSIOManager::set_specific_path(int fileno, const std::string& path) {
+    if (path.size() && (path.back() == '/')) {
+        specific_paths_[fileno] = path;
+    } else {
+        specific_paths_[fileno] = path + "/";
+    }
+}
+
 std::string PSIOManager::get_file_path(int fileno) {
     if (specific_paths_.count(fileno) != 0)
         return specific_paths_[fileno];

--- a/psi4/src/psi4/libpsio/filemanager.cc
+++ b/psi4/src/psi4/libpsio/filemanager.cc
@@ -64,7 +64,7 @@ PSIOManager::~PSIOManager() {}
 std::shared_ptr<PSIOManager> PSIOManager::shared_object() { return _default_psio_manager_; }
 
 void PSIOManager::set_default_path(const std::string& path) {
-    if (path.size() && (path.back() == '/')) {
+    if (!path.empty() && (path.back() == '/')) {
         default_path_ = path;
     } else {
         default_path_ = path + "/";
@@ -72,7 +72,7 @@ void PSIOManager::set_default_path(const std::string& path) {
 }
 
 void PSIOManager::set_specific_path(int fileno, const std::string& path) {
-    if (path.size() && (path.back() == '/')) {
+    if (!path.empty() && (path.back() == '/')) {
         specific_paths_[fileno] = path;
     } else {
         specific_paths_[fileno] = path + "/";

--- a/tests/pytests/addons.py
+++ b/tests/pytests/addons.py
@@ -170,7 +170,7 @@ def ctest_runner(inputdatloc, extra_infiles: List =None, outfiles: List =None):
     psiimport = Path(psi4.__file__).parent.parent
     env = os.environ.copy()
     if "PYTHONPATH" in env:
-        env["PYTHONPATH"] = env["PYTHONPATH"] + os.pathsep + str(psiimport)
+        env["PYTHONPATH"] += os.pathsep + str(psiimport)
     else:
         env["PYTHONPATH"] = str(psiimport)
 

--- a/tests/pywrap-cbs1/input.dat
+++ b/tests/pywrap-cbs1/input.dat
@@ -16,7 +16,7 @@ e_cbs = energy(cbs,
             scf_scheme=scf_xtpl_helgaker_3)
 
 compare_values(-7.4326961561955551, e_cbs, 7, "[1] Li ROHF extrapolated energy")  #TEST
-compare_values(3.0, variable('cbs number'), 6, '[1b]')  #TEST
+compare(3, variable('cbs number'), '[1b]')  #TEST
 clean()
 
 
@@ -43,7 +43,7 @@ e_cbs = energy(cbs,
             delta_basis='cc-pV[DT]Z',
             delta_scheme=driver_cbs.corl_xtpl_helgaker_2)
 compare_values(-1.148287763304, e_cbs, 7, "[2] H2 mp2 extrapolated energy with ccsd delta correction")  #TEST
-compare_values(3.0, variable('cbs number'), 6, '[2b]')  #TEST
+compare_values(3, variable('cbs number'), '[2b]')  #TEST
 clean()
 
 
@@ -65,7 +65,7 @@ e_cbs = energy(cbs,
             corl_scheme=driver_cbs.corl_xtpl_helgaker_2)
 
 compare_values(-2.9033043421572055642, e_cbs, 7, "[3] He ccsd extrapolated energy")  #TEST
-compare_values(3.0, variable('cbs number'), 6, '[3b]')  #TEST
+compare_values(3, variable('cbs number'), '[3b]')  #TEST
 clean()
 
 # Example with default extrapolation schemes
@@ -76,7 +76,7 @@ e_cbs = energy(cbs,
             delta_basis='cc-pVDZ')
 
 compare_values(-2.90394676, e_cbs, 6, '[4] MP5: minimal info')  #TEST
-compare_values(2.0, variable('cbs number'), 6, '[4b]')  #TEST
+compare_values(2, variable('cbs number'), '[4b]')  #TEST
 clean()
 
 


### PR DESCRIPTION
## Description
This is No. 5 of the DDD series, #1351.

## Todos
- [x] Add `psi4 --module` for find pymod. qcng already tries to use it
- [x] Add another mode to `prepare_options_for_modules` that instead of figuring out what options are active in a module (mediated mode, used previously for sow/reap, I think) now records the settings for reset (state mode, used in DDD). Added a context manager to "hold and restore" the options state.
- [x] Add `run_qcschema(..., postclean)` option that handles the trouble when this is called *from Psi4* of deleting the parent session's output file.
- [x] Be tolerant of missing files when cleaning numpy files. I don't remember why/if this was necessary, but on the whole, a missing numpy file isn't worth erroring on.
- [x] Aboid extra '/' in paths from psio. I don't remember if this was fixing an error or just aesthetic.
- [x] docstrings
- [x] ADDED: another attempt to fix Win conda package

## Checklist
- [x] ~Tests added for any new features~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
