### PR TITLE
ddd modifications to findif

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -710,7 +710,8 @@ def gradient(name, **kwargs):
             print('Performing finite difference calculations')
 
         # Obtain list of displacements
-        findif_meta_dict = driver_findif.gradient_from_energies_geometries(molecule)
+        fdargs = driver_findif.prep_findif(molecule, irrep=None, mode="1_0", gradient=None)
+        findif_meta_dict = driver_findif.gradient_from_energies_geometries(molecule, **fdargs)
         ndisp = len(findif_meta_dict["displacements"]) + 1
 
         print(""" %d displacements needed ...""" % (ndisp), end='')
@@ -1559,7 +1560,8 @@ def hessian(name, **kwargs):
             """hessian() will perform frequency computation by finite difference of analytic gradients.\n""")
 
         # Obtain list of displacements
-        findif_meta_dict = driver_findif.hessian_from_gradients_geometries(molecule, irrep)
+        fdargs = driver_findif.prep_findif(molecule, irrep, mode="2_0", gradient=G0)
+        findif_meta_dict = driver_findif.hessian_from_gradients_geometries(molecule, **fdargs)
 
         # Record undisplaced symmetry for projection of displaced point groups
         core.set_global_option("PARENT_SYMMETRY", molecule.schoenflies_symbol())
@@ -1615,7 +1617,8 @@ def hessian(name, **kwargs):
         optstash_conv = driver_util.negotiate_convergence_criterion((2, 0), lowername, return_optstash=True)
 
         # Obtain list of displacements
-        findif_meta_dict = driver_findif.hessian_from_energies_geometries(molecule, irrep)
+        fdargs = driver_findif.prep_findif(molecule, irrep, mode="2_0", gradient=G0)
+        findif_meta_dict = driver_findif.hessian_from_energies_geometries(molecule, **fdargs)
 
         # Record undisplaced symmetry for projection of diplaced point groups
         core.set_global_option("PARENT_SYMMETRY", molecule.schoenflies_symbol())

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -751,9 +751,7 @@ def gradient(name, **kwargs):
 
     optstash.restore()
 
-    if core.get_option('FINDIF', 'GRADIENT_WRITE'):
-        filename = core.get_writer_file_prefix(wfn.molecule().name()) + ".grad"
-        qcdb.gradparse.to_string(np.asarray(wfn.gradient()), filename, dtype='GRD', mol=molecule, energy=wfn.energy())
+    driver_findif.gradient_write(wfn)
 
     if return_wfn:
         return (wfn.gradient(), wfn)
@@ -1662,7 +1660,7 @@ def hessian(name, **kwargs):
         optstash.restore()
         optstash_conv.restore()
 
-    _hessian_write(wfn)
+    driver_findif.hessian_write(wfn)
 
     if return_wfn:
         return (wfn.hessian(), wfn)
