### PR TITLE
Intel compiler vs DirectJK

### DIFF
--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -596,10 +596,11 @@ void DirectJK::build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& int
     // => Benchmarks <= //
 
     num_computed_shells_ = 0L;
+    size_t computed_shells = 0L;
 
 // ==> Master Task Loop <== //
 
-#pragma omp parallel for num_threads(nthread) schedule(dynamic) reduction(+ : num_computed_shells_)
+#pragma omp parallel for num_threads(nthread) schedule(dynamic) reduction(+ : computed_shells)
     for (size_t task = 0L; task < ntask_pair2; task++) {
         size_t task1 = task / ntask_pair;
         size_t task2 = task % ntask_pair;
@@ -660,7 +661,7 @@ void DirectJK::build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& int
                         // if (thread == 0) timer_on("JK: Ints");
                         if (ints[thread]->compute_shell(P, Q, R, S) == 0)
                             continue;  // No integrals in this shell quartet
-                        num_computed_shells_++;
+                        computed_shells++;
                         // if (thread == 0) timer_off("JK: Ints");
 
                         const double* buffer = ints[thread]->buffer();
@@ -1006,6 +1007,7 @@ void DirectJK::build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& int
         }
     }
 
+    num_computed_shells_ = computed_shells;
     if (get_bench()) {
         computed_shells_per_iter_.push_back(num_computed_shells());
     }


### PR DESCRIPTION
## Description
With Intel compiler, current master throws:

```
/psi/gits/hrw-pybind/psi4/src/psi4/libfock/DirectJK.cc(1015): internal error: null pointer
  }
  ^

compilation aborted for /psi/gits/hrw-pybind/psi4/src/psi4/libfock/DirectJK.cc (code 4)
```

~The `size_t` is in the header, so I don't know why it should need it again, but it seems to want it. All the below fail, too. I'm glad to try any more rational variations.~
```
# out-of-date # all throw with above
# out-of-date num_computed_shells_ = 0L;
# out-of-date num_computed_shells_ = 0;
# out-of-date num_computed_shells_ = std::size_t{ 0 };
```


FYI @andyj10224 who has also hit this and @davpoolechem since it came about in #2547.

~EDIT: nevermind, this only lets it build but kills off the threading and doesn't count ints. Ignore PR for now.~

EDIT: ok, this works, though I don't see why Intel should have complained about the original. Throw seen on 2021.4 and 2021.6, btw.

## Checklist
- Tests added for any new features
- [x] ~ran smoke~ ran full tests

## Status
- [x] Ready for review
- [x] Ready for merge
