### PR TITLE
bump ambit, clear addons from azure

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -88,20 +88,8 @@ jobs:
         psi4/label/dev::gau2grid \
         psi4/label/dev::libint2=*=h2fe1556_15 \
         psi4/label/dev::libxc=5 \
-        psi4/label/dev::ambit \
-        psi4/label/dev::chemps2 \
-        psi4/label/dev::dkh \
-        psi4/label/dev::gdma \
-        psi4/label/dev::pcmsolver \
-        psi4/label/dev::simint \
         psi4/label/dev::dftd3 \
         psi4/label/dev::gcp \
-        psi4/label/dev::resp \
-        psi4/label/dev::pycppe \
-        psi4/label/dev::pylibefp \
-        psi4/label/dev::snsmp2 \
-        psi4/label/dev::fockci \
-        psi4/label/dev::mp2d \
         psi4/label/dev::pybind11-headers \
         blas=*=mkl \
         mkl-include \
@@ -112,18 +100,10 @@ jobs:
         msgpack-python \
         conda-forge::qcelemental \
         conda-forge::qcengine \
-        conda-forge::pymdi \
-        pandas!=1.3.0 \
-        adcc::adcc \
         scipy
       source activate p4env
       which python
-      pip install git+https://github.com/i-pi/i-pi.git@master-py3
       conda list
-      python -c "import adcc;print(adcc.__file__, adcc.__version__)"
-      # ADCC causing build failures, beleived to be related to use of pandas 1.3.0.
-      # Temporarily printing debug information until problem resolved without needing
-      # to blacklist 1.3.0.
     displayName: 'Build Environment'
 
   - bash: |
@@ -142,24 +122,13 @@ jobs:
         -DCMAKE_C_COMPILER=${C_COMPILER} \
         -DCMAKE_Fortran_COMPILER=${F_COMPILER} \
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-        -DMAX_AM_ERI=4 \
+        -DMAX_AM_ERI=5 \
         -DCMAKE_PREFIX_PATH=${CONDA}/envs/p4env \
         -DPython_EXECUTABLE="${CONDA}/envs/p4env/bin/python" \
         -DMPFR_ROOT=${CONDA}/envs/p4env \
         -DCMAKE_INSIST_FIND_PACKAGE_gau2grid=ON \
         -DCMAKE_INSIST_FIND_PACKAGE_Libint2=ON \
         -DCMAKE_INSIST_FIND_PACKAGE_Libxc=ON \
-        -DENABLE_adcc=ON \
-        -DENABLE_CheMPS2=OFF \
-        -DENABLE_dkh=ON \
-        -DENABLE_libefp=ON \
-        -DENABLE_erd=OFF \
-        -DENABLE_gdma=ON \
-        -DENABLE_PCMSolver=OFF \
-        -DENABLE_simint=ON \
-        -DENABLE_Libint1t=OFF \
-        -DENABLE_snsmp2=OFF \
-        -DENABLE_v2rdm_casscf=OFF \
         -DENABLE_PLUGIN_TESTING=ON \
         -DBUILD_Libint2_GENERATOR=OFF \
         -DCMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -122,7 +122,6 @@ jobs:
                         numpy ^
                         pint ^
                         pybind11=2.7.0 ^
-                        pymdi ^
                         pytest>=7.0.1 ^
                         pytest-xdist ^
                         python=%PYTHON_VERSION% ^
@@ -136,7 +135,6 @@ jobs:
                         conda-forge::qcelemental ^
                         conda-forge::qcengine ^
                         scipy
-          pip install git+https://github.com/i-pi/i-pi.git@master-py3
           conda install --only-deps anaconda-client
           pip install git+https://github.com/loriab/anaconda-client.git@upload-catch-silent
           which anaconda

--- a/external/upstream/ambit/CMakeLists.txt
+++ b/external/upstream/ambit/CMakeLists.txt
@@ -28,7 +28,7 @@ if(${ENABLE_ambit})
             DEPENDS lapack_external
                     hdf5_external
                     pybind11_external