@@ -1896,13 +1894,6 @@ def vibanal_wfn(wfn: core.Wavefunction, hess: np.ndarray = None, irrep: Union[in
             handle.write(qcdb.vib.print_molden_vibs(vibinfo, symbols, geom, standalone=True))
 
     return vibinfo
-
-
-def _hessian_write(wfn):
-    if core.get_option('FINDIF', 'HESSIAN_WRITE'):
-        filename = core.get_writer_file_prefix(wfn.molecule().name()) + ".hess"
-        with open(filename, 'wb') as handle:
-            qcdb.hessparse.to_string(np.asarray(wfn.hessian()), handle, dtype='psi4')
 
 
 def gdma(wfn, datafile=""):

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -1078,6 +1078,23 @@ def prep_findif(mol, irrep, mode, gradient=None):
         return fdargs
 
 
+def hessian_write(wfn: core.Wavefunction):
+    if core.get_option('FINDIF', 'HESSIAN_WRITE'):
+        filename = core.get_writer_file_prefix(wfn.molecule().name()) + ".hess"
+        with open(filename, 'wb') as handle:
+            qcdb.hessparse.to_string(np.asarray(wfn.hessian()), handle, dtype='psi4')
+
+
+def gradient_write(wfn: core.Wavefunction):
+    if core.get_option('FINDIF', 'GRADIENT_WRITE'):
+        filename = core.get_writer_file_prefix(wfn.molecule().name()) + ".grad"
+        qcdb.gradparse.to_string(np.asarray(wfn.gradient()),
+                                 filename,
+                                 dtype='GRD',
+                                 mol=wfn.molecule(),
+                                 energy=wfn.energy())
+
+
 def _rms(arr: Union[core.Matrix, np.ndarray]) -> float:
     """Compute root-mean-square of array, be it Psi4 or NumPy array."""
     if isinstance(arr, np.ndarray):

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -26,106 +26,139 @@
 # @END LICENSE
 #
 
+import copy
+import logging
+from functools import partial
+from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
+
 import numpy as np
+import pydantic
+from qcelemental.models import DriverEnum, AtomicResult
+from qcelemental import constants
+
 from psi4 import core
-from psi4.driver import p4util
+from psi4.driver import p4util, pp, qcdb, nppp10
 from psi4.driver.p4util.exceptions import ValidationError
-from psi4.driver import qcdb
+
+logger = logging.getLogger(__name__)
 
 # CONVENTIONS:
 # n_ at the start of a variable name is short for "number of."
 # _pi at the end of a variable name is short for "per irrep."
 # h is the index of an irrep.
 
-array_format = {"precision": 10}
 
-
-def _displace_cart(mol, geom, salc_list, i_m, step_size):
+def _displace_cart(mass: np.ndarray, geom: np.ndarray, salc_list: "psi4.core.CdSalcList", i_m: Iterator[Tuple], step_size: float) -> Tuple[np.ndarray, str]:
     """Displace a geometry along the specified displacement SALCs.
+    Called within :py:func:`_geom_generator` so from each displacement mode: [gradient|hessian]_from_[gradients|energies]_geometries.
 
     Parameters
     ----------
-    mol : qcdb.molecule or :py:class:`~psi4.core.Molecule`
-        The molecule to displace
-    geom : ndarray
+    mass
+        (nat, ) masses [u] of atoms of the molecule (const).
+    geom
         (nat, 3) reference geometry [a0] of the molecule (const).
-    salc_list : :py:class:`~psi4.core.CdSalcList`
+    salc_list
         A list of Cartesian displacement SALCs
-    i_m : iterator of tuples
+    i_m
         An iterator containing tuples. Each tuple has the index of a salc in
         salc_list and the number of steps (positive or negative) to displace
         the salc at that index.
-    step_size : float
+    step_size
         The size of a single "step," i.e., the stencil size.
 
     Returns
-    ------
-    label : str
+    -------
+    disp_geom
+        (nat, 3) Displaced geometry.
+    label
         Displacement label for the metadata dictionary.
 
     """
-    label = ""
+    label = []
+    disp_geom = np.copy(geom)
     # This for loop and tuple unpacking is why the function can handle
     # an arbitrary number of SALCs.
     for salc_index, disp_steps in i_m:
         # * Python error if iterate through `salc_list`
         for i in range(len(salc_list[salc_index])):
-            component = salc_list[salc_index][i]
-            geom[component.atom, component.xyz] += (
-                disp_steps * step_size * component.coef / np.sqrt(mol.mass(component.atom)))
-        # salc_index is in descending order. We want the label in ascending order, so...
-        # ...add the new label part from the left of the string, not the right.
-        label = "{:d}: {:d}".format(salc_index, disp_steps) + (", " if label else "") + label
-    return label
+            salc = salc_list[salc_index][i]
+            disp_geom[salc.atom, salc.xyz] += disp_steps * step_size * salc.coef / np.sqrt(mass[salc.atom])
+        label.append(f"{salc_index}: {disp_steps}")
+
+    # salc_index is in descending order. We want the label in ascending order, so...
+    # ...add the new label part from the left of the string, not the right.
+    label = ', '.join(reversed(label))
+    return disp_geom, label
 
 
-def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0):
+def _initialize_findif(mol: Union["qcdb.Molecule", core.Molecule],
+                       freq_irrep_only: int,
+                       mode: str,
+                       stencil_size: int,
+                       step_size: float,
+                       initialize_string: Callable,
+                       t_project: bool,
+                       r_project: bool,
+                       initialize: bool,
+                       verbose: int = 0) -> Dict:
     """Perform initialization tasks needed by all primary functions.
+    Called by _geom_generator and each assembly mode: assemble_[gradient|dipder|hessian]_from_[energies|dipoles|gradients].
 
     Parameters
     ----------
-    mol : qcdb.molecule or :py:class:`~psi4.core.Molecule`
+    mol
         The molecule to displace
-    freq_irrep_only : int
+    freq_irrep_only
         The Cotton ordered irrep to get frequencies for. Choose -1 for all
         irreps.
     mode : {"1_0", "2_0", "2_1"}
          The first number specifies the derivative level determined from
          displacements, and the second number is the level determined at.
-    initialize_string : function
+    stencil_size : {3, 5}
+        Number of points to evaluate for each displacement basis vector inclusive of central reference geometry.
+    step_size
+        [a0]
+    initialize_string
          A function that returns the string to print to show the caller was entered.
          The string is both caller-specific and dependent on values determined
          in this function.
-    verbose : int
+    initialize
+        For printing, whether call is from generator or assembly stages.
+    verbose
          Set to 0 to silence extra print information, regardless of the print level.
          Used so the information is printed only during geometry generation, and not
          during the derivative computation as well.
 
     Returns
     -------
-    data : dict
+    data
         Miscellaneous information required by callers.
     """
 
-    core.print_out("\n         ----------------------------------------------------------\n")
-    core.print_out("                                   FINDIF\n")
-    core.print_out("                     R. A. King and Jonathon Misiewicz\n")
-    core.print_out("         ---------------------------------------------------------\n\n")
+    info = """
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ----------------------------------------------------------
+
+"""
+    if initialize:
+        core.print_out(info)
+        logger.info(info)
 
     print_lvl = core.get_option("FINDIF", "PRINT")
-    num_pts = core.get_option("FINDIF", "POINTS")
-    disp_size = core.get_option("FINDIF", "DISP_SIZE")
 
-    data = {"print_lvl": print_lvl, "num_pts": num_pts, "disp_size": disp_size}
+    data = {"print_lvl": print_lvl, "stencil_size": stencil_size, "step_size": step_size}
 
     if print_lvl:
-        core.print_out(initialize_string(data))
+        info = initialize_string(data)
+        core.print_out(info)
+        logger.info(info)
 
     # Get settings for CdSalcList, then get the CdSalcList.
     method_allowed_irreps = 0x1 if mode == "1_0" else 0xFF
-    t_project = not core.get_global_option("EXTERN") and (not core.get_global_option("PERTURB_H"))
     # core.get_option returns an int, but CdSalcList expect a bool, so re-cast
-    r_project = t_project and bool(core.get_option("FINDIF", "FD_PROJECT"))
     salc_list = core.CdSalcList(mol, method_allowed_irreps, t_project, r_project)
 
     n_atom = mol.natom()
@@ -133,12 +166,14 @@ def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0)
     n_salc = salc_list.ncd()
 
     if print_lvl and verbose:
-        core.print_out(f"    Number of atoms is {n_atom}.\n")
+        info = f"    Number of atoms is {n_atom}.\n"
         if method_allowed_irreps != 0x1:
-            core.print_out(f"    Number of irreps is {n_irrep}.\n")
-        core.print_out("    Number of {!s}SALCs is {:d}.\n".format(
-            "" if method_allowed_irreps != 0x1 else "symmetric ", n_salc))
-        core.print_out("    Translations projected? {:d}. Rotations projected? {:d}.\n".format(t_project, r_project))
+            info += f"    Number of irreps is {n_irrep}.\n"
+        info += "    Number of {!s}SALCs is {:d}.\n".format("" if method_allowed_irreps != 0x1 else "symmetric ",
+                                                            n_salc)
+        info += f"    Translations projected? {t_project:d}. Rotations projected? {r_project:d}.\n"
+        core.print_out(info)
+        logger.info(info)
 
     # TODO: Replace with a generator from a stencil to a set of points.
     # Diagonal displacements differ between the totally symmetric irrep, compared to all others.
@@ -156,8 +191,10 @@ def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0)
         }
     }
 
