### PR TITLE
Tdscf excitations symmetry

### DIFF
--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -486,8 +486,8 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
             nvir = (nvir, )
         for h in range(nirrep):
             h_vir = x.irrep_trans_index ^ h
-            occ_irrep = wfn.molecule().irrep_labels()[h]
-            vir_irrep = wfn.molecule().irrep_labels()[h_vir]
+            occ_irrep = wfn.molecule().irrep_labels()[h].lower()
+            vir_irrep = wfn.molecule().irrep_labels()[h_vir].lower()
             for row in range(nocc[h][0]):
                 for col in range(nvir[h_vir][0]):
                     if nirrep == 1:
@@ -497,14 +497,14 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                     if abs(coef) > coeff_cutoff:
                         perc = 100 * coef**2
                         core.print_out(
-                            f"   {row+1: 4}{occ_irrep} ->{col+1+nocc[h_vir][0]: 4}{vir_irrep}  {coef: 10.6f} ({perc: >6.3f}%)\n"
+                            f"   {row+1: 4}{occ_irrep} (a) ->{col+1+nocc[h_vir][0]: 4}{vir_irrep} (a)  {coef: 10.6f} ({perc: >6.3f}%)\n"
                         )
         # De-excitations if not using TDA
         if not tda:
             for h in range(nirrep):
                 h_vir = x.irrep_trans_index ^ h
-                occ_irrep = wfn.molecule().irrep_labels()[h]
-                vir_irrep = wfn.molecule().irrep_labels()[h_vir]
+                occ_irrep = wfn.molecule().irrep_labels()[h].lower()
+                vir_irrep = wfn.molecule().irrep_labels()[h_vir].lower()
                 for row in range(nocc[h][0]):
                     for col in range(nvir[h_vir][0]):
                         if nirrep == 1:
@@ -514,7 +514,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                         if abs(coef) > coeff_cutoff:
                             perc = 100 * coef**2
                             core.print_out(
-                                f"   {row+1: 4}{occ_irrep} <-{col+1+nocc[h_vir][0]: 4}{vir_irrep}  {coef: 10.6f} ({perc: >6.3f}%)\n"
+                                f"   {row+1: 4}{occ_irrep} (a) <-{col+1+nocc[h_vir][0]: 4}{vir_irrep} (a)  {coef: 10.6f} ({perc: >6.3f}%)\n"
                             )
         # Now treat beta orbitals if needed
         if not restricted:
@@ -548,8 +548,8 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
             # Excitations (beta orbitals)
             for h in range(nirrep):
                 h_vir = x.irrep_trans_index ^ h
-                occ_irrep = wfn.molecule().irrep_labels()[h]
-                vir_irrep = wfn.molecule().irrep_labels()[h_vir]
+                occ_irrep = wfn.molecule().irrep_labels()[h].lower()
+                vir_irrep = wfn.molecule().irrep_labels()[h_vir].lower()
                 for row in range(nocc[h][0]):
                     for col in range(nvir[h_vir][0]):
                         if nirrep == 1:
@@ -559,14 +559,14 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                         if abs(coef) > coeff_cutoff:
                             perc = 100 * coef**2
                             core.print_out(
-                                f"   {row+1: 4}{occ_irrep}(B)->{col+1+nocc[h_vir][0]: 4}{vir_irrep}(B) {coef: 10.6f} ({perc: >6.3f}%)\n"
+                                f"   {row+1: 4}{occ_irrep}(B)->{col+1+nocc[h_vir][0]: 4}{vir_irrep} (b)  {coef: 10.6f} ({perc: >6.3f}%)\n"
                             )
                 # De-excitations if not using TDA (beta orbitals):
             if not tda:
                 for h in range(nirrep):
                     h_vir = x.irrep_trans_index ^ h
-                    occ_irrep = wfn.molecule().irrep_labels()[h]
-                    vir_irrep = wfn.molecule().irrep_labels()[h_vir]
+                    occ_irrep = wfn.molecule().irrep_labels()[h].lower()
+                    vir_irrep = wfn.molecule().irrep_labels()[h_vir].lower()
                     for row in range(nocc[h][0]):
                         for col in range(nvir[h_vir][0]):
                             if nirrep == 1:
@@ -576,7 +576,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                             if abs(coef) > coeff_cutoff:
                                 perc = 100 * coef**2
                                 core.print_out(
-                                    f"   {row+1: 4}{occ_irrep}(B)<-{col+1+nocc[h_vir][0]: 4}{vir_irrep}(B) {coef: 10.6f} ({perc: >6.3f}%)\n"
+                                    f"   {row+1: 4}{occ_irrep}(B)<-{col+1+nocc[h_vir][0]: 4}{vir_irrep} (b)  {coef: 10.6f} ({perc: >6.3f}%)\n"
                                 )
     core.print_out("\n")
 

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -540,7 +540,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                 )
 
             nocc = wfn.epsilon_b_subset("SO", "OCC").shape
-            nvir = wfn.epsilon_b_subset("SO", "OCC").shape
+            nvir = wfn.epsilon_b_subset("SO", "VIR").shape
             # Convert to list of lists for C1 case
             if nirrep == 1:
                 nocc = (nocc, )

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -497,7 +497,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                     if abs(coef) > coeff_cutoff:
                         perc = 100 * coef**2
                         core.print_out(
-                            f"   {row+1: 4}{occ_irrep} (a) ->{col+1+nocc[h_vir][0]: 4}{vir_irrep} (a)  {coef: 10.6f} ({perc: >6.3f}%)\n"
+                            f"   {row+1: 4}{occ_irrep} {'' if restricted else '(a)'} ->{col+1+nocc[h_vir][0]: 4}{vir_irrep} {'' if restricted else '(a)'}  {coef: 10.6f} ({perc: >6.3f}%)\n"
                         )
         # De-excitations if not using TDA
         if not tda:
@@ -514,7 +514,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                         if abs(coef) > coeff_cutoff:
                             perc = 100 * coef**2
                             core.print_out(
-                                f"   {row+1: 4}{occ_irrep} (a) <-{col+1+nocc[h_vir][0]: 4}{vir_irrep} (a)  {coef: 10.6f} ({perc: >6.3f}%)\n"
+                                f"   {row+1: 4}{occ_irrep} {'' if restricted else '(a)'} <-{col+1+nocc[h_vir][0]: 4}{vir_irrep} {'' if restricted else '(a)'}  {coef: 10.6f} ({perc: >6.3f}%)\n"
                             )
         # Now treat beta orbitals if needed
         if not restricted:

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -559,7 +559,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                         if abs(coef) > coeff_cutoff:
                             perc = 100 * coef**2
                             core.print_out(
-                                f"   {row+1: 4}{occ_irrep}(B)->{col+1+nocc[h_vir][0]: 4}{vir_irrep} (b)  {coef: 10.6f} ({perc: >6.3f}%)\n"
+                                f"   {row+1: 4}{occ_irrep} (b) ->{col+1+nocc[h_vir][0]: 4}{vir_irrep} (b)  {coef: 10.6f} ({perc: >6.3f}%)\n"
                             )
                 # De-excitations if not using TDA (beta orbitals):
             if not tda:
