### PR TITLE
Crash on NaN

### DIFF
--- a/psi4/src/psi4/libfock/dft_integrators.h
+++ b/psi4/src/psi4/libfock/dft_integrators.h
@@ -56,17 +56,17 @@ inline std::vector<double> rks_quadrature_integrate(std::shared_ptr<BlockOPoints
                                                     std::shared_ptr<PointFunctions> pworker) {
     // Block data
     int npoints = block->npoints();
-    double* x = block->x();
-    double* y = block->y();
-    double* z = block->z();
-    double* w = block->w();
+    auto x = block->x();
+    auto y = block->y();
+    auto z = block->z();
+    auto w = block->w();
 
     // Superfunctional data
-    double* zk = fworker->value("V")->pointer();
-    double* QTp = fworker->value("Q_TMP")->pointer();
+    auto zk = fworker->value("V")->pointer();
+    auto QTp = fworker->value("Q_TMP")->pointer();
 
     // Points data
-    double* rho_a = pworker->point_value("RHO_A")->pointer();
+    auto rho_a = pworker->point_value("RHO_A")->pointer();
 
     // Build quadrature
     std::vector<double> ret(5);

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -1408,7 +1408,7 @@ void RV::compute_V(std::vector<SharedMatrix> ret) {
     quad_values_["RHO_BY"] = quad_values_["RHO_AY"];
     quad_values_["RHO_BZ"] = quad_values_["RHO_AZ"];
 
-    if (isnan(quad_values_["FUNCTIONAL"])) {
+    if (std::isnan(quad_values_["FUNCTIONAL"])) {
         throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
     }
 
@@ -2026,7 +2026,7 @@ SharedMatrix RV::compute_gradient() {
     quad_values_["RHO_BY"] = quad_values_["RHO_AY"];
     quad_values_["RHO_BZ"] = quad_values_["RHO_AZ"];
 
-    if (isnan(quad_values_["FUNCTIONAL"])) {
+    if (std::isnan(quad_values_["FUNCTIONAL"])) {
         throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
     }
 
@@ -2360,7 +2360,7 @@ SharedMatrix RV::compute_hessian() {
         }
     }
 
-    if (isnan(quad_values_["FUNCTIONAL"])) {
+    if (std::isnan(quad_values_["FUNCTIONAL"])) {
         throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
     }
 
@@ -2702,7 +2702,7 @@ void UV::compute_V(std::vector<SharedMatrix> ret) {
     quad_values_["RHO_BY"] = std::accumulate(rhobyq.begin(), rhobyq.end(), 0.0);
     quad_values_["RHO_BZ"] = std::accumulate(rhobzq.begin(), rhobzq.end(), 0.0);
 
-    if (isnan(quad_values_["FUNCTIONAL"])) {
+    if (std::isnan(quad_values_["FUNCTIONAL"])) {
         throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
     }
 
@@ -3511,7 +3511,7 @@ SharedMatrix UV::compute_gradient() {
     quad_values_["RHO_BY"] = std::accumulate(rhobyq.begin(), rhobyq.end(), 0.0);
     quad_values_["RHO_BZ"] = std::accumulate(rhobzq.begin(), rhobzq.end(), 0.0);
 
-    if (isnan(quad_values_["FUNCTIONAL"])) {
+    if (std::isnan(quad_values_["FUNCTIONAL"])) {
         throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
     }
 

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -1313,7 +1313,7 @@ void RV::compute_V(std::vector<SharedMatrix> ret) {
     }
 
     auto V_AO = std::make_shared<Matrix>("V AO Temp", nbf_, nbf_);
-    double** Vp = V_AO->pointer();
+    auto Vp = V_AO->pointer();
 
     std::vector<double> functionalq(num_threads_);
     std::vector<double> rhoaq(num_threads_);
@@ -1332,9 +1332,9 @@ void RV::compute_V(std::vector<SharedMatrix> ret) {
 #endif
 
         // Get per-rank workers
-        std::shared_ptr<BlockOPoints> block = grid_->blocks()[Q];
-        std::shared_ptr<SuperFunctional> fworker = functional_workers_[rank];
-        std::shared_ptr<PointFunctions> pworker = point_workers_[rank];
+        auto block = grid_->blocks()[Q];
+        auto fworker = functional_workers_[rank];
+        auto pworker = point_workers_[rank];
 
         // Compute Rho, Phi, etc
         parallel_timer_on("Properties", rank);
@@ -1354,7 +1354,7 @@ void RV::compute_V(std::vector<SharedMatrix> ret) {
         parallel_timer_on("V_xc", rank);
 
         // => Compute quadrature <= //
-        std::vector<double> qvals = dft_integrators::rks_quadrature_integrate(block, fworker, pworker);
+        auto qvals = dft_integrators::rks_quadrature_integrate(block, fworker, pworker);
         functionalq[rank] += qvals[0];
         rhoaq[rank] += qvals[1];
         rhoaxq[rank] += qvals[2];
@@ -1365,8 +1365,8 @@ void RV::compute_V(std::vector<SharedMatrix> ret) {
         dft_integrators::rks_integrator(block, fworker, pworker, V_local[rank]);
 
         // => Unpacking <= //
-        double** V2p = V_local[rank]->pointer();
-        const std::vector<int>& function_map = block->functions_local_to_global();
+        auto V2p = V_local[rank]->pointer();
+        const auto& function_map = block->functions_local_to_global();
         int nlocal = function_map.size();
 
         for (int ml = 0; ml < nlocal; ml++) {
@@ -1407,6 +1407,10 @@ void RV::compute_V(std::vector<SharedMatrix> ret) {
     quad_values_["RHO_BX"] = quad_values_["RHO_AX"];
     quad_values_["RHO_BY"] = quad_values_["RHO_AY"];
     quad_values_["RHO_BZ"] = quad_values_["RHO_AZ"];
+
+    if (isnan(quad_values_["FUNCTIONAL"])) {
+        throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
+    }
 
     if (debug_) {
         outfile->Printf("   => Numerical Integrals <=\n\n");
@@ -1978,22 +1982,22 @@ SharedMatrix RV::compute_gradient() {
 #endif
 
         // Get per-rank workers
-        std::shared_ptr<BlockOPoints> block = grid_->blocks()[Q];
-        std::shared_ptr<SuperFunctional> fworker = functional_workers_[rank];
-        std::shared_ptr<PointFunctions> pworker = point_workers_[rank];
+        auto block = grid_->blocks()[Q];
+        auto fworker = functional_workers_[rank];
+        auto pworker = point_workers_[rank];
 
         parallel_timer_on("Properties", rank);
         pworker->compute_points(block);
         parallel_timer_off("Properties", rank);
 
         parallel_timer_on("Functional", rank);
-        std::map<std::string, SharedVector>& vals = fworker->compute_functional(pworker->point_values());
+        auto& vals = fworker->compute_functional(pworker->point_values());
         parallel_timer_off("Functional", rank);
 
         parallel_timer_on("V_xc gradient", rank);
 
         // => Compute quadrature <= //
-        std::vector<double> qvals = dft_integrators::rks_quadrature_integrate(block, fworker, pworker);
+        auto qvals = dft_integrators::rks_quadrature_integrate(block, fworker, pworker);
         functionalq[rank] += qvals[0];
         rhoaq[rank] += qvals[1];
         rhoaxq[rank] += qvals[2];
@@ -2021,6 +2025,10 @@ SharedMatrix RV::compute_gradient() {
     quad_values_["RHO_BX"] = quad_values_["RHO_AX"];
     quad_values_["RHO_BY"] = quad_values_["RHO_AY"];
     quad_values_["RHO_BZ"] = quad_values_["RHO_AZ"];
+
+    if (isnan(quad_values_["FUNCTIONAL"])) {
+        throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
+    }
 
     if (debug_) {
         outfile->Printf("   => XC Gradient: Numerical Integrals <=\n\n");
@@ -2352,7 +2360,9 @@ SharedMatrix RV::compute_hessian() {
         }
     }
 
-
+    if (isnan(quad_values_["FUNCTIONAL"])) {
+        throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
+    }
 
     if (debug_) {
         outfile->Printf("   => XC Hessian: Numerical Integrals <=\n\n");
@@ -2691,6 +2701,10 @@ void UV::compute_V(std::vector<SharedMatrix> ret) {
     quad_values_["RHO_BX"] = std::accumulate(rhobxq.begin(), rhobxq.end(), 0.0);
     quad_values_["RHO_BY"] = std::accumulate(rhobyq.begin(), rhobyq.end(), 0.0);
     quad_values_["RHO_BZ"] = std::accumulate(rhobzq.begin(), rhobzq.end(), 0.0);
+
+    if (isnan(quad_values_["FUNCTIONAL"])) {
+        throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
+    }
 
     if (debug_) {
         outfile->Printf("   => Numerical Integrals <=\n\n");
@@ -3496,6 +3510,10 @@ SharedMatrix UV::compute_gradient() {
     quad_values_["RHO_BX"] = std::accumulate(rhobxq.begin(), rhobxq.end(), 0.0);
     quad_values_["RHO_BY"] = std::accumulate(rhobyq.begin(), rhobyq.end(), 0.0);
     quad_values_["RHO_BZ"] = std::accumulate(rhobzq.begin(), rhobzq.end(), 0.0);
+
+    if (isnan(quad_values_["FUNCTIONAL"])) {
+        throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one.");
+    }
 
     if (debug_) {
         outfile->Printf("   => XC Gradient: Numerical Integrals <=\n\n");

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -602,6 +602,70 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             if (meta_) {
                 C_DAXPY(npoints, 0.5 * alpha_, fv_tau.data(), 1, v_tau_a, 1);
             }
+
+            // Data validation.
+            bool found_nan = false;
+            if (meta_) {
+                if (exc_) {
+                    for (int i = 0; i < npoints; i++) {
+                        if (std::isnan(v[i])) {
+                            outfile->Printf("v is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
+                            found_nan = true;
+                        }
+                    }
+                }
+                for (int i = 0; i < npoints; i++) {
+                    if (std::isnan(v_rho_a[i])) {
+                        outfile->Printf("v_rho_a is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
+                        found_nan = true;
+                    }
+                    if (std::isnan(v_gamma_aa[i])) {
+                        outfile->Printf("v_gamma_aa is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
+                        found_nan = true;
+                    }
+                    if (std::isnan(v_tau_a[i])) {
+                        outfile->Printf("v_tau_a is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
+                        found_nan = true;
+                    }
+                }
+            } else if (gga_) {
+                if (exc_) {
+                    for (int i = 0; i < npoints; i++) {
+                        if (std::isnan(v[i])) {
+                            outfile->Printf("v is NaN : rho_ap %12.8f   gamma_aap %12.8f\n", rho_ap[i], gamma_aap[i]);
+                            found_nan = true;
+                        }
+                    }
+                }
+                for (int i = 0; i < npoints; i++) {
+                    if (std::isnan(v_rho_a[i])) {
+                        outfile->Printf("v_rho_a is NaN : rho_ap %12.8f   gamma_aap %12.8f\n", rho_ap[i], gamma_aap[i]);
+                        found_nan = true;
+                    }
+                    if (std::isnan(v_gamma_aa[i])) {
+                        outfile->Printf("v_gamma_aa is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
+                        found_nan = true;
+                    }
+                }
+            } else {
+                if (exc_) {
+                    for (int i = 0; i < npoints; i++) {
+                        if (std::isnan(v[i])) {
+                            outfile->Printf("v is NaN : rho_ap %12.8f\n", rho_ap[i]);
+                            found_nan = true;
+                        }
+                    }
+                }
+                for (int i = 0; i < npoints; i++) {
+                    if (std::isnan(v_rho_a[i])) {
+                        outfile->Printf("v_rho_a is NaN : rho_ap %12.8f\n", rho_ap[i]);
+                        found_nan = true;
+                    }
+                }
+            }
+            if (found_nan) {
+                throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one. Provide your input and output files for debugging.");
+            }
         }
 
         // Compute second derivative

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -411,7 +411,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
         }
     }
 
-    // => Outut variables <= //
+    // => Output variables <= //
 
     double* v = nullptr;
 
@@ -606,59 +606,26 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             // Data validation.
             bool found_nan = false;
             if (meta_) {
-                if (exc_) {
-                    for (int i = 0; i < npoints; i++) {
-                        if (std::isnan(v[i])) {
-                            outfile->Printf("v is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
-                            found_nan = true;
-                        }
-                    }
-                }
                 for (int i = 0; i < npoints; i++) {
-                    if (std::isnan(v_rho_a[i])) {
-                        outfile->Printf("v_rho_a is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
-                        found_nan = true;
-                    }
-                    if (std::isnan(v_gamma_aa[i])) {
-                        outfile->Printf("v_gamma_aa is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
-                        found_nan = true;
-                    }
-                    if (std::isnan(v_tau_a[i])) {
-                        outfile->Printf("v_tau_a is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
+                    if ((exc_ && std::isnan(v[i])) || std::isnan(v_rho_a[i]) || std::isnan(v_gamma_aa[i]) || std::isnan(v_tau_a[i])) {
+                        outfile->Printf("NaN detected: %.6e %.6e %.6e %.6e %.6e 0 0 %.6e %.6e\n",
+                          rho_ap[i] / 2, rho_ap[i] / 2, gamma_aap[i] / 4, gamma_aap[i] / 4, gamma_aap[i] / 4, tau_ap[i] / 2, tau_ap[i] / 2);
                         found_nan = true;
                     }
                 }
             } else if (gga_) {
-                if (exc_) {
-                    for (int i = 0; i < npoints; i++) {
-                        if (std::isnan(v[i])) {
-                            outfile->Printf("v is NaN : rho_ap %12.8f   gamma_aap %12.8f\n", rho_ap[i], gamma_aap[i]);
-                            found_nan = true;
-                        }
-                    }
-                }
                 for (int i = 0; i < npoints; i++) {
-                    if (std::isnan(v_rho_a[i])) {
-                        outfile->Printf("v_rho_a is NaN : rho_ap %12.8f   gamma_aap %12.8f\n", rho_ap[i], gamma_aap[i]);
-                        found_nan = true;
-                    }
-                    if (std::isnan(v_gamma_aa[i])) {
-                        outfile->Printf("v_gamma_aa is NaN : rho_ap %12.8f   gamma_aap %12.8f   tau_ap %12.8f\n", rho_ap[i], gamma_aap[i], tau_ap[i]);
+                    if ((exc_ && std::isnan(v[i])) || std::isnan(v_rho_a[i]) || std::isnan(v_gamma_aa[i])) {
+                        outfile->Printf("NaN detected: %.6e %.6e %.6e %.6e %.6e 0 0 0 0\n",
+                          rho_ap[i] / 2, rho_ap[i] / 2, gamma_aap[i] / 4, gamma_aap[i] / 4, gamma_aap[i] / 4);
                         found_nan = true;
                     }
                 }
             } else {
-                if (exc_) {
-                    for (int i = 0; i < npoints; i++) {
-                        if (std::isnan(v[i])) {
-                            outfile->Printf("v is NaN : rho_ap %12.8f\n", rho_ap[i]);
-                            found_nan = true;
-                        }
-                    }
-                }
                 for (int i = 0; i < npoints; i++) {
-                    if (std::isnan(v_rho_a[i])) {
-                        outfile->Printf("v_rho_a is NaN : rho_ap %12.8f\n", rho_ap[i]);
+                    if ((exc_ && std::isnan(v[i])) || std::isnan(v_rho_a[i])) {
+                        outfile->Printf("NaN detected: %.6e %.6e 0 0 0 0 0 0 0\n",
+                          rho_ap[i] / 2, rho_ap[i] / 2);
                         found_nan = true;
                     }
                 }

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -359,6 +359,15 @@ std::vector<std::tuple<std::string, int, double>> LibXCFunctional::get_mix_data(
 }
 void LibXCFunctional::compute_functional(const std::map<std::string, SharedVector>& in,
                                          const std::map<std::string, SharedVector>& out, int npoints, int deriv) {
+// Uncomment below to enable the parallel_timer calls (which must individually be uncommented).
+/*
+        int rank = 0; 
+#ifdef _OPENMP
+        rank = omp_get_thread_num();
+#endif
+*/
+
+
     // => Input variables <= //
 
     if ((deriv >= 1) & (!vxc_)) {
@@ -601,6 +610,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             }
 
             // Data validation.
+            //parallel_timer_on("DFT NaN Check", rank);
             bool found_nan = false;
             if (meta_) {
                 for (int i = 0; i < npoints; i++) {
@@ -630,6 +640,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             if (found_nan) {
                 throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one. Provide your input and output files for debugging.");
             }
+            //parallel_timer_off("DFT NaN Check", rank);
         }
 
         // Compute second derivative
@@ -660,6 +671,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             }
 
             // Data validation.
+            //parallel_timer_on("DFT NaN Check", rank);
             bool found_nan = false;
             if (meta_) {
                 throw PSIEXCEPTION("Second derivative for meta functionals not yet available.");
@@ -683,6 +695,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             if (found_nan) {
                 throw PSIEXCEPTION("V: Integrated DFT functional derivative to get NaN. The functional is not numerically stable. Pick a different one. Provide your input and output files for debugging.");
             }
+            //parallel_timer_off("DFT NaN Check", rank);
         }
 
     } else {  // End unpolarized
@@ -763,6 +776,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             }
 
             // Data validation.
+            //parallel_timer_on("DFT NaN Check", rank);
             bool found_nan = false;
             if (meta_) {
                 for (int i = 0; i < npoints; i++) {
@@ -794,6 +808,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             if (found_nan) {
                 throw PSIEXCEPTION("V: Integrated DFT functional to get NaN. The functional is not numerically stable. Pick a different one. Provide your input and output files for debugging.");
             }
+            //parallel_timer_off("DFT NaN Check", rank);
         }
 
         // Compute second deriv
@@ -845,6 +860,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             }
 
             // Data validation.
+            //parallel_timer_on("DFT NaN Check", rank);
             bool found_nan = false;
             if (meta_) {
                 throw PSIEXCEPTION("Second derivative for meta functionals not yet available.");
@@ -872,6 +888,7 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
             if (found_nan) {
                 throw PSIEXCEPTION("V: Integrated DFT functional derivative to get NaN. The functional is not numerically stable. Pick a different one. Provide your input and output files for debugging.");
             }
+            //parallel_timer_off("DFT NaN Check", rank);
         }
         if (deriv > 2) {  // lgtm[cpp/constant-comparison]
             throw PSIEXCEPTION("TRYING TO COMPUTE DERIV >= 3 ");


### PR DESCRIPTION
## Description

If a DFT functional gives `NaN` when we attempt to numerically integrate it, throw the functional under the bus immediately instead of leaving my ADIIS code to take the blame, i.e., give a better error message.

Closes #2609.

## Status
- [x] Ready for review
- [x] Ready for merge