-    if num_pts not in pts_dict:
-        raise ValidationError("FINDIF: Invalid number of points!")
+    try:
+        disps = pts_dict[stencil_size]
+    except KeyError:
+        raise ValidationError(f"FINDIF: Number of points ({stencil_size}) not among {pts_dict.keys()}!")
 
     # Convention: x_pi means x_per_irrep. The ith element is x for irrep i, with Cotton ordering.
     salc_indices_pi = [[] for h in range(n_irrep)]
@@ -167,7 +204,8 @@ def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0)
         salc_indices_pi[freq_irrep_only]
     except (TypeError, IndexError):
         if freq_irrep_only != -1:
-            raise ValidationError("FINDIF: Irrep value not in valid range.")
+            raise ValidationError(
+                f"FINDIF: 0-indexed Irrep value ({freq_irrep_only}) not in valid range: <{len(salc_indices_pi)}.")
 
     # Populate salc_indices_pi for all irreps.
     # * Python error if iterate through `salc_list`
@@ -176,15 +214,17 @@ def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0)
 
     # If the method allows more than one irrep, print how the irreps partition the SALCS.
     if print_lvl and method_allowed_irreps != 0x1 and verbose:
-        core.print_out("    Index of SALCs per irrep:\n")
+        info = "    Index of SALCs per irrep:\n"
         for h in range(n_irrep):
             if print_lvl > 1 or freq_irrep_only in {h, -1}:
                 tmp = (" {:d} " * len(salc_indices_pi[h])).format(*salc_indices_pi[h])
-                core.print_out("     {:d} : ".format(h + 1) + tmp + "\n")
-        core.print_out("    Number of SALCs per irrep:\n")
+                info += "      {:d} : ".format(h + 1) + tmp + "\n"
+        info += "    Number of SALCs per irrep:\n"
         for h in range(n_irrep):
             if print_lvl > 1 or freq_irrep_only in {h, -1}:
-                core.print_out("     Irrep {:d}: {:d}\n".format(h + 1, len(salc_indices_pi[h])))
+                info += "      Irrep {:d}: {:d}\n".format(h + 1, len(salc_indices_pi[h]))
+        core.print_out(info)
+        logger.info(info)
 
     # Now that we've printed the SALCs, clear any that are not of user-specified symmetry.
     if freq_irrep_only != -1:
@@ -193,7 +233,6 @@ def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0)
                 salc_indices_pi[h].clear()
 
     n_disp_pi = []
-    disps = pts_dict[num_pts]  # We previously validated num_pts in pts_dict.
 
     for irrep, indices in enumerate(salc_indices_pi):
         n_disp = len(indices) * len(disps["asym_irr" if irrep != 0 else "sym_irr"])
@@ -204,11 +243,13 @@ def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0)
 
     # Let's print out the number of geometries, the displacement multiplicity, and the CdSALCs!
     if print_lvl and verbose:
-        core.print_out("    Number of geometries (including reference) is {:d}.\n".format(sum(n_disp_pi) + 1))
+        info = f"    Number of geometries (including reference) is {sum(n_disp_pi) + 1}.\n"
         if method_allowed_irreps != 0x1:
-            core.print_out("    Number of displacements per irrep:\n")
+            info += "    Number of displacements per irrep:\n"
             for i, ndisp in enumerate(n_disp_pi, start=1):
-                core.print_out(f"      Irrep {i}: {ndisp}\n")
+                info += f"      Irrep {i}: {ndisp}\n"
+        core.print_out(info)
+        logger.info(info)
 
     if print_lvl > 1 and verbose:
         for i in range(len(salc_list)):
@@ -229,7 +270,7 @@ def _initialize_findif(mol, freq_irrep_only, mode, initialize_string, verbose=0)
     return data
 
 
