### PR TITLE
More variable names for EOM properties. Required infrastructure changes

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -248,7 +248,7 @@ namespace cclambda {
 PsiReturnType cclambda(SharedWavefunction, Options&);
 }
 namespace ccdensity {
-PsiReturnType ccdensity(SharedWavefunction, Options&);
+PsiReturnType ccdensity(std::shared_ptr<ccenergy::CCEnergyWavefunction>, Options&);
 }
 namespace ccresponse {
 PsiReturnType ccresponse(SharedWavefunction, Options&);
@@ -256,7 +256,7 @@ void scatter(std::shared_ptr<Molecule> molecule, Options&, double step, std::vec
              std::vector<SharedMatrix> rot, std::vector<SharedMatrix> quad);
 }  // namespace ccresponse
 namespace cceom {
-PsiReturnType cceom(SharedWavefunction, Options&);
+PsiReturnType cceom(std::shared_ptr<ccenergy::CCEnergyWavefunction>, Options&);
 }
 
 extern int read_options(const std::string& name, Options& options, bool suppress_printing = false);
@@ -451,7 +451,7 @@ SharedWavefunction py_psi_cclambda(SharedWavefunction ref_wfn) {
     return cclambda;
 }
 
-double py_psi_ccdensity(SharedWavefunction ref_wfn) {
+double py_psi_ccdensity(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn) {
     py_psi_prepare_options_for_module("CCDENSITY");
     ccdensity::ccdensity(ref_wfn, Process::environment.options);
     return 0.0;
@@ -508,7 +508,7 @@ void py_psi_scatter(std::shared_ptr<Molecule> molecule, double step, py::list di
                         dip_quad_polar_tensors);
 }
 
-double py_psi_cceom(SharedWavefunction ref_wfn) {
+double py_psi_cceom(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn) {
     py_psi_prepare_options_for_module("CCEOM");
     if (cceom::cceom(ref_wfn, Process::environment.options) == Success) {
         return Process::environment.globals["CURRENT ENERGY"];

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -38,21 +38,22 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include "psi4/libpsio/psio.h"
-#include "psi4/libciomr/libciomr.h"
-#include "psi4/libdpd/dpd.h"
-#include "psi4/libiwl/iwl.h"
-#include "psi4/liboptions/liboptions.h"
-#include "psi4/psi4-dec.h"
 #include <cmath>
-#include "psi4/psifiles.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
 #include "globals.h"
+#include "psi4/cc/ccwave.h"
+#include "psi4/libciomr/libciomr.h"
+#include "psi4/libdpd/dpd.h"
+#include "psi4/libiwl/iwl.h"
+#include "psi4/liboptions/liboptions.h"
+#include "psi4/libpsio/psio.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libmints/matrix.h"
+#include "psi4/psi4-dec.h"
+#include "psi4/psifiles.h"
 namespace psi {
 
 class Molecule;
@@ -117,8 +118,8 @@ void get_td_params(Options &options);
 void td_setup(const struct TD_Params& S);
 void tdensity(const struct TD_Params& S);
 void td_print();
-void oscillator_strength(std::shared_ptr<Wavefunction> wfn, struct TD_Params *S);
-void rotational_strength(std::shared_ptr<Wavefunction> wfn, struct TD_Params *S);
+void oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S);
+void rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S);
 void ael(struct RHO_Params *rho_params);
 void cleanup();
 void td_cleanup();
@@ -130,13 +131,13 @@ void V_cc2();
 void ex_tdensity(char hand, const struct TD_Params& S, const struct TD_Params& U);
 void ex_td_setup(const struct TD_Params& S, const struct TD_Params& U);
 void ex_td_cleanup();
-void ex_oscillator_strength(std::shared_ptr<Wavefunction> wfn, struct TD_Params *S, struct TD_Params *U,
+void ex_oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S, struct TD_Params *U,
                             struct XTD_Params *xtd_data);
-void ex_rotational_strength(std::shared_ptr<Wavefunction>, struct TD_Params *S, struct TD_Params *U, struct XTD_Params *xtd_data);
+void ex_rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S, struct TD_Params *U, struct XTD_Params *xtd_data);
 void ex_td_print(std::vector<struct XTD_Params>);
 SharedMatrix block_to_matrix(double **);
 
-PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
+PsiReturnType ccdensity(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn, Options &options) {
     int i;
     int **cachelist, *cachefiles;
     struct iwlbuf OutBuf;
@@ -437,10 +438,10 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
             td_setup(td_params[i]);
             tdensity(td_params[i]);
             outfile->Printf("Doing transition\n");
-            oscillator_strength(ref_wfn, &(td_params[i]));
+            oscillator_strength(*ref_wfn, &(td_params[i]));
             outfile->Printf("Doing transition\n");
             if (params.ref == 0) {
-                rotational_strength(ref_wfn, &(td_params[i]));
+                rotational_strength(*ref_wfn, &(td_params[i]));
             }
             outfile->Printf("Doing transition\n");
             td_cleanup();
@@ -513,10 +514,10 @@ PsiReturnType ccdensity(std::shared_ptr<Wavefunction> ref_wfn, Options &options)
                                     moinfo.labels[td_params[state2].irrep].c_str());
 
                     // ex_oscillator_strength(&(td_params[j]),&(td_params[i+1]), &xtd_data);
-                    ex_oscillator_strength(ref_wfn, &(td_params[state1]), &(td_params[state2]), &xtd_data);
+                    ex_oscillator_strength(*ref_wfn, &(td_params[state1]), &(td_params[state2]), &xtd_data);
                     if (params.ref == 0) {
                         // ex_rotational_strength(&(td_params[j]),&(td_params[i+1]), &xtd_data);
-                        ex_rotational_strength(ref_wfn, &(td_params[state1]), &(td_params[state2]), &xtd_data);
+                        ex_rotational_strength(*ref_wfn, &(td_params[state1]), &(td_params[state2]), &xtd_data);
                     }
 
                     xtd_params.push_back(xtd_data);

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.h
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.h
@@ -35,15 +35,16 @@
            Refactoring needed, so pardon the mess, and help out if you can.
 */
 
+#include "psi4/cc/ccwave.h"
 #include "psi4/libmints/typedefs.h"
 #include "psi4/libmints/wavefunction.h"
 
 namespace psi {
 namespace ccdensity {
 // Save a scalar describing a ground->excited transition.
-void scalar_saver_ground(SharedWavefunction wfn, struct TD_Params *S, const std::string suffix, double val);
+void scalar_saver_ground(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S, const std::string suffix, double val);
 // Save a scalar describing a excited->excited transition.
-void scalar_saver_excited(SharedWavefunction wfn, struct TD_Params *S, struct TD_Params *U, const std::string suffix, double val);
+void scalar_saver_excited(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S, struct TD_Params *U, const std::string suffix, double val);
 
 }
 }

--- a/psi4/src/psi4/cc/ccdensity/ex_oscillator_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_oscillator_strength.cc
@@ -52,7 +52,7 @@ namespace psi {
 namespace ccdensity {
 #include "psi4/physconst.h"
 
-void ex_oscillator_strength(SharedWavefunction wfn, struct TD_Params *S, struct TD_Params *U,
+void ex_oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S, struct TD_Params *U,
                             struct XTD_Params *xtd_data) {
     int nmo, nso, i, I, h, j;
     int *order, *order_A, *order_B, *doccpi;
@@ -70,14 +70,14 @@ void ex_oscillator_strength(SharedWavefunction wfn, struct TD_Params *S, struct 
     double f;
 
     if ((params.ref == 0) || (params.ref == 1))
-        scf_pitzer = wfn->Ca()->to_block_matrix();
+        scf_pitzer = wfn.Ca()->to_block_matrix();
     else if (params.ref == 2) {
-        scf_pitzer_A = wfn->Ca()->to_block_matrix();
-        scf_pitzer_B = wfn->Cb()->to_block_matrix();
+        scf_pitzer_A = wfn.Ca()->to_block_matrix();
+        scf_pitzer_B = wfn.Cb()->to_block_matrix();
     }
 
-    nso = wfn->nso();
-    nmo = wfn->nmo();
+    nso = wfn.nso();
+    nmo = wfn.nmo();
 
     lt_x = lt_y = lt_z = 0.0;
     rt_x = rt_y = rt_z = 0.0;
@@ -129,7 +129,7 @@ void ex_oscillator_strength(SharedWavefunction wfn, struct TD_Params *S, struct 
 
     /*** Transform the SO dipole integrals to the MO basis ***/
 
-    MintsHelper mints(wfn->basisset(), Process::environment.options, 0);
+    MintsHelper mints(wfn.basisset(), Process::environment.options, 0);
     std::vector<SharedMatrix> dipole = mints.so_dipole();
     MUX_SO = dipole[0]->to_block_matrix();
     MUY_SO = dipole[1]->to_block_matrix();

--- a/psi4/src/psi4/cc/ccdensity/ex_rotational_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_rotational_strength.cc
@@ -57,7 +57,7 @@ void transdip(const MintsHelper &mints);
 void transp(const MintsHelper &mints, double sign);
 void transL(const MintsHelper &mints, double sign);
 
-void ex_rotational_strength(SharedWavefunction wfn, struct TD_Params *S, struct TD_Params *U, struct XTD_Params *xtd_data) {
+void ex_rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S, struct TD_Params *U, struct XTD_Params *xtd_data) {
     int i, j, k;
     int no, nv, nt;
     double lt_x, lt_y, lt_z;
@@ -69,7 +69,7 @@ void ex_rotational_strength(SharedWavefunction wfn, struct TD_Params *S, struct 
     double conv;
     double delta_ee;
     int nmo = moinfo.nmo;
-    const auto& mints = *wfn->mintshelper();
+    const auto& mints = *wfn.mintshelper();
 
     transdip(mints);
 

--- a/psi4/src/psi4/cc/ccdensity/oscillator_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/oscillator_strength.cc
@@ -52,7 +52,7 @@ namespace ccdensity {
 #include "psi4/physconst.h"
 
 // TODO: Do TD_Params
-void oscillator_strength(SharedWavefunction wfn, struct TD_Params *S) {
+void oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S) {
     int nmo, nso, i, I, h, j;
     int *order, *order_A, *order_B, *doccpi;
     double **scf_pitzer, **scf_pitzer_A, **scf_pitzer_B;
@@ -69,14 +69,14 @@ void oscillator_strength(SharedWavefunction wfn, struct TD_Params *S) {
     double f;
 
     if ((params.ref == 0) || (params.ref == 1))
-        scf_pitzer = wfn->Ca()->to_block_matrix();
+        scf_pitzer = wfn.Ca()->to_block_matrix();
     else if (params.ref == 2) {
-        scf_pitzer_A = wfn->Ca()->to_block_matrix();
-        scf_pitzer_B = wfn->Cb()->to_block_matrix();
+        scf_pitzer_A = wfn.Ca()->to_block_matrix();
+        scf_pitzer_B = wfn.Cb()->to_block_matrix();
     }
 
-    nso = wfn->nso();
-    nmo = wfn->nmo();
+    nso = wfn.nso();
+    nmo = wfn.nmo();
 
     lt_x = lt_y = lt_z = 0.0;
     rt_x = rt_y = rt_z = 0.0;
@@ -128,7 +128,7 @@ void oscillator_strength(SharedWavefunction wfn, struct TD_Params *S) {
 
     /*** Transform the SO dipole integrals to the MO basis ***/
 
-    MintsHelper mints(wfn->basisset(), Process::environment.options, 0);
+    MintsHelper mints(wfn.basisset(), Process::environment.options, 0);
     std::vector<SharedMatrix> dipole = mints.so_dipole();
     MUX_SO = dipole[0]->to_block_matrix();
     MUY_SO = dipole[1]->to_block_matrix();

--- a/psi4/src/psi4/cc/ccdensity/rotational_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/rotational_strength.cc
@@ -34,9 +34,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
+#include "psi4/cc/ccwave.h"
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
+#include "psi4/libiwl/iwl.h"
+#include "psi4/libmints/mintshelper.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
 #include "psi4/physconst.h"
@@ -44,7 +46,6 @@
 #include "Frozen.h"
 #include "MOInfo.h"
 #include "Params.h"
-#include "psi4/libmints/mintshelper.h"
 #define EXTERN
 #include "globals.h"
 
@@ -57,7 +58,7 @@ void transdip(const MintsHelper &mints);
 void transp(const MintsHelper &mints, double sign);
 void transL(const MintsHelper &mints, double sign);
 
-void rotational_strength(SharedWavefunction wfn, struct TD_Params *S) {
+void rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S) {
     int i, j, k;
     int no, nv, nt;
     double lt_x, lt_y, lt_z;
@@ -68,7 +69,7 @@ void rotational_strength(SharedWavefunction wfn, struct TD_Params *S) {
     double rs;
     double conv;
     int nmo = moinfo.nmo;
-    const auto& mints = *wfn->mintshelper();
+    const auto& mints = *wfn.mintshelper();
 
     transdip(mints);
 

--- a/psi4/src/psi4/cc/cceom/cceom.cc
+++ b/psi4/src/psi4/cc/cceom/cceom.cc
@@ -39,6 +39,7 @@
 #include "Local.h"
 #include "globals.h"
 
+#include "psi4/cc/ccwave.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
@@ -57,7 +58,7 @@ void init_io();
 void get_moinfo(std::shared_ptr<Wavefunction>);
 void cleanup();
 void exit_io();
-void diag();
+void diag(ccenergy::CCEnergyWavefunction&);
 void get_params(Options &);
 void get_eom_params(std::shared_ptr<Wavefunction>, Options &);
 void form_dpd_dp();
@@ -76,7 +77,7 @@ void local_done();
 namespace psi {
 namespace cceom {
 
-PsiReturnType cceom(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
+PsiReturnType cceom(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn, Options &options) {
     int i, h, done = 0, *cachefiles, **cachelist;
     init_io();
     outfile->Printf("\n\t**********************************************************\n");
@@ -120,7 +121,7 @@ PsiReturnType cceom(std::shared_ptr<Wavefunction> ref_wfn, Options &options) {
 
     if (params.local) local_init();
 
-    diag();
+    diag(*ref_wfn);
 
     dpd_close(0);
     if (params.local) local_done();

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -164,7 +164,7 @@ void diag(ccenergy::CCEnergyWavefunction& wfn) {
 
     // Total Energy, Transition Irrep, Correlation Energy, # Converged
     // We need the variables in this order for sorting purposes.
-    std::vector<std::tuple<double, int, double, int>> state_data;
+    std::vector<std::tuple<double, int, double>> state_data;
 
     outfile->Printf("Symmetry of ground state: %s\n", moinfo.irr_labs[moinfo.sym].c_str());
     // Master Loop over transition symmetries

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -41,6 +41,7 @@
 #include <string>
 #include <sstream>
 #include <cmath>
+#include "psi4/cc/ccwave.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
@@ -131,7 +132,7 @@ void amp_write_ROHF(dpdfile2 *, dpdfile2 *, dpdbuf4 *, dpdbuf4 *, dpdbuf4 *, int
 void overlap(int C_irr, int current);
 void overlap_stash(int C_irr);
 
-void diag() {
+void diag(ccenergy::CCEnergyWavefunction& wfn) {
     dpdfile2 CME, CME2, Cme, SIA, Sia, RIA, Ria, DIA, Dia, tIA, tia, LIA, Lia;
     dpdbuf4 CMNEF, Cmnef, CMnEf, SIJAB, Sijab, SIjAb, RIJAB, Rijab, RIjAb, RIjbA;
     dpdbuf4 CMnEf1, CMnfE1, CMnfE, CMneF, C2;
@@ -161,9 +162,9 @@ void diag() {
 
     if (params.wfn == "EOM_CC3") cc3_stage = 0; /* do EOM_CCSD first */
 
-    // Total Energy, Transition Irrep, Correlation Energy
+    // Total Energy, Transition Irrep, Correlation Energy, # Converged
     // We need the variables in this order for sorting purposes.
-    std::vector<std::tuple<double, int, double>> state_data;
+    std::vector<std::tuple<double, int, double, int>> state_data;
 
     outfile->Printf("Symmetry of ground state: %s\n", moinfo.irr_labs[moinfo.sym].c_str());
     // Master Loop over transition symmetries
@@ -1071,24 +1072,28 @@ void diag() {
 
     std::map<std::string, int> irrep_counts = { {moinfo.irr_labs[moinfo.sym], 1} };
     std::sort(state_data.begin(), state_data.end());
+    std::map<std::tuple<int, int>, int> state_idx_to_identifiers;
     for (int i = 0; i < state_data.size(); ++i) {
         const auto& tuple = state_data[i];
         auto total_energy = std::get<0>(tuple);
-        auto trans_irrep = moinfo.irr_labs[std::get<1>(tuple)];
-        auto target_irrep = moinfo.irr_labs[moinfo.sym ^ std::get<1>(tuple)];
+        auto trans_irrep_lbl = moinfo.irr_labs[std::get<1>(tuple)];
+        auto target_irrep = moinfo.sym ^ std::get<1>(tuple);
+        auto target_irrep_lbl = moinfo.irr_labs[moinfo.sym ^ std::get<1>(tuple)];
         auto corr_energy = std::get<2>(tuple);
-        auto irrep_idx = irrep_counts[target_irrep];
+        auto irrep_idx = irrep_counts[target_irrep_lbl];
         const std::vector<std::string> names {"CC", short_name};
+        state_idx_to_identifiers[{irrep_idx, target_irrep}] = i + 1;
         for (const auto& name : names) {
             Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " TOTAL ENERGY"] = total_energy;
             Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " CORRELATION ENERGY"] = corr_energy;
-            Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " TOTAL ENERGY - " + trans_irrep + " TRANSITION"] = total_energy;
-            Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " CORRELATION ENERGY - " + trans_irrep + " TRANSITION"] = corr_energy;
-            Process::environment.globals[name + " ROOT " + std::to_string(irrep_idx) + " (" + target_irrep + ") TOTAL ENERGY"] = total_energy;
-            Process::environment.globals[name + " ROOT " + std::to_string(irrep_idx) + " (" + target_irrep + ") CORRELATION ENERGY"] = corr_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " TOTAL ENERGY - " + trans_irrep_lbl + " TRANSITION"] = total_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(i + 1) + " CORRELATION ENERGY - " + trans_irrep_lbl + " TRANSITION"] = corr_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(irrep_idx) + " (" + target_irrep_lbl + ") TOTAL ENERGY"] = total_energy;
+            Process::environment.globals[name + " ROOT " + std::to_string(irrep_idx) + " (" + target_irrep_lbl + ") CORRELATION ENERGY"] = corr_energy;
         }
-        irrep_counts[target_irrep]++;
+        irrep_counts[target_irrep_lbl]++;
     }
+    wfn.state_idx_to_identifiers = state_idx_to_identifiers;
 
     outfile->Printf("\tTotal # of sigma evaluations: %d\n", nsigma_evaluations);
     return;

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -55,6 +55,7 @@ class CCEnergyWavefunction : public Wavefunction {
     double compute_energy() override;
 
     std::map<std::string, SharedMatrix> get_amplitudes();
+    std::map<std::tuple<int, int>, int> state_idx_to_identifiers;
 
    private:
     /* setup, info and teardown */

--- a/tests/cc56/input.dat
+++ b/tests/cc56/input.dat
@@ -39,19 +39,21 @@ compare_values(ref0A2, core.variable("CCSD ROOT 0 (A2) TOTAL ENERGY"), 6, "Root 
 ### Transition checks
 
 test_data = { # TEST
-"ROOT 0 (B1) -> ROOT 0 (A2)": {"OSCILLATOR STRENGTH (LEN)": 0.00407528, "EINSTEIN A (LEN)": 3.86413231e+07, "EINSTEIN B (LEN)": 1.36907729e+18}, # TEST
-"ROOT 0 (B1) -> ROOT 1 (B1)": {"OSCILLATOR STRENGTH (LEN)": 0.00317063, "EINSTEIN A (LEN)": 2.32728034e+07, "EINSTEIN B (LEN)": 1.21063018e+18}, # TEST
-"ROOT 1 (B1) -> ROOT 0 (A2)": {"OSCILLATOR STRENGTH (LEN)": 0.09372883, "EINSTEIN A (LEN)": 1.28314944e+07, "EINSTEIN B (LEN)": 2.62052705e+20}, # TEST
+(0, "B1", 0, 0, "A2", 2, "B2"): {"OSCILLATOR STRENGTH (LEN)": 0.00407528, "EINSTEIN A (LEN)": 3.86413231e+07, "EINSTEIN B (LEN)": 1.36907729e+18}, # TEST
+(0, "B1", 0, 1, "B1", 1, "A1"): {"OSCILLATOR STRENGTH (LEN)": 0.00317063, "EINSTEIN A (LEN)": 2.32728034e+07, "EINSTEIN B (LEN)": 1.21063018e+18}, # TEST
+(1, "B1", 1, 0, "A2", 2, "B2"): {"OSCILLATOR STRENGTH (LEN)": 0.09372883, "EINSTEIN A (LEN)": 1.28314944e+07, "EINSTEIN B (LEN)": 2.62052705e+20}, # TEST
 }
 
 for transition, data in test_data.items(): # TEST
     for property, value in data.items(): # TEST
-        # Change these numbers to 6 ASAP # TEST
-        if "EINSTEIN" not in property: # TEST
-            compare_values(value, wfn.variable(f"CC {transition} {property}"), 4, f"CC {transition} {property}") # TEST
-            compare_values(value, wfn.variable(f"CCSD {transition} {property}"), 4, f"CCSD {transition} {property}") # TEST
-        else: # TEST 
-            # Large numbers need "special" testing. # TEST
-            compare_values(value, wfn.variable(f"CC {transition} {property}"), f"CC {transition} {property}", atol=1e-6, rtol=1e-4) # TEST
-            compare_values(value, wfn.variable(f"CCSD {transition} {property}"), f"CCSD {transition} {property}", atol=1e-6, rtol=1e-4) # TEST
-
+        for name in {"CC", "CCSD"}: # TEST
+            prop1 = f"{name} ROOT {transition[0]} ({transition[1]}) -> ROOT {transition[3]} ({transition[4]}) {property}" # TEST
+            prop2 = f"{name} ROOT {transition[2]} -> ROOT {transition[5]} {property}" # TEST
+            prop3 = f"{name} ROOT {transition[2]} -> ROOT {transition[5]} {property} - {transition[6]} TRANSITION" # TEST
+            for propstring in {prop1, prop2, prop3}: # TEST
+                # Change these numbers to 6 ASAP # TEST
+                if "EINSTEIN" not in property: # TEST
+                    compare_values(value, wfn.variable(propstring), 4, propstring) # TEST
+                else: # TEST 
+                    # Large numbers need "special" testing. # TEST
+                    compare_values(value, wfn.variable(propstring), propstring, atol=1e-6, rtol=1e-4) # TEST

--- a/tests/cc56/output.ref
+++ b/tests/cc56/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {oscillator} 6a3e691 dirty
+                         Git: Rev {ccvar} 6447c91 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Wednesday, 30 March 2022 07:54PM
+    Psi4 started on: Friday, 08 April 2022 06:31AM
 
-    Process ID: 43953
+    Process ID: 3665
     Host:       Jonathons-MacBook-Pro.local
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
@@ -82,27 +82,28 @@ compare_values(ref0A2, core.variable("CCSD ROOT 0 (A2) TOTAL ENERGY"), 6, "Root 
 ### Transition checks
 
 test_data = { # TEST
-"ROOT 0 (B1) -> ROOT 0 (A2)": {"OSCILLATOR STRENGTH (LEN)": 0.00407528, "EINSTEIN A (LEN)": 3.86413231e+07, "EINSTEIN B (LEN)": 1.36907729e+18}, # TEST
-"ROOT 0 (B1) -> ROOT 1 (B1)": {"OSCILLATOR STRENGTH (LEN)": 0.00317063, "EINSTEIN A (LEN)": 2.32728034e+07, "EINSTEIN B (LEN)": 1.21063018e+18}, # TEST
-"ROOT 1 (B1) -> ROOT 0 (A2)": {"OSCILLATOR STRENGTH (LEN)": 0.09372883, "EINSTEIN A (LEN)": 1.28314944e+07, "EINSTEIN B (LEN)": 2.62052705e+20}, # TEST
+(0, "B1", 0, 0, "A2", 2, "B2"): {"OSCILLATOR STRENGTH (LEN)": 0.00407528, "EINSTEIN A (LEN)": 3.86413231e+07, "EINSTEIN B (LEN)": 1.36907729e+18}, # TEST
+(0, "B1", 0, 1, "B1", 1, "A1"): {"OSCILLATOR STRENGTH (LEN)": 0.00317063, "EINSTEIN A (LEN)": 2.32728034e+07, "EINSTEIN B (LEN)": 1.21063018e+18}, # TEST
+(1, "B1", 1, 0, "A2", 2, "B2"): {"OSCILLATOR STRENGTH (LEN)": 0.09372883, "EINSTEIN A (LEN)": 1.28314944e+07, "EINSTEIN B (LEN)": 2.62052705e+20}, # TEST
 }
 
 for transition, data in test_data.items(): # TEST
     for property, value in data.items(): # TEST
-        # Change these numbers to 6 ASAP # TEST
-        if "EINSTEIN" not in property: # TEST
-            compare_values(value, wfn.variable(f"CC {transition} {property}"), 4, f"CC {transition} {property}") # TEST
-            compare_values(value, wfn.variable(f"CCSD {transition} {property}"), 4, f"CCSD {transition} {property}") # TEST
-        else: # TEST 
-            # Large numbers need "special" testing. # TEST
-            compare_values(value, wfn.variable(f"CC {transition} {property}"), f"CC {transition} {property}", atol=1e-6, rtol=1e-4) # TEST
-            compare_values(value, wfn.variable(f"CCSD {transition} {property}"), f"CCSD {transition} {property}", atol=1e-6, rtol=1e-4) # TEST
-
-
+        for name in {"CC", "CCSD"}: # TEST
+            prop1 = f"{name} ROOT {transition[0]} ({transition[1]}) -> ROOT {transition[3]} ({transition[4]}) {property}" # TEST
+            prop2 = f"{name} ROOT {transition[2]} -> ROOT {transition[5]} {property}" # TEST
+            prop3 = f"{name} ROOT {transition[2]} -> ROOT {transition[5]} {property} - {transition[6]} TRANSITION" # TEST
+            for propstring in {prop1, prop2, prop3}: # TEST
+                # Change these numbers to 6 ASAP # TEST
+                if "EINSTEIN" not in property: # TEST
+                    compare_values(value, wfn.variable(propstring), 4, propstring) # TEST
+                else: # TEST 
+                    # Large numbers need "special" testing. # TEST
+                    compare_values(value, wfn.variable(propstring), propstring, atol=1e-6, rtol=1e-4) # TEST
 --------------------------------------------------------------------------
 
 *** tstart() called on Jonathons-MacBook-Pro.local
-*** at Wed Mar 30 19:54:09 2022
+*** at Fri Apr  8 06:31:06 2022
 
    => Loading Basis Set <=
 
@@ -219,12 +220,12 @@ for transition, data in test_data.items(): # TEST
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:   -75.45138545885210   -7.54514e+01   0.00000e+00 
-   @UHF iter   1:   -75.59434232951337   -1.42957e-01   1.97082e-02 ADIIS/DIIS
-   @UHF iter   2:   -75.63015583706979   -3.58135e-02   5.43743e-03 ADIIS/DIIS
-   @UHF iter   3:   -75.63268588969441   -2.53005e-03   2.01607e-03 ADIIS/DIIS
-   @UHF iter   4:   -75.63312484070842   -4.38951e-04   6.75724e-04 ADIIS/DIIS
-   @UHF iter   5:   -75.63322148552749   -9.66448e-05   3.18025e-04 ADIIS/DIIS
-   @UHF iter   6:   -75.63325293931678   -3.14538e-05   1.04643e-04 ADIIS/DIIS
+   @UHF iter   1:   -75.59434232951337   -1.42957e-01   1.97082e-02 DIIS/ADIIS
+   @UHF iter   2:   -75.63015583706979   -3.58135e-02   5.43743e-03 DIIS/ADIIS
+   @UHF iter   3:   -75.63268588969441   -2.53005e-03   2.01607e-03 DIIS/ADIIS
+   @UHF iter   4:   -75.63312484070842   -4.38951e-04   6.75724e-04 DIIS/ADIIS
+   @UHF iter   5:   -75.63322148552749   -9.66448e-05   3.18025e-04 DIIS/ADIIS
+   @UHF iter   6:   -75.63325293931678   -3.14538e-05   1.04643e-04 DIIS/ADIIS
    @UHF iter   7:   -75.63325683335215   -3.89404e-06   1.76417e-05 DIIS
    @UHF iter   8:   -75.63325691990526   -8.65531e-08   2.74375e-06 DIIS
    @UHF iter   9:   -75.63325692136199   -1.45673e-09   6.07445e-07 DIIS
@@ -323,15 +324,15 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Wed Mar 30 19:54:09 2022
+*** tstop() called on Jonathons-MacBook-Pro.local at Fri Apr  8 06:31:08 2022
 Module time:
-	user time   =       0.52 seconds =       0.01 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.91 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.52 seconds =       0.01 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.91 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -357,7 +358,7 @@ Total time:
 
 
 *** tstart() called on Jonathons-MacBook-Pro.local
-*** at Wed Mar 30 19:54:09 2022
+*** at Fri Apr  8 06:31:08 2022
 
 
 	Wfn Parameters:
@@ -501,15 +502,15 @@ Total time:
 	Two-electron energy          =     14.02531145411560
 	Reference energy             =    -75.63325692144656
 
-*** tstop() called on Jonathons-MacBook-Pro.local at Wed Mar 30 19:54:09 2022
+*** tstop() called on Jonathons-MacBook-Pro.local at Fri Apr  8 06:31:08 2022
 Module time:
-	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.20 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.58 seconds =       0.01 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       1.01 seconds =       0.02 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
             **************************
             *                        *
             *        CCENERGY        *
@@ -1308,26 +1309,62 @@ Doing transition
     Left-Right CCSD Overlap...............................................................PASSED
     Root 1 (A1) Energy....................................................................PASSED
     Root 0 (A2) Energy....................................................................PASSED
-    CC ROOT 0 (B1) -> ROOT 0 (A2) OSCILLATOR STRENGTH (LEN)...............................PASSED
+    CCSD ROOT 0 -> ROOT 2 OSCILLATOR STRENGTH (LEN) - B2 TRANSITION.......................PASSED
     CCSD ROOT 0 (B1) -> ROOT 0 (A2) OSCILLATOR STRENGTH (LEN).............................PASSED
-    CC ROOT 0 (B1) -> ROOT 0 (A2) EINSTEIN A (LEN)........................................PASSED
+    CCSD ROOT 0 -> ROOT 2 OSCILLATOR STRENGTH (LEN).......................................PASSED
+    CC ROOT 0 -> ROOT 2 OSCILLATOR STRENGTH (LEN).........................................PASSED
+    CC ROOT 0 (B1) -> ROOT 0 (A2) OSCILLATOR STRENGTH (LEN)...............................PASSED
+    CC ROOT 0 -> ROOT 2 OSCILLATOR STRENGTH (LEN) - B2 TRANSITION.........................PASSED
     CCSD ROOT 0 (B1) -> ROOT 0 (A2) EINSTEIN A (LEN)......................................PASSED
-    CC ROOT 0 (B1) -> ROOT 0 (A2) EINSTEIN B (LEN)........................................PASSED
+    CCSD ROOT 0 -> ROOT 2 EINSTEIN A (LEN)................................................PASSED
+    CCSD ROOT 0 -> ROOT 2 EINSTEIN A (LEN) - B2 TRANSITION................................PASSED
+    CC ROOT 0 (B1) -> ROOT 0 (A2) EINSTEIN A (LEN)........................................PASSED
+    CC ROOT 0 -> ROOT 2 EINSTEIN A (LEN)..................................................PASSED
+    CC ROOT 0 -> ROOT 2 EINSTEIN A (LEN) - B2 TRANSITION..................................PASSED
+    CCSD ROOT 0 -> ROOT 2 EINSTEIN B (LEN) - B2 TRANSITION................................PASSED
+    CCSD ROOT 0 -> ROOT 2 EINSTEIN B (LEN)................................................PASSED
     CCSD ROOT 0 (B1) -> ROOT 0 (A2) EINSTEIN B (LEN)......................................PASSED
-    CC ROOT 0 (B1) -> ROOT 1 (B1) OSCILLATOR STRENGTH (LEN)...............................PASSED
+    CC ROOT 0 -> ROOT 2 EINSTEIN B (LEN)..................................................PASSED
+    CC ROOT 0 (B1) -> ROOT 0 (A2) EINSTEIN B (LEN)........................................PASSED
+    CC ROOT 0 -> ROOT 2 EINSTEIN B (LEN) - B2 TRANSITION..................................PASSED
     CCSD ROOT 0 (B1) -> ROOT 1 (B1) OSCILLATOR STRENGTH (LEN).............................PASSED
-    CC ROOT 0 (B1) -> ROOT 1 (B1) EINSTEIN A (LEN)........................................PASSED
+    CCSD ROOT 0 -> ROOT 1 OSCILLATOR STRENGTH (LEN) - A1 TRANSITION.......................PASSED
+    CCSD ROOT 0 -> ROOT 1 OSCILLATOR STRENGTH (LEN).......................................PASSED
+    CC ROOT 0 -> ROOT 1 OSCILLATOR STRENGTH (LEN) - A1 TRANSITION.........................PASSED
+    CC ROOT 0 -> ROOT 1 OSCILLATOR STRENGTH (LEN).........................................PASSED
+    CC ROOT 0 (B1) -> ROOT 1 (B1) OSCILLATOR STRENGTH (LEN)...............................PASSED
+    CCSD ROOT 0 -> ROOT 1 EINSTEIN A (LEN) - A1 TRANSITION................................PASSED
+    CCSD ROOT 0 -> ROOT 1 EINSTEIN A (LEN)................................................PASSED
     CCSD ROOT 0 (B1) -> ROOT 1 (B1) EINSTEIN A (LEN)......................................PASSED
-    CC ROOT 0 (B1) -> ROOT 1 (B1) EINSTEIN B (LEN)........................................PASSED
+    CC ROOT 0 -> ROOT 1 EINSTEIN A (LEN) - A1 TRANSITION..................................PASSED
+    CC ROOT 0 -> ROOT 1 EINSTEIN A (LEN)..................................................PASSED
+    CC ROOT 0 (B1) -> ROOT 1 (B1) EINSTEIN A (LEN)........................................PASSED
+    CCSD ROOT 0 -> ROOT 1 EINSTEIN B (LEN)................................................PASSED
     CCSD ROOT 0 (B1) -> ROOT 1 (B1) EINSTEIN B (LEN)......................................PASSED
-    CC ROOT 1 (B1) -> ROOT 0 (A2) OSCILLATOR STRENGTH (LEN)...............................PASSED
+    CCSD ROOT 0 -> ROOT 1 EINSTEIN B (LEN) - A1 TRANSITION................................PASSED
+    CC ROOT 0 -> ROOT 1 EINSTEIN B (LEN)..................................................PASSED
+    CC ROOT 0 -> ROOT 1 EINSTEIN B (LEN) - A1 TRANSITION..................................PASSED
+    CC ROOT 0 (B1) -> ROOT 1 (B1) EINSTEIN B (LEN)........................................PASSED
     CCSD ROOT 1 (B1) -> ROOT 0 (A2) OSCILLATOR STRENGTH (LEN).............................PASSED
-    CC ROOT 1 (B1) -> ROOT 0 (A2) EINSTEIN A (LEN)........................................PASSED
+    CCSD ROOT 1 -> ROOT 2 OSCILLATOR STRENGTH (LEN).......................................PASSED
+    CCSD ROOT 1 -> ROOT 2 OSCILLATOR STRENGTH (LEN) - B2 TRANSITION.......................PASSED
+    CC ROOT 1 (B1) -> ROOT 0 (A2) OSCILLATOR STRENGTH (LEN)...............................PASSED
+    CC ROOT 1 -> ROOT 2 OSCILLATOR STRENGTH (LEN).........................................PASSED
+    CC ROOT 1 -> ROOT 2 OSCILLATOR STRENGTH (LEN) - B2 TRANSITION.........................PASSED
     CCSD ROOT 1 (B1) -> ROOT 0 (A2) EINSTEIN A (LEN)......................................PASSED
-    CC ROOT 1 (B1) -> ROOT 0 (A2) EINSTEIN B (LEN)........................................PASSED
+    CCSD ROOT 1 -> ROOT 2 EINSTEIN A (LEN) - B2 TRANSITION................................PASSED
+    CCSD ROOT 1 -> ROOT 2 EINSTEIN A (LEN)................................................PASSED
+    CC ROOT 1 -> ROOT 2 EINSTEIN A (LEN)..................................................PASSED
+    CC ROOT 1 (B1) -> ROOT 0 (A2) EINSTEIN A (LEN)........................................PASSED
+    CC ROOT 1 -> ROOT 2 EINSTEIN A (LEN) - B2 TRANSITION..................................PASSED
     CCSD ROOT 1 (B1) -> ROOT 0 (A2) EINSTEIN B (LEN)......................................PASSED
+    CCSD ROOT 1 -> ROOT 2 EINSTEIN B (LEN)................................................PASSED
+    CCSD ROOT 1 -> ROOT 2 EINSTEIN B (LEN) - B2 TRANSITION................................PASSED
+    CC ROOT 1 (B1) -> ROOT 0 (A2) EINSTEIN B (LEN)........................................PASSED
+    CC ROOT 1 -> ROOT 2 EINSTEIN B (LEN) - B2 TRANSITION..................................PASSED
+    CC ROOT 1 -> ROOT 2 EINSTEIN B (LEN)..................................................PASSED
 
-    Psi4 stopped on: Wednesday, 30 March 2022 07:54PM
-    Psi4 wall time for execution: 0:00:03.16
+    Psi4 stopped on: Friday, 08 April 2022 06:31AM
+    Psi4 wall time for execution: 0:00:06.36
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
This PR adds support for the remaining access patterns for EOM oscillator strengths and einstein coefficients.

The pieces are now in place to adapt densities and multipoles as well. I'm hopeful that will be the next PR, which should be enough to get 3 of the 4 remaining cc tests ported over.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Infrastructure Change: `ccdensity` and `cceom` now require an incoming `CCEnergyWavefunction`
- [x] Infrastructure Change: `CCEnergyWavefunction` now has a field to store excited state symmetry labels
- [x] Infrastructure Change: Some SharedWavefunction arguments became refernces to CCEnergyWavefunction
- [x] Fully moved `cceom` internal vars to new standard

## Checklist
- [x] `eom` ctests pass

## Status
- [x] Ready for review
- [x] Ready for merge
