### PR TITLE
Fix Numpy Python detection in Windows for new NumPy

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -112,7 +112,6 @@ jobs:
       - script: |
           conda install cmake ^
                         anaconda-project ^
-                        anaconda-client ^
                         conda-build ^
                         conda-forge::eigen ^
                         conda-verify ^
@@ -122,7 +121,7 @@ jobs:
                         msgpack-python ^
                         networkx ^
                         ninja ^
-                        numpy=1.22 ^
+                        numpy ^
                         pint ^
                         pybind11=2.7.0 ^
                         pytest>=7.0.1 ^
@@ -136,6 +135,8 @@ jobs:
                         conda-forge::qcelemental ^
                         conda-forge::qcengine ^
                         scipy
+          conda install --only-deps anaconda-client
+          pip install git+https://github.com/loriab/anaconda-client.git@upload-catch-silent-110
           which anaconda
           conda list
         displayName: "Install conda packages"

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -92,7 +92,7 @@ jobs:
       # Install Miniconda
       - script: |
           choco install miniconda3 --yes
-          set PATH=C:\tools\miniconda3\Scripts;C:\tools\miniconda3;C:\tools\miniconda3\Library\bin;%PATH%
+          set PATH=C:\tools\miniconda3\Scripts;C:\tools\miniconda3;C:\tools\miniconda3\Library;C:\tools\miniconda3\Library\bin;C:\tools\miniconda3\Library\mingw-w64\bin;%PATH%
           echo '##vso[task.setvariable variable=PATH]%PATH%'
           set LIB=C:\tools\miniconda3\Library\lib;%LIB%
           echo '##vso[task.setvariable variable=LIB]%LIB%'

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -92,7 +92,7 @@ jobs:
       # Install Miniconda
       - script: |
           choco install miniconda3 --yes
-          set PATH=C:\tools\miniconda3\Scripts;C:\tools\miniconda3;C:\tools\miniconda3\Library;C:\tools\miniconda3\Library\bin;C:\tools\miniconda3\Library\mingw-w64\bin;%PATH%
+          set PATH=C:\tools\miniconda3\Scripts;C:\tools\miniconda3;C:\tools\miniconda3\Library;C:\tools\miniconda3\Library\bin;%PATH%
           echo '##vso[task.setvariable variable=PATH]%PATH%'
           set LIB=C:\tools\miniconda3\Library\lib;%LIB%
           echo '##vso[task.setvariable variable=LIB]%LIB%'

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -121,7 +121,7 @@ jobs:
                         msgpack-python ^
                         networkx ^
                         ninja ^
-                        anaconda::numpy ^
+                        numpy ^
                         pint ^
                         pybind11=2.7.0 ^
                         pytest>=7.0.1 ^
@@ -139,6 +139,7 @@ jobs:
           pip install git+https://github.com/loriab/anaconda-client.git@upload-catch-silent-110
           which anaconda
           conda list
+          python -c "import sys\ntry: import numpy; sys.stdout.write(numpy.get_include())\nexcept:pass\n"
         displayName: "Install conda packages"
 
       # Install LLVM

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -139,7 +139,6 @@ jobs:
           pip install git+https://github.com/loriab/anaconda-client.git@upload-catch-silent-110
           which anaconda
           conda list
-          python -c "import sys\ntry: import numpy; sys.stdout.write(numpy.get_include())\nexcept:pass\n"
         displayName: "Install conda packages"
 
       # Install LLVM
@@ -183,6 +182,7 @@ jobs:
                 -DCMAKE_CXX_FLAGS="/arch:AVX" ^
                 -DMAX_AM_ERI=!MAX_AM_ERI! ^
                 -DPython_EXECUTABLE="C:/tools/miniconda3/python.exe" ^
+                -DPython_NumPy_INCLUDE_DIR="C:/tools/miniconda3/lib/site-packages/numpy/core/include" ^
                 -DEigen3_ROOT="C:/tools/miniconda3/Library" ^
                 -DBOOST_ROOT="C:/tools/miniconda3/Library" ^
                 -DMultiprecision_ROOT="C:/tools/miniconda3/Library" ^

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -92,7 +92,7 @@ jobs:
       # Install Miniconda
       - script: |
           choco install miniconda3 --yes
-          set PATH=C:\tools\miniconda3\Scripts;C:\tools\miniconda3;C:\tools\miniconda3\Library;C:\tools\miniconda3\Library\bin;%PATH%
+          set PATH=C:\tools\miniconda3\Scripts;C:\tools\miniconda3;C:\tools\miniconda3\Library\bin;C:\tools\miniconda3\Library\mingw-w64\bin;%PATH%
           echo '##vso[task.setvariable variable=PATH]%PATH%'
           set LIB=C:\tools\miniconda3\Library\lib;%LIB%
           echo '##vso[task.setvariable variable=LIB]%LIB%'

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -112,6 +112,7 @@ jobs:
       - script: |
           conda install cmake ^
                         anaconda-project ^
+                        anaconda-client ^
                         conda-build ^
                         conda-forge::eigen ^
                         conda-verify ^
