### PR TITLE
update deprecation warnings text

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -222,7 +222,6 @@ jobs:
 
       # Spot Test
       - script: |
-          setlocal EnableDelayedExpansion
           set PATH=$(Build.BinariesDirectory)\install\bin;%PATH%
           psi4 $(Build.SourcesDirectory)\tests\tu1-h2o-energy\input.dat -o stdout
         displayName: 'Run, Run, Spot, Run Test'

--- a/psi4/driver/driver_cbs_helper.py
+++ b/psi4/driver/driver_cbs_helper.py
@@ -29,14 +29,16 @@
 import math
 from functools import partial
 from typing import Callable, Optional, Union
+import logging
 
 import numpy as np
 
 from psi4 import core
-from psi4.driver.p4util.exceptions import *
+from psi4.driver.p4util.exceptions import ValidationError
 nppp = partial(np.array_str, max_line_width=120, precision=8, suppress_small=True)  # when safe, "from psi4.driver import nppp"
 from psi4.driver.aliases import sherrill_gold_standard, allen_focal_point
 
+logger = logging.getLogger(__name__)
 
 _zeta_val2sym = {k + 2: v for k, v in enumerate('dtq5678')}
 Extrapolatable = Union[float, core.Matrix, core.Vector]
@@ -82,6 +84,7 @@ def xtpl_highest_1(functionname: str, zHI: int, valueHI: Extrapolatable, verbose
             cbsscheme += f"""   HI-zeta ({zHI}) Energy:               {valueHI: 16.12f}\n"""
 
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         return valueHI
 
@@ -93,6 +96,7 @@ def xtpl_highest_1(functionname: str, zHI: int, valueHI: Extrapolatable, verbose
             cbsscheme += f"""   HI-zeta ({zHI}) Data\n"""
             cbsscheme += nppp(valueHI)
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         valueHI = core.Matrix.from_array(valueHI)
         return valueHI
@@ -175,6 +179,7 @@ def scf_xtpl_helgaker_2(functionname: str, zLO: int, valueLO: Extrapolatable, zH
             cbsscheme += " " * (18 - len(name_str))
             cbsscheme += """% 16.12f\n\n""" % value
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         return value
 
@@ -199,6 +204,7 @@ def scf_xtpl_helgaker_2(functionname: str, zLO: int, valueLO: Extrapolatable, zH
             cbsscheme += nppp(value)
             cbsscheme += "\n"
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         value = core.Matrix.from_array(value)
         return value
@@ -279,6 +285,7 @@ def scf_xtpl_truhlar_2(functionname: str, zLO: int, valueLO: Extrapolatable, zHI
             cbsscheme += " " * (18 - len(name_str))
             cbsscheme += """% 16.12f\n\n""" % value
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         return value
 
@@ -303,6 +310,7 @@ def scf_xtpl_truhlar_2(functionname: str, zLO: int, valueLO: Extrapolatable, zHI
             cbsscheme += nppp(value)
             cbsscheme += "\n"
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         value = core.Matrix.from_array(value)
         return value
@@ -385,6 +393,7 @@ def scf_xtpl_karton_2(functionname: str, zLO: int, valueLO: Extrapolatable, zHI:
             cbsscheme += " " * (18 - len(name_str))
             cbsscheme += """% 16.12f\n\n""" % value
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         return value
 
@@ -409,6 +418,7 @@ def scf_xtpl_karton_2(functionname: str, zLO: int, valueLO: Extrapolatable, zHI:
             cbsscheme += nppp(value)
             cbsscheme += "\n"
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         value = core.Matrix.from_array(value)
         return value
@@ -500,6 +510,7 @@ def scf_xtpl_helgaker_3(functionname: str, zLO: int, valueLO: Extrapolatable, zM
             cbsscheme += " " * (18 - len(name_str))
             cbsscheme += """% 16.12f\n\n""" % value
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         return value
 
@@ -536,6 +547,7 @@ def scf_xtpl_helgaker_3(functionname: str, zLO: int, valueLO: Extrapolatable, zM
             cbsscheme += nppp(np_value)
             cbsscheme += "\n"
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         ## Build and set from numpy routines
         #value = core.Matrix(*valueHI.shape)
@@ -625,6 +637,7 @@ def corl_xtpl_helgaker_2(functionname: str, zLO: int, valueLO: Extrapolatable, z
             cbsscheme += " " * (19 - len(name_str))
             cbsscheme += """% 16.12f\n\n""" % final
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         return final
 
@@ -649,6 +662,7 @@ def corl_xtpl_helgaker_2(functionname: str, zLO: int, valueLO: Extrapolatable, z
             cbsscheme += nppp(value)
             cbsscheme += "\n"
             core.print_out(cbsscheme)
+            logger.debug(cbsscheme)
 
         value = core.Matrix.from_array(value)
         return value

--- a/psi4/driver/p4util/procutil.py
+++ b/psi4/driver/p4util/procutil.py
@@ -181,7 +181,7 @@ def format_kwargs_for_input(filename, lmode=1, **kwargs):
 
     """
     warnings.warn(
-        "Using `psi4.driver.p4util.format_kwargs_for_input` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.driver.p4util.format_kwargs_for_input` is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.get_legacy_gradient()
@@ -273,7 +273,7 @@ def extract_sowreap_from_output(sowout, quantity, sownum, linkage, allvital=Fals
 
     """
     warnings.warn(
-        "Using `psi4.driver.p4util.extract_sowreap_from_output` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.driver.p4util.extract_sowreap_from_output` is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
 
@@ -556,7 +556,7 @@ def mat2arr(mat):
 
     """
     warnings.warn(
-        "Using `psi4.driver.p4util.mat2arr` instead of `MatrixInstance.to_array().tolist()` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.driver.p4util.mat2arr` instead of `MatrixInstance.to_array().tolist()` is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
 
@@ -578,7 +578,7 @@ def format_currentstate_for_input(func, name, allButMol=False, **kwargs):
 
     """
     warnings.warn(
-        "Using `psi4.driver.p4util.format_currentstate_for_input` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.driver.p4util.format_currentstate_for_input` is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
 

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -478,7 +478,7 @@ def set_module_options(module: str, options_dict: Dict[str, Any]) -> None:
     Sets Psi4 module options from a module specification and input dictionary.
     """
     warnings.warn(
-        "Using `psi4.set_module_options(<module>, {<key>: <val>})` instead of `psi4.set_options({<module>__<key>: <val>})` is deprecated, and in 1.5 it will stop working\n",
+        "Using `psi4.set_module_options(<module>, {<key>: <val>})` instead of `psi4.set_options({<module>__<key>: <val>})` is deprecated, and as soon as 1.5 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
 
@@ -658,7 +658,7 @@ def _qcvar_warnings(key: str) -> str:
 
     if key.upper() in _qcvar_transitions:
         warnings.warn(
-            f"Using QCVariable `{key.upper()}` instead of `{_qcvar_transitions[key.upper()]}` is deprecated, and in 1.5 it will stop working\n",
+            f"Using QCVariable `{key.upper()}` instead of `{_qcvar_transitions[key.upper()]}` is deprecated, and as soon as 1.5 it will stop working\n",
             category=FutureWarning,
             stacklevel=3)
         return _qcvar_transitions[key.upper()]
@@ -1002,7 +1002,7 @@ def _core_get_variable(key):
 
     """
     warnings.warn(
-        "Using `psi4.core.get_variable` instead of `psi4.core.variable` (or `psi4.core.scalar_variable` for scalar variables only) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.get_variable` instead of `psi4.core.variable` (or `psi4.core.scalar_variable` for scalar variables only) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.scalar_variable(key)
@@ -1015,7 +1015,7 @@ def _core_get_variables():
 
     """
     warnings.warn(
-        "Using `psi4.core.get_variables` instead of `psi4.core.variables` (or `psi4.core.scalar_variables` for scalar variables only) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.get_variables` instead of `psi4.core.variables` (or `psi4.core.scalar_variables` for scalar variables only) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.scalar_variables()
@@ -1028,7 +1028,7 @@ def _core_get_array_variable(key):
 
     """
     warnings.warn(
-        "Using `psi4.core.get_array_variable` instead of `psi4.core.variable` (or `psi4.core.array_variable` for array variables only) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.get_array_variable` instead of `psi4.core.variable` (or `psi4.core.array_variable` for array variables only) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.array_variable(key)
@@ -1041,7 +1041,7 @@ def _core_get_array_variables():
 
     """
     warnings.warn(
-        "Using `psi4.core.get_array_variables` instead of `psi4.core.variables` (or `psi4.core.array_variables` for array variables only) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.get_array_variables` instead of `psi4.core.variables` (or `psi4.core.array_variables` for array variables only) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.array_variables()
@@ -1060,7 +1060,7 @@ def _core_wavefunction_get_variable(cls, key):
 
     """
     warnings.warn(
-        "Using `psi4.core.Wavefunction.get_variable` instead of `psi4.core.Wavefunction.variable` (or `psi4.core.Wavefunction.scalar_variable` for scalar variables only) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Wavefunction.get_variable` instead of `psi4.core.Wavefunction.variable` (or `psi4.core.Wavefunction.scalar_variable` for scalar variables only) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return cls.scalar_variable(key)
@@ -1073,7 +1073,7 @@ def _core_wavefunction_get_array(cls, key):
 
     """
     warnings.warn(
-        "Using `psi4.core.Wavefunction.get_array` instead of `psi4.core.Wavefunction.variable` (or `psi4.core.Wavefunction.array_variable` for array variables only) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Wavefunction.get_array` instead of `psi4.core.Wavefunction.variable` (or `psi4.core.Wavefunction.array_variable` for array variables only) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return cls.array_variable(key)
@@ -1086,7 +1086,7 @@ def _core_wavefunction_set_array(cls, key, val):
 
     """
     warnings.warn(
-        "Using `psi4.core.Wavefunction.set_array` instead of `psi4.core.Wavefunction.set_variable` (or `psi4.core.Wavefunction.set_array_variable` for array variables only) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Wavefunction.set_array` instead of `psi4.core.Wavefunction.set_variable` (or `psi4.core.Wavefunction.set_array_variable` for array variables only) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return cls.set_array_variable(key, val)
@@ -1099,7 +1099,7 @@ def _core_wavefunction_arrays(cls):
 
     """
     warnings.warn(
-        "Using `psi4.core.Wavefunction.arrays` instead of `psi4.core.Wavefunction.variables` (or `psi4.core.Wavefunction.array_variables` for array variables only) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Wavefunction.arrays` instead of `psi4.core.Wavefunction.variables` (or `psi4.core.Wavefunction.array_variables` for array variables only) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return cls.array_variables()
@@ -1126,7 +1126,7 @@ def _core_wavefunction_legacy_frequencies(cls):
 
     """
     warnings.warn(
-        "Using `psi4.core.Wavefunction.legacy_frequencies` (accessing c-side member data) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Wavefunction.legacy_frequencies` (accessing c-side member data) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return cls.legacy_frequencies()
@@ -1138,7 +1138,7 @@ def _core_wavefunction_set_frequencies(cls, val):
 
     """
     warnings.warn(
-        "Using `psi4.core.Wavefunction.set_frequencies` (accessing c-side member data) instead of `psi4.core.Wavefunction.frequency_analysis` (py-side member data) is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Wavefunction.set_frequencies` (accessing c-side member data) instead of `psi4.core.Wavefunction.frequency_analysis` (py-side member data) is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return cls.set_legacy_frequencies(val)
@@ -1151,7 +1151,7 @@ core.Wavefunction.set_frequencies = _core_wavefunction_set_frequencies
 
 def _core_wavefunction_X(cls):
     warnings.warn(
-        "Using `psi4.core.Wavefunction.X` instead of `psi4.core.Wavefunction.lagrangian` is deprecated, and in 1.5 it will stop working\n",
+        "Using `psi4.core.Wavefunction.X` instead of `psi4.core.Wavefunction.lagrangian` is deprecated, and as soon as 1.5 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return cls.lagrangian()
@@ -1168,7 +1168,7 @@ def _core_get_gradient():
 
     """
     warnings.warn(
-        "Using `psi4.core.get_gradient` (only used internally for C++ optking; deprecated silently in 1.2) is deprecated, and in 1.5 (or whenever Py optking is adopted) it will stop working\n",
+        "Using `psi4.core.get_gradient` (only used internally for C++ optking; deprecated silently in 1.2) is deprecated, and as soon as 1.6 (or whenever Py optking is adopted) it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.get_legacy_gradient()
@@ -1180,7 +1180,7 @@ def _core_set_gradient(val):
 
     """
     warnings.warn(
-        "Using `psi4.core.set_gradient` (only used internally for C++ optking; deprecated silently in 1.2) is deprecated, and in 1.5 (or whenever Py optking is adopted) it will stop working\n",
+        "Using `psi4.core.set_gradient` (only used internally for C++ optking; deprecated silently in 1.2) is deprecated, and as soon as 1.6 (or whenever Py optking is adopted) it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.set_legacy_gradient(val)
@@ -1198,7 +1198,7 @@ def _core_doublet(A, B, transA, transB):
 
     """
     warnings.warn(
-        "Using `psi4.core.Matrix.doublet` instead of `psi4.core.doublet` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Matrix.doublet` instead of `psi4.core.doublet` is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.doublet(A, B, transA, transB)
@@ -1212,7 +1212,7 @@ def _core_triplet(A, B, C, transA, transB, transC):
 
     """
     warnings.warn(
-        "Using `psi4.core.Matrix.triplet` instead of `psi4.core.triplet` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.core.Matrix.triplet` instead of `psi4.core.triplet` is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
     return core.triplet(A, B, C, transA, transB, transC)

--- a/psi4/driver/p4util/text.py
+++ b/psi4/driver/p4util/text.py
@@ -42,7 +42,7 @@ class Table(object):
 
     def __init__(self, rows=(), row_label_width=10, row_label_precision=4, cols=(), width=16, precision=10):
         warnings.warn(
-            "Using `psi4.driver.p4util.Table` is deprecated, and in 1.4 it will stop working\n",
+            "Using `psi4.driver.p4util.Table` is deprecated, and as soon as 1.4 it will stop working\n",
             category=FutureWarning,
             stacklevel=2)
         self.row_label_width = row_label_width
@@ -191,7 +191,7 @@ def banner(text, type=1, width=35, strNotOutfile=False):
 def print_stdout(stuff):
     """Function to print *stuff* to standard output stream."""
     warnings.warn(
-        "Using `psi4.driver.p4util.print_stdout` instead of `print` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.driver.p4util.print_stdout` instead of `print` is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
 
@@ -201,7 +201,7 @@ def print_stdout(stuff):
 def print_stderr(stuff):
     """Function to print *stuff* to standard error stream."""
     warnings.warn(
-        "Using `psi4.driver.p4util.print_stderr` instead of `print(..., file=sys.stderr)` is deprecated, and in 1.4 it will stop working\n",
+        "Using `psi4.driver.p4util.print_stderr` instead of `print(..., file=sys.stderr)` is deprecated, and as soon as 1.4 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -3504,7 +3504,7 @@ def run_adc(name, **kwargs):
     proc_util.check_iwl_file_from_scf_type(core.get_global_option('SCF_TYPE'), ref_wfn)
 
     warnings.warn("Using built-in `adc` module instead of add-on `adcc` interface is deprecated due "
-                  "to certain wrong results, and in 1.7, it will stop working.", category=FutureWarning)
+                  "to certain wrong results, and as soon as 1.7, it will stop working.", category=FutureWarning)
 
     error_msg = ("\n\t\t\t\t!!!!! WARNING !!!!!\n" +
             "\t\tThe built-in ADC(2) method may give incorrect results if\n"

--- a/psi4/driver/procrouting/proc_table.py
+++ b/psi4/driver/procrouting/proc_table.py
@@ -194,7 +194,8 @@ procedures = {
         # Upon adding a method to this list, add it to the docstring in driver.optimize below
     },
     'hessian' : {
-        # Upon adding a method to this list, add it to the docstring in driver.frequency
+        # Upon adding a method to this list:
+        # * add it to the docstring in driver.frequency
         'hf'            : proc.run_scf_hessian,
         'scf'           : proc.run_scf_hessian,
     },

--- a/psi4/driver/qcdb/align.py
+++ b/psi4/driver/qcdb/align.py
@@ -99,7 +99,7 @@ def B787(cgeom,
 
     """
     warnings.warn(
-        "Using `qcdb.align.B787` instead of `qcelemental.molutil.B787` is deprecated, and in 1.5 it will stop working\n",
+        "Using `qcdb.align.B787` instead of `qcelemental.molutil.B787` is deprecated, and as soon as 1.5 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
 
@@ -149,7 +149,7 @@ def compute_scramble(nat, do_resort=True, do_shift=True, do_rotate=True, deflect
 
     """
     warnings.warn(
-        "Using `qcdb.align.compute_scramble` instead of `qcelemental.molutil.compute_scramble` is deprecated, and in 1.5 it will stop working\n",
+        "Using `qcdb.align.compute_scramble` instead of `qcelemental.molutil.compute_scramble` is deprecated, and as soon as 1.5 it will stop working\n",
         category=FutureWarning,
         stacklevel=2)
 

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -1576,7 +1576,7 @@ def _basis_file_warner_and_aliaser(filename):
     for k, v in aliased_in_1p4.items():
         if filename.endswith(k + ".gbs"):
             warnings.warn(
-                f"Using basis set `{k}` instead of its generic name `{v}` is deprecated, and in 1.5 it will stop working\n",
+                f"Using basis set `{k}` instead of its generic name `{v}` is deprecated, and as soon as 1.5 it will stop working\n",
                 category=FutureWarning,
                 stacklevel=2)
             return filename.replace(k, v)

--- a/psi4/driver/qmmm.py
+++ b/psi4/driver/qmmm.py
@@ -124,7 +124,7 @@ class QMMM():
     """Hold charges and :py:class:`psi4.core.ExternalPotential`. Use :py:class:`psi4.driver.QMMMbohr` instead."""
 
     def __init__(self):
-        raise UpgradeHelper(self.__class__.__name__, "QMMMbohr", 1.6, ' Replace object with a list of charges and locations in Bohr passed as keyword argument, e.g., `energy(..., embedding_charges=[[0.5, [0, 0, 1]], [-0.5, [0, 0, -1]]])`.')
+        raise UpgradeHelper(self.__class__.__name__, "QMMMbohr", 1.6, ' Replace object with a list of charges and locations in Bohr passed as keyword argument, e.g., `energy(..., external_potentials=[[0.5, [0, 0, 1]], [-0.5, [0, 0, -1]]])`.')
 
 
 class QMMMbohr():

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -482,7 +482,7 @@ def run_qcschema(input_data: Union[Dict[str, Any], qcel.models.AtomicInput], cle
 def run_json(json_data, clean=True):
 
     warnings.warn(
-        "Using `psi4.schema_wrapper.run_json` or `psi4.json_wrapper.run_json` instead of `psi4.schema_wrapper.run_qcschema` is deprecated, and in 1.7 it will stop working\n",
+        "Using `psi4.schema_wrapper.run_json` or `psi4.json_wrapper.run_json` instead of `psi4.schema_wrapper.run_qcschema` is deprecated, and as soon as 1.5 it will stop working\n",
         category=FutureWarning)
 
     # Set scratch

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -570,7 +570,7 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
         molschemus = json_data["molecule"]  # dtype >=2
     else:
         molschemus = json_data  # dtype =1
-    mol = core.Molecule.from_schema(molschemus)
+    mol = core.Molecule.from_schema(molschemus, nonphysical=True)
 
     # Update molecule geometry as we orient and fix_com
     json_data["molecule"]["geometry"] = mol.geometry().np.ravel().tolist()

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1014,10 +1014,10 @@ void py_psi_set_n_threads(size_t nthread, bool quiet) {
 int py_psi_get_n_threads() { return Process::environment.get_n_threads(); }
 
 PSI_DEPRECATED("Using core.legacy_wavefunction rather than setting return_wfn=True for a computation is deprecated, "
-        "and in 1.5, it will stop working.")
+        "and as soon as 1.5, it will stop working.")
 std::shared_ptr<Wavefunction> py_psi_legacy_wavefunction() { return Process::environment.legacy_wavefunction(); }
 PSI_DEPRECATED("Using core.set_legacy_wavefunction rather than passing a wavefunction into a computation is deprecated, "
-        "and in 1.5, it will stop working.")
+        "and as soon as 1.5, it will stop working.")
 void py_psi_set_legacy_wavefunction(SharedWavefunction wfn) { Process::environment.set_legacy_wavefunction(wfn); }
 
 void py_psi_print_variable_map() {

--- a/psi4/src/export_plugins.cc
+++ b/psi4/src/export_plugins.cc
@@ -109,7 +109,7 @@ SharedWavefunction py_psi_plugin(std::string fullpathname, SharedWavefunction re
         return info.plugin(ref_wfn, Process::environment.options);
     } else if (Process::environment.legacy_wavefunction()) {
         outfile->Printf(
-            "Using the legacy wavefunction from global memory instead of explicit wavefunction passing is deprecated, and in 1.5 it will stop working.");
+            "Using the legacy wavefunction from global memory instead of explicit wavefunction passing is deprecated, and as soon as 1.5 it will stop working.");
         return info.plugin(Process::environment.legacy_wavefunction(), Process::environment.options);
     } else {
         throw PSIEXCEPTION("Psi4::plugin: No wavefunction passed into the plugin, aborting");

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -3927,7 +3927,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
 
 PSI_DEPRECATED(
     "MolecularGrid: This grid builder is outdated"
-    "and will stop working in an upcoming version.")
+    "and, as soon as 1.7 it will stop working.")
 void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const std::vector<std::vector<double>> &rs,
                                          const std::vector<std::vector<double>> &ws,
                                          const std::vector<std::vector<int>> &Ls) {

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -289,7 +289,7 @@ void LibXCFunctional::set_tweak(std::vector<double> values, bool quiet) {
 
     outfile->Printf(
         "Using `LibXCFunctional.set_tweak(std::vector<double>)` instead of "
-        "`LibXCFunctional.set_tweak(std::map<std::string, double>)` is deprecated, and in 1.5 it will stop working. "
+        "`LibXCFunctional.set_tweak(std::map<std::string, double>)` is deprecated, and as soon as 1.5 it will stop working. "
         "Allowed keys are: %s\n",
         allowed_keys_join.c_str());
 

--- a/psi4/src/psi4/libmints/cdsalclist.cc
+++ b/psi4/src/psi4/libmints/cdsalclist.cc
@@ -62,7 +62,7 @@ namespace psi {
 void CdSalc::print() const {
     outfile->Printf("\tirrep = %d, ncomponent = %ld\n", irrep_, ncomponent());
     for (size_t i = 0; i < ncomponent(); ++i) {
-        outfile->Printf("\t\t%d: atom %d, direction %c, coef %lf\n", i, components_[i].atom,
+        outfile->Printf("\t\t%d: atom %d, direction %c, coef % lf\n", i, components_[i].atom,
                         direction(components_[i].xyz), components_[i].coef);
     }
 }

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -289,7 +289,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     enum SaveType { Full
     PSI_DEPRECATED(
         "Using `Matrix::SaveType::Full` instead of `Matrix::SaveType::SubBlocks` is deprecated, "
-        "and in 1.5 it will stop working"),
+        "and as soon as 1.5 it will stop working"),
     SubBlocks, LowerTriangle, ThreeIndexLowerTriangle };
 
     /**
@@ -1133,35 +1133,35 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     void rotate_columns(int h, int i, int j, double theta);
 
     PSI_DEPRECATED(
-        "Using `Matrix::matrix` instead of `linalg::detail::matrix` is deprecated, and in 1.4 it will "
+        "Using `Matrix::matrix` instead of `linalg::detail::matrix` is deprecated, and as soon as 1.4 it will "
         "stop working")
     static double** matrix(int nrow, int ncol) { return linalg::detail::matrix(nrow, ncol); }
 
     PSI_DEPRECATED(
-        "Using `Matrix::free` instead of `linalg::detail::free` is deprecated, and in 1.4 it will "
+        "Using `Matrix::free` instead of `linalg::detail::free` is deprecated, and as soon as 1.4 it will "
         "stop working")
     static void free(double** Block) { linalg::detail::free(Block); }
 
     PSI_DEPRECATED(
         "Using `Matrix::create` instead of `auto my_mat = std::make_shared<Matrix>(name, rows, cols);` "
-        "is deprecated, and in 1.4 it will "
+        "is deprecated, and as soon as 1.4 it will "
         "stop working")
     static SharedMatrix create(const std::string& name, const Dimension& rows, const Dimension& cols) {
         return std::make_shared<Matrix>(name, rows, cols);
     }
 
     PSI_DEPRECATED(
-        "Using `Matrix::horzcat` instead of `linalg::horzcat` is deprecated, and in 1.4 it will "
+        "Using `Matrix::horzcat` instead of `linalg::horzcat` is deprecated, and as soon as 1.4 it will "
         "stop working")
     static SharedMatrix horzcat(const std::vector<SharedMatrix>& mats) { return linalg::horzcat(mats); }
 
     PSI_DEPRECATED(
-        "Using `Matrix::vertcat` instead of `linalg::vertcat` is deprecated, and in 1.4 it will "
+        "Using `Matrix::vertcat` instead of `linalg::vertcat` is deprecated, and as soon as 1.4 it will "
         "stop working")
     static SharedMatrix vertcat(const std::vector<SharedMatrix>& mats) { return linalg::vertcat(mats); }
 
     PSI_DEPRECATED(
-        "Using `Matrix::doublet` instead of `doublet` is deprecated, and in 1.4 it will "
+        "Using `Matrix::doublet` instead of `doublet` is deprecated, and as soon as 1.4 it will "
         "stop working")
     static SharedMatrix doublet(const SharedMatrix& A, const SharedMatrix& B, bool transA = false,
                                 bool transB = false) {
@@ -1169,7 +1169,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     }
 
     PSI_DEPRECATED(
-        "Using `Matrix::triplet` instead of `triplet` is deprecated, and in 1.4 it will "
+        "Using `Matrix::triplet` instead of `triplet` is deprecated, and as soon as 1.4 it will "
         "stop working")
     static SharedMatrix triplet(const SharedMatrix& A, const SharedMatrix& B, const SharedMatrix& C,
                                 bool transA = false, bool transB = false, bool transC = false) {

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -242,7 +242,7 @@ class PSI_API Vector final {
 
     PSI_DEPRECATED(
         "Using `Vector::create` instead of `auto my_vec = std::make_shared<Vector>(name, dim);` "
-        "is deprecated, and in 1.4 it will "
+        "is deprecated, and as soon as 1.4 it will "
         "stop working")
     static SharedVector create(const std::string &name, const Dimension &dim) {
         return std::make_shared<Vector>(name, dim);

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -429,7 +429,7 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     int nirrep() const { return nirrep_; }
     /// Returns the energy
     PSI_DEPRECATED(
-        "Using `Wavefunction.reference_energy` instead of `Wavefunction.energy` is deprecated, and in 1.4 it will "
+        "Using `Wavefunction.reference_energy` instead of `Wavefunction.energy` is deprecated, and as soon as 1.4 it will "
         "stop working")
     double reference_energy() const { return energy_; }
     double energy() const { return energy_; }
@@ -590,12 +590,12 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Returns the SO basis Lagrangian
     PSI_DEPRECATED(
         "Using `Wavefunction.Lagrangian` instead of `Wavefunction.lagrangian` is deprecated,"
-        " and in 1.5 it will stop working")
+        " and as soon as 1.5 it will stop working")
     SharedMatrix Lagrangian() const { return lagrangian(); }
     /// Returns the SO basis Lagrangian (duplicated one)
     PSI_DEPRECATED(
         "Using `Wavefunction.X` instead of `Wavefunction.lagrangian` is deprecated,"
-        " and in 1.5 it will stop working")
+        " and as soon as 1.5 it will stop working")
     SharedMatrix X() const { return lagrangian(); }
 
     /// Returns the gradient
@@ -647,12 +647,12 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
 
     /// Returns the frequencies
     PSI_DEPRECATED(
-        "Using `Wavefunction.frequencies` c-side instead of `Wavefunction.frequencies` py-side is deprecated, and in "
+        "Using `Wavefunction.frequencies` c-side instead of `Wavefunction.frequencies` py-side is deprecated, and as soon as "
         "1.4 it will stop working")
     SharedVector frequencies() const;
 
     /// Set the frequencies for the wavefunction
-    PSI_DEPRECATED("Using `Wavefunction.set_frequencies` is deprecated, and in 1.4 it will stop working")
+    PSI_DEPRECATED("Using `Wavefunction.set_frequencies` is deprecated, and as soon as 1.4 it will stop working")
     void set_frequencies(std::shared_ptr<Vector> freqs);
 
     /// Set the wavefunction name (e.g. "RHF", "ROHF", "UHF", "CCEnergyWavefunction")
@@ -705,27 +705,27 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     std::map<std::string, std::shared_ptr<ExternalPotential>> potential_variables();
 
     PSI_DEPRECATED(
-        "Using `Wavefunction.get_variable` instead of `Wavefunction.scalar_variable` is deprecated, and in 1.4 it will "
+        "Using `Wavefunction.get_variable` instead of `Wavefunction.scalar_variable` is deprecated, and as soon as 1.4 it will "
         "stop working")
     double get_variable(const std::string& key);
     PSI_DEPRECATED(
-        "Using `Wavefunction.set_variable` instead of `Wavefunction.set_scalar_variable` is deprecated, and in 1.4 it "
+        "Using `Wavefunction.set_variable` instead of `Wavefunction.set_scalar_variable` is deprecated, and as soon as 1.4 it "
         "will stop working")
     void set_variable(const std::string& key, double value);
     PSI_DEPRECATED(
-        "Using `Wavefunction.variables` instead of `Wavefunction.scalar_variables` is deprecated, and in 1.4 it will "
+        "Using `Wavefunction.variables` instead of `Wavefunction.scalar_variables` is deprecated, and as soon as 1.4 it will "
         "stop working")
     std::map<std::string, double> variables();
     PSI_DEPRECATED(
-        "Using `Wavefunction.get_array` instead of `Wavefunction.array_variable` is deprecated, and in 1.4 it will "
+        "Using `Wavefunction.get_array` instead of `Wavefunction.array_variable` is deprecated, and as soon as 1.4 it will "
         "stop working")
     SharedMatrix get_array(const std::string& key);
     PSI_DEPRECATED(
-        "Using `Wavefunction.set_array` instead of `Wavefunction.set_array_variable` is deprecated, and in 1.4 it will "
+        "Using `Wavefunction.set_array` instead of `Wavefunction.set_array_variable` is deprecated, and as soon as 1.4 it will "
         "stop working")
     void set_array(const std::string& key, SharedMatrix value);
     PSI_DEPRECATED(
-        "Using `Wavefunction.arrays` instead of `Wavefunction.array_variables` is deprecated, and in 1.4 it will stop "
+        "Using `Wavefunction.arrays` instead of `Wavefunction.array_variables` is deprecated, and as soon as 1.4 it will stop "
         "working")
     std::map<std::string, SharedMatrix> arrays();
 

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -49,7 +49,7 @@ using namespace psi;
 
 MoldenWriter::MoldenWriter(std::shared_ptr<Wavefunction> wavefunction) : wavefunction_(wavefunction) {
     outfile->Printf("\tConstructing a MoldenWriter and then calling write instead of using `wfn.write_molden(name)`\n");
-    outfile->Printf("\tis both buggy and deprecated, and in 1.5 it will stop working.\n\n");
+    outfile->Printf("\tis both buggy and deprecated, and as soon as 1.5 it will stop working.\n\n");
 }
 
 void MoldenWriter::write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb,
@@ -638,7 +638,7 @@ void FCHKWriter::write(const std::string &filename) {
 
 NBOWriter::NBOWriter(std::shared_ptr<Wavefunction> wavefunction) : wavefunction_(wavefunction) {
     outfile->Printf("\tConstructing an NBOWriter and then calling write instead of using `wfn.nbo_write(name)`\n");
-    outfile->Printf("\tis both buggy and deprecated, and in 1.5 it will stop working.\n\n");
+    outfile->Printf("\tis both buggy and deprecated, and as soon as 1.5 it will stop working.\n\n");
 }
 
 void NBOWriter::write(const std::string &filename) {

--- a/psi4/src/psi4/libmints/writer.h
+++ b/psi4/src/psi4/libmints/writer.h
@@ -77,12 +77,12 @@ class PSI_API MoldenWriter {
    public:
     PSI_DEPRECATED(
         "Constructing an MoldenWriter and then calling write instead of using `wfn.write_molden(name)` "
-        "is both buggy and deprecated, and in 1.5 it will stop working")
+        "is both buggy and deprecated, and as soon as 1.5 it will stop working")
     MoldenWriter(std::shared_ptr<Wavefunction> wavefunction);
 
     PSI_DEPRECATED(
         "Constructing an MoldenWriter and then calling write instead of using `wfn.write_molden(name)` "
-        "is both buggy and deprecated, and in 1.5 it will stop working")
+        "is both buggy and deprecated, and as soon as 1.5 it will stop working")
     void write(const std::string &filename, std::shared_ptr<Matrix> Ca, std::shared_ptr<Matrix> Cb,
                std::shared_ptr<Vector> Ea, std::shared_ptr<Vector> Eb, std::shared_ptr<Vector> OccA,
                std::shared_ptr<Vector> OccB, bool dovirtual);
@@ -109,12 +109,12 @@ class PSI_API NBOWriter {
    public:
     PSI_DEPRECATED(
         "Constructing an NBOWriter and then calling write instead of using `wfn.nbo_write(name)` "
-        "is both buggy and deprecated, and in 1.5 it will stop working")
+        "is both buggy and deprecated, and as soon as 1.5 it will stop working")
     NBOWriter(std::shared_ptr<Wavefunction> wavefunction);
 
     PSI_DEPRECATED(
         "Constructing an NBOWriter and then calling write instead of using `wfn.nbo_write(name)` "
-        "is both buggy and deprecated, and in 1.5 it will stop working")
+        "is both buggy and deprecated, and as soon as 1.5 it will stop working")
     void write(const std::string &filename);
 };
 }  // namespace psi

--- a/tests/cbs-xtpl-func/input.dat
+++ b/tests/cbs-xtpl-func/input.dat
@@ -19,7 +19,29 @@ compare_values(E0, E1, 5, '[1a]')
 E2 = energy('sherrill_gold_standard', scf_basis='cc-pVTZ', corl_basis='cc-pV[DT]Z', delta_basis='3-21g')
 compare_values(E1, E2, 5, '[1] Match gold_standard energy')  #TEST
 
+# findif
+ene_fd = -76.3707500218  #TEST
+R_fd = 0.960940174888  #TEST
+A_fd = 103.436972667  #TEST
+G0_fd = psi4.core.Matrix.from_list([[0.00000000000000,     0.00000000000000,    -0.06342827014937],   #TEST
+                                    [0.00000000000000,    -0.00458359046476,     0.03171413507468],   #TEST
+                                    [0.00000000000000,     0.00458359046476,     0.03171413507468]])  #TEST
+# analytic
+ene_ana = -76.37082222234929  #TEST
+R_ana = 0.9609448952766658  #TEST
+A_ana = 103.4370330968766  #TEST
+G0_ana = psi4.core.Matrix.from_list([[0.00000000000000,     0.00000000000000,   -6.34173012e-02 ],    #TEST
+                                     [0.00000000000000,    -4.58320481e-03,      3.17086506e-02 ],    #TEST
+                                     [0.00000000000000,     4.58320481e-03,      3.17086506e-02 ]])   #TEST
+
+ene = ene_fd  #TEST
+R = R_fd  #TEST
+A = A_fd  #TEST
+G0 = G0_fd  #TEST
+
 G1 = gradient("cbs", corl_wfn='mp2', corl_basis='cc-pV[DT]Z', delta_wfn='ccsd(t)', delta_basis='3-21g', dertype='energy')
+compare_matrices(G0, G1, 5, '[2a] Match gold_standard gradient')  #TEST
+
 G2 = gradient('sherrill_gold_standard', scf_basis='cc-pVTZ', corl_basis='cc-pV[DT]Z', delta_basis='3-21g')
 compare_matrices(G1, G2, 5, '[2] Match gold_standard gradient')  #TEST
 
@@ -27,17 +49,17 @@ compare_matrices(G1, G2, 5, '[2] Match gold_standard gradient')  #TEST
 mol.R = 1.0
 mol.A = 100.0
 E = optimize("cbs", corl_wfn='mp2', corl_basis='cc-pV[DT]Z', delta_wfn='ccsd(t)', delta_basis='3-21g', dertype=0)
-compare_values(-76.3707500218, E, 5, '[3a] opt(cbs, sherrill) energy')  #TEST
-compare_values(0.960940174888, mol.R, 3, '[3b] opt(cbs, sherrill) bond')  #TEST
-compare_values(103.436972667, mol.A, 2, '[3c] opt(cbs, sherrill) angle')  #TEST
+compare_values(ene, E, 5, '[3a] opt(cbs, sherrill) energy')  #TEST
+compare_values(R, mol.R, 3, '[3b] opt(cbs, sherrill) bond')  #TEST
+compare_values(A, mol.A, 2, '[3c] opt(cbs, sherrill) angle')  #TEST
 
 # Reset mol geometries
 mol.R = 1.0
 mol.A = 100.0
 E = optimize('sherrill_gold_standard', scf_basis='cc-pVTZ', corl_basis='cc-pV[DT]Z', delta_basis='3-21g')
-compare_values(-76.3707500218, E, 5, '[4a] opt(sherrill) energy')  #TEST
-compare_values(0.960940174888, mol.R, 3, '[4b] opt(sherrill) bond')  #TEST
-compare_values(103.436972667, mol.A, 2, '[4c] opt(sherrill) angle')  #TEST
+compare_values(ene, E, 5, '[4a] opt(sherrill) energy')  #TEST
+compare_values(R, mol.R, 3, '[4b] opt(sherrill) bond')  #TEST
+compare_values(A, mol.A, 2, '[4c] opt(sherrill) angle')  #TEST
 
 # Note: with new analytical ccsd(t) gradients, calcs G1 and 3 default  #TEST
 #   to sum-of-analytic. Want to compare with custom_func values that are  #TEST

--- a/tests/cbs-xtpl-nbody/input.dat
+++ b/tests/cbs-xtpl-nbody/input.dat
@@ -1,7 +1,10 @@
 #! RHF interaction energies using nbody and cbs parts of the driver
 #! Ne dimer with mp2/v[dt]z + d:ccsd(t)/vdz
 
-ans = 0.0131222  #TEST
+df_ans = 0.0131222  #TEST
+uncp_conv_ans = 0.01303175  #TEST
+cp_conv_ans = 0.01400641  #TEST
+ans = df_ans  #TEST
 
 molecule ne2 {
     0 1

--- a/tests/dfmp2-1/input.dat
+++ b/tests/dfmp2-1/input.dat
@@ -2,7 +2,8 @@
 #! using automatic counterpoise correction.  Monomers are specified using Cartesian coordinates.
 
 Enuc = 235.94662124        #TEST
-Ecp  = -0.0224119246       #TEST
+df_Ecp  = -0.0224119246    #TEST
+conv_Ecp = -0.0224253      #TEST
 
 molecule formic_dim {
    0 1
@@ -35,4 +36,4 @@ set {
 e_cp = energy('mp2', bsse_type='cp')
 
 compare_values(Enuc, formic_dim.nuclear_repulsion_energy(), 7, "Nuclear Repulsion Energy") #TEST
-compare_values(Ecp, e_cp, 5, "CP Corrected cc-pVDZ/cc-pVDZ-RI DFMP2")                      #TEST
+compare_values(df_Ecp, e_cp, 5, "CP Corrected cc-pVDZ/cc-pVDZ-RI DFMP2")                   #TEST


### PR DESCRIPTION
## Description
This is No. 10 of the DDD series, #1351.

## Todos
- mostly a few little differences with ddd that will reduce the changed line overhead
  - [x] add logging printing, minimize imports
  - [x] `mol = core.Molecule.from_schema(molschemus, nonphysical=True)` allows freq-masses test to run in ddd. nonphysical flag allows user-set atomic masses outside the known isotope range. the schema runner shouldn't be the block to this.
  - [x] in tests add some alternate ref values. sometimes these are conventional, which can be handy reusing a test in a non-df program
- [x] adding deprecation warnings is good, but we don't often actually delete the fn promptly at the version we say it will stop working at. this is harmless, in my opinion, as it gives people longer to adapt, and developers can clear away the old fns when they actually become inconvenient. to better reflect this state of affairs, the standard message "Using blah is deprecated, and in version it will stop working" has been changed to "Using blah is deprecated, and as soon as version it will stop working". this also removes the temptation to keep incrementing <version>, which gives a misleading impression about how long ago users were warned. have backtracked on run_json accordingly from 1.7 to 1.5.

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