-def _geom_generator(mol, freq_irrep_only, mode):
+def _geom_generator(mol: Union["qcdb.Molecule", core.Molecule], freq_irrep_only: int, mode: str, *, t_project: bool = True, r_project: bool = True, stencil_size: int = 3, step_size: float = 0.005) -> Dict:
     """
     Generate geometries for the specified molecule and derivative levels.
     You probably want to instead use one of the convenience functions:
@@ -238,19 +279,23 @@ def _geom_generator(mol, freq_irrep_only, mode):
 
     Parameters
     ----------
-    mol : qcdb.molecule or :py:class:`~psi4.core.Molecule`
+    mol
         The molecule on which to perform a finite difference calculation.
-    freq_irrep_only : int
+    freq_irrep_only
         The Cotton ordered irrep to get frequencies for. Choose -1 for all
-        irreps.
+        irreps. Irrelevant for "1_0".
     mode : {"1_0", "2_0", "2_1"}
         The first number specifies the targeted derivative level. The
         second number is the compute derivative level. E.g., "2_0"
         is hessian from energies.
+    stencil_size : {3, 5}
+        Number of points to evaluate for each displacement basis vector inclusive of central reference geometry.
+    step_size
+        Displacement size [a0].
 
     Returns
     -------
-    findifrec : dict
+    findifrec
         Dictionary of finite difference data, specified below.
         The dictionary makes findifrec _extensible_. If you need a new field
         in the record, just add it.
@@ -333,44 +378,47 @@ def _geom_generator(mol, freq_irrep_only, mode):
         raise ValidationError("FINDIF: Mode {} not recognized.".format(mode))
 
     def init_string(data):
-        return ("  Using finite-differences of {:s}.\n"
-                "    Generating geometries for use with {:d}-point formula.\n"
-                "    Displacement size will be {:6.2e}.\n".format(print_msg, data["num_pts"], data["disp_size"]))
+        return f"""  Using finite-differences of {print_msg}.
+    Generating geometries for use with {data["stencil_size"]}-point formula.
+    Displacement size will be {data["step_size"]:6.2e}.\n"""
 
     # Genuine support for qcdb molecules would be nice. But that requires qcdb CdSalc tech.
     # Until then, silently swap the qcdb molecule out for a psi4.core.molecule.
     if isinstance(mol, qcdb.Molecule):
         mol = core.Molecule.from_dict(mol.to_dict())
 
-    data = _initialize_findif(mol, freq_irrep_only, mode, init_string, 1)
+    data = _initialize_findif(mol, freq_irrep_only, mode, stencil_size, step_size, init_string, t_project, r_project,
+                              True, 1)
 
     # We can finally start generating displacements.
-    ref_geom = mol.geometry().clone()
+    ref_geom = np.array(mol.geometry())
 
     # Now we generate the metadata...
     findifrec = {
         "step": {
             "units": "bohr",
-            "size": data["disp_size"]
+            "size": data["step_size"]
         },
-        "stencil_size": data["num_pts"],
+        "stencil_size": data["stencil_size"],
         "displacement_space": "CdSALC",
         "project_translations": data["project_translations"],
         "project_rotations": data["project_rotations"],
-        "molecule": mol.to_schema(dtype=1, units='Bohr'),
+        "molecule": mol.to_schema(dtype=2, units='Bohr'),
         "displacements": {},
         "reference": {}
     }
 
     def append_geoms(indices, steps):
         """Given a list of indices and a list of steps to displace each, append the corresponding geometry to the list."""
-        new_geom = ref_geom.clone().np
+
         # Next, to make this salc/magnitude composite.
-        index_steps = zip(indices, steps)
-        label = _displace_cart(mol, new_geom, data["salc_list"], index_steps, data["disp_size"])
+        disp_geom, label = _displace_cart(findifrec['molecule']['masses'], ref_geom, data["salc_list"],
+                                          zip(indices, steps), data["step_size"])
         if data["print_lvl"] > 2:
-            core.print_out("\nDisplacement '{}'\n{}\n".format(label, np.array_str(new_geom, **array_format)))
-        findifrec["displacements"][label] = {"geometry": new_geom.ravel().tolist()}
+            info = "\nDisplacement '{}'\n{}\n".format(label, nppp10(disp_geom))
+            core.print_out(info)
+            logger.info(info)
+        findifrec["displacements"][label] = {"geometry": disp_geom}
 
     for h in range(data["n_irrep"]):
         active_indices = data["salc_indices_pi"][h]
@@ -390,26 +438,56 @@ def _geom_generator(mol, freq_irrep_only, mode):
                         append_geoms((index, index2), val)
 
     if data["print_lvl"] > 2:
-        core.print_out("\nReference\n{}\n".format(np.array_str(ref_geom.np, **array_format)))
-    findifrec["reference"]["geometry"] = ref_geom.np.ravel().tolist()
+        logger.info("\nReference\n{}\n".format(nppp10(ref_geom)))
+    findifrec["reference"]["geometry"] = ref_geom
 
     if data["print_lvl"] > 1:
-        core.print_out("\n-------------------------------------------------------------\n")
+        logger.info("\n-------------------------------------------------------------")
 
     return findifrec
 
 
-def assemble_gradient_from_energies(findifrec):
+_der_from_lesser_docstring = """
+    Parameters
+    ----------
+    mol
+        The molecule on which to perform a finite difference calculation.
+    freq_irrep_only
+        The Cotton ordered irrep to get frequencies for. Choose -1 for all
+        irreps. Irrelevant for "1_0".
+    stencil_size : {3, 5}
+        Number of points to evaluate for each displacement basis vector inclusive of central reference geometry.
+    step_size
+        Displacement size [a0].
+
+    Returns
+    -------
+    findifrec : dict
+        Dictionary of finite difference data, specified in _geom_generator docstring.
+
+"""
+
+
+gradient_from_energies_geometries = partial(_geom_generator, freq_irrep_only=-1, mode="1_0")
+hessian_from_gradients_geometries = partial(_geom_generator, mode="2_1")
+hessian_from_energies_geometries = partial(_geom_generator, mode="2_0")
+
+gradient_from_energies_geometries.__doc__ = "Generate geometries for a gradient by finite difference of energies." + _der_from_lesser_docstring
+hessian_from_gradients_geometries.__doc__ = "Generate geometries for a Hessian by finite difference of gradients." + _der_from_lesser_docstring
+hessian_from_energies_geometries.__doc__ = "Generate geometries for a Hessian by finite difference of energies." + _der_from_lesser_docstring
+
+
+def assemble_gradient_from_energies(findifrec: Dict) -> np.ndarray:
     """Compute the gradient by finite difference of energies.
 
     Parameters
     ----------
-    findifrec : dict
+    findifrec
         Dictionary of finite difference data, specified in _geom_generator docstring.
 
     Returns
     -------
-    gradient : ndarray
+    gradient
         (nat, 3) Cartesian gradient [Eh/a0].
     """
 
@@ -417,14 +495,14 @@ def assemble_gradient_from_energies(findifrec):
     mol = core.Molecule.from_schema(findifrec["molecule"], nonphysical=True, verbose=0)
 
     def init_string(data):
-        return ("  Computing gradient from energies.\n"
-                "    Using {:d}-point formula.\n"
-                "    Energy without displacement: {:15.10f}\n"
-                "    Check energies below for precision!\n"
-                "    Forces are for mass-weighted, symmetry-adapted cartesians (in au).\n".format(
-                    findifrec["stencil_size"], findifrec["reference"]["energy"]))
+        return f"""  Computing gradient from energies.
+    Using {findifrec["stencil_size"]}-point formula.
+    Energy without displacement: {findifrec["reference"]["energy"]:15.10f}
+    Check energies below for precision!
+    Forces are for mass-weighted, symmetry-adapted cartesians [a0].\n"""
 
-    data = _initialize_findif(mol, -1, "1_0", init_string)
+    data = _initialize_findif(mol, -1, "1_0", findifrec['stencil_size'], findifrec['step']['size'], init_string,
+                              findifrec['project_translations'], findifrec['project_rotations'], False)
     salc_indices = data["salc_indices_pi"][0]
 
     # Extract the energies, and turn then into an ndarray for easy manipulating
@@ -452,12 +530,13 @@ def assemble_gradient_from_energies(findifrec):
         energy_string = ""
         for i in range(1, max_disp + 1):
             energy_string = f"Energy(-{i})        " + energy_string + f"Energy(+{i})        "
-        core.print_out("\n     Coord      " + energy_string + "    Force\n")
+        info = "\n     Coord      " + energy_string + "    Force"
         for salc in range(data["n_salc"]):
-            print_str = "    {:5d}" + " {:17.10f}" * (e_per_salc) + " {force:17.10f}" + "\n"
+            print_str = "\n    {:5d}" + " {:17.10f}" * (e_per_salc) + " {force:17.10f}"
             energies = E[salc]
-            core.print_out(print_str.format(salc, force=g_q[salc], *energies))
-        core.print_out("\n")
+            info += print_str.format(salc, force=g_q[salc], *energies)
+        core.print_out(info)
+        logger.info(info)
 
     # Transform the gradient from mass-weighted SALCs to non-mass-weighted Cartesians
     B = data["salc_list"].matrix()
@@ -467,34 +546,37 @@ def assemble_gradient_from_energies(findifrec):
     g_cart = (g_cart.T * massweighter).T
 
     if data["print_lvl"]:
-        core.print_out("\n-------------------------------------------------------------\n")
+        info = "\n         -------------------------------------------------------------\n"
+        core.print_out(info)
+        logger.info(info)
 
     return g_cart
 
 
-def _process_hessian_symmetry_block(H_block, B_block, massweighter, irrep, print_lvl):
+def _process_hessian_symmetry_block(H_block: np.ndarray, B_block: np.ndarray, massweighter: np.ndarray, irrep: str, print_lvl: int) -> np.ndarray:
     """Perform post-construction processing for a symmetry block of the Hessian.
        Statements need to be printed, and the Hessian must be made orthogonal.
