### PR TITLE
driver import reorganization: p4util

### DIFF
--- a/doc/sphinxman/source/appendices.rst
+++ b/doc/sphinxman/source/appendices.rst
@@ -51,8 +51,10 @@ Basis Sets
    basissets_byelement
    basissets_byfamily
 
-PSI Variables
-=============
+.. _`sec:appendices:qcvars`:
+
+QCVariables (aka PSI Variables)
+===============================
 
 .. toctree::
    :maxdepth: 2

--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -200,7 +200,8 @@ Bibliography
 
 .. [Verma:2015]
    P. Verma, W. D. Derricotte, F. A. Evangelista,
-   *J. Chem. Theory Comput.* **DOI: 10.1021/acs.jctc.5b00817** (2015).
+   *J. Chem. Theory Comput.* (2015).
+   https://doi.org/10.1021/acs.jctc.5b00817
 
 .. [Jeziorski:1981:1668]
    B. Jeziorski and H. J. Monkhorst,
@@ -438,23 +439,23 @@ Bibliography
 
 .. [Lehtola:2019:1593]
    S. Lehtola
-   *J. Chem. Theory Comput.* **15**, 1593 (2019), doi: 10.1021/acs.jctc.8b01089.
+   *J. Chem. Theory Comput.* **15**, 1593 (2019), https://doi.org/10.1021/acs.jctc.8b01089.
 
 .. [Lehtola:2019:241102]
    S. Lehtola
-   *J. Chem. Phys.* **151**, 241102 (2019), doi: 10.1063/1.5139948.
+   *J. Chem. Phys.* **151**, 241102 (2019), https://doi.org/10.1063/1.5139948.
 
  .. [Lehtola:2019:25945]
    S. Lehtola
-   *Int. J. Quantum Chem.* **119**, e25945 (2019), doi: 10.1002/qua.25945.
+   *Int. J. Quantum Chem.* **119**, e25945 (2019), https://doi.org/10.1002/qua.25945.
 
 .. [Lehtola:2020:012516]
    S. Lehtola
-   *Phys. Rev. A.* **101**, 012516 (2020), doi: 10.1103/PhysRevA.101.012516.
+   *Phys. Rev. A.* **101**, 012516 (2020), https://doi.org/10.1103/PhysRevA.101.012516.
 
 .. [Lehtola:2020:032504]
    S. Lehtola
-   *Phys. Rev. A.* **101**, 032504 (2020), doi: 10.1103/PhysRevA.101.032504.
+   *Phys. Rev. A.* **101**, 032504 (2020), https://doi.org/10.1103/PhysRevA.101.032504.
 
 .. [Lehtola:2020:04224]
    S. Lehtola
@@ -490,28 +491,28 @@ Bibliography
 
 .. [stratmann:1998]
    R. Eric Stratmann, G. E. Scuseria, and M. J. Frisch
-   *J. Chem. Phys.* **109**, 8218 (1998), doi: 10.1063/1.477483.
+   *J. Chem. Phys.* **109**, 8218 (1998), https://doi.org/10.1063/1.477483.
 
 .. [Pedersen1995-du]
    T. B. Pedersen, A. E. Hansen
-   *Chem. Phys. Lett.* **246**, 1 (1995), doi: 10.1016/0009-2614(95)01036-9.
+   *Chem. Phys. Lett.* **246**, 1 (1995), https://doi.org/10.1016/0009-2614(95)01036-9.
 
 .. [Lestrange2015-xn]
    P. J. Lestrange, F. Egidi, X. Li
-   *J. Chem. Phys.* **143**, 234103 (2015), doi: 10.1063/1.4937410.
+   *J. Chem. Phys.* **143**, 234103 (2015), https://doi.org/10.1063/1.4937410.
 
 .. [Rizzo2011-to]
-    A. Rizzo, S. Coriani, K. Ruud, "Response Function Theory Computational Approaches to Linear and Nonlinear Optical Spectroscopy". In Computational Strategies for Spectroscopy, doi: 10.1002/9781118008720.ch2.
+    A. Rizzo, S. Coriani, K. Ruud, "Response Function Theory Computational Approaches to Linear and Nonlinear Optical Spectroscopy". In Computational Strategies for Spectroscopy, https://doi.org/10.1002/9781118008720.ch2.
 
 .. [Dreuw2005-wp]
    A. Dreuw, M. Head-Gordon
-   *Chem. Rev.* **105**, 4009 (2005), doi: 10.1021/cr0505627.
+   *Chem. Rev.* **105**, 4009 (2005), https://doi.org/10.1021/cr0505627.
 
 .. [Norman2018-tn]
    P. Norman, K. Ruud, T. Saue, "Principles and Practices of Molecular Properties: Theory, Modeling, and Simulations". John Wiley & Sons, 2018
 
 .. [Verstraelen:2016]
-   T. Verstraelen et al. "Minimal Basis Iterative Stockholder: Atoms in Molecules for Force-Field Development". *J. Chem. Theory and Comput.* doi: 10.1021/acs.jctc.6b00456.
+   T. Verstraelen et al. "Minimal Basis Iterative Stockholder: Atoms in Molecules for Force-Field Development". *J. Chem. Theory and Comput.* https://doi.org/10.1021/acs.jctc.6b00456.
 
 ..
    [Misquitta:2005:214103]
@@ -570,26 +571,26 @@ Bibliography
 .. [Haser:1989:104]
    M. Haser and R. Ahlrichs,
    *J. Comp. Chem.* **10(1)**, 104 (1989).
-   doi: 10.1002/jcc.540100111
+   https://doi.org/10.1002/jcc.540100111
    
 .. [Thompson:2017:144101]
    T. H. Thompson and C. Ochsenfeld
    *J. Chem. Phys.* **147**, 144101 (2017).
-   doi: 10.1063/1.4994190
+   https://doi.org/10.1063/1.4994190
    
 .. [Smith:2020:184108]
     "PSI4 1.4: Open-source software for high-throughput quantum chemistry",
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish, M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio, A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer, R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni, J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein, B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov, K. Patkowski, A. E. DePrince III, U. Bozkaya, R. King, F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill
     *J. Chem. Phys.* **152**, 184108 (2020).
-    doi: 10.1063/5.0006002
+    https://doi.org/10.1063/5.0006002
 
 .. [Waldrop:2021:024103]
    "Nonapproximated third-order exchange induction energy in symmetry-adapted perturbation theory",
    J. M. Waldrop and K. Patkowski
    *J. Chem. Phys.* **154**, 024103 (2021).
-   doi: 10.1063/1.4994190
+   https://doi.org/10.1063/1.4994190
    
 .. [Ochsenfeld:1998:1663]
    C. Ochsenfeld, C. A. White, M. Head-Gordon
    *J. Chem. Phys.* **109**, 1663 (1998)
-   doi: 10.1063/1.476741
+   https://doi.org/10.1063/1.476741

--- a/doc/sphinxman/source/oeprop.rst
+++ b/doc/sphinxman/source/oeprop.rst
@@ -80,6 +80,8 @@ summarized in the table below.
    +------------------------------------+-----------------------+-----------------------------------------------------------------------------------+
    | Stockholder Atomic Multipoles      | MBIS_CHARGES          | Generates atomic charges, dipoles, etc. See :ref:`sec:oeprop_mbis`                |
    +------------------------------------+-----------------------+-----------------------------------------------------------------------------------+
+   | Free-atom volumes                  | MBIS_VOLUME_RATIOS    |                                                                                   |
+   +------------------------------------+-----------------------+-----------------------------------------------------------------------------------+
 
 There are two ways the computation of one-electron properties can be requested. 
 Firstly, the properties can be evaluated from the last

--- a/doc/sphinxman/source/psi4api.rst
+++ b/doc/sphinxman/source/psi4api.rst
@@ -38,3 +38,5 @@
 
 .. automodapi:: psi4.driver
 
+.. automodapi:: psi4.driver.p4util
+

--- a/psi4/driver/diatomic.py
+++ b/psi4/driver/diatomic.py
@@ -26,7 +26,7 @@
 # @END LICENSE
 #
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import numpy as np
 
@@ -36,7 +36,7 @@ from psi4.driver.p4util.exceptions import *
 
 
 def least_squares_fit_polynomial(xvals, fvals, localization_point, no_factorials=True, weighted=True, polynomial_order=4):
-    """Performs and unweighted least squares fit of a polynomial, with specified order
+    """Performs an unweighted least squares fit of a polynomial, with specified order
        to an array of input function values (fvals) evaluated at given locations (xvals).
        See https://doi.org/10.1063/1.4862157, particularly eqn (7) for details. """
     xpts = np.array(xvals) - localization_point
