### PR TITLE
change default for SAPT0 aux

### DIFF
--- a/doc/sphinxman/CMakeLists.txt
+++ b/doc/sphinxman/CMakeLists.txt
@@ -71,7 +71,7 @@ if(PERL_FOUND AND SPHINX_FOUND AND SPHINX_STUFF_FOUND)
     prog_full_integration.rst prog_style_py.rst prog_help.rst
     prog_debug_profile.rst manage_release.rst plugin_psi4fockci.rst
     brianqc.rst tdscf.rst prog_integrals.rst prog_tour.rst mcscf.rst
-    code_style.rst nitpick-exceptions external_apis.rst
+    code_style.rst nitpick-exceptions external_apis.rst ecpint.rst
     )
 
     # * compute relative path btwn top_srcdir and objdir/doc/sphinxman

--- a/doc/sphinxman/document_tests.pl
+++ b/doc/sphinxman/document_tests.pl
@@ -70,6 +70,7 @@ my %ExeFolder = (
    "psi4numpy/" => "psi4numpy",
    "python/"    => "python",
    "brianqc/"   => "brianqc",
+   "dftd4/"     => "dftd4",
 );
 
 foreach my $exe (keys %ExeFolder) {
@@ -102,6 +103,7 @@ foreach my $File(readdir SAMPLES){
     next if $File =~ /^json$/;
     next if $File =~ /^psi4numpy$/;
     next if $File =~ /^brianqc$/;
+    next if $File =~ /^dftd4$/;
     next if (-d $File);  # Don't remove subdirectories
     remove_tree("$SamplesFolder/$File");
 }

--- a/doc/sphinxman/source/adc.rst
+++ b/doc/sphinxman/source/adc.rst
@@ -42,6 +42,9 @@ ADC: Ab Initio Polarization Propagator
 
 *Module:* :ref:`Keywords <apdx:adc>`, :ref:`PSI Variables <apdx:adc_psivar>`, :source:`ADC <psi4/src/psi4/adc>`
 
+.. caution:: As of Spring 2022, v1.6, the built-in backend is deprecated and will only be active
+   when adcc addon backend is unavailable. Eventually built-in ADC will be removed.
+
 Algebraic-diagrammatic construction methods for the polarization propagator (ADC)
 determine correlated excitation energies by investigating the pole structure
 of said propagator. For this the propagator is expressed in a representation

--- a/doc/sphinxman/source/build_planning.rst
+++ b/doc/sphinxman/source/build_planning.rst
@@ -243,6 +243,8 @@ Dropped Dependencies:
 
 * MPFR https://www.mpfr.org/ (Mar 2022; dropped by v1.6) no longer needed to compile against Libint2
 
+* Perl for testing (April 2022; dropped by v1.6)
+
 
 .. _`faq:addondepend`:
 
@@ -258,7 +260,6 @@ are available pre-built from conda.
 * |PSIfour| Testing
 
   * CTest https://cmake.org/download/
-  * Perl (for some coupled-cluster CTest tests) https://www.perl.org/
   * pytest (for installed testing) http://doc.pytest.org/en/latest/
   * pytest-xdist (for installed testing many tests at once) https://github.com/pytest-dev/pytest-xdist
 

--- a/doc/sphinxman/source/cbs.rst
+++ b/doc/sphinxman/source/cbs.rst
@@ -197,7 +197,7 @@ Basis set extrapolations are encoded into individual functions like the built-in
 .. autofunction:: psi4.driver.driver_cbs._get_default_xtpl
 
 Additional extrapolation schemes are easy to define by the
-user. Follow models in :src:`psi4/driver/driver_cbs_helper.py`
+user. Follow models in :source:`psi4/driver/driver_cbs_helper.py`
 and :srcsample:`pywrap-cbs1` and use the
 :py:func:`psi4.driver.driver_cbs_helper.register_xtpl_function` to make
 user-defined functions known to |PSIfour|.
@@ -218,7 +218,7 @@ Some existing examples are below.
 .. autofunction:: psi4.driver.aliases.allen_focal_point
 
 Additional composite aliases are easy to define by the
-user. Follow models in :src:`psi4/driver/aliases.py`
+user. Follow models in :source:`psi4/driver/aliases.py`
 and :srcsample:`cbs-xtpl-nbody` and use the
 :py:func:`psi4.driver.driver_cbs_helper.register_composite_function`
 to make user-defined functions known to |PSIfour|.

--- a/doc/sphinxman/source/ecpint.rst
+++ b/doc/sphinxman/source/ecpint.rst
@@ -1,0 +1,137 @@
+.. #
+.. # @BEGIN LICENSE
+.. #
+.. # Psi4: an open-source quantum chemistry software package
+.. #
+.. # Copyright (c) 2007-2022 The Psi4 Developers.
+.. #
+.. # The copyrights for code used from other parties are included in
+.. # the corresponding files.
+.. #
+.. # This file is part of Psi4.
+.. #
+.. # Psi4 is free software; you can redistribute it and/or modify
+.. # it under the terms of the GNU Lesser General Public License as published by
+.. # the Free Software Foundation, version 3.
+.. #
+.. # Psi4 is distributed in the hope that it will be useful,
+.. # but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. # GNU Lesser General Public License for more details.
+.. #
+.. # You should have received a copy of the GNU Lesser General Public License along
+.. # with Psi4; if not, write to the Free Software Foundation, Inc.,
+.. # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. #
+.. # @END LICENSE
+.. #
+
+.. include:: autodoc_abbr_options_c.rst
+
+.. index:: LibECPInt, ecpint
+.. _`sec:ecpint`:
+
+Interface to LibECPInt by R. Shaw
+=================================
+
+.. codeauthor:: Andrew C. Simmonett
+.. sectionauthor:: Lori A. Burns
+
+.. image:: https://img.shields.io/badge/home-LibECPInt-5077AB.svg
+   :target: https://github.com/robashaw/libecpint
+
+.. raw:: html
+
+   <br>
+
+.. image:: https://img.shields.io/badge/docs-latest-5077AB.svg
+   :target: https://libecpint.readthedocs.io/en/latest/index.html
+
+
+Installation
+~~~~~~~~~~~~
+
+**Binary**
+
+* .. image:: https://anaconda.org/psi4/libecpint/badges/version.svg
+     :target: https://anaconda.org/psi4/libecpint
+
+* .. image:: https://anaconda.org/conda-forge/libecpint/badges/version.svg
+     :target: https://anaconda.org/conda-forge/libecpint
+
+* LibECPInt is available as a conda package for Linux and macOS.
+
+* If using the |PSIfour| binary, LibECPInt has already been installed alongside.
+
+* If using |PSIfour| built from source, and anaconda or miniconda has
+  already been installed (instructions at :ref:`sec:quickconda`),
+  LibECPInt can be obtained through ``conda install libecpint``.
+  Then enable it as a feature with :makevar:`ENABLE_ecpint`,
+  hint its location with :makevar:`CMAKE_PREFIX_PATH`,
+  and rebuild |PSIfour| to detect LibECPInt and activate dependent code.
+
+* To remove a conda installation, ``conda remove libecpint``.
+
+**Source**
+
+* .. image:: https://img.shields.io/github/tag/robashaw/libecpint.svg?maxAge=2592000
+     :target: https://github.com/robashaw/libecpint
+
+* If using |PSIfour| built from source and you want LibECPInt built from
+  from source also,
+  enable it as a feature with :makevar:`ENABLE_ecpint`,
+  and let the build system fetch and build it and activate dependent code.
+
+
+.. _`cmake:ecpint`:
+
+How to configure LibECPInt for building Psi4
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Role and Dependencies**
+
+* Role |w---w| In |PSIfour|, LibECPInt is a library that provides additional
+  quantum chemical capabilities (ECP integrals).
+
+* Downstream Dependencies |w---w| |PSIfour| (\ |dr| optional) LibECPInt
+
+* Upstream Dependencies |w---w| LibECPInt |dr| None
+
+**CMake Variables**
+
+* :makevar:`ENABLE_ecpint` |w---w| CMake variable toggling whether Psi4 builds with LibECPInt
+* :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For LibECPInt, set to an installation directory containing ``include/libecpint.hpp``
+* :makevar:`ecpint_DIR` |w---w| CMake variable to specify where pre-built LibECPInt can be found. Set to installation directory containing ``lib/cmake/ecpint/ecpint-config.cmake``
+* :makevar:`CMAKE_DISABLE_FIND_PACKAGE_ecpint` |w---w| CMake variable to force internal build of ecpint instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_ecpint` |w---w| CMake variable to force detecting pre-built LibECPInt and not falling back on internal build
+
+**Examples**
+
+A. Build bundled
+
+  .. code-block:: bash
+
+    >>> cmake -DENABLE_ecpint=ON
+
+B. Build *without* LibECPInt
+
+  .. code-block:: bash
+
+    >>> cmake
+
+C. Link against pre-built
+
+  .. code-block:: bash
+
+    >>> cmake -DENABLE_ecpint=ON -DCMAKE_PREFIX_PATH=/path/to/ecpint/root
+
+  .. code-block:: bash
+
+    >>> cmake -DENABLE_ecpint=ON -Decpint_DIR=/path/to/ecpint/configdir
+
+D. Build bundled despite pre-built being detectable
+
+  .. code-block:: bash
+
+    >>> cmake -DENABLE_ecpint=ON -DCMAKE_PREFIX_PATH=/path/to/unwanted/ecpint/root/and/wanted/other/dependencies/root -DCMAKE_DISABLE_FIND_PACKAGE_ecpint=ON
+

--- a/doc/sphinxman/source/interfacing.rst
+++ b/doc/sphinxman/source/interfacing.rst
@@ -50,6 +50,7 @@ platform capabilities, *etc*.
    cppe
    dftd3
    dkh
+   ecpint
    libefp
    erd
    fchk

--- a/doc/sphinxman/source/introduction.rst
+++ b/doc/sphinxman/source/introduction.rst
@@ -594,7 +594,7 @@ Architectures
     principle, it should work on any Unix system. The latest version of the
     |PSIfour| program package may be obtained at `psicode.org <http://psicode.org>`_.
     The package is available as a binary (:ref:`Installing from Binary
-    <sec:conda>`) for Linux, macOS, or Windows (both native and via Windows Subsystem for
+    <sec:conda>`) for Linux, macOS (not arm64), or Windows (both native and via Windows Subsystem for
     Linux aka `Bash on Ubuntu on Windows
     <https://docs.microsoft.com/en-us/windows/wsl/about>`_)
     or as source code (git repository or zipped archive from
@@ -602,7 +602,7 @@ Architectures
 Compilers
     |PSIfour| has been successfully compiled using Intel, GCC, and Clang
     compilers. :ref:`Compiler requirements <faq:approvedcxx>` are primarily
-    C++14 compliance (now GCC version 6.0 or above).
+    C++17 compliance (now GCC version 7.0 or above).
     For some architectures, a :ref:`precompiled binary
     <sec:conda>` is available. See :ref:`Compiling and Installing
     <sec:installFile>` for details.
@@ -614,6 +614,7 @@ Python
     |PSIfour| 1.3 supports Python 3.6 and 3.7.
     |PSIfour| 1.4 supports Python 3.6, 3.7, 3.8, and 3.9.
     |PSIfour| 1.5 supports Python 3.7, 3.8, and 3.9.
+    |PSIfour| 1.6 supports Python 3.8, 3.9, and 3.10.
     The future plan is to support the two or three latest Python versions.
     The current master supports 3.8, 3.9, and 3.10.
     

--- a/doc/sphinxman/source/libint.rst
+++ b/doc/sphinxman/source/libint.rst
@@ -65,35 +65,38 @@ Installation
 
 **Binary**
 
-* .. image:: https://anaconda.org/psi4/libint/badges/version.svg
-     :target: https://anaconda.org/psi4/libint
+* .. image:: https://anaconda.org/psi4/libint2/badges/version.svg
+     :target: https://anaconda.org/psi4/libint2
 
-* Libint is available as a conda package for Linux and macOS (and Windows, through the Ubuntu shell).
+* Libint is available as a conda package for Linux and macOS and Windows.
 
 * If using the |PSIfour| binary, Libint has already been installed alongside.
 
 * If using |PSIfour| built from source, and anaconda or miniconda has
   already been installed (instructions at :ref:`sec:quickconda`),
-  Libint can be obtained through ``conda install libint -c psi4``.
+  Libint can be obtained through ``conda install libint2 -c psi4``.
   Then, hint its location with :makevar:`CMAKE_PREFIX_PATH`,
   and rebuild |PSIfour| to detect Libint and activate dependent code.
 
 .. * Previous bullet had details. To build |PSIfour| from source and use 
 ..   Libint from conda without thinking, consult.
 
-* To remove a conda installation, ``conda remove libint``.
+* To remove a conda installation, ``conda remove libint2``.
 
 **Source**
 
 * .. image:: https://img.shields.io/github/tag/evaleev/libint.svg?maxAge=2592000
-     :target: https://github.com/evaleev/libint/tree/v1
+     :target: https://github.com/evaleev/libint/pull/233
 
-  Note that |PSIfour| uses v1.
+  Note that |PSIfour| uses v2 and a modified branch.
 
 * If using |PSIfour| built from source and you want Libint built from
   from source also,
   let the build system fetch and build it and activate dependent code.
-
+  Note that Libint2 has many more integral class enabling and AM knobs
+  than Libint2 and that the generation step (generator source to
+  library source) preceding the compilation step (library source to
+  built library) takes far longer than in Libint1 for production builds.
 
 .. _`cmake:libint`:
 
@@ -111,10 +114,11 @@ How to configure Libint for building Psi4
 
 **CMake Variables**
 
-* :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For Libint, set to an installation directory containing ``include/libint/libint.h``
-* :makevar:`Libint_DIR` |w---w| CMake variable to specify where pre-built Libint can be found. Set to installation directory containing ``share/cmake/Libint/LibintConfig.cmake``
-* :makevar:`CMAKE_DISABLE_FIND_PACKAGE_Libint` |w---w| CMake variable to force internal build of Libint instead of detecting pre-built
-* :makevar:`CMAKE_INSIST_FIND_PACKAGE_Libint` |w---w| CMake variable to force detecting pre-built Libint and not falling back on internal build
+* :makevar:`CMAKE_PREFIX_PATH` |w---w| CMake list variable to specify where pre-built dependencies can be found. For Libint, set to an installation directory containing ``include/libint2.h``
+* :makevar:`Libint2_DIR` |w---w| CMake variable to specify where pre-built Libint can be found. Set to installation directory containing ``lib/cmake/libint2/libint2-config.cmake``
+* :makevar:`CMAKE_DISABLE_FIND_PACKAGE_Libint2` |w---w| CMake variable to force internal build of Libint instead of detecting pre-built
+* :makevar:`CMAKE_INSIST_FIND_PACKAGE_Libint2` |w---w| CMake variable to force detecting pre-built Libint and not falling back on internal build
+* :makevar:`BUILD_Libint2_GENERATOR` |w---w| CMake variable to allow internal build to start from generator source, not generated source
 * :makevar:`MAX_AM_ERI` |w---w| CMake variable to specify minimum highest angular momentum built or detected
 
 **Examples**
@@ -133,17 +137,25 @@ B. Link against pre-built
 
   .. code-block:: bash
 
-    >>> cmake -DLibint_DIR=/path/to/libint/configdir
+    >>> cmake -DLibint_DIR2=/path/to/libint/configdir
 
 C. Build bundled despite pre-built being detectable
 
   .. code-block:: bash
 
-    >>> cmake -DCMAKE_PREFIX_PATH=/path/to/unwanted/libint/root/and/wanted/other/dependencies/root -DCMAKE_DISABLE_FIND_PACKAGE_Libint=ON
+    >>> cmake -DCMAKE_PREFIX_PATH=/path/to/unwanted/libint/root/and/wanted/other/dependencies/root -DCMAKE_DISABLE_FIND_PACKAGE_Libint2=ON
 
-D. Build bundled shared library with AM=6
+D. Build bundled shared library with up to AM=5
 
   .. code-block:: bash
 
-    >>> cmake -DMAX_AM_ERI=6 -DBUILD_SHARED_LIBS=ON
+    >>> cmake -DBUILD_SHARED_LIBS=ON
+
+E. Build custom library from generator source
+
+  .. code-block:: bash
+
+    >>> # find the "new-cmake-harness-lab-rb1" block at :source:`external/upstream/libint2/CMakeLists.txt`
+    >>> # edit the "ENABLE" and "AM" variables
+    >>> cmake -DBUILD_Libint2_GENERATOR=ON -DCMAKE_DISABLE_FIND_PACKAGE_Libint2=ON
 

--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -69,6 +69,27 @@ SAPT: Symmetry-Adapted Perturbation Theory
    this, a discrepency between these values was possible when one of the monomers was (exclusively) 
    a charged alkali metal. 
 
+.. _`note:saptfitA`:
+
+.. caution:: May 2022 c. v1.6, the default for |sapt__df_basis_elst|
+   changed from the value of |sapt__df_basis_sapt| (which itself
+   defaults to the RI of the orbital basis) to the JKFIT of the orbital
+   basis. This affects SAPT0 and sSAPT0 computed with the :ref:`SAPT
+   module<sec:sapt>` (the default code for ``energy("sapt0")`` that
+   can also compute higher-order SAPT). Electostatics, exchange,
+   and induction terms for SAPT0 and sSAPT0 accessed through
+   ``energy("sapt0")`` or ``energy("ssapt0")`` change; the dispersion
+   term does not change. The SAPT0 and sSAPT0 terms accessed as
+   subsidiary calculations of higher-order SAPT do not change; that is,
+   the :ref:`SAPT module<sec:sapt>` breaks the consistency of its SAPT0
+   results. The reasoning and reward behind this change is that the JKFIT
+   basis better describes the physics (see :ref:`note:saptfitB`) and the
+   default SAPT0 results from the :ref:`SAPT module<sec:sapt>` are now
+   consistent with those from the :ref:`FISAPT module<sec:fisapt>` and
+   the sapt(dft) module. See :srcsample:`sapt-compare` for an example.
+   To reproduce former behavior, set |sapt__df_basis_elst| to the
+   orbital basis set's RI auxiliary basis.
+
 Symmetry-adapted perturbation theory (SAPT) provides a means of directly
 computing the noncovalent interaction between two molecules, that is, the
 interaction energy is determined without computing the total energy of the
@@ -882,22 +903,23 @@ The scaling factor is reported at the top (here ``1.0072``) together with the
 label. Note that if Exch10 is less than :math:`10^{-5}`, the scaling factor is
 set to :math:`1.0`.
 
+.. _`note:saptfitB`:
+
 .. caution:: To density fit the dispersion terms in SAPT, the RI auxiliary
    basis set (*e.g.*, aug-cc-pVDZ-RI) controlled through
    |sapt__df_basis_sapt| performs well. For Fock-type terms (*i.e.*,
    electrostatics, exchange, induction, and core Fock matrix elements in
-   exchange-dispersion), the density-fitting auxiliary basis in the
-   :ref:`SAPT module<sec:sapt>` (both SAPT0 and higher-order) is RI (more
-   efficient for the small basis sets at which SAPT0 performs best) while
-   the :ref:`FISAPT module<sec:fisapt>` uses the more appropriate JKFIT
-   (*e.g.*, aug-cc-pVDZ-JKFIT). For heavier elements (*i.e.*, second-row
-   and beyond), the RI auxiliary basis is unsound for this role
-   (insufficiently flexible). For SAPT0 in the :ref:`SAPT
-   module<sec:sapt>`, a workaround is to set |sapt__df_basis_elst| (which
-   controls Elst10 and Exch10 terms) to a JKFIT basis. For higher-order
-   methods in :ref:`SAPT module<sec:sapt>`, there is no workaround;
-   on-the-fly construction of an auxiliary basis through Cholesky
-   decomposition (not implemented) is the long-term solution.
+   exchange-dispersion), the JKFIT density-fitting auxiliary basis
+   (*e.g.*, aug-cc-pVDZ-JKFIT) is more appropriate. The :ref:`FISAPT
+   module<sec:fisapt>` has always used JKFIT in this role. The
+   :ref:`SAPT module<sec:sapt>` newly (see :ref:`note:saptfitA`) uses
+   JKFIT for computations targeting SAPT0 and sSAPT0 methods. But the
+   :ref:`SAPT module<sec:sapt>` still uses the RI basis for higher-order
+   SAPT. For heavier elements (*i.e.*, second-row and beyond), the RI
+   auxiliary basis is unsound for this role (insufficiently flexible).
+   For higher-order methods in :ref:`SAPT module<sec:sapt>`, there is
+   no workaround; on-the-fly construction of an auxiliary basis through
+   Cholesky decomposition (not implemented) is the long-term solution.
 
 Spin-Flip SAPT
 ^^^^^^^^^^^^^^

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -925,7 +925,9 @@ Effective core potentials (ECPs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 |PSIfour| supports the use of effective core potentials to describe the
-innermost electrons in heavy elements.  If a basis set is designed to use an
+innermost electrons in heavy elements.
+ECPs are only available if |PSIfour| is compiled with the :ref:`LibECPInt <cmake:ecpint>` library.
+If a basis set is designed to use an
 effective core potential, the ECP definition should be simply placed alongside
 the orbital basis set definition, *c.f.* :ref:`sec:basissets-ecps`.  All
 information related to the definition and number of core electrons will
@@ -933,7 +935,7 @@ automatically be detected and no further input is required to use the
 ECP-containing basis set.  See :srcsample:`scf-ecp` and :srcsample:`dfmp2-ecp`
 for examples of computations with ECP-containing basis sets.
 
-.. warning:: Analytic derivatives of ECPs are not yet available.  The HF and DFT derivatives are implemented in a semi-numerical scheme, where numerical ECP gradients are added to analytic SCF gradients.  Analytic gradients for (DF)MP2 are not yet available, but the standard numerical gradients will work correctly.  Fully analytic gradients will be implemented soon.
+.. warning:: As of May 2022, v1.6, the LibECPInt library is used, and analytic derivatives and Hessians of ECPs are available. Previously, built-in code was used for ECPs, and analytic derivatives were not available. Then, the HF and DFT derivatives were implemented in a semi-numerical scheme, where numerical ECP gradients are added to analytic SCF gradients.  Analytic gradients for (DF)MP2 were not yet available, but the standard numerical gradients will work correctly.
 
 .. warning:: ECPs have not been tested with projected basis set guesses or with FI-SAPT calculations.  If you require this functionality, please contact the developers on GitHub and/or the `forum <http://forum.psicode.org>`_.
 

--- a/doc/sphinxman/source/testsuite.rst
+++ b/doc/sphinxman/source/testsuite.rst
@@ -44,12 +44,12 @@ Sample inputs accessible through :ref:`interfaced executables
 
 .. toctree::
 
-   autodoc_testsuite_adcc.rst
    autodoc_testsuite_brianqc.rst
    autodoc_testsuite_cfour
    autodoc_testsuite_chemps2
    autodoc_testsuite_cookbook
    autodoc_testsuite_dftd3
+   autodoc_testsuite_dftd4
    autodoc_testsuite_dkh
    autodoc_testsuite_libefp
    autodoc_testsuite_erd

--- a/external/upstream/libint2/CMakeLists.txt
+++ b/external/upstream/libint2/CMakeLists.txt
@@ -64,11 +64,20 @@ else()
 
         message(STATUS "Suitable Libint2 could not be located, ${Magenta}Building Libint2 ${_url_am_src}${ColourReset} instead.")
 
+        if (MSVC)
+            # Windows shared (dll) can't work
+            set(_build_shared_libs "OFF")
+        else()
+            # stopgap to avert a report that static lib not working on Linux
+            set(_build_shared_libs "ON")
+        endif()
+
         ExternalProject_Add(libint2_external
             URL ${_url_l2_tarball}
             CMAKE_ARGS -GNinja
                        -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
-                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                       #-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                       -DCMAKE_BUILD_TYPE=Release
                        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                        -DCMAKE_INSTALL_BINDIR=${CMAKE_INSTALL_BINDIR}
@@ -78,7 +87,7 @@ else()
                        -DEigen3_DIR=${Eigen3_DIR}
                        -DLIBINT2_SHGAUSS_ORDERING=gaussian
                        #-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                       -DBUILD_SHARED_LIBS=OFF
+                       -DBUILD_SHARED_LIBS=${_build_shared_libs}
                        -DREQUIRE_CXX_API=ON
                        -DREQUIRE_CXX_API_COMPILED=OFF
                        -DENABLE_FORTRAN=OFF
@@ -140,7 +149,7 @@ else()
     # CHOOSE! `make export`
     #set(Libint2_DIR ${STAGED_INSTALL_PREFIX}/lib/cmake/libint2 CACHE PATH "path to internally built libint2-config.cmake" FORCE)
     # CHOOSE! pure cmake
-    set(Libint2_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/Libint2 CACHE PATH "path to internally built Libint2Config.cmake" FORCE)
+    set(Libint2_DIR ${STAGED_INSTALL_PREFIX}/lib/cmake/libint2 CACHE PATH "path to internally built libint2-config.cmake" FORCE)
 
 endif()
 

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -37,6 +37,7 @@ import numpy as np
 pp = pprint.PrettyPrinter(width=120, compact=True, indent=1)
 nppp = partial(np.array_str, max_line_width=120, precision=8, suppress_small=True)
 nppp10 = partial(np.array_str, max_line_width=120, precision=10, suppress_small=True)
+del partial
 
 from qcelemental import constants
 from psi4.driver import psifiles as psif

--- a/psi4/driver/driver_cbs_helper.py
+++ b/psi4/driver/driver_cbs_helper.py
@@ -693,7 +693,7 @@ def register_xtpl_function(func: Callable):
     ----------
     func
         A Python function that applies a basis set extrapolation formula to scalars and optionally to
-        NumPy arrays. See :src:`psi4/driver/driver_cbs_helper.py` and :srcsample:`pywrap-cbs1` for
+        NumPy arrays. See :source:`psi4/driver/driver_cbs_helper.py` and :srcsample:`pywrap-cbs1` for
         examples. The name of the function should follow the pattern ``<scf|corl>_xtpl_<scientist>_<#basis>``.
 
     """
@@ -710,7 +710,7 @@ def register_composite_function(func: Callable):
     ----------
     func
         A Python function that defines a configuration of the :py:func:`psi4.cbs` wrapper.
-        See :src:`psi4/driver/aliases.py` and :srcsample:`cbs-xtpl-nbody` for examples.
+        See :source:`psi4/driver/aliases.py` and :srcsample:`cbs-xtpl-nbody` for examples.
 
     """
     composite_procedures[func.__name__] = func

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -4409,12 +4409,10 @@ def run_sapt(name, **kwargs):
     aux_basis = core.BasisSet.build(dimer_wfn.molecule(), "DF_BASIS_SAPT", core.get_global_option("DF_BASIS_SAPT"),
                                     "RIFIT", core.get_global_option("BASIS"))
     dimer_wfn.set_basisset("DF_BASIS_SAPT", aux_basis)
-    if core.get_global_option("DF_BASIS_ELST") == "":
-        dimer_wfn.set_basisset("DF_BASIS_ELST", aux_basis)
-    else:
-        aux_basis = core.BasisSet.build(dimer_wfn.molecule(), "DF_BASIS_ELST", core.get_global_option("DF_BASIS_ELST"),
-                                        "RIFIT", core.get_global_option("BASIS"))
-        dimer_wfn.set_basisset("DF_BASIS_ELST", aux_basis)
+
+    aux_basis = core.BasisSet.build(dimer_wfn.molecule(), "DF_BASIS_ELST", core.get_global_option("DF_BASIS_ELST"),
+                                    "JKFIT", core.get_global_option("BASIS"))
+    dimer_wfn.set_basisset("DF_BASIS_ELST", aux_basis)
 
     core.print_out('\n')
     p4util.banner(name.upper())

--- a/psi4/share/psi4/scripts/test_threading.py
+++ b/psi4/share/psi4/scripts/test_threading.py
@@ -90,6 +90,7 @@ set {
     BASIS jun-cc-pVQZ
     SCF_TYPE DF
     FREEZE_CORE True
+    DF_BASIS_ELST jun-cc-pVQZ-RI
 }
 
 energy('sapt0')

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1002,7 +1002,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("DF_BASIS_SAPT", "");
         /*- Auxiliary basis set for SAPT Elst10 and Exch10 density fitting
         computations, may be important if heavier elements are involved.
-        Defaults to |sapt__df_basis_sapt|. -*/
+        :ref:`Defaults <apdx:basisFamily>` to a JKFIT basis.
+        Previous to v1.6, defaulted to |sapt__df_basis_sapt|. See :ref:`note:saptfitA`. -*/
         options.add_str("DF_BASIS_ELST", "");
         /*- Maximum error allowed (Max error norm in Delta tensor)
         in the approximate energy denominators employed for most of the

--- a/tests/json/schema-1-energy/input.py
+++ b/tests/json/schema-1-energy/input.py
@@ -1,4 +1,4 @@
-#! test QC_JSON Schema for energy
+#! test QCSchema for energy
 
 import numpy as np
 import psi4

--- a/tests/json/schema-1-ghost/input.py
+++ b/tests/json/schema-1-ghost/input.py
@@ -1,4 +1,4 @@
-#! test QC_JSON Schema with ghost atoms
+#! test QCSchema with ghost atoms
 
 import numpy as np
 import psi4

--- a/tests/json/schema-1-gradient/input.py
+++ b/tests/json/schema-1-gradient/input.py
@@ -1,4 +1,4 @@
-#! test QC_JSON Schema for gradient
+#! test QCSchema for gradient
 
 import numpy as np
 import psi4

--- a/tests/json/schema-1-orient/input.py
+++ b/tests/json/schema-1-orient/input.py
@@ -1,4 +1,4 @@
-#! test QC_JSON Schema mol orientation
+#! test QCSchema mol orientation
 
 import numpy as np
 import psi4

--- a/tests/json/schema-1-properties/input.py
+++ b/tests/json/schema-1-properties/input.py
@@ -1,4 +1,4 @@
-#! test QC_JSON Schema for properties
+#! test QCSchema for properties
 
 import numpy as np
 import psi4

--- a/tests/json/schema-1-response/input.py
+++ b/tests/json/schema-1-response/input.py
@@ -1,4 +1,4 @@
-#! test QC_JSON Schema for response properties
+#! test QCSchema for response properties
 
 import psi4
 import numpy as np

--- a/tests/json/schema-1-tamps/input.py
+++ b/tests/json/schema-1-tamps/input.py
@@ -1,3 +1,5 @@
+#! test QCSchema for CCSD amplitudes saving
+
 import numpy as np
 import psi4
 import json

--- a/tests/json/schema-1-throws/input.py
+++ b/tests/json/schema-1-throws/input.py
@@ -1,4 +1,4 @@
-#! test QC_JSON Schema noncontiguous mol
+#! test QCSchema noncontiguous mol
 
 import numpy as np
 import psi4

--- a/tests/pytests/test_psi4.py
+++ b/tests/pytests/test_psi4.py
@@ -160,6 +160,7 @@ def test_psi4_sapt():
 
     psi4.set_options({
         "basis": "cc-pvdz",
+        "df_basis_elst": "cc-pvdz-ri",
         "guess": "sad",
         "scf_type": "df",
         "sad_print": 2,

--- a/tests/pytests/test_psi4_qcschema/jatin6.ref
+++ b/tests/pytests/test_psi4_qcschema/jatin6.ref
@@ -152,6 +152,7 @@
   },
   "keywords": {
     "d_convergence": 1e-11,
+    "df_basis_elst": "cc-pVDZ-RI",
     "guess": "SAD",
     "print": 1,
     "puream": 1,

--- a/tests/sapt-compare/input.dat
+++ b/tests/sapt-compare/input.dat
@@ -1,12 +1,18 @@
-#! SAPT0 cc-pVDZ computation of the ethene-ethyne interaction energy, using the cc-pVDZ-JKFIT RI basis for SCF
-#! and cc-pVDZ-RI for SAPT.  Monomer geometries are specified using Cartesian coordinates.
+#! SAPT0 aug-cc-pVDZ computation of the water-water interaction energy, using the three SAPT codes.
 
 memory 1250 mb
 
 Eref = {"SAPT ELST ENERGY":  -0.01337793703, #TEST
         "SAPT EXCH ENERGY":   0.01121567840, #TEST
-        "SAPT IND ENERGY":   -0.00352942288, #TEST
+        "SAPT IND ENERGY":   -0.00352435852, #TEST  # Rob; May 2022 switch ref from Ed (now below) to Rob
         "SAPT DISP ENERGY":  -0.00289879691} #TEST
+
+Eref_longstanding_riri_egh = {
+    "SAPT ELST ENERGY": -0.01337542907,  #TEST
+    "SAPT EXCH ENERGY":  0.01121822627,  #TEST
+    "SAPT IND ENERGY":  -0.00352942288,  #TEST  # Ed
+    "SAPT DISP ENERGY": Eref["SAPT DISP ENERGY"],
+}
 
 molecule dimer {
   O -2.930978458   -0.216411437    0.000000000
@@ -39,14 +45,30 @@ energy('sapt(dft)', molecule=dimer)
 sapt_dft_vars = psi4.core.variables() #TEST
 
 for k in ["SAPT ELST ENERGY", "SAPT EXCH ENERGY", "SAPT IND ENERGY"]: #TEST
-    compare_values(Eref[k], sapt_dft_vars[k], 5, "SAPT(DFT) " + k) #TEST
-    compare_values(Eref[k], fisapt0_vars[k], 5, "F-SAPT " + k) #TEST
-    compare_values(Eref[k], sapt0_vars[k], 5, "SAPT 0" + k) #TEST
-
+    compare_values(Eref[k], sapt_dft_vars[k], 7, "SAPT(DFT) " + k) #TEST
+    compare_values(Eref[k], fisapt0_vars[k], 7, "F-SAPT " + k) #TEST
+    compare_values(Eref[k], sapt0_vars[k], 7, "SAPT0 " + k) #TEST
 
 uks_disp = sapt_dft_vars["DISP20,U"] + sapt_dft_vars["EXCH-DISP20,U"] #TEST
-compare_values(Eref["SAPT DISP ENERGY"], uks_disp, 4, "SAPT(DFT) SAPT DISP ENERGY") #TEST
-compare_values(Eref["SAPT DISP ENERGY"], fisapt0_vars["SAPT DISP ENERGY"], 5, "F-SAPT SAPT DISP ENERGY") #TEST
-compare_values(Eref["SAPT DISP ENERGY"], sapt0_vars["SAPT DISP ENERGY"],   5, "SAPT0 SAPT DISP ENERGY") #TEST
+compare_values(Eref["SAPT DISP ENERGY"], uks_disp, 7, "SAPT(DFT) SAPT DISP ENERGY") #TEST
+compare_values(Eref["SAPT DISP ENERGY"], fisapt0_vars["SAPT DISP ENERGY"], 7, "F-SAPT SAPT DISP ENERGY") #TEST
+compare_values(Eref["SAPT DISP ENERGY"], sapt0_vars["SAPT DISP ENERGY"],   7, "SAPT0 SAPT DISP ENERGY") #TEST
 
+# May 2022: Longstanding SAPT (EGH; libsapt_solver) behavior was to
+#   use RIFIT basis for both DF_BASIS_SAPT and DF_BASIS_ELST. With that
+#   in place, compare_values agreement had to be set to 5 5 5; 4 5 5 for
+#   elst/exch/ind ; disp.
+#   Now, with libsapt_solver using DF_BASIS_ELST defaulted to JKFIT,
+#   agreement to 7 7 7; 7 7 7 can be achieved. The former values for SAPT0
+#   are reproduced below by forcibly setting DF_BASIS_ELST to the RIFIT of
+#   the current orbital basis
+
+clean()
+clean_variables()
+
+set df_basis_elst aug-cc-pvdz-ri
+
+e = energy("sapt0", molecule=dimer)
+for k in ["SAPT ELST ENERGY", "SAPT EXCH ENERGY", "SAPT IND ENERGY", "SAPT DISP ENERGY"]:  #TEST
+    compare_values(Eref_longstanding_riri_egh[k], variable(k), 7, "pre-v1.6 SAPT0 " + k)  #TEST
 

--- a/tests/sapt1/input.dat
+++ b/tests/sapt1/input.dat
@@ -35,6 +35,7 @@ set {
     d_convergence 11
     puream        true
     print         1
+    df_basis_elst cc-pvdz-ri
 }
 
 energy('sapt0', molecule=ethene_ethyne)

--- a/tests/sapt6/input.dat
+++ b/tests/sapt6/input.dat
@@ -363,7 +363,8 @@ codes = [
 set EXCH_SCALE_ALPHA 1.0
 alpha = 'qa1'
 
-for codelist in [codes[0], codes[2], codes[6], codes[14]]:
+# May 2022: codes[0] removed from codelist iter
+for codelist in [codes[2], codes[6], codes[14]]:
     method = codelist[0]
     energy(method)
     print('        <<< %s >>>' % method)
@@ -383,7 +384,8 @@ for codelist in [codes[0], codes[2], codes[6], codes[14]]:
 set EXCH_SCALE_ALPHA 0.0
 alpha = 'a0'
 
-for codelist in [codes[1], codes[3], codes[9]]:
+# May 2022: codes[1] removed from codelist iter
+for codelist in [codes[3], codes[9]]:
     method = codelist[0]
     energy(method)
     print('        <<< %s >>>' % method)
@@ -401,3 +403,6 @@ for codelist in [codes[1], codes[3], codes[9]]:
     clean()
     clean_variables()
 
+# May 2022: energy("SAPT0") and energy("sSAPT0") removed from tests
+#   since their default aux basis changed to no longer coincide with higher-order sapt.
+#   file w/o removals can also pass with `set df_basis_elst aug-cc-pvdz-ri`.

--- a/tests/tu5-sapt/input.dat
+++ b/tests/tu5-sapt/input.dat
@@ -22,6 +22,7 @@ set {
     BASIS jun-cc-pVDZ
     SCF_TYPE DF
     FREEZE_CORE True
+    DF_BASIS_ELST jun-cc-pVDZ-RI
 }
 
 energy('sapt0')


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] update various build docs, especially for Libint2 and libecpint
- [x] a coalition including @konpat and @CDSherrill agree that it's better to update the default for elst terms for sapt0 in Ed's code for (1) physics and (2) match the other two sapt codes. this implements that decision. hopefully the docs additions are clear. glad of suggestions.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