+       Called by assemble_hessian_from_gradients|energies functions.
 
     Parameters
     ---------
-    H_block : ndarray
+    H_block
         A block of the Hessian for an irrep, in mass-weighted salcs.
-        Dimensions # cdsalcs by # cdsalcs.
-    B_block : ndarray
+        (nsalc, nsalc)
+    B_block
         A block of the B matrix for an irrep, which transforms CdSalcs to Cartesians.
-        Dimensions # cdsalcs by # cartesians.
-    massweighter : ndarray
+        (nsalc, 3 * nat)
+    massweighter
         The mass associated with each atomic coordinate.
-        Dimension # cartesians. Due to x, y, z, values appear in groups of three.
-    irrep : str
+        (3 * nat, ) Due to x, y, z, values appear in groups of three.
+    irrep
         A string identifying the irrep H_block and B_block are of.
-    print_lvl : int
+    print_lvl
         The level of printing information requested by the user.
 
     Returns
     -------
-    H_block : ndarray
+    H_block
         H_block, but made into an orthogonal array.
     """
 
@@ -503,9 +585,8 @@ def _process_hessian_symmetry_block(H_block, B_block, massweighter, irrep, print
     H_block = (H_block + H_block.T) / 2.0
 
     if print_lvl >= 3:
-        core.print_out("\n    Force Constants for irrep {} in mass-weighted, ".format(irrep))
-        core.print_out("symmetry-adapted cartesian coordinates.\n")
-        core.print_out("\n{}\n".format(np.array_str(H_block, **array_format)))
+        core.print_out(f"Force Constants for irrep {irrep} in mass-weighted, symmetry-adapted Cartesian coordinates.")
+        core.print_out("\n{}\n".format(nppp10(H_block)))
 
     evals, evects = np.linalg.eigh(H_block)
     # Get our eigenvalues and eigenvectors in descending order.
@@ -517,34 +598,40 @@ def _process_hessian_symmetry_block(H_block, B_block, massweighter, irrep, print
 
     if print_lvl >= 2:
         core.print_out("\n    Normal coordinates (non-mass-weighted) for irrep {}:\n".format(irrep))
-        core.print_out("\n{}\n".format(np.array_str(normal_irr, **array_format)))
+        core.print_out("\n{}\n".format(nppp10(normal_irr)))
 
     return H_block
 
 
-def _process_hessian(H_blocks, B_blocks, massweighter, print_lvl):
+def _process_hessian(H_blocks: List[np.ndarray], B_blocks: List[np.ndarray], massweighter: np.ndarray, print_lvl: int) -> np.ndarray:
     """Perform post-construction processing for the Hessian.
        Statements need to be printed, and the Hessian must be transformed.
+       Final step in assemble_hessian_from_gradients|energies functions.
 
     Parameters
     ----------
-    H_blocks : list of ndarray
+    H_blocks
         A list of blocks of the Hessian per irrep, in mass-weighted salcs.