@@ -121,7 +122,7 @@ jobs:
                         msgpack-python ^
                         networkx ^
                         ninja ^
-                        numpy ^
+                        numpy=1.22 ^
                         pint ^
                         pybind11=2.7.0 ^
                         pytest>=7.0.1 ^
@@ -135,8 +136,6 @@ jobs:
                         conda-forge::qcelemental ^
                         conda-forge::qcengine ^
                         scipy
-          conda install --only-deps anaconda-client
-          pip install git+https://github.com/loriab/anaconda-client.git@upload-catch-silent
           which anaconda
           conda list
         displayName: "Install conda packages"

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -121,7 +121,7 @@ jobs:
                         msgpack-python ^
                         networkx ^
                         ninja ^
-                        numpy ^
+                        anaconda::numpy ^
                         pint ^
                         pybind11=2.7.0 ^
                         pytest>=7.0.1 ^
@@ -132,8 +132,8 @@ jobs:
                         conda-forge::gau2grid ^
                         conda-forge::libxc ^
                         psi4/label/dev::libint2=*=h2e52968_4 ^
-                        conda-forge::qcelemental ^
-                        conda-forge::qcengine ^
+                        conda-forge::qcelemental=0.25.0 ^
+                        conda-forge::qcengine=0.23.0 ^
                         scipy
           conda install --only-deps anaconda-client
           pip install git+https://github.com/loriab/anaconda-client.git@upload-catch-silent-110

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,6 @@ if(DEFINED ENV{LGTM_SRC})
 else()
     find_package(Python 3.8 COMPONENTS Interpreter Development NumPy REQUIRED)
 endif()
-message("${_Python_NumPy_INCLUDE_DIR}")
 message(STATUS "${Cyan}Found Python ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}${ColourReset}: ${Python_EXECUTABLE} (found version ${Python_VERSION})")
 
 if(DEFINED ENV{LGTM_SRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ if(DEFINED ENV{LGTM_SRC})
 else()
     find_package(Python 3.8 COMPONENTS Interpreter Development NumPy REQUIRED)
 endif()
+message("${_Python_NumPy_INCLUDE_DIR}")
 message(STATUS "${Cyan}Found Python ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}${ColourReset}: ${Python_EXECUTABLE} (found version ${Python_VERSION})")
 
 if(DEFINED ENV{LGTM_SRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ ExternalProject_Add(psi4-core
               -DPython_EXECUTABLE=${Python_EXECUTABLE}
               -DPython_INCLUDE_DIR=${Python_INCLUDE_DIRS}
               -DPython_LIBRARY=${Python_LIBRARIES}
+              -DPython_NumPy_INCLUDE_DIRS=${_Python_NumPy_INCLUDE_DIR}
               -DPSI4_ROOT=${CMAKE_CURRENT_SOURCE_DIR}
               -DENABLE_ambit=${ENABLE_ambit}
               -DENABLE_CheMPS2=${ENABLE_CheMPS2}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ ExternalProject_Add(psi4-core
               -DPython_EXECUTABLE=${Python_EXECUTABLE}
               -DPython_INCLUDE_DIR=${Python_INCLUDE_DIRS}
               -DPython_LIBRARY=${Python_LIBRARIES}
-              -DPython_NumPy_INCLUDE_DIRS=${_Python_NumPy_INCLUDE_DIR}
+              -DPython_NumPy_INCLUDE_DIR=${Python_NumPy_INCLUDE_DIR}
               -DPSI4_ROOT=${CMAKE_CURRENT_SOURCE_DIR}
               -DENABLE_ambit=${ENABLE_ambit}
               -DENABLE_CheMPS2=${ENABLE_CheMPS2}

--- a/conda/win/meta.yaml
+++ b/conda/win/meta.yaml
@@ -15,8 +15,8 @@ requirements:
     - numpy
     - pytest>=7.0.1
     - python={{ PY_VER }}
-    - qcelemental
-    - qcengine
+    - qcelemental=0.25.0
+    - qcengine=0.23.0
     - msgpack-python
     - gau2grid
     - libint2 2.6.0 h2e52968_4


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Todos
- [x] Something about how CMake detects NumPy during FindPython is different between NumPy 1.22 and 1.23; only on Windows. No apparent changes in CMake FindPython. No apparent changes in conda NumPy recipe. All header files in the same places in a Windows c-f 1.22 and 1.23 NumPy distribution. Linux builds fine with a c-f NumPy 1.23. I don't know what's the real change, so we'll tell CMake where to look in the Azure recipe and pass the hint on to psi4/CM for the second `find_package(Python ...)`.
- [x] My other theory for solving the Azure problem was that my patched `anaconda-client` was behind the times. That wasn't the problem, but it's updated to v1.10.0 anyways.
- [x] Pinned qcelemental and qcengine in Windows recipe
  * There's upcoming changes to those packages such that all of psi4 should be pinned and then advanced with the changes. This does that for the Windows recipe.
  * fixes #2614 where Windows conda package had _no_ qcel pinning, so depending on channel order, sometimes took a really old qcel and pydantic. after this, channel order shouldn't matter.

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
