### PR TITLE
findif number and nbody number and testing label.

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -808,6 +808,8 @@ def gradient(name, **kwargs):
             wfn.set_variable(f"{lowername.upper()} TOTAL GRADIENT", grad_psi_matrix)
         core.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
         wfn.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
+        core.set_variable("FINDIF NUMBER", ndisp)
+        wfn.set_variable("FINDIF NUMBER", ndisp)
 
     optstash.restore()
 
@@ -1654,6 +1656,8 @@ def hessian(name, **kwargs):
             wfn.set_variable(f"{lowername.upper()} TOTAL GRADIENT", G0)
         core.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
         wfn.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
+        core.set_variable("FINDIF NUMBER", ndisp)
+        wfn.set_variable("FINDIF NUMBER", ndisp)
 
         core.set_global_option("PARENT_SYMMETRY", "")
         optstash.restore()
@@ -1705,6 +1709,8 @@ def hessian(name, **kwargs):
             wfn.set_variable(f"{lowername.upper()} TOTAL GRADIENT", G0)
         core.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
         wfn.set_variable('CURRENT ENERGY', findif_meta_dict["reference"]["energy"])
+        core.set_variable("FINDIF NUMBER", ndisp)
+        wfn.set_variable("FINDIF NUMBER", ndisp)
 
         core.set_global_option("PARENT_SYMMETRY", "")
         optstash.restore()

--- a/pytest.ini
+++ b/pytest.ini
@@ -33,6 +33,7 @@ markers =
     df: "tests that employ density-fitting"
     dft
     dipole
+    ecp: "tests that use effective core potentials"
     extern: "tests that use the ExternalPotential object"
     fcidump
     freq

--- a/tests/cbs-xtpl-gradient/input.dat
+++ b/tests/cbs-xtpl-gradient/input.dat
@@ -40,13 +40,17 @@ scf_dz = gradient('SCF/cc-pVDZ')
 compare_matrices(ref_scf_dz, scf_dz, 6, "[1] SCF/cc-pVDZ Gradient")  #TEST
 
 scf_tz = gradient('SCF/cc-pVTZ', dertype=0)
-compare_matrices(ref_scf_tz, scf_tz, 6, "SCF/cc-pVTZ Gradient, dertype=0")  #TEST
+compare_matrices(ref_scf_tz, scf_tz, 6, "[1b] SCF/cc-pVTZ Gradient, dertype=0")  #TEST
+compare(3, variable('findif number'), "[1b] findif no.")  #TEST
 
 scf_dtz = gradient('SCF/cc-pV[23]Z', dertype=0)
-compare_matrices(ref_scf_dtz, scf_dtz, 6, "SCF/cc-pV[DT]Z Gradient, dertype=0")  #TEST
+compare_matrices(ref_scf_dtz, scf_dtz, 6, "[4b] SCF/cc-pV[DT]Z Gradient, dertype=0")  #TEST
+compare(3, variable('findif number'), "[4b] findif no.")  #TEST
+compare(2, variable('cbs number'), "[4b] cbs no.")  #TEST
 
 scf_dtz = gradient('SCF/cc-pV[23]Z')
 compare_matrices(ref_scf_dtz, scf_dtz, 6, "[4] SCF/cc-pV[DT]Z Gradient, dertype=1")  #TEST
+compare(2, variable('cbs number'), "[4] cbs no.")  #TEST
 
 # We do not currently test at this high of angular momentum
 # scf_dtqz = gradient('SCF/cc-pV[DTQ]Z')
@@ -56,6 +60,9 @@ compare_matrices(ref_scf_dtz, scf_dtz, 6, "[4] SCF/cc-pV[DT]Z Gradient, dertype=
 # MP2 TESTS
 mp2_dtz = gradient('MP2/cc-pV[DT]Z')
 compare_matrices(ref_mp2_dtz, mp2_dtz, 6, "[6] MP2/cc-pV[DT]Z Gradient")  #TEST
+compare(4, variable('cbs number'), "[6] cbs no.")  #TEST
 
 mp2_dtz = gradient('MP2/cc-pV[DT]Z', dertype='energy')
-compare_matrices(ref_mp2_dtz, mp2_dtz, 6, "MP2/cc-pV[DT]Z Gradient, dertype=0")  #TEST
+compare_matrices(ref_mp2_dtz, mp2_dtz, 6, "[6b] MP2/cc-pV[DT]Z Gradient, dertype=0")  #TEST
+compare(3, variable('findif number'), "[6b] findif no.")  #TEST
+compare(2, variable('cbs number'), "[6b] cbs no.")  #TEST

--- a/tests/cbs-xtpl-nbody/CMakeLists.txt
+++ b/tests/cbs-xtpl-nbody/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cbs-xtpl-nbody "psi;cbs")
+add_regression_test(cbs-xtpl-nbody "psi;cbs;nbody")

--- a/tests/cbs-xtpl-nbody/test_input.py
+++ b/tests/cbs-xtpl-nbody/test_input.py
@@ -1,6 +1,6 @@
 from addons import *
 
-@ctest_labeler("cbs")
+@ctest_labeler("cbs;nbody")
 def test_cbs_xtpl_nbody():
     ctest_runner(__file__)
 