-        Each is dimension # cdsalcs-in-irrep by # cdsalcs-in-irrep.
-    B_blocks : list of ndarray
+        Each is dimension (# cdsalcs-in-irrep, # cdsalcs-in-irrep).
+    B_blocks
         A block of the B matrix per irrep, which transforms CdSalcs to Cartesians.
-        Each is dimensions # cdsalcs-in-irrep by # cartesians.
-    massweighter : ndarray
+        Each is dimension (# cdsalcs-in-irrep, # cartesians).
+    massweighter
         The mass associated with each atomic coordinate.
-        Dimension 3 * natom. Due to x, y, z, values appear in groups of three.
-    print_lvl : int
+        Dimension (3 * nat). Due to x, y, z, values appear in groups of three.
+    print_lvl
         The level of printing information requested by the user.
 
     Returns
     -------
-    Hx : ndarray
+    Hx
         The Hessian in non-mass weighted cartesians.
     """
+
+    # Handle empty case (atom)
+    if not H_blocks and not B_blocks:
+        nat3 = massweighter.size
+        return np.zeros((nat3, nat3), dtype=np.float64)
 
     # We have the Hessian in each irrep! The final task is to perform coordinate transforms.
     H = p4util.block_diagonal_array(*H_blocks)
@@ -552,7 +639,7 @@ def _process_hessian(H_blocks, B_blocks, massweighter, print_lvl):
 
     if print_lvl >= 3:
         core.print_out("\n    Force constant matrix for all computed irreps in mass-weighted SALCS.\n")
-        core.print_out("\n{}\n".format(np.array_str(H, **array_format)))
+        core.print_out("\n{}\n".format(nppp10(H)))
 
     # Transform the massweighted Hessian from the CdSalc basis to Cartesians.
     # The Hessian is the matrix not of a linear transformation, but of a (symmetric) bilinear form
@@ -561,14 +648,14 @@ def _process_hessian(H_blocks, B_blocks, massweighter, print_lvl):
     Hx = np.dot(np.dot(B.T, H), B)
     if print_lvl >= 3:
         core.print_out("\n    Force constants in mass-weighted Cartesian coordinates.\n")
-        core.print_out("\n{}\n".format(np.array_str(Hx, **array_format)))
+        core.print_out("\n{}\n".format(nppp10(Hx)))
 
     # Un-massweight the Hessian.
     Hx = np.transpose(Hx / massweighter) / massweighter
 
     if print_lvl >= 3:
         core.print_out("\n    Force constants in Cartesian coordinates.\n")
-        core.print_out("\n{}\n".format(np.array_str(Hx, **array_format)))
+        core.print_out("\n{}\n".format(nppp10(Hx)))
 
     if print_lvl:
         core.print_out("\n-------------------------------------------------------------\n")
@@ -576,20 +663,101 @@ def _process_hessian(H_blocks, B_blocks, massweighter, print_lvl):
     return Hx
 
 
-def assemble_hessian_from_gradients(findifrec, freq_irrep_only):
-    """Compute the Hessian by finite difference of gradients.
+def assemble_dipder_from_dipoles(findifrec: Dict, freq_irrep_only: int) -> np.ndarray:
+    """Compute the dipole derivatives by finite difference of dipoles.
 
     Parameters
     ----------
-    findifrec : dict
+    findifrec
         Dictionary of finite difference data, specified in _geom_generator docstring.
-    freq_irrep_only : int
+    freq_irrep_only
         The Cotton ordered irrep to get frequencies for. Choose -1 for all
         irreps.
 
     Returns
     -------
-    hessian : ndarray
+    dipder
+        (3 * nat, 3) Cartesian Dipole Derivatives [Eh/a0^2]
+
+    """
+
+    # This *must* be a Psi molecule at present - CdSalcList generation panics otherwise
+    mol = core.Molecule.from_schema(findifrec["molecule"], nonphysical=True, verbose=0)
+
+    pg = mol.point_group()
+    ct = pg.char_table()
+    order = pg.order()
+
+    displacements = findifrec["displacements"]
+
+    def init_string(data):
+        return ("")
+
+    data = _initialize_findif(mol, freq_irrep_only, "2_1", findifrec['stencil_size'], findifrec['step']['size'],
+                              init_string, findifrec['project_translations'], findifrec['project_rotations'], False)
+    salc_indices = data["salc_indices_pi"][0]
+    max_disp = (findifrec["stencil_size"] - 1) // 2  # The numerator had better be divisible by two.
+    d_per_salc = 2 * max_disp
+
+    # Populating with positive and negative displacements for the identity point group
+    dipole = np.zeros(shape=(data['n_salc'], d_per_salc, 3))
+    for salc_index in salc_indices:
+        for j in range(1, max_disp + 1):
+            dipole[salc_index, max_disp - j] = displacements[f"{salc_index}: {-j}"]["dipole"]
+            dipole[salc_index, max_disp + j - 1] = displacements[f"{salc_index}: {j}"]["dipole"]
+
+    for h in range(1, data["n_irrep"]):
+        # Find the group operation that converts + to - displacements.
+        gamma = ct.gamma(h)
+        for group_op in range(order):
+            if gamma.character(group_op) == -1:
+                break
+        else:
+            raise ValidationError("A symmetric dipole passed for a non-symmetric one.")
+
+        sym_op = np.array(ct.symm_operation(group_op).matrix())
+        salc_indices = data["salc_indices_pi"][h]
+
+        # Creating positive displacements and populating for the other point groups
+        for salc_index in salc_indices:
+            for j in range(1, max_disp + 1):
+                pos_disp_dipole = np.dot(sym_op, displacements[f"{salc_index}: {-j}"]["dipole"].T)
+                dipole[salc_index, max_disp - j] = displacements[f"{salc_index}: {-j}"]["dipole"]
+                dipole[salc_index, max_disp + j - 1] = pos_disp_dipole
+
+    # Computing the dipole derivative by finite differnce
+    if findifrec["stencil_size"] == 3:
+        dipder_q = (dipole[:, 1] - dipole[:, 0]) / (2.0 * findifrec["step"]["size"])
+    elif findifrec["stencil_size"] == 5:
+        dipder_q = (dipole[:, 0] - 8.0 * dipole[:, 1] + 8.0 * dipole[:, 2] -
+                    dipole[:, 3]) / (12.0 * findifrec["step"]["size"])
+
+    # Transform the dipole derivates from mass-weighted SALCs to non-mass-weighted Cartesians
+    B = np.asarray(data["salc_list"].matrix())
+    dipder_cart = np.dot(dipder_q.T, B)
+    dipder_cart = dipder_cart.T.reshape(data["n_atom"], 9)
+
+    massweighter = np.array([mol.mass(a) for a in range(data["n_atom"])])**(0.5)
+    dipder_cart = (dipder_cart.T * massweighter).T
+
+    dipder_cart = dipder_cart.reshape(3 * data["n_atom"], 3)
+    return dipder_cart
+
+
+def assemble_hessian_from_gradients(findifrec: Dict, freq_irrep_only: int) -> np.ndarray:
+    """Compute the Hessian by finite difference of gradients.
+
+    Parameters
+    ----------
+    findifrec
+        Dictionary of finite difference data, specified in _geom_generator docstring.
+    freq_irrep_only
+        The Cotton ordered irrep to get frequencies for. Choose -1 for all
+        irreps.
+
+    Returns
+    -------
+    hessian
         (3 * nat, 3 * nat) Cartesian Hessian [Eh/a0^2]
     """
 
@@ -603,7 +771,8 @@ def assemble_hessian_from_gradients(findifrec, freq_irrep_only):
                 "  symmetry-adapted, cartesian coordinates.\n\n"
                 "  {:d} gradients passed in, including the reference geometry.\n".format(len(displacements) + 1))
 
-    data = _initialize_findif(mol, freq_irrep_only, "2_1", init_string)
+    data = _initialize_findif(mol, freq_irrep_only, "2_1", findifrec['stencil_size'], findifrec['step']['size'],
+                              init_string, findifrec['project_translations'], findifrec['project_rotations'], False)
 
     # For non-totally symmetric CdSALCs, a symmetry operation can convert + and - displacements.
     # Good News: By taking advantage of that, we (potentially) ran less computations.
@@ -643,7 +812,7 @@ def assemble_hessian_from_gradients(findifrec, freq_irrep_only):
     if data["print_lvl"] >= 3:
         core.print_out("    Symmetric gradients\n")
         for gradient in gradients_pi[0]:
-            core.print_out("\n{}\n".format(np.array_str(gradient, **array_format)))
+            core.print_out("\n{}\n".format(nppp10(gradient)))
 
     # Asymmetric gradient. There's always SOME operation that transforms a positive
     # into a negative displacement.By doing extra things here, we can find the
@@ -701,7 +870,7 @@ def assemble_hessian_from_gradients(findifrec, freq_irrep_only):
         core.print_out("    All mass-weighted gradients\n")
         for gradients in gradients_pi:
             for grad in gradients:
-                core.print_out("\n{}\n".format(np.array_str(grad, **array_format)))
+                core.print_out("\n{}\n".format(nppp10(grad)))
 
     # We have all our gradients generated now!
     # Next, time to get our Hessian.
@@ -749,19 +918,19 @@ def assemble_hessian_from_gradients(findifrec, freq_irrep_only):
     return _process_hessian(H_pi, B_pi, massweighter, data["print_lvl"])
 
 
-def assemble_hessian_from_energies(findifrec, freq_irrep_only):
+def assemble_hessian_from_energies(findifrec: Dict, freq_irrep_only: int) -> np.ndarray:
     """Compute the Hessian by finite difference of energies.
 
     Parameters
     ----------
-    findifrec : dict
+    findifrec
         Dictionary of finite difference data, specified in _geom_generator docstring.
-    freq_irrep_only : int
+    freq_irrep_only
         The 0-indexed Cotton ordered irrep to get frequencies for. Choose -1 for all irreps.
 
     Returns
     -------
-    hessian : ndarray
+    hessian
         (3 * nat, 3 * nat) Cartesian Hessian [Eh/a0^2].
     """
 
@@ -772,7 +941,7 @@ def assemble_hessian_from_energies(findifrec, freq_irrep_only):
     ref_energy = findifrec["reference"]["energy"]
 
     def init_string(data):
-        max_label_len = str(max([len(label) for label in displacements]))
+        max_label_len = str(max([len(label) for label in displacements], default=3))
         out_str = ""
         for label, disp_data in displacements.items():
             out_str += ("    {:" + max_label_len + "s} : {:20.10f}\n").format(label, disp_data["energy"])
@@ -784,7 +953,8 @@ def assemble_hessian_from_energies(findifrec, freq_irrep_only):
                 "    Check energies below for precision!\n{}".format(
                     len(displacements) + 1, findifrec["stencil_size"], ref_energy, out_str))
 
