### PR TITLE
Fix Incfock Convergence Bug

### DIFF
--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -385,7 +385,7 @@ void DirectJK::compute_JK() {
         timer_on("DirectJK: INCFOCK Preprocessing");
         incfock_setup();
         int reset = options_.get_int("INCFOCK_FULL_FOCK_EVERY");
-        double dconv = options_.get_double("D_CONVERGENCE");
+        double dconv = options_.get_double("INCFOCK_CONVERGENCE");
         double Dnorm = Process::environment.globals["SCF D NORM"];
         // Do IFB on this iteration?
         do_incfock_iter_ = (Dnorm >= dconv) && !initial_iteration_ && (incfock_count_ % reset != reset - 1);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1456,6 +1456,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Frequency with which to compute the full Fock matrix if using |scf__incfock| . 
         N means rebuild every N SCF iterations to avoid accumulating error from the incremental procedure. -*/
         options.add_int("INCFOCK_FULL_FOCK_EVERY", 5);
+        /*- The density threshold in which to stop performing INCFOCK -*/
+        options.add_double("INCFOCK_CONVERGENCE", 1.0e-5);
 
         /*- Perform the linear scaling exchange (LinK) algorithm, as described in [Ochsenfeld:1998:1663]_.
             Only applies to Direct SCF. -*/


### PR DESCRIPTION
## Description
Incremental Fock Build (In Direct JK algorithm), was supposed to have a feature where it stops after the density matrix has dropped below a certain cutoff. In my old code, I set that value to be the value of SCF D_CONVERGENCE, but that was a mistake, as this value is supposed to be higher than the SCF D_CONVERGENCE value. I fix that bug in this PR.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Fix INCFOCK bug

## Status
- [x] Ready for review
- [ ] Ready for merge