--- a/tests/cc7/input.dat
+++ b/tests/cc7/input.dat
@@ -23,3 +23,4 @@ set findif points 5
 findif = gradient('ccsd', dertype=0)
 
 compare_matrices(analytic, findif, 7, "Perturbed CCSD finite-diff (5-pt) vs. analytic gradient to 10^-7") #TEST
+compare(13, variable("findif number"), "trans and rot NOT projected")  #TEST

--- a/tests/dfmp2-1/CMakeLists.txt
+++ b/tests/dfmp2-1/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dfmp2-1 "psi;quicktests;smoketests;df;dfmp2;cart")
+add_regression_test(dfmp2-1 "psi;quicktests;smoketests;df;dfmp2;cart;nbody")

--- a/tests/dfmp2-1/test_input.py
+++ b/tests/dfmp2-1/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;smoke;df;dfmp2;cart;nbody")
+def test_dfmp2_1():
+    ctest_runner(__file__)
+

--- a/tests/dfmp2-ecp/CMakeLists.txt
+++ b/tests/dfmp2-ecp/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dfmp2-ecp "quicktests;df;dfmp2;ecp")
+add_regression_test(dfmp2-ecp "quicktests;df;dfmp2;ecp;nbody")

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -39,6 +39,7 @@ set guess read
 # [He] electrons on Ne frozen,  only ECP electrons on Xe frozen
 EfHe = energy('mp2')
 compare_values(reffHe, EfHe, 8, "MP2 energy with frozen [He] and ECP")                   #TEST
+compare_integers(1, int(variable('SCF ITERATIONS')), 'niter')                            #TEST
 
 molecule ghne {
     0 1

--- a/tests/dfmp2-ecp/test_input.py
+++ b/tests/dfmp2-ecp/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;df;dfmp2;ecp;nbody")
+def test_dfmp2_ecp():
+    ctest_runner(__file__)
+

--- a/tests/dfmp2-fc/CMakeLists.txt
+++ b/tests/dfmp2-fc/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dfmp2-fc "quicktests;df;dfmp2")
+add_regression_test(dfmp2-fc "quicktests;df;dfmp2;nbody")

--- a/tests/dfmp2-fc/test_input.py
+++ b/tests/dfmp2-fc/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;df;dfmp2;nbody")
+def test_dfmp2_fc():
+    ctest_runner(__file__)
+

--- a/tests/dft-custom-dhdf/CMakeLists.txt
+++ b/tests/dft-custom-dhdf/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dft-custom-dhdf "psi;dft;scf")
+add_regression_test(dft-custom-dhdf "psi;dft;scf;nbody")

--- a/tests/dft-custom-dhdf/test_input.py
+++ b/tests/dft-custom-dhdf/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("dft;scf;nbody")
+def test_dft_custom_dhdf():
+    ctest_runner(__file__)
+

--- a/tests/dft-dsd/CMakeLists.txt
+++ b/tests/dft-dsd/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(dft-dsd "psi;dft;scf;cart")
+add_regression_test(dft-dsd "psi;dft;scf;cart;nbody")

--- a/tests/dft-dsd/test_input.py
+++ b/tests/dft-dsd/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("dft;scf;cart;nbody")
+def hide_test_dft_dsd():
+    ctest_runner(__file__)
+

--- a/tests/dft-freq/input.dat
+++ b/tests/dft-freq/input.dat
@@ -15,5 +15,4 @@ ref_freqs.set(0, 1, 3728.54) #TEST
 ref_freqs.set(0, 2, 3850.17) #TEST
 
 fd_freqs = scf_wfn.frequencies() #TEST
-compare_vectors(ref_freqs, fd_freqs, 1, "Reference vs computed frequencies to 0.1 cm^-1") #TEST 
-
+compare_vectors(ref_freqs, fd_freqs, "Reference vs computed frequencies to 0.2 cm^-1", atol=0.2)  #TEST

--- a/tests/fd-freq-energy-large/CMakeLists.txt
+++ b/tests/fd-freq-energy-large/CMakeLists.txt
@@ -1,4 +1,9 @@
 include(TestingMacros)
 
 add_regression_test(fd-freq-energy-large "psi;longtests;findif;cart;noc1")
-set_tests_properties(fd-freq-energy-large PROPERTIES COST 200)
+set_tests_properties(
+  fd-freq-energy-large
+  PROPERTIES
+    COST 1000
+    TIMEOUT 3000
+  )

--- a/tests/fd-freq-energy/input.dat
+++ b/tests/fd-freq-energy/input.dat
@@ -1,6 +1,10 @@
 #! SCF STO-3G finite-difference frequencies from energies for H2O
 import numpy as np
 