@@ -576,7 +576,7 @@ def _analyze_tdscf_excitations(tdscf_results, wfn, tda, coeff_cutoff,
                             if abs(coef) > coeff_cutoff:
                                 perc = 100 * coef**2
                                 core.print_out(
-                                    f"   {row+1: 4}{occ_irrep}(B)<-{col+1+nocc[h_vir][0]: 4}{vir_irrep} (b)  {coef: 10.6f} ({perc: >6.3f}%)\n"
+                                    f"   {row+1: 4}{occ_irrep} (b) <-{col+1+nocc[h_vir][0]: 4}{vir_irrep} (b)  {coef: 10.6f} ({perc: >6.3f}%)\n"
                                 )
     core.print_out("\n")
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1708,7 +1708,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("TDSCF_MAXITER", 60);
         /*- Verbosity level in TDSCF -*/
         options.add_int("TDSCF_PRINT", 1);
-        /*- Cutoff for printing excitations and de-excitations icontributing to each excited state -*/
+        /*- Cutoff for printing excitations and de-excitations contributing to each excited state -*/
         options.add_double("TDSCF_COEFF_CUTOFF", 0.1);
         /*- Which transition dipole moments to print out:
             - E_TDM_LEN : electric transition dipole moments, length representation

--- a/tests/tdscf-1/output.ref
+++ b/tests/tdscf-1/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.7a1.dev7 
 
-                         Git: Rev {tdscf_var} c8200ee dirty
+                         Git: Rev {tdscf_excitations_symmetry} 7a26583 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 08 March 2022 09:38AM
+    Psi4 started on: Tuesday, 14 June 2022 07:41PM
 
-    Process ID: 4294
-    Host:       dhcp189-161.emerson.emory.edu
-    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Process ID: 2869
+    Host:       sat.lazhome.net
+    PSIDATADIR: /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -80,18 +80,16 @@ for n, ref in enumerate(UHF_RPA_cc_pvdz):
 
 Scratch directory: /tmp/
 
-Scratch directory: /tmp/
-
-*** tstart() called on dhcp189-161.emerson.emory.edu
-*** at Tue Mar  8 09:38:24 2022
+*** tstart() called on sat.lazhome.net
+*** at Tue Jun 14 19:41:55 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry C          line   138 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -196,24 +194,24 @@ Scratch directory: /tmp/
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter SAD:   -38.17324753824924   -3.81732e+01   0.00000e+00 
-   @UHF iter   1:   -38.90234371202389   -7.29096e-01   5.27401e-03 DIIS/ADIIS
-   @UHF iter   2:   -38.91513876275199   -1.27951e-02   1.70345e-03 DIIS/ADIIS
-   @UHF iter   3:   -38.91704423443393   -1.90547e-03   5.21791e-04 DIIS/ADIIS
-   @UHF iter   4:   -38.91728854267783   -2.44308e-04   2.55301e-04 DIIS/ADIIS
-   @UHF iter   5:   -38.91736728514920   -7.87425e-05   8.98095e-05 DIIS
-   @UHF iter   6:   -38.91737802885026   -1.07437e-05   2.28830e-05 DIIS
-   @UHF iter   7:   -38.91737868823718   -6.59387e-07   5.16256e-06 DIIS
-   @UHF iter   8:   -38.91737871259110   -2.43539e-08   9.97946e-07 DIIS
-   @UHF iter   9:   -38.91737871345227   -8.61164e-10   2.36834e-07 DIIS
-   @UHF iter  10:   -38.91737871350313   -5.08606e-11   3.58628e-08 DIIS
-   @UHF iter  11:   -38.91737871350434   -1.21503e-12   7.95207e-09 DIIS
+   @UHF iter SAD:   -38.17324753824930   -3.81732e+01   0.00000e+00 
+   @UHF iter   1:   -38.90234371202387   -7.29096e-01   5.27401e-03 ADIIS/DIIS
+   @UHF iter   2:   -38.91513876275199   -1.27951e-02   1.70345e-03 ADIIS/DIIS
+   @UHF iter   3:   -38.91704423443395   -1.90547e-03   5.21791e-04 ADIIS/DIIS
+   @UHF iter   4:   -38.91728818663926   -2.43952e-04   2.55762e-04 ADIIS/DIIS
+   @UHF iter   5:   -38.91736725680569   -7.90702e-05   8.98879e-05 DIIS
+   @UHF iter   6:   -38.91737802868979   -1.07719e-05   2.28855e-05 DIIS
+   @UHF iter   7:   -38.91737868822885   -6.59539e-07   5.16332e-06 DIIS
+   @UHF iter   8:   -38.91737871259078   -2.43619e-08   9.98120e-07 DIIS
+   @UHF iter   9:   -38.91737871345227   -8.61490e-10   2.36812e-07 DIIS
+   @UHF iter  10:   -38.91737871350315   -5.08891e-11   3.58512e-08 DIIS
+   @UHF iter  11:   -38.91737871350432   -1.16529e-12   7.94455e-09 DIIS
   Energy and wave function converged.
 
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   1.210199220E-02
+   @Spin Contamination Metric:   1.210199221E-02
    @S^2 Expected:                2.000000000E+00
    @S^2 Observed:                2.012101992E+00
    @S   Expected:                1.000000000E+00
@@ -256,14 +254,14 @@ Scratch directory: /tmp/
     DOCC [     3 ]
     SOCC [     2 ]
 
-  @UHF Final Energy:   -38.91737871350434
+  @UHF Final Energy:   -38.91737871350432
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              6.0682991182693025
-    One-Electron Energy =                 -63.7147379959311451
-    Two-Electron Energy =                  18.7290601641575023
-    Total Energy =                        -38.9173787135043412
+    One-Electron Energy =                 -63.7147379959333620
+    Two-Electron Energy =                  18.7290601641597405
+    Total Energy =                        -38.9173787135043199
 
   UHF NO Occupations:
   HONO-2 :    3  A 1.9967234
@@ -282,28 +280,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -1.0254
 
-  Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     0.7742
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:    -0.2512     Total:     0.2512
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:     0.0000      Y:    -0.0000      Z:    -0.6386     Total:     0.6386
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Z            :          0.7741865           -1.0254198           -0.2512332
+ Magnitude           :                                                    0.2512332
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:25 2022
+*** tstop() called on sat.lazhome.net at Tue Jun 14 19:41:59 2022
 Module time:
-	user time   =       0.51 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 Total time:
-	user time   =       0.51 seconds =       0.01 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -351,9 +351,9 @@ Total time:
   HamiltonianSolver iter   3:   8.57371e-04  1.16616e-02     72      
   HamiltonianSolver iter   4:   1.77790e-05  1.84521e-03     90      
   HamiltonianSolver iter   5:   1.80632e-07  1.62254e-04    108      
-  HamiltonianSolver iter   6:   1.44464e-09  1.70693e-05    118      
-  HamiltonianSolver iter   7:   2.00971e-11  1.69677e-06    124      
-  HamiltonianSolver iter   8:   1.72973e-13  4.27528e-07    128      Converged
+  HamiltonianSolver iter   6:   1.44465e-09  1.70693e-05    118      
+  HamiltonianSolver iter   7:   2.01164e-11  1.69677e-06    124      
+  HamiltonianSolver iter   8:   1.49214e-13  4.27528e-07    128      Converged
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -363,110 +363,110 @@ Total time:
                                     Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
-     1        A->A (1 A)       0.24455         6.65443        -38.67283        0.0007          0.0021         -0.0000         -0.0000        
+     1        A->A (1 A)       0.24455         6.65443        -38.67283        0.0007          0.0021         -0.0000          0.0000        
      2        A->A (1 A)       0.28784         7.83264        -38.62953        0.0000          0.0000         -0.0000         -0.0000        
-     3        A->A (1 A)       0.31787         8.64972        -38.59951        0.0181          0.0176         -0.0000         -0.0000        
-     4        A->A (1 A)       0.35472         9.65236        -38.56266        0.0000          0.0000          0.0000         -0.0000        
+     3        A->A (1 A)       0.31787         8.64973        -38.59951        0.0181          0.0176          0.0000          0.0000        
+     4        A->A (1 A)       0.35472         9.65236        -38.56266        0.0000          0.0000          0.0000          0.0000        
      5        A->A (1 A)       0.38788         10.55483       -38.52950        0.0235          0.0223         -0.0000         -0.0000        
-     6        A->A (1 A)       0.40378         10.98736       -38.51360        0.0059          0.0056         -0.0000         -0.0000        
-     7        A->A (1 A)       0.43527         11.84437       -38.48211        0.1141          0.1200          0.0000          0.0000        
+     6        A->A (1 A)       0.40378         10.98736       -38.51360        0.0059          0.0056          0.0000          0.0000        
+     7        A->A (1 A)       0.43527         11.84437       -38.48211        0.1141          0.1200         -0.0000         -0.0000        
      8        A->A (1 A)       0.45079         12.26650       -38.46659        0.1839          0.1864          0.0000          0.0000        
-     9        A->A (1 A)       0.48344         13.15512       -38.43394        0.3899          0.4128          0.0000          0.0000        
+     9        A->A (1 A)       0.48344         13.15512       -38.43394        0.3899          0.4128         -0.0000         -0.0000        
 
 
 
 Contributing excitations and de-excitations
-Only contributions with coefficients > 1.00e-01 will be printed:
+Only contributions with abs(coeff) > 1.00e-01 will be printed:
 
 Excited State    1 (1 A):   0.24455 au   186.32 nm f = 0.0007
 Alpha orbitals:
   Sums of squares: Xssq =  9.328429e-03; Yssq =  2.548749e-03; Xssq - Yssq =  6.779679e-03
 Beta orbitals:
   Sums of squares: Xssq =  9.947973e-01; Yssq =  1.577004e-03; Xssq - Yssq =  9.932203e-01
-     3B->  4B  -0.983428 (96.713%)
+      3a (b) ->   4a (b)   -0.983428 (96.713%)
 
 Excited State    2 (1 A):   0.28784 au   158.29 nm f = 0.0000
 Alpha orbitals:
   Sums of squares: Xssq =  2.283312e-02; Yssq =  8.597404e-04; Xssq - Yssq =  2.197338e-02
-     5 ->  7    0.141137 ( 1.992%)
+      5a (a) ->   7a (a)    0.141137 ( 1.992%)
 Beta orbitals:
   Sums of squares: Xssq =  9.784668e-01; Yssq =  4.401742e-04; Xssq - Yssq =  9.780266e-01
-     3B->  5B  -0.976655 (95.386%)
-     3B-> 10B  -0.148948 ( 2.219%)
+      3a (b) ->   5a (b)   -0.976655 (95.386%)
+      3a (b) ->  10a (b)   -0.148948 ( 2.219%)
 
 Excited State    3 (1 A):   0.31787 au   143.34 nm f = 0.0181
 Alpha orbitals:
   Sums of squares: Xssq =  9.890945e-01; Yssq =  1.206152e-03; Xssq - Yssq =  9.878883e-01
-     5 ->  6   -0.981007 (96.238%)
-     5 -> 11   -0.110087 ( 1.212%)
-     5 -> 13    0.113362 ( 1.285%)
+      5a (a) ->   6a (a)    0.981007 (96.238%)
+      5a (a) ->  11a (a)    0.110087 ( 1.212%)
+      5a (a) ->  13a (a)   -0.113362 ( 1.285%)
 Beta orbitals:
   Sums of squares: Xssq =  1.323955e-02; Yssq =  1.127871e-03; Xssq - Yssq =  1.211168e-02
-     2B->  5B   0.106199 ( 1.128%)
+      2a (b) ->   5a (b)   -0.106199 ( 1.128%)
 
 Excited State    4 (1 A):   0.35472 au   128.45 nm f = 0.0000
 Alpha orbitals:
   Sums of squares: Xssq =  9.804419e-01; Yssq =  1.914675e-03; Xssq - Yssq =  9.785272e-01
-     5 ->  7    0.966771 (93.465%)
-     5 -> 12    0.201884 ( 4.076%)
+      5a (a) ->   7a (a)    0.966771 (93.465%)
+      5a (a) ->  12a (a)    0.201884 ( 4.076%)
 Beta orbitals:
   Sums of squares: Xssq =  2.171951e-02; Yssq =  2.467586e-04; Xssq - Yssq =  2.147275e-02
-     3B->  5B   0.146877 ( 2.157%)
+      3a (b) ->   5a (b)    0.146877 ( 2.157%)
 
 Excited State    5 (1 A):   0.38788 au   117.47 nm f = 0.0235
 Alpha orbitals:
   Sums of squares: Xssq =  8.341528e-01; Yssq =  3.699185e-03; Xssq - Yssq =  8.304536e-01
-     3 ->  7   -0.292514 ( 8.556%)
-     4 ->  6   -0.841837 (70.869%)
-     4 -> 11   -0.108092 ( 1.168%)
+      3a (a) ->   7a (a)    0.292514 ( 8.556%)
+      4a (a) ->   6a (a)    0.841837 (70.869%)
+      4a (a) ->  11a (a)    0.108092 ( 1.168%)
 Beta orbitals:
   Sums of squares: Xssq =  1.741692e-01; Yssq =  4.622860e-03; Xssq - Yssq =  1.695464e-01
-     2B->  4B   0.189634 ( 3.596%)
-     2B->  6B   0.128143 ( 1.642%)
-     3B->  7B   0.323280 (10.451%)
-     3B-> 12B   0.106790 ( 1.140%)
+      2a (b) ->   4a (b)   -0.189634 ( 3.596%)
+      2a (b) ->   6a (b)   -0.128143 ( 1.642%)
+      3a (b) ->   7a (b)   -0.323280 (10.451%)
+      3a (b) ->  12a (b)   -0.106790 ( 1.140%)
 
 Excited State    6 (1 A):   0.40378 au   112.84 nm f = 0.0059
 Alpha orbitals:
   Sums of squares: Xssq =  5.332611e-01; Yssq =  3.945240e-03; Xssq - Yssq =  5.293158e-01
-     3 ->  6   -0.513920 (26.411%)
-     4 ->  7   -0.483284 (23.356%)
-     4 -> 12   -0.101206 ( 1.024%)
+      3a (a) ->   6a (a)    0.513920 (26.411%)
+      4a (a) ->   7a (a)    0.483284 (23.356%)
+      4a (a) ->  12a (a)    0.101206 ( 1.024%)
 Beta orbitals:
   Sums of squares: Xssq =  4.742126e-01; Yssq =  3.528427e-03; Xssq - Yssq =  4.706842e-01
-     2B->  7B   0.124901 ( 1.560%)
-     3B->  6B   0.656205 (43.060%)
-     3B-> 11B   0.123273 ( 1.520%)
+      2a (b) ->   7a (b)   -0.124901 ( 1.560%)
+      3a (b) ->   6a (b)   -0.656205 (43.060%)
+      3a (b) ->  11a (b)   -0.123273 ( 1.520%)
 
 Excited State    7 (1 A):   0.43527 au   104.68 nm f = 0.1141
 Alpha orbitals:
   Sums of squares: Xssq =  4.885897e-01; Yssq =  5.698129e-03; Xssq - Yssq =  4.828916e-01
-     3 ->  7   -0.444051 (19.718%)
-     3 -> 12   -0.142765 ( 2.038%)
-     4 ->  6    0.492742 (24.279%)
+      3a (a) ->   7a (a)    0.444051 (19.718%)
+      3a (a) ->  12a (a)    0.142765 ( 2.038%)
+      4a (a) ->   6a (a)   -0.492742 (24.279%)
 Beta orbitals:
   Sums of squares: Xssq =  5.198062e-01; Yssq =  2.697795e-03; Xssq - Yssq =  5.171084e-01
-     2B->  4B   0.525870 (27.654%)
-     3B->  7B   0.456964 (20.882%)
-     3B-> 12B   0.134310 ( 1.804%)
+      2a (b) ->   4a (b)   -0.525870 (27.654%)
+      3a (b) ->   7a (b)   -0.456964 (20.882%)
+      3a (b) ->  12a (b)   -0.134310 ( 1.804%)
 
 Excited State    8 (1 A):   0.45079 au   101.08 nm f = 0.1839
 Alpha orbitals:
   Sums of squares: Xssq =  7.951684e-01; Yssq =  1.525832e-03; Xssq - Yssq =  7.936425e-01
-     3 ->  6   -0.214145 ( 4.586%)
-     4 ->  7    0.845574 (71.500%)
-     4 -> 12    0.161500 ( 2.608%)
+      3a (a) ->   6a (a)   -0.214145 ( 4.586%)
+      4a (a) ->   7a (a)    0.845574 (71.500%)
+      4a (a) ->  12a (a)    0.161500 ( 2.608%)
 Beta orbitals:
   Sums of squares: Xssq =  2.069012e-01; Yssq =  5.437353e-04; Xssq - Yssq =  2.063575e-01
-     3B->  6B   0.442574 (19.587%)
+      3a (b) ->   6a (b)    0.442574 (19.587%)
 
 Excited State    9 (1 A):   0.48344 au   94.25 nm f = 0.3899
 Alpha orbitals:
   Sums of squares: Xssq =  6.672618e-01; Yssq =  3.682473e-04; Xssq - Yssq =  6.668935e-01
-     3 ->  6   -0.801067 (64.171%)
+      3a (a) ->   6a (a)    0.801067 (64.171%)
 Beta orbitals:
   Sums of squares: Xssq =  3.337961e-01; Yssq =  6.896392e-04; Xssq - Yssq =  3.331065e-01
-     3B->  6B  -0.567551 (32.211%)
+      3a (b) ->   6a (b)    0.567551 (32.211%)
 
 
 ******************************************************************************************
@@ -487,7 +487,7 @@ Beta orbitals:
     TD-UHF/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A TRANSITION......................PASSED
     TD-UHF/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION......................PASSED
 
-    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
-    Psi4 wall time for execution: 0:00:01.94
+    Psi4 stopped on: Tuesday, 14 June 2022 07:42PM
+    Psi4 wall time for execution: 0:00:11.16
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-2/output.ref
+++ b/tests/tdscf-2/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.7a1.dev7 
 
-                         Git: Rev {tdscf_var} c8200ee dirty
+                         Git: Rev {tdscf_excitations_symmetry} 7a26583 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 08 March 2022 09:38AM
+    Psi4 started on: Tuesday, 14 June 2022 07:42PM
 
-    Process ID: 4296
-    Host:       dhcp189-161.emerson.emory.edu
-    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Process ID: 2899
+    Host:       sat.lazhome.net
+    PSIDATADIR: /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -81,18 +81,16 @@ for n, ref in enumerate(UHF_TDA_cc_pvdz):
 
 Scratch directory: /tmp/
 
-Scratch directory: /tmp/
-
-*** tstart() called on dhcp189-161.emerson.emory.edu
-*** at Tue Mar  8 09:38:27 2022
+*** tstart() called on sat.lazhome.net
+*** at Tue Jun 14 19:42:08 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry C          line   138 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -197,24 +195,24 @@ Scratch directory: /tmp/
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter SAD:   -38.17324753824924   -3.81732e+01   0.00000e+00 
-   @UHF iter   1:   -38.90234371202389   -7.29096e-01   5.27401e-03 ADIIS/DIIS
-   @UHF iter   2:   -38.91513876275199   -1.27951e-02   1.70345e-03 ADIIS/DIIS
-   @UHF iter   3:   -38.91704423443393   -1.90547e-03   5.21791e-04 ADIIS/DIIS
-   @UHF iter   4:   -38.91728854267783   -2.44308e-04   2.55301e-04 ADIIS/DIIS
-   @UHF iter   5:   -38.91736728514920   -7.87425e-05   8.98095e-05 DIIS
-   @UHF iter   6:   -38.91737802885026   -1.07437e-05   2.28830e-05 DIIS
-   @UHF iter   7:   -38.91737868823718   -6.59387e-07   5.16256e-06 DIIS
-   @UHF iter   8:   -38.91737871259110   -2.43539e-08   9.97946e-07 DIIS
-   @UHF iter   9:   -38.91737871345227   -8.61164e-10   2.36834e-07 DIIS
-   @UHF iter  10:   -38.91737871350313   -5.08606e-11   3.58628e-08 DIIS
-   @UHF iter  11:   -38.91737871350434   -1.21503e-12   7.95207e-09 DIIS
+   @UHF iter SAD:   -38.17324753824930   -3.81732e+01   0.00000e+00 
+   @UHF iter   1:   -38.90234371202387   -7.29096e-01   5.27401e-03 DIIS/ADIIS
+   @UHF iter   2:   -38.91513876275199   -1.27951e-02   1.70345e-03 DIIS/ADIIS
+   @UHF iter   3:   -38.91704423443395   -1.90547e-03   5.21791e-04 DIIS/ADIIS
+   @UHF iter   4:   -38.91728818663926   -2.43952e-04   2.55762e-04 DIIS/ADIIS
+   @UHF iter   5:   -38.91736725680569   -7.90702e-05   8.98879e-05 DIIS
+   @UHF iter   6:   -38.91737802868979   -1.07719e-05   2.28855e-05 DIIS
+   @UHF iter   7:   -38.91737868822885   -6.59539e-07   5.16332e-06 DIIS
+   @UHF iter   8:   -38.91737871259078   -2.43619e-08   9.98120e-07 DIIS
+   @UHF iter   9:   -38.91737871345227   -8.61490e-10   2.36812e-07 DIIS
+   @UHF iter  10:   -38.91737871350315   -5.08891e-11   3.58512e-08 DIIS
+   @UHF iter  11:   -38.91737871350432   -1.16529e-12   7.94455e-09 DIIS
   Energy and wave function converged.
 
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   1.210199220E-02
+   @Spin Contamination Metric:   1.210199221E-02
    @S^2 Expected:                2.000000000E+00
    @S^2 Observed:                2.012101992E+00
    @S   Expected:                1.000000000E+00
@@ -257,14 +255,14 @@ Scratch directory: /tmp/
     DOCC [     3 ]
     SOCC [     2 ]
 
-  @UHF Final Energy:   -38.91737871350434
+  @UHF Final Energy:   -38.91737871350432
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              6.0682991182693025
-    One-Electron Energy =                 -63.7147379959311451
-    Two-Electron Energy =                  18.7290601641575023
-    Total Energy =                        -38.9173787135043412
+    One-Electron Energy =                 -63.7147379959333620
+    Two-Electron Energy =                  18.7290601641597405
+    Total Energy =                        -38.9173787135043199
 
   UHF NO Occupations:
   HONO-2 :    3  A 1.9967234
@@ -283,28 +281,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -1.0254
 
-  Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:     0.7742
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:     0.0000      Y:    -0.0000      Z:    -0.2512     Total:     0.2512
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:     0.0000      Y:    -0.0000      Z:    -0.6386     Total:     0.6386
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Z            :          0.7741865           -1.0254198           -0.2512332
+ Magnitude           :                                                    0.2512332
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:28 2022
+*** tstop() called on sat.lazhome.net at Tue Jun 14 19:42:08 2022
 Module time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -353,8 +353,8 @@ Total time:
   DavidsonSolver iter   4:   1.46308e-05  9.09692e-04     63      
   DavidsonSolver iter   5:   1.74360e-07  9.62295e-05     72      
   DavidsonSolver iter   6:   2.12837e-09  9.99771e-06     81      
-  DavidsonSolver iter   7:   2.74178e-11  1.31154e-06     84      
-  DavidsonSolver iter   8:   3.79086e-13  7.60128e-07     86      Converged
+  DavidsonSolver iter   7:   2.74174e-11  1.31154e-06     84      
+  DavidsonSolver iter   8:   3.78142e-13  7.60128e-07     86      Converged
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -364,108 +364,108 @@ Total time:
                                     Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
-     1        A->A (1 A)       0.24879         6.76994        -38.66859        0.0006          0.0040         -0.0000         -0.0000        
+     1        A->A (1 A)       0.24879         6.76994        -38.66859        0.0006          0.0040          0.0000          0.0000        
      2        A->A (1 A)       0.28968         7.88267        -38.62770        0.0000          0.0000         -0.0000         -0.0000        
      3        A->A (1 A)       0.32054         8.72234        -38.59684        0.0150          0.0291          0.0000          0.0000        
      4        A->A (1 A)       0.35741         9.72562        -38.55997        0.0000          0.0000          0.0000          0.0000        
-     5        A->A (1 A)       0.39501         10.74870       -38.52237        0.0356          0.0332          0.0000          0.0000        
-     6        A->A (1 A)       0.41142         11.19542       -38.50595        0.0061          0.0021          0.0000          0.0000        
+     5        A->A (1 A)       0.39501         10.74870       -38.52237        0.0356          0.0332         -0.0000         -0.0000        
+     6        A->A (1 A)       0.41142         11.19542       -38.50595        0.0061          0.0021         -0.0000         -0.0000        
      7        A->A (1 A)       0.44454         12.09643       -38.47284        0.1042          0.0870          0.0000          0.0000        
-     8        A->A (1 A)       0.45358         12.34258       -38.46380        0.1997          0.1607         -0.0000         -0.0000        
-     9        A->A (1 A)       0.48481         13.19234       -38.43257        0.4129          0.3788          0.0000          0.0000        
+     8        A->A (1 A)       0.45358         12.34258       -38.46380        0.1997          0.1607          0.0000          0.0000        
+     9        A->A (1 A)       0.48481         13.19234       -38.43257        0.4129          0.3788         -0.0000         -0.0000        
 
 
 
 Contributing excitations
-Only contributions with coefficients > 1.00e-01 will be printed:
+Only contributions with abs(coeff) > 1.00e-01 will be printed:
 
 Excited State    1 (1 A):   0.24879 au   183.14 nm f = 0.0006
 Alpha orbitals:
   Sums of squares: Xssq =  7.426208e-03
 Beta orbitals:
   Sums of squares: Xssq =  9.925738e-01
-     3B->  4B  -0.982608 (96.552%)
+      3a (b) ->   4a (b)   -0.982608 (96.552%)
 
 Excited State    2 (1 A):   0.28968 au   157.29 nm f = 0.0000
 Alpha orbitals:
   Sums of squares: Xssq =  2.026403e-02
-     5 ->  7   -0.132771 ( 1.763%)
+      5a (a) ->   7a (a)    0.132771 ( 1.763%)
 Beta orbitals:
   Sums of squares: Xssq =  9.797360e-01
-     3B->  5B   0.977538 (95.558%)
-     3B-> 10B   0.147970 ( 2.190%)
+      3a (b) ->   5a (b)   -0.977538 (95.558%)
+      3a (b) ->  10a (b)   -0.147970 ( 2.190%)
 
 Excited State    3 (1 A):   0.32054 au   142.15 nm f = 0.0150
 Alpha orbitals:
   Sums of squares: Xssq =  9.877030e-01
-     5 ->  6    0.981275 (96.290%)
-     5 -> 11    0.103828 ( 1.078%)
-     5 -> 13   -0.111456 ( 1.242%)
+      5a (a) ->   6a (a)   -0.981275 (96.290%)
+      5a (a) ->  11a (a)   -0.103828 ( 1.078%)
+      5a (a) ->  13a (a)    0.111456 ( 1.242%)
 Beta orbitals:
   Sums of squares: Xssq =  1.229700e-02
-     2B->  5B  -0.102339 ( 1.047%)
+      2a (b) ->   5a (b)    0.102339 ( 1.047%)
 
 Excited State    4 (1 A):   0.35741 au   127.48 nm f = 0.0000
 Alpha orbitals:
   Sums of squares: Xssq =  9.806620e-01
-     5 ->  7   -0.967800 (93.664%)
-     5 -> 12   -0.197509 ( 3.901%)
+      5a (a) ->   7a (a)    0.967800 (93.664%)
+      5a (a) ->  12a (a)    0.197509 ( 3.901%)
 Beta orbitals:
   Sums of squares: Xssq =  1.933797e-02
-     3B->  5B  -0.138606 ( 1.921%)
+      3a (b) ->   5a (b)    0.138606 ( 1.921%)
 
 Excited State    5 (1 A):   0.39501 au   115.35 nm f = 0.0356
 Alpha orbitals:
   Sums of squares: Xssq =  8.852916e-01
-     3 ->  7   -0.229917 ( 5.286%)
-     4 ->  6   -0.895219 (80.142%)
-     4 -> 13    0.100344 ( 1.007%)
+      3a (a) ->   7a (a)   -0.229917 ( 5.286%)
+      4a (a) ->   6a (a)   -0.895219 (80.142%)
+      4a (a) ->  13a (a)    0.100344 ( 1.007%)
 Beta orbitals:
   Sums of squares: Xssq =  1.147084e-01
-     2B->  4B   0.142221 ( 2.023%)
-     2B->  6B   0.110517 ( 1.221%)
-     3B->  7B   0.268023 ( 7.184%)
+      2a (b) ->   4a (b)    0.142221 ( 2.023%)
+      2a (b) ->   6a (b)    0.110517 ( 1.221%)
+      3a (b) ->   7a (b)    0.268023 ( 7.184%)
 
 Excited State    6 (1 A):   0.41142 au   110.75 nm f = 0.0061
 Alpha orbitals:
   Sums of squares: Xssq =  5.242575e-01
-     3 ->  6   -0.501572 (25.157%)
-     4 ->  7   -0.491952 (24.202%)
+      3a (a) ->   6a (a)   -0.501572 (25.157%)
+      4a (a) ->   7a (a)   -0.491952 (24.202%)
 Beta orbitals:
   Sums of squares: Xssq =  4.757425e-01
-     2B->  7B   0.117682 ( 1.385%)
-     3B->  6B   0.660893 (43.678%)
-     3B-> 11B   0.116402 ( 1.355%)
+      2a (b) ->   7a (b)    0.117682 ( 1.385%)
+      3a (b) ->   6a (b)    0.660893 (43.678%)
+      3a (b) ->  11a (b)    0.116402 ( 1.355%)
 
 Excited State    7 (1 A):   0.44454 au   102.50 nm f = 0.1042
 Alpha orbitals:
   Sums of squares: Xssq =  4.323560e-01
-     3 ->  7    0.480286 (23.067%)
-     3 -> 12    0.143547 ( 2.061%)
-     4 ->  6   -0.391102 (15.296%)
+      3a (a) ->   7a (a)    0.480286 (23.067%)
+      3a (a) ->  12a (a)    0.143547 ( 2.061%)
+      4a (a) ->   6a (a)   -0.391102 (15.296%)
 Beta orbitals:
   Sums of squares: Xssq =  5.676440e-01
-     2B->  4B  -0.547450 (29.970%)
-     3B->  7B  -0.483990 (23.425%)
-     3B-> 12B  -0.130742 ( 1.709%)
+      2a (b) ->   4a (b)   -0.547450 (29.970%)
+      3a (b) ->   7a (b)   -0.483990 (23.425%)
+      3a (b) ->  12a (b)   -0.130742 ( 1.709%)
 
 Excited State    8 (1 A):   0.45358 au   100.45 nm f = 0.1997
 Alpha orbitals:
   Sums of squares: Xssq =  7.838693e-01
-     3 ->  6    0.212919 ( 4.533%)
-     4 ->  7   -0.840382 (70.624%)
-     4 -> 12   -0.156598 ( 2.452%)
+      3a (a) ->   6a (a)   -0.212919 ( 4.533%)
+      4a (a) ->   7a (a)    0.840382 (70.624%)
+      4a (a) ->  12a (a)    0.156598 ( 2.452%)
 Beta orbitals:
   Sums of squares: Xssq =  2.161307e-01
-     3B->  6B  -0.452833 (20.506%)
+      3a (b) ->   6a (b)    0.452833 (20.506%)
 
 Excited State    9 (1 A):   0.48481 au   93.98 nm f = 0.4129
 Alpha orbitals:
   Sums of squares: Xssq =  6.824258e-01
-     3 ->  6    0.810667 (65.718%)
+      3a (a) ->   6a (a)   -0.810667 (65.718%)
 Beta orbitals:
   Sums of squares: Xssq =  3.175742e-01
-     3B->  6B   0.553505 (30.637%)
+      3a (b) ->   6a (b)   -0.553505 (30.637%)
 
 
 ******************************************************************************************
@@ -486,7 +486,7 @@ Beta orbitals:
     TD-UHF/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A TRANSITION......................PASSED
     TD-UHF/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION......................PASSED
 
-    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
-    Psi4 wall time for execution: 0:00:01.51
+    Psi4 stopped on: Tuesday, 14 June 2022 07:42PM
+    Psi4 wall time for execution: 0:00:01.80
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-3/output.ref
+++ b/tests/tdscf-3/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.7a1.dev7 
 
-                         Git: Rev {tdscf_var} c8200ee dirty
+                         Git: Rev {tdscf_excitations_symmetry} 7a26583 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 08 March 2022 09:38AM
+    Psi4 started on: Tuesday, 14 June 2022 07:42PM
 
-    Process ID: 4299
-    Host:       dhcp189-161.emerson.emory.edu
-    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Process ID: 2926
+    Host:       sat.lazhome.net
+    PSIDATADIR: /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -81,22 +81,23 @@ tdscf(wfn)
 for n, ref in enumerate(rhf_wB97X_RPA_cc_pvdz):
     ex_en = wfn.variable(f"TD-wB97X ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
     compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    ex_en = wfn.variable(f"TD-DFT ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+    compare_values(ref,ex_en, 4, f"TD-wB97X/cc-pvdz ROOT 0 -> ROOT {n+1} EXCITATION ENERGY - A TRANSITION")
+
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
 
-Scratch directory: /tmp/
-
-*** tstart() called on dhcp189-161.emerson.emory.edu
-*** at Tue Mar  8 09:38:31 2022
+*** tstart() called on sat.lazhome.net
+*** at Tue Jun 14 19:42:11 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -258,17 +259,17 @@ Scratch directory: /tmp/
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RKS iter SAD:   -75.82538727182798   -7.58254e+01   0.00000e+00 
-   @RKS iter   1:   -76.24870831810148   -4.23321e-01   2.28250e-02 ADIIS/DIIS
-   @RKS iter   2:   -76.24436550816516    4.34281e-03   2.48492e-02 ADIIS/DIIS
-   @RKS iter   3:   -76.37349855046513   -1.29133e-01   7.45202e-04 ADIIS/DIIS
-   @RKS iter   4:   -76.37369202322047   -1.93473e-04   2.73557e-04 ADIIS/DIIS
-   @RKS iter   5:   -76.37371552037376   -2.34972e-05   3.96467e-05 DIIS
-   @RKS iter   6:   -76.37371627547660   -7.55103e-07   6.37382e-06 DIIS
-   @RKS iter   7:   -76.37371632343006   -4.79535e-08   1.42622e-06 DIIS
-   @RKS iter   8:   -76.37371632570053   -2.27047e-09   1.37058e-07 DIIS
-   @RKS iter   9:   -76.37371632571876   -1.82325e-11   1.76597e-08 DIIS
-   @RKS iter  10:   -76.37371632571880   -4.26326e-14   1.27570e-09 DIIS
+   @RKS iter SAD:   -75.82538727182806   -7.58254e+01   0.00000e+00 
+   @RKS iter   1:   -76.24870831810129   -4.23321e-01   2.28250e-02 ADIIS/DIIS
+   @RKS iter   2:   -76.24436550816512    4.34281e-03   2.48492e-02 ADIIS/DIIS
+   @RKS iter   3:   -76.37349855046509   -1.29133e-01   7.45202e-04 ADIIS/DIIS
+   @RKS iter   4:   -76.37369202322043   -1.93473e-04   2.73557e-04 ADIIS/DIIS
+   @RKS iter   5:   -76.37371552037372   -2.34972e-05   3.96467e-05 DIIS
+   @RKS iter   6:   -76.37371627547654   -7.55103e-07   6.37382e-06 DIIS
+   @RKS iter   7:   -76.37371632342999   -4.79534e-08   1.42622e-06 DIIS
+   @RKS iter   8:   -76.37371632570049   -2.27050e-09   1.37058e-07 DIIS
+   @RKS iter   9:   -76.37371632571872   -1.82325e-11   1.76597e-08 DIIS
+   @RKS iter  10:   -76.37371632571882   -9.94760e-14   1.27570e-09 DIIS
   Energy and wave function converged.
 
 
@@ -299,17 +300,17 @@ Scratch directory: /tmp/
               A 
     DOCC [     5 ]
 
-  @RKS Final Energy:   -76.37371632571880
+  @RKS Final Energy:   -76.37371632571882
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.0023638541353055
-    One-Electron Energy =                -121.0198712309101268
-    Two-Electron Energy =                  43.1406036044107140
-    DFT Exchange-Correlation Energy =      -6.4968125533546965
+    One-Electron Energy =                -121.0198712309100983
+    Two-Electron Energy =                  43.1406036044106571
+    DFT Exchange-Correlation Energy =      -6.4968125533546939
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
-    Total Energy =                        -76.3737163257188030
+    Total Energy =                        -76.3737163257188172
 
 Computation Completed
 
@@ -318,28 +319,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -1.1273
 
-  Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:     0.3322
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:    -0.7951     Total:     0.7951
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:    -0.0000      Y:    -0.0000      Z:    -2.0208     Total:     2.0208
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.3322323           -1.1272918           -0.7950595
+ Magnitude           :                                                    0.7950595
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:33 2022
+*** tstop() called on sat.lazhome.net at Tue Jun 14 19:42:14 2022
 Module time:
-	user time   =       2.25 seconds =       0.04 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.42 seconds =       0.04 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       2.25 seconds =       0.04 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.42 seconds =       0.04 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -386,7 +389,7 @@ Total time:
   HamiltonianSolver iter   2:   2.65603e-03  7.34528e-03     60      
   HamiltonianSolver iter   3:   3.75488e-06  8.07100e-04     80      
   HamiltonianSolver iter   4:   1.26255e-08  5.90177e-05     92      
-  HamiltonianSolver iter   5:   4.91595e-11  2.27018e-12     95      Converged
+  HamiltonianSolver iter   5:   4.91747e-11  3.44191e-12     95      Converged
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -396,70 +399,70 @@ Total time:
                                     Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
-     1        A->A (1 A)       0.24719         6.72642        -76.12652        0.0121          0.0794          0.0000          0.0000        
-     2        A->A (1 A)       0.31320         8.52260        -76.06052        0.0000          0.0000          0.0000          0.0000        
-     3        A->A (1 A)       0.34444         9.37279        -76.02927        0.0884          0.1765         -0.0000         -0.0000        
+     1        A->A (1 A)       0.24719         6.72642        -76.12652        0.0121          0.0794         -0.0000         -0.0000        
+     2        A->A (1 A)       0.31320         8.52260        -76.06052        0.0000          0.0000         -0.0000         -0.0000        
+     3        A->A (1 A)       0.34444         9.37279        -76.02927        0.0884          0.1765          0.0000          0.0000        
      4        A->A (1 A)       0.41036         11.16660       -75.96335        0.0477          0.0536          0.0000          0.0000        
-     5        A->A (1 A)       0.45277         12.32056       -75.92094        0.4396          0.4587          0.0000          0.0000        
+     5        A->A (1 A)       0.45277         12.32056       -75.92094        0.4396          0.4587         -0.0000         -0.0000        
      6        A->A (1 A)       0.56744         15.44078       -75.80628        0.2021          0.2217         -0.0000         -0.0000        
-     7        A->A (1 A)       0.71910         19.56767       -75.65462        0.0000          0.0000          0.0000          0.0000        
-     8        A->A (1 A)       0.75183         20.45836       -75.62189        0.0688          0.0749         -0.0000         -0.0000        
-     9        A->A (1 A)       0.82955         22.57317       -75.54417        0.0685          0.0645          0.0000         -0.0000        
+     7        A->A (1 A)       0.71910         19.56767       -75.65462        0.0000          0.0000          0.0000         -0.0000        
+     8        A->A (1 A)       0.75183         20.45836       -75.62189        0.0688          0.0749          0.0000          0.0000        
+     9        A->A (1 A)       0.82955         22.57317       -75.54417        0.0685          0.0645          0.0000          0.0000        
      10       A->A (1 A)       0.84004         22.85867       -75.53368        0.0014          0.0062         -0.0000         -0.0000        
 
 
 
 Contributing excitations and de-excitations
-Only contributions with coefficients > 1.00e-01 will be printed:
+Only contributions with abs(coeff) > 1.00e-01 will be printed:
 
 Excited State    1 (1 A):   0.24719 au   184.32 nm f = 0.0121
   Sums of squares: Xssq =  1.001414e+00; Yssq =  1.414379e-03; Xssq - Yssq =  1.000000e+00
-     5 ->  6   -0.999040 (99.808%)
+      5a  ->   6a     0.999040 (99.808%)
 
 Excited State    2 (1 A):   0.31320 au   145.48 nm f = 0.0000
   Sums of squares: Xssq =  1.000365e+00; Yssq =  3.646789e-04; Xssq - Yssq =  1.000000e+00
-     5 ->  7    0.995324 (99.067%)
+      5a  ->   7a     0.995324 (99.067%)
 
 Excited State    3 (1 A):   0.34444 au   132.28 nm f = 0.0884
   Sums of squares: Xssq =  1.003331e+00; Yssq =  3.330699e-03; Xssq - Yssq =  1.000000e+00
-     3 ->  7    0.152682 ( 2.331%)
-     4 ->  6    0.986843 (97.386%)
+      3a  ->   7a     0.152682 ( 2.331%)
+      4a  ->   6a     0.986843 (97.386%)
 
 Excited State    4 (1 A):   0.41036 au   111.03 nm f = 0.0477
   Sums of squares: Xssq =  1.001633e+00; Yssq =  1.632695e-03; Xssq - Yssq =  1.000000e+00
-     3 ->  6   -0.297362 ( 8.842%)
-     4 ->  7   -0.951947 (90.620%)
+      3a  ->   6a    -0.297362 ( 8.842%)
+      4a  ->   7a    -0.951947 (90.620%)
 
 Excited State    5 (1 A):   0.45277 au   100.63 nm f = 0.4396
   Sums of squares: Xssq =  1.002596e+00; Yssq =  2.595737e-03; Xssq - Yssq =  1.000000e+00
-     3 ->  6   -0.952405 (90.708%)
-     4 ->  7    0.298174 ( 8.891%)
+      3a  ->   6a    -0.952405 (90.708%)
+      4a  ->   7a     0.298174 ( 8.891%)
 
 Excited State    6 (1 A):   0.56744 au   80.30 nm f = 0.2021
   Sums of squares: Xssq =  1.009159e+00; Yssq =  9.158933e-03; Xssq - Yssq =  1.000000e+00
-     3 ->  7   -0.974139 (94.895%)
-     4 ->  6    0.148797 ( 2.214%)
-     4 ->  9    0.110131 ( 1.213%)
-     5 -> 11    0.112746 ( 1.271%)
+      3a  ->   7a    -0.974139 (94.895%)
+      4a  ->   6a     0.148797 ( 2.214%)
+      4a  ->   9a     0.110131 ( 1.213%)
+      5a  ->  11a     0.112746 ( 1.271%)
 
 Excited State    7 (1 A):   0.71910 au   63.36 nm f = 0.0000
   Sums of squares: Xssq =  1.000076e+00; Yssq =  7.630217e-05; Xssq - Yssq =  1.000000e+00
-     5 ->  8    0.995433 (99.089%)
+      5a  ->   8a     0.995433 (99.089%)
 
 Excited State    8 (1 A):   0.75183 au   60.60 nm f = 0.0688
   Sums of squares: Xssq =  1.000582e+00; Yssq =  5.822575e-04; Xssq - Yssq =  1.000000e+00
-     5 ->  9    0.997371 (99.475%)
+      5a  ->   9a    -0.997371 (99.475%)
 
 Excited State    9 (1 A):   0.82955 au   54.93 nm f = 0.0685
   Sums of squares: Xssq =  1.001533e+00; Yssq =  1.533186e-03; Xssq - Yssq =  1.000000e+00
-     3 ->  9    0.238210 ( 5.674%)
-     4 ->  8   -0.965791 (93.275%)
+      3a  ->   9a     0.238210 ( 5.674%)
+      4a  ->   8a    -0.965791 (93.275%)
 
 Excited State   10 (1 A):   0.84004 au   54.24 nm f = 0.0014
   Sums of squares: Xssq =  1.000950e+00; Yssq =  9.497346e-04; Xssq - Yssq =  1.000000e+00
-     2 ->  6    0.166260 ( 2.764%)
-     3 ->  8    0.159010 ( 2.528%)
-     4 ->  9   -0.965396 (93.199%)
+      2a  ->   6a     0.166260 ( 2.764%)
+      3a  ->   8a     0.159010 ( 2.528%)
+      4a  ->   9a    -0.965396 (93.199%)
 
 
 ******************************************************************************************
@@ -471,17 +474,27 @@ Excited State   10 (1 A):   0.84004 au   54.24 nm f = 0.0014
 ******************************************************************************************
 
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 2 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 3 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 4 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 5 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 6 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 7 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 8 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION....................PASSED
+    TD-wB97X/cc-pvdz ROOT 0 -> ROOT 10 EXCITATION ENERGY - A TRANSITION...................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 10 EXCITATION ENERGY - A TRANSITION...................PASSED
 
-    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
-    Psi4 wall time for execution: 0:00:07.13
+    Psi4 stopped on: Tuesday, 14 June 2022 07:42PM
+    Psi4 wall time for execution: 0:00:10.94
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-4/output.ref
+++ b/tests/tdscf-4/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.7a1.dev7 
 
-                         Git: Rev {tdscf_var} c8200ee dirty
+                         Git: Rev {tdscf_excitations_symmetry} 7a26583 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 08 March 2022 09:38AM
+    Psi4 started on: Tuesday, 14 June 2022 07:42PM
 
-    Process ID: 4305
-    Host:       dhcp189-161.emerson.emory.edu
-    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Process ID: 2953
+    Host:       sat.lazhome.net
+    PSIDATADIR: /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -83,18 +83,16 @@ for n, ref in enumerate(rhf_wB97X_TDA_cc_pvdz):
 
 Scratch directory: /tmp/
 
-Scratch directory: /tmp/
-
-*** tstart() called on dhcp189-161.emerson.emory.edu
-*** at Tue Mar  8 09:38:39 2022
+*** tstart() called on sat.lazhome.net
+*** at Tue Jun 14 19:42:24 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -256,17 +254,17 @@ Scratch directory: /tmp/
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RKS iter SAD:   -75.82538727182798   -7.58254e+01   0.00000e+00 
-   @RKS iter   1:   -76.24870831810148   -4.23321e-01   2.28250e-02 ADIIS/DIIS
-   @RKS iter   2:   -76.24436550816516    4.34281e-03   2.48492e-02 ADIIS/DIIS
-   @RKS iter   3:   -76.37349855046513   -1.29133e-01   7.45202e-04 ADIIS/DIIS
-   @RKS iter   4:   -76.37369202322047   -1.93473e-04   2.73557e-04 ADIIS/DIIS
-   @RKS iter   5:   -76.37371552037376   -2.34972e-05   3.96467e-05 DIIS
-   @RKS iter   6:   -76.37371627547660   -7.55103e-07   6.37382e-06 DIIS
-   @RKS iter   7:   -76.37371632343006   -4.79535e-08   1.42622e-06 DIIS
-   @RKS iter   8:   -76.37371632570053   -2.27047e-09   1.37058e-07 DIIS
-   @RKS iter   9:   -76.37371632571876   -1.82325e-11   1.76597e-08 DIIS
-   @RKS iter  10:   -76.37371632571880   -4.26326e-14   1.27570e-09 DIIS
+   @RKS iter SAD:   -75.82538727182806   -7.58254e+01   0.00000e+00 
+   @RKS iter   1:   -76.24870831810129   -4.23321e-01   2.28250e-02 DIIS/ADIIS
+   @RKS iter   2:   -76.24436550816512    4.34281e-03   2.48492e-02 DIIS/ADIIS
+   @RKS iter   3:   -76.37349855046509   -1.29133e-01   7.45202e-04 DIIS/ADIIS
+   @RKS iter   4:   -76.37369202322043   -1.93473e-04   2.73557e-04 DIIS/ADIIS
+   @RKS iter   5:   -76.37371552037372   -2.34972e-05   3.96467e-05 DIIS
+   @RKS iter   6:   -76.37371627547654   -7.55103e-07   6.37382e-06 DIIS
+   @RKS iter   7:   -76.37371632342999   -4.79534e-08   1.42622e-06 DIIS
+   @RKS iter   8:   -76.37371632570049   -2.27050e-09   1.37058e-07 DIIS
+   @RKS iter   9:   -76.37371632571872   -1.82325e-11   1.76597e-08 DIIS
+   @RKS iter  10:   -76.37371632571882   -9.94760e-14   1.27570e-09 DIIS
   Energy and wave function converged.
 
 
@@ -297,17 +295,17 @@ Scratch directory: /tmp/
               A 
     DOCC [     5 ]
 
-  @RKS Final Energy:   -76.37371632571880
+  @RKS Final Energy:   -76.37371632571882
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.0023638541353055
-    One-Electron Energy =                -121.0198712309101268
-    Two-Electron Energy =                  43.1406036044107140
-    DFT Exchange-Correlation Energy =      -6.4968125533546965
+    One-Electron Energy =                -121.0198712309100983
+    Two-Electron Energy =                  43.1406036044106571
+    DFT Exchange-Correlation Energy =      -6.4968125533546939
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
-    Total Energy =                        -76.3737163257188030
+    Total Energy =                        -76.3737163257188172
 
 Computation Completed
 
@@ -316,27 +314,29 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -1.1273
 
-  Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:     0.3322
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:    -0.7951     Total:     0.7951
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:    -0.0000      Y:    -0.0000      Z:    -2.0208     Total:     2.0208
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.3322323           -1.1272918           -0.7950595
+ Magnitude           :                                                    0.7950595
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:41 2022
+*** tstop() called on sat.lazhome.net at Tue Jun 14 19:42:26 2022
 Module time:
-	user time   =       1.85 seconds =       0.03 minutes
-	system time =       0.12 seconds =       0.00 minutes
+	user time   =       2.38 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       1.85 seconds =       0.03 minutes
-	system time =       0.12 seconds =       0.00 minutes
+	user time   =       2.38 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
 ******************************************************************************************
@@ -384,7 +384,7 @@ Total time:
   DavidsonSolver iter   2:   2.70401e-03  2.42998e-03     50      
   DavidsonSolver iter   3:   1.71329e-06  1.97103e-04     60      
   DavidsonSolver iter   4:   2.99649e-09  1.04489e-05     70      
-  DavidsonSolver iter   5:   1.13888e-11  7.16840e-07     77      Converged
+  DavidsonSolver iter   5:   1.13891e-11  7.16840e-07     77      Converged
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -395,70 +395,70 @@ Total time:
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
      1        A->A (1 A)       0.24888         6.77226        -76.12484        0.0115          0.1095          0.0000          0.0000        
-     2        A->A (1 A)       0.31363         8.53423        -76.06009        0.0000          0.0000          0.0000          0.0000        
-     3        A->A (1 A)       0.34848         9.48266        -76.02524        0.0959          0.1190         -0.0000         -0.0000        
-     4        A->A (1 A)       0.41300         11.23824       -75.96072        0.0470          0.0137         -0.0000         -0.0000        
+     2        A->A (1 A)       0.31363         8.53423        -76.06009        0.0000          0.0000         -0.0000         -0.0000        
+     3        A->A (1 A)       0.34848         9.48266        -76.02524        0.0959          0.1190          0.0000          0.0000        
+     4        A->A (1 A)       0.41300         11.23824       -75.96072        0.0470          0.0137          0.0000         -0.0000        
      5        A->A (1 A)       0.45629         12.41639       -75.91742        0.5107          0.3505          0.0000          0.0000        
      6        A->A (1 A)       0.58222         15.84290       -75.79150        0.2592          0.1462          0.0000          0.0000        
      7        A->A (1 A)       0.71925         19.57181       -75.65447        0.0000          0.0000         -0.0000         -0.0000        
-     8        A->A (1 A)       0.75329         20.49815       -75.62042        0.0760          0.0527          0.0000          0.0000        
+     8        A->A (1 A)       0.75329         20.49815       -75.62042        0.0760          0.0527         -0.0000         -0.0000        
      9        A->A (1 A)       0.83260         22.65611       -75.54112        0.0890          0.0321         -0.0000         -0.0000        
-     10       A->A (1 A)       0.84182         22.90705       -75.53190        0.0004          0.0108         -0.0000         -0.0000        
+     10       A->A (1 A)       0.84182         22.90705       -75.53190        0.0004          0.0108          0.0000          0.0000        
 
 
 
 Contributing excitations
-Only contributions with coefficients > 1.00e-01 will be printed:
+Only contributions with abs(coeff) > 1.00e-01 will be printed:
 
 Excited State    1 (1 A):   0.24888 au   183.08 nm f = 0.0115
   Sums of squares: Xssq =  1.000000e+00
-     5 ->  6    0.998415 (99.683%)
+      5a  ->   6a     0.998415 (99.683%)
 
 Excited State    2 (1 A):   0.31363 au   145.28 nm f = 0.0000
   Sums of squares: Xssq =  1.000000e+00
-     5 ->  7   -0.995202 (99.043%)
+      5a  ->   7a     0.995202 (99.043%)
 
 Excited State    3 (1 A):   0.34848 au   130.75 nm f = 0.0959
   Sums of squares: Xssq =  1.000000e+00
-     3 ->  7    0.191057 ( 3.650%)
-     4 ->  6    0.977183 (95.489%)
+      3a  ->   7a    -0.191057 ( 3.650%)
+      4a  ->   6a    -0.977183 (95.489%)
 
 Excited State    4 (1 A):   0.41300 au   110.32 nm f = 0.0470
   Sums of squares: Xssq =  1.000000e+00
-     3 ->  6    0.334350 (11.179%)
-     4 ->  7    0.938417 (88.063%)
+      3a  ->   6a     0.334350 (11.179%)
+      4a  ->   7a     0.938417 (88.063%)
 
 Excited State    5 (1 A):   0.45629 au   99.86 nm f = 0.5107
   Sums of squares: Xssq =  1.000000e+00
-     3 ->  6   -0.938371 (88.054%)
-     4 ->  7    0.332320 (11.044%)
+      3a  ->   6a    -0.938371 (88.054%)
+      4a  ->   7a     0.332320 (11.044%)
 
 Excited State    6 (1 A):   0.58222 au   78.26 nm f = 0.2592
   Sums of squares: Xssq =  1.000000e+00
-     3 ->  7    0.951590 (90.552%)
-     4 ->  6   -0.170897 ( 2.921%)
-     4 ->  9   -0.139849 ( 1.956%)
-     4 -> 10    0.105797 ( 1.119%)
-     5 -> 11   -0.143840 ( 2.069%)
+      3a  ->   7a     0.951590 (90.552%)
+      4a  ->   6a    -0.170897 ( 2.921%)
+      4a  ->   9a    -0.139849 ( 1.956%)
+      4a  ->  10a     0.105797 ( 1.119%)
+      5a  ->  11a    -0.143840 ( 2.069%)
 
 Excited State    7 (1 A):   0.71925 au   63.35 nm f = 0.0000
   Sums of squares: Xssq =  1.000000e+00
-     5 ->  8   -0.995436 (99.089%)
+      5a  ->   8a    -0.995436 (99.089%)
 
 Excited State    8 (1 A):   0.75329 au   60.49 nm f = 0.0760
   Sums of squares: Xssq =  1.000000e+00
-     5 ->  9   -0.996902 (99.381%)
+      5a  ->   9a    -0.996902 (99.381%)
 
 Excited State    9 (1 A):   0.83260 au   54.72 nm f = 0.0890
   Sums of squares: Xssq =  1.000000e+00
-     3 ->  9    0.268963 ( 7.234%)
-     4 ->  8   -0.955637 (91.324%)
+      3a  ->   9a    -0.268963 ( 7.234%)
+      4a  ->   8a     0.955637 (91.324%)
 
 Excited State   10 (1 A):   0.84182 au   54.12 nm f = 0.0004
   Sums of squares: Xssq =  1.000000e+00
-     2 ->  6   -0.185480 ( 3.440%)
-     3 ->  8   -0.184067 ( 3.388%)
-     4 ->  9    0.954674 (91.140%)
+      2a  ->   6a     0.185480 ( 3.440%)
+      3a  ->   8a     0.184067 ( 3.388%)
+      4a  ->   9a    -0.954674 (91.140%)
 
 
 ******************************************************************************************
@@ -480,7 +480,7 @@ Excited State   10 (1 A):   0.84182 au   54.12 nm f = 0.0004
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 9 EXCITATION ENERGY - A TRANSITION....................PASSED
     TD-wB97X/cc-pvdz ROOT 0 -> ROOT 10 EXCITATION ENERGY - A TRANSITION...................PASSED
 
-    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
-    Psi4 wall time for execution: 0:00:05.55
+    Psi4 stopped on: Tuesday, 14 June 2022 07:42PM
+    Psi4 wall time for execution: 0:00:08.94
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-5/output.ref
+++ b/tests/tdscf-5/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.7a1.dev7 
 
-                         Git: Rev {tdscf_var} c8200ee dirty
+                         Git: Rev {tdscf_excitations_symmetry} 7a26583 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 08 March 2022 09:38AM
+    Psi4 started on: Tuesday, 14 June 2022 07:42PM
 
-    Process ID: 4307
-    Host:       dhcp189-161.emerson.emory.edu
-    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Process ID: 2986
+    Host:       sat.lazhome.net
+    PSIDATADIR: /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -72,18 +72,16 @@ res = tdscf_excitations(wfn, states=1, tda=True)
 
 Scratch directory: /tmp/
 
-Scratch directory: /tmp/
-
-*** tstart() called on dhcp189-161.emerson.emory.edu
-*** at Tue Mar  8 09:38:45 2022
+*** tstart() called on sat.lazhome.net
+*** at Tue Jun 14 19:42:34 2022
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   331 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
-    atoms 2-3 entry H          line    40 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 1   entry O          line   331 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
+    atoms 2-3 entry H          line    40 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -201,8 +199,8 @@ Scratch directory: /tmp/
     Name: (AUG-CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   286 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 1   entry O          line   286 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/aug-cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -252,16 +250,16 @@ Scratch directory: /tmp/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter SAD:   -75.99649856945162   -7.59965e+01   0.00000e+00 
-   @DF-RKS iter   1:   -76.27848037838424   -2.81982e-01   7.43710e-03 ADIIS/DIIS
-   @DF-RKS iter   2:   -76.13846395305951    1.40016e-01   1.00918e-02 ADIIS/DIIS
-   @DF-RKS iter   3:   -76.43792342004775   -2.99459e-01   1.44390e-04 ADIIS/DIIS
-   @DF-RKS iter   4:   -76.43802433927998   -1.00919e-04   5.53433e-05 DIIS
-   @DF-RKS iter   5:   -76.43803373954702   -9.40027e-06   7.62052e-06 DIIS
-   @DF-RKS iter   6:   -76.43803397919825   -2.39651e-07   1.01649e-06 DIIS
-   @DF-RKS iter   7:   -76.43803398667335   -7.47509e-09   1.11109e-07 DIIS
-   @DF-RKS iter   8:   -76.43803398687703   -2.03684e-10   1.90677e-08 DIIS
-   @DF-RKS iter   9:   -76.43803398688198   -4.94538e-12   1.72436e-09 DIIS
+   @DF-RKS iter SAD:   -75.99649856949712   -7.59965e+01   0.00000e+00 
+   @DF-RKS iter   1:   -76.27848037841602   -2.81982e-01   7.43710e-03 ADIIS/DIIS
+   @DF-RKS iter   2:   -76.13846395308045    1.40016e-01   1.00918e-02 ADIIS/DIIS
+   @DF-RKS iter   3:   -76.43792342007802   -2.99459e-01   1.44390e-04 ADIIS/DIIS
+   @DF-RKS iter   4:   -76.43802433931030   -1.00919e-04   5.53433e-05 DIIS
+   @DF-RKS iter   5:   -76.43803373957769   -9.40027e-06   7.62052e-06 DIIS
+   @DF-RKS iter   6:   -76.43803397922862   -2.39651e-07   1.01649e-06 DIIS
+   @DF-RKS iter   7:   -76.43803398670352   -7.47490e-09   1.11109e-07 DIIS
+   @DF-RKS iter   8:   -76.43803398690724   -2.03727e-10   1.90677e-08 DIIS
+   @DF-RKS iter   9:   -76.43803398691261   -5.37170e-12   1.72436e-09 DIIS
   Energy and wave function converged.
 
 
@@ -314,17 +312,17 @@ Scratch directory: /tmp/
               A 
     DOCC [     5 ]
 
-  @DF-RKS Final Energy:   -76.43803398688198
+  @DF-RKS Final Energy:   -76.43803398691261
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1873335747049811
-    One-Electron Energy =                -123.0232657260598614
-    Two-Electron Energy =                  44.2113887867615816
-    DFT Exchange-Correlation Energy =      -6.8134906222886888
+    One-Electron Energy =                -123.0232657260727507
+    Two-Electron Energy =                  44.2113887867510726
+    DFT Exchange-Correlation Energy =      -6.8134906222959195
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
-    Total Energy =                        -76.4380339868819902
+    Total Energy =                        -76.4380339869126146
 
 Computation Completed
 
@@ -333,28 +331,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9763
 
-  Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:    -0.2317
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.7446     Total:     0.7446
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     1.8926     Total:     1.8926
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Z            :         -0.2316643            0.9762758            0.7446116
+ Magnitude           :                                                    0.7446116
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:50 2022
+*** tstop() called on sat.lazhome.net at Tue Jun 14 19:42:41 2022
 Module time:
-	user time   =       4.10 seconds =       0.07 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       5.81 seconds =       0.10 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
 Total time:
-	user time   =       4.10 seconds =       0.07 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       5.81 seconds =       0.10 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -417,13 +417,13 @@ Total time:
 
 
 Contributing excitations
-Only contributions with coefficients > 1.00e-01 will be printed:
+Only contributions with abs(coeff) > 1.00e-01 will be printed:
 
 Excited State    1 (1 A):   0.26284 au   173.35 nm f = 0.0504
   Sums of squares: Xssq =  1.000000e+00
-     5 ->  6    0.950891 (90.419%)
-     5 ->  8    0.261758 ( 6.852%)
-     5 -> 10    0.151293 ( 2.289%)
+      5a  ->   6a     0.950891 (90.419%)
+      5a  ->   8a     0.261758 ( 6.852%)
+      5a  ->  10a     0.151293 ( 2.289%)
 
 
 ******************************************************************************************
@@ -435,7 +435,7 @@ Excited State    1 (1 A):   0.26284 au   173.35 nm f = 0.0504
 ******************************************************************************************
 
 
-    Psi4 stopped on: Tuesday, 08 March 2022 09:38AM
-    Psi4 wall time for execution: 0:00:08.85
+    Psi4 stopped on: Tuesday, 14 June 2022 07:42PM
+    Psi4 wall time for execution: 0:00:13.43
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-6/output.ref
+++ b/tests/tdscf-6/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.7a1.dev7 
 
-                         Git: Rev {tdscf_var} c8200ee dirty
+                         Git: Rev {tdscf_excitations_symmetry} 7a26583 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,11 +30,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 08 March 2022 09:38AM
+    Psi4 started on: Tuesday, 14 June 2022 07:42PM
 
-    Process ID: 4309
-    Host:       dhcp189-161.emerson.emory.edu
-    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Process ID: 3015
+    Host:       sat.lazhome.net
+    PSIDATADIR: /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -86,16 +86,16 @@ compare_values(ref, wfn.variable(string), 4, string)
 
 Scratch directory: /tmp/
 
-*** tstart() called on dhcp189-161.emerson.emory.edu
-*** at Tue Mar  8 09:38:55 2022
+*** tstart() called on sat.lazhome.net
+*** at Tue Jun 14 19:42:49 2022
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
 
 
          ---------------------------------------------------------
@@ -213,8 +213,8 @@ Scratch directory: /tmp/
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -264,16 +264,16 @@ Scratch directory: /tmp/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter SAD:   -75.96686470860365   -7.59669e+01   0.00000e+00 
-   @DF-RKS iter   1:   -76.20148342915417   -2.34619e-01   2.43937e-02 DIIS/ADIIS
-   @DF-RKS iter   2:   -76.17589780043996    2.55856e-02   2.74605e-02 DIIS/ADIIS
-   @DF-RKS iter   3:   -76.32970494934206   -1.53807e-01   5.70032e-04 DIIS/ADIIS
-   @DF-RKS iter   4:   -76.32977981408435   -7.48647e-05   1.42003e-04 DIIS/ADIIS
-   @DF-RKS iter   5:   -76.32978482197544   -5.00789e-06   2.20692e-05 DIIS
-   @DF-RKS iter   6:   -76.32978496157291   -1.39597e-07   1.50265e-06 DIIS
-   @DF-RKS iter   7:   -76.32978496392973   -2.35681e-09   2.80977e-07 DIIS
-   @DF-RKS iter   8:   -76.32978496400891   -7.91829e-11   2.39853e-08 DIIS
-   @DF-RKS iter   9:   -76.32978496400948   -5.68434e-13   1.68862e-09 DIIS
+   @DF-RKS iter SAD:   -75.96686470859512   -7.59669e+01   0.00000e+00 
+   @DF-RKS iter   1:   -76.20148342914328   -2.34619e-01   2.43937e-02 DIIS/ADIIS
+   @DF-RKS iter   2:   -76.17589780042755    2.55856e-02   2.74605e-02 DIIS/ADIIS
+   @DF-RKS iter   3:   -76.32970494933325   -1.53807e-01   5.70032e-04 DIIS/ADIIS
+   @DF-RKS iter   4:   -76.32977981407545   -7.48647e-05   1.42003e-04 DIIS/ADIIS
+   @DF-RKS iter   5:   -76.32978482196658   -5.00789e-06   2.20692e-05 DIIS
+   @DF-RKS iter   6:   -76.32978496156416   -1.39598e-07   1.50265e-06 DIIS
+   @DF-RKS iter   7:   -76.32978496392096   -2.35680e-09   2.80977e-07 DIIS
+   @DF-RKS iter   8:   -76.32978496400020   -7.92397e-11   2.39853e-08 DIIS
+   @DF-RKS iter   9:   -76.32978496400064   -4.40536e-13   1.68862e-09 DIIS
   Energy and wave function converged.
 
 
@@ -304,17 +304,17 @@ Scratch directory: /tmp/
               A 
     DOCC [     5 ]
 
-  @DF-RKS Final Energy:   -76.32978496400948
+  @DF-RKS Final Energy:   -76.32978496400064
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1873335747049811
-    One-Electron Energy =                -123.1023942495666432
-    Two-Electron Energy =                  44.4154516912874300
-    DFT Exchange-Correlation Energy =      -6.8301759804352375
+    One-Electron Energy =                -123.1023942496045436
+    Two-Electron Energy =                  44.4154516913365782
+    DFT Exchange-Correlation Energy =      -6.8301759804376605
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
-    Total Energy =                        -76.3297849640094768
+    Total Energy =                        -76.3297849640006376
 
 Computation Completed
 
@@ -323,28 +323,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9763
 
-  Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:     0.0000      Z:    -0.1835
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:    -0.0000      Y:     0.0000      Z:     0.7928     Total:     0.7928
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:    -0.0000      Y:     0.0000      Z:     2.0151     Total:     2.0151
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Z            :         -0.1834852            0.9762758            0.7927906
+ Magnitude           :                                                    0.7927906
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:38:58 2022
+*** tstop() called on sat.lazhome.net at Tue Jun 14 19:42:53 2022
 Module time:
-	user time   =       2.65 seconds =       0.04 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       3.06 seconds =       0.05 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 Total time:
-	user time   =       2.65 seconds =       0.04 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       3.06 seconds =       0.05 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -400,16 +402,16 @@ Total time:
                                     Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
-     1        A->A (1 A)       0.28346         7.71343        -76.04632        0.0179          0.1293         -0.0000         -0.0000        
+     1        A->A (1 A)       0.28346         7.71343        -76.04632        0.0179          0.1293          0.0000          0.0000        
 
 
 
 Contributing excitations
-Only contributions with coefficients > 1.00e-01 will be printed:
+Only contributions with abs(coeff) > 1.00e-01 will be printed:
 
 Excited State    1 (1 A):   0.28346 au   160.74 nm f = 0.0179
   Sums of squares: Xssq =  1.000000e+00
-     5 ->  6    0.998965 (99.793%)
+      5a  ->   6a     0.998965 (99.793%)
 
 
 ******************************************************************************************
@@ -424,16 +426,16 @@ Excited State    1 (1 A):   0.28346 au   160.74 nm f = 0.0179
 
 Scratch directory: /tmp/
 
-*** tstart() called on dhcp189-161.emerson.emory.edu
-*** at Tue Mar  8 09:39:00 2022
+*** tstart() called on sat.lazhome.net
+*** at Tue Jun 14 19:42:55 2022
 
    => Loading Basis Set <=
 
     Name: DEF2-SVP
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   130 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
-    atoms 2-3 entry H          line    15 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 1   entry O          line   130 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-3 entry H          line    15 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
 
 
          ---------------------------------------------------------
@@ -551,8 +553,8 @@ Scratch directory: /tmp/
     Name: (DEF2-SVP AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   318 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
-    atoms 2-3 entry H          line    18 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 1   entry O          line   318 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -603,16 +605,16 @@ Scratch directory: /tmp/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RKS iter SAD:   -75.96686470860524   -7.59669e+01   0.00000e+00 
-   @DF-RKS iter   1:   -76.20148342915220   -2.34619e-01   2.43937e-02 DIIS/ADIIS
-   @DF-RKS iter   2:   -76.17589780043848    2.55856e-02   2.74605e-02 DIIS/ADIIS
-   @DF-RKS iter   3:   -76.32970494933926   -1.53807e-01   5.70032e-04 DIIS/ADIIS
-   @DF-RKS iter   4:   -76.32977981408150   -7.48647e-05   1.42003e-04 DIIS/ADIIS
-   @DF-RKS iter   5:   -76.32978482197259   -5.00789e-06   2.20692e-05 DIIS
-   @DF-RKS iter   6:   -76.32978496157017   -1.39598e-07   1.50265e-06 DIIS
-   @DF-RKS iter   7:   -76.32978496392698   -2.35681e-09   2.80977e-07 DIIS
-   @DF-RKS iter   8:   -76.32978496400614   -7.91545e-11   2.39853e-08 DIIS
-   @DF-RKS iter   9:   -76.32978496400666   -5.25802e-13   1.68862e-09 DIIS
+   @DF-RKS iter SAD:   -75.96686470859305   -7.59669e+01   0.00000e+00 
+   @DF-RKS iter   1:   -76.20148342914189   -2.34619e-01   2.43937e-02 DIIS/ADIIS
+   @DF-RKS iter   2:   -76.17589780042583    2.55856e-02   2.74605e-02 DIIS/ADIIS
+   @DF-RKS iter   3:   -76.32970494933220   -1.53807e-01   5.70032e-04 DIIS/ADIIS
+   @DF-RKS iter   4:   -76.32977981407433   -7.48647e-05   1.42003e-04 DIIS/ADIIS
+   @DF-RKS iter   5:   -76.32978482196553   -5.00789e-06   2.20692e-05 DIIS
+   @DF-RKS iter   6:   -76.32978496156308   -1.39598e-07   1.50265e-06 DIIS
+   @DF-RKS iter   7:   -76.32978496391989   -2.35681e-09   2.80977e-07 DIIS
+   @DF-RKS iter   8:   -76.32978496399900   -7.91118e-11   2.39853e-08 DIIS
+   @DF-RKS iter   9:   -76.32978496399956   -5.54223e-13   1.68862e-09 DIIS
   Energy and wave function converged.
 
 
@@ -643,17 +645,17 @@ Scratch directory: /tmp/
               A 
     DOCC [     5 ]
 
-  @DF-RKS Final Energy:   -76.32978496400666
+  @DF-RKS Final Energy:   -76.32978496399956
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.1873335747049811
-    One-Electron Energy =                -123.1023942495575909
-    Two-Electron Energy =                  44.4154516912800474
-    DFT Exchange-Correlation Energy =      -6.8301759804340980
+    One-Electron Energy =                -123.1023942496054815
+    Two-Electron Energy =                  44.4154516913391646
+    DFT Exchange-Correlation Energy =      -6.8301759804382236
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
-    Total Energy =                        -76.3297849640066488
+    Total Energy =                        -76.3297849639995576
 
 Computation Completed
 
@@ -662,28 +664,30 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9763
 
-  Electronic Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:    -0.1835
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:    -0.0000      Y:    -0.0000      Z:     0.7928     Total:     0.7928
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:    -0.0000      Y:    -0.0000      Z:     2.0151     Total:     2.0151
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.1834852            0.9762758            0.7927906
+ Magnitude           :                                                    0.7927906
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:39:02 2022
+*** tstop() called on sat.lazhome.net at Tue Jun 14 19:42:58 2022
 Module time:
-	user time   =       2.12 seconds =       0.04 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.87 seconds =       0.05 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       6.28 seconds =       0.10 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =       8.37 seconds =       0.14 minutes
+	system time =       0.65 seconds =       0.01 minutes
+	total time  =          9 seconds =       0.15 minutes
 
 ******************************************************************************************
 **********                               WARNING                                **********
@@ -739,16 +743,16 @@ Total time:
                                     Excitation Energy         Total Energy        Oscillator Strength             Rotatory Strength       
      #   Sym: GS->ES (Trans)        au              eV              au          au (length)    au (velocity)    au (length)    au (velocity) 
     ---- -------------------- --------------- --------------- --------------- --------------- --------------- --------------- ---------------
-     1        A->A (1 A)       0.28346         7.71343        -76.04632        0.0179          0.1293         -0.0000         -0.0000        
+     1        A->A (1 A)       0.28346         7.71343        -76.04632        0.0179          0.1293          0.0000          0.0000        
 
 
 
 Contributing excitations
-Only contributions with coefficients > 1.00e-01 will be printed:
+Only contributions with abs(coeff) > 1.00e-01 will be printed:
 
 Excited State    1 (1 A):   0.28346 au   160.74 nm f = 0.0179
   Sums of squares: Xssq =  1.000000e+00
-     5 ->  6    0.998965 (99.793%)
+      5a  ->   6a     0.998965 (99.793%)
 
 
 ******************************************************************************************
@@ -761,7 +765,7 @@ Excited State    1 (1 A):   0.28346 au   160.74 nm f = 0.0179
 
     TD-CAM-B3LYP ROOT 0 -> ROOT 1 EXCITATION ENERGY - A TRANSITION........................PASSED
 
-    Psi4 stopped on: Tuesday, 08 March 2022 09:39AM
-    Psi4 wall time for execution: 0:00:07.99
+    Psi4 stopped on: Tuesday, 14 June 2022 07:43PM
+    Psi4 wall time for execution: 0:00:10.18
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/tdscf-7/output.ref
+++ b/tests/tdscf-7/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 undefined 
+                               Psi4 1.7a1.dev7 
 
-                         Git: Rev {tdscf_var} c8200ee dirty
+                         Git: Rev {tdscf_excitations_symmetry} 7a26583 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,17 +30,18 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 08 March 2022 09:39AM
+    Psi4 started on: Tuesday, 14 June 2022 07:43PM
 
-    Process ID: 4311
-    Host:       dhcp189-161.emerson.emory.edu
-    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Process ID: 3048
+    Host:       sat.lazhome.net
+    PSIDATADIR: /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
   ==> Input File <==
 
 --------------------------------------------------------------------------
+#! TD-HF test variable access
 molecule h2o {
   1 2 
   O
@@ -61,10 +62,14 @@ exc_2 = 0.27347 # TEST
 exc_3 = 0.57815 # TEST
 exc_4 = 0.63789 # TEST
 
-compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A1) EXCITATION ENERGY"), 5, "First Excitation Energy")        # TEST
-compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")       # TEST
-compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 1 (B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")        # TEST
-compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 0 (A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")       # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (IN B1) -> ROOT 0 (IN A1) EXCITATION ENERGY"), 5, "First Excitation Energy")        # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (IN B1) -> ROOT 0 (IN B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")       # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (IN B1) -> ROOT 1 (IN B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")        # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (IN B1) -> ROOT 0 (IN A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")       # TEST
+compare_values(exc_1, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 1 (A1) EXCITATION ENERGY"), 5, "First Excitation Energy")        # TEST
+compare_values(exc_2, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 2 (B2) EXCITATION ENERGY"), 5, "Second Excitation Energy")       # TEST
+compare_values(exc_3, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 3 (B1) EXCITATION ENERGY"), 5, "Third Excitation Energy")        # TEST
+compare_values(exc_4, wfn.variable("TD-HF ROOT 0 (B1) -> ROOT 4 (A2) EXCITATION ENERGY"), 5, "Fourth Excitation Energy")       # TEST
 compare_values(exc_1, wfn.variable("TD-HF ROOT 0 -> ROOT 1 EXCITATION ENERGY"), 5, "First Excitation Energy")                  # TEST
 compare_values(exc_2, wfn.variable("TD-HF ROOT 0 -> ROOT 2 EXCITATION ENERGY"), 5, "Second Excitation Energy")                 # TEST
 compare_values(exc_3, wfn.variable("TD-HF ROOT 0 -> ROOT 3 EXCITATION ENERGY"), 5, "Third Excitation Energy")                  # TEST
@@ -77,16 +82,16 @@ compare_values(exc_4, wfn.variable("TD-HF ROOT 0 -> ROOT 4 EXCITATION ENERGY - B
 
 Scratch directory: /tmp/
 
-*** tstart() called on dhcp189-161.emerson.emory.edu
-*** at Tue Mar  8 09:39:04 2022
+*** tstart() called on sat.lazhome.net
+*** at Tue Jun 14 19:43:01 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   198 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry O          line   198 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -148,8 +153,8 @@ Scratch directory: /tmp/
     Name: (CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   221 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /home/laz/src/psi4laz/psi4/objdir/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -200,22 +205,22 @@ Scratch directory: /tmp/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-UHF iter SAD:   -75.58765897087146   -7.55877e+01   0.00000e+00 
-   @DF-UHF iter   1:   -75.57843545735250    9.22351e-03   1.98316e-02 DIIS/ADIIS
-   @DF-UHF iter   2:   -75.61445301952274   -3.60176e-02   5.18490e-03 DIIS/ADIIS
-   @DF-UHF iter   3:   -75.61660995565767   -2.15694e-03   1.73720e-03 DIIS/ADIIS
-   @DF-UHF iter   4:   -75.61692032828329   -3.10373e-04   5.44294e-04 DIIS/ADIIS
-   @DF-UHF iter   5:   -75.61697259988762   -5.22716e-05   2.21843e-04 DIIS/ADIIS
-   @DF-UHF iter   6:   -75.61698427055263   -1.16707e-05   6.14164e-05 DIIS
-   @DF-UHF iter   7:   -75.61698524513895   -9.74586e-07   1.02000e-05 DIIS
-   @DF-UHF iter   8:   -75.61698526830453   -2.31656e-08   1.60396e-06 DIIS
-   @DF-UHF iter   9:   -75.61698526874258   -4.38050e-10   2.81746e-07 DIIS
+   @DF-UHF iter SAD:   -75.58765897087372   -7.55877e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.57843545735474    9.22351e-03   1.98316e-02 DIIS/ADIIS
+   @DF-UHF iter   2:   -75.61445301952490   -3.60176e-02   5.18490e-03 DIIS/ADIIS
+   @DF-UHF iter   3:   -75.61660995565978   -2.15694e-03   1.73720e-03 DIIS/ADIIS
+   @DF-UHF iter   4:   -75.61691962202362   -3.09666e-04   5.46171e-04 DIIS/ADIIS
+   @DF-UHF iter   5:   -75.61697252394906   -5.29019e-05   2.22714e-04 DIIS/ADIIS
+   @DF-UHF iter   6:   -75.61698426834147   -1.17444e-05   6.13981e-05 DIIS
+   @DF-UHF iter   7:   -75.61698524513905   -9.76798e-07   1.02003e-05 DIIS
+   @DF-UHF iter   8:   -75.61698526830665   -2.31676e-08   1.60401e-06 DIIS
+   @DF-UHF iter   9:   -75.61698526874474   -4.38092e-10   2.81759e-07 DIIS
   Energy and wave function converged.
 
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   5.210098139E-03
+   @Spin Contamination Metric:   5.210098149E-03
    @S^2 Expected:                7.500000000E-01
    @S^2 Observed:                7.552100981E-01
    @S   Expected:                5.000000000E-01
@@ -259,14 +264,14 @@ Scratch directory: /tmp/
     DOCC [     3,    0,    0,    1 ]
     SOCC [     0,    0,    1,    0 ]
 
-  @DF-UHF Final Energy:   -75.61698526874258
+  @DF-UHF Final Energy:   -75.61698526874474
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              9.7806701448786271
-    One-Electron Energy =                -118.9744363721655986
-    Two-Electron Energy =                  33.5767809585443970
-    Total Energy =                        -75.6169852687425816
+    One-Electron Energy =                -118.9744363712695474
+    Two-Electron Energy =                  33.5767809576461929
+    Total Energy =                        -75.6169852687447275
 
   UHF NO Occupations:
   HONO-2 :    1 B2 1.9994184
@@ -285,27 +290,29 @@ Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9223
 
-  Electronic Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.0027
+ Multipole Moments:
 
-  Dipole Moment: [e a0]
-     X:     0.0000      Y:     0.0000      Z:     0.9250     Total:     0.9250
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: [D]
-     X:     0.0000      Y:     0.0000      Z:     2.3511     Total:     2.3511
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0026706            0.9223292            0.9249997
+ Magnitude           :                                                    0.9249997
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on dhcp189-161.emerson.emory.edu at Tue Mar  8 09:39:05 2022
+*** tstop() called on sat.lazhome.net at Tue Jun 14 19:43:02 2022
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 
 ******************************************************************************************
@@ -379,7 +386,7 @@ Total time:
   HamiltonianSolver iter   5:   4.00777e-05  6.19018e-03     12      
   HamiltonianSolver iter   6:   3.01081e-06  1.95184e-03     14      
   HamiltonianSolver iter   7:   1.49613e-07  2.89779e-04     16      
-  HamiltonianSolver iter   8:   5.21947e-09  3.99349e-05     18      Converged
+  HamiltonianSolver iter   8:   5.21948e-09  3.99349e-05     18      Converged
 
 
   ==> Seeking the lowest 1 singlet states with B1 symmetry
@@ -439,7 +446,47 @@ Total time:
 
 
 
-Contributing excitations and de-excitations...only curently available with C1 symmetry
+Contributing excitations and de-excitations
+Only contributions with abs(coeff) > 1.00e-01 will be printed:
+
+Excited State    1 (1 A1):   0.09302 au   489.82 nm f = 0.0017
+Alpha orbitals:
+  Sums of squares: Xssq =  1.303949e-03; Yssq =  1.079826e-03; Xssq - Yssq =  2.241231e-04
+Beta orbitals:
+  Sums of squares: Xssq =  1.001826e+00; Yssq =  2.050598e-03; Xssq - Yssq =  9.997759e-01
+      3a1 (b) ->   1b1 (b)    0.989812 (97.973%)
+      3a1 (b) ->   2b1 (b)    0.145645 ( 2.121%)
+
+Excited State    2 (1 B2):   0.27347 au   166.61 nm f = 0.0000
+Alpha orbitals:
+  Sums of squares: Xssq =  1.878487e-03; Yssq =  6.536506e-04; Xssq - Yssq =  1.224836e-03
+Beta orbitals:
+  Sums of squares: Xssq =  9.992088e-01; Yssq =  4.336252e-04; Xssq - Yssq =  9.987752e-01
+      1b2 (b) ->   1b1 (b)    0.990671 (98.143%)
+      1b2 (b) ->   2b1 (b)    0.130178 ( 1.695%)
+
+Excited State    3 (1 B1):   0.57815 au   78.81 nm f = 0.0078
+Alpha orbitals:
+  Sums of squares: Xssq =  2.408907e-01; Yssq =  2.122968e-03; Xssq - Yssq =  2.387677e-01
+      3a1 (a) ->   4a1 (a)   -0.457197 (20.903%)
+      3a1 (a) ->   5a1 (a)    0.112140 ( 1.258%)
+Beta orbitals:
+  Sums of squares: Xssq =  7.629124e-01; Yssq =  1.680114e-03; Xssq - Yssq =  7.612323e-01
+      3a1 (b) ->   4a1 (b)    0.846548 (71.664%)
+      3a1 (b) ->   5a1 (b)   -0.160656 ( 2.581%)
+
+Excited State    4 (1 A2):   0.63789 au   71.43 nm f = 0.0075
+Alpha orbitals:
+  Sums of squares: Xssq =  2.524776e-01; Yssq =  2.456051e-03; Xssq - Yssq =  2.500215e-01
+      3a1 (a) ->   2b2 (a)   -0.404654 (16.374%)
+      3a1 (a) ->   3b2 (a)   -0.164534 ( 2.707%)
+      1b2 (a) ->   4a1 (a)   -0.216432 ( 4.684%)
+Beta orbitals:
+  Sums of squares: Xssq =  7.526613e-01; Yssq =  2.682875e-03; Xssq - Yssq =  7.499785e-01
+      3a1 (b) ->   2b2 (b)    0.781681 (61.103%)
+      3a1 (b) ->   3b2 (b)    0.242368 ( 5.874%)
+      3a1 (b) ->   4b2 (b)    0.118882 ( 1.413%)
+      1b2 (b) ->   4a1 (b)    0.238588 ( 5.692%)
 
 
 ******************************************************************************************
@@ -462,8 +509,12 @@ Contributing excitations and de-excitations...only curently available with C1 sy
     Second Excitation Energy..............................................................PASSED
     Third Excitation Energy...............................................................PASSED
     Fourth Excitation Energy..............................................................PASSED
+    First Excitation Energy...............................................................PASSED
+    Second Excitation Energy..............................................................PASSED
+    Third Excitation Energy...............................................................PASSED
+    Fourth Excitation Energy..............................................................PASSED
 
-    Psi4 stopped on: Tuesday, 08 March 2022 09:39AM
-    Psi4 wall time for execution: 0:00:00.91
+    Psi4 stopped on: Tuesday, 14 June 2022 07:43PM
+    Psi4 wall time for execution: 0:00:01.69
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
Adds contributing excitations to tdscf output for non-C1 symmetry.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
