### PR TITLE
Destroy `TaskListComputer`

### DIFF
--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -40,20 +40,6 @@ using namespace pybind11::literals;
 void export_oeprop(py::module &m) {
     py::class_<Prop, std::shared_ptr<Prop> >(m, "Prop", "docstring");
 
-    py::class_<TaskListComputer, std::shared_ptr<TaskListComputer> >(m, "TaskListComputer", "docstring")
-        .def("add", py::overload_cast<const std::string&>(&TaskListComputer::add), "Append the given task to the list of properties to compute.")
-        .def("set_title", &TaskListComputer::set_title, "docstring");
-
-    //     def(init<std::shared_ptr<Wavefunction> >()).
-    //     def("print_header", pure_virtual(&Prop::print_header)).
-    //     def("compute", pure_virtual(&Prop::compute)).
-    //     def("set_Da_ao", &Prop::set_Da_ao, "docstring").
-    //     def("set_Db_ao", &Prop::set_Db_ao, "docstring").
-    //     def("set_Da_so", &Prop::set_Da_so, "docstring").
-    //     def("set_Db_so", &Prop::set_Db_so, "docstring").
-    //     def("set_Da_mo", &Prop::set_Da_mo, "docstring").
-    //     def("set_Db_mo", &Prop::set_Db_mo, "docstring");
-
     py::class_<ESPPropCalc, std::shared_ptr<ESPPropCalc>, Prop>(
         m, "ESPPropCalc", "ESPPropCalc gives access to routines calculating the ESP on a grid")
         .def(py::init<std::shared_ptr<Wavefunction> >())
@@ -62,10 +48,9 @@ void export_oeprop(py::module &m) {
         .def("compute_field_over_grid_in_memory", &ESPPropCalc::compute_field_over_grid_in_memory,
              "Computes field on specified grid Nx3 (as SharedMatrix)");
 
-    py::class_<OEProp, std::shared_ptr<OEProp>, TaskListComputer>(m, "OEProp", "docstring")
-        .
-        // TODO had no_init but init member present
-        def(py::init<std::shared_ptr<Wavefunction> >())
+    py::class_<OEProp, std::shared_ptr<OEProp>>(m, "OEProp", "docstring")
+        .def(py::init<std::shared_ptr<Wavefunction> >())
+        .def("add", py::overload_cast<const std::string&>(&OEProp::add), "Append the given task to the list of properties to compute.")
         .def("compute", &OEProp::compute, "Compute the properties.")
         .def("clear", &OEProp::clear, "Clear the list of properties to compute.")
         .def("set_Da_ao", &OEProp::set_Da_ao, "docstring", "Da"_a, "symmetry"_a = 0)
@@ -77,7 +62,8 @@ void export_oeprop(py::module &m) {
         .def("Vvals", &OEProp::Vvals, "The electrostatic potential (in a.u.) at each grid point")
         .def("Exvals", &OEProp::Exvals, "The x component of the field (in a.u.) at each grid point")
         .def("Eyvals", &OEProp::Eyvals, "The y component of the field (in a.u.) at each grid point")
-        .def("Ezvals", &OEProp::Ezvals, "The z component of the field (in a.u.) at each grid point");
+        .def("Ezvals", &OEProp::Ezvals, "The z component of the field (in a.u.) at each grid point")
+        .def("set_title", &OEProp::set_title, "docstring");
 
     // class_<GridProp, std::shared_ptr<GridProp> >("GridProp", "docstring").
     //    def("add", &GridProp::gridpy_add, "docstring").

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -261,19 +261,9 @@ void Prop::set_Db_mo(SharedMatrix D) {
         C_DGEMM('N', 'N', nsol, nsor, nmol, 1.0, Clp[0], nmol, temp_ptr, nsor, 0.0, Dsop[0], nsor);
     }
 }
-TaskListComputer::TaskListComputer() {
-    title_ = "";
-    print_ = 1;
-    debug_ = 0;
-    tasks_.clear();
-}
-void TaskListComputer::add(const std::string& prop) { tasks_.insert(prop); }
-void TaskListComputer::add(std::vector<std::string> props) {
-    for (int i = 0; i < (int)props.size(); i++) {
-        tasks_.insert(props[i]);
-    }
-}
-void TaskListComputer::clear() { tasks_.clear(); }
+void OEProp::add(const std::string& prop) { tasks_.insert(prop); }
+void OEProp::add(std::vector<std::string> props) { tasks_.insert(props.begin(), props.end()); }
+void OEProp::clear() { tasks_.clear(); }
 SharedVector Prop::epsilon_a() { return SharedVector(epsilon_a_->clone()); }
 SharedVector Prop::epsilon_b() { return SharedVector(epsilon_b_->clone()); }
 SharedMatrix Prop::Da_ao() {
@@ -697,6 +687,7 @@ OEProp::~OEProp() {}
 void OEProp::common_init() {
     Options& options = Process::environment.options;
     print_ = options.get_int("PRINT");
+    title_ = "";
 
     // Determine number of NOONs to print; default is 3
     if (options.get_str("PRINT_NOONS") == "ALL")

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -47,8 +47,6 @@ class BasisSet;
 /**
  * The Prop object, base class of OEProp and GridProp objects
  *
- * Word on the street:
- *
  *  Wavefunction is not finalized, so we have no idea what bases
  *  general density matrices/orbital coefficients will be in.
  *  Additionally, there are questions of natural/local/canonical orbitals,
@@ -190,23 +188,6 @@ class PSI_API Prop {
     SharedMatrix overlap_so();
 };
 
-/**
- * The TaskListComputer, a utility base class to add, remove tasks to a tasklist.
- *
- * Historically this class was part of Prop. As Prop provides lots of meaningful
- * functionality without the need to actually compute everything asap in a task loop,
- * it was split off here.
- *
- * Recommendations:
- *   - This class should be removed in the future. A clear API with directly exposed
- *     functions (using SharedPointer return values) without writing into global
- *     environments is the way to go.
- *
- *   - Before using this as a base in a new class, it should be investigated, whether a direct
- *     API would be a better approach with a "PropFactory" for use in the interactive
- *     interpreter.
- */
-
 class PSI_API TaskListComputer {
    protected:
     /// Print flag
@@ -225,15 +206,7 @@ class PSI_API TaskListComputer {
     virtual void print_header() = 0;
     // => Queue/Compute Routines <= //
 
-    /// Add a single task to the queue
-    void add(const std::string& task);
-    /// Add a set of tasks to the queue
-    void add(std::vector<std::string> tasks);
-    /// Clear task queue
-    void clear();
 
-    /// Set title for use in saving information
-    void set_title(const std::string& title) { title_ = title; }
 
     /// Compute properties
     virtual void compute() = 0;
@@ -384,7 +357,7 @@ class ESPPropCalc : public Prop {
  * The OEProp object, computes arbitrary expectation values (scalars)
  * analyses (typically vectors)
  **/
-class PSI_API OEProp : public TaskListComputer {
+class PSI_API OEProp {
    private:
     /// Constructor, uses globals and Process::environment::reference wavefunction, Implementation does not exist.
     OEProp();
@@ -392,10 +365,16 @@ class PSI_API OEProp : public TaskListComputer {
    protected:
     /// The wavefunction object this Prop is built around
     std::shared_ptr<Wavefunction> wfn_;
+    /// Print flag
+    int print_;
+    /// The title of this OEProp object, for use in saving info
+    std::string title_;
+    /// The set of tasks to complete
+    std::set<std::string> tasks_;
     /// Common initialization
     void common_init();
     /// Print header and information
-    void print_header() override;
+    void print_header();
 
     // Compute routines
     /// Compute arbitrary-order multipoles up to (and including) l=order
@@ -439,10 +418,18 @@ class PSI_API OEProp : public TaskListComputer {
     /// Constructor, uses globals
     OEProp(std::shared_ptr<Wavefunction> wfn);
     /// Destructor
-    ~OEProp() override;
+    ~OEProp();
 
+    /// Add a single task to the queue
+    void add(const std::string& task);
+    /// Add a set of tasks to the queue
+    void add(std::vector<std::string> tasks);
+    /// Clear task queue
+    void clear();
+    /// Set title for use in saving information
+    void set_title(const std::string& title) { title_ = title; }
     /// Compute and print/save the properties
-    void compute() override;
+    void compute();
 
     std::vector<double> const& Vvals() const { return epc_.Vvals(); }
     std::vector<double> const& Exvals() const { return epc_.Exvals(); }


### PR DESCRIPTION
## Description
This PR gets rid of the `TaskListComputer` base class, condensing it into `OEProp`, the only class that inherited from it. We gained nothing from having that class around.

## Checklist
- [x] Properties tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