@@ -58,7 +58,7 @@ def least_squares_fit_polynomial(xvals, fvals, localization_point, no_factorials
     return fit
 
 
-def anharmonicity(rvals: List, energies: List, plot_fit: str = '', mol = None) -> Dict:
+def anharmonicity(rvals: List[float], energies: List[float], plot_fit: str = '', mol = None) -> Dict[str, Any]:
     """Generates spectroscopic constants for a diatomic molecules.
        Fits a diatomic potential energy curve using a weighted least squares approach
        (c.f. https://doi.org/10.1063/1.4862157, particularly eqn. 7), locates the minimum

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -25,10 +25,10 @@
 #
 # @END LICENSE
 #
-"""Module with a *procedures* dictionary specifying available quantum
-chemical methods and functions driving the main quantum chemical
-functionality, namely single-point energies, geometry optimizations,
-properties, and vibrational frequency calculations.
+"""
+Nexus of psi4.driver module with primary user-facing functions, including
+single-point energies, geometry optimizations, properties, and vibrational
+frequency calculations.
 
 """
 import json
@@ -38,7 +38,7 @@ import copy
 import shutil
 import sys
 import logging
-from typing import Union
+from typing import Dict, Optional, Union
 import logging
 
 import numpy as np
@@ -1583,7 +1583,14 @@ def frequency(name, **kwargs):
         return core.variable('CURRENT ENERGY')
 
 
-def vibanal_wfn(wfn: core.Wavefunction, hess: np.ndarray = None, irrep: Union[int, str] = None, molecule=None, project_trans: bool = True, project_rot: bool = True):
+def vibanal_wfn(
+    wfn: core.Wavefunction,
+    hess: Optional[np.ndarray] = None,
+    irrep: Optional[Union[int, str]] = None,
+    molecule=None,
+    project_trans: bool = True,
+    project_rot: bool = True,
+) -> Dict[str, np.ndarray]:
     """Function to perform analysis of a hessian or hessian block, specifically...
     calling for and printing vibrational and thermochemical analysis, setting thermochemical variables,
     and writing the vibrec and normal mode files.
@@ -1596,7 +1603,8 @@ def vibanal_wfn(wfn: core.Wavefunction, hess: np.ndarray = None, irrep: Union[in
         Hessian to analyze, if not the hessian in wfn.
         (3*nat, 3*nat) non-mass-weighted Hessian in atomic units, [Eh/a0/a0].
     irrep
-        The irrep for which frequencies are calculated. Thermochemical analysis is skipped if this is given,
+        The irrep for which frequencies are calculated. Thermochemical analysis
+        is skipped if this is specified (non-None),
         as only one symmetry block of the hessian has been computed.
     molecule : :py:class:`~psi4.core.Molecule` or qcdb.Molecule, optional
         The molecule to pull information from, if not the molecule in wfn. Must at least have similar
@@ -1608,8 +1616,9 @@ def vibanal_wfn(wfn: core.Wavefunction, hess: np.ndarray = None, irrep: Union[in
 
     Returns
     -------
-    vibinfo : dict
+    vibinfo : ~typing.Dict[str, ~numpy.ndarray]
         A dictionary of vibrational information. See :py:func:`~psi4.driver.qcdb.vib.harmonic_analysis`
+
     """
 
     if hess is None:

--- a/psi4/driver/driver_util.py
+++ b/psi4/driver/driver_util.py
@@ -276,8 +276,8 @@ def negotiate_derivative_type(
             # untested
             analytic = [highest_analytic_properties_available(mtd, proc) for mtd in method]
             if verbose > 1:
-                print(method, analytic, '->', min(analytic))
-            highest_analytic_dertype, proc_messages = min(analytic)
+                print(method, analytic, '->', min(analytic, key=lambda t: t[0]))
+            highest_analytic_dertype, proc_messages = min(analytic, key=lambda t: t[0])
         else:
             highest_analytic_dertype, proc_messages = highest_analytic_properties_available(method, proc)
 
@@ -287,8 +287,8 @@ def negotiate_derivative_type(
         if isinstance(method, list):
             analytic = [highest_analytic_derivative_available(mtd, proc) for mtd in method]
             if verbose > 1:
-                print(method, analytic, '->', min(analytic))
-            highest_analytic_dertype, proc_messages = min(analytic)
+                print(method, analytic, '->', min(analytic, key=lambda t: t[0]))
+            highest_analytic_dertype, proc_messages = min(analytic, key=lambda t: t[0])
         else:
             highest_analytic_dertype, proc_messages = highest_analytic_derivative_available(method, proc)
 

--- a/psi4/driver/molutil.py
+++ b/psi4/driver/molutil.py
@@ -249,7 +249,7 @@ dynamic_variable_bind(core.Molecule)  # pass class type, not class instance
 #   H  0.0 1.0 0.0
 #   H  0.0 0.0 0.0
 #
-def geometry(geom, name="default"):
+def geometry(geom: str, name: str = "default") -> core.Molecule:
     """Function to create a molecule object of name *name* from the
     geometry in string *geom*. Permitted for user use but deprecated
     in driver in favor of explicit molecule-passing. Comments within
@@ -289,7 +289,7 @@ def geometry(geom, name="default"):
     return molecule
 
 
-def activate(mol):
+def activate(mol: core.Molecule):
     """Function to set molecule object *mol* as the current active molecule.
     Permitted for user use but deprecated in driver in favor of explicit
     molecule-passing.

--- a/psi4/driver/p4util/__init__.py
+++ b/psi4/driver/p4util/__init__.py
@@ -26,17 +26,23 @@
 # @END LICENSE
 #
 
-from .optproc import *
-from .text import *
-from .procutil import *
-from .util import *
-from .testing import *
+"""
+Miscellaneous tools for driver and users.
+"""
+
 from .exceptions import *
+from .fchk import *
+from .fcidump import *
 from .inpsight import *
 from .numpy_helper import *
+from .optproc import *
 from .p4regex import *
+from .procutil import *
+from .prop_util import *
 from .python_helpers import *
 from .solvers import *
-from .prop_util import *
-from .spectrum import spectrum
-from . import writer
+from .spectrum import *
+from .testing import *
+from .text import *
+from .util import *
+from .writer import *

--- a/psi4/driver/p4util/exceptions.py
+++ b/psi4/driver/p4util/exceptions.py
@@ -27,24 +27,51 @@
 #
 """Module with non-generic exceptions classes."""
 
+__all__ = [
+    "ConvergenceError",
+    "MissingMethodError",
+    "ManagedMethodError",
+    "OptimizationConvergenceError",
+    "ParsingError",
+    "PastureRequiredError",
+    "PsiException",
+    "SCFConvergenceError",
+    "TDSCFConvergenceError",
+    "TestComparisonError",
+    "UpgradeHelper",
+    "ValidationError",
+]
+
+from typing import Any, Dict, List, Optional
 from psi4 import core, extras
 
 
 class PsiException(Exception):
-    """Error class for Psi."""
+    """Error class for |PSIfour|. Flags success as False (triggering coffee)."""
     extras._success_flag_ = False
     pass
 
 
 class ValidationError(PsiException):
-    """Error called for problems with the input file. Prints
-    error message *msg* to standard output stream and output file.
+    """Input specification has problems.
+
+    Error message *msg* directed both to standard output stream and to outfile.
+
+    Parameters
+    ----------
+    msg
+        Human readable string describing the exception.
+
+    Attributes
+    ----------
+    message
+        Human readable string describing the exception.
 
     """
+    message: str
 
-    def __init__(self, msg):
+    def __init__(self, msg: str):
         PsiException.__init__(self, msg)
-        # print("%s" % repr(msg))
         self.message = '\nPsiException: %s\n\n' % repr(msg)
 
 
@@ -52,6 +79,8 @@ class ParsingError(PsiException):
     """Error called for problems parsing a text file. Prints error message
     *msg* to standard output stream and output file.
 
+    Only used by untested distributed CC response machinery.
+
     """
 
     def __init__(self, msg):
@@ -59,24 +88,42 @@ class ParsingError(PsiException):
         self.message = '\nPsiException: %s\n\n' % msg
 
 
-class PsiImportError(PsiException):
-    """Error called for problems import python dependencies. Prints error message
-    *msg* to standard output stream and output file.
-    """
-
-    def __init__(self, msg):
-        PsiException.__init__(self, msg)
-        self.message = '\nPsiException: %s\n\n' % msg
+# PsiImportError ceased to be used by v1.1. Class removed by v1.7
+# class PsiImportError(PsiException):
 
 
 class TestComparisonError(PsiException):
-    """Error called when a test case fails due to a failed
-    compare_values() call. Prints error message *msg* to standard
-    output stream and output file.
+    """Error called when a :func:`~psi4.compare_values` or other comparison
+    function fails.
+
+    Error message *msg* directed both to standard output stream and to outfile.
+
+    Parameters
+    ----------
+    msg
+        Human readable string describing the exception.
+
+    Attributes
+    ----------
+    message
+        Human readable string describing the exception.
+
+    Example
+    -------
+    >>> psi4.compare_values(2, 3, 2, "asdf")
+    asdf..................................................................................FAILED
+    psi4.driver.p4util.exceptions.TestComparisonError:  asdf: computed value (3.0000) does not match (2.0000) to atol=0.01 by difference (1.0000).
+    !----------------------------------------------------------------------------------!
+    !                                                                                  !
+    !         asdf: computed value (3.0000) does not match (2.0000) to atol=0.01 by    !
+    !     difference (1.0000).                                                         !
+    !                                                                                  !
+    !----------------------------------------------------------------------------------!
 
     """
+    message: str
 
-    def __init__(self, msg):
+    def __init__(self, msg: str):
         PsiException.__init__(self, msg)
         self.message = '\nPsiException: %s\n\n' % msg
 
@@ -86,13 +133,29 @@ class UpgradeHelper(PsiException):
     simple syntax transition is possible.
 
     It is much preferred to leave the old syntax valid for a release
-    cycle and have the old syntax raise a deprecation FutureWarning. For
-    cases where the syntax just has to jump, this can be used to trap
-    the old syntax at first error and suggest the new.
+    cycle and have the old syntax raise a deprecation :class:`FutureWarning`.
+    For cases where the syntax just has to jump, an UpgradeHelper can be used
+    to trap the old syntax at first error and suggest the new.
+
+    An UpgradeHelper can also be used after the :class:`FutureWarning`
+    described above has expired. Then the body of the code can be deleted while
+    the definition is preserved, and an UpgradeHelper called in place of the
+    body to guide users with lagging syntax.
+
+    Parameters
+    ----------
+    old
+        Previously valid syntax.
+    new
+        Suggested replacement syntax.
+    version
+        First Major.minor version at which `old` syntax won't run. Generally
+        the next release at time of commit.
+    elaboration
+        Any additional message to convey. Should start with a space.
 
     """
-
-    def __init__(self, old, new, version, elaboration):
+    def __init__(self, old: str, new: str, version: str, elaboration: str):
         msg = "Using `{}` instead of `{}` is obsolete as of {}.{}".format(old, new, version, elaboration)
         PsiException.__init__(self, msg)
         core.print_out('\nPsiException: %s\n\n' % (msg))
@@ -103,14 +166,25 @@ class ConvergenceError(PsiException):
 
     Parameters
     ----------
-    eqn_description : str
-        Type of QC routine that has failed (e.g., SCF)
-    iteration : int
-        What iteration we failed on
+    eqn_description
+        Type of QC routine that has failed (e.g., SCF, optimization).
+    iteration
+        Iteration number on which routine failed.
+    additional_info
+        Any additional message to convey.
+
+    Attributes
+    ----------
+    message
+        Human readable string describing the exception.
+    iteration
+        Iteration number on which routine failed.
 
     """
+    message: str
+    iteration: int
 
-    def __init__(self, eqn_description, iteration, additional_info=None):
+    def __init__(self, eqn_description: str, iteration: int, additional_info: Optional[str] = None):
         msg = f"Could not converge {eqn_description:s} in {iteration:d} iterations."
         if additional_info is not None:
             msg += f"\n\n{additional_info}"
@@ -121,9 +195,32 @@ class ConvergenceError(PsiException):
 
 
 class OptimizationConvergenceError(ConvergenceError):
-    """Error called for problems with geometry optimizer."""
+    """Error called for problems with geometry optimizer.
 
-    def __init__(self, eqn_description, iteration, wfn):
+    Parameters
+    ----------
+    eqn_description
+        Type of QC routine that has failed (e.g., geometry optimization).
+    iteration
+        Iteration number on which routine failed.
+    wfn
+        Wavefunction at time of exception.
+
+    Attributes
+    ----------
+    message
+        Human readable string describing the exception.
+    iteration
+        Iteration number on which routine failed.
+    wfn
+        Wavefunction at time of exception.
+
+    """
+    message: str
+    iteration: int
+    wfn: core.Wavefunction
+
+    def __init__(self, eqn_description: str, iteration: int, wfn: core.Wavefunction):
         ConvergenceError.__init__(self, eqn_description, iteration)
         self.wfn = wfn
 
@@ -133,16 +230,45 @@ class SCFConvergenceError(ConvergenceError):
 
     Parameters
     ----------
-    wfn : psi4.core.Wavefunction
-        Wavefunction at time of exception
-    e_conv : float
-        Change in energy for last iteration
-    d_conv : float
-        RMS change in density for last iteration
+    eqn_description
+        Type of QC routine that has failed (e.g., SCF preiterations).
+    iteration
+        Iteration number on which routine failed.
+    wfn
+        Wavefunction at time of exception.
+    e_conv
+        Change in energy for last iteration.
+    d_conv
+        RMS change in density for last iteration.
+
+    Attributes
+    ----------
+    message
+        Human readable string describing the exception.
+    iteration
+        Iteration number on which routine failed.
+    wfn
+        Wavefunction at time of exception.
+    e_conv
+        Change in energy for last iteration.
+    d_conv
+        RMS change in density for last iteration.
 
     """
+    message: str
+    iteration: int
+    wfn: core.Wavefunction
+    e_conv: float
+    d_conv: float
 
-    def __init__(self, eqn_description, iteration, wfn, e_conv, d_conv):
+    def __init__(
+        self,
+        eqn_description: str,
+        iteration: int,
+        wfn: core.Wavefunction,
+        e_conv: float,
+        d_conv: float,
+    ):
         ConvergenceError.__init__(self, eqn_description, iteration)
         self.e_conv = e_conv
         self.d_conv = d_conv
@@ -154,24 +280,44 @@ class TDSCFConvergenceError(ConvergenceError):
 
     Parameters
     ----------
-    wfn : psi4.core.Wavefunction
+    wfn
         Wavefunction at time of exception
-    what : str
+    what
         What we were trying to solve for (singlets/triplets, irrep) when we failed to converge
-    stats : Dict
+    stats
         Dictionary of convergence statistics of last iteration.
         Keys are:
 
-          count : int, iteration number
-          res_norm : np.ndarray (nroots, ), the norm of residual vector for each roots
-          val : np.ndarray (nroots, ), the eigenvalue corresponding to each root
-          delta_val : np.ndarray (nroots, ), the change in eigenvalue from the last iteration to this ones
-          collapse : bool, if a subspace collapse was performed
-          product_count : int, the running total of product evaluations that was performed
-          done : bool, if all roots were converged
-    """
+          - count : int, iteration number
+          - res_norm : np.ndarray (nroots, ), the norm of residual vector for each roots
+          - val : np.ndarray (nroots, ), the eigenvalue corresponding to each root
+          - delta_val : np.ndarray (nroots, ), the change in eigenvalue from the last iteration to this ones
+          - collapse : bool, if a subspace collapse was performed
+          - product_count : int, the running total of product evaluations that was performed
+          - done : bool, if all roots were converged
 
-    def __init__(self, iteration, wfn, what, stats):
+    Attributes
+    ----------
+    message
+        Human readable string describing the exception.
+    iteration
+        Iteration number on which routine failed.
+    wfn
+        Wavefunction at time of exception
+    what
+        What we were trying to solve for (singlets/triplets, irrep) when we
+        failed to converge.
+    stats
+        Dictionary of convergence statistics of last iteration. See keys above.
+
+    """
+    message: str
+    iteration: int
+    wfn: core.Wavefunction
+    what: str
+    stats: Dict[str, Any]
+
+    def __init__(self, iteration: int, wfn: core.Wavefunction, what: str, stats: Dict[str, Any]):
         # prepare message, including excitation energies and residual norm
         conv_info = "==> Convergence statistics from last iteration <==\n\n"
         conv_info += "Excitation Energy".center(21) + f" {'D[value]':^15}" + "|R|".center(11) + "\n"
@@ -187,28 +333,52 @@ class TDSCFConvergenceError(ConvergenceError):
         self.stats = stats
 
 
-class CSXError(PsiException):
-    """Error called when CSX generation fails.
-
-    """
-
-    def __init__(self, msg):
-        PsiException.__init__(self, msg)
-        self.message = '\nCSXException: %s\n\n' % msg
+# CSXError ceased to be used by v1.4. Class removed by v1.7
+# class CSXError(PsiException):
 
 
 class MissingMethodError(ValidationError):
-    """Error called when method not available.
+    """Error called when requested level or theory or derivative level are not
+    available.
+
+    Parameters
+    ----------
+    msg
+        Human readable string describing the exception.
+
+    Attributes
+    ----------
+    message
+        Human readable string describing the exception.
 
     """
+    message: str
 
-    def __init__(self, msg):
+    def __init__(self, msg: str):
         ValidationError.__init__(self, msg)
         self.message = '\nMissingMethodError: %s\n\n' % msg
 
 
 class ManagedMethodError(PsiException):
-    def __init__(self, circs):
+    """Error called when a requested level of theory and derivative level are
+    nominally available but not for the particular conditions (e.g., reference,
+    algorithm, active orbitals, QC module, etc.) requested.
+
+    Parameters
+    ----------
+    circs
+        List providing calling function name, level of theory, algorithm,
+        reference, QC module, and frozen-core/all-electron requested conditions.
+
+    Attributes
+    ----------
+    message
+        Human readable string describing the exception.
+
+    """
+    message: str
+
+    def __init__(self, circs: List[str]):
         if circs[5] == '':
             modulemsg = "not available"
         else:
@@ -222,14 +392,8 @@ class ManagedMethodError(PsiException):
         self.message = '\nPsiException: %s\n\n' % msg
 
 
-class Dftd3Error(PsiException):
-    """
-
-    """
-
-    def __init__(self, msg):
-        PsiException.__init__(self, msg)
-        self.message = '\nDftd3Error: %s\n\n' % msg
+# Dftd3Error ceased to be used by v1.4. Class removed by v1.7
+# class Dftd3Error(PsiException):
 
 
 class PastureRequiredError(PsiException):

--- a/psi4/driver/p4util/fchk.py
+++ b/psi4/driver/p4util/fchk.py
@@ -28,12 +28,17 @@
 """Module with utility functions for FCHK files."""
 
 import re
+from typing import Union
+
 import numpy as np
 from psi4.driver.p4util.testing import compare_strings, compare_arrays, compare_values, compare_integers
 from psi4 import core
 from .exceptions import ValidationError
 
-__all__ = ['fchkfile_to_string','compare_fchkfiles', "compare_moldenfiles"]
+__all__ = [
+    "compare_fchkfiles",
+    "compare_moldenfiles",
+]
 
 def _consume_fchk_section(input_list, index):
     """compare a float or integer matrix section"""
@@ -62,17 +67,17 @@ def _consume_fchk_section(input_list, index):
     return offset + 1, field
 
 
-def fchkfile_to_string(fname):
+def _fchkfile_to_string(fname: str) -> str:
     """ Load FCHK file into a string"""
     with open(fname, 'r') as handle:
         fchk_string = handle.read()
     return fchk_string
 
 
-def compare_fchkfiles(expected, computed, atol_exponent, label):
-    """Comparison function for output data in FCHK (formatted checkpoint) file format.
-    Compares many fields including number of electrons, highest angular momentum, basis
-    set exponents, densities, final gradient.
+def compare_fchkfiles(expected: str, computed: str, atol_exponent: Union[int, float], label: str):
+    """Comparison function for output data in FCHK (formatted checkpoint) file
+    format. Compares many fields including number of electrons, highest angular
+    momentum, basis set exponents, densities, final gradient.
 
     Note only Psi4-style signature (``(expected, computed, atol_exponent, label)``) available.
 
@@ -84,21 +89,21 @@ def compare_fchkfiles(expected, computed, atol_exponent, label):
 
     Parameters
     ----------
-    expected : file
-        Reference FCHK file against which `computed` is compared.
-    computed : file
-        Input FCHK file to compare against `expected`.
-    atol_exponent : int or float
+    expected
+        Path to reference FCHK file against which `computed` is compared.
+    computed
+        Path to input FCHK file to compare against `expected`.
+    atol_exponent
         Absolute tolerance for high accuracy fields -- 1.e-8 or 1.e-9 is suitable.
         Values less than one are taken literally; one or greater taken as decimal digits for comparison.
         So `1` means `atol=0.1` and `2` means `atol=0.01` but `0.04` means `atol=0.04`
         Note that the largest expressable processed atol will be `~0.99`.
-    label : str
+    label
         Label for passed and error messages.
 
     """
-    fchk_ref = fchkfile_to_string(expected).splitlines()
-    fchk_calc = fchkfile_to_string(computed).splitlines()
+    fchk_ref = _fchkfile_to_string(expected).splitlines()
+    fchk_calc = _fchkfile_to_string(computed).splitlines()
 
     high_accuracy = atol_exponent
     low_accuracy = 3
@@ -143,7 +148,11 @@ def compare_fchkfiles(expected, computed, atol_exponent, label):
     return compare_integers(True, all(tests), label)
 
 
-def compare_moldenfiles(expected, computed, atol_exponent=7, label="Compare Molden"):
+def compare_moldenfiles(
+    expected: str,
+    computed: str,
+    atol_exponent: Union[int, float] = 1.e-7,
+    label: str = "Compare Molden"):
     """Comparison function for output data in Molden file format.
     Compares many fields including geometry, basis set, occupations, symmetries, energies.
 
@@ -153,16 +162,16 @@ def compare_moldenfiles(expected, computed, atol_exponent=7, label="Compare Mold
 
     Parameters
     ----------
-    expected : file
-        Reference Molden file against which `computed` is compared.
-    computed : file
-        Input Molden file to compare against `expected`.
-    atol_exponent : int or float
+    expected
+        Path to reference Molden file against which `computed` is compared.
+    computed
+        Path to input Molden file to compare against `expected`.
+    atol_exponent
         Absolute tolerance for high accuracy fields -- 1.e-8 or 1.e-9 is suitable.
         Values less than one are taken literally; one or greater taken as decimal digits for comparison.
         So `1` means `atol=0.1` and `2` means `atol=0.01` but `0.04` means `atol=0.04`
         Note that the largest expressable processed atol will be `~0.99`.
-    label : str
+    label
         Label for passed and error messages.
 
     """

--- a/psi4/driver/p4util/fcidump.py
+++ b/psi4/driver/p4util/fcidump.py
@@ -27,6 +27,15 @@
 #
 """Module with utility function for dumping the Hamiltonian to file in FCIDUMP format."""
 
+__all__ = [
+    "compare_fcidumps",
+    "energies_from_fcidump",
+    "fcidump",
+    "fcidump_from_file",
+]
+
+from typing import Any, Dict, List, Optional
+
 import numpy as np
 
 from psi4.driver import psifiles as psif
@@ -37,22 +46,29 @@ from psi4 import core
 from .exceptions import ValidationError, TestComparisonError
 
 
-def fcidump(wfn, fname='INTDUMP', oe_ints=None):
-    """Save integrals to file in FCIDUMP format as defined in Comp. Phys. Commun. 54 75 (1989)
+def fcidump(wfn: core.Wavefunction, fname: str = 'INTDUMP', oe_ints: Optional[List] = None):
+    """Save integrals to file in FCIDUMP format as defined in Comp. Phys. Commun. 54 75 (1989),
+    https://doi.org/10.1016/0010-4655(89)90033-7 .
     Additional one-electron integrals, including orbital energies, can also be saved.
     This latter format can be used with the HANDE QMC code but is not standard.
 
-    :returns: None
+    Parameters
+    ----------
+    wfn
+        Set of molecule, basis, orbitals from which to generate FCIDUMP file.
+    fname
+        Name of the integrals file, defaults to INTDUMP.
+    oe_ints
+        List of additional one-electron integrals to save to file. So far only
+        EIGENVALUES is a valid option.
 
-    :raises: ValidationError when SCF wavefunction is not RHF
+    Raises
+    ------
+    ValidationError
+        When SCF wavefunction is not RHF.
 
-    :type wfn: :py:class:`~psi4.core.Wavefunction`
-
-    :param wfn: set of molecule, basis, orbitals from which to generate cube files
-    :param fname: name of the integrals file, defaults to INTDUMP
-    :param oe_ints: list of additional one-electron integrals to save to file. So far only EIGENVALUES is a valid option.
-
-    :examples:
+    Examples
+    --------
 
     >>> # [1] Save one- and two-electron integrals to standard FCIDUMP format
     >>> E, wfn = energy('scf', return_wfn=True)
@@ -233,7 +249,7 @@ def _irrep_map(wfn):
     return np.array(irrep_map, dtype='int')
 
 
-def fcidump_from_file(fname):
+def fcidump_from_file(fname: str) -> Dict[str, Any]:
     """Function to read in a FCIDUMP file.
 
     :returns: a dictionary with FCIDUMP header and integrals
@@ -324,7 +340,7 @@ def fcidump_from_file(fname):
     return intdump
 
 
-def compare_fcidumps(expected, computed, label):
+def compare_fcidumps(expected: str, computed: str, label: str):
     """Comparison function for FCIDUMP files.
     Compares the first six below, then computes energies from MO integrals and compares the last four.
 
@@ -370,7 +386,19 @@ def compare_fcidumps(expected, computed, label):
     compare_integers(True, (pass_1el and pass_2el and pass_scf and pass_mp2), label)
 
 
-def energies_from_fcidump(intdump):
+def energies_from_fcidump(intdump) -> Dict[str, float]:
+    """From integrals dictionary generated from :py:func:`fcidump_from_file`,
+    compute energies.
+
+    :returns: a dictionary with energies
+
+      - 'NUCLEAR REPULSION ENERGY'
+      - 'ONE-ELECTRON ENERGY'
+      - 'TWO-ELECTRON ENERGY'
+      - 'SCF TOTAL ENERGY'
+      - 'MP2 CORRELATION ENERGY'
+
+    """
     energies = {}
     energies['NUCLEAR REPULSION ENERGY'] = intdump['enuc']
     epsilon = intdump['epsilon']

--- a/psi4/driver/p4util/inpsight.py
+++ b/psi4/driver/p4util/inpsight.py
@@ -26,6 +26,8 @@
 # @END LICENSE
 #
 
+__all__ = ["InPsight"]
+
 import math
 import os
 from datetime import date
@@ -33,6 +35,7 @@ from datetime import date
 
 # yapf: disable
 class InPsight:
+    """POV-Ray visualization."""
 
     # POV-Ray defines
     defines = {}

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -25,9 +25,24 @@
 #
 # @END LICENSE
 #
+"""
+Array function, including NumPy interface and Python extensions to core array
+classes:
+
+ - Matrix (constructor, view, access, serialization)
+ - Vector (constructor, view, access, serialization)
+ - Dimension (constructor)
+ - CIVector (view)
+"""
+
+__all__ = [
+    "array_to_matrix",
+    "block_diagonal_array",
+]
+
 
 import sys
-from typing import List, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -67,28 +82,40 @@ def _find_dim(arr, ndim):
         raise ValidationError("Input array does not have a valid shape.")
 
 
-def array_to_matrix(self, arr: Union[np.ndarray, List[np.ndarray]], name: str = "New Matrix", dim1: Union[List, Tuple, core.Dimension] = None, dim2: core.Dimension = None) -> Union[core.Matrix, core.Vector]:
+def array_to_matrix(
+    self: Union[core.Matrix, core.Vector],
+    arr: Union[np.ndarray, List[np.ndarray]],
+    name: str = "New Matrix",
+    dim1: Optional[Union[List, Tuple, core.Dimension]] = None,
+    dim2: Optional[core.Dimension] = None,
+) -> Union[core.Matrix, core.Vector]:
     """
-    Converts a numpy array or list of numpy arrays into a Psi4 Matrix (irreped if list).
+    Converts a `NumPy array
+    <https://numpy.org/doc/stable/reference/arrays.ndarray.html>`_ or list of
+    NumPy arrays into a |PSIfour| :class:`~psi4.core.Matrix` or
+    :class:`~psi4.core.Vector` (irreped if list).
 
     Parameters
     ----------
+    self
+        Matrix or Vector class.
     arr
-        Numpy array or list of arrays to use as the data for a new core.Matrix
+        NumPy array or list of arrays to use as the data for a new
+        :class:`~psi4.core.Matrix` or :class:`~psi4.core.Vector`.
     name
-        Name to give the new core.Matrix
+        Name to give the new :class:`~psi4.core.Matrix`.
     dim1
-        If a single dense numpy array is given, a dimension can be supplied to
+        If a single dense NumPy array is given, a dimension can be supplied to
         apply irreps to this array. Note that this discards all extra information
         given in the matrix besides the diagonal blocks determined by the passed
         dimension.
     dim2
-        Same as dim1 only if using a psi4.core.Dimension object.
+        Same as `dim1` only if using a :class:`~psi4.core.Dimension` object.
 
     Returns
     -------
     Matrix or Vector
-       Returns the given Psi4 object
+       Returns the given (`self`) Psi4 object.
 
     Notes
     -----
@@ -212,10 +239,14 @@ def array_to_matrix(self, arr: Union[np.ndarray, List[np.ndarray]], name: str = 
             raise ValidationError("Array_to_Matrix: type '%s' is not recognized." % str(arr_type))
 
 
-def _to_array(matrix: Union[core.Matrix, core.Vector], copy: bool = True, dense: bool = False) -> Union[np.ndarray, List[np.ndarray]]:
+def _to_array(
+    matrix: Union[core.Matrix, core.Vector],
+    copy: bool = True,
+    dense: bool = False,
+) -> Union[np.ndarray, List[np.ndarray]]:
     """
-    Converts a Psi4 Matrix or Vector to a NumPy array. Either copies the data or simply
-    constructs a view.
+    Converts a |PSIfour| Matrix or Vector to a NumPy array. Either copies the
+    data or simply constructs a view.
 
     Parameters
     ----------
@@ -224,12 +255,13 @@ def _to_array(matrix: Union[core.Matrix, core.Vector], copy: bool = True, dense:
     copy
         Copy the data if `True`, return a view otherwise
     dense
-        Converts irreped Psi4 objects to diagonally blocked dense arrays if `True`. Returns a list of arrays otherwise.
+        Converts irreped Psi4 objects to diagonally blocked dense arrays if
+        `True`. Returns a list of arrays otherwise.
 
     Returns
     -------
-    numpy.ndarray
-       Returns either a list of np.array's or the base array depending on options.
+    ~numpy.ndarray or ~typing.List[~numpy.ndarray]
+        Returns a single or list of NumPy arrays depending on options.
 
     Notes
     -----
@@ -344,13 +376,33 @@ def _array_conversion(self):
         return self.np.__array_interface__
 
 
-def _np_write(self, filename=None, prefix=""):
+def _np_write(
+    self: Union[core.Matrix, core.Vector],
+    filename: Optional[str] = None,
+    prefix: str = "",
+) -> Optional[Dict[str, Any]]:
     """
-    Writes the irreped matrix to a NumPy zipped file.
+    Writes the irreped matrix to a NumPy uncompressed file using :func:`numpy.savez`.
 
     Can return the packed data for saving many matrices into the same file.
-    """
 
+    Parameters
+    ----------
+    self
+        Instance to be serialized.
+    filename
+        File name where the data will be saved.
+    prefix
+        Name of instance prepared for NumPy.
+
+    Returns
+    -------
+    None or ~typing.Dict[str, ~typing.Any]
+        When `filename` given, it and dict serialization passed to
+        :func:`numpy.savez`, so ``.npz`` file saved and None returned.
+        When `filename` None, dict serialization returned.
+
+    """
     ret = {}
     ret[prefix + "Irreps"] = self.nirrep()
     ret[prefix + "Name"] = self.name
@@ -373,9 +425,22 @@ def _np_write(self, filename=None, prefix=""):
     np.savez(filename, **ret)
 
 
-def _np_read(self, filename, prefix=""):
-    """
-    Reads the data from a NumPy compress file.
+def _np_read(
+    self: Union[core.Matrix, core.Vector],
+    filename: str,
+    prefix: str = "",
+) -> Union[core.Matrix, core.Vector]:
+    """Reads the data from a NumPy compressed or uncompressed file using
+    :func:`numpy.load`.
+
+    Parameters
+    ----------
+    self
+        Pointer to which class to be constructed.
+    filename
+        File name to read.
+    prefix
+        Name under which array was saved for NumPy.
     """
 
     if isinstance(filename, np.lib.npyio.NpzFile):
@@ -411,16 +476,30 @@ def _np_read(self, filename, prefix=""):
     return ret
 
 
-def _to_serial(data):
+def _to_serial(self: Union[core.Matrix, core.Vector]) -> Dict[str, Any]:
     """
-    Converts an object with a .nph accessor to a serialized dictionary
-    """
+    Converts an object with a ``.nph`` accessor to a serialized dictionary
 
+    Parameters
+    ----------
+    self
+        Matrix or Vector instance.
+
+    Returns
+    -------
+    ~typing.Dict[str, ~typing.Any]
+        Serialized dictionary with keys:
+
+        - shape
+        - data : List[str]
+        - type : {'matrix', 'vector'}
+
+    """
     json_data = {}
     json_data["shape"] = []
     json_data["data"] = []
 
-    for view in data.nph:
+    for view in self.nph:
         json_data["shape"].append(view.shape)
         json_data["data"].append(view.tostring())
 
@@ -434,9 +513,17 @@ def _to_serial(data):
     return json_data
 
 
-def _from_serial(self, json_data):
+def _from_serial(self, json_data: Dict[str, Any]) -> Union[core.Matrix, core.Vector]:
     """
     Converts serialized data to the correct Psi4 data type
+
+    Parameters
+    ----------
+    self
+        Pointer to which class to be constructed.
+    json_data
+        Serialization of class. See :meth:`to_serial` for data layout.
+
     """
 
     if json_data["type"] == "vector":
@@ -455,13 +542,20 @@ def _from_serial(self, json_data):
     return ret
 
 
-def _chain_dot(*args, **kwargs):
-    """
-    Chains dot products together from a series of Psi4 Matrix classes.
+def _chain_dot(*args, **kwargs) -> core.Matrix:
+    """Chains dot products together from a series of Psi4 Matrix classes.
+    Uses :func:`~psi4.core.doublet`.
 
-    By default there is no transposes, an optional vector of booleans can be passed in.
-    """
+    Parameters
+    ----------
+    args
+        Arbitrary number of :class:`~psi4.core.Matrix` arguments to be
+        multiplied.
+    trans
+        Optional iterable of booleans of length number of `args` to designate
+        transposes, if any.
 
+    """
     trans = kwargs.pop("trans", None)
     if trans is None:
         trans = [False for x in range(len(args))]
@@ -538,12 +632,23 @@ core.CIVector.np = _civec_view
 
 
 @classmethod
-def _dimension_from_list(self, dims, name="New Dimension"):
+def _dimension_from_list(
+    self,
+    dims: Union[Tuple[int], List[int], np.ndarray, core.Dimension],
+    name="New Dimension",
+) -> core.Dimension:
     """
-    Builds a core.Dimension object from a python list or tuple. If a dimension
-    object is passed a copy will be returned.
-    """
+    Builds a Dimension object from a Python list or tuple. If a
+    :class:`~psi4.core.Dimension` object is passed, a copy will be returned.
 
+    Parameters
+    ----------
+    dims
+        Iterable of integers defining irrep dimensions.
+    name
+        Name for new instance.
+
+    """
     if isinstance(dims, (tuple, list, np.ndarray)):
         irreps = len(dims)
     elif isinstance(dims, core.Dimension):
@@ -557,30 +662,29 @@ def _dimension_from_list(self, dims, name="New Dimension"):
     return ret
 
 
-def _dimension_to_tuple(dim):
-    """
-    Converts a core.Dimension object to a tuple.
-    """
+def _dimension_to_tuple(self: core.Dimension) -> Tuple[int]:
+    """Serializes :class:`~psi4.core.Dimension` to a tuple."""
 
-    if isinstance(dim, (tuple, list)):
-        return tuple(dim)
+    if isinstance(self, (tuple, list)):
+        return tuple(self)
 
-    irreps = dim.n()
+    irreps = self.n()
     ret = []
     for i in range(irreps):
-        ret.append(dim[i])
+        ret.append(self[i])
     return tuple(ret)
 
 
-def _dimension_iter(dim):
+def _dimension_iter(dim) -> Iterator[int]:
     """
     Provides an iterator class for the Dimension object.
 
-    Allows:
-        dim = psi4.core.Dimension(...)
-        list(dim)
-    """
+    Example
+    -------
+    >>> dim = psi4.core.Dimension(...)
+    >>> list(dim)
 
+    """
     for i in range(dim.n()):
         yield dim[i]
 
@@ -592,10 +696,15 @@ core.Dimension.__iter__ = _dimension_iter
 
 
 # General functions for NumPy array manipulation
-def block_diagonal_array(*args):
+def block_diagonal_array(*args: List[np.ndarray]) -> np.ndarray:
     """
     Convert square NumPy array to a single block diagonal array.
-    Mimic of SciPy's block_diag.
+    Mimic of SciPy's :func:`scipy.linalg.block_diag`.
+
+    Parameters
+    ----------
+    args
+        Arbitrary number of square arrays.
     """
 
     # Validate the input matrices.

--- a/psi4/driver/p4util/optproc.py
+++ b/psi4/driver/p4util/optproc.py
@@ -28,27 +28,44 @@
 r"""Module to provide mechanism to store and restore option states in driver.
 
 """
+
+__all__ = [
+    "OptionState",
+    "OptionsStateCM",
+    "OptionsState",
+]
+
 import sys
 from contextlib import contextmanager
+from typing import Optional, Iterator, List
 
 from psi4 import core
 
 from .exceptions import ValidationError
 
 
-class OptionState(object):
-    """Class to store the state of a single *option*. If *module* given, the *option*
-    value and has_changed value is stored for global, local to *module*, and used by
-    *module* scopes; otherwise (used for BASIS keywords), only global scope is stored.
-    Class can store, print, and restore option values. ::
+class OptionState():
+    """Store the state (value and changed status) of a single `option`.
 
-        >>> OptionState('E_CONVERGENCE', 'SCF')
+    Parameters
+    ----------
+    option
+        Name of read_options keyword. All caps.
+    module
+        Name of read_options module or None if global. All caps.
+        If `module` given, the `option` value and has_changed value is stored
+        for global, local to `module`, and used by `module` scopes. Otherwise
+        (used for BASIS keywords), only global scope is stored.
 
-        >>> print(OptionState('DF_BASIS_MP2'))
+    Examples
+    --------
+    >>> OptionState('E_CONVERGENCE', 'SCF')
+
+    >>> print(OptionState('DF_BASIS_MP2'))
 
     """
 
-    def __init__(self, option, module=None):
+    def __init__(self, option: str, module: Optional[str] = None):
         self.option = option.upper()
         if module:
             self.module = module.upper()
@@ -86,6 +103,7 @@ class OptionState(object):
         return text
 
     def restore(self):
+        """Restore value and has_changed status to saved condition."""
         core.set_global_option(self.option, self.value_global)
         if not self.haschanged_global:
             core.revoke_global_option_changed(self.option)
@@ -95,28 +113,44 @@ class OptionState(object):
                 core.revoke_local_option_changed(self.module, self.option)
 
 
-class OptionsState(object):
-    """Class to contain multiple :py:func:`~psi4.driver.p4util.OptionState` objects.
-    Used in python driver functions to collect several options before altering
-    them, then restoring before function return. ::
+class OptionsState():
+    """Store multiple :py:func:`OptionState` objects.
+    Use in driver functions to collect several keywords before altering them,
+    then restore them before function return.
 
-        >>> optstash = OptionsState(
-                ['DF_BASIS_SCF'],
-                ['SCF_TYPE'],
-                ['SCF', 'REFERENCE'])
+    Parameters
+    ----------
+    largs
+        Specify which keywords to store value and has_changed state.
 
-        >>> print(optstash)
+    Examples
+    --------
+    >>> optstash = OptionsState(
+            ['DF_BASIS_SCF'],
+            ['SCF_TYPE'],
+            ['SCF', 'REFERENCE'])
 
-        >>> optstash.restore()
+    >>> print(optstash)
+
+    >>> optstash.restore()
 
     """
 
-    def __init__(self, *largs):
+    def __init__(self, *largs: List[List[str]]):
         self.data = {}
         for item in largs:
             self.add_option(item)
 
-    def add_option(self, item):
+    def add_option(self, item: List[str]):
+        """Store info for another keyword, `item`.
+
+        Parameters
+        ----------
+        item
+            A one-membered list with a global keyword or a two-membered list
+            with a module keyword and module.
+
+        """
         if len(item) == 2:
             key = (item[1], item[0])
         elif len(item) == 1:
@@ -139,12 +173,19 @@ class OptionsState(object):
         return text
 
     def restore(self):
+        """Restore value and has_changed status of each keyword to saved condition."""
         for key, item in self.data.items():
             item.restore()
 
 
 @contextmanager
-def OptionsStateCM(osd):
+def OptionsStateCM(osd) -> Iterator[None]:
+    """Return a context manager that will collect the state (value and changed
+    status) of a list of keywords `osd` that can initialize
+    :py:class:`OptionsState` on entry to the with-statement and restore the
+    collected state when exiting the with-statement.
+
+    """
     oso = OptionsState(osd)
     yield
     oso.restore()

--- a/psi4/driver/p4util/p4regex.py
+++ b/psi4/driver/p4util/p4regex.py
@@ -26,6 +26,8 @@
 # @END LICENSE
 #
 
+__all__ = ["der0th", "der1st", "der2nd", "no", "yes"]
+
 import re
 
 yes = re.compile(r'^(yes|true|on|1$)', re.IGNORECASE)

--- a/psi4/driver/p4util/procutil.py
+++ b/psi4/driver/p4util/procutil.py
@@ -26,6 +26,26 @@
 # @END LICENSE
 #
 """Module with utility functions used by several Python functions."""
+
+__all__ = [
+    "all_casings",
+    "drop_duplicates",
+    "expand_psivars",
+    "format_molecule_for_input",
+    "format_options_for_input",
+    "get_psifile",
+    "getattr_ignorecase",
+    "hold_options_state",
+    "import_ignorecase",
+    "kwargs_lower",
+    "mat2arr",
+    "prepare_options_for_modules",
+    "prepare_options_for_set_options",
+    "provenance_stamp",
+    "plump_qcvar",
+    "state_to_atomicinput",
+]
+
 import os
 import ast
 import sys
@@ -33,12 +53,13 @@ import math
 import pickle
 import inspect
 import warnings
-import contextlib
+from contextlib import contextmanager
 import collections
-from typing import Dict, List, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Union
+from types import ModuleType
 
 import numpy as np
-import qcelemental as qcel
+from qcelemental.models import AtomicInput
 
 from psi4 import core
 from psi4.metadata import __version__
@@ -46,12 +67,20 @@ from .exceptions import ValidationError
 from . import p4regex
 
 
-def kwargs_lower(kwargs):
-    """Function to rebuild and return *kwargs* dictionary
-    with all keys made lowercase. Should be called by every
-    function that could be called directly by the user.
-    Also turns boolean-like values into actual booleans.
-    Also turns values lowercase if sensible.
+def kwargs_lower(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Function to rebuild and return *kwargs* dictionary sanitized. Should be
+    called by every function that could be called directly by the user.
+
+    Parameters
+    ----------
+    kwargs
+        Input kwargs for any user-facing function.
+
+    Returns
+    -------
+    lowered : Dict[str, Any]
+        Sanitized kwargs with all keys made lowercase. Also turns boolean-like
+        values into actual booleans. Also turns values lowercase if sensible.
 
     """
     caseless_kwargs = {}
@@ -92,9 +121,20 @@ def kwargs_lower(kwargs):
     return caseless_kwargs
 
 
-def get_psifile(fileno, pidspace=str(os.getpid())):
-    """Function to return the full path and filename for psi file
-    *fileno* (e.g., psi.32) in current namespace *pidspace*.
+def get_psifile(fileno: int, pidspace: str = str(os.getpid())) -> str:
+    """Form full path and filename for psi scratch file.
+
+    Parameters
+    ----------
+    fileno
+        Psi file, e.g., ``psi.32``.
+    pidspace
+        Current namespace. Defaults to ``os.getpid()``.
+
+    Returns
+    -------
+    flpath : str
+        Full path and filename for psi file.
 
     """
     psioh = core.IOManager.shared_object()
@@ -105,16 +145,33 @@ def get_psifile(fileno, pidspace=str(os.getpid())):
     return targetfile
 
 
-def format_molecule_for_input(mol, name='', forcexyz=False):
+def format_molecule_for_input(
+    mol: Union[str, core.Molecule],
+    name: str = '',
+    forcexyz: bool = False) -> str:
     """Function to return a string of the output of
-    :py:func:`inputparser.process_input` applied to the XYZ
+    :py:func:`~psi4.driver.inputparser.process_input` applied to the XYZ
     format of molecule, passed as either fragmented
     geometry string *mol* or molecule instance *mol*.
     Used to capture molecule information from database
     modules and for distributed (sow/reap) input files.
-    For the reverse, see :py:func:`molutil.geometry`.
+    For the reverse, see :py:func:`~psi4.driver.geometry`.
+
+    Parameters
+    ----------
+    mol
+        Fragmented geometry string or molecule instance.
+    name
+        Name to call the resulting molecule.
+    forcexyz
+        Use Cartesians, even for Z-Matrix molecules.
 
     """
+    warnings.warn(
+        "Using `psi4.driver.p4util.format_molecule_for_input` instead of `Molecule.to_string(dtype='psi4')` is deprecated, and as soon as 1.8 it will stop working\n",
+        category=FutureWarning,
+        stacklevel=2)
+
     # when mol is already a string
     if isinstance(mol, str):
         mol_string = mol
@@ -136,7 +193,7 @@ def format_molecule_for_input(mol, name='', forcexyz=False):
     return commands
 
 
-def format_options_for_input(molecule=None, **kwargs):
+def format_options_for_input(molecule: Optional[core.Molecule] = None, **kwargs) -> str:
     """Function to return a string of commands to replicate the
     current state of user-modified options. Used to capture C++
     options information for distributed (sow/reap) input files.
@@ -146,6 +203,11 @@ def format_options_for_input(molecule=None, **kwargs):
        - Does not cover local (as opposed to global) options.
 
     """
+    warnings.warn(
+        "Using `psi4.driver.p4util.format_molecule_for_input` instead of `Molecule.to_string(dtype='psi4')` is deprecated, and as soon as 1.8 it will stop working\n",
+        category=FutureWarning,
+        stacklevel=2)
+
     if molecule is not None:
         symmetry = molecule.find_point_group(0.00001).symbol()
     commands = ''
@@ -173,34 +235,14 @@ def format_options_for_input(molecule=None, **kwargs):
     return commands
 
 
-def format_kwargs_for_input(filename, lmode=1, **kwargs):
-    """Function to pickle to file *filename* the options dictionary
-    *kwargs*. Mode *lmode* =2 pickles appropriate settings for
-    reap mode. Used to capture Python options information for
-    distributed (sow/reap) input files.
+def drop_duplicates(seq: Iterable) -> List:
+    """Return a copy of collection *seq* without any duplicate entries.
 
-    """
-    warnings.warn(
-        "Using `psi4.driver.p4util.format_kwargs_for_input` is deprecated, and as soon as 1.4 it will stop working\n",
-        category=FutureWarning,
-        stacklevel=2)
-    return core.get_legacy_gradient()
-
-    if lmode == 2:
-        kwargs['mode'] = 'reap'
-        kwargs['linkage'] = os.getpid()
-    filename.write('''\npickle_kw = ("""'''.encode('utf-8'))
-    pickle.dump(kwargs, filename)
-    filename.write('''""")\n'''.encode('utf-8'))
-    filename.write("""\nkwargs = pickle.loads(pickle_kw)\n""".encode('utf-8'))
-    if lmode == 2:
-        kwargs['mode'] = 'sow'
-        del kwargs['linkage']
-
-
-def drop_duplicates(seq):
-    """Function that given an array *seq*, returns an array without any duplicate
-    entries. There is no guarantee of which duplicate entry is dropped.
+    Parameters
+    ----------
+    seq
+        Collection to be de-duplicated. There is no guarantee of which
+        duplicate entry is dropped.
 
     """
     noDupes = []
@@ -208,9 +250,15 @@ def drop_duplicates(seq):
     return noDupes
 
 
-def all_casings(input_string):
-    """Return a generator of all lettercase permutations of `input_string`."""
+def all_casings(input_string: str) -> Iterator[str]:
+    """Return a generator of all lettercase permutations of `input_string`.
 
+    Parameters
+    ----------
+    input_string
+        String of which to permute the case.
+
+    """
     if not input_string:
         yield ""
     else:
@@ -224,94 +272,60 @@ def all_casings(input_string):
                 yield first.upper() + sub_casing
 
 
-def getattr_ignorecase(module, attr):
-    """Function to extract attribute *attr* from *module* if *attr*
-    is available in any possible lettercase permutation. Returns
-    attribute if available, None if not.
+def getattr_ignorecase(module: str, attr: str):
+    """Extract attribute *attr* from *module* if *attr*
+    is available in any possible lettercase permutation.
+
+    Parameters
+    ----------
+    module
+        Object on which to seek `attr`.
+    attr
+        Name of attribute with uncertain case.
+
+    Returns
+    -------
+    attribute : Any
+        Module attribute returned if available. None if not.
 
     """
-    array = None
-    for per in list(all_casings(attr)):
+    obj_attr = None
+    for permutation in list(all_casings(attr)):
         try:
-            getattr(module, per)
+            getattr(module, permutation)
         except AttributeError:
             pass
         else:
-            array = getattr(module, per)
+            obj_attr = getattr(module, permutation)
             break
 
-    return array
+    return obj_attr
 
 
-def import_ignorecase(module):
-    """Function to import *module* in any possible lettercase
-    permutation. Returns module object if available, None if not.
+def import_ignorecase(module: str) -> ModuleType:
+    """Import loader for *module* in any possible lettercase permutation.
+
+    Parameters
+    ----------
+    module
+        Name of module with uncertain case.
+
+    Returns
+    -------
+    types.ModuleType
+        Module object.
 
     """
     modobj = None
-    for per in list(all_casings(module)):
+    for permutation in list(all_casings(module)):
         try:
-            modobj = __import__(per)
+            modobj = __import__(permutation)
         except ImportError:
             pass
         else:
             break
 
     return modobj
-
-
-def extract_sowreap_from_output(sowout, quantity, sownum, linkage, allvital=False, label='electronic energy'):
-    """Function to examine file *sowout* from a sow/reap distributed job
-    for formatted line with electronic energy information about index
-    *sownum* to be used for construction of *quantity* computations as
-    directed by master input file with *linkage* kwarg. When file *sowout*
-    is missing or incomplete files, function will either return zero
-    (*allvital* is ``False``) or terminate (*allvital* is ``True``) since
-    some sow/reap procedures can produce meaningful results (database)
-    from an incomplete set of sown files, while others cannot (gradient,
-    hessian).
-
-    """
-    warnings.warn(
-        "Using `psi4.driver.p4util.extract_sowreap_from_output` is deprecated, and as soon as 1.4 it will stop working\n",
-        category=FutureWarning,
-        stacklevel=2)
-
-    E = 0.0
-
-    try:
-        freagent = open('%s.out' % (sowout), 'r')
-    except IOError:
-        if allvital:
-            raise ValidationError('Aborting upon output file \'%s.out\' not found.\n' % (sowout))
-        else:
-            return 0.0
-    else:
-        while True:
-            line = freagent.readline()
-            if not line:
-                if E == 0.0:
-                    raise ValidationError(
-                        'Aborting upon output file \'%s.out\' has no %s RESULT line.\n' % (sowout, quantity))
-                break
-            s = line.strip().split(None, 10)
-            if (len(s) != 0) and (s[0:3] == [quantity, 'RESULT:', 'computation']):
-                if int(s[3]) != linkage:
-                    raise ValidationError(
-                        'Output file \'%s.out\' has linkage %s incompatible with master.in linkage %s.' %
-                        (sowout, str(s[3]), str(linkage)))
-                if s[6] != str(sownum + 1):
-                    raise ValidationError(
-                        'Output file \'%s.out\' has nominal affiliation %s incompatible with item %s.' %
-                        (sowout, s[6], str(sownum + 1)))
-                if label == 'electronic energy' and s[8:10] == ['electronic', 'energy']:
-                    E = float(s[10])
-                    core.print_out('%s RESULT: electronic energy = %20.12f\n' % (quantity, E))
-                if label == 'electronic gradient' and s[8:10] == ['electronic', 'gradient']:
-                    E = ast.literal_eval(s[-1])
-                    core.print_out('%s RESULT: electronic gradient = %r\n' % (quantity, E))
-        freagent.close()
-    return E
 
 
 _modules = [
@@ -355,10 +369,13 @@ _modules = [
 ]
 
 
-@contextlib.contextmanager
-def hold_options_state():
-    """Context manager to collect the current state of the ``Process:environment.options`` object upon start and restore it upon finish."""
+@contextmanager
+def hold_options_state() -> Iterator[None]:
+    """Return a context manager that will collect the current state of
+    ``Process:environment.options`` on entry to the with-statement and clear
+    and restore the collected keywords state when exiting the with-statement.
 
+    """
     pofm = prepare_options_for_modules(
         changedOnly=True, commandsInsteadDict=False, globalsOnly=False, stateInsteadMediated=True
     )
@@ -367,16 +384,15 @@ def hold_options_state():
 
 
 def _reset_pe_options(pofm: Dict):
-    """Acts on ``Process::environment.options`` to clear it, then set it to state encoded in **pofm**.
+    """Acts on ``Process::environment.options`` to clear it, then set it to
+    state encoded in `pofm`.
 
     Parameters
     ----------
     pofm
-        Result of :py:func:`psi4.driver.p4util.prepare_options_for_modules(changedOnly=True, commandsInsteadDict=False, stateInsteadMediated=True)`
-
-    Returns
-    -------
-    None
+        Result of :py:func:`prepare_options_for_modules` with
+        ``changedOnly=True``, ``commandsInsteadDict=False``, and
+        ``stateInsteadMediated=True``.
 
     """
     core.clean_options()
@@ -408,7 +424,7 @@ def prepare_options_for_modules(
     globalsOnly: bool = False,
     stateInsteadMediated: bool = False,
 ) -> Union[Dict, str]:
-    """Capture current state of C++ psi4.core.Options information.
+    """Capture current state of :py:class:`psi4.core.Options` information.
 
     Parameters
     ----------
@@ -420,7 +436,8 @@ def prepare_options_for_modules(
         When False, return nested dictionary with globals in 'GLOBALS' subdictionary
         and locals in subdictionaries by module.
     globalsOnly
-        Record only global options to save time querying the psi4.core.Options object.
+        Record only global options to save time querying the
+        :py:class:`~psi4.core.Options` object.
         When False, record module-level options, too.
     stateInsteadMediated
         When ``True``, querying this function for options to be later *reset* into the same
@@ -431,10 +448,11 @@ def prepare_options_for_modules(
 
     Returns
     -------
-    dict
-        When ``commandsInsteadDict=False``.
+    Dict
+        When `commandsInsteadDict` is False.
     str
-        When ``commandsInsteadDict=True``.
+        When `commandsInsteadDict` is True.
+
 
     .. caution:: Some features are not yet implemented. Buy a developer a coffee.
 
@@ -483,14 +501,16 @@ def prepare_options_for_modules(
         return options
 
 
-def prepare_options_for_set_options():
-    """Capture current state of C++ psi4.core.Options information for reloading by `psi4.set_options()`.
+def prepare_options_for_set_options() -> Dict[str, Any]:
+    """Collect current state of :py:class:`psi4.core.Options` information for
+    reloading by :py:func:`~psi4.driver.p4util.set_options`.
 
     Returns
     -------
-    dict
-        Dictionary where keys are option names to be set globally or module__option
-        mangled names to be set locally. Values are option values.
+    Dict[str, Any]
+        Dictionary where keys are keyword names, either plain for those to be
+        set globally or mangled "module__keyword" for those to be set locally,
+        and values are keyword values.
 
     """
     flat_options = {}
@@ -519,9 +539,36 @@ def prepare_options_for_set_options():
     return flat_options
 
 
-def state_to_atomicinput(*, driver, method, basis=None, molecule=None, function_kwargs=None) -> "AtomicInput":
-    """Form a QCSchema for job input from the current state of Psi4 settings."""
+def state_to_atomicinput(
+    *,
+    driver: str,
+    method: str,
+    basis: Optional[str] = None,
+    molecule: Optional[core.Molecule] = None,
+    function_kwargs: Optional[Dict[str, Any]] = None) -> "AtomicInput":
+    """Form a QCSchema for job input from the current state of |PSIfour| settings.
 
+    Parameters
+    ----------
+    driver
+        {'energy', 'gradient', 'hessian'}
+        Target derivative level.
+    method
+        Level of theory for job.
+    basis
+        Basis set for job, if not to be extracted from :term:`BASIS <BASIS (MINTS)>`.
+    molecule
+        Molecule for job, if not the active one from
+        :py:func:`~psi4.core.get_active_molecule`.
+    function_kwargs
+        Additional keyword arguments to pass to the driver function.
+
+    Returns
+    -------
+    AtomicInput
+        QCSchema instance including current keyword set and provenance.
+
+    """
     if molecule is None:
         molecule = core.get_active_molecule()
 
@@ -532,7 +579,7 @@ def state_to_atomicinput(*, driver, method, basis=None, molecule=None, function_
     kw_basis = keywords.pop("basis", None)
     basis = basis or kw_basis
 
-    resi = qcel.models.AtomicInput(
+    resi = AtomicInput(
          **{
             "driver": driver,
             "extras": {
@@ -550,9 +597,18 @@ def state_to_atomicinput(*, driver, method, basis=None, molecule=None, function_
     return resi
 
 
-def mat2arr(mat):
-    """Function to convert core.Matrix *mat* to Python array of arrays.
-    Expects core.Matrix to be flat with respect to symmetry.
+def mat2arr(mat: core.Matrix) -> List[List[float]]:
+    """Convert Matrix to List.
+
+    Parameters
+    ----------
+    mat
+        |PSIfour| matrix. Should be flat with respect to symmetry.
+
+    Returns
+    -------
+    List[List[float]]
+        Pure Python representation of `mat`.
 
     """
     warnings.warn(
@@ -571,43 +627,34 @@ def mat2arr(mat):
     return arr
 
 
-def format_currentstate_for_input(func, name, allButMol=False, **kwargs):
-    """Function to return an input file in preprocessed psithon.
-    Captures memory, molecule, options, function, method, and kwargs.
-    Used to write distributed (sow/reap) input files.
+def expand_psivars(
+    pvdefs: Dict[str, Dict[str, Union[List[str], Callable]]],
+    verbose: Optional[int] = None):
+    """From rules on building QCVariables from others, set new variables to
+    P::e if all the contributors are available.
+
+    Parameters
+    ----------
+    pvdefs
+        Dictionary with keys with names of QCVariables to be created and values
+        with dictionary of two keys: 'args', the QCVariables that contribute to
+        the key and 'func', a function (or lambda) to combine them.
+    verbose
+        Control print level. If unspecified (None), value taken from
+        :term:`PRINT <PRINT (GLOBALS)>`. Status printing when verbose > 2.
+
+    Examples
+    --------
+    >>> pv1 = dict()
+    >>> pv1['SAPT CCD DISP'] = {'func': lambda x: x[0] * x[1] + x[2] + x[3] + x[4],
+                                'args': ['SAPT EXCHSCAL', 'SAPT EXCH-DISP20 ENERGY', 'SAPT DISP2(CCD) ENERGY',
+                                     'SAPT DISP22(S)(CCD) ENERGY', 'SAPT EST.DISP22(T)(CCD) ENERGY']}
+    >>> pv1['SAPT0 ELST ENERGY'] = {'func': sum, 'args': ['SAPT ELST10,R ENERGY']}
+    >>> expand_psivars(pv1)
 
     """
-    warnings.warn(
-        "Using `psi4.driver.p4util.format_currentstate_for_input` is deprecated, and as soon as 1.4 it will stop working\n",
-        category=FutureWarning,
-        stacklevel=2)
-
-    commands = """\n# This is a psi4 input file auto-generated from the %s() wrapper.\n\n""" % (inspect.stack()[1][3])
-    commands += """memory %d mb\n\n""" % (int(0.000001 * core.get_memory()))
-    if not allButMol:
-        molecule = core.get_active_molecule()
-        molecule.update_geometry()
-        commands += format_molecule_for_input(molecule)
-        commands += '\n'
-    commands += prepare_options_for_modules(changedOnly=True, commandsInsteadDict=True)
-    commands += """\n%s('%s', """ % (func.__name__, name.lower())
-    for key in kwargs.keys():
-        commands += """%s=%r, """ % (key, kwargs[key])
-    commands += ')\n\n'
-
-    return commands
-
-
-def expand_psivars(pvdefs):
-    """Dictionary *pvdefs* has keys with names of PsiVariables to be
-    created and values with dictionary of two keys: 'args', the
-    PsiVariables that contribute to the key and 'func', a function (or
-    lambda) to combine them. This function builds those PsiVariables if
-    all the contributors are available. Helpful printing is available when
-    PRINT > 2.
-
-    """
-    verbose = core.get_global_option('PRINT')
+    if verbose is None:
+        verbose = core.get_global_option('PRINT')
 
     for pvar, action in pvdefs.items():
         if verbose >= 2:
@@ -634,10 +681,21 @@ def expand_psivars(pvdefs):
 
 
 def provenance_stamp(routine: str, module: str = None) -> Dict[str, str]:
-    """Return dictionary satisfying QCSchema,
-    https://github.com/MolSSI/QCSchema/blob/master/qcschema/dev/definitions.py#L23-L41
-    with Psi4's credentials for creator and version. The
-    generating routine's name is passed in through `routine`.
+    """Prepare QCSchema Provenance with |PSIfour| credentials.
+
+    Parameters
+    ----------
+    routine
+        Name of driver function generating the QCSchema.
+    module
+        Primary contributing |PSIfour| library, like ``ccenergy`` or ``dfmp2``.
+
+    Returns
+    -------
+    provenance : Dict[str, str]
+        Dictionary satisfying QCSchema, with |PSIfour| credentials for creator
+        and version.
+        https://github.com/MolSSI/QCSchema/blob/master/qcschema/dev/definitions.py#L23-L41
 
     """
     prov = {'creator': 'Psi4', 'version': __version__, 'routine': routine}
@@ -647,19 +705,24 @@ def provenance_stamp(routine: str, module: str = None) -> Dict[str, str]:
     return prov
 
 
-def plump_qcvar(val: Union[float, str, List], shape_clue: str, ret: str = 'np') -> Union[float, np.ndarray, core.Matrix]:
-    """Prepare serialized QCVariable for set_variable by convert flat arrays into shaped ones and floating strings.
+def plump_qcvar(
+    val: Union[float, str, List],
+    shape_clue: str,
+    ret: str = 'np') -> Union[float, np.ndarray, core.Matrix]:
+    """Prepare serialized QCVariable for :py:func:`~psi4.core.set_variable` by
+    converting flat arrays into shaped ones and floating strings.
 
     Parameters
     ----------
-    val :
+    val
         flat (?, ) list or scalar or string, probably from JSON storage.
     shape_clue
         Label that includes (case insensitive) one of the following as
         a clue to the array's natural dimensions: 'gradient', 'hessian'
     ret
         {'np', 'psi4'}
-        Whether to return `np.ndarray` or `psi4.core.Matrix`.
+        Whether for arrays to return :py:class:`numpy.ndarray` or
+        :py:class:`psi4.core.Matrix`.
 
     Returns
     -------

--- a/psi4/driver/p4util/prop_util.py
+++ b/psi4/driver/p4util/prop_util.py
@@ -33,11 +33,11 @@ from . import optproc
 __all__ = ['free_atom_volumes']
 
 
-def free_atom_volumes(wfn, **kwargs):
+def free_atom_volumes(wfn: psi4.core.Wavefunction, **kwargs):
     """ 
     Computes free-atom volumes using MBIS density partitioning.
     The free-atom volumes are computed for all unique (inc. basis set)
-    atoms in a molecule and stored as wavefunction variables.
+    atoms in a molecule and stored as wavefunction variables, :psivar:`MBIS FREE ATOM n VOLUME`.
     Free-atom densities are computed at the same level of theory as the molecule, 
     and we use unrestricted references as needed in computing the ground-state. 
 
@@ -45,7 +45,7 @@ def free_atom_volumes(wfn, **kwargs):
 
     Parameters
     ----------
-    wfn : psi4.core.Wavefunction
+    wfn
         The wave function associated with the molecule, method, and basis for 
         atomic computations
     """

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -26,6 +26,29 @@
 # @END LICENSE
 #
 
+"""
+Module with PsiAPI helpers for PSIthon `{...}` syntax.
+Also, many Python extensions to core classes:
+
+ - core (variable-related, gradient, python option),
+ - Wavefunction (variable-related, freq, Lagrangian, constructor, scratch file, serialization),
+ - Matrix (doublet, triplet),
+ - BasisSet (constructor)
+ - JK (constructor)
+ - VBase (grid)
+ - OEProp (avail prop)
+
+"""
+
+__all__ = [
+    "basis_helper",
+    "pcm_helper",
+    "set_options",
+    "set_module_options",
+    "temp_circular_import_blocker",  # retire ASAP
+]
+
+
 import os
 import re
 import sys
@@ -35,7 +58,7 @@ from collections import Counter
 from itertools import product
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -48,17 +71,66 @@ from .exceptions import TestComparisonError, ValidationError, UpgradeHelper
 
 ## Python basis helps
 
-
 @staticmethod
-def _pybuild_basis(mol,
-                   key=None,
-                   target=None,
-                   fitrole='ORBITAL',
-                   other=None,
-                   puream=-1,
-                   return_atomlist=False,
-                   *,
-                   quiet=False):
+def _pybuild_basis(
+        mol: core.Molecule,
+        key: Optional[str] = None,
+        target: Optional[Union[str, Callable]] = None,
+        fitrole: str = "ORBITAL",
+        other: Optional[Union[str, Callable]] = None,
+        puream: int = -1,
+        return_atomlist: bool = False,
+        *,
+        quiet: bool = False,
+    ) -> Union[core.BasisSet, List[core.BasisSet]]:
+    """Build a primary or auxiliary basis set.
+
+    Parameters
+    ----------
+    mol
+        Molecule for which to build the basis set instance.
+    key
+        {'BASIS', 'ORBITAL', 'DF_BASIS_SCF', 'DF_BASIS_MP2', 'DF_BASIS_CC', 'BASIS_RELATIVISTIC', 'DF_BASIS_SAD'}
+        Label (effectively Psi4 keyword) to append the basis on the molecule.
+        The primary basis set is indicated by any of values None or
+        ``"ORBITAL"`` or ``"BASIS"``.
+    target
+        Defines the basis set to be constructed. Can be a string (naming a
+        basis file) or a callable (providing shells or multiple basis files).
+        For auxiliary bases to be built entirely from primary default, can be
+        an empty string. If None, value taken from `key` in global options. If
+        a user-defined-basis callable is available at string `target`, `target`
+        value will be set to it. In practice, setting this argument to a
+        |PSIfour| keyword (e.g., ``core.get_option("SCF", "DF_BASIS_SCF")`` or
+        ``core.get_global_option("BASIS")``) works to handle both simple and
+        user-defined bases.
+    fitrole
+        {'ORBITAL', 'JKFIT', 'RIFIT', 'DECON'}
+        Role for which to build basis. Only used when `key` indicates auxiliary
+        (i.e., *is not* ``"BASIS"``) and auxiliary spec from processing `target`
+        can't complete the `mol`. Then, primary spec from `other` can be used
+        to complete the auxiliary basis by looking up suitable default basis
+        according to `fitrole`.
+    other
+        Only used when building auxiliary basis sets. Defines the primary basis through a string or callable like `target`.
+    puream
+        Whether to override the native spherical/cartesian-ness of `target` for
+        returned basis? Value ``1`` forces spherical, value ``0`` forces
+        Cartesian, value ``-1`` (default) uses native puream. Note that
+        explicitly setting :term:`PUREAM <PUREAM (GLOBALS)>` trumps both native
+        puream and this `puream` argument.
+    return_atomlist
+        Build one-atom basis sets (e.g., for SAD) rather than one whole-`mol`
+        basis set.
+    quiet
+        When True, do not print to the output file.
+
+    Returns
+    -------
+    BasisSet or ~typing.List[BasisSet]
+        Single basis for `mol`, unless `return_atomlist` is True.
+
+    """
     if key == 'ORBITAL':
         key = 'BASIS'
 
@@ -119,7 +191,26 @@ core.BasisSet.build = _pybuild_basis
 
 
 @staticmethod
-def _core_wavefunction_build(mol, basis=None, *, quiet: bool = False):
+def _core_wavefunction_build(
+        mol: core.Molecule,
+        basis: Union[None, str, core.BasisSet] = None,
+        *,
+        quiet: bool = False,
+    ) -> core.Wavefunction:
+    """Build a wavefunction from minimal inputs, molecule and basis set.
+
+    Parameters
+    ----------
+    mol
+        Molecule for which to build the wavefunction instance.
+    basis
+        Basis set for which to build the wavefunction instance. If a
+        :class:`BasisSet`, taken as-is. If a string, taken as a name for the
+        primary basis. If None, name taken from :term:`BASIS <BASIS (MINTS)>`.
+    quiet
+        When True, do not print to the output file.
+
+    """
     if basis is None:
         basis = core.BasisSet.build(mol, quiet=quiet)
     elif isinstance(basis, str):
@@ -135,9 +226,17 @@ def _core_wavefunction_build(mol, basis=None, *, quiet: bool = False):
 core.Wavefunction.build = _core_wavefunction_build
 
 
-def _core_wavefunction_get_scratch_filename(self, filenumber):
-    """ Given a wavefunction and a scratch file number, canonicalizes the name
-        so that files can be consistently written and read """
+def _core_wavefunction_get_scratch_filename(self: core.Wavefunction, filenumber: int) -> str:
+    """Return canonical path to scratch file `filenumber` based on molecule on `self`.
+
+    Parameters
+    ----------
+    self
+        Wavefunction instance.
+    filenumber
+        Scratch file number from :source:`psi4/include/psi4/psifiles.h`.
+
+    """
     fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(self.molecule().name())))[1]
     psi_scratch = core.IOManager.shared_object().get_default_path()
     return os.path.join(psi_scratch, fname + '.' + str(filenumber))
@@ -148,13 +247,14 @@ core.Wavefunction.get_scratch_filename = _core_wavefunction_get_scratch_filename
 
 @staticmethod
 def _core_wavefunction_from_file(wfn_data: Union[str, Dict, Path]) -> core.Wavefunction:
-    r"""Build Wavefunction from data.
+    r"""Build Wavefunction from data laid out like
+    :meth:`~psi4.core.Wavefunction.to_file`.
 
     Parameters
     ----------
     wfn_data
-        If a dict, use data directly. Otherwise, path-like passed to :py:func:`numpy.load`
-        to read from disk.
+        If a dict, use data directly. Otherwise, path-like passed to
+        :py:func:`numpy.load` to read from disk.
 
     Returns
     -------
@@ -229,19 +329,20 @@ def _core_wavefunction_from_file(wfn_data: Union[str, Dict, Path]) -> core.Wavef
 core.Wavefunction.from_file = _core_wavefunction_from_file
 
 
-def _core_wavefunction_to_file(wfn: core.Wavefunction, filename: str = None) -> Dict:
-    """Converts a Wavefunction object to a base class
+def _core_wavefunction_to_file(wfn: core.Wavefunction, filename: str = None) -> Dict[str, Dict[str, Any]]:
+    """Serialize a Wavefunction object. Opposite of
+    :meth:`~psi4.core.Wavefunction.from_file`.
 
     Parameters
     ----------
     wfn
-        A Wavefunction or inherited class
+        Wavefunction or inherited class instance.
     filename
-        An optional filename to write the data to
+        An optional filename to which to write the data.
 
     Returns
     -------
-    dict
+    ~typing.Dict[str, ~typing.Dict[str, ~typing.Any]]
         A dictionary and NumPy representation of the Wavefunction.
 
     """
@@ -327,7 +428,13 @@ core.Wavefunction.to_file = _core_wavefunction_to_file
 
 
 @staticmethod
-def _core_jk_build(orbital_basis: core.BasisSet, aux: core.BasisSet = None, jk_type: str = None, do_wK: bool = None, memory: int = None) -> core.JK:
+def _core_jk_build(
+        orbital_basis: core.BasisSet,
+        aux: Optional[core.BasisSet] = None,
+        jk_type: Optional[str] = None,
+        do_wK: Optional[bool] = None,
+        memory: Optional[int] = None,
+    ) -> core.JK:
     """
     Constructs a Psi4 JK object from an input basis.
 
@@ -337,11 +444,17 @@ def _core_jk_build(orbital_basis: core.BasisSet, aux: core.BasisSet = None, jk_t
         Orbital basis to use in the JK object.
     aux
         Optional auxiliary basis set for density-fitted tensors. Defaults
-        to the DF_BASIS_SCF if set, otherwise the correspond JKFIT basis
+        to the :term:`DF_BASIS_SCF <DF_BASIS_SCF (SCF)>` if set, otherwise the corresponding JKFIT basis
         to the passed in `orbital_basis`.
     jk_type
         Type of JK object to build (DF, Direct, PK, etc). Defaults to the
-        current global SCF_TYPE option.
+        current :term:`SCF_TYPE <SCF_TYPE (GLOBALS)>` option.
+    do_wK
+        Set up JK to do omega K tasks. Set `do_wK` and `memory` together to
+        activate either.
+    memory
+        Memory in doubles to use for JK. Set `do_wK` and `memory` together to
+        activate either.
 
     Returns
     -------
@@ -350,18 +463,14 @@ def _core_jk_build(orbital_basis: core.BasisSet, aux: core.BasisSet = None, jk_t
 
     Example
     -------
-
-    jk = psi4.core.JK.build(bas)
-    jk.set_memory(int(5e8)) # 4GB of memory
-    jk.initialize()
-
-    ...
-
-    jk.C_left_add(matirx)
-    jk.compute()
-    jk.C_clear()
-
-    ...
+    >>> jk = psi4.core.JK.build(bas)
+    >>> jk.set_memory(int(5e8))  # 4GB of memory
+    >>> jk.initialize()
+    >>> ...
+    >>> jk.C_left_add(matirx)
+    >>> jk.compute()
+    >>> jk.C_clear()
+    >>> ...
 
     """
 
@@ -391,9 +500,15 @@ core.JK.build = _core_jk_build
 ## Grid Helpers
 
 
-def _core_vbase_get_np_xyzw(Vpot):
+def _core_vbase_get_np_xyzw(self: core.VBase) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Returns the x, y, z, and weights of a grid as a tuple of NumPy array objects.
+
+    Parameters
+    ----------
+    self
+        VBase instance.
+
     """
     x_list = []
     y_list = []
@@ -401,10 +516,10 @@ def _core_vbase_get_np_xyzw(Vpot):
     w_list = []
 
     # Loop over every block in the potenital
-    for b in range(Vpot.nblocks()):
+    for b in range(self.nblocks()):
 
         # Obtain the block
-        block = Vpot.get_block(b)
+        block = self.get_block(b)
 
         # Obtain the x, y, and z coordinates along with the weight
         x_list.append(block.x())
@@ -425,18 +540,32 @@ core.VBase.get_np_xyzw = _core_vbase_get_np_xyzw
 ## Python other helps
 
 
-def set_options(options_dict: Dict[str, Any], verbose: int = 1) -> None:
+def set_options(options_dict: Dict[str, Any], verbose: int = 1):
     """Sets Psi4 options from an input dictionary.
 
     Parameters
     ----------
     options_dict
-        Dictionary where keys are "option_name" for global options or
-        "module_name__option_name" (double underscore separation) for
-        option local to "module_name". Values are the option value. All
-        are case insensitive.
+        Dictionary where keys are case insensitive and values are the option value.
+
+        - For global options, keys are ``"<option_name>"``.
+        - For option local to "<module_name>", keys are ``"<module_name>__<option_name>"``
+          (double underscore separation).
+        - For contents that would be in ``pcm = {...}``, use ``"PCM__INPUT"`` key.
     verbose
         Control print volume.
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    >>> psi4.set_options({
+            "basis": "cc-pvtz",
+            "df_basis_scf": "cc-pvtz-jkfit",
+            "scf__reference": "uhf",
+            "print": 2})
 
     """
     optionre = re.compile(r'\A(?P<module>\w+__)?(?P<option>\w+)\Z', re.IGNORECASE)
@@ -477,6 +606,10 @@ def set_options(options_dict: Dict[str, Any], verbose: int = 1) -> None:
 def set_module_options(module: str, options_dict: Dict[str, Any]) -> None:
     """
     Sets Psi4 module options from a module specification and input dictionary.
+
+    .. deprecated:: 1.5
+       Use :py:func:`psi4.driver.p4util.set_options` instead.
+
     """
     warnings.warn(
         "Using `psi4.set_module_options(<module>, {<key>: <val>})` instead of `psi4.set_options({<module>__<key>: <val>})` is deprecated, and as soon as 1.5 it will stop working\n",
@@ -491,13 +624,14 @@ def set_module_options(module: str, options_dict: Dict[str, Any]) -> None:
 
 
 def pcm_helper(block: str):
-    """
-    Passes multiline string *block* to PCMSolver parser.
+    """Helper to specify the multiline PCMSolver syntax for PCM.
+    Prefer to use :py:func:`set_options` with key ``"PCM__INPUT"``.
 
     Parameters
     ----------
     block
-        multiline string with PCM input in PCMSolver syntax.
+        Text that goes in a PSIthon ``pcm = {...}`` block.
+
     """
     import pcmsolver
 
@@ -511,8 +645,8 @@ def pcm_helper(block: str):
         core.set_local_option("PCM", "PCMSOLVER_PARSED_FNAME", fl.name)
 
 
-def basname(name):
-    """Imitates BasisSet.make_filename() without the gbs extension"""
+def _basname(name: str) -> str:
+    """Imitates :py:meth:`core.BasisSet.make_filename` without the gbs extension."""
     return name.lower().replace('+', 'p').replace('*', 's').replace('(', '_').replace(')', '_').replace(',', '_')
 
 
@@ -520,18 +654,30 @@ def temp_circular_import_blocker():
     pass
 
 
-def basis_helper(block, name='', key='BASIS', set_option=True):
-    """For PsiAPI mode, forms a basis specification function from *block*
+def basis_helper(block: str, name: str = '', key: str = 'BASIS', set_option: bool = True):
+    """Helper to specify a custom basis set in PsiAPI mode.
+
+    This function forms a basis specification function from *block*
     and associates it with keyword *key* under handle *name*. Registers
     the basis spec with Psi4 so that it can be applied again to future
-    molecules. For usage, see mints2, mints9, and cc54 test cases. Unless
-    *set_option* is False, *name* will be set as current active *key*,
-    equivalent to `set key name` or `set_option({key: name})`.
+    molecules. For usage, see :srcsample:`mints2`, :srcsample:`mints9`, and
+    :srcsample:`cc54` test cases.
+
+    Parameters
+    ----------
+    block
+        Text that goes in a PSIthon ``basis {...}`` block.
+    name
+        Name label to associated with basis specified by `block`.
+    key
+        Basis keyword specified by `block`.
+    set_option
+        When True, execute the equivalent of ``set key name`` or ``set_option({key: name})``. When False, skip execution.
 
     """
     key = key.upper()
     name = ('anonymous' + str(uuid.uuid4())[:8]) if name == '' else name
-    cleanbas = basname(name).replace('-', '')  # further remove hyphens so can be function name
+    cleanbas = _basname(name).replace('-', '')  # further remove hyphens so can be function name
     block = qcel.util.filter_comments(block)
     command_lines = re.split('\n', block)
 
@@ -575,7 +721,7 @@ def basis_helper(block, name='', key='BASIS', set_option=True):
             if not assignments:
                 # case with no [basname] markers where whole block is contents of gbs file
                 mol.set_basis_all_atoms(name, role=role)
-                basstrings[basname(name)] = basblock[0]
+                basstrings[_basname(name)] = basblock[0]
             else:
                 message = (
                     "Conflicting basis set specification: assign lines present but shells have no [basname] label."
@@ -584,7 +730,7 @@ def basis_helper(block, name='', key='BASIS', set_option=True):
         else:
             # case with specs separated by [basname] markers
             for idx in range(0, len(basblock), 2):
-                basstrings[basname(basblock[idx])] = basblock[idx + 1]
+                basstrings[_basname(basblock[idx])] = basblock[idx + 1]
 
         return basstrings
 
@@ -670,6 +816,10 @@ _qcvar_cancellations = {
 
 
 def _qcvar_warnings(key: str) -> str:
+    """Intercept QCVariable keys to issue warnings or upgrade hints. Otherwise,
+    pass through.
+
+    """
     if any([key.upper().endswith(" DIPOLE " + cart) for cart in ["X", "Y", "Z"]]):
         raise UpgradeHelper(key.upper(), key.upper()[:-2], 1.6, " Note the Debye -> a.u. units change.")
 
@@ -695,9 +845,11 @@ for order in range(5, 10):
     _multipole_order.append(f"{int(2**order)}-POLE")
 
 
-def _qcvar_reshape_set(key, val):
-    """Reverse `_qcvar_reshape_get` for internal psi4.core.Matrix storage."""
+def _qcvar_reshape_set(key: str, val: np.ndarray) -> np.ndarray:
+    """Reverse :py:func:`_qcvar_reshape_get` for internal
+    :py:class:`psi4.core.Matrix` storage.
 
+    """
     reshaper = None
     if key.upper().startswith("MBIS"):
         if key.upper().endswith("CHARGES"):
@@ -730,9 +882,11 @@ def _qcvar_reshape_set(key, val):
         return val
 
 
-def _qcvar_reshape_get(key, val):
-    """For QCVariables where the 2D psi4.core.Matrix shape is unnatural, convert to natural shape in ndarray."""
+def _qcvar_reshape_get(key: str, val: Union[core.Matrix, np.ndarray]) -> Union[core.Matrix, np.ndarray]:
+    """For QCVariables where the 2D :py:class:`psi4.core.Matrix` shape is
+    unnatural, convert to natural shape in :class:`numpy.ndarray`.
 
+    """
     reshaper = None
     if key.upper().startswith("MBIS"):
         if key.upper().endswith("CHARGES"):
@@ -763,19 +917,20 @@ def _qcvar_reshape_get(key, val):
     else:
         return val
 
-def _multipole_compressor(complete, order):
+
+def _multipole_compressor(complete: np.ndarray, order: int) -> np.ndarray:
     """Form flat unique components multipole array from complete Cartesian array.
 
     Parameters
     ----------
-    order : int
+    order
         Multipole order. e.g., 1 for dipole, 4 for hexadecapole.
-    complete : ndarray
+    complete
         Multipole array, order-dimensional Cartesian array expanded to complete components.
 
     Returns
     -------
-    compressed : ndarray
+    compressed : numpy.ndarray
         Multipole array, length (order + 1) * (order + 2) / 2 compressed to unique components.
 
     """
@@ -834,26 +989,60 @@ def _multipole_plumper(compressed: np.ndarray, order: int) -> np.ndarray:
 
 
 def _core_has_variable(key: str) -> bool:
-    """Whether scalar or array QCVariable *key* has been set in global memory."""
+    """Whether scalar or array :ref:`QCVariable <sec:appendices:qcvars>` *key*
+    has been set in global memory.
 
+    Parameters
+    ----------
+    key
+        Case-insensitive key to global double or :py:class:`~psi4.core.Matrix`
+        storage maps.
+
+    """
     return core.has_scalar_variable(key) or core.has_array_variable(key)
 
 
-def _core_wavefunction_has_variable(cls: core.Wavefunction, key: str) -> bool:
-    """Whether scalar or array QCVariable *key* has been set on *self* :class:`psi4.core.Wavefunction`."""
+def _core_wavefunction_has_variable(self: core.Wavefunction, key: str) -> bool:
+    """Whether scalar or array :ref:`QCVariable <sec:appendices:qcvars>` *key*
+    has been set on *self*.
 
-    return cls.has_scalar_variable(key) or cls.has_array_variable(key)
+    Parameters
+    ----------
+    self
+        Wavefunction instance.
+    key
+        Case-insensitive key to instance's double or
+        :py:class:`~psi4.core.Matrix` storage maps.
+
+    """
+    return self.has_scalar_variable(key) or self.has_array_variable(key)
 
 
 def _core_variable(key: str) -> Union[float, core.Matrix, np.ndarray]:
-    """Return copy of scalar or array QCVariable *key* from global memory.
+    """Return copy of scalar or array :ref:`QCVariable <sec:appendices:qcvars>`
+    *key* from global memory.
+
+    Parameters
+    ----------
+    key
+        Case-insensitive key to global double or :py:class:`~psi4.core.Matrix`
+        storage maps.
 
     Returns
     -------
-    float or numpy.ndarray or Matrix
-        Scalar variables are returned as floats.
-        Array variables not naturally 2D (like multipoles) are returned as :class:`numpy.ndarray` of natural dimensionality.
-        Other array variables are returned as :py:class:`~psi4.core.Matrix` and may have an extra dimension with symmetry information.
+    float or ~numpy.ndarray or Matrix
+        Requested QCVariable from global memory.
+
+        - Scalar variables are returned as floats.
+        - Array variables not naturally 2D (like multipoles or per-atom charges)
+          are returned as :class:`~numpy.ndarray` of natural dimensionality.
+        - Other array variables are returned as :py:class:`~psi4.core.Matrix` and
+          may have an extra dimension with symmetry information.
+
+    Raises
+    ------
+    KeyError
+        If `key` not set on `self`.
 
     Example
     -------
@@ -879,15 +1068,33 @@ def _core_variable(key: str) -> Union[float, core.Matrix, np.ndarray]:
         raise KeyError(f"psi4.core.variable: Requested variable '{key}' was not set!\n")
 
 
-def _core_wavefunction_variable(cls: core.Wavefunction, key: str) -> Union[float, core.Matrix, np.ndarray]:
-    """Return copy of scalar or array QCVariable *key* from *self* :class:`psi4.core.Wavefunction`.
+def _core_wavefunction_variable(self: core.Wavefunction, key: str) -> Union[float, core.Matrix, np.ndarray]:
+    """Return copy of scalar or array :ref:`QCVariable <sec:appendices:qcvars>`
+    *key* from *self*.
+
+    Parameters
+    ----------
+    self
+        Wavefunction instance.
+    key
+        Case-insensitive key to instance's double or :py:class:`~psi4.core.Matrix`
+        storage maps.
 
     Returns
     -------
-    float or numpy.ndarray or Matrix
-        Scalar variables are returned as floats.
-        Array variables not naturally 2D (like multipoles) are returned as :class:`numpy.ndarray` of natural dimensionality.
-        Other array variables are returned as :py:class:`~psi4.core.Matrix` and may have an extra dimension with symmetry information.
+    float or ~numpy.ndarray or Matrix
+        Requested QCVariable from `self`.
+
+        - Scalar variables are returned as floats.
+        - Array variables not naturally 2D (like multipoles or per-atom charges)
+          are returned as :class:`~numpy.ndarray` of natural dimensionality.
+        - Other array variables are returned as :py:class:`~psi4.core.Matrix` and
+          may have an extra dimension with symmetry information.
+
+    Raises
+    ------
+    KeyError
+        If `key` not set on `self`.
 
     Example
     -------
@@ -905,17 +1112,36 @@ def _core_wavefunction_variable(cls: core.Wavefunction, key: str) -> Union[float
     """
     key = _qcvar_warnings(key)
 
-    if cls.has_scalar_variable(key):
-        return cls.scalar_variable(key)
-    elif cls.has_array_variable(key):
-        return _qcvar_reshape_get(key, cls.array_variable(key))
+    if self.has_scalar_variable(key):
+        return self.scalar_variable(key)
+    elif self.has_array_variable(key):
+        return _qcvar_reshape_get(key, self.array_variable(key))
     else:
         raise KeyError(f"psi4.core.Wavefunction.variable: Requested variable '{key}' was not set!\n")
 
 
 def _core_set_variable(key: str, val: Union[core.Matrix, np.ndarray, float]) -> None:
-    """Sets scalar or array QCVariable *key* to *val* in global memory."""
+    """Sets scalar or array :ref:`QCVariable <sec:appendices:qcvars>` *key* to
+    *val* in global memory.
 
+    Parameters
+    ----------
+    key
+        Case-insensitive key to global double or :py:class:`~psi4.core.Matrix`
+        storage maps.
+    val
+        Scalar or array to be stored in `key`. If :class:`~numpy.ndarray` and
+        data `key` does not naturally fit in 2D Matrix (often charge and
+        multipole QCVariables), it will be reshaped, as all
+        :class:`~numpy.ndarray` are stored as :class:`~psi4.core.Matrix`.
+
+    Raises
+    ------
+    ValidationError
+        If `val` is a scalar but `key` already exists as an array variable. Or
+        if `val` is an array but `key` already exists as a scalar variable.
+
+    """
     if isinstance(val, core.Matrix):
         if core.has_scalar_variable(key):
             raise ValidationError(f"psi4.core.set_variable: Target variable '{key}' already a scalar variable!")
@@ -935,66 +1161,147 @@ def _core_set_variable(key: str, val: Union[core.Matrix, np.ndarray, float]) -> 
     # TODO _qcvar_warnings(key)
 
 
-def _core_wavefunction_set_variable(cls: core.Wavefunction, key: str, val: Union[core.Matrix, np.ndarray, float]) -> None:
-    """Sets scalar or array QCVariable *key* to *val* on *cls*."""
+def _core_wavefunction_set_variable(self: core.Wavefunction, key: str, val: Union[core.Matrix, np.ndarray, float]) -> None:
+    """Sets scalar or array :ref:`QCVariable <sec:appendices:qcvars>` *key* to
+    *val* on *self*.
 
+    Parameters
+    ----------
+    self
+        Wavefunction instance.
+    key
+        Case-insensitive key to instance's double or :class:`~psi4.core.Matrix`
+        storage maps.
+
+        - If ``CURRENT ENERGY``, syncs with :attr:`self.energy_`.
+        - If ``CURRENT GRADIENT``, syncs with :attr:`gradient_`.
+        - If ``CURRENT HESSIAN``, syncs with :attr:`self.hessian_`.
+    val
+        Scalar or array to be stored in `key`. If :class:`~numpy.ndarray` and
+        data `key` does not naturally fit in 2D Matrix (often charge and
+        multipole QCVariables), it will be reshaped, as all
+        :class:`~numpy.ndarray` are stored as :class:`~psi4.core.Matrix`.
+
+    Raises
+    ------
+    ValidationError
+        If `val` is a scalar but `key` already exists as an array variable. Or
+        if `val` is an array but `key` already exists as a scalar variable.
+
+    """
     if isinstance(val, core.Matrix):
-        if cls.has_scalar_variable(key):
+        if self.has_scalar_variable(key):
             raise ValidationError("psi4.core.Wavefunction.set_variable: Target variable '{key}' already a scalar variable!")
         else:
-            cls.set_array_variable(key, val)
+            self.set_array_variable(key, val)
     elif isinstance(val, np.ndarray):
-        if cls.has_scalar_variable(key):
+        if self.has_scalar_variable(key):
             raise ValidationError("psi4.core.Wavefunction.set_variable: Target variable '{key}' already a scalar variable!")
         else:
-            cls.set_array_variable(key, core.Matrix.from_array(_qcvar_reshape_set(key, val)))
+            self.set_array_variable(key, core.Matrix.from_array(_qcvar_reshape_set(key, val)))
     else:
-        if cls.has_array_variable(key):
+        if self.has_array_variable(key):
             raise ValidationError("psi4.core.Wavefunction.set_variable: Target variable '{key}' already an array variable!")
         else:
-            cls.set_scalar_variable(key, val)
+            self.set_scalar_variable(key, val)
 
     # TODO _qcvar_warnings(key)
 
 
 def _core_del_variable(key: str) -> None:
-    """Removes scalar or array QCVariable *key* from global memory if present."""
+    """Removes scalar or array :ref:`QCVariable <sec:appendices:qcvars>` *key*
+    from global memory if present.
 
+    Parameters
+    ----------
+    key
+        Case-insensitive key to global double or :py:class:`~psi4.core.Matrix`
+        storage maps.
+
+    """
     if core.has_scalar_variable(key):
         core.del_scalar_variable(key)
     elif core.has_array_variable(key):
         core.del_array_variable(key)
 
 
-def _core_wavefunction_del_variable(cls: core.Wavefunction, key: str) -> None:
-    """Removes scalar or array QCVariable *key* from *cls* if present."""
+def _core_wavefunction_del_variable(self: core.Wavefunction, key: str) -> None:
+    """Removes scalar or array :ref:`QCVariable <sec:appendices:qcvars>` *key*
+    from *self* if present.
 
-    if cls.has_scalar_variable(key):
-        cls.del_scalar_variable(key)
-    elif cls.has_array_variable(key):
-        cls.del_array_variable(key)
+    Parameters
+    ----------
+    self
+        Wavefunction instance.
+    key
+        Case-insensitive key to instance's double or
+        :py:class:`~psi4.core.Matrix` storage maps.
+
+    """
+    if self.has_scalar_variable(key):
+        self.del_scalar_variable(key)
+    elif self.has_array_variable(key):
+        self.del_array_variable(key)
 
 
 def _core_variables(include_deprecated_keys: bool = False) -> Dict[str, Union[float, core.Matrix, np.ndarray]]:
-    """Return all scalar or array QCVariables from global memory."""
+    """Return all scalar or array :ref:`QCVariables <sec:appendices:qcvars>`
+    from global memory.
 
+    Parameters
+    ----------
+    include_deprecated_keys
+        Also return duplicate entries with keys that have been deprecated.
+
+    Returns
+    -------
+    ~typing.Dict[str, ~typing.Union[float, ~numpy.ndarray, Matrix]
+        Map of all QCVariables that have been set.
+
+        - Scalar variables are returned as floats.
+        - Array variables not naturally 2D (like multipoles or per-atom charges)
+          are returned as :class:`~numpy.ndarray` of natural dimensionality.
+        - Other array variables are returned as :py:class:`~psi4.core.Matrix` and
+          may have an extra dimension with symmetry information.
+
+    """
     dicary = {**core.scalar_variables(), **{k: _qcvar_reshape_get(k, v) for k, v in core.array_variables().items()}}
 
     if include_deprecated_keys:
-        for old_key, current_key in _qcvar_transitions.items():
+        for old_key, (current_key, version) in _qcvar_transitions.items():
             if current_key in dicary:
                 dicary[old_key] = dicary[current_key]
 
     return dicary
 
 
-def _core_wavefunction_variables(cls, include_deprecated_keys: bool = False) -> Dict[str, Union[float, core.Matrix, np.ndarray]]:
-    """Return all scalar or array QCVariables from *cls*."""
+def _core_wavefunction_variables(self, include_deprecated_keys: bool = False) -> Dict[str, Union[float, core.Matrix, np.ndarray]]:
+    """Return all scalar or array :ref:`QCVariables <sec:appendices:qcvars>`
+    from *self*.
 
-    dicary = {**cls.scalar_variables(), **{k: _qcvar_reshape_get(k, v) for k, v in cls.array_variables().items()}}
+    Parameters
+    ----------
+    self
+        Wavefunction instance.
+    include_deprecated_keys
+        Also return duplicate entries with keys that have been deprecated.
+
+    Returns
+    -------
+    ~typing.Dict[str, ~typing.Union[float, ~numpy.ndarray, Matrix]
+        Map of all QCVariables that have been set on `self`.
+
+        - Scalar variables are returned as floats.
+        - Array variables not naturally 2D (like multipoles or per-atom charges)
+          are returned as :class:`~numpy.ndarray` of natural dimensionality.
+        - Other array variables are returned as :py:class:`~psi4.core.Matrix` and
+          may have an extra dimension with symmetry information.
+
+    """
+    dicary = {**self.scalar_variables(), **{k: _qcvar_reshape_get(k, v) for k, v in self.array_variables().items()}}
 
     if include_deprecated_keys:
-        for old_key, current_key in _qcvar_transitions.items():
+        for old_key, (current_key, version) in _qcvar_transitions.items():
             if current_key in dicary:
                 dicary[old_key] = dicary[current_key]
 
@@ -1019,7 +1326,7 @@ core.Wavefunction.variables = _core_wavefunction_variables
 def _core_get_variable(key):
     """
     .. deprecated:: 1.4
-       Use :py:func:`psi4.variable` instead.
+       Use :py:func:`psi4.core.variable` instead.
 
     """
     warnings.warn(
@@ -1045,7 +1352,7 @@ def _core_get_variables():
 def _core_get_array_variable(key):
     """
     .. deprecated:: 1.4
-       Use :py:func:`psi4.variable` instead.
+       Use :py:func:`psi4.core.variable` instead.
 
     """
     warnings.warn(
@@ -1132,11 +1439,24 @@ core.Wavefunction.set_array = _core_wavefunction_set_array
 core.Wavefunction.arrays = _core_wavefunction_arrays
 
 
-def _core_wavefunction_frequencies(cls):
-    if not hasattr(cls, 'frequency_analysis'):
+def _core_wavefunction_frequencies(self):
+    """Returns the results of a frequency analysis.
+
+    Parameters
+    ----------
+    self
+        Wavefunction instance.
+
+    Returns
+    -------
+    ~typing.Optional[~typing.Dict[str, ~numpy.ndarray]]
+        A dictionary of vibrational information. See :py:func:`psi4.driver.qcdb.vib.harmonic_analysis`
+
+    """
+    if not hasattr(self, 'frequency_analysis'):
         return None
 
-    vibinfo = cls.frequency_analysis
+    vibinfo = self.frequency_analysis
     vibonly = qcdb.vib.filter_nonvib(vibinfo)
     return core.Vector.from_array(qcdb.vib.filter_omega_to_real(vibonly['omega'].data))
 
@@ -1144,6 +1464,7 @@ def _core_wavefunction_frequencies(cls):
 def _core_wavefunction_legacy_frequencies(cls):
     """
     .. deprecated:: 1.4
+       Use :py:meth:`~psi4.core.Wavefunction.frequencies` instead.
 
     """
     warnings.warn(
@@ -1171,6 +1492,11 @@ core.Wavefunction.set_frequencies = _core_wavefunction_set_frequencies
 
 
 def _core_wavefunction_X(cls):
+    """
+    .. deprecated:: 1.5
+       Use :py:meth:`~psi4.core.Wavefunction.lagrangian` instead.
+
+    """
     warnings.warn(
         "Using `psi4.core.Wavefunction.X` instead of `psi4.core.Wavefunction.lagrangian` is deprecated, and as soon as 1.5 it will stop working\n",
         category=FutureWarning,

--- a/psi4/driver/p4util/solvers.py
+++ b/psi4/driver/p4util/solvers.py
@@ -25,9 +25,18 @@
 #
 # @END LICENSE
 #
+
+__all__ = [
+    "cg_solver",
+    "davidson_solver",
+    "DIIS",
+    "hamiltonian_solver",
+    "SolverEngine",
+]
+
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, List
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import numpy as np
 
@@ -41,9 +50,17 @@ Generalized iterative solvers for Psi4.
 """
 
 
-def cg_solver(rhs_vec: List[core.Matrix], hx_function: Callable, preconditioner: Callable, guess: List[core.Matrix] = None, printer: Callable = None, printlvl: int = 1, maxiter: int = 20, rcond: float = 1.e-6) -> List[core.Matrix]:
+def cg_solver(
+    rhs_vec: List[core.Matrix],
+    hx_function: Callable,
+    preconditioner: Callable,
+    guess: Optional[List[core.Matrix]] = None,
+    printer: Optional[Callable] = None,
+    printlvl: int = 1,
+    maxiter: int = 20,
+    rcond: float = 1.e-6) -> List[core.Matrix]:
     """
-    Solves the Ax = b linear equations via Conjugate Gradient. The `A` matrix must be a hermitian, positive definite matrix.
+    Solves the :math:`Ax = b` linear equations via Conjugate Gradient. The `A` matrix must be a hermitian, positive definite matrix.
 
     Parameters
     ----------
@@ -54,7 +71,7 @@ def cg_solver(rhs_vec: List[core.Matrix], hx_function: Callable, preconditioner:
     preconditioner
         Takes in a list of :py:class:`~psi4.core.Matrix` objects and a mask of active indices. Returns the preconditioned value.
     guess
-        Starting vectors, if None use a preconditioner(rhs) guess
+        Starting vectors. If None, use a preconditioner (rhs) guess
     printer
         Takes in a list of current x and residual vectors and provides a print function. This function can also
         return a value that represents the current residual.
@@ -68,17 +85,12 @@ def cg_solver(rhs_vec: List[core.Matrix], hx_function: Callable, preconditioner:
     Returns
     -------
     ret : List[Matrix]
-        Returns the solved `x` vectors and `r` vectors.
+        Solved `x` vectors and `r` vectors.
 
     Notes
     -----
     This is a generalized cg solver that can also take advantage of solving multiple RHS's simultaneously when
     it is advantageous to do so.
-
-    Examples
-    --------
-
-
 
     """
 
@@ -191,22 +203,18 @@ def cg_solver(rhs_vec: List[core.Matrix], hx_function: Callable, preconditioner:
 class DIIS:
     """
     An object to assist in the DIIS extrpolation procedure.
+
+    Parameters
+    ----------
+    max_vec
+        The maximum number of error and state vectors to hold. These are pruned based off the removal policy.
+    removal_policy : {"OLDEST", "LARGEST"}
+        How the state and error vectors are removed once at the maximum. OLDEST will remove the oldest vector while
+        largest will remove the residual with the largest RMS value.
+
     """
 
     def __init__(self, max_vec: int = 6, removal_policy: str = "OLDEST"):
-        """
-        An object to assist in the DIIS extrpolation procedure.
-
-        Parameters
-        ----------
-        max_vec
-            The maximum number of error and state vectors to hold. These are pruned based off the removal policy.
-        removal_policy
-            {"OLDEST", "LARGEST"}
-            How the state and error vectors are removed once at the maximum. OLDEST will remove the oldest vector while
-            largest will remove the residual with the largest RMS value.
-
-        """
         self.error = []
         self.state = []
         self.max_vec = max_vec
@@ -215,20 +223,22 @@ class DIIS:
         if self.removal_policy not in ["LARGEST", "OLDEST"]:
             raise ValidationError("DIIS: removal_policy must either be oldest or largest.")
 
-    def add(self, state, error):
+    def add(self, state: core.Matrix, error: core.Matrix):
         """
         Adds a DIIS state and error vector to the DIIS object.
 
-        state : :py:class:`~psi4.core.Matrix`
+        Parameters
+        ----------
+        state
             The current state vector.
-        error : :py:class:`~psi4.core.Matrix`
+        error
             The current error vector.
 
         """
         self.error.append(error.clone())
         self.state.append(state.clone())
 
-    def extrapolate(self, out: core.Matrix = None) -> core.Matrix:
+    def extrapolate(self, out: Optional[core.Matrix] = None) -> core.Matrix:
         """
         Extrapolates next state vector from the current set of state and error vectors.
 
@@ -398,7 +408,7 @@ def _print_array(name, arr, verbose):
         core.print_out(f"\n\n{name}:\n{str(arr)}\n")
 
 
-def _gs_orth(engine, U, V, thresh=1.0e-8):
+def _gs_orth(engine, U, V, thresh: float = 1.0e-8):
     """Perform Gram-Schmidt orthonormalization of a set V against a previously orthonormalized set U
 
     Parameters
@@ -409,7 +419,7 @@ def _gs_orth(engine, U, V, thresh=1.0e-8):
         A set of orthonormal vectors, len(U) = l; satisfies ||I^{lxl}-U^tU|| < thresh
     V : list of `vectors`
         The vectors used to augment U
-    thresh : float
+    thresh
        If the orthogonalized vector has a norm smaller than this value it is considered LD to the set
 
     Returns
@@ -472,27 +482,29 @@ class SolverEngine(ABC):
     that the required methods are defined.
 
 
-     ..note:: The `vector` referred to here is intentionally vague, the solver
-              does not care what it is and only holds individual or sets of
-              them. In fact an individual `vector` could be split across two
-              elements in a list, such as for different spin.
-              Whatever data type is used and individual vector should be a
-              single element in a list such that len(list) returns the number
-              of vector-like objects.
+    .. note:: The `vector` referred to here is intentionally vague, the solver
+       does not care what it is and only holds individual or sets of
+       them. In fact an individual `vector` could be split across two
+       elements in a list, such as for different spin.
+       Whatever data type is used and individual vector should be a
+       single element in a list such that len(list) returns the number
+       of vector-like objects.
     """
 
     @abstractmethod
     def compute_products(self, X):
         r"""Compute a Matrix * trial vector products
+
         Parameters
         ----------
-        X : list of `vectors`
+        X : List[`vector`]
+            Trial vectors.
 
         Returns
         -------
         Expected by :func:`davidson_solver`
 
-        AX : list of `vectors`
+        AX : List[`vector`]
            The product :math:`A x X_{i}` for each `X_{i}` in `X`, in that
            order. Where `A` is the hermitian matrix to be diagonalized.
            `len(AX) == len(X)`
@@ -502,14 +514,14 @@ class SolverEngine(ABC):
 
         Expected by :func:`hamiltonian_solver`
 
-        H1X : list of `vectors`
+        H1X : List[`vector`]
            The product :math:`H1 x X_{i}` for each `X_{i}` in `X`, in that
            order. Where H1 is described in :func:`hamiltonian_solver`.
-           `len(H1X) == len(X)`
-        H2X : list of `vectors`
+           ``len(H1X) == len(X)``
+        H2X : List[`vector`]
            The product :math:`H2 x X_{i}` for each `X_{i}` in `X`, in that
            order. Where H2 is described in :func:`hamiltonian_solver`.
-           `len(H2X) == len(X)`
+           ``len(H2X) == len(X)``
         """
         pass
 
@@ -555,7 +567,7 @@ class SolverEngine(ABC):
         """
         pass
 
-    def vector_dot(X, Y):
+    def vector_dot(X, Y) -> float:
         """Compute a dot product between two `vectors`
 
         Parameters
@@ -574,12 +586,12 @@ class SolverEngine(ABC):
     vector_dot = staticmethod(abstractmethod(vector_dot))
 
     @abstractmethod
-    def vector_axpy(a, X, Y):
+    def vector_axpy(a: float, X, Y):
         """Compute scaled `vector` addition operation `a*X + Y`
 
         Parameters
         ----------
-        a : float
+        a
           The scale factor applied to `X`
         X : singlet `vector`
           The `vector` which will be scaled and added to `Y`
@@ -595,12 +607,12 @@ class SolverEngine(ABC):
         pass
 
     @abstractmethod
-    def vector_scale(a, X):
+    def vector_scale(a: float, X):
         """Scale a vector by some factor
 
         Parameters
         ----------
-        a : float
+        a
            The scale facor
         X : single `vector`
            The vector that will be scaled
@@ -651,9 +663,16 @@ class SolverEngine(ABC):
         pass
 
 
-def davidson_solver(engine, guess: List, *, nroot: int, r_convergence: float = 1.0E-4, max_ss_size: int = 100, maxiter: int = 60, verbose: int = 1):
+def davidson_solver(
+    engine: Type[SolverEngine],
+    guess: List,
+    *,
+    nroot: int,
+    r_convergence: float = 1.0E-4,
+    max_ss_size: int = 100,
+    maxiter: int = 60,
+    verbose: int = 1) -> Dict[str, Any]:
     """Solves for the lowest few eigenvalues and eigenvectors of a large problem emulated through an engine.
-
 
     If the large matrix `A` has dimension `{NxN}` and N is very large, and only
     a small number of roots, `k` are desired this algorithm is preferable to
@@ -666,8 +685,8 @@ def davidson_solver(engine, guess: List, *, nroot: int, r_convergence: float = 1
     used.
 
     Parameters
-    -----------
-    engine : object (subclass of :class:`SolverEngine`)
+    ----------
+    engine
        The engine drive all operations involving data structures that have at
        least one "large" dimension. See :class:`SolverEngine` for requirements
     guess
@@ -677,7 +696,7 @@ def davidson_solver(engine, guess: List, *, nroot: int, r_convergence: float = 1
         Number of roots desired
     r_convergence
         Convergence tolerance for residual vectors
-    max_ss_size:
+    max_ss_size
        The maximum number of trial vectors in the iterative subspace that will
        be stored before a collapse is done.
     maxiter
@@ -687,27 +706,27 @@ def davidson_solver(engine, guess: List, *, nroot: int, r_convergence: float = 1
 
     Returns
     -------
-    best_values : numpy.ndarray (nroots, )
-       The best approximation of the eigenvalues of A, computed on the last iteration of the solver
-    best_vectors: list of `vector` (nroots)
-       The best approximation of the eigenvectors of A, computed on the last iteration of the solver
+    best_values : numpy.ndarray
+       (nroots, ) The best approximation of the eigenvalues of A, computed on the last iteration of the solver
+    best_vectors: List[`vector`]
+       (nroots) The best approximation of the eigenvectors of A, computed on the last iteration of the solver
     stats : List[Dict]
        Statistics collected on each iteration
 
-       count : int, iteration number
-       res_norm : np.ndarray (nroots, ), the norm of residual vector for each roots
-       val : np.ndarray (nroots, ), the eigenvalue corresponding to each root
-       delta_val : np.ndarray (nroots, ), the change in eigenvalue from the last iteration to this ones
-       collapse : bool, if a subspace collapse was performed
-       product_count : int, the running total of product evaluations that was performed
-       done : bool, if all roots were converged
+       - count : int, iteration number
+       - res_norm : np.ndarray (nroots, ), the norm of residual vector for each roots
+       - val : np.ndarray (nroots, ), the eigenvalue corresponding to each root
+       - delta_val : np.ndarray (nroots, ), the change in eigenvalue from the last iteration to this ones
+       - collapse : bool, if a subspace collapse was performed
+       - product_count : int, the running total of product evaluations that was performed
+       - done : bool, if all roots were converged
 
     Notes
     -----
     The solution vector is normalized to 1/2
 
-    The solver will return even when ``maxiter`` iterations are performed without convergence.
-    The caller **must check** `stats[-1]['done']` for failure and handle each case accordingly.
+    The solver will return even when `maxiter` iterations are performed without convergence.
+    The caller **must check** ``stats[-1]['done']`` for failure and handle each case accordingly.
     """
     nk = nroot
 
@@ -830,40 +849,48 @@ def davidson_solver(engine, guess: List, *, nroot: int, r_convergence: float = 1
     return {"eigvals": best_eigvals, "eigvecs": list(zip(best_eigvecs, best_eigvecs)), "stats": stats}
 
 
-def hamiltonian_solver(engine, guess: List, *, nroot: int, r_convergence: float = 1.0E-4, max_ss_size: int = 100, maxiter: int = 60, verbose: int = 1):
+def hamiltonian_solver(
+    engine: Type[SolverEngine],
+    guess: List,
+    *,
+    nroot: int,
+    r_convergence: float = 1.0E-4,
+    max_ss_size: int = 100,
+    maxiter: int = 60,
+    verbose: int = 1):
     """Finds the smallest eigenvalues and associated right and left hand
     eigenvectors of a large real Hamiltonian eigenvalue problem emulated
     through an engine.
 
-    A Hamiltonian eigenvalue problem (EVP) has the following structure:
+    A Hamiltonian eigenvalue problem (EVP) has the following structure::
 
-    [A  B][X]  = [1   0](w)[X]
-    [B  A][Y]    [0  -1](w)[Y]
+        [A  B][X]  = [1   0](w)[X]
+        [B  A][Y]    [0  -1](w)[Y]
 
     with A, B of some large dimension N, the problem is of dimension 2Nx2N.
 
     The real, Hamiltonian EVP can be rewritten as the NxN, non-hermitian EVP:
-    (A+B)(A-B)(X+Y) = w^2(X+Y)
+    :math:`(A+B)(A-B)(X+Y) = w^2(X+Y)`
 
     With left-hand eigenvectors:
-    (X-Y)(A-B)(A+B) = w^2(X-Y)
+    :math:`(X-Y)(A-B)(A+B) = w^2(X-Y)`
 
-    if (A-B) is positive definite, we can transform the problem to arrive at the hermitian NxN EVP:
-    (A-B)^1/2(A+B)(A-B)^1/2 = w^2 T
+    if :math:`(A-B)` is positive definite, we can transform the problem to arrive at the hermitian NxN EVP:
+    :math:`(A-B)^{1/2}(A+B)(A-B)^{1/2} = w^2 T`
 
-    Where T = (A-B)^-1/2(X+Y).
+    Where :math:`T = (A-B)^{-1/2}(X+Y)`.
 
-    We use a Davidson like iteration where we transform (A+B) (H1) and (A-B)
+    We use a Davidson like iteration where we transform :math:`(A+B)` (H1) and :math:`(A-B)`
     (H2) in to the subspace defined by the trial vectors.
-    The subspace analog of the NxN hermitian EVP is diagonalized and left (X-Y)
-    and right (X+Y) eigenvectors of the NxN non-hermitian EVP are approximated.
+    The subspace analog of the NxN hermitian EVP is diagonalized and left :math:`(X-Y)`
+    and right :math:`(X+Y)` eigenvectors of the NxN non-hermitian EVP are approximated.
     Residual vectors are formed for both and the guess space is augmented with
     two correction vectors per iteration. The advantages and properties of this
     algorithm are described in the literature [stratmann:1998]_ .
 
     Parameters
-    -----------
-    engine : object (subclass of :class:`SolverEngine`)
+    ----------
+    engine
        The engine drive all operations involving data structures that have at
        least one "large" dimension. See :class:`SolverEngine` for requirements
     guess
@@ -873,7 +900,7 @@ def hamiltonian_solver(engine, guess: List, *, nroot: int, r_convergence: float 
         Number of roots desired
     r_convergence
         Convergence tolerance for residual vectors
-    max_ss_size:
+    max_ss_size
        The maximum number of trial vectors in the iterative subspace that will
        be stored before a collapse is done.
     maxiter
@@ -883,33 +910,32 @@ def hamiltonian_solver(engine, guess: List, *, nroot: int, r_convergence: float 
 
     Returns
     -------
-    best_values : numpy.ndarray (nroots, )
-       The best approximation of the eigenvalues of `w`, computed on the last iteration of the solver
-    best_R: list of `vector` (nroots)
-       The best approximation of the  right hand eigenvectors, `X+Y`, computed on the last iteration of the solver.
-    best_L: list of `vector` (nroots)
-       The best approximation of the left hand eigenvectors, `X-Y`, computed on the last iteration of the solver.
-    stats : list of `dict`
+    best_values : numpy.ndarray
+        (nroots, ) The best approximation of the eigenvalues of `w`, computed on the last iteration of the solver
+    best_R: List[`vector`]
+        (nroots) The best approximation of the  right hand eigenvectors, :math:`X+Y`, computed on the last iteration of the solver.
+    best_L: List[`vector`]
+        (nroots) The best approximation of the left hand eigenvectors, :math:`X-Y`, computed on the last iteration of the solver.
+    stats : List[Dict]
        Statistics collected on each iteration
 
-       count : int, iteration number
-       res_norm : np.ndarray (nroots, ), the norm of residual vector for each roots
-       val : np.ndarray (nroots, ), the eigenvalue corresponding to each root
-       delta_val : np.ndarray (nroots, ), the change in eigenvalue from the last iteration to this ones
-       collapse : bool, if a subspace collapse was performed
-       product_count : int, the running total of product evaluations that was performed
-       done : bool, if all roots were converged
+       - count : int, iteration number
+       - res_norm : np.ndarray (nroots, ), the norm of residual vector for each roots
+       - val : np.ndarray (nroots, ), the eigenvalue corresponding to each root
+       - delta_val : np.ndarray (nroots, ), the change in eigenvalue from the last iteration to this ones
+       - collapse : bool, if a subspace collapse was performed
+       - product_count : int, the running total of product evaluations that was performed
+       - done : bool, if all roots were converged
 
     Notes
     -----
     The solution vector is normalized to 1/2
 
-    The solver will return even when ``maxiter`` iterations are performed without convergence.
-    The caller **must check** `stats[-1]['done']` for failure and handle each case accordingly.
+    The solver will return even when `maxiter` iterations are performed without convergence.
+    The caller **must check** ``stats[-1]['done']`` for failure and handle each case accordingly.
 
     References
     ----------
-
     R. Eric Stratmann, G. E. Scuseria, and M. J. Frisch, "An efficient
     implementation of time-dependent density-functional theory for the
     calculation of excitation energies of large molecules." J. Chem. Phys.,

--- a/psi4/driver/p4util/spectrum.py
+++ b/psi4/driver/p4util/spectrum.py
@@ -26,6 +26,15 @@
 # @END LICENSE
 #
 
+__all__ = [
+    "Gaussian",
+    "Lineshape",
+    "Lorentzian",
+    "prefactor_ecd",
+    "prefactor_opa",
+    "spectrum",
+]
+
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Union
@@ -40,9 +49,9 @@ class Lineshape:
 
     Attributes
     ----------
-    domain : Union[numpy.ndarray, List[float]]
+    domain
         Domain of the spectral band.
-    gamma : Callable[[float], float]
+    gamma
         A function returning the broadening factor.
 
     Notes
@@ -67,9 +76,9 @@ class Gaussian(Lineshape):
 
     Parameters
     ----------
-    domain : Union[List[float], numpy.ndarray]
+    domain
         The domain of the Gaussian profile.
-    gamma : float
+    gamma
         Broadening parameter.
         This is related to the full width at half maximum as :math:`\mathrm{FWHM} = \gamma \sqrt{2\ln 2}`
 
@@ -79,17 +88,18 @@ class Gaussian(Lineshape):
     """
 
     def lineshape(self, x_0: float) -> np.ndarray:
-        """Gaussian function on `self.domain`, centered at `x_0` with broadening `self.gamma`.
+        """Gaussian function on :py:attr:`Lineshape.domain`, centered at `x_0` with broadening :py:attr:`Lineshape.gamma`.
 
         Parameters
         ----------
-        x_0 : float
+        x_0
             Center of the Gaussian, i.e. its maximum.
 
         Returns
         -------
-        gauss : numpy.ndarray
+        numpy.ndarray
             The Gaussian profile.
+
         """
         prefactor = 2.0 / (self.gamma(x_0) * np.sqrt(2.0 * np.pi))
         exponent = -2.0 * ((self.domain - x_0) / self.gamma(x_0))**2
@@ -97,6 +107,14 @@ class Gaussian(Lineshape):
         return prefactor * np.exp(exponent)
 
     def maximum(self, x_0: float) -> float:
+        """Maximum value of Gaussian profile centered at `x_0`.
+
+        Parameters
+        ----------
+        x_0
+            Center of the Lorentzian, i.e. its maximum.
+
+        """
         return 2.0 / (self.gamma(x_0) * np.sqrt(2.0 * np.pi))
 
 
@@ -105,9 +123,9 @@ class Lorentzian(Lineshape):
 
     Parameters
     ----------
-    domain : Union[List[float], numpy.ndarray]
+    domain
         The domain of the Lorentzian profile.
-    gamma : float
+    gamma
         Broadening parameter.
         This is the full width at half maximum (FWHM).
 
@@ -126,7 +144,7 @@ class Lorentzian(Lineshape):
 
         Returns
         -------
-        lorentz : numpy.ndarray
+        numpy.ndarray
             The Lorentzian profile.
         """
         prefactor = 1.0 / np.pi
@@ -136,16 +154,20 @@ class Lorentzian(Lineshape):
         return prefactor * (numerator / denominator)
 
     def maximum(self, x_0: float) -> float:
+        """Maximum value of Lorentzian profile centered at `x_0`.
+
+        Parameters
+        ----------
+        x_0
+            Center of the Lorentzian, i.e. its maximum.
+
+        """
         return 2.0 / (np.pi * self.gamma(x_0))
 
 
 def prefactor_opa() -> float:
     r"""Prefactor for converting microscopic observable to decadic molar
     extinction coefficient in one-photon absorption.
-
-    Returns
-    -------
-    prefactor : float
 
     Notes
     -----
@@ -178,10 +200,6 @@ def prefactor_opa() -> float:
 def prefactor_ecd() -> float:
     r"""Prefactor for converting microscopic observable to decadic molar
     extinction coefficient in electronic circular dichroism.
-
-    Returns
-    -------
-    prefactor : float
 
     Notes
     -----
@@ -281,7 +299,7 @@ def spectrum(*,
 
     Returns
     -------
-    spectrum : Dict
+    spectrum : Dict[str, numpy.ndarray]
         The fitted electronic absorption spectrum, with units for the x axis specified by the `out_units` parameter.
         This is a dictionary containing the convoluted (key: `convolution`) and the infinitely narrow spectra (key: `sticks`).
 
@@ -304,6 +322,7 @@ def spectrum(*,
     References
     ----------
     A. Rizzo, S. Coriani, K. Ruud, "Response Function Theory Computational Approaches to Linear and Nonlinear Optical Spectroscopy". In Computational Strategies for Spectroscopy.
+    https://doi.org/10.1002/9781118008720.ch2
     """
 
     # Transmute inputs to np.ndarray

--- a/psi4/driver/p4util/testing.py
+++ b/psi4/driver/p4util/testing.py
@@ -25,7 +25,21 @@
 #
 # @END LICENSE
 #
-"""Module with comparison functions with output configures for Psi4."""
+"""Module with comparison functions with output configured for Psi4."""
+
+__all__ = [
+    "compare",
+    "compare_arrays",
+    "compare_cubes",
+    "compare_integers",
+    "compare_matrices",
+    "compare_molrecs",
+    "compare_recursive",
+    "compare_strings",
+    "compare_values",
+    "compare_vectors",
+    "compare_wavefunctions",
+]
 
 import sys
 from functools import partial
@@ -36,11 +50,6 @@ import qcelemental as qcel
 from psi4 import core
 from psi4.driver import qcdb
 from .exceptions import TestComparisonError
-
-__all__ = [
-    'compare', 'compare_integers', 'compare_strings', 'compare_values', 'compare_arrays', 'compare_recursive',
-    'compare_molrecs', 'compare_cubes', 'compare_vectors', 'compare_matrices', 'compare_wavefunctions'
-]
 
 # TODO in multistage compare_* fns, we're potentially stopping the fn prematurely and not in the manner of the handling fn.
 

--- a/psi4/driver/p4util/text.py
+++ b/psi4/driver/p4util/text.py
@@ -29,6 +29,16 @@
 to data tables and text.
 
 """
+
+__all__ = [
+    "banner",
+    "find_approximate_string_matches",
+    "levenshtein",
+    "message_box",
+]
+
+from typing import List, Optional
+
 import sys
 import warnings
 
@@ -37,130 +47,27 @@ from psi4.driver import constants
 from psi4 import core
 
 
-class Table(object):
-    """Class defining a flexible Table object for storing data."""
+def banner(text: str, type: int = 1, width: int = 35, strNotOutfile: bool = False) -> Optional[str]:
+    """Format `text` into a banner style and print or return it.
 
-    def __init__(self, rows=(), row_label_width=10, row_label_precision=4, cols=(), width=16, precision=10):
-        warnings.warn(
-            "Using `psi4.driver.p4util.Table` is deprecated, and as soon as 1.4 it will stop working\n",
-            category=FutureWarning,
-            stacklevel=2)
-        self.row_label_width = row_label_width
-        self.row_label_precision = row_label_precision
-        self.width = width
-        self.precision = precision
-        self.rows = rows
+    Parameters
+    ----------
+    text
+        String to be emphasized.
+    type
+        Style 1 has minimum three-line height. Style 2 has minimum one-light
+        height.
+    width
+        Minimum length of banner string.
+    strNotOutfile
+        Controls mode of return.
 
-        if isinstance(cols, str):
-            self.cols = (cols, )
-        else:
-            self.cols = cols
-
-        self.labels = []
-        self.data = []
-
-    def format_label(self):
-        """Function to pad the width of Table object labels."""
-        #str = lambda x: (('%%%d.%df' % (self.row_label_width, self.row_label_precision)) % x)
-        str = lambda x: (('%%%ds' % (self.row_label_width)) % x)
-        return " ".join(map(str, self.labels))
-
-    def format_values(self, values):
-        """Function to pad the width of Table object data cells."""
-        str = lambda x: (('%%%d.%df' % (self.width, self.precision)) % x)
-        return " ".join(map(str, values))
-
-    def __getitem__(self, value):
-        self.labels.append(value)
-        return self
-
-    def __setitem__(self, name, value):
-        self.labels.append(name)
-        label = self.format_label()
-        self.labels = []
-
-        if isinstance(value, list):
-            self.data.append((label, value))
-        else:
-            self.data.append((label, [value]))
-
-    def save(self, file):
-        """Function to save string of the Table object to *file*."""
-        import pickle
-        pickle_str = pickle.dumps(self)
-        fileobj = open(file, "w")
-        fileobj.write(str(self))
-        fileobj.close()
-
-    def __str__(self):
-        rowstr = lambda x: '%%%ds' % self.row_label_width % x
-        colstr = lambda x: '%%%ds' % self.width % x
-
-        lines = []
-
-        table_header = ""
-        if isinstance(self.rows, str):
-            table_header += "%%%ds" % self.row_label_width % self.rows
-        else:
-            table_header += " ".join(map(rowstr, self.rows))
-        table_header += " ".join(map(colstr, self.cols))
-
-        lines.append(table_header)
-
-        for datarow in self.data:
-            #print datarow
-            row_data = datarow[0]
-            row_data += self.format_values(datarow[1])
-            lines.append(row_data)
-
-        return "\n".join(lines) + "\n"
-
-    def copy(self):
-        """Function to return a copy of the Table object."""
-        import copy
-        return copy.deepcopy(self)
-
-    def absolute_to_relative(self, Factor=constants.hartree2kcalmol):
-        """Function to shift the data of each column of the Table object
-        such that the lowest value is zero. A scaling factor of *Factor* is applied.
-
-        """
-        import copy
-
-        if len(self.data) == 0:
-            return
-
-        current_min = list(copy.deepcopy(self.data[0][1]))
-        for datarow in self.data:
-            for col in range(0, len(datarow[1])):
-                if current_min[col] > datarow[1][col]:
-                    current_min[col] = datarow[1][col]
-
-        for datarow in self.data:
-            for col in range(0, len(datarow[1])):
-                #print datarow[1][col]
-                datarow[1][col] = (datarow[1][col] - current_min[col]) * Factor
-
-    def scale(self, Factor=constants.hartree2kcalmol):
-        """Function to apply a scaling factor *Factor* to the
-        data of the Table object.
-
-        """
-        if len(self.data) == 0:
-            return
-
-        for datarow in self.data:
-            for col in range(0, len(datarow[1])):
-                #print datarow[1][col]
-                datarow[1][col] = datarow[1][col] * Factor
-
-
-def banner(text, type=1, width=35, strNotOutfile=False):
-    """Function to print *text* to output file in a banner of
-    minimum width *width* and minimum three-line height for
-    *type* = 1 or one-line height for *type* = 2. If *strNotOutfile*
-    is True, function returns string rather than printing it
-    to output file.
+    Returns
+    -------
+    str
+        If *strNotOutfile* is True, return string.
+    None
+        If *strNotOutfile* is False, print it to output file.
 
     """
     lines = text.split('\n')
@@ -188,29 +95,17 @@ def banner(text, type=1, width=35, strNotOutfile=False):
         core.print_out(banner)
 
 
-def print_stdout(stuff):
-    """Function to print *stuff* to standard output stream."""
-    warnings.warn(
-        "Using `psi4.driver.p4util.print_stdout` instead of `print` is deprecated, and as soon as 1.4 it will stop working\n",
-        category=FutureWarning,
-        stacklevel=2)
+def levenshtein(seq1: str, seq2:str) -> int:
+    """Compute the Levenshtein distance between two strings.
 
-    print(stuff, file=sys.stdout)
+    Parameters
+    ----------
+    seq1
+        First string.
+    seq2
+        Second string.
 
-
-def print_stderr(stuff):
-    """Function to print *stuff* to standard error stream."""
-    warnings.warn(
-        "Using `psi4.driver.p4util.print_stderr` instead of `print(..., file=sys.stderr)` is deprecated, and as soon as 1.4 it will stop working\n",
-        category=FutureWarning,
-        stacklevel=2)
-
-    print(stuff, file=sys.stderr)
-
-
-def levenshtein(seq1, seq2):
-    """Compute the Levenshtein distance between two strings."""
-
+    """
     oneago = None
     thisrow = list(range(1, len(seq2) + 1)) + [0]
     for x in range(len(seq1)):
@@ -223,26 +118,38 @@ def levenshtein(seq1, seq2):
     return thisrow[len(seq2) - 1]
 
 
-def find_approximate_string_matches(seq1, options, max_distance):
-    """Find list of approximate (within `max_distance`) matches to string `seq1` among `options`."""
-
-    return [seq2 for seq2 in options if (levenshtein(seq1, seq2) <= max_distance)]
-
-def message_box(message: str = None, max_width: int = 80, min_width: int = 30):
-    """ put a message string into a box for extra attention
+def find_approximate_string_matches(seq1: str, options: List[str], max_distance: int) -> List[str]:
+    """Find list of approximate (within `max_distance`) matches to string `seq1` among `options`.
 
     Parameters
-    -----------
-    message
-       message string to be boxed
+    ----------
+    seq1
+        Target string to look for near matches to.
+    options
+        Alternatives among which to look for near matches to `seq1`.
+    max_distance
+        Maximum Levenshtein distance from `seq1` to return.
 
+    """
+    return [seq2 for seq2 in options if (levenshtein(seq1, seq2) <= max_distance)]
+
+
+def message_box(message: str, max_width: int = 80, min_width: int = 30) -> str:
+    """Put a message string into a box for extra attention.
+
+    Parameters
+    ----------
+    message
+       Message string to be boxed.
     max_width
-        maximal character width of the box
+        Maximal character width of the box.
+    min_width
+        Minimal character width of the box.
 
     Returns
-    --------
+    -------
     str
-       box containing the message as a multiline string
+       Box containing the message as a multiline string.
     """
     from textwrap import wrap
 

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -27,25 +27,38 @@
 #
 """Module with utility functions for use in input files."""
 
+__all__ = [
+    "copy_file_to_scratch",
+    "copy_file_from_scratch",
+    "cubeprop",
+    "get_memory",
+    "oeprop",
+    "set_memory",
+]
+
 import os
 import re
 import sys
 import warnings
-from typing import Union
+from typing import List, Union
 
 from psi4 import core
 from psi4.driver.procrouting import *
 from .exceptions import ValidationError
 from .prop_util import *
 
-def oeprop(wfn: core.Wavefunction, *args, **kwargs):
+
+def oeprop(wfn: core.Wavefunction, *args: List[str], **kwargs):
     """Evaluate one-electron properties.
 
     :returns: None
 
     :param wfn: set of molecule, basis, orbitals from which to compute properties
 
-    How to specify args, which are actually the most important
+    :param args:
+
+        Arbitrary-number of properties to be computed from *wfn*.
+        See :ref:`Available One-Electron Properties <table:oe_features>`.
 
     :type title: str
     :param title: label prepended to all psivars computed
@@ -74,7 +87,7 @@ def oeprop(wfn: core.Wavefunction, *args, **kwargs):
     oe.compute()
 
 
-def cubeprop(wfn, **kwargs):
+def cubeprop(wfn: core.Wavefunction, **kwargs):
     """Evaluate properties on a grid and generate cube files.
 
     .. versionadded:: 0.5
@@ -82,7 +95,6 @@ def cubeprop(wfn, **kwargs):
 
     :returns: None
 
-    :type wfn: :py:class:`~psi4.core.Wavefunction`
     :param wfn: set of molecule, basis, orbitals from which to generate cube files
 
     :examples:
@@ -111,17 +123,31 @@ def cubeprop(wfn, **kwargs):
 
 
 def set_memory(inputval: Union[str, int, float], execute: bool = True, quiet: bool = False) -> int:
-    """Function to reset the total memory allocation. Takes memory value
-    *inputval* as type int, float, or str; int and float are taken literally
-    as bytes to be set, string taken as a unit-containing value (e.g., 30 mb)
-    which is case-insensitive. Set *execute* to False to interpret *inputval*
-    without setting in Psi4 core.
+    """Reset the total memory allocation.
 
-    :returns: *memory_amount* Number of bytes of memory set
+    Parameters
+    ----------
+    inputval
+        Memory value. An Integer or float is taken literally as bytes to be set.
+        A string is taken as a unit-containing value (e.g., 30 mb), which is
+        case-insensitive.
+    execute
+        When False, interpret *inputval* without setting in Psi4 core.
+    quiet
+        When True, do not print to the output file.
 
-    :raises: :py:class:`psi4.ValidationError` when <500MiB or disallowed type or misformatted
+    Returns
+    -------
+    int
+        Number of bytes of memory set.
 
-    :examples:
+    Raises
+    ------
+    ValidationError
+        When <500MiB or disallowed type or misformatted.
+
+    Examples
+    --------
 
     >>> # [1] Passing absolute number of bytes
     >>> psi4.set_memory(600000000)
@@ -198,38 +224,41 @@ def set_memory(inputval: Union[str, int, float], execute: bool = True, quiet: bo
     return memory_amount
 
 
-def get_memory():
-    """Function to return the total memory allocation."""
+def get_memory() -> int:
+    """Return the total memory allocation in bytes."""
     return core.get_memory()
 
 
-def copy_file_to_scratch(filename, prefix, namespace, unit, move=False):
-    """Function to move file into scratch with correct naming
-    convention.
+def copy_file_to_scratch(filename: str, prefix: str, namespace: str, unit: int, move: bool = False):
+    """Move a file into scratch following the naming convention.
 
-    Arguments:
+    Parameters
+    ----------
+    filename
+        Full path to file.
+    prefix
+        Computation prefix, usually 'psi'.
+    namespace
+        Context namespace, usually molecule name.
+    unit
+        Unit number, e.g. 32.
+    move
+        Whether to copy (default) or move?
 
-    @arg filename  full path to file
-    @arg prefix    computation prefix, usually 'psi'
-    @arg namespace context namespace, usually molecule name
-    @arg unit      unit number, e.g. 32
-    @arg move      copy or move? (default copy)
+    Examples
+    --------
 
-    Example:
-
-    Assume PID is 12345 and SCRATCH is /scratch/parrish/
-
-    copy_file_to_scratch('temp', 'psi', 'h2o', 32):
-        -cp ./temp /scratch/parrish/psi.12345.h2o.32
-    copy_file_to_scratch('/tmp/temp', 'psi', 'h2o', 32):
-        -cp /tmp/temp /scratch/parrish/psi.12345.h2o.32
-    copy_file_to_scratch('/tmp/temp', 'psi', '', 32):
-        -cp /tmp/temp /scratch/parrish/psi.12345.32
-    copy_file_to_scratch('/tmp/temp', 'psi', '', 32, True):
-        -mv /tmp/temp /scratch/parrish/psi.12345.32
+    >>> # Assume PID is 12345 and SCRATCH is /scratch/parrish/
+    >>> copy_file_to_scratch('temp', 'psi', 'h2o', 32):
+    Out[1]:  -cp ./temp /scratch/parrish/psi.12345.h2o.32
+    >>> copy_file_to_scratch('/tmp/temp', 'psi', 'h2o', 32):
+    Out[2]:  -cp /tmp/temp /scratch/parrish/psi.12345.h2o.32
+    >>> copy_file_to_scratch('/tmp/temp', 'psi', '', 32):
+    Out[3]:  -cp /tmp/temp /scratch/parrish/psi.12345.32
+    >>> copy_file_to_scratch('/tmp/temp', 'psi', '', 32, True):
+    Out[4]:  -mv /tmp/temp /scratch/parrish/psi.12345.32
 
     """
-
     pid = str(os.getpid())
     scratch = core.IOManager.shared_object().get_file_path(int(unit))
 
@@ -252,33 +281,37 @@ def copy_file_to_scratch(filename, prefix, namespace, unit, move=False):
     command = ('%s %s %s/%s' % (cp, filename, scratch, target))
 
     os.system(command)
-    #print command
 
 
-def copy_file_from_scratch(filename, prefix, namespace, unit, move=False):
-    """Function to move file out of scratch with correct naming
-    convention.
+def copy_file_from_scratch(filename: str, prefix: str, namespace: str, unit: int, move: bool = False):
+    """Move a file out of scratch following the naming convention.
 
-    Arguments:
+    Parameters
+    ----------
 
-    @arg filename  full path to target file
-    @arg prefix    computation prefix, usually 'psi'
-    @arg namespace context namespace, usually molecule name
-    @arg unit      unit number, e.g. 32
-    @arg move      copy or move? (default copy)
+    filename
+        Full path to target file.
+    prefix
+        Computation prefix, usually 'psi'.
+    namespace
+        Context namespace, usually molecule name.
+    unit
+        Unit number, e.g. 32
+    move
+        Whether to copy (default) or move?
 
-    Example:
+    Examples
+    --------
 
-    Assume PID is 12345 and SCRATCH is /scratch/parrish/
-
-    copy_file_to_scratch('temp', 'psi', 'h2o', 32):
-        -cp /scratch/parrish/psi.12345.h2o.32 .temp
-    copy_file_to_scratch('/tmp/temp', 'psi', 'h2o', 32):
-        -cp /scratch/parrish/psi.12345.h2o.32 /tmp/temp
-    copy_file_to_scratch('/tmp/temp', 'psi', '', 32):
-        -cp /scratch/parrish/psi.12345.32 /tmp/temp
-    copy_file_to_scratch('/tmp/temp', 'psi', '', 32, True):
-        -mv /scratch/parrish/psi.12345.32 /tmp/temp
+    >>> # Assume PID is 12345 and SCRATCH is /scratch/parrish/
+    >>> copy_file_to_scratch('temp', 'psi', 'h2o', 32):
+    Out[1]:  -cp /scratch/parrish/psi.12345.h2o.32 .temp
+    >>> copy_file_to_scratch('/tmp/temp', 'psi', 'h2o', 32):
+    Out[2]:  -cp /scratch/parrish/psi.12345.h2o.32 /tmp/temp
+    >>> copy_file_to_scratch('/tmp/temp', 'psi', '', 32):
+    Out[3]:  -cp /scratch/parrish/psi.12345.32 /tmp/temp
+    >>> copy_file_to_scratch('/tmp/temp', 'psi', '', 32, True):
+    Out[4]:  -mv /scratch/parrish/psi.12345.32 /tmp/temp
 
     """
 

--- a/psi4/driver/p4util/writer.py
+++ b/psi4/driver/p4util/writer.py
@@ -25,13 +25,28 @@
 #
 # @END LICENSE
 #
-"""Module for writing input files to external codes."""
+"""Module for writing input files to external codes (e.g., Molden, NBO).
+Only contains extensions to the :py:class:`psi4.core.Wavefunction` class.
+
+"""
+
+__all__ = []
+
+from typing import Optional
 
 from psi4.driver import constants
 
 from psi4 import core
 
-def _write_nbo(self, name):
+def _write_nbo(self, name: str):
+    """Write wavefunction information in *wfn* to *name* in NBO format.
+
+    Parameters
+    ----------
+    name
+        Destination file name for NBO file.
+
+    """
     basisset = self.basisset()
     mints = core.MintsHelper(basisset)
     mol = self.molecule()
@@ -199,12 +214,16 @@ def _write_nbo(self, name):
 
 core.Wavefunction.write_nbo = _write_nbo
 
-def _write_molden(self, filename=None, do_virtual=None, use_natural=False):
-
-    """Function to write wavefunction information in *wfn* to *filename* in
+def _write_molden(
+    self: core.Wavefunction,
+    filename: Optional[str] = None,
+    do_virtual: Optional[bool] = None,
+    use_natural: bool = False,
+):
+    """Writes wavefunction information in *wfn* to *filename* in
     molden format. Will write natural orbitals from *density* (MO basis) if supplied.
-    Warning! Most post-SCF Wavefunctions do not build the density as this is often
-    much more costly than the energy. In addition, the Wavefunction density attributes
+    Warning! most post-SCF wavefunctions do not build the density as this is often
+    much more costly than the energy. In addition, the wavefunction density attributes
     (Da and Db) return the SO density and must be transformed to the MO basis
     to use with this function.
 
@@ -213,14 +232,23 @@ def _write_molden(self, filename=None, do_virtual=None, use_natural=False):
 
     :returns: None
 
-    :type filename: string
-    :param filename: destination file name for MOLDEN file (optional)
+    :type filename:
+    :param filename:
 
-    :type do_virtual: bool
-    :param do_virtual: do write all the MOs to the MOLDEN file (true) or discard the unoccupied MOs, not valid for NO's (false) (optional)
+        Destination file name for MOLDEN file. If unspecified (None), a file
+        name will be generated from the molecule name.
 
-    :type use_natural: bool
-    :param use_natural: write natural orbitals determined from density on wavefunction
+    :type do_virtual:
+    :param do_virtual:
+
+        Do write all the MOs to the MOLDEN file (True) or discard the unoccupied
+        MOs (False). Not valid for NO's. If unspecified (None), value taken from
+        :term:`MOLDEN_WITH_VIRTUAL <MOLDEN_WITH_VIRTUAL (GLOBALS)>`.
+
+    :type use_natural:
+    :param use_natural:
+
+        Write natural orbitals determined from density on wavefunction.
 
     :examples:
 
@@ -237,8 +265,9 @@ def _write_molden(self, filename=None, do_virtual=None, use_natural=False):
 
     3. To supply a custom density matrix, manually set the Da and Db of the wavefunction.
        This is used, for example, to write natural orbitals coming from a root computed
-       by a ``CIWavefunction`` computation, e.g., ``detci``, ``fci``, ``casscf``.`
-       The first two arguments of ``get_opdm`` can be set to ``n, n`` where n => 0 selects the root to
+       by a ``CIWavefunction`` computation, e.g., ``detci``, ``fci``, ``casscf``.
+       The first two arguments of :py:meth:`~psi4.core.Wavefunction.get_opdm`
+       can be set to ``n, n`` where n => 0 selects the root to
        write out, provided these roots were computed, see :term:`NUM_ROOTS <NUM_ROOTS (DETCI)>`. The
        third argument controls the spin (``"A"``, ``"B"`` or ``"SUM"``) and the final
        boolean option determines whether inactive orbitals are included.

--- a/psi4/driver/task_base.py
+++ b/psi4/driver/task_base.py
@@ -74,7 +74,7 @@ class AtomicComputer(BaseComputer):
         "Note for finite difference that this should be the target driver, not the means driver.")
     keywords: Dict[str, Any] = Field(default_factory=dict, description="The keywords to use in the computation.")
     computed: bool = Field(False, description="Whether quantum chemistry has been run on this task.")
-    result: Any = Field(default_factory=dict, description="AtomicResult return.")
+    result: Any = Field(default_factory=dict, description=":py:class:~`qcelemental.models.AtomicResult` return.")
     result_id: Optional[str] = Field(None, description="The optional ID for the computation.")
 
     class Config(qcel.models.ProtoModel.Config):

--- a/psi4/driver/wrapper_autofrag.py
+++ b/psi4/driver/wrapper_autofrag.py
@@ -26,12 +26,15 @@
 # @END LICENSE
 #
 
-from typing import List
+from typing import List, Optional
 
 from psi4 import core
 
 
-def auto_fragments(molecule: core.Molecule = None, seed_atoms: List = None) -> core.Molecule:
+def auto_fragments(
+    molecule: Optional[core.Molecule] = None,
+    seed_atoms: Optional[List[List[int]]] = None,
+) -> core.Molecule:
     r"""Detects fragments in unfragmented molecule using BFS algorithm.
     Currently only used for the WebMO implementation of SAPT.
 

--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -26,9 +26,8 @@
 # @END LICENSE
 #
 
-"""Module with functions that call the four main :py:mod:`driver`
-functions: :py:mod:`driver.energy`, :py:mod:`driver.optimize`,
-:py:mod:`driver.response`, and :py:mod:`driver.frequency`.
+"""
+Module with database functionality.
 
 """
 import collections
@@ -37,6 +36,7 @@ import os
 import re
 import sys
 
+from psi4 import core
 from psi4.driver import constants
 from psi4.driver import p4util
 from psi4.driver.driver import *

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -281,37 +281,39 @@ void export_wavefunction(py::module& m) {
         .def("set_external_potential", &Wavefunction::set_external_potential, "Sets the requested external potential.")
         .def("external_pot", &Wavefunction::external_pot, "Gets the requested external potential.")
         .def("has_scalar_variable", &Wavefunction::has_scalar_variable,
-             "Is the double QC variable (case-insensitive) set?")
+             "Is the double QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.Wavefunction.has_variable`.")
         .def("has_array_variable", &Wavefunction::has_array_variable,
-             "Is the Matrix QC variable (case-insensitive) set?")
+             "Is the Matrix QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.Wavefunction.has_variable`.")
         .def("has_potential_variable", &Wavefunction::has_potential_variable,
              "Is the ExternalPotential QC variable (case-insensitive) set? "
              "(This function is provisional and might be removed in the future.)")
         .def("scalar_variable", &Wavefunction::scalar_variable,
-             "Returns the requested (case-insensitive) double QC variable.")
+             "Returns the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.Wavefunction.variable`.")
         .def("array_variable", &Wavefunction::array_variable,
-             "Returns copy of the requested (case-insensitive) Matrix QC variable.")
+             "Returns copy of the requested (case-insensitive) Matrix QC variable. Prefer :meth:`~psi4.core.Wavefunction.variable`.")
         .def("potential_variable", &Wavefunction::potential_variable,
              "key"_a, "Returns copy of the requested (case-insensitive) ExternalPotential QC variable *key*. "
              "(This function is provisional and might be removed in the future.)")
         .def("set_scalar_variable", &Wavefunction::set_scalar_variable,
              "Sets the requested (case-insensitive) double QC variable. Syncs with ``Wavefunction.energy_`` if CURRENT "
-             "ENERGY.")
+             "ENERGY. Prefer :meth:`~psi4.core.Wavefunction.set_variable`.")
         .def("set_array_variable", &Wavefunction::set_array_variable,
              "Sets the requested (case-insensitive) Matrix QC variable. Syncs with ``Wavefunction.gradient_`` or "
-             "``hessian_`` if CURRENT GRADIENT or HESSIAN.")
+             "``hessian_`` if CURRENT GRADIENT or HESSIAN. Prefer :meth:`~psi4.core.Wavefunction.set_variable`.")
         .def("set_potential_variable", &Wavefunction::set_potential_variable,
              "Sets the requested (case-insensitive) ExternalPotential QC variable. "
              "(This function is provisional and might be removed in the future.)")
         .def("del_scalar_variable", &Wavefunction::del_scalar_variable,
-             "Removes the requested (case-insensitive) double QC variable.")
+             "Removes the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.Wavefunction.del_variable`.")
         .def("del_array_variable", &Wavefunction::del_array_variable,
-             "Removes the requested (case-insensitive) Matrix QC variable.")
+             "Removes the requested (case-insensitive) Matrix QC variable. Prefer :meth:`~psi4.core.Wavefunction.del_variable`.")
         .def("del_potential_variable", &Wavefunction::del_potential_variable,
              "Removes the requested (case-insensitive) ExternalPotential QC variable. "
              "(This function is provisional and might be removed in the future.)")
-        .def("scalar_variables", &Wavefunction::scalar_variables, "Returns the dictionary of all double QC variables.")
-        .def("array_variables", &Wavefunction::array_variables, "Returns the dictionary of all Matrix QC variables.")
+        .def("scalar_variables", &Wavefunction::scalar_variables,
+             "Returns the dictionary of all double QC variables. Prefer :meth:`~psi4.core.Wavefunction.variables`.")
+        .def("array_variables", &Wavefunction::array_variables,
+             "Returns the dictionary of all Matrix QC variables. Prefer :meth:`~psi4.core.Wavefunction.variables`.")
         .def("potential_variables", &Wavefunction::potential_variables, "Returns the dictionary of all ExternalPotential QC variables. "
              "(This function is provisional and might be removed in the future.)")
 

--- a/tests/pytests/test_misc.py
+++ b/tests/pytests/test_misc.py
@@ -13,6 +13,20 @@ from psi4.driver import qcdb
 pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.quick]
 
 
+def test_variables_deprecated():
+    psi4.geometry("he")
+    psi4.set_options({"basis": "cc-pvtz", "qc_module": "occ"})
+    psi4.energy("mp2")
+
+    qcvars = psi4.core.variables()
+    assert "SCS(N)-MP2 CORRELATION ENERGY" in qcvars.keys()
+    assert "SCSN-MP2 CORRELATION ENERGY" not in qcvars.keys()
+
+    qcvars = psi4.core.variables(include_deprecated_keys=True)
+    assert "SCS(N)-MP2 CORRELATION ENERGY" in qcvars.keys()
+    assert "SCSN-MP2 CORRELATION ENERGY" in qcvars.keys()
+
+
 @pytest.mark.parametrize("call",
     [psi4.energy, psi4.optimize, psi4.gradient, psi4.hessian, psi4.frequencies, psi4.properties])
 def test_typo_method_calls(call):

--- a/tests/pywrap-align/input.dat
+++ b/tests/pywrap-align/input.dat
@@ -1,5 +1,6 @@
 #! apply linear fragmentation algorithm to a water cluster
 
+import math
 from psi4.driver import qcdb
 
 s22_12 = qcdb.Molecule("""


### PR DESCRIPTION
## Description
If you look closely, the driver structure and its autodoc are a little weird, as reviewed in #2166. Also, many driver functions are minimally documented or don't take advantage of typing to guide the developer. This PR considers only `driver/p4utils/` directory and fills in docstrings and typing while checking the built docs for maximum info and links. Even when I saw good things to change in code, for this most part, this PR leaves them be and focuses on docstrings.

Piece 1 from the "driver import" series, #2166 

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] add `__all__` to guide `from module import *`. This same effect can be had by `def _functionname` but the PEP https://peps.python.org/pep-0008/#public-and-internal-interfaces still recommends `__all__`.
- [x] a few things actually retired: 
  - `PsiImportError`, `CSXError`, `Dftd3Error` -- not used since v1.4 at latest
  - `fchkfile_to_string` hidden in fchk.py (just opening and reading a file)
  - `basname` hidden in python_helpers.py (one-liner)
  - `format_kwargs_for_input` (as soon as v1.4)
  - `extract_sowreap_from_output` (as soon as v1.4)
  - `format_currentstate_for_input` (as soon as v1.4)
  - `Table` (as soon as v1.4)
  - `print_stdout` (as soon as v1.4)
  - `print_stderr` (as soon as v1.4)

## Checklist
- Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