+findif_numbers_w_rproj = [13, 37, 8, 7, 2, 19]
+findif_numbers_wo_rproj = [43, 145, 13, 7, 5, 33]
+findif_numbers = findif_numbers_w_rproj
+
 molecule h2o {
   symmetry c1
   O
@@ -24,16 +28,18 @@ set findif {print 3}
 
 scf_e, scf_wfn = frequencies('scf', dertype=0, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()                                              #TEST
-compare_arrays(anal_freqs, fd_freqs, 1,                                                  #TEST
- "Analytic vs. Finite-difference (3-pt.) frequencies from energies to 0.1 cm^-1 (C1) ")  #TEST
+compare(findif_numbers[0], variable('findif number'), '3-point stencil points')          #TEST
+compare_values(anal_freqs, fd_freqs,                                                     #TEST
+ "Analytic vs. Finite-difference (3-pt.) frequencies from energies to 0.1 cm^-1 (C1) ", atol=1.e-1)  #TEST
 
 # Frequencies by 5-pt formula in C1 point group.
 set { points 5 }
 
 scf_e, scf_wfn = frequencies('scf', dertype=0, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()                                               #TEST
-compare_arrays(anal_freqs, fd_freqs, 3,                                                   #TEST
- "Analytic vs. Finite-difference (5-pt.) frequencies from energies to 0.001 cm^-1 (C1) ") #TEST
+compare(findif_numbers[1], variable('findif number'), '5-point stencil points')           #TEST
+compare_values(anal_freqs, fd_freqs,                                                      #TEST
+ "Analytic vs. Finite-difference (5-pt.) frequencies from energies to 0.001 cm^-1 (C1) ", atol=1.e-3) #TEST
 
 clean()
 
@@ -50,8 +56,9 @@ set { points 3 }
 
 scf_e, scf_wfn = frequencies('scf', dertype=0, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()                                              #TEST
-compare_arrays(anal_freqs, fd_freqs, 1,                                                  #TEST
- "Analytic vs. Finite-difference (3-pt.) frequencies from energies to 0.1 cm^-1 (C2v) ") #TEST
+compare(findif_numbers[2], variable('findif number'), '3-point stencil points')          #TEST
+compare_values(anal_freqs, fd_freqs,                                                     #TEST
+ "Analytic vs. Finite-difference (3-pt.) frequencies from energies to 0.1 cm^-1 (C2v) ", atol=1.e-1) #TEST
 
 scf_vibinfo = scf_wfn.frequency_analysis
 scf_vibonly = qcdb.vib.filter_nonvib(scf_vibinfo)
@@ -61,22 +68,24 @@ ref_b2_vibonly = qcdb.vib.filter_nonvib(scf_vibonly, remove=[i for i, d in enume
 # Compute A1 frequencies only.
 scf_e, scf_wfn = frequencies('scf', dertype=0, irrep=1, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()               #TEST
-compare_arrays(a1_freqs, fd_freqs, 1,         #TEST
- "Analytic vs. 3-pt finite-diff A1 freq from grad to 0.1 cm^-1") #TEST
+compare(findif_numbers[3], variable('findif number'), '3-point stencil points')  #TEST
+compare_values(a1_freqs, fd_freqs,         #TEST
+ "Analytic vs. 3-pt finite-diff A1 freq from grad to 0.1 cm^-1", atol=1.e-1) #TEST
 
 a1_vibinfo = scf_wfn.frequency_analysis
 a1_vibonly = qcdb.vib.filter_nonvib(a1_vibinfo)
-compare_integers(1, qcdb.compare_vibinfos(ref_a1_vibonly, a1_vibonly, 2, 'A1 analyses', verbose=0, forgive=[]), 'A1 analyses')
+compare(1, qcdb.compare_vibinfos(ref_a1_vibonly, a1_vibonly, 2, 'A1 analyses', verbose=0, forgive=[]), 'A1 analyses')
 
 # Compute B2 frequency only.
 scf_e, scf_wfn = frequencies('scf', dertype=0, irrep=4, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()               #TEST
-compare_arrays(b2_freqs, fd_freqs, 1,         #TEST
- "Analytic vs. 3-pt finite-diff B2 freq from grad to 0.1 cm^-1") #TEST
+compare(findif_numbers[4], variable('findif number'), '3-point stencil points')  #TEST
+compare_values(b2_freqs, fd_freqs,         #TEST
+ "Analytic vs. 3-pt finite-diff B2 freq from grad to 0.1 cm^-1", atol=1.e-1) #TEST
 
 b2_vibinfo = scf_wfn.frequency_analysis
 b2_vibonly = qcdb.vib.filter_nonvib(b2_vibinfo)
-compare_integers(1, qcdb.compare_vibinfos(ref_b2_vibonly, b2_vibonly, 2, 'B2 analyses', verbose=0, forgive=[]), 'B2 analyses')
+compare(1, qcdb.compare_vibinfos(ref_b2_vibonly, b2_vibonly, 2, 'B2 analyses', verbose=0, forgive=[]), 'B2 analyses')
 
 # Frequencies by 5-pt formula in C2v.
 set { points 5 }
@@ -85,8 +94,9 @@ set normal_modes_write on
 
 scf_e, scf_wfn = frequencies('scf', dertype=0, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()                                                #TEST
-compare_arrays(anal_freqs, fd_freqs, 3,                                                    #TEST
- "Analytic vs. Finite-difference (5-pt.) frequencies from energies to 0.001 cm^-1 (C2v) ") #TEST
+compare(findif_numbers[5], variable('findif number'), '3-point stencil points')            #TEST
+compare_values(anal_freqs, fd_freqs,                                                       #TEST
+ "Analytic vs. Finite-difference (5-pt.) frequencies from energies to 0.001 cm^-1 (C2v) ", atol=1.e-3) #TEST
 
 clean()
 

--- a/tests/fd-freq-gradient/input.dat
+++ b/tests/fd-freq-gradient/input.dat
@@ -14,6 +14,10 @@ set {
   scf_type pk
 }
 
+findif_numbers_w_rproj = [7, 13, 6, 5, 2, 11]
+findif_numbers_wo_rproj = [13, 25, 9, 5, 3, 17]
+findif_numbers = findif_numbers_w_rproj
+
 # Test against analytic second derivatives
 anal_freqs = np.array([2170.0460, 4140.0021, 4391.0669])  #TEST
 a1_freqs, b2_freqs = np.split(anal_freqs, [2])              #TEST
@@ -24,16 +28,18 @@ set findif {print 3}
 
 scf_e, scf_wfn = frequencies('scf', dertype=1, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()   #TEST
-compare_arrays(anal_freqs, fd_freqs, 1,       #TEST
- "Analytic vs. Finite-difference (3-pt.) frequencies from energies to 0.1 cm^-1 (C1) ")  #TEST
+compare(findif_numbers[0], variable('findif number'), '3-point stencil points')  #TEST
+compare_values(anal_freqs, fd_freqs,  #TEST
+ "Analytic vs. Finite-difference (3-pt.) frequencies from energies to 0.1 cm^-1 (C1) ", atol=1.e-1)  #TEST
 
 # Frequencies by 5-pt formula in C1 point group.
 set { points 5 }
 
 scf_e, scf_wfn = frequencies('scf', dertype=1, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()                                               #TEST
-compare_arrays(anal_freqs, fd_freqs, 3,                                                   #TEST
- "Analytic vs. Finite-difference (5-pt.) frequencies from energies to 0.001 cm^-1 (C1) ") #TEST
+compare(findif_numbers[1], variable('findif number'), '5-point stencil points')           #TEST
+compare_values(anal_freqs, fd_freqs,                                                      #TEST
+ "Analytic vs. Finite-difference (5-pt.) frequencies from energies to 0.001 cm^-1 (C1) ", atol=1.e-3) #TEST
 
 clean()
 
@@ -48,8 +54,9 @@ set { points 3 }
 
 scf_e, scf_wfn = frequencies('scf', dertype=1, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()                                               #TEST
-compare_arrays(anal_freqs, fd_freqs, 1,                                                   #TEST
- "Analytic vs. Finite-difference (3-pt.) frequencies from energies to 0.1 cm^-1 (C2v) ")  #TEST
+compare(findif_numbers[2], variable('findif number'), '3-point stencil points')           #TEST
+compare_values(anal_freqs, fd_freqs,                                                      #TEST
+ "Analytic vs. Finite-difference (3-pt.) frequencies from energies to 0.1 cm^-1 (C2v) ", atol=1.e-1)  #TEST
 
 scf_vibinfo = scf_wfn.frequency_analysis
 scf_vibonly = qcdb.vib.filter_nonvib(scf_vibinfo)
@@ -59,22 +66,24 @@ ref_b2_vibonly = qcdb.vib.filter_nonvib(scf_vibonly, remove=[i for i, d in enume
 # Compute A1 frequencies only.
 scf_e, scf_wfn = frequencies('scf', dertype=1, irrep=1, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()               #TEST
-compare_arrays(a1_freqs, fd_freqs, 1,         #TEST
- "Analytic vs. 3-pt finite-diff A1 freq from grad to 0.1 cm^-1") #TEST
+compare(findif_numbers[3], variable('findif number'), '3-point stencil points')  #TEST
+compare_values(a1_freqs, fd_freqs,         #TEST
+ "Analytic vs. 3-pt finite-diff A1 freq from grad to 0.1 cm^-1", atol=1.e-1) #TEST
 
 a1_vibinfo = scf_wfn.frequency_analysis
 a1_vibonly = qcdb.vib.filter_nonvib(a1_vibinfo)
-compare_integers(1, qcdb.compare_vibinfos(ref_a1_vibonly, a1_vibonly, 2, 'A1 analyses', verbose=0, forgive=[]), 'A1 analyses')
+compare(1, qcdb.compare_vibinfos(ref_a1_vibonly, a1_vibonly, 2, 'A1 analyses', verbose=0, forgive=[]), 'A1 analyses')
 
 # Compute B2 frequency only.
 scf_e, scf_wfn = frequencies('scf', dertype=1, irrep=4, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()               #TEST
-compare_arrays(b2_freqs, fd_freqs, 1,         #TEST
- "Analytic vs. 3-pt finite-diff B2 freq from grad to 0.1 cm^-1") #TEST
+compare(findif_numbers[4], variable('findif number'), '3-point stencil points')  #TEST
+compare_values(b2_freqs, fd_freqs,          #TEST
+ "Analytic vs. 3-pt finite-diff B2 freq from grad to 0.1 cm^-1", atol=1.e-1) #TEST
 
 b2_vibinfo = scf_wfn.frequency_analysis
 b2_vibonly = qcdb.vib.filter_nonvib(b2_vibinfo)
-compare_integers(1, qcdb.compare_vibinfos(ref_b2_vibonly, b2_vibonly, 2, 'B2 analyses', verbose=0, forgive=[]), 'B2 analyses')
+compare(1, qcdb.compare_vibinfos(ref_b2_vibonly, b2_vibonly, 2, 'B2 analyses', verbose=0, forgive=[]), 'B2 analyses')
 
 # Compute all frequencies with 5-point formula.
 set findif { points 5 }
@@ -83,7 +92,8 @@ set normal_modes_write on
 
 scf_e, scf_wfn = frequencies('scf', dertype=1, return_wfn=True)
 fd_freqs = scf_wfn.frequencies().to_array()               #TEST
-compare_arrays(anal_freqs, fd_freqs, 3,       #TEST
- "Analytic vs. 5-pt finite-diff freq from grad to 0.001 cm^-1") #TEST
+compare(findif_numbers[5], variable('findif number'), '5-point stencil points')  #TEST
+compare_values(anal_freqs, fd_freqs,       #TEST
+ "Analytic vs. 5-pt finite-diff freq from grad to 0.001 cm^-1", atol=1.e-3) #TEST
 
 clean()

--- a/tests/fd-gradient/input.dat
+++ b/tests/fd-gradient/input.dat
@@ -17,12 +17,14 @@ set findif { points 3 }
 fd_grad = gradient('scf', dertype=0)
 
 compare_matrices(fd_grad, anal_grad, 4, "3-point finite-difference vs. analytic gradient to 10^-4 (C1)") #TEST
+compare(7, variable('findif number'), '3-point stencil points')  #TEST
 
 # Test gradient by 5-point formula
 set findif { points 5 }
 fd_grad = gradient('scf', dertype=0)
 
 compare_matrices(fd_grad, anal_grad, 8, "5-point finite-difference vs. analytic gradient to 10^-8 (C1)") #TEST
+compare(13, variable('findif number'), '5-point stencil points')  #TEST
 
 clean()
 
@@ -39,9 +41,11 @@ set findif { points 3 }
 fd_grad = gradient('scf', dertype=0)
 
 compare_matrices(fd_grad, anal_grad, 4, "3-point finite-difference vs. analytic gradient to 10^-4 (C2v)") #TEST
+compare(5, variable('findif number'), '3-point stencil points')  #TEST
 
 # Test gradient by 5-point formula
 set findif { points 5 }
 fd_grad = gradient('scf', dertype=0)
 
 compare_matrices(fd_grad, anal_grad, 8, "5-point finite-difference vs. analytic gradient to 10^-8 (C2v)") #TEST
+compare(9, variable('findif number'), '5-point stencil points')  #TEST

--- a/tests/mp2-def2/CMakeLists.txt
+++ b/tests/mp2-def2/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(mp2-def2 "psi;mp2;cart")
+add_regression_test(mp2-def2 "psi;mp2;cart;nbody")

--- a/tests/mp2-def2/test_input.py
+++ b/tests/mp2-def2/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("mp2;cart;nbody")
+def test_mp2_def2():
+    ctest_runner(__file__)
+

--- a/tests/nbody-convergence/CMakeLists.txt
+++ b/tests/nbody-convergence/CMakeLists.txt
@@ -1,5 +1,9 @@
 include(TestingMacros)
 
 add_regression_test(nbody-convergence "psi;nbody;gradient")
-set_tests_properties(nbody-convergence PROPERTIES TIMEOUT 3000)
-set_tests_properties(nbody-convergence PROPERTIES COST 1500)
+set_tests_properties(
+  nbody-convergence
+  PROPERTIES
+    COST 1500
+    TIMEOUT 3000
+  )

--- a/tests/nbody-convergence/test_input.py
+++ b/tests/nbody-convergence/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;gradient")
+def test_nbody_convergence():
+    ctest_runner(__file__)
+

--- a/tests/nbody-cp-gradient/test_input.py
+++ b/tests/nbody-cp-gradient/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;gradient")
+def test_nbody_cp_gradient():
+    ctest_runner(__file__)
+

--- a/tests/nbody-freq/test_input.py
+++ b/tests/nbody-freq/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;freq;hessian;gradient;opt")
+def test_nbody_freq():
+    ctest_runner(__file__)
+

--- a/tests/nbody-he-cluster/test_input.py
+++ b/tests/nbody-he-cluster/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;cart")
+def test_nbody_he_cluster():
+    ctest_runner(__file__)
+

--- a/tests/nbody-hessian/test_input.py
+++ b/tests/nbody-hessian/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;hessian")
+def test_nbody_hessian():
+    ctest_runner(__file__)
+

--- a/tests/nbody-intermediates/test_input.py
+++ b/tests/nbody-intermediates/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody") 
+def test_nbody_intermediates():
+    ctest_runner(__file__)
+

--- a/tests/nbody-nocp-gradient/input.dat
+++ b/tests/nbody-nocp-gradient/input.dat
@@ -22,6 +22,7 @@ units bohr
 
 g, wfn = gradient('SCF/STO-3G', molecule=water_trimer, bsse_type='nocp', max_nbody=2,
                                       return_total_data=True, return_wfn=True)
+compare(6, wfn.variable("NBODY NUMBER"), "nbody number")  #TEST
 core.clean()
 
 nocp_scheme = {'((1, 2), (1, 2))': 1, '((1, 3), (1, 3))': 1, '((2, 3), (2, 3))': 1, #TEST

--- a/tests/nbody-nocp-gradient/test_input.py
+++ b/tests/nbody-nocp-gradient/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;gradient")
+def test_nbody_nocp_gradient():
+    ctest_runner(__file__)
+

--- a/tests/nbody-vmfc-gradient/test_input.py
+++ b/tests/nbody-vmfc-gradient/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;gradient")
+def test_nbody_vmfc_gradient():
+    ctest_runner(__file__)
+

--- a/tests/nbody-vmfc-hessian/test_input.py
+++ b/tests/nbody-vmfc-hessian/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("nbody;hessian")
+def test_nbody_vmfc_hessian():
+    ctest_runner(__file__)
+

--- a/tests/pytests/test_addons.py
+++ b/tests/pytests/test_addons.py
@@ -904,6 +904,7 @@ def test_gpu_dfcc():
 
 
 
+@pytest.mark.nbody
 @uusing("dftd3")
 @uusing("gcp")
 def test_grimme_3c():

--- a/tests/pytests/test_addons_qcschema.py
+++ b/tests/pytests/test_addons_qcschema.py
@@ -562,6 +562,7 @@ def test_v2rdm_casscf():
 #    assert psi4.compare_values(en_gpu_dfcc, en_dfcc, 8, "CCSD total energy")
 
 
+@pytest.mark.nbody
 @uusing("dftd3")
 @uusing("gcp")
 def test_grimme_3c():

--- a/tests/pytests/test_dft_benchmarks.py
+++ b/tests/pytests/test_dft_benchmarks.py
@@ -176,6 +176,7 @@ def test_dft_bench_ionization(func, expected, basis, dft_bench_systems, request)
 
 
 
+@pytest.mark.nbody
 @pytest.mark.scf
 @pytest.mark.dft
 @pytest.mark.long

--- a/tests/pytests/test_nbody.py
+++ b/tests/pytests/test_nbody.py
@@ -1,0 +1,145 @@
+import re
+import pytest
+import numpy as np
+from qcelemental.testing import compare, compare_values
+import psi4
+
+pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.nbody]
+
+_tot_cp_ene = -155.40761029
+_ie_cp_ene = -0.00172611
+_tot_uncp_ene = -155.40887161
+_ie_uncp_ene = -0.00298743
+
+_tot_cp_grad = np.array(
+    [[-0.            ,  0.003989481299,  0.000257671876],
+     [ 0.            , -0.003989481299,  0.000257671876],
+     [-0.007206301768,  0.004333142371,  0.000029433226],
+     [ 0.007206301768,  0.004333142371,  0.000029433226],
+     [ 0.007206301768, -0.004333142371,  0.000029433226],
+     [-0.007206301768, -0.004333142371,  0.000029433226],
+     [-0.            , -0.            , -0.035555548002],
+     [-0.            ,  0.            ,  0.035547129205],
+     [ 0.            , -0.            ,  0.00840988492 ],
+     [ 0.            ,  0.            , -0.009034542779]])
+_ie_cp_grad = np.array(
+    [[-0.           ,   0.000831523566,  0.000095334214],
+     [ 0.           ,  -0.000831523566,  0.000095334214],
+     [-0.00011127085,   0.000096261386,  0.000110602057],
+     [ 0.00011127085,   0.000096261386,  0.000110602057],
+     [ 0.00011127085,  -0.000096261386,  0.000110602057],
+     [-0.00011127085,  -0.000096261386,  0.000110602057],
+     [-0.           ,   0.            , -0.00139615575 ],
+     [-0.           ,   0.            , -0.000684195246],
+     [ 0.           ,   0.            ,  0.001393980177],
+     [ 0.           ,   0.            ,  0.000053294161]])
+_tot_uncp_grad = np.array(
+    [[-0.            ,  0.004688102439,  0.000019589414],
+     [ 0.            , -0.004688102439,  0.000019589414],
+     [-0.007232900028,  0.004303778033,  0.000005580357],
+     [ 0.007232900028,  0.004303778033,  0.000005580357],
+     [ 0.007232900028, -0.004303778033,  0.000005580357],
+     [-0.007232900028, -0.004303778033,  0.000005580357],
+     [-0.            ,  0.            , -0.035419642667],
+     [-0.            ,  0.            ,  0.03585801241 ],
+     [ 0.            ,  0.            ,  0.008543047852],
+     [ 0.            ,  0.            , -0.009042917851]])
+_ie_uncp_grad = np.array(
+    [[-0.           ,   0.001530144706, -0.000142748248],
+     [ 0.           ,  -0.001530144706, -0.000142748248],
+     [-0.00013786911,   0.000066897048,  0.000086749188],
+     [ 0.00013786911,   0.000066897048,  0.000086749188],
+     [ 0.00013786911,  -0.000066897048,  0.000086749188],
+     [-0.00013786911,  -0.000066897048,  0.000086749188],
+     [-0.           ,   0.            , -0.001260250416],
+     [-0.           ,  -0.            , -0.000373312041],
+     [ 0.           ,   0.            ,  0.00152714311 ],
+     [ 0.           ,   0.            ,  0.000044919089]])
+
+
+_stdouts = {
+    "cp_T": r"""
+\s*   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+\s*  n-Body     Total Energy \[Eh\]       I.E. \[kcal/mol\]      Delta \[kcal/mol\]
+\s*        1     -155.4058841\d\d\d\d\d        0.000000000000        0.000000000000
+\s*        2     -155.4076102\d\d\d\d\d       -1.08315\d\d\d\d\d\d\d       -1.08315\d\d\d\d\d\d\d
+""",
+    "cp_F": r"""
+\s*   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+\s*  n-Body     Total Energy \[Eh\]       I.E. \[kcal/mol\]      Delta \[kcal/mol\]
+\s*        1                   N/A        0.000000000000        0.000000000000
+\s*        2                   N/A       -1.08315\d\d\d\d\d\d\d       -1.08315\d\d\d\d\d\d\d
+""",
+    "uncp": r"""
+\s*   ==> N-Body: Non-Counterpoise Corrected \(NoCP\) energies <==
+\s*  n-Body     Total Energy \[Eh\]       I.E. \[kcal/mol\]      Delta \[kcal/mol\]
+\s*        1     -155.4058841\d\d\d\d\d        0.000000000000        0.000000000000
+\s*        2     -155.4088716\d\d\d\d\d       -1.87464\d\d\d\d\d\d\d       -1.87464\d\d\d\d\d\d\d
+""",
+}
+_stdouts["cpuncp"] = _stdouts["cp_T"] + _stdouts["uncp"]
+
+
+@pytest.mark.parametrize("driver,bsse_type,return_total_data,nbody_number,return_result,stdoutkey", [
+    ("energy",   ["cp"],         True , 5, _tot_cp_ene,   "cp_T"),     # return CP tot         5
+    ("energy",   ["cp"],         False, 3, _ie_cp_ene,    "cp_F"),     # return CP IE          3
+    ("energy",   ["cp"],         None , 3, _ie_cp_ene,    "cp_F"),     # return CP IE          3
+    ("energy",   ["nocp"],       True , 3, _tot_uncp_ene, "uncp"),     # return tot            3
+    ("energy",   ["nocp"],       False, 3, _ie_uncp_ene,  "uncp"),     # return IE             3
+    ("energy",   ["nocp"],       None , 3, _ie_uncp_ene,  "uncp"),     # return IE             3
+    ("energy",   ["cp", "nocp"], True , 5, _tot_cp_ene,   "cpuncp"),   # return CP tot         5
+    ("energy",   ["cp", "nocp"], False, 5, _ie_cp_ene,    "cpuncp"),   # return CP IE          5
+    ("energy",   ["cp", "nocp"], None , 5, _ie_cp_ene,    "cpuncp"),   # return CP IE          5
+    ("energy",   ["nocp", "cp"], True , 5, _tot_uncp_ene, "cpuncp"),   # return tot            5
+    ("energy",   ["nocp", "cp"], False, 5, _ie_uncp_ene,  "cpuncp"),   # return IE             5
+    ("energy",   ["nocp", "cp"], None , 5, _ie_uncp_ene,  "cpuncp"),   # return IE             5
+    ("gradient", ["cp"],         True , 5, _tot_cp_grad,   "cp_T"),    # return CP tot G       5
+    ("gradient", ["cp"],         False, 3, _ie_cp_grad,    "cp_F"),    # return CP IE G        3
+    ("gradient", ["cp"],         None , 5, _tot_cp_grad,   "cp_T"),    # return CP tot G       5
+    ("gradient", ["nocp"],       True , 3, _tot_uncp_grad, "uncp"),    # return tot G          3
+    ("gradient", ["nocp"],       False, 3, _ie_uncp_grad,  "uncp"),    # return IE G           3
+    ("gradient", ["nocp"],       None , 3, _tot_uncp_grad, "uncp"),    # return tot G          3
+    ("gradient", ["cp", "nocp"], True , 5, _tot_cp_grad,   "cpuncp"),  # return CP tot G       5
+    ("gradient", ["cp", "nocp"], False, 5, _ie_cp_grad,    "cpuncp"),  # return CP IE G        5
+    ("gradient", ["cp", "nocp"], None , 5, _tot_cp_grad,   "cpuncp"),  # return CP tot G       5
+    ("gradient", ["nocp", "cp"], True , 5, _tot_uncp_grad, "cpuncp"),  # return tot G          5
+    ("gradient", ["nocp", "cp"], False, 5, _ie_uncp_grad,  "cpuncp"),  # return IE G           5
+    ("gradient", ["nocp", "cp"], None , 5, _tot_uncp_grad, "cpuncp"),  # return tot G          5
+])
+def test_nbody_number(driver, bsse_type, return_total_data, nbody_number, return_result, stdoutkey):
+
+    eneyne = psi4.geometry("""
+C   0.000000  -0.667578  -2.124659
+C   0.000000   0.667578  -2.124659
+H   0.923621  -1.232253  -2.126185
+H  -0.923621  -1.232253  -2.126185
+H  -0.923621   1.232253  -2.126185
+H   0.923621   1.232253  -2.126185
+--
+C   0.000000   0.000000   2.900503
+C   0.000000   0.000000   1.693240
+H   0.000000   0.000000   0.627352
+H   0.000000   0.000000   3.963929
+""")
+
+    atin = {
+        "driver": driver,
+        "model": {
+            "method": "mp2",
+            "basis": "cc-pvdz",
+        },
+        "molecule": eneyne.to_schema(dtype=2),
+        "keywords": {
+            "function_kwargs": {
+                "bsse_type": bsse_type,
+                "return_total_data": return_total_data,
+            },
+        },
+    }
+
+    ret = psi4.schema_wrapper.run_qcschema(atin)
+
+    assert compare_values(return_result, ret.return_result, atol=1.e-6, label="manybody")
+    assert compare(nbody_number, ret.extras["qcvars"]["NBODY NUMBER"], label="nbody number")
+    assert re.search(_stdouts[stdoutkey], ret.stdout, re.MULTILINE), f"N-Body pattern not found: {_stdouts[stdoutkey]}"
+

--- a/tests/pytests/test_nbody_multi_level_qcschema.py
+++ b/tests/pytests/test_nbody_multi_level_qcschema.py
@@ -1,0 +1,81 @@
+#! Multilevel computation of water trimer energy (geometry from J. Chem. Theory Comput. 11, 2126-2136 (2015))
+import copy
+import pprint
+
+import pytest
+
+import psi4
+
+pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.nbody]
+
+@pytest.fixture
+def base_schema():
+    h2o_trimer = psi4.geometry("""
+    O      -2.76373224  -1.24377706  -0.15444566
+    H      -1.12357791  -2.06227970  -0.05243799
+    H      -3.80792362  -2.08705525   1.06090407
+    --
+    O       2.46924614  -1.75437739  -0.17092884
+    H       3.76368260  -2.21425403   1.00846104
+    H       2.30598330   0.07098445  -0.03942473
+    --
+    O       0.29127930   3.00875625   0.20308515
+    H      -1.21253048   1.95820900   0.10303324
+    H       0.10002049   4.24958115  -1.10222079
+    units bohr
+    """)
+
+    _base_schema = {
+        'schema_name': 'qcschema_input',
+        'schema_version': 1,
+        "extras": {
+            "psiapi": True,
+            "wfn_qcvars_only": True,
+        },
+        'molecule': h2o_trimer.to_schema(dtype=2),
+        'keywords': {
+            'function_kwargs': {
+            },
+            'cc_type': 'df',
+        },
+        'model': {
+            'basis': '(auto)',
+        },
+        'driver': 'energy',
+    }
+
+    return _base_schema
+
+
+@pytest.mark.parametrize("inp,expected", [
+    # Compute 1-body contribution with ccsd(t) and 2-body contribution with mp2
+    pytest.param({'method': '', 'kfk': {'bsse_type': ['nocp', 'cp', 'vmfc'], 'return_total_data': True, 'levels': {1: 'mp2/sto-3g', 2: 'scf/sto-3g'}}},
+                 {'2NOCP': -225.019408434635, '2CP': -225.000173661598, '2VMFC': -224.998744381484},
+                 id='nbody-multilevel'),
+    # Compute 1-body contribution with ccsd(t) and estimate all higher order contributions with scf
+    pytest.param({'method': '', 'kfk': {'bsse_type': 'nocp', 'return_total_data': True, 'levels': {1: 'mp2/sto-3g', 'supersystem': 'scf/sto-3g'}}},
+                 {'1NOCP': -224.998373505116, '3NOCP': -225.023509855159},
+                 id='nbody-multilevel-supersys'),
+    # Compute electrostatically embedded  many-body expansion energy.with TIP3P charges
+    pytest.param({'method': 'scf/sto-3g', 'kfk': {'bsse_type': 'vmfc', 'return_total_data': True, 'levels': None, 'max_nbody': 2,
+                                                  'embedding_charges': {i: [j for j in [-0.834, 0.417, 0.417]] for i in range(1, 4)}}},
+                 {'1': -224.940138148882, '2': -224.943882712817},
+                 id='nbody-embedded'),
+])
+def test_nbody_levels(inp, expected, base_schema):
+    # reference for nbody-multilevel generated with this larger fitting basis for sto-3g. fails otherwise by 3.e-5
+    basfams = psi4.driver.qcdb.basislist.load_basis_families()
+    for fam in basfams:
+        if fam.ornate == "STO-3G":
+            fam.add_rifit("def2-qzvpp-ri")
+
+    jin = copy.deepcopy(base_schema)
+    jin['model']['method'] = inp['method']
+    jin['keywords']['function_kwargs'] = inp['kfk']
+
+    otp = psi4.schema_wrapper.run_qcschema(jin)
+    pprint.pprint(otp)
+
+    for b, v in expected.items():
+        assert psi4.compare_values(v, otp.extras["qcvars"][b], 6, b)
+

--- a/tests/pytests/test_psi4.py
+++ b/tests/pytests/test_psi4.py
@@ -82,6 +82,7 @@ def test_psi4_cas():
     assert psi4.compare_values(-76.073865006902, casscf_energy, 6, 'CASSCF Energy')
 
 
+@pytest.mark.nbody
 @pytest.mark.smoke
 def test_psi4_dfmp2():
     """dfmp2-1"""

--- a/tests/tu6-cp-ne2/CMakeLists.txt
+++ b/tests/tu6-cp-ne2/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(tu6-cp-ne2 "psi;tutorial")
+add_regression_test(tu6-cp-ne2 "psi;tutorial;nbody")

--- a/tests/tu6-cp-ne2/test_input.py
+++ b/tests/tu6-cp-ne2/test_input.py
@@ -1,6 +1,6 @@
 from addons import *
 
-@ctest_labeler("tutorial")
+@ctest_labeler("tutorial;nbody")
 def test_tu6_cp_ne2():
     ctest_runner(__file__)
 


### PR DESCRIPTION
## Description
This is No. 8 of the DDD series, #1351.

## Todos
- [x] qcvars `FINDIF NUMBER` and `NBODY NUMBER` are handy to confirm those wrappers are planning correctly. This PR forward-ports more tests of those vars
- [x] two more detailed nbody tests are forward-ported. one is a copy of a ctest only run through qcschema. the other checks the total vs ie return that was wrong in nbody for a while and solved by #2221.
- [x] add "nbody" label/mark to ctests and pytests systematically. make all nbody tests runable through pytest.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