-            URL https://github.com/jturney/ambit/archive/v0.6.tar.gz
+            URL https://github.com/jturney/ambit/archive/733c529.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/ambit/CMakeLists.txt
+++ b/external/upstream/ambit/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${ENABLE_ambit})
-    find_package(ambit CONFIG QUIET)
+    find_package(ambit 0.6 CONFIG QUIET)
 
     if(${ambit_FOUND})
         get_property(_loc TARGET ambit::ambit PROPERTY LOCATION)
@@ -27,7 +27,8 @@ if(${ENABLE_ambit})
         ExternalProject_Add(ambit_external
             DEPENDS lapack_external
                     hdf5_external
-            URL https://github.com/jturney/ambit/archive/v0.5.1.tar.gz
+                    pybind11_external
+            URL https://github.com/jturney/ambit/archive/v0.6.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -37,6 +38,7 @@ if(${ENABLE_ambit})
                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                        -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+                       -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
                        -DSTATIC_ONLY=${_a_only}
                        -DSHARED_ONLY=${_so_only}
                        -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant
@@ -46,22 +48,12 @@ if(${ENABLE_ambit})
                        -DEXTRA_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                        -DPython_EXECUTABLE=${Python_EXECUTABLE}
                        -DPython_INCLUDE_DIR=${Python_INCLUDE_DIRS}
-                       -DPython_LIBRARY=${Python_LIBRARIES}
-                       -DPYTHON_EXECUTABLE=${Python_EXECUTABLE}
-                       -DPYTHON_INCLUDE_DIR=${Python_INCLUDE_DIRS}
-                       -DPYTHON_LIBRARY=${Python_LIBRARIES}
-                       -DPYTHON_INTERPRETER=${Python_EXECUTABLE}
+                       -DPython_LIBRARY=${Python_LIBRARIES}                       
                        -DENABLE_XHOST=${ENABLE_XHOST}
                        -DBUILD_FPIC=${BUILD_FPIC}
                        -DENABLE_GENERIC=${ENABLE_GENERIC}
                        -DLIBC_INTERJECT=${LIBC_INTERJECT}
                        -DENABLE_TESTS=OFF
-                       #-DENABLE_STATIC=${ENABLE_STATIC}
-                       #-DENABLE_PSI4=ON
-                       #-DPSI4_SOURCE_DIR=${PROJECT_SOURCE_DIR}/psi4
-                       #-DPSI4_BINARY_DIR=${CMAKE_BINARY_DIR}
-                       #-DPSI4_INCLUDE_DIRS=${PYTHON_INCLUDE_DIR}
-                       #-DENABLE_CXX11_SUPPORT=ON
                        -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
                        -DTargetLAPACK_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetLAPACK
                        -DTargetHDF5_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/TargetHDF5

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -74,7 +74,7 @@ message(STATUS "${Cyan}Using Python ${Python_VERSION_MAJOR}.${Python_VERSION_MIN
 find_package(DL)
 
 if(${ENABLE_ambit})
-    find_package(ambit CONFIG REQUIRED)
+    find_package(ambit 0.6 CONFIG REQUIRED)
     get_property(_loc TARGET ambit::ambit PROPERTY LOCATION)
     list(APPEND _addons ${_loc})
     message(STATUS "${Cyan}Using ambit${ColourReset}: ${_loc} (version ${ambit_VERSION})")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Todos
- [x] Psi doesn't use ambit directly so never has required a version. Now that it's had its python interface updated (kill the boost!), most uses in the presence of Psi4 will need the new version, so let's not let lingering old versions pass.
- [x] The ecosystem GHA seems to have settled in nicely to testing addons, so let's remove that responsibility from the Azure CI lanes.
  - leaving dftd3 and gcp since they're fast, easy, and important
  - now addons tested with less compiler variety on Linux, but I don't think that's too big a problem

## Status
- [x] Ready for review
- [x] Ready for merge
