### PR TITLE
tag reminder and cbs bug fix

### DIFF
--- a/psi4/driver/driver_util.py
+++ b/psi4/driver/driver_util.py
@@ -276,8 +276,8 @@ def negotiate_derivative_type(
             # untested
             analytic = [highest_analytic_properties_available(mtd, proc) for mtd in method]
             if verbose > 1:
-                print(method, analytic, '->', min(analytic))
-            highest_analytic_dertype, proc_messages = min(analytic)
+                print(method, analytic, '->', min(analytic, key=lambda t: t[0]))
+            highest_analytic_dertype, proc_messages = min(analytic, key=lambda t: t[0])
         else:
             highest_analytic_dertype, proc_messages = highest_analytic_properties_available(method, proc)
 
@@ -287,8 +287,8 @@ def negotiate_derivative_type(
         if isinstance(method, list):
             analytic = [highest_analytic_derivative_available(mtd, proc) for mtd in method]
             if verbose > 1:
-                print(method, analytic, '->', min(analytic))
-            highest_analytic_dertype, proc_messages = min(analytic)
+                print(method, analytic, '->', min(analytic, key=lambda t: t[0]))
+            highest_analytic_dertype, proc_messages = min(analytic, key=lambda t: t[0])
         else:
             highest_analytic_dertype, proc_messages = highest_analytic_derivative_available(method, proc)
 

--- a/psi4/header.py
+++ b/psi4/header.py
@@ -32,6 +32,11 @@ import socket
 
 from . import core
 from .metadata import __version__, version_formatter
+ 
+if "undef" in __version__:
+    raise TypeError(
+        """Using custom build without tags. Please pull git tags with `git pull origin master --tags`. If building from source, `git fetch upstream "refs/tags/*:refs/tags/*"`."""
+    )
 
 time_string = datetime.datetime.now().strftime('%A, %d %B %Y %I:%M%p')
 pid = os.getpid()


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] If you build from source, and your tags aren't synced with upstream, the Psi4 version will be undefined. QCEngine balks at that and urges you to pull tags. But this only pops up for cbs/findif/nbody jobs, which can be confusing. This PR promotes to tag complaint to upon `import psi4` for uniformity.
- [x] "OliP" [reported a bug at the forum](http://forum.psicode.org/t/problems-with-cbs-and-version-1-6/2494) where an input like the below returned `‘<’ not supported between instances of ‘dict’ and ‘dict’ `. This came about because I was comparing well-behaved dertype per method tuples like
```
['hf', 'mp2', 'ccsd(t)', 'ccsd(t)']
[(2, {}), (1, {}), (1, {}), (1, {})]
```

rather than the real-life cases one gets with ROHF. Sorting on only the dertype fixes the bug.
```
['hf', 'mp2', 'ccsd(t)', 'ccsd(t)']
[(2, {}), (0, {1: "\nPsiException: select_mp2_gradient: Method 'mp2' with MP2_TYPE 'DF', FREEZE_CORE 'True', and REFERENCE 'ROHF' not available\n\n"}), (0, {1: "\nPsiException: select_ccsd_t__gradient: Method 'ccsd(t)' with CC_TYPE 'CONV' and REFERENCE 'ROHF' not available\n\n"}), (0, {1: "\nPsiException: select_ccsd_t__gradient: Method 'ccsd(t)' with CC_TYPE 'CONV' and REFERENCE 'ROHF' not available\n\n"})]
```

```
molecule N {
0 4
N 0.00 0.00 0.00
}

set {
scf_type direct
reference rohf
r_convergence 6
d_convergence 7
e_convergence 8
freeze_core true
}

e_cbs = energy(‘cbs’,
scf_basis=‘aug-cc-pV[TQ5]Z’,
corl_wfn=‘mp2’,
corl_basis=‘aug-cc-pV[TQ]Z’,
delta_wfn=‘ccsd(t)’,
delta_basis=‘aug-cc-pV[DT]Z’)
```

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