-    data = _initialize_findif(mol, freq_irrep_only, "2_0", init_string)
+    data = _initialize_findif(mol, freq_irrep_only, "2_0", findifrec['stencil_size'], findifrec['step']['size'],
+                              init_string, findifrec['project_translations'], findifrec['project_rotations'], False)
 
     massweighter = np.repeat([mol.mass(a) for a in range(data["n_atom"])], 3)**(-0.5)
     B_pi = []
@@ -831,15 +1001,16 @@ def assemble_hessian_from_energies(findifrec, freq_irrep_only):
         # ...define offdiag_en to do that for us.
         for i, salc in enumerate(salc_indices):
             for j, salc2 in enumerate(salc_indices[:i]):
-                offdiag_en = lambda index: displacements["{l}: {}, {k}: {}".format(k=salc, l=salc2, *data["disps"]["off"][index])]["energy"]
+                offdiag_en = lambda index: displacements["{l}: {}, {k}: {}".format(
+                    k=salc, l=salc2, *data["disps"]["off"][index])]["energy"]
                 if findifrec["stencil_size"] == 3:
-                    fc = (+offdiag_en(0) + offdiag_en(1) + 2 * ref_energy - E[i][0] - E[i][1] - E[j][0] - E[j][1]) / (
-                        2 * findifrec["step"]["size"]**2)
+                    fc = (+offdiag_en(0) + offdiag_en(1) + 2 * ref_energy - E[i][0] - E[i][1] - E[j][0] -
+                          E[j][1]) / (2 * findifrec["step"]["size"]**2)
                 elif findifrec["stencil_size"] == 5:
                     fc = (-offdiag_en(0) - offdiag_en(1) + 9 * offdiag_en(2) - offdiag_en(3) - offdiag_en(4) +
                           9 * offdiag_en(5) - offdiag_en(6) - offdiag_en(7) + E[i][0] - 7 * E[i][1] - 7 * E[i][2] +
-                          E[i][3] + E[j][0] - 7 * E[j][1] - 7 * E[j][2] + E[j][3] + 12 * ref_energy) / (
-                              12 * findifrec["step"]["size"]**2)
+                          E[i][3] + E[j][0] - 7 * E[j][1] - 7 * E[j][2] + E[j][3] +
+                          12 * ref_energy) / (12 * findifrec["step"]["size"]**2)
                 H_irr[i, j] = fc
                 H_irr[j, i] = fc
 
@@ -850,63 +1021,70 @@ def assemble_hessian_from_energies(findifrec, freq_irrep_only):
     return _process_hessian(H_pi, B_pi, massweighter, data["print_lvl"])
 
 
