### PR TITLE
fix docs build

### DIFF
--- a/doc/sphinxman/document_tests.pl
+++ b/doc/sphinxman/document_tests.pl
@@ -69,7 +69,6 @@ my %ExeFolder = (
    "json/"      => "json",
    "psi4numpy/" => "psi4numpy",
    "python/"    => "python",
-   "adcc/"      => "adcc",
    "brianqc/"   => "brianqc",
 );
 

--- a/doc/sphinxman/document_tests.pl
+++ b/doc/sphinxman/document_tests.pl
@@ -101,7 +101,6 @@ foreach my $File(readdir SAMPLES){
     next if $File =~ /^python$/;
     next if $File =~ /^json$/;
     next if $File =~ /^psi4numpy$/;
-    next if $File =~ /^adcc$/;
     next if $File =~ /^brianqc$/;
     next if (-d $File);  # Don't remove subdirectories
     remove_tree("$SamplesFolder/$File");


### PR DESCRIPTION
## Description
Fixes the documentation build because I forgot to remove the deleted `adcc` cmake test dir from `doc/sphinxman/document_tests.pl`

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
