### PR TITLE
Compute, Don't Store, DOCC/SOCC

### DIFF
--- a/external/downstream/v2rdm_casscf/CMakeLists.txt
+++ b/external/downstream/v2rdm_casscf/CMakeLists.txt
@@ -16,6 +16,7 @@ if(${ENABLE_v2rdm_casscf})
 
         ExternalProject_Add(v2rdm_casscf_external
             DEPENDS psi4-core
+            # Re-change source URL once V2RDM is compatible with Vector/IntVector change and docc/socc change.
             URL https://github.com/loriab/v2rdm_casscf/archive/v2rdm8.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}

--- a/external/downstream/v2rdm_casscf/CMakeLists.txt
+++ b/external/downstream/v2rdm_casscf/CMakeLists.txt
@@ -16,7 +16,7 @@ if(${ENABLE_v2rdm_casscf})
 
         ExternalProject_Add(v2rdm_casscf_external
             DEPENDS psi4-core
-            URL https://github.com/loriab/v2rdm_casscf/archive/929d7fc.tar.gz
+            URL https://github.com/loriab/v2rdm_casscf/archive/v2rdm8.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -249,14 +249,14 @@ void export_wavefunction(py::module& m) {
             )pbdoc")
         .def("beta_orbital_space", &Wavefunction::beta_orbital_space, "docstring")
         .def("molecule", &Wavefunction::molecule, "Returns the Wavefunction's molecule.")
-        .def("doccpi", &Wavefunction::doccpi, py::return_value_policy::copy,
+        .def("doccpi", &Wavefunction::doccpi, py::return_value_policy::copy, "assume_socc_alpha"_a = true,
              "Returns the number of doubly occupied orbitals per irrep.")
         .def("density_fitted", &Wavefunction::density_fitted,
              "Returns whether this wavefunction was obtained using density fitting or not.")
         .def("force_doccpi", &Wavefunction::force_doccpi,
              "Specialized expert use only. Sets the number of doubly occupied oribtals per irrep. Note that this "
              "results in inconsistent Wavefunction objects for SCF, so caution is advised.")
-        .def("soccpi", &Wavefunction::soccpi, py::return_value_policy::copy,
+        .def("soccpi", &Wavefunction::soccpi, py::return_value_policy::copy, "assume_socc_alpha"_a = true,
              "Returns the number of singly occupied orbitals per irrep.")
         .def("force_soccpi", &Wavefunction::force_soccpi,
              "Specialized expert use only. Sets the number of singly occupied oribtals per irrep. Note that this "

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -253,14 +253,11 @@ void export_wavefunction(py::module& m) {
              "Returns the number of doubly occupied orbitals per irrep.")
         .def("density_fitted", &Wavefunction::density_fitted,
              "Returns whether this wavefunction was obtained using density fitting or not.")
-        .def("force_doccpi", &Wavefunction::force_doccpi,
-             "Specialized expert use only. Sets the number of doubly occupied oribtals per irrep. Note that this "
+        .def("force_occpi", &Wavefunction::force_occpi,
+             "Specialized expert use only. Sets the number of doubly and singly occupied oribtals per irrep. Note that this "
              "results in inconsistent Wavefunction objects for SCF, so caution is advised.")
         .def("soccpi", &Wavefunction::soccpi, py::return_value_policy::copy, "assume_socc_alpha"_a = true,
              "Returns the number of singly occupied orbitals per irrep.")
-        .def("force_soccpi", &Wavefunction::force_soccpi,
-             "Specialized expert use only. Sets the number of singly occupied oribtals per irrep. Note that this "
-             "results in inconsistent Wavefunction objects for SCF, so caution is advised.")
         .def("nsopi", &Wavefunction::nsopi, py::return_value_policy::copy,
              "Returns the number of symmetry orbitals per irrep.")
         .def("nmopi", &Wavefunction::nmopi, py::return_value_policy::copy,

--- a/psi4/src/psi4/adc/adc.cc
+++ b/psi4/src/psi4/adc/adc.cc
@@ -66,7 +66,7 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) : Wavefunction(opti
     if (!psio_) {
         throw PSIEXCEPTION("The wavefunction passed in lacks a PSIO object, crashing ADC. See GitHub issue #1851.");
     }
-    if (nopen_) throw PSIEXCEPTION("Openshell calculation has not been implemented yet!");
+    if (nopen_) throw PSIEXCEPTION("Open-shell calculation has not been implemented yet!");
 
     aoccount = 0, boccount = 0, avircount = 0, bvircount = 0;
     for (int h = 0; h < nirrep_; h++) {

--- a/psi4/src/psi4/adc/adc.cc
+++ b/psi4/src/psi4/adc/adc.cc
@@ -47,8 +47,8 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) : Wavefunction(opti
     std::vector<std::string> irreps_ = molecule_->irrep_labels();
     aoccpi_ = nalphapi_ - frzcpi_;
     boccpi_ = nbetapi_ - frzcpi_;
-    avirpi_ = nmopi_ - nalphapi_ - frzvpi_;
-    bvirpi_ = nmopi_ - nbetapi_ - frzvpi_;
+    avirpi_ = nmopi_ - frzvpi_ - nalphapi_;
+    bvirpi_ = nmopi_ - frzvpi_ - nbetapi_;
 
     int naocc = aoccpi_.sum();
     int nbocc = boccpi_.sum();

--- a/psi4/src/psi4/adc/adc.cc
+++ b/psi4/src/psi4/adc/adc.cc
@@ -45,31 +45,24 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) : Wavefunction(opti
     module_ = "adc";
 
     std::vector<std::string> irreps_ = molecule_->irrep_labels();
-    aoccpi_ = new int[nirrep_];
-    boccpi_ = new int[nirrep_];
-    avirpi_ = new int[nirrep_];
-    bvirpi_ = new int[nirrep_];
+    aoccpi_ = nalphapi_ - frzcpi_;
+    boccpi_ = nbetapi_ - frzcpi_;
+    avirpi_ = nmopi_ - nalphapi_ - frzvpi_;
+    bvirpi_ = nmopi_ - nbetapi_ - frzvpi_;
 
-    int naocc = 0, nbocc = 0, navir = 0, nbvir = 0;
+    int naocc = aoccpi_.sum();
+    int nbocc = boccpi_.sum();
+    int navir = avirpi_.sum();
+    int nbvir = bvirpi_.sum();
+
     int aoccount = 0, boccount = 0, avircount = 0, bvircount = 0;
-    for (int h = 0; h < nirrep_; h++) {
-        aoccpi_[h] = doccpi_[h] + soccpi_[h] - frzcpi_[h];
-        boccpi_[h] = doccpi_[h] - frzcpi_[h];
-        avirpi_[h] = nmopi_[h] - doccpi_[h] - soccpi_[h] - frzvpi_[h];
-        bvirpi_[h] = nmopi_[h] - doccpi_[h] - frzvpi_[h];
 
-        naocc += aoccpi_[h];
-        nbocc += boccpi_[h];
-        navir += avirpi_[h];
-        nbvir += bvirpi_[h];
-    }
     aocce_ = new double[naocc];
     bocce_ = new double[nbocc];
     avire_ = new double[navir];
     bvire_ = new double[nbvir];
 
-    nopen_ = 0;
-    for (int h = 0; h < nirrep_; h++) nopen_ += soccpi_[h];
+    nopen_ = soccpi().sum();
     if (!psio_) {
         throw PSIEXCEPTION("The wavefunction passed in lacks a PSIO object, crashing ADC. See GitHub issue #1851.");
     }
@@ -77,21 +70,23 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) : Wavefunction(opti
 
     aoccount = 0, boccount = 0, avircount = 0, bvircount = 0;
     for (int h = 0; h < nirrep_; h++) {
-        for (int a = frzcpi_[h]; a < doccpi_[h] + soccpi_[h]; a++) aocce_[aoccount++] = epsilon_a_->get(h, a);
+        for (int a = frzcpi_[h]; a < nalphapi_[h]; a++) aocce_[aoccount++] = epsilon_a_->get(h, a);
 
-        for (int b = frzcpi_[h]; b < doccpi_[h]; b++) bocce_[boccount++] = epsilon_b_->get(h, b);
+        for (int b = frzcpi_[h]; b < nbetapi_[h]; b++) bocce_[boccount++] = epsilon_b_->get(h, b);
 
-        for (int a = doccpi_[h] + soccpi_[h]; a < nmopi_[h] - frzvpi_[h]; a++)
+        for (int a = nalphapi_[h]; a < nmopi_[h] - frzvpi_[h]; a++)
             avire_[avircount++] = epsilon_a_->get(h, a);
 
-        for (int b = doccpi_[h]; b < nmopi_[h] - frzvpi_[h]; b++) bvire_[bvircount++] = epsilon_b_->get(h, b);
+        for (int b = nbetapi_[h]; b < nmopi_[h] - frzvpi_[h]; b++) bvire_[bvircount++] = epsilon_b_->get(h, b);
     }
 
+    const auto docc = doccpi();
+    const auto socc = soccpi();
     outfile->Printf("\n\n\tIrrep  Core  Docc  Socc  aOcc  aVir  bOcc  bVir  FVir\n");
     outfile->Printf("\t*****************************************************\n");
     for (int h = 0; h < nirrep_; h++) {
         outfile->Printf("\t %3s   %3d   %3d   %3d   %3d   %3d   %3d   %3d   %3d\n", irreps_[h].c_str(), frzcpi_[h],
-                        doccpi_[h], soccpi_[h], aoccpi_[h], avirpi_[h], boccpi_[h], bvirpi_[h], frzvpi_[h]);
+                        docc[h] + socc[h], soccpi()[h], aoccpi_[h], avirpi_[h], boccpi_[h], bvirpi_[h], frzvpi_[h]);
     }
     outfile->Printf("\t*****************************************************\n\n");
 

--- a/psi4/src/psi4/adc/adc.cc
+++ b/psi4/src/psi4/adc/adc.cc
@@ -86,7 +86,7 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) : Wavefunction(opti
     outfile->Printf("\t*****************************************************\n");
     for (int h = 0; h < nirrep_; h++) {
         outfile->Printf("\t %3s   %3d   %3d   %3d   %3d   %3d   %3d   %3d   %3d\n", irreps_[h].c_str(), frzcpi_[h],
-                        docc[h] + socc[h], soccpi()[h], aoccpi_[h], avirpi_[h], boccpi_[h], bvirpi_[h], frzvpi_[h]);
+                        docc[h], socc[h], aoccpi_[h], avirpi_[h], boccpi_[h], bvirpi_[h], frzvpi_[h]);
     }
     outfile->Printf("\t*****************************************************\n\n");
 

--- a/psi4/src/psi4/adc/adc.h
+++ b/psi4/src/psi4/adc/adc.h
@@ -96,13 +96,13 @@ class ADCWfn : public Wavefunction {
     // Number of components of transition amplitudes printed in outfile
     int num_amps_;
     // Number of alpha active occupied MOs per irrep
-    int *aoccpi_;
+    Dimension aoccpi_;
     // Number of alpha active virtual MOs per irrep
-    int *avirpi_;
+    Dimension avirpi_;
     // Number of beta active occupied MOs per irrep
-    int *boccpi_;
+    Dimension boccpi_;
     // Number of beta active virtual MOs per irrep
-    int *bvirpi_;
+    Dimension bvirpi_;
     // Number of doubly occupied MOs per irrep
     int *clsdpi_;
     // Roots sought per irrep

--- a/psi4/src/psi4/cc/ccenergy/MOInfo.h
+++ b/psi4/src/psi4/cc/ccenergy/MOInfo.h
@@ -50,7 +50,7 @@ struct MOInfo {
     int *sosym;                      /* SO symmetry (Pitzer) */
     int *orbspi;                     /* no. of MOs per irrep */
     Dimension clsdpi;                /* no. of closed-shells per irrep excl. frdocc */
-    int *openpi;                     /* no. of open-shells per irrep */
+    Dimension openpi;                /* no. of open-shells per irrep */
     int *uoccpi;                     /* no. of unoccupied orbitals per irr. ex. fruocc */
     int *frdocc;                     /* no. of frozen core orbitals per irrep */
     int *fruocc;                     /* no. of frozen unoccupied orbitals per irrep */

--- a/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
+++ b/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
@@ -54,7 +54,7 @@ void CCEnergyWavefunction::form_df_ints(Options &options, int **cachelist, int *
      * Set up the DF tensor machinery
      */
     std::shared_ptr<BasisSet> dfBasis = get_basisset("DF_BASIS_CC");
-    int nocc = doccpi_.sum();
+    int nocc = doccpi().sum();
     int nvir = nmo_ - nocc;
     int nbf = basisset_->nbf();
     int nbf2 = nbf * nbf;

--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -78,9 +78,9 @@ void CCEnergyWavefunction::get_moinfo() {
         moinfo_.escf = energy_;
     moinfo_.sopi = nsopi_;
     moinfo_.orbspi = nmopi_;
-    moinfo_.openpi = soccpi_;
+    moinfo_.openpi = soccpi();
     // We'll remove the frzcpi later in this file.
-    moinfo_.clsdpi = doccpi_;
+    moinfo_.clsdpi = doccpi();
 
     auto nirreps = moinfo_.nirreps;
 

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -157,7 +157,7 @@ class CCEnergyWavefunction : public Wavefunction {
     void pair_energies(std::vector<double>& epair_aa, std::vector<double>& epair_ab) const;
     // Use input AA and AB pair energies to save pair energies to the wavefunction and print them.
     void print_pair_energies(const std::vector<double>& emp2_aa, const std::vector<double>& emp2_ab, const std::vector<double>& ecc_aa, const std::vector<double>& ecc_ab);
-
+    // Form density-fitted integrals and connect them to DPD. Only implemented for RHF.
     void form_df_ints(Options &options, int **cachelist, int *cachefiles);
 
     /* diagnostics */

--- a/psi4/src/psi4/dct/dct_gradient_RHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_RHF.cc
@@ -105,8 +105,8 @@ void DCTSolver::compute_lagrangian_OO_RHF(bool separate_gbargamma) {
     // If we have gbar_gamma separate, just like when computing the OO gradient, we compute these terms special.
     if (separate_gbargamma) {
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, soccpi_ + doccpi_), Slice(zero, nsopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(zero, soccpi_ + doccpi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, nalphapi_), Slice(zero, nsopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(zero, nalphapi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
 
         global_dpd_->file2_init(&H, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "X JK <O|O>");
@@ -243,8 +243,8 @@ void DCTSolver::compute_lagrangian_VV_RHF(bool separate_gbargamma) {
 
     if (separate_gbargamma) {
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(soccpi_ + doccpi_, nsopi_), Slice(zero, nsopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(soccpi_ + doccpi_, nsopi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(nalphapi_, nsopi_), Slice(zero, nsopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(nalphapi_, nsopi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
 
         global_dpd_->file2_init(&H, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "X JK <V|V>");

--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -3093,10 +3093,10 @@ void DCTSolver::compute_lagrangian_OO(bool separate_gbargamma) {
     // If we have gbar_gamma separate, just like when computing the OO gradient, we compute these terms special.
     if (separate_gbargamma) {
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, soccpi_ + doccpi_), Slice(zero, nsopi_));
-        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(zero, doccpi_), Slice(zero, nsopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(zero, soccpi_ + doccpi_));
-        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nsopi_), Slice(zero, doccpi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, nalphapi_), Slice(zero, nsopi_));
+        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(zero, nbetapi_), Slice(zero, nsopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(zero, nalphapi_));
+        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nsopi_), Slice(zero, nbetapi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
         auto beta_jk = linalg::doublet(gbar_beta_block, gamma_beta_block, false, false);
 
@@ -3338,10 +3338,10 @@ void DCTSolver::compute_lagrangian_VV(bool separate_gbargamma) {
     // If we have gbar_gamma separate, just like when computing the OO gradient, we compute these terms special.
     if (separate_gbargamma) {
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(soccpi_ + doccpi_, nsopi_), Slice(zero, nsopi_));
-        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(doccpi_, nsopi_), Slice(zero, nsopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(soccpi_ + doccpi_, nsopi_));
-        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nsopi_), Slice(doccpi_, nsopi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(nalphapi_, nsopi_), Slice(zero, nsopi_));
+        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(nbetapi_, nsopi_), Slice(zero, nsopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nsopi_), Slice(nalphapi_, nsopi_));
+        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nsopi_), Slice(nbetapi_, nsopi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
         auto beta_jk = linalg::doublet(gbar_beta_block, gamma_beta_block, false, false);
 

--- a/psi4/src/psi4/dct/dct_memory.cc
+++ b/psi4/src/psi4/dct/dct_memory.cc
@@ -54,8 +54,6 @@ void DCTSolver::init() {
         reference_wavefunction_->get_dipole_field_strength());
     scf_energy_ = reference_wavefunction_->energy();
     ntriso_ = nso_ * (nso_ + 1) / 2;
-    soccpi_ = reference_wavefunction_->soccpi();
-    doccpi_ = reference_wavefunction_->doccpi();
     frzcpi_ = reference_wavefunction_->frzcpi();
     frzvpi_ = reference_wavefunction_->frzvpi();
     nmopi_ = reference_wavefunction_->nmopi();

--- a/psi4/src/psi4/dct/dct_oo_RHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_RHF.cc
@@ -306,8 +306,8 @@ void DCTSolver::compute_orbital_gradient_OV_RHF(bool separate_gbargamma) {
         // and not the full gamma for the other 2RDM terms.
         // All we need is (gbargamma)^i_p gamma^p_a.
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, soccpi_ + doccpi_), Slice(zero, nmopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(soccpi_ + doccpi_, nmopi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(zero, nalphapi_), Slice(zero, nmopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(nalphapi_, nmopi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
 
         global_dpd_->file2_init(&H, PSIF_DCT_DPD, 0, ID('O'), ID('V'), "X JK <O|V>");
@@ -492,8 +492,8 @@ void DCTSolver::compute_orbital_gradient_VO_RHF(bool separate_gbargamma) {
         // and not the full gamma for the other 2RDM terms.
         // All we need is (gbargamma)^a_p gamma^p_i.
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(soccpi_ + doccpi_, nmopi_), Slice(zero, nmopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(zero, soccpi_ + doccpi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(nalphapi_, nmopi_), Slice(zero, nmopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(zero, nalphapi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
 
         global_dpd_->file2_init(&H, PSIF_DCT_DPD, 0, ID('V'), ID('O'), "X JK <V|O>");

--- a/psi4/src/psi4/dct/dct_oo_UHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_UHF.cc
@@ -698,10 +698,10 @@ void DCTSolver::compute_orbital_gradient_VO(bool separate_gbargamma) {
         // and not the full gamma for the other 2RDM terms.
         // All we need is (gbargamma)^a_p gamma^p_i.
         auto zero = Dimension(nirrep_);
-        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(soccpi_ + doccpi_, nmopi_), Slice(zero, nmopi_));
-        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(doccpi_, nmopi_), Slice(zero, nmopi_));
-        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(zero, soccpi_ + doccpi_));
-        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nmopi_), Slice(zero, doccpi_));
+        auto gbar_alpha_block = mo_gbarGamma_A_.get_block(Slice(nalphapi_, nmopi_), Slice(zero, nmopi_));
+        auto gbar_beta_block = mo_gbarGamma_B_.get_block(Slice(nbetapi_, nmopi_), Slice(zero, nmopi_));
+        auto gamma_alpha_block = mo_gammaA_.get_block(Slice(zero, nmopi_), Slice(zero, nalphapi_));
+        auto gamma_beta_block = mo_gammaB_.get_block(Slice(zero, nmopi_), Slice(zero, nbetapi_));
         auto alpha_jk = linalg::doublet(gbar_alpha_block, gamma_alpha_block, false, false);
         auto beta_jk = linalg::doublet(gbar_beta_block, gamma_beta_block, false, false);
 

--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -98,8 +98,6 @@ void CIWavefunction::common_init() {
     // Data should come from get_dimension(space)
     for (int h = 0; h < nirrep_; ++h) {
         frzcpi_[h] = CalcInfo_->dropped_docc[h];
-        doccpi_[h] = CalcInfo_->docc[h];
-        soccpi_[h] = CalcInfo_->socc[h];
         frzvpi_[h] = CalcInfo_->dropped_uocc[h];
     }
 

--- a/psi4/src/psi4/detci/params.cc
+++ b/psi4/src/psi4/detci/params.cc
@@ -1364,8 +1364,8 @@ void CIWavefunction::print_ras_parameters() {
     orbital_info << seperator;
     orbital_info << _concat_dim("Nso", sdist, nsopi_, tdist, hdist);
     orbital_info << _concat_dim("Nmo", sdist, nmopi_, tdist, hdist);
-    orbital_info << _concat_dim("Ndocc", sdist, doccpi_, tdist, hdist);
-    orbital_info << _concat_dim("Nsocc", sdist, soccpi_, tdist, hdist);
+    orbital_info << _concat_dim("Ndocc", sdist, doccpi(), tdist, hdist);
+    orbital_info << _concat_dim("Nsocc", sdist, soccpi(), tdist, hdist);
     orbital_info << seperator;
 
     // Occupied spaces

--- a/psi4/src/psi4/dfocc/get_moinfo.cc
+++ b/psi4/src/psi4/dfocc/get_moinfo.cc
@@ -57,7 +57,6 @@ void DFOCC::get_moinfo() {
         nmo_ = reference_wavefunction_->nmo();
         nmopi_ = reference_wavefunction_->nmopi();
         nsopi_ = reference_wavefunction_->nsopi();
-        doccpi_ = reference_wavefunction_->doccpi();
         frzcpi_ = reference_wavefunction_->frzcpi();
         frzvpi_ = reference_wavefunction_->frzvpi();
         nalphapi_ = reference_wavefunction_->nalphapi();
@@ -76,7 +75,7 @@ void DFOCC::get_moinfo() {
         // figure out number of MO spaces
         nfrzc = frzcpi_[0];
         nfrzv = frzvpi_[0];
-        noccA = doccpi_[0];
+        noccA = nalphapi_.sum();
         nvirA = nmo_ - noccA;         // Number of virtual orbitals
         naoccA = noccA - nfrzc;       // Number of active occupied orbitals
         navirA = nvirA - nfrzv;       // Number of active virtual orbitals
@@ -162,8 +161,6 @@ void DFOCC::get_moinfo() {
         nmo_ = reference_wavefunction_->nmo();
         nmopi_ = reference_wavefunction_->nmopi();
         nsopi_ = reference_wavefunction_->nsopi();
-        doccpi_ = reference_wavefunction_->doccpi();
-        soccpi_ = reference_wavefunction_->soccpi();
         frzcpi_ = reference_wavefunction_->frzcpi();
         frzvpi_ = reference_wavefunction_->frzvpi();
         nalphapi_ = reference_wavefunction_->nalphapi();
@@ -182,8 +179,8 @@ void DFOCC::get_moinfo() {
         // figure out number of MO spaces
         nfrzc = frzcpi_[0];
         nfrzv = frzvpi_[0];
-        noccA = doccpi_[0] + soccpi_[0];
-        noccB = doccpi_[0];
+        noccA = nalphapi_.sum();
+        noccB = nbetapi_.sum();
         nvirA = nmo_ - noccA;         // Number of virtual orbitals
         nvirB = nmo_ - noccB;         // Number of virtual orbitals
         naoccA = noccA - nfrzc;       // Number of active occupied orbitals

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -89,8 +89,6 @@ void CoupledCluster::common_init() {
     isccsd = options_.get_bool("RUN_CCSD");
 
     escf = reference_wavefunction_->energy();
-    doccpi_ = reference_wavefunction_->doccpi();
-    soccpi_ = reference_wavefunction_->soccpi();
     frzcpi_ = reference_wavefunction_->frzcpi();
     frzvpi_ = reference_wavefunction_->frzvpi();
     nmopi_ = reference_wavefunction_->nmopi();
@@ -103,14 +101,11 @@ void CoupledCluster::common_init() {
     nalpha_ = reference_wavefunction_->nalpha();
     nbeta_ = reference_wavefunction_->nbeta();
 
-    nso = nmo = ndocc = nvirt = nfzc = nfzv = 0;
-    for (int h = 0; h < nirrep_; h++) {
-        nfzc += frzcpi_[h];
-        nfzv += frzvpi_[h];
-        nso += nsopi_[h];
-        nmo += nmopi_[h] - frzcpi_[h] - frzvpi_[h];
-        ndocc += doccpi_[h];
-    }
+    nfzc = frzcpi_.sum();
+    nfzv = frzvpi_.sum();
+    nso = nsopi_.sum();
+    nmo = nmopi_.sum() - nfzc - nfzv;
+    ndocc = doccpi().sum();
     ndoccact = ndocc - nfzc;
     nvirt = nmo - ndoccact;
 
@@ -794,12 +789,12 @@ void CoupledCluster::AllocateMemory() {
     eps = (double *)malloc((ndoccact + nvirt) * sizeof(double));
     std::shared_ptr<Vector> eps_test = reference_wavefunction_->epsilon_a();
     for (int h = 0; h < nirrep_; h++) {
-        for (int norb = frzcpi_[h]; norb < doccpi_[h]; norb++) {
+        for (int norb = frzcpi_[h]; norb < nalphapi_[h]; norb++) {
             eps[count++] = eps_test->get(h, norb);
         }
     }
     for (int h = 0; h < nirrep_; h++) {
-        for (int norb = doccpi_[h]; norb < nmopi_[h] - frzvpi_[h]; norb++) {
+        for (int norb = nalphapi_[h]; norb < nmopi_[h] - frzvpi_[h]; norb++) {
             eps[count++] = eps_test->get(h, norb);
         }
     }

--- a/psi4/src/psi4/fnocc/df_ccsd.cc
+++ b/psi4/src/psi4/fnocc/df_ccsd.cc
@@ -553,12 +553,12 @@ void DFCoupledCluster::AllocateMemory() {
     eps = (double *)malloc((ndoccact + nvirt) * sizeof(double));
     std::shared_ptr<Vector> eps_test = reference_wavefunction_->epsilon_a();
     for (int h = 0; h < nirrep_; h++) {
-        for (int norb = frzcpi_[h]; norb < doccpi_[h]; norb++) {
+        for (int norb = frzcpi_[h]; norb < nalphapi_[h]; norb++) {
             eps[count++] = eps_test->get(h, norb);
         }
     }
     for (int h = 0; h < nirrep_; h++) {
-        for (int norb = doccpi_[h]; norb < nmopi_[h] - frzvpi_[h]; norb++) {
+        for (int norb = nalphapi_[h]; norb < nmopi_[h] - frzvpi_[h]; norb++) {
             eps[count++] = eps_test->get(h, norb);
         }
     }

--- a/psi4/src/psi4/fnocc/opdm.cc
+++ b/psi4/src/psi4/fnocc/opdm.cc
@@ -91,16 +91,16 @@ void CoupledPair::OPDM() {
     }
     // active doubly occupied
     for (int h = 0; h < nirrep_; h++) {
-        int norbs = doccpi_[h] - frzcpi_[h];
+        int norbs = nalphapi_[h] - frzcpi_[h];
         for (int i = 0; i < norbs; i++) {
             reorder[irrepoffset[h] + i + frzcpi_[h]] = count++;
         }
     }
     // active virtual
     for (int h = 0; h < nirrep_; h++) {
-        int norbs = nmopi_[h] - frzvpi_[h] - doccpi_[h];
+        int norbs = nmopi_[h] - frzvpi_[h] - nalphapi_[h];
         for (int i = 0; i < norbs; i++) {
-            reorder[irrepoffset[h] + i + doccpi_[h]] = count++;
+            reorder[irrepoffset[h] + i + nalphapi_[h]] = count++;
         }
     }
     // frozen virtual

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -744,7 +744,7 @@ const Dimension Wavefunction::doccpi(bool warn_on_beta_socc) const {
     for (int h = 0; h < nalphapi_.n(); h++) {
         docc_vec.push_back(std::min(nalphapi_[h], nbetapi_[h]));
         if (warn_on_beta_socc && nbetapi_[h] > nalphapi_[h]) {
-            outfile->Printf("Warning! Irrep has more beta than alpha electrons in symmetry %d orbitals.\n", d);
+            outfile->Printf("Warning! Irrep has more beta than alpha electrons in symmetry %d orbitals.\n", h);
         }
     }
     return docc_vec;

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -744,7 +744,7 @@ const Dimension Wavefunction::doccpi(bool warn_on_beta_socc) const {
     for (int h = 0; h < nalphapi_.n(); h++) {
         docc_vec.push_back(std::min(nalphapi_[h], nbetapi_[h]));
         if (warn_on_beta_socc && nbetapi_[h] > nalphapi_[h]) {
-            outfile->Printf("Warning! Irrep has more beta than alpha electrons.\n");
+            outfile->Printf("Warning! Irrep has more beta than alpha electrons in symmetry %d orbitals.\n", d);
         }
     }
     return docc_vec;
@@ -755,7 +755,7 @@ const Dimension Wavefunction::soccpi(bool warn_on_beta_socc) const {
     for (int h = 0; h < nalphapi_.n(); h++) {
         socc_vec.push_back(std::abs(nalphapi_[h] - nbetapi_[h]));
         if (warn_on_beta_socc && nbetapi_[h] > nalphapi_[h]) {
-            outfile->Printf("Warning! Irrep has more beta than alpha electrons.\n");
+            outfile->Printf("Warning! Irrep has more beta than alpha electrons in symmetry %d orbitals.\n", h);
         }
     }
     return socc_vec;

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -739,6 +739,28 @@ void Wavefunction::initialize_singletons() {
     done = true;
 }
 
+const Dimension Wavefunction::doccpi(bool assume_socc_alpha) const {
+    std::vector<int> docc_vec;
+    for (int h = 0; h < nalphapi_.n(); h++) {
+        docc_vec.push_back(std::min(nalphapi_[h], nbetapi_[h]));
+        if (assume_socc_alpha && nbetapi_[h] > nalphapi_[h]) {
+            outfile->Printf("Warning! Irrep has more beta than alpha electrons.\n");
+        }
+    }
+    return docc_vec;
+}
+/// Returns the SOCC per irrep array. Not recommended for unrestricted code.
+const Dimension Wavefunction::soccpi(bool assume_socc_alpha) const {
+    std::vector<int> socc_vec;
+    for (int h = 0; h < nalphapi_.n(); h++) {
+        socc_vec.push_back(std::abs(nalphapi_[h] - nbetapi_[h]));
+        if (assume_socc_alpha && nbetapi_[h] > nalphapi_[h]) {
+            outfile->Printf("Warning! Irrep has more beta than alpha electrons.\n");
+        }
+    }
+    return socc_vec;
+}
+
 std::shared_ptr<Molecule> Wavefunction::molecule() const { return molecule_; }
 
 std::shared_ptr<PSIO> Wavefunction::psio() const { return psio_; }

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -375,21 +375,9 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     static void initialize_singletons();
 
     /// Returns the DOCC per irrep array. Not recommended for unrestricted code.
-    const Dimension doccpi() const {
-        std::vector<int> docc_vec;
-        for (int h = 0; h < nalphapi_.n(); h++) {
-            docc_vec.push_back(std::min(nalphapi_[h], nbetapi_[h]));
-        }
-        return docc_vec;
-    }
+    const Dimension doccpi(bool assume_socc_alpha = true) const;
     /// Returns the SOCC per irrep array. Not recommended for unrestricted code.
-    const Dimension soccpi() const {
-        std::vector<int> socc_vec;
-        for (int h = 0; h < nalphapi_.n(); h++) {
-            socc_vec.push_back(std::abs(nalphapi_[h] - nbetapi_[h]));
-        }
-        return socc_vec;
-    }
+    const Dimension soccpi(bool assume_socc_alpha = true) const;
     /// Returns the number of SOs per irrep array.
     const Dimension& nsopi() const { return nsopi_; }
     /// Returns the number of MOs per irrep array.

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -375,8 +375,12 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     static void initialize_singletons();
 
     /// Returns the DOCC per irrep array. Not recommended for unrestricted code.
+    /// Flag `warn_on_beta_socc` triggers warning on singly occupied beta orbitals,
+    /// which break assumptions made in pre-1.7 DOCC/SOCC handling.
     const Dimension doccpi(bool warn_on_beta_socc = true) const;
     /// Returns the SOCC per irrep array. Not recommended for unrestricted code.
+    /// Flag `warn_on_beta_socc` triggers warning on singly occupied beta orbitals,
+    /// which break assumptions made in pre-1.7 DOCC/SOCC handling.
     const Dimension soccpi(bool warn_on_beta_socc = true) const;
     /// Returns the number of SOs per irrep array.
     const Dimension& nsopi() const { return nsopi_; }

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -142,10 +142,6 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Total frozen core orbitals
     int nfrzc_;
 
-    /// Number of doubly occupied per irrep
-    Dimension doccpi_;
-    /// Number of singly occupied per irrep
-    Dimension soccpi_;
     /// Number of frozen core per irrep
     Dimension frzcpi_;
     /// Number of frozen virtuals per irrep
@@ -378,10 +374,22 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     int get_print() const { return print_; }
     static void initialize_singletons();
 
-    /// Returns the DOCC per irrep array.
-    const Dimension& doccpi() const { return doccpi_; }
-    /// Returns the SOCC per irrep array.
-    const Dimension& soccpi() const { return soccpi_; }
+    /// Returns the DOCC per irrep array. Not recommended for unrestricted code.
+    const Dimension doccpi() const {
+        std::vector<int> docc_vec;
+        for (int h = 0; h < nalphapi_.n(); h++) {
+            docc_vec.push_back(std::min(nalphapi_[h], nbetapi_[h]));
+        }
+        return docc_vec;
+    }
+    /// Returns the SOCC per irrep array. Not recommended for unrestricted code.
+    const Dimension soccpi() const {
+        std::vector<int> socc_vec;
+        for (int h = 0; h < nalphapi_.n(); h++) {
+            socc_vec.push_back(std::abs(nalphapi_[h] - nbetapi_[h]));
+        }
+        return socc_vec;
+    }
     /// Returns the number of SOs per irrep array.
     const Dimension& nsopi() const { return nsopi_; }
     /// Returns the number of MOs per irrep array.

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -375,9 +375,9 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     static void initialize_singletons();
 
     /// Returns the DOCC per irrep array. Not recommended for unrestricted code.
-    const Dimension doccpi(bool assume_socc_alpha = true) const;
+    const Dimension doccpi(bool warn_on_beta_socc = true) const;
     /// Returns the SOCC per irrep array. Not recommended for unrestricted code.
-    const Dimension soccpi(bool assume_socc_alpha = true) const;
+    const Dimension soccpi(bool warn_on_beta_socc = true) const;
     /// Returns the number of SOs per irrep array.
     const Dimension& nsopi() const { return nsopi_; }
     /// Returns the number of MOs per irrep array.
@@ -396,17 +396,11 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     FieldType get_dipole_perturbation_type() const;
 
     /**
-     * @brief Expert specialized use only. Sets the number of doubly occupied orbitals per irrep. Results in an
+     * @brief Expert specialized use only. Sets the number of doubly and singly occupied orbitals per irrep. Results in an
      * inconsistent Wavefunction object for SCF purposes, so caution is advised.
      * @param doccpi the new list of doubly occupied orbitals per irrep
      */
-    void force_doccpi(const Dimension& doccpi);
-    /**
-     * @brief Expert specialized use only. Sets the number of singly occupied orbitals per irrep. Results in an
-     * inconsistent Wavefunction object for SCF purposes, so caution is advised.
-     * @param soccpi the new list of singly occupied orbitals per irrep
-     */
-    void force_soccpi(const Dimension& soccpi);
+    void force_occpi(const Dimension& input_doccpi, const Dimension& input_soccpi);
 
     /// Sets the frozen virtual orbitals per irrep array.
     void set_frzvpi(const Dimension& frzvpi);

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -59,10 +59,10 @@ void normalize(double** A, int rows, int cols);
 double invert_matrix(double** a, double** y, int N, std::string out_fname);
 void solve_2x2_pep(double** H, double S, double* evals, double** evecs);
 PSI_API
-void reorder_qt(int* docc_in, int* socc_in, int* frozen_docc_in, int* frozen_uocc_in, int* order, int* orbs_per_irrep,
+void reorder_qt(const int* docc_in, const int* socc_in, int* frozen_docc_in, int* frozen_uocc_in, int* order, int* orbs_per_irrep,
                 int nirreps);
 PSI_API
-void reorder_qt_uhf(int* docc, int* socc, int* frozen_docc, int* frozen_uocc, int* order_alpha, int* order_beta,
+void reorder_qt_uhf(const int* docc, const int* socc, int* frozen_docc, int* frozen_uocc, int* order_alpha, int* order_beta,
                     int* orbspi, int nirreps);
 // int ras_set(int nirreps, int nbfso, int freeze_core, int *orbspi,
 //      int *docc, int *socc, int *frdocc, int *fruocc,

--- a/psi4/src/psi4/libqt/reorder_qt.cc
+++ b/psi4/src/psi4/libqt/reorder_qt.cc
@@ -70,7 +70,7 @@ namespace psi {
 **
 ** \ingroup QT
 */
-PSI_API void reorder_qt(int *docc_in, int *socc_in, int *frozen_docc_in, int *frozen_uocc_in, int *order,
+PSI_API void reorder_qt(const int *docc_in, const int *socc_in, int *frozen_docc_in, int *frozen_uocc_in, int *order,
                         int *orbs_per_irrep, int nirreps) {
     int cnt = 0, irrep, point, tmpi;
     int *used, *offset;
@@ -193,7 +193,7 @@ PSI_API void reorder_qt(int *docc_in, int *socc_in, int *frozen_docc_in, int *fr
 **
 ** \ingroup QT
 */
-PSI_API void reorder_qt_uhf(int *docc, int *socc, int *frozen_docc, int *frozen_uocc, int *order_alpha, int *order_beta,
+PSI_API void reorder_qt_uhf(const int *docc, const int *socc, int *frozen_docc, int *frozen_uocc, int *order_alpha, int *order_beta,
                             int *orbspi, int nirreps) {
     int p, nmo;
     int cnt_alpha, cnt_beta, irrep, tmpi;

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -114,12 +114,11 @@ void CUHF::finalize() {
         for (int m = 0; m < Lagrangian_->rowdim(h); ++m) {
             for (int n = 0; n < Lagrangian_->coldim(h); ++n) {
                 double sum = 0.0;
-                for (int i = 0; i < doccpi_[h]; ++i) {
-                    sum += epsilon_a_->get(h, i) * Ca_->get(h, m, i) * Ca_->get(h, n, i) +
-                           epsilon_b_->get(h, i) * Cb_->get(h, m, i) * Cb_->get(h, n, i);
-                }
-                for (int i = doccpi_[h]; i < doccpi_[h] + soccpi_[h]; ++i)
+                for (int i = 0; i < nalphapi_[h]; ++i) {
                     sum += epsilon_a_->get(h, i) * Ca_->get(h, m, i) * Ca_->get(h, n, i);
+                }
+                for (int i = 0; i < nbetapi_[h]; ++i)
+                    sum += epsilon_b_->get(h, i) * Cb_->get(h, m, i) * Cb_->get(h, n, i);
 
                 Lagrangian_->set(h, m, n, sum);
             }
@@ -273,8 +272,8 @@ void CUHF::form_F() {
     //            [   0   Fm_vo Fm_vv ]
     //
     for (int h = 0; h < nirrep_; ++h) {
-        for (int i = 0; i < doccpi_[h]; ++i) {
-            for (int j = doccpi_[h] + soccpi_[h]; j < nmopi_[h]; ++j) {
+        for (int i = 0; i < nbetapi_[h]; ++i) {
+            for (int j = nalphapi_[h]; j < nmopi_[h]; ++j) {
                 Fm_->set(h, i, j, 0.0);
                 Fm_->set(h, j, i, 0.0);
             }

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1209,15 +1209,13 @@ void HF::print_occupation() {
         for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", socc[h]);
         outfile->Printf(" %4d ]\n", socc[nirrep_ - 1]);
     }
-    if (MOM_excited_) {
-        // Also print nalpha and nbeta per irrep, which are more physically meaningful
-        outfile->Printf("    NA   [ ");
-        for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", nalphapi_[h]);
-        outfile->Printf(" %4d ]\n", nalphapi_[nirrep_ - 1]);
-        outfile->Printf("    NB   [ ");
-        for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", nbetapi_[h]);
-        outfile->Printf(" %4d ]\n", nbetapi_[nirrep_ - 1]);
-    }
+    // Also print nalpha and nbeta per irrep, which are more physically meaningful
+    outfile->Printf("    NA   [ ");
+    for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", nalphapi_[h]);
+    outfile->Printf(" %4d ]\n", nalphapi_[nirrep_ - 1]);
+    outfile->Printf("    NB   [ ");
+    for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", nbetapi_[h]);
+    outfile->Printf(" %4d ]\n", nbetapi_[nirrep_ - 1]);
 
     outfile->Printf("\n");
 }

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -361,11 +361,8 @@ void HF::rotate_orbitals(SharedMatrix C, const SharedMatrix x) {
     U->expm(4, true);
 
     // Need to build a new one here incase nmo != nso
-    SharedMatrix tmp = linalg::doublet(C, U, false, false);
+    auto tmp = linalg::doublet(C, U, false, false);
     C->copy(tmp);
-
-    U.reset();
-    tmp.reset();
 }
 void HF::initialize_gtfock_jk() {
     // Build the JK from options, symmetric type
@@ -670,11 +667,11 @@ void HF::form_H() {
         if (options_.get_bool("EXTERNAL_POTENTIAL_SYMMETRY") == false && H_->nirrep() != 1)
             throw PSIEXCEPTION("SCF: External Fields are not consistent with symmetry. Set symmetry c1.");
 
-        SharedMatrix Vprime = external_pot_->computePotentialMatrix(basisset_);
+        auto Vprime = external_pot_->computePotentialMatrix(basisset_);
 
         if (options_.get_bool("EXTERNAL_POTENTIAL_SYMMETRY")) {
             // Attempt to apply symmetry. No error checking is performed.
-            SharedMatrix Vprimesym = factory_->create_shared_matrix("External Potential");
+            auto Vprimesym = factory_->create_shared_matrix("External Potential");
             Vprimesym->apply_symmetry(Vprime, AO2SO_);
             Vprime = Vprimesym;
         }
@@ -1157,7 +1154,7 @@ void HF::guess() {
         if (print_)
             outfile->Printf("  SCF Guess: Superposition of Atomic Potentials (doi:10.1021/acs.jctc.8b01089).\n\n");
 
-        std::shared_ptr<psi::VBase> builder = VBase::build_V(basisset_, functional_, options_, "SAP");
+        auto builder = VBase::build_V(basisset_, functional_, options_, "SAP");
         builder->initialize();
 
         // Print info on the integration grid
@@ -1227,8 +1224,8 @@ void HF::check_phases() {
 }
 
 void HF::print_occupation() {
-    std::vector<std::string> labels = molecule_->irrep_labels();
-    std::string reference = options_.get_str("REFERENCE");
+    auto labels = molecule_->irrep_labels();
+    auto reference = options_.get_str("REFERENCE");
     outfile->Printf("          ");
     for (int h = 0; h < nirrep_; ++h) outfile->Printf(" %4s ", labels[h].c_str());
     outfile->Printf("\n");

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -125,6 +125,7 @@ void HF::common_init() {
 
     // Read in DOCC and SOCC from memory
     input_docc_ = false;
+    Dimension docc(nirrep_);
     if (options_["DOCC"].has_changed()) {
         input_docc_ = true;
         // Map the symmetry of the input DOCC, to account for displacements
@@ -140,18 +141,19 @@ void HF::common_init() {
             for (int h = 0; h < full_nirreps; ++h) {
                 temp_docc[h] = options_["DOCC"][h].to_integer();
             }
-            doccpi_ = map_irreps(temp_docc);
+            docc = map_irreps(temp_docc);
         } else {
             // This is a normal calculation; check the dimension against the current point group
             // then read
             if (options_["DOCC"].size() != nirrep_) throw PSIEXCEPTION("Input DOCC array has the wrong dimensions");
             for (int h = 0; h < nirrep_; ++h) {
-                doccpi_[h] = options_["DOCC"][h].to_integer();
+                docc[h] = options_["DOCC"][h].to_integer();
             }
         }
     }  // else take the reference wavefunctions doccpi
 
     input_socc_ = false;
+    Dimension socc(nirrep_);
     if (options_["SOCC"].has_changed()) {
         input_socc_ = true;
         // Map the symmetry of the input SOCC, to account for displacements
@@ -167,33 +169,22 @@ void HF::common_init() {
             for (int h = 0; h < full_nirreps; ++h) {
                 temp_socc[h] = options_["SOCC"][h].to_integer();
             }
-            soccpi_ = map_irreps(temp_socc);
+            socc = map_irreps(temp_socc);
         } else {
             // This is a normal calculation; check the dimension against the current point group
             // then read
             if (options_["SOCC"].size() != nirrep_) throw PSIEXCEPTION("Input SOCC array has the wrong dimensions");
             for (int h = 0; h < nirrep_; ++h) {
-                soccpi_[h] = options_["SOCC"][h].to_integer();
+                socc[h] = options_["SOCC"][h].to_integer();
             }
         }
     }  // else take the reference wavefunctions soccpi
 
-    // Check that we have enough basis functions
-    for (int h = 0; h < nirrep_; ++h) {
-        if (doccpi_[h] + soccpi_[h] > nsopi_[h]) {
-            throw PSIEXCEPTION("Not enough basis functions to satisfy requested occupancies");
-        }
-    }
-
     if (input_socc_ || input_docc_) {
-        int alphacount = 0;
-        int betacount = 0;
-        for (int h = 0; h < nirrep_; h++) {
-            nalphapi_[h] = doccpi_[h] + soccpi_[h];
-            nbetapi_[h] = doccpi_[h];
-            alphacount += nalphapi_[h];
-            betacount += nbetapi_[h];
-        }
+        nalphapi_ = docc + socc;
+        nbetapi_ = docc;
+        int alphacount = nalphapi_.sum();
+        int betacount = nbetapi_.sum();
         if (alphacount != nalpha_) {
             std::ostringstream oss;
             oss << "Got " << alphacount << " alpha electrons, expected " << nalpha_ << ".\n";
@@ -208,6 +199,13 @@ void HF::common_init() {
         }
     }
 
+    // Check that we have enough basis functions
+    for (int h = 0; h < nirrep_; ++h) {
+        if (std::max(nalphapi_[h], nbetapi_[h]) > nsopi_[h]) {
+            throw PSIEXCEPTION("Not enough basis functions to satisfy requested occupancies");
+        }
+    }
+
     // Set additional information
     nuclearrep_ = molecule_->nuclear_repulsion_energy(dipole_field_strength_);
     charge_ = molecule_->molecular_charge();
@@ -215,8 +213,8 @@ void HF::common_init() {
     nelectron_ = nbeta_ + nalpha_;
 
     // Copy data for storage
-    original_doccpi_ = doccpi_;
-    original_soccpi_ = soccpi_;
+    original_nalphapi_ = nalphapi_;
+    original_nbetapi_ = nbetapi_;
     original_nalpha_ = nalpha_;
     original_nbeta_ = nbeta_;
 
@@ -336,7 +334,7 @@ void HF::rotate_orbitals(SharedMatrix C, const SharedMatrix x) {
     if ((reference != "ROHF") && (tsize != nmopi_)) {
         throw PSIEXCEPTION("HF::rotate_orbitals: x dimensions do not match nmo_ dimension.");
     }
-    tsize = x->colspi() + x->rowspi() - soccpi_;
+    tsize = x->colspi() + x->rowspi() - soccpi();
     if ((reference == "ROHF") && (tsize != nmopi_)) {
         throw PSIEXCEPTION("HF::rotate_orbitals: x dimensions do not match nmo_ dimension.");
     }
@@ -421,6 +419,8 @@ void HF::find_occupation() {
     if (MOM_performed_) {
         MOM();
     } else {
+        auto old_nalphapi = nalphapi_;
+        auto old_nbetapi = nbetapi_;
         if (!input_docc_ && !input_socc_) {
             assert(nirrep_ == epsilon_a_->nirrep());
             assert(nirrep_ == epsilon_b_->nirrep());
@@ -459,19 +459,9 @@ void HF::find_occupation() {
             for (int i = 0; i < nbeta_; ++i) nbetapi_[pairs_b[i].second]++;
         }
 
-        // Copies of socc and docc
-        Dimension old_socc = soccpi_;
-        Dimension old_docc = doccpi_;
-
         if (!input_docc_ && !input_socc_) {
-            int alphacount = 0;
-            int betacount = 0;
-            for (int h = 0; h < nirrep_; ++h) {
-                soccpi_[h] = std::abs(nalphapi_[h] - nbetapi_[h]);
-                doccpi_[h] = std::min(nalphapi_[h], nbetapi_[h]);
-                alphacount += doccpi_[h] + soccpi_[h];
-                betacount += doccpi_[h];
-            }
+            int alphacount = nalphapi_.sum();
+            int betacount = nbetapi_.sum();
             if (alphacount != nalpha_) {
                 std::ostringstream oss;
                 oss << "Count " << alphacount << " alpha electrons, expected " << nalpha_ << ".\n";
@@ -486,7 +476,7 @@ void HF::find_occupation() {
             }
         }
 
-        bool occ_changed = (soccpi_ != old_socc) || (doccpi_ != old_docc);
+        bool occ_changed = (nalphapi_ != old_nalphapi) || (nbetapi_ != old_nbetapi);
 
         // If print > 2 (diagnostics), print always
         if ((print_ > 2 || (print_ && occ_changed)) && iteration_ > 0) {
@@ -1025,8 +1015,6 @@ void HF::guess() {
             nbetapi_ = guess_Cb_->colspi();
             nalpha_ = nalphapi_.sum();
             nbeta_ = nbetapi_.sum();
-            soccpi_ = nalphapi_ - nbetapi_;
-            doccpi_ = nalphapi_ - soccpi_;
         }
 
         format_guess();
@@ -1211,13 +1199,15 @@ void HF::print_occupation() {
     outfile->Printf("          ");
     for (int h = 0; h < nirrep_; ++h) outfile->Printf(" %4s ", labels[h].c_str());
     outfile->Printf("\n");
+    auto docc = doccpi();
+    auto socc = soccpi();
     outfile->Printf("    DOCC [ ");
-    for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", doccpi_[h]);
-    outfile->Printf(" %4d ]\n", doccpi_[nirrep_ - 1]);
+    for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", docc[h]);
+    outfile->Printf(" %4d ]\n", docc[nirrep_ - 1]);
     if (reference != "RHF" && reference != "RKS") {
         outfile->Printf("    SOCC [ ");
-        for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", soccpi_[h]);
-        outfile->Printf(" %4d ]\n", soccpi_[nirrep_ - 1]);
+        for (int h = 0; h < nirrep_ - 1; ++h) outfile->Printf(" %4d,", socc[h]);
+        outfile->Printf(" %4d ]\n", socc[nirrep_ - 1]);
     }
     if (MOM_excited_) {
         // Also print nalpha and nbeta per irrep, which are more physically meaningful
@@ -1285,10 +1275,8 @@ void HF::diagonalize_F(const SharedMatrix& Fm, SharedMatrix& Cm, std::shared_ptr
 
 void HF::reset_occupation() {
     // RHF style for now
-    doccpi_ = original_doccpi_;
-    soccpi_ = original_soccpi_;
-    nalphapi_ = doccpi_ + soccpi_;
-    nbetapi_ = doccpi_;
+    nalphapi_ = original_nalphapi_;
+    nbetapi_ = original_nbetapi_;
 
     // These may not match the per irrep. Will remap correctly next find_occupation call
     nalpha_ = original_nalpha_;

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -109,9 +109,8 @@ class HF : public Wavefunction {
     bool broken_symmetry_;
 
     // Initial SAD doubly occupied may be more than ndocc
-    // int sad_nocc_[8];
-    Dimension original_doccpi_;
-    Dimension original_soccpi_;
+    Dimension original_nalphapi_;
+    Dimension original_nbetapi_;
     int original_nalpha_;
     int original_nbeta_;
     // Reset occupations in SCF iteration?

--- a/psi4/src/psi4/libscf_solver/mom.cc
+++ b/psi4/src/psi4/libscf_solver/mom.cc
@@ -201,7 +201,6 @@ void HF::MOM_start() {
                 // Redo indexing
                 nalphapi_[hi]--;
                 nbetapi_[hi]--;
-                doccpi_[hi]--;
 
                 // Vir -> Occ
                 int pa = orbs_a[a].second.second;
@@ -229,7 +228,6 @@ void HF::MOM_start() {
                 // Redo indexing
                 nalphapi_[ha]++;
                 nbetapi_[ha]++;
-                doccpi_[ha]++;
 
                 outfile->Printf("   %8s: %4d%-4s -> %4d%-4s \n", "AB -> AB", pi + 1, ct.gamma(hi).symbol(), pa + 1,
                                 ct.gamma(ha).symbol());
@@ -545,41 +543,6 @@ void HF::MOM_start() {
             }
             if (nalpha_ < nbeta_)
                 throw PSIEXCEPTION("PSI::MOM_start: Nbeta ends up being less than Nalpha, this is not supported");
-
-            // Fix doccpi/soccpi. In MOM, we do _not_ assume that all singly occupied orbitals are alpha.
-            // All we assume is that when you pair the alpha and beta orbitals of a given irrep by energy,
-            // two being occupied increments docc, and one being occupied increments soccpi.
-            for (int h = 0; h < nirrep_; h++) {
-                std::vector<std::pair<double, std::pair<int, bool> > > alphas;
-                std::vector<std::pair<double, std::pair<int, bool> > > betas;
-
-                for (int i = 0; i < nalphapi_[h]; i++) {
-                    alphas.push_back(std::make_pair(epsilon_a_->get(h, i), std::make_pair(i, true)));
-                }
-                for (int i = 0; i < nbetapi_[h]; i++) {
-                    betas.push_back(std::make_pair(epsilon_b_->get(h, i), std::make_pair(i, true)));
-                }
-                for (int i = nalphapi_[h]; i < nmopi_[h]; i++) {
-                    alphas.push_back(std::make_pair(epsilon_a_->get(h, i), std::make_pair(i, false)));
-                }
-                for (int i = nbetapi_[h]; i < nmopi_[h]; i++) {
-                    betas.push_back(std::make_pair(epsilon_b_->get(h, i), std::make_pair(i, false)));
-                }
-                sort(alphas.begin(), alphas.end());
-                sort(betas.begin(), betas.end());
-
-                doccpi_[h] = 0;
-                soccpi_[h] = 0;
-
-                for (int i = 0; i < nmopi_[h]; i++) {
-                    bool alpha_occ = alphas[i].second.second;
-                    bool beta_occ = betas[i].second.second;
-                    if (alpha_occ && beta_occ)
-                        doccpi_[h]++;
-                    else if (alpha_occ || beta_occ)  // Careful, could be beta occ
-                        soccpi_[h]++;
-                }
-            }
 
         } else if (options_.get_str("REFERENCE") == "ROHF") {
             throw PSIEXCEPTION("SCF::MOM_start: MOM excited states are not implemented for ROHF");

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -138,27 +138,27 @@ void ROHF::semicanonicalize() {
 
     // Pick out occ-occ, and vir-vir subsets of the Fock matrices
     Dimension dim_zero(nirrep_);
-    Dimension aoccpi = doccpi_ + soccpi_;
-    Dimension boccpi = doccpi_;
-    Dimension avirpi = nmopi_ - aoccpi;
-    Dimension bvirpi = nmopi_ - boccpi;
+    auto aoccpi = nalphapi_;
+    auto boccpi = nbetapi_;
+    auto avirpi = nmopi_ - aoccpi;
+    auto bvirpi = nmopi_ - boccpi;
     Slice aocc_slice(dim_zero, aoccpi);
     Slice bocc_slice(dim_zero, boccpi);
     Slice avir_slice(aoccpi, nmopi_);
     Slice bvir_slice(boccpi, nmopi_);
-    SharedMatrix aFOO = moFa->get_block(aocc_slice, aocc_slice);
-    SharedMatrix aFVV = moFa->get_block(avir_slice, avir_slice);
-    SharedMatrix bFOO = moFb->get_block(bocc_slice, bocc_slice);
-    SharedMatrix bFVV = moFb->get_block(bvir_slice, bvir_slice);
+    auto aFOO = moFa->get_block(aocc_slice, aocc_slice);
+    auto aFVV = moFa->get_block(avir_slice, avir_slice);
+    auto bFOO = moFb->get_block(bocc_slice, bocc_slice);
+    auto bFVV = moFb->get_block(bvir_slice, bvir_slice);
 
     // Canonicalize the Alpha occ-occ block
     evecs = std::make_shared<Matrix>(aoccpi, aoccpi);
     evals = std::make_shared<Vector>(aoccpi);
     aFOO->diagonalize(evecs, evals);
     for (int h = 0; h < nirrep_; ++h) {
-        double** pC = Crohf->pointer(h);
-        double** pCa = Ca_->pointer(h);
-        double** pR = evecs->pointer(h);
+        auto pC = Crohf->pointer(h);
+        auto pCa = Ca_->pointer(h);
+        auto pR = evecs->pointer(h);
         if (aoccpi[h]) {
             C_DGEMM('n', 'n', nsopi_[h], aoccpi[h], aoccpi[h], 1.0, pC[0], nmopi_[h], pR[0], aoccpi[h], 0.0, pCa[0],
                     nmopi_[h]);
@@ -176,9 +176,9 @@ void ROHF::semicanonicalize() {
     evals = std::make_shared<Vector>(avirpi);
     aFVV->diagonalize(evecs, evals);
     for (int h = 0; h < nirrep_; ++h) {
-        double** pC = Crohf->pointer(h);
-        double** pCa = Ca_->pointer(h);
-        double** pR = evecs->pointer(h);
+        auto pC = Crohf->pointer(h);
+        auto pCa = Ca_->pointer(h);
+        auto pR = evecs->pointer(h);
         if (avirpi[h]) {
             C_DGEMM('n', 'n', nsopi_[h], avirpi[h], avirpi[h], 1.0, &(pC[0][aoccpi[h]]), nmopi_[h], pR[0], avirpi[h],
                     0.0, &(pCa[0][aoccpi[h]]), nmopi_[h]);
@@ -196,9 +196,9 @@ void ROHF::semicanonicalize() {
     evals = std::make_shared<Vector>(boccpi);
     bFOO->diagonalize(evecs, evals);
     for (int h = 0; h < nirrep_; ++h) {
-        double** pC = Crohf->pointer(h);
-        double** pCb = Cb_->pointer(h);
-        double** pR = evecs->pointer(h);
+        auto pC = Crohf->pointer(h);
+        auto pCb = Cb_->pointer(h);
+        auto pR = evecs->pointer(h);
         if (boccpi[h]) {
             C_DGEMM('n', 'n', nsopi_[h], boccpi[h], boccpi[h], 1.0, pC[0], nmopi_[h], pR[0], boccpi[h], 0.0, pCb[0],
                     nmopi_[h]);
@@ -216,9 +216,9 @@ void ROHF::semicanonicalize() {
     evals = std::make_shared<Vector>(bvirpi);
     bFVV->diagonalize(evecs, evals);
     for (int h = 0; h < nirrep_; ++h) {
-        double** pC = Crohf->pointer(h);
-        double** pCb = Cb_->pointer(h);
-        double** pR = evecs->pointer(h);
+        auto pC = Crohf->pointer(h);
+        auto pCb = Cb_->pointer(h);
+        auto pR = evecs->pointer(h);
         if (bvirpi[h]) {
             C_DGEMM('n', 'n', nsopi_[h], bvirpi[h], bvirpi[h], 1.0, &(pC[0][boccpi[h]]), nmopi_[h], pR[0], bvirpi[h],
                     0.0, &(pCb[0][boccpi[h]]), nmopi_[h]);
@@ -249,19 +249,19 @@ void ROHF::finalize() {
     // --EGH
     //
     // Let's build the MO Lagrangian in moFeff_
-    // ...I'm assuming these bitches are square
+    // ...I'm assuming these are square
     moFeff_->zero();
     moFa_->transform(Fa_, Ca_);
     moFb_->transform(Fb_, Ca_);
     for (int h = 0; h < nirrep_; ++h) {
         for (int m = 0; m < moFeff_->rowdim(h); ++m) {
             double tval;
-            for (int i = 0; i < doccpi_[h]; ++i) {
+            for (int i = 0; i < nbetapi_[h]; ++i) {
                 tval = moFa_->get(h, m, i);
                 tval += moFb_->get(h, m, i);
                 moFeff_->set(h, m, i, tval);
             }
-            for (int i = doccpi_[h]; i < doccpi_[h] + soccpi_[h]; ++i) {
+            for (int i = nbetapi_[h]; i < nalphapi_[h]; ++i) {
                 tval = moFa_->get(h, m, i);
                 moFeff_->set(h, m, i, tval);
             }
@@ -345,15 +345,15 @@ void ROHF::form_F() {
     moFeff_->add(moFb_);
     moFeff_->scale(0.5);
     for (int h = 0; h < nirrep_; ++h) {
-        for (int i = doccpi_[h]; i < doccpi_[h] + soccpi_[h]; ++i) {
+        for (int i = nbetapi_[h]; i < nalphapi_[h]; ++i) {
             // Set the open/closed portion
-            for (int j = 0; j < doccpi_[h]; ++j) {
+            for (int j = 0; j < nbetapi_[h]; ++j) {
                 double val = moFb_->get(h, i, j);
                 moFeff_->set(h, i, j, val);
                 moFeff_->set(h, j, i, val);
             }
             // Set the open/virtual portion
-            for (int j = doccpi_[h] + soccpi_[h]; j < nmopi_[h]; ++j) {
+            for (int j = nalphapi_[h]; j < nmopi_[h]; ++j) {
                 double val = moFa_->get(h, i, j);
                 moFeff_->set(h, i, j, val);
                 moFeff_->set(h, j, i, val);
@@ -391,14 +391,14 @@ void ROHF::form_C(double shift) {
         Dimension dim_zero(nirrep_);
 
         // Shift open-shell orbitals by 0.5*shift
-        Dimension ospi = nalphapi_ - nbetapi_;
-        SharedMatrix Cos = Ct_->get_block({dim_zero, nmopi_}, {nbetapi_, nbetapi_ + ospi});
+        auto ospi = nalphapi_ - nbetapi_;
+        auto Cos = Ct_->get_block({dim_zero, nmopi_}, {nbetapi_, nbetapi_ + ospi});
         Cos->set_name("Cos");
         shifted_F->gemm(false, true, 0.5 * shift, Cos, Cos, 0.0);
 
         // Shift virtuals by shift
-        Dimension virpi = nmopi_ - nalphapi_;
-        SharedMatrix Cvir = Ct_->get_block({dim_zero, nmopi_}, {nalphapi_, nalphapi_ + virpi});
+        auto virpi = nmopi_ - nalphapi_;
+        auto Cvir = Ct_->get_block({dim_zero, nmopi_}, {nalphapi_, nalphapi_ + virpi});
         Cvir->set_name("Cvir");
         shifted_F->gemm(false, true, shift, Cvir, Cvir, 1.0);
 
@@ -461,9 +461,9 @@ void ROHF::form_D() {
 
         if (nso == 0 || nmo == 0) continue;
 
-        double** Ca = Ca_->pointer(h);
-        double** Da = Da_->pointer(h);
-        double** Db = Db_->pointer(h);
+        auto Ca = Ca_->pointer(h);
+        auto Da = Da_->pointer(h);
+        auto Db = Db_->pointer(h);
 
         C_DGEMM('N', 'T', nso, nso, na, 1.0, Ca[0], nmo, Ca[0], nmo, 0.0, Da[0], nso);
         C_DGEMM('N', 'T', nso, nso, nb, 1.0, Ca[0], nmo, Ca[0], nmo, 0.0, Db[0], nso);
@@ -507,9 +507,11 @@ void ROHF::Hx(SharedMatrix x, SharedMatrix ret) {
     // o = docc + socc, v = socc + vir
 
     // Spaces
-    Dimension occpi = doccpi_ + soccpi_;
-    Dimension virpi = nmopi_ - doccpi_;
-    Dimension pvir = nmopi_ - doccpi_ - soccpi_;
+    auto occpi = nalphapi_;
+    auto virpi = nmopi_ - nbetapi_;
+    auto pvir = nmopi_ - nalphapi_;
+    auto docc = doccpi();
+    auto socc = soccpi();
 
     if (ret->rowspi() != occpi) {
         throw PSIEXCEPTION("ROHF:Hx First dimension of rotation matrix is not correct.");
@@ -523,92 +525,92 @@ void ROHF::Hx(SharedMatrix x, SharedMatrix ret) {
     auto Hx_right = std::make_shared<Matrix>("Partial Hx tensor right", ret->rowspi(), ret->colspi());
 
     // Passing these guys is annoying, pretty cheap to rebuild
-    Dimension dim_zero = Dimension(nirrep_, "Zero Dim");
+    auto dim_zero = Dimension(nirrep_, "Zero Dim");
 
-    SharedMatrix Cocc = Ca_->get_block({dim_zero, nsopi_}, {dim_zero, ret->rowspi()});
+    auto Cocc = Ca_->get_block({dim_zero, nsopi_}, {dim_zero, ret->rowspi()});
     Cocc->set_name("Cocc");
-    SharedMatrix Cvir = Ca_->get_block({dim_zero, nsopi_}, {doccpi_, doccpi_ + ret->colspi()});
+    auto Cvir = Ca_->get_block({dim_zero, nsopi_}, {docc, docc + ret->colspi()});
     Cvir->set_name("Cvir");
 
     for (size_t h = 0; h < nirrep_; h++) {
         if (!occpi[h] || !virpi[h]) continue;
 
-        double** leftp = Hx_left->pointer(h);
-        double** rightp = Hx_right->pointer(h);
-        double** xp = x->pointer(h);
-        double** Fap = moFa_->pointer(h);
-        double** Fbp = moFb_->pointer(h);
+        auto leftp = Hx_left->pointer(h);
+        auto rightp = Hx_right->pointer(h);
+        auto xp = x->pointer(h);
+        auto Fap = moFa_->pointer(h);
+        auto Fbp = moFb_->pointer(h);
 
         // left_ov += 0.5 * x_op Fa_pv
-        C_DGEMM('N', 'N', occpi[h], virpi[h], pvir[h], 0.5, (xp[0] + soccpi_[h]), virpi[h],
-                (Fap[occpi[h]] + doccpi_[h]), nmopi_[h], 0.0, leftp[0], virpi[h]);
+        C_DGEMM('N', 'N', occpi[h], virpi[h], pvir[h], 0.5, (xp[0] + socc[h]), virpi[h],
+                (Fap[occpi[h]] + docc[h]), nmopi_[h], 0.0, leftp[0], virpi[h]);
 
         // left_ov -= Fa_oo x_ov
         C_DGEMM('N', 'N', occpi[h], virpi[h], occpi[h], -0.5, Fap[0], nmopi_[h], xp[0], virpi[h], 1.0, leftp[0],
                 virpi[h]);
 
         // right_ov += 0.5 * x_ov Fb_vv
-        C_DGEMM('N', 'N', occpi[h], virpi[h], virpi[h], 0.5, xp[0], virpi[h], (Fbp[doccpi_[h]] + doccpi_[h]), nmopi_[h],
+        C_DGEMM('N', 'N', occpi[h], virpi[h], virpi[h], 0.5, xp[0], virpi[h], (Fbp[docc[h]] + docc[h]), nmopi_[h],
                 0.0, rightp[0], virpi[h]);
 
         // right_ov -= Fb_oi x_iv
-        C_DGEMM('N', 'N', occpi[h], virpi[h], doccpi_[h], -0.5, Fbp[0], nmopi_[h], xp[0], virpi[h], 1.0, rightp[0],
+        C_DGEMM('N', 'N', occpi[h], virpi[h], docc[h], -0.5, Fbp[0], nmopi_[h], xp[0], virpi[h], 1.0, rightp[0],
                 virpi[h]);
-        if (soccpi_[h]) {
+        if (socc[h]) {
             // Socc terms
             // left_av += 0.5 * x_oa.T Fb_ov
-            C_DGEMM('T', 'N', soccpi_[h], virpi[h], occpi[h], 0.5, xp[0], virpi[h], (Fbp[0] + doccpi_[h]), nmopi_[h],
-                    1.0, leftp[doccpi_[h]], virpi[h]);
+            C_DGEMM('T', 'N', socc[h], virpi[h], occpi[h], 0.5, xp[0], virpi[h], (Fbp[0] + docc[h]), nmopi_[h],
+                    1.0, leftp[docc[h]], virpi[h]);
 
             // right_oa += 0.5 * Fb_op x_ap.T
-            C_DGEMM('N', 'T', occpi[h], soccpi_[h], pvir[h], 0.5, (Fbp[0] + occpi[h]), nmopi_[h],
-                    (xp[doccpi_[h]] + soccpi_[h]), virpi[h], 1.0, rightp[0], virpi[h]);
+            C_DGEMM('N', 'T', occpi[h], socc[h], pvir[h], 0.5, (Fbp[0] + occpi[h]), nmopi_[h],
+                    (xp[docc[h]] + socc[h]), virpi[h], 1.0, rightp[0], virpi[h]);
         }
     }
 
     // => Two electron part <= //
-    std::vector<SharedMatrix>& Cl = jk_->C_left();
-    std::vector<SharedMatrix>& Cr = jk_->C_right();
+    auto& Cl = jk_->C_left();
+    auto& Cr = jk_->C_right();
     Cl.clear();
     Cr.clear();
 
     // If scf_type is DF we can do some extra JK voodo
     if ((options_.get_str("SCF_TYPE").find("DF") != std::string::npos) || (options_.get_str("SCF_TYPE") == "CD")) {
-        SharedMatrix Cdocc = Ca_->get_block({dim_zero, nsopi_}, {dim_zero, doccpi_});
+        auto Cdocc = Ca_->get_block({dim_zero, nsopi_}, {dim_zero, docc});
         Cdocc->set_name("Cdocc");
 
-        SharedMatrix Csocc = Ca_->get_block({dim_zero, nsopi_}, {doccpi_, doccpi_ + soccpi_});
+        auto Csocc = Ca_->get_block({dim_zero, nsopi_}, {docc, nalphapi_});
         Csocc->set_name("Csocc");
 
-        auto Cr_i = std::make_shared<Matrix>("Cright for docc", nsopi_, doccpi_);
-        auto Cr_a = std::make_shared<Matrix>("Cright for socc", nsopi_, soccpi_);
-        auto Cl_a = std::make_shared<Matrix>("Cleft for socc", nsopi_, soccpi_);
+        auto Cr_i = std::make_shared<Matrix>("Cright for docc", nsopi_, docc);
+        auto Cr_a = std::make_shared<Matrix>("Cright for socc", nsopi_, socc);
+        auto Cl_a = std::make_shared<Matrix>("Cleft for socc", nsopi_, socc);
 
         for (size_t h = 0; h < nirrep_; h++) {
             if (!nsopi_[h]) continue;
 
-            double** xp = x->pointer(h);
-            double** Cp = Ca_->pointer(h);
-            double** Cr_ip = Cr_i->pointer(h);
-            double** Cr_ap = Cr_a->pointer(h);
-            double** Cl_ap = Cl_a->pointer(h);
+            auto xp = x->pointer(h);
+            auto Cp = Ca_->pointer(h);
+            auto Cr_ip = Cr_i->pointer(h);
+            auto Cr_ap = Cr_a->pointer(h);
+            auto Cl_ap = Cl_a->pointer(h);
 
-            if (doccpi_[h] && pvir[h]) {
+            if (docc[h] && pvir[h]) {
                 // C_lambda,i = C_lambda,p x_ip.T
-                C_DGEMM('N', 'T', nsopi_[h], doccpi_[h], pvir[h], 1.0, Cp[0] + occpi[h], nmopi_[h],
-                        (xp[0] + soccpi_[h]), virpi[h], 0.0, Cr_ip[0], doccpi_[h]);
+                C_DGEMM('N', 'T', nsopi_[h], docc[h], pvir[h], 1.0, Cp[0] + occpi[h], nmopi_[h],
+                        (xp[0] + socc[h]), virpi[h], 0.0, Cr_ip[0], docc[h]);
             }
 
-            if (soccpi_[h] && pvir[h]) {
+            if (socc[h] && pvir[h]) {
                 // C_lambda,a = C_lambda,p x_ap.T
-                C_DGEMM('N', 'T', nsopi_[h], soccpi_[h], pvir[h], 1.0, Cp[0] + occpi[h], nmopi_[h],
-                        (xp[doccpi_[h]] + soccpi_[h]), virpi[h], 0.0, Cr_ap[0], soccpi_[h]);
+                C_DGEMM('N', 'T', nsopi_[h], socc[h], pvir[h], 1.0, Cp[0] + occpi[h], nmopi_[h],
+                        (xp[docc[h]] + socc[h]), virpi[h], 0.0, Cr_ap[0], socc[h]);
             }
 
-            if (soccpi_[h] && doccpi_[h]) {
+            if (socc[h] && docc[h]) {
                 // C_lambda,a = C_lambda,i x_ia
-                C_DGEMM('N', 'N', nsopi_[h], soccpi_[h], doccpi_[h], 1.0, Cp[0], nmopi_[h], xp[0], virpi[h], 0.0,
-                        Cl_ap[0], soccpi_[h]);
+                C_DGEMM('N', 'N', nsopi_[h], socc[h], docc[h], 1.0, Cp[0], nmopi_[h], xp[0], virpi[h], 0.0,
+                        Cl_ap[0], socc[h]);
             }
         }
 
@@ -631,8 +633,8 @@ void ROHF::Hx(SharedMatrix x, SharedMatrix ret) {
         Cr_a.reset();
         Cl_a.reset();
 
-        const std::vector<SharedMatrix>& J = jk_->J();
-        const std::vector<SharedMatrix>& K = jk_->K();
+        const auto& J = jk_->J();
+        const auto& K = jk_->K();
 
         // Collect left terms
         J[0]->scale(2.0);
@@ -664,33 +666,33 @@ void ROHF::Hx(SharedMatrix x, SharedMatrix ret) {
         half_trans.reset();
 
     } else {
-        SharedMatrix Cdocc = Ca_->get_block({dim_zero, nsopi_}, {dim_zero, doccpi_});
+        auto Cdocc = Ca_->get_block({dim_zero, nsopi_}, {dim_zero, docc});
         Cdocc->set_name("Cdocc");
 
         Cl.push_back(Cocc);
         Cl.push_back(Cdocc);
 
         auto Cr_a = std::make_shared<Matrix>("Cright for alpha", nsopi_, occpi);
-        auto Cr_b = std::make_shared<Matrix>("Cright for beta", nsopi_, doccpi_);
+        auto Cr_b = std::make_shared<Matrix>("Cright for beta", nsopi_, docc);
 
         for (size_t h = 0; h < nirrep_; h++) {
             if (!nsopi_[h]) continue;
 
-            double** xp = x->pointer(h);
-            double** Cp = Ca_->pointer(h);
-            double** Cr_ap = Cr_a->pointer(h);
-            double** Cr_bp = Cr_b->pointer(h);
+            auto xp = x->pointer(h);
+            auto Cp = Ca_->pointer(h);
+            auto Cr_ap = Cr_a->pointer(h);
+            auto Cr_bp = Cr_b->pointer(h);
 
             if (occpi[h] && pvir[h]) {
                 // C_lambda,o = C_lambda,p x_op.T
-                C_DGEMM('N', 'T', nsopi_[h], occpi[h], pvir[h], 1.0, Cp[0] + occpi[h], nmopi_[h], (xp[0] + soccpi_[h]),
+                C_DGEMM('N', 'T', nsopi_[h], occpi[h], pvir[h], 1.0, Cp[0] + occpi[h], nmopi_[h], (xp[0] + socc[h]),
                         virpi[h], 0.0, Cr_ap[0], occpi[h]);
             }
 
-            if (doccpi_[h] && virpi[h]) {
+            if (docc[h] && virpi[h]) {
                 // C_lambda,i = C_lambda,p x_ip.T
-                C_DGEMM('N', 'T', nsopi_[h], doccpi_[h], virpi[h], 1.0, Cp[0] + doccpi_[h], nmopi_[h], xp[0], virpi[h],
-                        0.0, Cr_bp[0], doccpi_[h]);
+                C_DGEMM('N', 'T', nsopi_[h], docc[h], virpi[h], 1.0, Cp[0] + docc[h], nmopi_[h], xp[0], virpi[h],
+                        0.0, Cr_bp[0], docc[h]);
             }
         }
 
@@ -706,8 +708,8 @@ void ROHF::Hx(SharedMatrix x, SharedMatrix ret) {
         Cr_b.reset();
         Cdocc.reset();
 
-        const std::vector<SharedMatrix>& J = jk_->J();
-        const std::vector<SharedMatrix>& K = jk_->K();
+        const auto& J = jk_->J();
+        const auto& K = jk_->K();
 
         // Collect left terms
         J[0]->add(J[1]);
@@ -738,15 +740,15 @@ void ROHF::Hx(SharedMatrix x, SharedMatrix ret) {
     for (size_t h = 0; h < nirrep_; h++) {
         if (!occpi[h] || !virpi[h]) continue;
 
-        double** leftp = Hx_left->pointer(h);
-        double** rightp = Hx_right->pointer(h);
+        auto leftp = Hx_left->pointer(h);
+        auto rightp = Hx_right->pointer(h);
 
-        for (size_t i = 0; i < soccpi_[h]; i++) {
+        for (size_t i = 0; i < socc[h]; i++) {
             for (size_t j = 0; j < occpi[h]; j++) {
                 leftp[j][i] = 0.0;
             }
             for (size_t j = 0; j < virpi[h]; j++) {
-                rightp[doccpi_[h] + i][j] = 0.0;
+                rightp[docc[h] + i][j] = 0.0;
             }
         }
     }
@@ -778,43 +780,45 @@ int ROHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter
     // => Build gradient and preconditioner <= //
 
     // Only the inact-act, inact-vir, and act-vir rotations are non-redundant
-    Dimension dim_zero = Dimension(nirrep_, "Zero Dim");
-    Dimension occpi = doccpi_ + soccpi_;
-    Dimension virpi = nmopi_ - doccpi_;
+    auto dim_zero = Dimension(nirrep_, "Zero Dim");
+    auto occpi = nalphapi_;
+    auto virpi = nmopi_ - nbetapi_;
+    auto docc = doccpi();
+    auto socc = soccpi();
 
-    SharedMatrix Gradient = moFeff_->get_block({dim_zero, occpi}, {doccpi_, nmopi_});
+    auto Gradient = moFeff_->get_block({dim_zero, occpi}, {docc, nmopi_});
     Gradient->scale(-4.0);
     auto Precon = std::make_shared<Matrix>("Precon", nirrep_, occpi, virpi);
 
     for (size_t h = 0; h < nirrep_; h++) {
         if (!occpi[h] || !virpi[h]) continue;
 
-        double** preconp = Precon->pointer(h);
-        double** gradientp = Gradient->pointer(h);
-        double** feffp = moFeff_->pointer(h);
+        auto preconp = Precon->pointer(h);
+        auto gradientp = Gradient->pointer(h);
+        auto feffp = moFeff_->pointer(h);
 
         // Precon
         for (size_t i = 0; i < occpi[h]; i++) {
             for (size_t j = 0; j < virpi[h]; j++) {
                 // Should be scaled but 3.5 works better (4 * 0.875 or GWH coef)
-                preconp[i][j] = -3.5 * (feffp[i][i] - feffp[doccpi_[h] + j][doccpi_[h] + j]);
+                preconp[i][j] = -3.5 * (feffp[i][i] - feffp[docc[h] + j][docc[h] + j]);
             }
         }
 
         // Divide docc-socc and socc-vir by two
         // Fix socc-socc term to avoid divide by zero errors
-        for (size_t i = 0; i < soccpi_[h]; i++) {
+        for (size_t i = 0; i < socc[h]; i++) {
             for (size_t j = 0; j < occpi[h]; j++) {
                 gradientp[j][i] *= 0.5;
                 preconp[j][i] *= 0.5;
             }
             for (size_t j = 0; j < virpi[h]; j++) {
-                gradientp[doccpi_[h] + i][j] *= 0.5;
-                preconp[doccpi_[h] + i][j] *= 0.5;
+                gradientp[docc[h] + i][j] *= 0.5;
+                preconp[docc[h] + i][j] *= 0.5;
             }
-            for (size_t j = 0; j < soccpi_[h]; j++) {
-                preconp[doccpi_[h] + i][j] = 1.0;
-                gradientp[doccpi_[h] + i][j] = 0.0;
+            for (size_t j = 0; j < socc[h]; j++) {
+                preconp[docc[h] + i][j] = 1.0;
+                gradientp[docc[h] + i][j] = 0.0;
             }
         }
     }
@@ -839,12 +843,12 @@ int ROHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter
     }
 
     // => Initial CG guess <= //
-    SharedMatrix x = Gradient->clone();
+    auto x = Gradient->clone();
     x->set_name("Current ROHF CG Guess");
     x->apply_denominator(Precon);
 
     // Calc hessian vector product, find residual and conditioned residual
-    SharedMatrix r = Gradient->clone();
+    auto r = Gradient->clone();
     auto Ap = std::make_shared<Matrix>("Ap", nirrep_, occpi, virpi);
     Hx(x, Ap);
     r->subtract(Ap);
@@ -928,17 +932,17 @@ int ROHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter
 }
 
 void ROHF::form_G() {
-    Dimension dim_zero = Dimension(nirrep_, "Zero Dim");
+    Dimension dim_zero(nirrep_, "Zero Dim");
 
-    std::vector<SharedMatrix>& C = jk_->C_left();
+    auto& C = jk_->C_left();
     C.clear();
 
     // Push back docc orbitals
-    SharedMatrix Cdocc = Ca_->get_block({dim_zero, nsopi_}, {dim_zero, doccpi_});
+    SharedMatrix Cdocc = Ca_->get_block({dim_zero, nsopi_}, {dim_zero, nbetapi_});
     C.push_back(Cdocc);
 
     // Push back socc orbitals
-    SharedMatrix Csocc = Ca_->get_block({dim_zero, nsopi_}, {doccpi_, doccpi_ + soccpi_});
+    SharedMatrix Csocc = Ca_->get_block({dim_zero, nsopi_}, {nbetapi_, nalphapi_});
     C.push_back(Csocc);
 
     // Run the JK object
@@ -967,11 +971,12 @@ bool ROHF::stability_analysis() {
     if (scf_type_ == "DF" || scf_type_ == "CD") {
         throw PSIEXCEPTION("Stability analysis has not been implemented for density fitted wavefunctions yet.");
     } else {
-        Dimension nvirpi = nmopi_ - nalphapi_;
-        Dimension zero = Dimension(nirrep_);
-        Dimension soccpi = nalphapi_ - doccpi_;
-        Dimension navir = nmopi_ - nalphapi_;
-        Dimension nbvir = nmopi_ - nbetapi_;
+        auto nvirpi = nmopi_ - nalphapi_;
+        auto zero = Dimension(nirrep_);
+        auto docc = doccpi();
+        auto socc = soccpi();
+        auto navir = nmopi_ - nalphapi_;
+        auto nbvir = nmopi_ - nbetapi_;
 
         auto FIJ = std::make_shared<Matrix>("Alpha occupied MO basis Fock matrix", nalphapi_, nalphapi_);
         auto Fij = std::make_shared<Matrix>("Beta occupied MO basis Fock matrix", nalphapi_, nalphapi_);
@@ -983,7 +988,7 @@ bool ROHF::stability_analysis() {
         SharedMatrix Cocc = Ca_->get_block({zero, nsopi_}, {zero, nalphapi_});
         std::vector<SharedMatrix> virandsoc;
         virandsoc.push_back(Ca_->get_block({zero, nsopi_}, {nalphapi_, nmopi_}));
-        virandsoc.push_back(Ca_->get_block({zero, nsopi_}, {doccpi_, nalphapi_}));
+        virandsoc.push_back(Ca_->get_block({zero, nsopi_}, {docc, nalphapi_}));
         SharedMatrix Cvir = linalg::horzcat(virandsoc);
         FIJ->transform(Fa_, Cocc);
         Fij->transform(Fb_, Cocc);
@@ -1009,12 +1014,12 @@ bool ROHF::stability_analysis() {
         }
         // Zero out beta socc terms corresponding to occ indices
         for (int h = 0; h < nirrep_; ++h) {
-            for (int mo1 = doccpi_[h]; mo1 < nalphapi_[h]; ++mo1) {
-                for (int mo2 = doccpi_[h]; mo2 < nalphapi_[h]; ++mo2) {
+            for (int mo1 = docc[h]; mo1 < nalphapi_[h]; ++mo1) {
+                for (int mo2 = docc[h]; mo2 < nalphapi_[h]; ++mo2) {
                     Fij->set(h, mo1, mo2, 0.0);
                 }
             }
-            for (int mo1 = doccpi_[h]; mo1 < nalphapi_[h]; ++mo1) {
+            for (int mo1 = docc[h]; mo1 < nalphapi_[h]; ++mo1) {
                 for (int mo2 = 0; mo2 < nbvir[h]; ++mo2) {
                     Fia->set(h, mo1, mo2, 0.0);
                 }
@@ -1024,11 +1029,11 @@ bool ROHF::stability_analysis() {
         // Some indexing arrays to allow us to compare occ and vir spatial orbitals, below.
         int occ_offsets[8];
         occ_offsets[0] = 0;
-        for (int h = 1; h < nirrep_; ++h) occ_offsets[h] = occ_offsets[h - 1] + doccpi_[h - 1];
+        for (int h = 1; h < nirrep_; ++h) occ_offsets[h] = occ_offsets[h - 1] + docc[h - 1];
 
         int vir_offsets[8];
-        vir_offsets[0] = doccpi_[0] - navir[0];
-        for (int h = 1; h < nirrep_; ++h) vir_offsets[h] = vir_offsets[h - 1] + doccpi_[h] - navir[h];
+        vir_offsets[0] = docc[0] - navir[0];
+        for (int h = 1; h < nirrep_; ++h) vir_offsets[h] = vir_offsets[h - 1] + docc[h] - navir[h];
 
         std::vector<std::shared_ptr<MOSpace> > spaces;
         spaces.push_back(MOSpace::occ);
@@ -1131,7 +1136,7 @@ bool ROHF::stability_analysis() {
                     }
                     if ((aabs == babs) && (isym == jsym)) val -= 0.5 * Fij->get(isym, irel, jrel);
                     // Zero out any socc-socc terms
-                    if (irel >= doccpi_[isym] || jrel >= doccpi_[jsym]) val = 0.0;
+                    if (irel >= docc[isym] || jrel >= docc[jsym]) val = 0.0;
                     Abb.matrix[h][ia][jb] = val;
                 }
             }
@@ -1164,7 +1169,7 @@ bool ROHF::stability_analysis() {
                     if (((irel + occ_offsets[isym]) == (brel + vir_offsets[bsym])) && (jsym == asym))
                         Aab.matrix[h][ia][jb] += 0.5 * Fia->get(jsym, jrel, arel);
                     // Zero out any socc-socc terms
-                    if (jrel >= doccpi_[jsym] || arel >= navir[asym]) Aab.matrix[h][ia][jb] = 0.0;
+                    if (jrel >= docc[jsym] || arel >= navir[asym]) Aab.matrix[h][ia][jb] = 0.0;
                 }
             }
             global_dpd_->buf4_mat_irrep_wrt(&Aab, h);
@@ -1228,7 +1233,7 @@ bool ROHF::stability_analysis() {
                 int asym = Aab.params->qsym[aabs];
                 int irel = iabs - Aab.params->poff[isym];
                 int arel = aabs - Aab.params->qoff[asym];
-                if ((arel >= nvirpi[asym]) && (irel >= doccpi_[isym])) {
+                if ((arel >= nvirpi[asym]) && (irel >= docc[isym])) {
                     U[ia][ia] = 0.0;
                 } else {
                     U[ia][ia] = 1.0;

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -833,10 +833,10 @@ void HF::compute_SAD_guess(bool natorb) {
 
             if (!nso || !nmo) continue;
 
-            double** Cap = Ca_->pointer(h);
-            double** Cbp = Cb_->pointer(h);
-            double** Ca2p = Ca_sad->pointer(h);
-            double** Cb2p = Cb_sad->pointer(h);
+            auto Cap = Ca_->pointer(h);
+            auto Cbp = Cb_->pointer(h);
+            auto Ca2p = Ca_sad->pointer(h);
+            auto Cb2p = Cb_sad->pointer(h);
             for (int i = 0; i < nso; i++) {
                 C_DCOPY(nmo, Ca2p[i], 1, Cap[i], 1);
                 C_DCOPY(nmo, Cb2p[i], 1, Cbp[i], 1);
@@ -847,8 +847,6 @@ void HF::compute_SAD_guess(bool natorb) {
         nbetapi_ = sad_dim;
         nalpha_ = sad_dim.sum();
         nbeta_ = sad_dim.sum();
-        doccpi_ = sad_dim;
-        soccpi_ = Dimension(Da_->nirrep(), "SAD SOCC dim (0's)");
         energies_["Total Energy"] = 0.0;  // This is the -1th iteration
     }
 }

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -542,8 +542,8 @@ std::vector<SharedMatrix> UHF::twoel_Hx(std::vector<SharedMatrix> x_vec, bool co
     }
 
     // Setup jk
-    std::vector<SharedMatrix>& Cl = jk_->C_left();
-    std::vector<SharedMatrix>& Cr = jk_->C_right();
+    auto& Cl = jk_->C_left();
+    auto& Cr = jk_->C_right();
     Cl.clear();
     Cr.clear();
 
@@ -739,8 +739,8 @@ std::vector<SharedMatrix> UHF::twoel_Hx(std::vector<SharedMatrix> x_vec, bool co
 }
 std::vector<SharedMatrix> UHF::cphf_Hx(std::vector<SharedMatrix> x_vec) {
     // Compute quantities
-    std::vector<SharedMatrix> onel = onel_Hx(x_vec);
-    std::vector<SharedMatrix> twoel = twoel_Hx(x_vec, true, "MO");
+    auto onel = onel_Hx(x_vec);
+    auto twoel = twoel_Hx(x_vec, true, "MO");
 
     for (size_t i = 0; i < onel.size(); i++) {
         onel[i]->add(twoel[i]);
@@ -780,25 +780,25 @@ std::vector<SharedMatrix> UHF::cphf_solve(std::vector<SharedMatrix> x_vec, doubl
 
     if (needs_ao) {
         // MO (C1) Fock Matrix (Inactive Fock in Helgaker's language)
-        SharedMatrix Caocc_ao = Ca_subset("AO", "ALL");
-        SharedMatrix Cbocc_ao = Cb_subset("AO", "ALL");
-        SharedMatrix Fa_ao = matrix_subset_helper(Fa_, Ca_, "AO", "Fock");
-        SharedMatrix Fb_ao = matrix_subset_helper(Fb_, Cb_, "AO", "Fock");
-        SharedMatrix IFock_ao_a = linalg::triplet(Caocc_ao, Fa_ao, Caocc_ao, true, false, false);
-        SharedMatrix IFock_ao_b = linalg::triplet(Cbocc_ao, Fb_ao, Cbocc_ao, true, false, false);
+        auto Caocc_ao = Ca_subset("AO", "ALL");
+        auto Cbocc_ao = Cb_subset("AO", "ALL");
+        auto Fa_ao = matrix_subset_helper(Fa_, Ca_, "AO", "Fock");
+        auto Fb_ao = matrix_subset_helper(Fb_, Cb_, "AO", "Fock");
+        auto IFock_ao_a = linalg::triplet(Caocc_ao, Fa_ao, Caocc_ao, true, false, false);
+        auto IFock_ao_b = linalg::triplet(Cbocc_ao, Fb_ao, Cbocc_ao, true, false, false);
         Precon_ao_a = std::make_shared<Matrix>("Precon", nalpha_, nmo_ - nalpha_);
         Precon_ao_b = std::make_shared<Matrix>("Precon", nbeta_, nmo_ - nbeta_);
 
-        double* denom_ap = Precon_ao_a->pointer()[0];
-        double** f_ap = IFock_ao_a->pointer();
+        auto denom_ap = Precon_ao_a->pointer()[0];
+        auto f_ap = IFock_ao_a->pointer();
         for (size_t i = 0, target = 0; i < nalpha_; i++) {
             for (size_t a = nalpha_; a < nmo_; a++) {
                 denom_ap[target++] = -f_ap[i][i] + f_ap[a][a];
             }
         }
 
-        double* denom_bp = Precon_ao_b->pointer()[0];
-        double** f_bp = IFock_ao_b->pointer();
+        auto denom_bp = Precon_ao_b->pointer()[0];
+        auto f_bp = IFock_ao_b->pointer();
         for (size_t i = 0, target = 0; i < nbeta_; i++) {
             for (size_t a = nbeta_; a < nmo_; a++) {
                 denom_bp[target++] = -f_bp[i][i] + f_bp[a][a];
@@ -1059,13 +1059,13 @@ int UHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter,
     // => Build gradient and preconditioner <= //
 
     // Grab occ and vir orbitals
-    SharedMatrix Cocc_a = Ca_subset("SO", "OCC");
-    SharedMatrix Cvir_a = Ca_subset("SO", "VIR");
-    SharedMatrix Gradient_a = linalg::triplet(Cocc_a, Fa_, Cvir_a, true, false, false);
+    auto Cocc_a = Ca_subset("SO", "OCC");
+    auto Cvir_a = Ca_subset("SO", "VIR");
+    auto Gradient_a = linalg::triplet(Cocc_a, Fa_, Cvir_a, true, false, false);
 
-    SharedMatrix Cocc_b = Cb_subset("SO", "OCC");
-    SharedMatrix Cvir_b = Cb_subset("SO", "VIR");
-    SharedMatrix Gradient_b = linalg::triplet(Cocc_b, Fb_, Cvir_b, true, false, false);
+    auto Cocc_b = Cb_subset("SO", "OCC");
+    auto Cvir_b = Cb_subset("SO", "VIR");
+    auto Gradient_b = linalg::triplet(Cocc_b, Fb_, Cvir_b, true, false, false);
 
     // Make sure the MO gradient is reasonably small
     if ((Gradient_a->absmax() > 0.3) || (Gradient_b->absmax() > 0.3)) {
@@ -1074,7 +1074,7 @@ int UHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter,
         }
         return 0;
     }
-    std::vector<SharedMatrix> ret_x =
+    auto ret_x =
         cphf_solve({Gradient_a, Gradient_b}, soscf_conv, soscf_max_iter, soscf_print ? 2 : 0);
 
     // => Rotate orbitals <= //

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -133,11 +133,11 @@ void UHF::finalize() {
             for (int n = 0; n < Lagrangian_->coldim(h); ++n) {
                 double sum = 0.0;
                 for (int i = 0; i < nalphapi_[h]; ++i) {
-                    sum += epsilon_a_->get(h, i) * Ca_->get(h, m, i) * Ca_->get(h, n, i) +
+                    sum += epsilon_a_->get(h, i) * Ca_->get(h, m, i) * Ca_->get(h, n, i);
                 }
                 for (int i = 0; i < nbetapi_[h]; ++i) {
                     sum += epsilon_b_->get(h, i) * Cb_->get(h, m, i) * Cb_->get(h, n, i);
-
+                }
                 Lagrangian_->set(h, m, n, sum);
             }
         }

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -132,12 +132,11 @@ void UHF::finalize() {
         for (int m = 0; m < Lagrangian_->rowdim(h); ++m) {
             for (int n = 0; n < Lagrangian_->coldim(h); ++n) {
                 double sum = 0.0;
-                for (int i = 0; i < doccpi_[h]; ++i) {
+                for (int i = 0; i < nalphapi_[h]; ++i) {
                     sum += epsilon_a_->get(h, i) * Ca_->get(h, m, i) * Ca_->get(h, n, i) +
-                           epsilon_b_->get(h, i) * Cb_->get(h, m, i) * Cb_->get(h, n, i);
                 }
-                for (int i = doccpi_[h]; i < doccpi_[h] + soccpi_[h]; ++i)
-                    sum += epsilon_a_->get(h, i) * Ca_->get(h, m, i) * Ca_->get(h, n, i);
+                for (int i = 0; i < nbetapi_[h]; ++i) {
+                    sum += epsilon_b_->get(h, i) * Cb_->get(h, m, i) * Cb_->get(h, n, i);
 
                 Lagrangian_->set(h, m, n, sum);
             }

--- a/psi4/src/psi4/mcscf/scf_save_info.cc
+++ b/psi4/src/psi4/mcscf/scf_save_info.cc
@@ -57,13 +57,13 @@ void SCF::save_info() {
     for (int h = 0; h < nirreps; ++h) frz.push_back(0);
     std::vector<std::pair<double, int> > sorted_evals;
     for (int h = 0; h < nirreps; ++h)
-        for (int i = 0; i < sopi[h]; ++i) sorted_evals.push_back(std::make_pair(epsilon->get(h, i), h));
+        for (int i = 0; i < sopi[h]; ++i) sorted_evals.emplace_back(epsilon->get(h, i), h);
     sort(sorted_evals.begin(), sorted_evals.end());
     for (int i = 0; i < nfrzc; ++i) frz[sorted_evals[i].second]++;
 
     for (int h = 0; h < nirreps; ++h) {
-        doccpi_[h] = docc[h];
-        soccpi_[h] = actv[h];
+        nalphapi_[h] = docc[h] + actv[h];
+        nbetapi_[h] = docc[h];
         nmopi_[h] = nsopi_[h];
         frzcpi_[h] = frz[h];
         frzvpi_[h] = 0;

--- a/psi4/src/psi4/occ/get_moinfo.cc
+++ b/psi4/src/psi4/occ/get_moinfo.cc
@@ -59,44 +59,23 @@ void OCCWave::get_moinfo() {
         nmo_ = reference_wavefunction_->nmo();
         nmopi_ = reference_wavefunction_->nmopi();
         nsopi_ = reference_wavefunction_->nsopi();
-        doccpi_ = reference_wavefunction_->doccpi();
-        soccpi_ = reference_wavefunction_->soccpi();
         frzcpi_ = reference_wavefunction_->frzcpi();
         frzvpi_ = reference_wavefunction_->frzvpi();
         nalphapi_ = reference_wavefunction_->nalphapi();
         nbetapi_ = reference_wavefunction_->nbetapi();
 
         // get nfrzc and nfrzv
-        nfrzc = 0;
-        nfrzv = 0;
-        for (int h = 0; h < nirrep_; h++) {
-            nfrzc += frzcpi_[h];
-            nfrzv += frzvpi_[h];
-        }
+        nfrzc = frzcpi_.sum();
+        nfrzv = frzvpi_.sum();
 
         // form occpi and virtpi
-        occpiA = init_int_array(nirrep_);
-        virtpiA = init_int_array(nirrep_);
-        memset(occpiA, 0, sizeof(int) * nirrep_);
-        memset(virtpiA, 0, sizeof(int) * nirrep_);
-        for (int h = 0; h < nirrep_; h++) {
-            virtpiA[h] = nmopi_[h] - doccpi_[h];
-            occpiA[h] = doccpi_[h];
-        }
+        occpiA = nalphapi_;
+        virtpiA = nmopi_ - nalphapi_;
         occpi_ = {{SpinType::Alpha, occpiA}};
 
         // active occ and virt
-        adoccpi = init_int_array(nirrep_);
-        aoccpiA = init_int_array(nirrep_);
-        avirtpiA = init_int_array(nirrep_);
-        memset(adoccpi, 0, sizeof(int) * nirrep_);
-        memset(aoccpiA, 0, sizeof(int) * nirrep_);
-        memset(avirtpiA, 0, sizeof(int) * nirrep_);
-        for (int h = 0; h < nirrep_; h++) {
-            adoccpi[h] = doccpi_[h] - frzcpi_[h];
-            avirtpiA[h] = virtpiA[h] - frzvpi_[h];
-            aoccpiA[h] = doccpi_[h] - frzcpi_[h];
-        }
+        aoccpiA = occpiA - frzcpi_;
+        avirtpiA = virtpiA - frzvpi_;
 
         // Read in nuclear repulsion energy
         Enuc = reference_wavefunction_->molecule()->nuclear_repulsion_energy(
@@ -130,12 +109,7 @@ void OCCWave::get_moinfo() {
         }
 
         // find nooA
-        nooA = 0;
-        for (int h = 0; h < nirrep_; h++) {
-            for (int p = 0; p < doccpi_[h]; p++) {
-                nooA++;
-            }
-        }
+        nooA = nalphapi_.sum();
 
         // PitzerOffset
         PitzerOffset = new int[nirrep_];
@@ -217,7 +191,7 @@ void OCCWave::get_moinfo() {
         memset(qt2pitzerA, 0, sizeof(int) * nmo_);
         memset(pitzer2qtA, 0, sizeof(int) * nmo_);
 
-        reorder_qt(doccpi_, soccpi_, frzcpi_, frzvpi_, pitzer2qtA, nmopi_, nirrep_);
+        reorder_qt(doccpi(), soccpi(), frzcpi_, frzvpi_, pitzer2qtA, nmopi_, nirrep_);
         for (int p = 0; p < nmo_; p++) {
             int pa = pitzer2qtA[p];
             qt2pitzerA[pa] = p;
@@ -398,56 +372,27 @@ void OCCWave::get_moinfo() {
         nmo_ = reference_wavefunction_->nmo();
         nmopi_ = reference_wavefunction_->nmopi();
         nsopi_ = reference_wavefunction_->nsopi();
-        doccpi_ = reference_wavefunction_->doccpi();
-        soccpi_ = reference_wavefunction_->soccpi();
         frzcpi_ = reference_wavefunction_->frzcpi();
         frzvpi_ = reference_wavefunction_->frzvpi();
         nalphapi_ = reference_wavefunction_->nalphapi();
         nbetapi_ = reference_wavefunction_->nbetapi();
 
         // get nfrzc and nfrzv
-        nfrzc = 0;
-        nfrzv = 0;
-        for (int h = 0; h < nirrep_; h++) {
-            nfrzc += frzcpi_[h];
-            nfrzv += frzvpi_[h];
-        }
+        nfrzc = frzcpi_.sum();
+        nfrzv = frzvpi_.sum();
 
         // form occpi and virtpi
-        occpiA = init_int_array(nirrep_);
-        occpiB = init_int_array(nirrep_);
-        virtpiA = init_int_array(nirrep_);
-        virtpiB = init_int_array(nirrep_);
-        memset(occpiA, 0, sizeof(int) * nirrep_);
-        memset(occpiB, 0, sizeof(int) * nirrep_);
-        memset(virtpiA, 0, sizeof(int) * nirrep_);
-        memset(virtpiB, 0, sizeof(int) * nirrep_);
-        for (int h = 0; h < nirrep_; h++) {
-            virtpiA[h] = nmopi_[h] - soccpi_[h] - doccpi_[h];
-            virtpiB[h] = nmopi_[h] - doccpi_[h];
-            occpiB[h] = doccpi_[h];
-            occpiA[h] = doccpi_[h] + soccpi_[h];
-        }
+        occpiA = nalphapi_;
+        occpiB = nbetapi_;
+        virtpiA = nmopi_ - nalphapi_;
+        virtpiB = nmopi_ - nbetapi_;
         occpi_ = {{SpinType::Alpha, occpiA}, {SpinType::Beta, occpiB}};
 
         // active occ and virt
-        adoccpi = init_int_array(nirrep_);
-        aoccpiA = init_int_array(nirrep_);
-        aoccpiB = init_int_array(nirrep_);
-        avirtpiA = init_int_array(nirrep_);
-        avirtpiB = init_int_array(nirrep_);
-        memset(adoccpi, 0, sizeof(int) * nirrep_);
-        memset(aoccpiA, 0, sizeof(int) * nirrep_);
-        memset(aoccpiB, 0, sizeof(int) * nirrep_);
-        memset(avirtpiA, 0, sizeof(int) * nirrep_);
-        memset(avirtpiB, 0, sizeof(int) * nirrep_);
-        for (int h = 0; h < nirrep_; h++) {
-            adoccpi[h] = doccpi_[h] - frzcpi_[h];
-            avirtpiA[h] = virtpiA[h] - frzvpi_[h];
-            avirtpiB[h] = virtpiB[h] - frzvpi_[h];
-            aoccpiB[h] = doccpi_[h] - frzcpi_[h];
-            aoccpiA[h] = doccpi_[h] + soccpi_[h] - frzcpi_[h];
-        }
+        aoccpiA = occpiA - frzcpi_;
+        aoccpiB = occpiB - frzcpi_;
+        avirtpiA = virtpiA - frzvpi_;
+        avirtpiB = virtpiB - frzvpi_;
 
         // Read in nuclear repulsion energy
         Enuc = reference_wavefunction_->molecule()->nuclear_repulsion_energy(
@@ -481,20 +426,8 @@ void OCCWave::get_moinfo() {
         }
 
         // find nooB
-        nooB = 0;
-        for (int h = 0; h < nirrep_; h++) {
-            for (int p = 0; p < doccpi_[h]; p++) {
-                nooB++;
-            }
-        }
-
-        // find nooA
-        nooA = nooB;
-        for (int h = 0; h < nirrep_; h++) {
-            for (int p = 0; p < soccpi_[h]; p++) {
-                nooA++;
-            }
-        }
+        nooA = nalphapi_.sum();
+        nooB = nbetapi_.sum();
 
         // PitzerOffset
         PitzerOffset = new int[nirrep_];
@@ -608,7 +541,7 @@ void OCCWave::get_moinfo() {
         memset(pitzer2qtA, 0, sizeof(int) * nmo_);
         memset(qt2pitzerB, 0, sizeof(int) * nmo_);
         memset(pitzer2qtB, 0, sizeof(int) * nmo_);
-        reorder_qt_uhf(doccpi_, soccpi_, frzcpi_, frzvpi_, pitzer2qtA, pitzer2qtB, nmopi_, nirrep_);
+        reorder_qt_uhf(doccpi(), soccpi(), frzcpi_, frzvpi_, pitzer2qtA, pitzer2qtB, nmopi_, nirrep_);
         for (int p = 0; p < nmo_; p++) {
             int pa = pitzer2qtA[p];
             int pb = pitzer2qtB[p];

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -377,22 +377,14 @@ class OCCWave : public Wavefunction {
     std::string comput_s2_;
 
     // Several of these int*'s seem like they should be Dimension objects.
-    int *mopi; /* number of all MOs per irrep */
-    int *sopi; /* number of all SOs per irrep */
-    int *occpi;
-    int *doccpi;           /* number of doubly occupied MOs per irrep */
-    int *occpiA;           /* number of alpha occupied MOs per irrep */
-    int *occpiB;           /* number of beta occupied MOs per irrep */
-    int *soccpi;           /* number of all singly occupied MOs per irrep */
-    int *virtpiA;          /* number of alpha virtual MOs per irrep */
-    int *virtpiB;          /* number of beta virtual MOs per irrep */
-    int *frzcpi;           /* number of frozen occupied MOs per irrep */
-    int *frzvpi;           /* number of frozen virtual MOs per irrep */
-    int *adoccpi;          /* number of active doubly occupied MOs per irrep */
-    int *aoccpiA;          /* number of active alpha occupied MOs per irrep */
-    int *aoccpiB;          /* number of active beta occupied MOs per irrep */
-    int *avirtpiA;         /* number of active alpha virtual MOs per irrep */
-    int *avirtpiB;         /* number of active beta virtual MOs per irrep */
+    Dimension occpiA;           /* number of alpha occupied MOs per irrep */
+    Dimension occpiB;           /* number of beta occupied MOs per irrep */
+    Dimension virtpiA;     /* number of alpha virtual MOs per irrep */
+    Dimension virtpiB;     /* number of beta virtual MOs per irrep */
+    Dimension aoccpiA;     /* number of active alpha occupied MOs per irrep */
+    Dimension aoccpiB;     /* number of active beta occupied MOs per irrep */
+    Dimension avirtpiA;         /* number of active alpha virtual MOs per irrep */
+    Dimension avirtpiB;         /* number of active beta virtual MOs per irrep */
     int *mosym;            /* symmetry of all MOs in pitzer order */
     int *sosym;            /* symmetry of all SOs in pitzer order */
     int *mosym_c1;         /* symmetry of all MOs in energy order */


### PR DESCRIPTION
## Description
#2476 and #2594 indicate a major problem in Psi's SCF code: the simplistic formula `nalphapi = doccpi + soccpi` and `nbetapi = doccpi` is incapable of describing references where there are more beta than alpha orbitals of a given irrep. This occurs in MOM (where we instead use ugly hacks) and in UHF (where we crash). Furthermore, storing all of these irrep quantities is redundant.

This PR remedies the situation by only storing `nalphapi` and `nbetapi`. `doccpi` and `soccpi` can be computed from these when needed. The Py-side API is unchanged `doccpi(), soccpi()`, while the C-side API changes from `doccpi_, soccpi_` to `doccpi(), soccpi()`. While we are doing some extra work to compute docc and socc every time they're needed, the computational cost is negligible in comparison to Fock diagonalizations, integral transforms, and tensor contractions. 

To prevent scope creep, this PR aims solely to change the wavefunction. **This is a major undertaking and should not be done lightly.** A subsequent PR will fix the linked issues (if not fixed by this PR) and add them as test cases once the fix is confirmed.

Obligatory @susilehtola ping.

## Todos
- [x] DOCC and SOCC are now computed rather than stored
- [x] MOM simplified
- [x] Lots of docc/socc replaced with alphapi/betapi where more appropriate
- [x] More auto
- [x] More dimension, fewer raw arrays 

## Checklist
- [x] Passes ctest and pytest (all, except addons)

## Status
- [x] Ready for review
- [x] Ready for merge