-def gradient_from_energies_geometries(molecule):
-    """
-    Generate geometries for a gradient by finite difference of energies.
-    
-    Parameters
-    ----------
-    molecule : qcdb.molecule or :py:class:`~psi4.core.Molecule`
-        The molecule to compute the gradient of.
+########
 
-    Returns
-    -------
-    findifrec : dict
-        Dictionary of finite difference data, specified in _geom_generator docstring.
+# This function is shifting `_energy_is_invariant` from driver to findif but isn't in final DDD form.
+def prep_findif(mol, irrep, mode, gradient=None):
 
-    Notes
-    -----
-    Only symmetric displacements are necessary, so user specification of
-    symmetry is disabled.
-    """
-    return _geom_generator(molecule, -1, "1_0")
+        findif_stencil_size = core.get_option("FINDIF", "POINTS")
+        findif_step_size = core.get_option("FINDIF", "DISP_SIZE")
+
+        translations_projection_sound = (not core.get_option('SCF', 'EXTERN')
+                                         and not core.get_option('SCF', 'PERTURB_H')
+                                         and not hasattr(mol, 'EFP'))
+        if gradient is not None:
+            stationary_criterion = 1.e-2  # pulled out of a hat
+            stationary_point = _rms(gradient) < stationary_criterion
+
+            rotations_projection_sound = translations_projection_sound and stationary_point
+            core.print_out(
+                '\n  Based on options and gradient (rms={:.2E}), recommend {}projecting translations and {}projecting rotations.\n'
+                .format(_rms(gradient), '' if translations_projection_sound else 'not ',
+                        '' if rotations_projection_sound else 'not '))
+        else:
+            stationary_point = False  # unknown, so F to be safe
+        rotations_projection_sound_grad = translations_projection_sound
+        rotations_projection_sound_hess = translations_projection_sound and stationary_point
+
+        if core.has_option_changed('FINDIF', 'FD_PROJECT'):
+            r_project_grad = core.get_option('FINDIF', 'FD_PROJECT')
+            r_project_hess = core.get_option('FINDIF', 'FD_PROJECT')
+        else:
+            r_project_grad = rotations_projection_sound_grad
+            r_project_hess = rotations_projection_sound_hess
+
+        if mode == "1_0":
+            fdargs = {
+                "stencil_size": findif_stencil_size,
+                "step_size": findif_step_size,
+                "t_project": translations_projection_sound,
+                "r_project": r_project_grad,
+            }
+
+        elif mode == "2_1":
+            fdargs = {
+                "freq_irrep_only": irrep,
+                "stencil_size": findif_stencil_size,
+                "step_size": findif_step_size,
+                "t_project": translations_projection_sound,
+                "r_project": r_project_hess,
+            }
+
+        elif mode == "2_0":
+            fdargs = {
+                "freq_irrep_only": irrep,
+                "stencil_size": findif_stencil_size,
+                "step_size": findif_step_size,
+                "t_project": translations_projection_sound,
+                "r_project": r_project_hess,
+            }
+
+        return fdargs
 
 
-def hessian_from_gradients_geometries(molecule, irrep):
-    """
-    Generate geometries for a hessian by finite difference of energies.
-    
-    Parameters
-    ----------
-    molecule : qcdb.molecule or :py:class:`~psi4.core.Molecule`
-        The molecule to compute the frequencies of.
-    irrep : int
-        The Cotton ordered irrep to get frequencies for. Choose -1 for all
-        irreps.
-
-    Returns
-    -------
-    findifrec : dict
-        Dictionary of finite difference data, specified in _geom_generator docstring.
-    """
-    return _geom_generator(molecule, irrep, "2_1")
-
-
-def hessian_from_energies_geometries(molecule, irrep):
-    """
-    Generate geometries for a hessian by finite difference of energies.
-    
-    Parameters
-    ----------
-    molecule : qcdb.molecule or :py:class:`~psi4.core.Molecule`
-        The molecule to compute the frequencies of.
-    irrep : int
-        The Cotton ordered irrep to get frequencies for. Choose -1 for all
-        irreps.
-
-    Returns
-    -------
-    findifrec : dict
-        Dictionary of finite difference data, specified in _geom_generator docstring.
-    """
-    return _geom_generator(molecule, irrep, "2_0")
+def _rms(arr: Union[core.Matrix, np.ndarray]) -> float:
+    """Compute root-mean-square of array, be it psi4.core.Matrix or np.ndarray."""
+    if isinstance(arr, np.ndarray):
+        return np.sqrt(np.mean(np.square(arr)))
+    else:
+        return arr.rms()

--- a/tests/psimrcc-fd-freq1/input.dat
+++ b/tests/psimrcc-fd-freq1/input.dat
@@ -18,6 +18,7 @@ set {
   e_convergence 10
   d_convergence 10
   r_convergence 10
+  fd_project 1
 }
 
 set mcscf {

--- a/tests/pytests/test_vibanalysis.py
+++ b/tests/pytests/test_vibanalysis.py
@@ -1010,9 +1010,6 @@ def test_harmonic_analysis_vs_cfour(subject, request):
 def test_hessian_vs_cfour(scf_type, subject, dertype, request):
     """compare analytic, findif by G, findif by E vibrational analyses for several mols"""
 
-    if 'atom' in request.node.name and 'H_by' in request.node.name:
-        pytest.skip("fix atomic findif Hessian in ddd")
-
     tol = 1.e-2
     if scf_type == "pk":
         toldict = {'IR_intensity': 1.e-1} if subject in ['nh3'] else {}

--- a/tests/scf-uhf-grad-nobeta/input.dat
+++ b/tests/scf-uhf-grad-nobeta/input.dat
@@ -14,6 +14,7 @@ molecule h2 {
 set globals = {
    basis      6-31G**
    reference uhf
+   gradient_write on
 }
 
 grad = gradient('scf')


### PR DESCRIPTION
## Description
The first eight DDD extracts PRs reduced the delta from
99 changed files, and 5,314 additions and 2,946 deletions. c. dgasmith:recursive to
59 changed files, and 3,408 additions and 1,885 deletions. c. loriab:recursive62
so here's No. 9 of the DDD series, #1351.

## Todos
- [x] This is the non-class parts of changes to finite difference. Mostly
 * using pieces from Mol, rather than mol, to reduce dependence on psi objects
 * use more numpy, less Matrix
 * consolidate printing so can go to logging
 * start to pass finite difference options (points, steps, projection) as kwargs rather than having findif consult global options
- [x] added in the dipder from dipole but it's not used
- closes #1683
- [x] along the way, psimrcc-fd-freq1 failed. as far as I can judge now, this is an existing bug. part of the old output is below. psi is evaulating the gradient, finding it over the cutoff, and so recommending not projecting rotations. then, because of https://github.com/psi4/psi4/blob/master/psi4/driver/driver.py#L1613, that setting of FD_PROJECT gets tossed, and findif runs projecting rotations, and the test passes. I'm calling this a bug and setting fd_project in the input to force the array dimensions to match and the test to pass. glad to hear other interpretations.

```

  Based on options and gradient (rms=3.60E-02), recommend projecting translations and not projecting rotations.
hessian() will perform frequency computation by finite difference of analytic energies.

         ----------------------------------------------------------
                                   FINDIF
                     R. A. King and Jonathon Misiewicz
         ---------------------------------------------------------

  Using finite-differences of gradients to determine vibrational frequencies and
  normal modes. Resulting frequencies are only valid at stationary points.
    Generating geometries for use with 5-point formula.
    Displacement size will be 1.00e-02.
    Number of atoms is 2.
    Number of irreps is 8.
    Number of SALCs is 1.
    Translations projected? 1. Rotations projected? 1.
    Index of SALCs per irrep:
```
- [x] ADDED: moved the write_hessian fn and collected write_gradient into a matching fn.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
