### PR TITLE
Make OEProp names flexible, to fix CC prop name bug.

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3171,7 +3171,8 @@ def run_cc_property(name, **kwargs):
         # TODO: When Psi is Py 3.9+, transition to the removeprefix version.
         title = name.upper().replace("EOM-", "")
         #title = name.upper().removeprefix("EOM-")
-        oe.set_titles({title + " {}", "CC {}"})
+        oe.set_title(title + " {}")
+        oe.set_names({title + " {}", "CC {}"})
         for oe_name in one:
             oe.add(oe_name.upper())
         oe.compute()

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3171,7 +3171,7 @@ def run_cc_property(name, **kwargs):
         # TODO: When Psi is Py 3.9+, transition to the removeprefix version.
         title = name.upper().replace("EOM-", "")
         #title = name.upper().removeprefix("EOM-")
-        oe.set_title(title + " {}")
+        oe.set_title(title)
         oe.set_names({title + " {}", "CC {}"})
         for oe_name in one:
             oe.add(oe_name.upper())

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3171,17 +3171,17 @@ def run_cc_property(name, **kwargs):
         # TODO: When Psi is Py 3.9+, transition to the removeprefix version.
         title = name.upper().replace("EOM-", "")
         #title = name.upper().removeprefix("EOM-")
-        oe.set_title(title)
+        oe.set_titles({title + " {}", "CC {}"})
         for oe_name in one:
             oe.add(oe_name.upper())
         oe.compute()
         # call oe prop for each ES density
         if name.startswith('eom'):
             # copy GS CC DIP/QUAD ... to CC ROOT 0 DIP/QUAD ... if we are doing multiple roots
-            if 'dipole' in one:
+            if 'DIPOLE' in one:
                 core.set_variable("CC ROOT 0 DIPOLE", core.variable("CC DIPOLE"))
                 # core.set_variable("CC ROOT n DIPOLE", core.variable("CC DIPOLE"))  # P::e CCENERGY
-            if 'quadrupole' in one:
+            if 'QUADRUPOLE' in one:
                 core.set_variable("CC ROOT 0 QUADRUPOLE", core.variable("CC QUADRUPOLE"))
                 # core.set_variable("CC ROOT n QUADRUPOLE", core.variable("CC QUADRUPOLE"))  # P::e CCENERGY
 

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -63,7 +63,10 @@ void export_oeprop(py::module &m) {
         .def("Exvals", &OEProp::Exvals, "The x component of the field (in a.u.) at each grid point")
         .def("Eyvals", &OEProp::Eyvals, "The y component of the field (in a.u.) at each grid point")
         .def("Ezvals", &OEProp::Ezvals, "The z component of the field (in a.u.) at each grid point")
-        .def("set_title", &OEProp::set_title, "docstring");
+        .def("set_title", &OEProp::set_title, "Instruct OEProp to save variables as title + propertyname", "title"_a)
+        .def("set_titles", &OEProp::set_titles,
+             "Instruct OEProp to save variables under all specified names. The property name will "
+             "be inserted at every occurrence of {}, like Python format strings.");
 
     // class_<GridProp, std::shared_ptr<GridProp> >("GridProp", "docstring").
     //    def("add", &GridProp::gridpy_add, "docstring").

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -63,10 +63,12 @@ void export_oeprop(py::module &m) {
         .def("Exvals", &OEProp::Exvals, "The x component of the field (in a.u.) at each grid point")
         .def("Eyvals", &OEProp::Eyvals, "The y component of the field (in a.u.) at each grid point")
         .def("Ezvals", &OEProp::Ezvals, "The z component of the field (in a.u.) at each grid point")
-        .def("set_title", &OEProp::set_title, "Instruct OEProp to save variables as title + propertyname", "title"_a)
-        .def("set_titles", &OEProp::set_titles,
+        .def("set_title", &OEProp::set_title,
+             "Title OEProp for print purposes. As a side effect, saves variables as title + propertyname and only that. "
+             "Follow up with side names, if the side effect is undesired,", "title"_a)
+        .def("set_names", &OEProp::set_names,
              "Instruct OEProp to save variables under all specified names. The property name will "
-             "be inserted at every occurrence of {}, like Python format strings.");
+             "be inserted at every occurrence of {}, like Python format strings. Wipes other names-to-save-by.");
 
     // class_<GridProp, std::shared_ptr<GridProp> >("GridProp", "docstring").
     //    def("add", &GridProp::gridpy_add, "docstring").

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -789,7 +789,12 @@ bool from_string(T& t, const std::string& s, std::ios_base& (*f)(std::ios_base&)
 }
 
 void OEProp::compute() {
-    outfile->Printf("\nProperties computed using the %s (α) and %s (β) density matrices\n\n", mpc_.Da_name().c_str(), mpc_.Db_name().c_str());
+    if (title_ == "") {
+        outfile->Printf("OEProp: No title given, name of density matrix used for the following properties is '%s'\n",
+                        mpc_.Da_name().c_str());
+    } else {
+        outfile->Printf("\nProperties computed using the %s density matrix\n\n", title_.c_str());
+    }
 
     // Search for multipole strings, which are handled separately
     std::set<std::string>::const_iterator iter = tasks_.begin();

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -29,10 +29,11 @@
 #ifndef _psi_src_lib_oeprop_h
 #define _psi_src_lib_oeprop_h
 
-#include <set>
-#include <vector>
 #include <map>
+#include <set>
 #include <string>
+#include <unordered_set>
+#include <vector>
 
 #include "typedefs.h"
 #include "psi4/libmints/vector3.h"
@@ -183,42 +184,11 @@ class PSI_API Prop {
 
     /// Density Matrix title, used for fallback naming of OEProp compute jobs
     std::string Da_name() const;
+    /// Density Matrix title, used for fallback naming of OEProp compute jobs
+    std::string Db_name() const;
 
     // => Some integral helpers <= //
     SharedMatrix overlap_so();
-};
-
-class PSI_API TaskListComputer {
-   protected:
-    /// Print flag
-    int print_;
-    /// Debug flag
-    int debug_;
-
-    /// The title of this Prop object, for use in saving info
-    std::string title_;
-
-    /// The set of tasks to complete
-    std::set<std::string> tasks_;
-
-   public:
-    /// Print header
-    virtual void print_header() = 0;
-    // => Queue/Compute Routines <= //
-
-
-
-    /// Compute properties
-    virtual void compute() = 0;
-
-    // => Utility Routines <= //
-    void set_print(int print) { print_ = print; }
-    void set_debug(int debug) { debug_ = debug; }
-
-    // Constructor, sets defaults for print and debug
-    TaskListComputer();
-    // Destructor
-    virtual ~TaskListComputer() {}
 };
 
 /**
@@ -367,8 +337,10 @@ class PSI_API OEProp {
     std::shared_ptr<Wavefunction> wfn_;
     /// Print flag
     int print_;
-    /// The title of this OEProp object, for use in saving info
-    std::string title_;
+    /// Variable names, for printout purposes. Each should have a single '{}' substring to indicate
+    /// where the variable name goes. The full generality of format strings are needed for excited
+    /// state purposes.
+    std::unordered_set<std::string> names_;
     /// The set of tasks to complete
     std::set<std::string> tasks_;
     /// Common initialization
@@ -427,7 +399,9 @@ class PSI_API OEProp {
     /// Clear task queue
     void clear();
     /// Set title for use in saving information
-    void set_title(const std::string& title) { title_ = title; }
+    void set_title(const std::string& title) { names_ = {title + (title.empty() ? "" : " ") + "{}"}; }
+    /// Set titles for use in saving information
+    void set_titles(const std::unordered_set<std::string> titles) { names_ = titles; }
     /// Compute and print/save the properties
     void compute();
 

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -337,7 +337,15 @@ class PSI_API OEProp {
     std::shared_ptr<Wavefunction> wfn_;
     /// Print flag
     int print_;
-    /// Variable names, for printout purposes. Each should have a single '{}' substring to indicate
+    /// OEProp name, for printout purposes.
+    /// TODO: Standardize density matrix names across Psi so we can remove `title_`.
+    ///   `title_` is redundant. Ideally, we'd print the density matrix names and not bother naming the
+    ///   OEProp object itself. But if a user sets an MO density matrix and gives it a name asserting
+    ///   it is an MO density matrix, OEProp would need to recognize that and rename the SO basis matrix
+    ///   it creates. Without a standard naming scheme for densities, OEProp can't do that. Therefore,
+    ///   until density names are standardized, we need to awkwardly keep `title_` around.
+    std::string title_;
+    /// Variable names, for variable saving purposes. Each should have a single '{}' substring to indicate
     /// where the variable name goes. The full generality of format strings are needed for excited
     /// state purposes.
     std::unordered_set<std::string> names_;
@@ -398,10 +406,11 @@ class PSI_API OEProp {
     void add(std::vector<std::string> tasks);
     /// Clear task queue
     void clear();
-    /// Set title for use in saving information
-    void set_title(const std::string& title) { names_ = {title + (title.empty() ? "" : " ") + "{}"}; }
+    /// Set title for use in printout. Set the same title to be the name for printout.
+    /// We do both because in older OEProp, the same member variable was used for both tasks.
+    void set_title(const std::string& title) { names_ = {title + (title.empty() ? "" : " ") + "{}"}; title_ = title; }
     /// Set titles for use in saving information
-    void set_titles(const std::unordered_set<std::string> titles) { names_ = titles; }
+    void set_names(const std::unordered_set<std::string> names) { names_ = names; }
     /// Compute and print/save the properties
     void compute();
 

--- a/tests/cc46/input.dat
+++ b/tests/cc46/input.dat
@@ -90,6 +90,8 @@ for root in range(1, 5):
     root_refs_arr[f"CC ROOT {root} QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
 
 
+compare_values(psi4.variable("CC ROOT 0 DIPOLE"), psi4.variable("CC DIPOLE"), 6, "CC ROOT 0 vs CC Dipole")
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
 
@@ -107,3 +109,4 @@ with warnings.catch_warnings():
     for tag,refval in gs_refs_arr.items():
         oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
         compare_values(refval, oeprop_val, 4, "CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST
+

--- a/tests/cc46/output.ref
+++ b/tests/cc46/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {oeprop} b7c163e dirty
+                         Git: Rev {oeprop} 558962e dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Wednesday, 06 April 2022 10:26AM
+    Psi4 started on: Wednesday, 06 April 2022 12:43PM
 
-    Process ID: 12635
+    Process ID: 17743
     Host:       dhcp189-247.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
@@ -156,7 +156,7 @@ with warnings.catch_warnings():
 --------------------------------------------------------------------------
 
 *** tstart() called on dhcp189-247.emerson.emory.edu
-*** at Wed Apr  6 10:26:05 2022
+*** at Wed Apr  6 12:43:34 2022
 
    => Loading Basis Set <=
 
@@ -272,10 +272,10 @@ with warnings.catch_warnings():
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:  -150.13109142562013   -1.50131e+02   0.00000e+00 
-   @RHF iter   1:  -150.72994418505670   -5.98853e-01   1.20798e-02 DIIS/ADIIS
-   @RHF iter   2:  -150.77474437542543   -4.48002e-02   3.93712e-03 DIIS/ADIIS
-   @RHF iter   3:  -150.77872862263519   -3.98425e-03   9.99210e-04 DIIS/ADIIS
-   @RHF iter   4:  -150.77914039140370   -4.11769e-04   2.79341e-04 DIIS/ADIIS
+   @RHF iter   1:  -150.72994418505670   -5.98853e-01   1.20798e-02 ADIIS/DIIS
+   @RHF iter   2:  -150.77474437542543   -4.48002e-02   3.93712e-03 ADIIS/DIIS
+   @RHF iter   3:  -150.77872862263519   -3.98425e-03   9.99210e-04 ADIIS/DIIS
+   @RHF iter   4:  -150.77914039140370   -4.11769e-04   2.79341e-04 ADIIS/DIIS
    @RHF iter   5:  -150.77918120037543   -4.08090e-05   4.90416e-05 DIIS
    @RHF iter   6:  -150.77918362626571   -2.42589e-06   1.25561e-05 DIIS
    @RHF iter   7:  -150.77918384927833   -2.23013e-07   3.89306e-06 DIIS
@@ -331,7 +331,7 @@ Computation Completed
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
-Properties computed using the SCF density (α) and SCF density (β) density matrices
+Properties computed using the SCF density matrix
 
 
  Multipole Moments:
@@ -348,15 +348,15 @@ Properties computed using the SCF density (α) and SCF density (β) density matr
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-247.emerson.emory.edu at Wed Apr  6 10:26:06 2022
+*** tstop() called on dhcp189-247.emerson.emory.edu at Wed Apr  6 12:43:36 2022
 Module time:
-	user time   =       0.74 seconds =       0.01 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.13 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.74 seconds =       0.01 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.13 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -382,7 +382,7 @@ Total time:
 
 
 *** tstart() called on dhcp189-247.emerson.emory.edu
-*** at Wed Apr  6 10:26:06 2022
+*** at Wed Apr  6 12:43:36 2022
 
 
 	Wfn Parameters:
@@ -461,15 +461,15 @@ Total time:
 	Two-electron energy          =     45.23861563749188
 	Reference energy             =   -150.77918387212975
 
-*** tstop() called on dhcp189-247.emerson.emory.edu at Wed Apr  6 10:26:06 2022
+*** tstop() called on dhcp189-247.emerson.emory.edu at Wed Apr  6 12:43:36 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.16 seconds =       0.00 minutes
+	user time   =       0.10 seconds =       0.00 minutes
+	system time =       0.21 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.91 seconds =       0.02 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.36 seconds =       0.02 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -1593,7 +1593,7 @@ Doing transition
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
-Properties computed using the SCF density (α) and SCF density (β) density matrices
+Properties computed using the CC2 {} density matrix
 
 
  Multipole Moments:
@@ -1641,7 +1641,7 @@ Properties computed using the SCF density (α) and SCF density (β) density matr
   LUNO+3 :    7  B    0.019
 
 
-Properties computed using the T (α) and T (β) density matrices
+Properties computed using the CC ROOT 1 density matrix
 
 
  Multipole Moments:
@@ -1689,7 +1689,7 @@ Properties computed using the T (α) and T (β) density matrices
   LUNO+3 :    7  A    0.006
 
 
-Properties computed using the T (α) and T (β) density matrices
+Properties computed using the CC ROOT 2 density matrix
 
 
  Multipole Moments:
@@ -1737,7 +1737,7 @@ Properties computed using the T (α) and T (β) density matrices
   LUNO+3 :    7  B    0.005
 
 
-Properties computed using the T (α) and T (β) density matrices
+Properties computed using the CC ROOT 3 density matrix
 
 
  Multipole Moments:
@@ -1785,7 +1785,7 @@ Properties computed using the T (α) and T (β) density matrices
   LUNO+3 :    7  B    0.005
 
 
-Properties computed using the T (α) and T (β) density matrices
+Properties computed using the CC ROOT 4 density matrix
 
 
  Multipole Moments:
@@ -1847,7 +1847,7 @@ Properties computed using the T (α) and T (β) density matrices
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
-Properties computed using the SCF density (α) and SCF density (β) density matrices
+Properties computed using the CCDENSITY-SET-WFN-TEST CC2 density matrix
 
 
  Multipole Moments:
@@ -1877,7 +1877,7 @@ Properties computed using the SCF density (α) and SCF density (β) density matr
     CCDENSITY-SET-WFN-TEST CC2 DIPOLE.....................................................PASSED
     CCDENSITY-SET-WFN-TEST CC2 QUADRUPOLE.................................................PASSED
 
-    Psi4 stopped on: Wednesday, 06 April 2022 10:26AM
-    Psi4 wall time for execution: 0:00:05.96
+    Psi4 stopped on: Wednesday, 06 April 2022 12:43PM
+    Psi4 wall time for execution: 0:00:07.60
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc46/output.ref
+++ b/tests/cc46/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {oeprop} 294c406 dirty
+                         Git: Rev {oeprop} b7c163e dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 05 April 2022 04:03PM
+    Psi4 started on: Wednesday, 06 April 2022 10:26AM
 
-    Process ID: 29695
+    Process ID: 12635
     Host:       dhcp189-247.emerson.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
@@ -133,6 +133,8 @@ for root in range(1, 5):
     root_refs_arr[f"CC ROOT {root} QUADRUPOLE"] = np.array(pole).reshape((3, 3)) * q2au  #TEST
 
 
+compare_values(psi4.variable("CC ROOT 0 DIPOLE"), psi4.variable("CC DIPOLE"), 6, "CC ROOT 0 vs CC Dipole")
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
 
@@ -150,10 +152,11 @@ with warnings.catch_warnings():
     for tag,refval in gs_refs_arr.items():
         oeprop_val = psi4.variable("CCDENSITY-SET-WFN-TEST {}".format(tag))
         compare_values(refval, oeprop_val, 4, "CCDENSITY-SET-WFN-TEST {}".format(tag))   #TEST
+
 --------------------------------------------------------------------------
 
 *** tstart() called on dhcp189-247.emerson.emory.edu
-*** at Tue Apr  5 16:03:46 2022
+*** at Wed Apr  6 10:26:05 2022
 
    => Loading Basis Set <=
 
@@ -269,10 +272,10 @@ with warnings.catch_warnings():
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:  -150.13109142562013   -1.50131e+02   0.00000e+00 
-   @RHF iter   1:  -150.72994418505670   -5.98853e-01   1.20798e-02 ADIIS/DIIS
-   @RHF iter   2:  -150.77474437542543   -4.48002e-02   3.93712e-03 ADIIS/DIIS
-   @RHF iter   3:  -150.77872862263519   -3.98425e-03   9.99210e-04 ADIIS/DIIS
-   @RHF iter   4:  -150.77914039140370   -4.11769e-04   2.79341e-04 ADIIS/DIIS
+   @RHF iter   1:  -150.72994418505670   -5.98853e-01   1.20798e-02 DIIS/ADIIS
+   @RHF iter   2:  -150.77474437542543   -4.48002e-02   3.93712e-03 DIIS/ADIIS
+   @RHF iter   3:  -150.77872862263519   -3.98425e-03   9.99210e-04 DIIS/ADIIS
+   @RHF iter   4:  -150.77914039140370   -4.11769e-04   2.79341e-04 DIIS/ADIIS
    @RHF iter   5:  -150.77918120037543   -4.08090e-05   4.90416e-05 DIIS
    @RHF iter   6:  -150.77918362626571   -2.42589e-06   1.25561e-05 DIIS
    @RHF iter   7:  -150.77918384927833   -2.23013e-07   3.89306e-06 DIIS
@@ -328,7 +331,7 @@ Computation Completed
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
-Properties computed using the SCF density matrix
+Properties computed using the SCF density (α) and SCF density (β) density matrices
 
 
  Multipole Moments:
@@ -345,15 +348,15 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-247.emerson.emory.edu at Tue Apr  5 16:03:50 2022
+*** tstop() called on dhcp189-247.emerson.emory.edu at Wed Apr  6 10:26:06 2022
 Module time:
-	user time   =       1.15 seconds =       0.02 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.15 seconds =       0.02 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -379,7 +382,7 @@ Total time:
 
 
 *** tstart() called on dhcp189-247.emerson.emory.edu
-*** at Tue Apr  5 16:03:51 2022
+*** at Wed Apr  6 10:26:06 2022
 
 
 	Wfn Parameters:
@@ -458,15 +461,15 @@ Total time:
 	Two-electron energy          =     45.23861563749188
 	Reference energy             =   -150.77918387212975
 
-*** tstop() called on dhcp189-247.emerson.emory.edu at Tue Apr  5 16:03:51 2022
+*** tstop() called on dhcp189-247.emerson.emory.edu at Wed Apr  6 10:26:06 2022
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.23 seconds =       0.00 minutes
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.41 seconds =       0.02 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       0.91 seconds =       0.02 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -1590,7 +1593,7 @@ Doing transition
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
-Properties computed using the CC2 density matrix
+Properties computed using the SCF density (α) and SCF density (β) density matrices
 
 
  Multipole Moments:
@@ -1638,7 +1641,7 @@ Properties computed using the CC2 density matrix
   LUNO+3 :    7  B    0.019
 
 
-Properties computed using the CC ROOT 1 density matrix
+Properties computed using the T (α) and T (β) density matrices
 
 
  Multipole Moments:
@@ -1686,7 +1689,7 @@ Properties computed using the CC ROOT 1 density matrix
   LUNO+3 :    7  A    0.006
 
 
-Properties computed using the CC ROOT 2 density matrix
+Properties computed using the T (α) and T (β) density matrices
 
 
  Multipole Moments:
@@ -1734,7 +1737,7 @@ Properties computed using the CC ROOT 2 density matrix
   LUNO+3 :    7  B    0.005
 
 
-Properties computed using the CC ROOT 3 density matrix
+Properties computed using the T (α) and T (β) density matrices
 
 
  Multipole Moments:
@@ -1782,7 +1785,7 @@ Properties computed using the CC ROOT 3 density matrix
   LUNO+3 :    7  B    0.005
 
 
-Properties computed using the CC ROOT 4 density matrix
+Properties computed using the T (α) and T (β) density matrices
 
 
  Multipole Moments:
@@ -1829,6 +1832,7 @@ Properties computed using the CC ROOT 4 density matrix
   LUNO+2 :    6  B    0.017
   LUNO+3 :    7  A    0.006
 
+    CC ROOT 0 vs CC Dipole................................................................PASSED
     CC2 DIPOLE............................................................................PASSED
     CC2 QUADRUPOLE........................................................................PASSED
     CC ROOT 1 DIPOLE......................................................................PASSED
@@ -1843,7 +1847,7 @@ Properties computed using the CC ROOT 4 density matrix
 
 Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
-Properties computed using the CCDENSITY-SET-WFN-TEST CC2 density matrix
+Properties computed using the SCF density (α) and SCF density (β) density matrices
 
 
  Multipole Moments:
@@ -1873,7 +1877,7 @@ Properties computed using the CCDENSITY-SET-WFN-TEST CC2 density matrix
     CCDENSITY-SET-WFN-TEST CC2 DIPOLE.....................................................PASSED
     CCDENSITY-SET-WFN-TEST CC2 QUADRUPOLE.................................................PASSED
 
-    Psi4 stopped on: Tuesday, 05 April 2022 04:04PM
-    Psi4 wall time for execution: 0:00:13.48
+    Psi4 stopped on: Wednesday, 06 April 2022 10:26AM
+    Psi4 wall time for execution: 0:00:05.96
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This PR changes how `OEProp` saves variables and fixes a bug where "CC ROOT 0" variables were not being set.

Previously, OEProp overloaded `title_` to refer to both the name used for the density matrix (for print purposes) and for the name used for properties (as a prefix for variable saving purposes). Only one such name can be used.
Now, OEProp uses the density matrix's name as the density matrix's name (for print purposes) and for the names used for properties (for variable saving purposes, and with the generality of format strings). Multiples names can be used.

With this, I can now save the CC dipoles as both "CC DIPOLE" and "CC2 DIPOLE", so "CC DIPOLE" can be found. The Psi code that tried to access this was never entered previously because it checked for a 'dipole' variable rather than a 'DIPOLE' variable.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] More flexibility in OEProp names
- [x] Previously missing CC property variables are set

## Checklist
- [x] Properties tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
