### PR TITLE
Refactor `Vector` and `IntVector`

### DIFF
--- a/external/downstream/v2rdm_casscf/CMakeLists.txt
+++ b/external/downstream/v2rdm_casscf/CMakeLists.txt
@@ -16,8 +16,7 @@ if(${ENABLE_v2rdm_casscf})
 
         ExternalProject_Add(v2rdm_casscf_external
             DEPENDS psi4-core
-            # Re-change source URL once V2RDM is compatible with Vector/IntVector change and docc/socc change.
-            URL https://github.com/loriab/v2rdm_casscf/archive/v2rdm8.tar.gz
+            URL https://github.com/loriab/v2rdm_casscf/archive/dfdaae7.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -93,7 +93,7 @@ def array_to_matrix(
     Converts a `NumPy array
     <https://numpy.org/doc/stable/reference/arrays.ndarray.html>`_ or list of
     NumPy arrays into a |PSIfour| :class:`~psi4.core.Matrix` or
-    :class:`~psi4.core.Vector` (irreped if list).
+    :class:`~psi4.core.Vector` (irrepped if list).
 
     Parameters
     ----------
@@ -136,7 +136,7 @@ def array_to_matrix(
     # What type is it? MRO can help.
     arr_type = self.__mro__[0]
 
-    # Irreped case
+    # Irrepped case
     if isinstance(arr, (list, tuple)):
         if (dim1 is not None) or (dim2 is not None):
             raise ValidationError("Array_to_Matrix: If passed input is list of arrays dimension cannot be specified.")
@@ -174,7 +174,7 @@ def array_to_matrix(
     else:
         if arr_type == core.Matrix:
 
-            # Build an irreped array back out
+            # Build an irrepped array back out
             if dim1 is not None:
                 if dim2 is None:
                     raise ValidationError("Array_to_Matrix: If dim1 is supplied must supply dim2 also")
@@ -209,7 +209,7 @@ def array_to_matrix(
                 return ret
 
         elif arr_type == core.Vector:
-            # Build an irreped array back out
+            # Build an irrepped array back out
             if dim1 is not None:
                 if dim2 is not None:
                     raise ValidationError("Array_to_Matrix: If dim2 should not be supplied for 1D vectors.")
@@ -255,7 +255,7 @@ def _to_array(
     copy
         Copy the data if `True`, return a view otherwise
     dense
-        Converts irreped Psi4 objects to diagonally blocked dense arrays if
+        Converts irrepped Psi4 objects to diagonally blocked dense arrays if
         `True`. Returns a list of arrays otherwise.
 
     Returns
@@ -382,7 +382,7 @@ def _np_write(
     prefix: str = "",
 ) -> Optional[Dict[str, Any]]:
     """
-    Writes the irreped matrix to a NumPy uncompressed file using :func:`numpy.savez`.
+    Writes the irrepped matrix to a NumPy uncompressed file using :func:`numpy.savez`.
 
     Can return the packed data for saving many matrices into the same file.
 
@@ -578,7 +578,7 @@ def _chain_dot(*args, **kwargs) -> core.Matrix:
 
 def _irrep_access(self, *args, **kwargs):
     """
-    Warns user when iterating/accessing an irreped object.
+    Warns user when iterating/accessing an irrepped object.
     """
     raise ValidationError("Attempted to access by index/iteration a Psi4 data object that supports multiple"
                           " irreps. Please use .np or .nph explicitly.")

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -979,11 +979,6 @@ void py_psi_set_gradient(SharedMatrix grad) { Process::environment.set_gradient(
 
 SharedMatrix py_psi_get_gradient() { return Process::environment.gradient(); }
 
-std::shared_ptr<Vector> py_psi_get_atomic_point_charges() {
-    auto empty = std::make_shared<psi::Vector>();
-    return empty;  // charges not added to process.h for environment - yet(?)
-}
-
 void py_psi_set_memory(size_t mem, bool quiet) {
     Process::environment.set_memory(mem);
     if (!quiet) {
@@ -1208,7 +1203,6 @@ PYBIND11_MODULE(core, core) {
              "Returns the global gradient as a (nat, 3) :py:class:`~psi4.core.Matrix` object. FOR INTERNAL OPTKING USE ONLY.");
     core.def("set_legacy_gradient", py_psi_set_gradient, "grad"_a,
         "Assigns the global gradient to the values in the (nat, 3) Matrix argument. FOR INTERNAL OPTKING USE ONLY.");
-    core.def("get_atomic_point_charges", []() { PyErr_SetString(PyExc_AttributeError, "psi4.core.get_atomic_point_charges removed since hasn't been working as intended. Use Wavefunction.get_atomic_point_charges() instead."); }, ".. deprecated:: 1.4");
     core.def("set_memory_bytes", py_psi_set_memory, "memory"_a, "quiet"_a = false,
              "Sets the memory available to Psi (in bytes); prefer :func:`psi4.driver.set_memory`.");
     core.def("get_memory", py_psi_get_memory, "Returns the amount of memory available to Psi (in bytes).");

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -347,9 +347,9 @@ void export_mints(py::module& m) {
         .def("begin", &Slice::begin, "Get the first element of this slice")
         .def("end", &Slice::end, "Get the past-the-end element of this slice");
 
-    py::class_<IrrepedVector<double>, std::shared_ptr<IrrepedVector<double>>>(m, "ProtoVector");
+    py::class_<IrreppedVector<double>, std::shared_ptr<IrreppedVector<double>>>(m, "ProtoVector");
 
-    py::class_<Vector, std::shared_ptr<Vector>, IrrepedVector<double>>(m, "Vector", "Class for creating and manipulating vectors",
+    py::class_<Vector, std::shared_ptr<Vector>, IrreppedVector<double>>(m, "Vector", "Class for creating and manipulating vectors",
                                                 py::dynamic_attr())
         .def(py::init<int>())
         .def(py::init<const Dimension&>())
@@ -429,13 +429,13 @@ void export_mints(py::module& m) {
             },
             py::return_value_policy::reference_internal);
 
-    py::class_<IrrepedVector<int>, std::shared_ptr<IrrepedVector<int>>>(m, "ProtoIntVector");
+    py::class_<IrreppedVector<int>, std::shared_ptr<IrreppedVector<int>>>(m, "ProtoIntVector");
 
     typedef int (IntVector::*int_vector_get_1)(int) const;
     typedef int (IntVector::*int_vector_get_2)(int, int) const;
     typedef void (IntVector::*int_vector_set_1)(int, int);
     typedef void (IntVector::*int_vector_set_2)(int, int, int);
-    py::class_<IntVector, std::shared_ptr<IntVector>, IrrepedVector<int>>(m, "IntVector", "Class handling vectors with integer values")
+    py::class_<IntVector, std::shared_ptr<IntVector>, IrreppedVector<int>>(m, "IntVector", "Class handling vectors with integer values")
         .def(py::init<int>())
         .def(py::init<const Dimension&>())
         .def(py::init<const std::string&, int>())

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -373,7 +373,7 @@ void export_mints(py::module& m) {
             },
             "Clone the vector")
         .def("zero", &Vector::zero, "Zeros the vector")
-        .def("print_out", &Vector::print_out, "Prints the vector to the output file")
+        .def("print_out", &Vector::print, "Prints the vector to the output file")
         .def("scale", &Vector::scale, "Scales the elements of a vector by sc", "sc"_a)
         .def("dim", &Vector::dim, "Returns the dimensions of the vector per irrep h", "h"_a = 0)
         .def("dimpi", &Vector::dimpi, "Returns the Dimension object")
@@ -434,7 +434,7 @@ void export_mints(py::module& m) {
         .def("get", int_vector_get(&IntVector::get), "Returns a single element value located at m in irrep h", "h"_a, "m"_a)
         .def("set", int_vector_set(&IntVector::set), "Sets a single element value located at m in irrep h", "h"_a,
              "m"_a, "val"_a)
-        .def("print_out", &IntVector::print_out, "Prints the vector to the output file")
+        .def("print_out", &IntVector::print, "Prints the vector to the output file")
         .def("dim", &IntVector::dim, "Returns the number of dimensions per irrep h", "h"_a)
         .def("nirrep", &IntVector::nirrep, "Returns the number of irreps");
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -356,8 +356,6 @@ void export_mints(py::module& m) {
         .def(py::init<const std::string&, const Dimension&>())
         .def_property("name", &Vector::name, &Vector::set_name,
                       "The name of the Vector. Used in printing.")
-        //.def_property("name", py::cpp_function(&Vector::name), py::cpp_function(&Vector::set_name),
-        //              "The name of the Vector. Used in printing.")
         .def("get", vector_getitem_1(&Vector::get), "Returns a single element value located at m", "m"_a)
         .def("get", vector_getitem_2(&Vector::get), "Returns a single element value located at m in irrep h", "h"_a,
              "m"_a)
@@ -373,7 +371,7 @@ void export_mints(py::module& m) {
             },
             "Clone the vector")
         .def("zero", &Vector::zero, "Zeros the vector")
-        .def("print_out", &Vector::print, "Prints the vector to the output file")
+        .def("print_out", [](Vector& vec) {vec.print();}, "Prints the vector to the output file")
         .def("scale", &Vector::scale, "Scales the elements of a vector by sc", "sc"_a)
         .def("dim", &Vector::dim, "Returns the dimensions of the vector per irrep h", "h"_a = 0)
         .def("dimpi", &Vector::dimpi, "Returns the Dimension object")
@@ -434,7 +432,7 @@ void export_mints(py::module& m) {
         .def("get", int_vector_get(&IntVector::get), "Returns a single element value located at m in irrep h", "h"_a, "m"_a)
         .def("set", int_vector_set(&IntVector::set), "Sets a single element value located at m in irrep h", "h"_a,
              "m"_a, "val"_a)
-        .def("print_out", &IntVector::print, "Prints the vector to the output file")
+        .def("print_out", [](IntVector& vec) {vec.print();}, "Prints the vector to the output file")
         .def("dim", &IntVector::dim, "Returns the number of dimensions per irrep h", "h"_a)
         .def("nirrep", &IntVector::nirrep, "Returns the number of irreps");
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -355,6 +355,7 @@ void export_mints(py::module& m) {
         .def(py::init<const std::string&, const Dimension&>())
         .def_property("name", &Vector::name, &Vector::set_name,
                       "The name of the Vector. Used in printing.")
+        .def("init", &Vector::init, "Reallocate the data of the Vector. Consider making a new object.")
         .def("get", vector_getitem_1(&Vector::get), "Returns a single element value located at m", "m"_a)
         .def("get", vector_getitem_2(&Vector::get), "Returns a single element value located at m in irrep h", "h"_a,
              "m"_a)
@@ -364,7 +365,7 @@ void export_mints(py::module& m) {
         .def("add", vector_setitem_1(&Vector::add), "Add to a single element value located at m", "m"_a, "val"_a)
         .def("add", vector_setitem_2(&Vector::add), "Add to a single element value located at m in irrep h", "h"_a, "m"_a,
              "val"_a)
-        .def("copy", &Vector::copy, "Returns a copy of the vector")
+        .def("copy", &Vector::copy, "Copy another vector into this.")
         .def(
             "clone",
             [](Vector& vec) {
@@ -437,6 +438,7 @@ void export_mints(py::module& m) {
         .def(py::init<const std::string&, const Dimension&>())
         .def_property("name", &IntVector::name, &IntVector::set_name,
                       "The name of the IntVector. Used in printing.")
+        .def("init", &IntVector::init, "Reallocate the data of the Vector. Consider making a new object.")
         .def("get", int_vector_get_1(&IntVector::get), "Returns a single element value located at m", "m"_a)
         .def("get", int_vector_get_2(&IntVector::get), "Returns a single element value located at m in irrep h", "h"_a, "m"_a)
         .def("set", int_vector_set_1(&IntVector::set), "Sets a single element value located at m", "m"_a, "val"_a)
@@ -445,12 +447,19 @@ void export_mints(py::module& m) {
         .def("add", int_vector_set_1(&IntVector::add), "Add to a single element value located at m", "m"_a, "val"_a)
         .def("add", int_vector_set_2(&IntVector::add), "Add to a single element value located at m in irrep h", "h"_a, "m"_a,
              "val"_a)
-        .def("copy", &IntVector::copy, "Returns a copy of the vector")
+        .def("copy", &IntVector::copy, "Copy another vector into this.")
+        .def(
+            "clone",
+            [](IntVector& vec) {
+                return std::make_shared<IntVector>(std::move(vec.clone()));
+            },
+            "Clone the vector")
         .def("zero", &IntVector::zero, "Zeros the vector")
         .def("print_out", [](IntVector& vec) {vec.print();}, "Prints the vector to the output file")
         .def("dim", &IntVector::dim, "Returns the number of dimensions per irrep h", "h"_a = 0)
         .def("dimpi", &IntVector::dimpi, "Returns the Dimension object")
-        .def("nirrep", &IntVector::nirrep, "Returns the number of irreps");
+        .def("nirrep", &IntVector::nirrep, "Returns the number of irreps")
+        .def_static("iota", &IntVector::iota);
 
     py::enum_<diagonalize_order>(m, "DiagonalizeOrder", "Defines ordering of eigenvalues after diagonalization")
         .value("Ascending", ascending)

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -354,8 +354,10 @@ void export_mints(py::module& m) {
         .def(py::init<const Dimension&>())
         .def(py::init<const std::string&, int>())
         .def(py::init<const std::string&, const Dimension&>())
-        .def_property("name", py::cpp_function(&Vector::name), py::cpp_function(&Vector::set_name),
+        .def_property("name", &Vector::name, &Vector::set_name,
                       "The name of the Vector. Used in printing.")
+        //.def_property("name", py::cpp_function(&Vector::name), py::cpp_function(&Vector::set_name),
+        //              "The name of the Vector. Used in printing.")
         .def("get", vector_getitem_1(&Vector::get), "Returns a single element value located at m", "m"_a)
         .def("get", vector_getitem_2(&Vector::get), "Returns a single element value located at m in irrep h", "h"_a,
              "m"_a)
@@ -425,10 +427,11 @@ void export_mints(py::module& m) {
             },
             py::return_value_policy::reference_internal);
 
+    typedef int (IntVector::*int_vector_get)(int, int) const;
     typedef void (IntVector::*int_vector_set)(int, int, int);
     py::class_<IntVector, std::shared_ptr<IntVector>>(m, "IntVector", "Class handling vectors with integer values")
         .def(py::init<int>())
-        .def("get", &IntVector::get, "Returns a single element value located at m in irrep h", "h"_a, "m"_a)
+        .def("get", int_vector_get(&IntVector::get), "Returns a single element value located at m in irrep h", "h"_a, "m"_a)
         .def("set", int_vector_set(&IntVector::set), "Sets a single element value located at m in irrep h", "h"_a,
              "m"_a, "val"_a)
         .def("print_out", &IntVector::print_out, "Prints the vector to the output file")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -347,7 +347,9 @@ void export_mints(py::module& m) {
         .def("begin", &Slice::begin, "Get the first element of this slice")
         .def("end", &Slice::end, "Get the past-the-end element of this slice");
 
-    py::class_<Vector, std::shared_ptr<Vector>>(m, "Vector", "Class for creating and manipulating vectors",
+    py::class_<IrrepedVector<double>, std::shared_ptr<IrrepedVector<double>>>(m, "ProtoVector");
+
+    py::class_<Vector, std::shared_ptr<Vector>, IrrepedVector<double>>(m, "Vector", "Class for creating and manipulating vectors",
                                                 py::dynamic_attr())
         .def(py::init<int>())
         .def(py::init<const Dimension&>())
@@ -427,11 +429,13 @@ void export_mints(py::module& m) {
             },
             py::return_value_policy::reference_internal);
 
+    py::class_<IrrepedVector<int>, std::shared_ptr<IrrepedVector<int>>>(m, "ProtoIntVector");
+
     typedef int (IntVector::*int_vector_get_1)(int) const;
     typedef int (IntVector::*int_vector_get_2)(int, int) const;
     typedef void (IntVector::*int_vector_set_1)(int, int);
     typedef void (IntVector::*int_vector_set_2)(int, int, int);
-    py::class_<IntVector, std::shared_ptr<IntVector>>(m, "IntVector", "Class handling vectors with integer values")
+    py::class_<IntVector, std::shared_ptr<IntVector>, IrrepedVector<int>>(m, "IntVector", "Class handling vectors with integer values")
         .def(py::init<int>())
         .def(py::init<const Dimension&>())
         .def(py::init<const std::string&, int>())
@@ -459,6 +463,8 @@ void export_mints(py::module& m) {
         .def("dim", &IntVector::dim, "Returns the number of dimensions per irrep h", "h"_a = 0)
         .def("dimpi", &IntVector::dimpi, "Returns the Dimension object")
         .def("nirrep", &IntVector::nirrep, "Returns the number of irreps")
+        .def("get_block", &IntVector::get_block, "Get a vector block", "slice"_a)
+        .def("set_block", &IntVector::set_block, "Set a vector block", "slice"_a, "block"_a)
         .def_static("iota", &IntVector::iota);
 
     py::enum_<diagonalize_order>(m, "DiagonalizeOrder", "Defines ordering of eigenvalues after diagonalization")

--- a/psi4/src/psi4/adc/adc.cc
+++ b/psi4/src/psi4/adc/adc.cc
@@ -103,9 +103,9 @@ ADCWfn::ADCWfn(SharedWavefunction ref_wfn, Options& options) : Wavefunction(opti
             outfile->Printf("dim of states_per_irrep vector must be %d\n", nirrep_);
             throw PsiException("adc input comparison error ROOTS_PER_IRREP and nirrep_", __FILE__, __LINE__);
         }
-        rpi_ = options_.get_int_vector("ROOTS_PER_IRREP");
+        rpi_ = Dimension(options_.get_int_vector("ROOTS_PER_IRREP"));
     } else {
-        rpi_ = std::vector<int>(nirrep_, 1);
+        rpi_ = Dimension(std::vector<int>(nirrep_, 1));
     }
 
     // Setting up dimensions for each irrep block and totoal dimension of S manifold.

--- a/psi4/src/psi4/adc/adc.h
+++ b/psi4/src/psi4/adc/adc.h
@@ -106,7 +106,7 @@ class ADCWfn : public Wavefunction {
     // Number of doubly occupied MOs per irrep
     int *clsdpi_;
     // Roots sought per irrep
-    std::vector<int> rpi_;
+    Dimension rpi_;
     // Number of sngly excited configurations per irrep
     int *nxspi_;
     // Irreps for X, Y and Z

--- a/psi4/src/psi4/adc/compute_energy.cc
+++ b/psi4/src/psi4/adc/compute_energy.cc
@@ -54,7 +54,7 @@ double ADCWfn::compute_energy() {
     double *omega, omega_o, omega_diff, theta;
     dpdfile2 B, V;
 
-    omega_guess_ = std::make_shared<Vector>(nirrep_, rpi_.data());
+    omega_guess_ = std::make_shared<Vector>(rpi_);
 
     if (options_.get_str("REFERENCE") == "RHF") {
         corr_energy = rhf_init_tensors();

--- a/psi4/src/psi4/dct/dct.cc
+++ b/psi4/src/psi4/dct/dct.cc
@@ -116,10 +116,6 @@ void DCTSolver::dpd_buf4_add(dpdbuf4 *A, dpdbuf4 *B, double alpha) {
 }
 
 DCTSolver::~DCTSolver() {
-    delete[] aocc_off_;
-    delete[] avir_off_;
-    delete[] bocc_off_;
-    delete[] bvir_off_;
 }
 
 }  // namespace dct

--- a/psi4/src/psi4/dct/dct.h
+++ b/psi4/src/psi4/dct/dct.h
@@ -363,13 +363,13 @@ class DCTSolver : public Wavefunction {
     /// The number of virtual beta orbitals per irrep
     Dimension nbvirpi_;
     /// Alpha occupied MO offset
-    int* aocc_off_;
+    std::vector<int> aocc_off_;
     /// Alpha virtual MO offset
-    int* avir_off_;
+    std::vector<int> avir_off_;
     /// Beta occupied MO offset
-    int* bocc_off_;
+    std::vector<int> bocc_off_;
     /// Beta virtual MO offset
-    int* bvir_off_;
+    std::vector<int> bvir_off_;
     /// The nuclear repulsion energy in Hartree
     double enuc_;
     /// The cutoff below which and integral is assumed to be zero

--- a/psi4/src/psi4/dct/dct_intermediates_RHF.cc
+++ b/psi4/src/psi4/dct/dct_intermediates_RHF.cc
@@ -264,8 +264,8 @@ void DCTSolver::form_density_weighted_fock_RHF() {
     global_dpd_->file2_close(&T_OO);
     global_dpd_->file2_close(&T_VV);
 
-    auto a_evecs = std::make_shared<Matrix>("Tau Eigenvectors (Alpha)", nirrep_, nmopi_, nmopi_);
-    auto a_evals = std::make_shared<Vector>("Tau Eigenvalues (Alpha)", nirrep_, nmopi_);
+    auto a_evecs = std::make_shared<Matrix>("Tau Eigenvectors (Alpha)", nmopi_, nmopi_);
+    auto a_evals = std::make_shared<Vector>("Tau Eigenvalues (Alpha)", nmopi_);
 
     // Diagonalize Tau
     a_tau_mo.diagonalize(a_evecs, a_evals);

--- a/psi4/src/psi4/dct/dct_intermediates_UHF.cc
+++ b/psi4/src/psi4/dct/dct_intermediates_UHF.cc
@@ -522,8 +522,8 @@ void DCTSolver::form_density_weighted_fock() {
 
     auto a_evecs = std::make_shared<Matrix>("Tau Eigenvectors (Alpha)", nirrep_, nmopi_, nmopi_);
     auto b_evecs = std::make_shared<Matrix>("Tau Eigenvectors (Beta)", nirrep_, nmopi_, nmopi_);
-    auto a_evals = std::make_shared<Vector>("Tau Eigenvalues (Alpha)", nirrep_, nmopi_);
-    auto b_evals = std::make_shared<Vector>("Tau Eigenvalues (Beta)", nirrep_, nmopi_);
+    auto a_evals = std::make_shared<Vector>("Tau Eigenvalues (Alpha)",  nmopi_);
+    auto b_evals = std::make_shared<Vector>("Tau Eigenvalues (Beta)", nmopi_);
 
     // Diagonalize Tau
     a_tau_mo.diagonalize(a_evecs, a_evals);

--- a/psi4/src/psi4/dct/dct_memory.cc
+++ b/psi4/src/psi4/dct/dct_memory.cc
@@ -98,8 +98,8 @@ void DCTSolver::init() {
     ao_s_ = std::make_shared<Matrix>("SO Basis Overlap Integrals", nirrep_, nsopi_, nsopi_);
     so_h_ = Matrix("SO basis one-electron integrals", nirrep_, nsopi_, nsopi_);
     s_half_inv_ = std::make_shared<Matrix>("SO Basis Inverse Square Root Overlap Matrix", nirrep_, nsopi_, nsopi_);
-    epsilon_a_ = std::make_shared<Vector>(nirrep_, nsopi_);
-    epsilon_b_ = std::make_shared<Vector>(nirrep_, nsopi_);
+    epsilon_a_ = std::make_shared<Vector>(nsopi_);
+    epsilon_b_ = std::make_shared<Vector>(nsopi_);
     kappa_mo_a_ = std::make_shared<Matrix>("MO basis Kappa (Alpha)", nirrep_, nmopi_, nmopi_);
     kappa_mo_b_ = std::make_shared<Matrix>("MO basis Kappa (Beta)", nirrep_, nmopi_, nmopi_);
     tau_so_a_ = std::make_shared<Matrix>("Alpha Tau Matrix", nirrep_, nsopi_, nsopi_);
@@ -110,8 +110,8 @@ void DCTSolver::init() {
     bvir_tau_ = Matrix("MO basis Tau (Beta Virtual)", nirrep_, nbvirpi_, nbvirpi_);
 
     // Compute MO offsets
-    aocc_off_ = new int[nirrep_];
-    avir_off_ = new int[nirrep_];
+    aocc_off_ = std::vector<int>(nirrep_);
+    avir_off_ = std::vector<int>(nirrep_);
     double ocount = naoccpi_[0];
     double vcount = navirpi_[0];
     aocc_off_[0] = 0;
@@ -123,8 +123,8 @@ void DCTSolver::init() {
         vcount += navirpi_[h];
     }
 
-    bocc_off_ = new int[nirrep_];
-    bvir_off_ = new int[nirrep_];
+    bocc_off_ = std::vector<int>(nirrep_);
+    bvir_off_ = std::vector<int>(nirrep_);
     ocount = nboccpi_[0];
     vcount = nbvirpi_[0];
     bocc_off_[0] = 0;
@@ -185,7 +185,7 @@ void DCTSolver::init() {
     Matrix eigvec(nirrep_, nsopi_, nsopi_);
     Matrix eigtemp(nirrep_, nsopi_, nsopi_);
     Matrix eigtemp2(nirrep_, nsopi_, nsopi_);
-    Vector eigval(nirrep_, nsopi_);
+    Vector eigval(nsopi_);
     ao_s_->diagonalize(eigvec, eigval);
     // Convert the eigenvales to 1/sqrt(eigenvalues)
     for (int h = 0; h < nirrep_; ++h) {

--- a/psi4/src/psi4/dct/dct_qc.cc
+++ b/psi4/src/psi4/dct/dct_qc.cc
@@ -1783,7 +1783,7 @@ int DCTSolver::iterate_nr_conjugate_gradients() {
 
         // Compute new conjugate direction vector orthogonal to the previous search direction
         D_->scale(beta);
-        D_->add(S_);
+        D_->add(*S_);
 
         // Compute RMS of the residual
         residual_rms = std::sqrt(residual_rms / nidp_);

--- a/psi4/src/psi4/dct/dct_scf_RHF.cc
+++ b/psi4/src/psi4/dct/dct_scf_RHF.cc
@@ -53,8 +53,8 @@ namespace dct {
 void DCTSolver::initialize_orbitals_from_reference_R() {
     dct_timer_on("DCTSolver::rhf_guess");
 
-    epsilon_a_->copy(reference_wavefunction_->epsilon_a().get());
-    epsilon_b_->copy(epsilon_a_.get());
+    epsilon_a_->copy(*reference_wavefunction_->epsilon_a());
+    epsilon_b_->copy(*epsilon_a_);
     Ca_->copy(reference_wavefunction_->Ca());
     Cb_->copy(Ca_);
     moFa_->copy(reference_wavefunction_->Fa());

--- a/psi4/src/psi4/dct/dct_scf_UHF.cc
+++ b/psi4/src/psi4/dct/dct_scf_UHF.cc
@@ -115,8 +115,8 @@ bool DCTSolver::correct_mo_phase_spincase(Matrix& temp, Matrix& overlap, const M
 void DCTSolver::initialize_orbitals_from_reference_U() {
     dct_timer_on("DCTSolver::scf_guess");
 
-    epsilon_a_->copy(reference_wavefunction_->epsilon_a().get());
-    epsilon_b_->copy(reference_wavefunction_->epsilon_b().get());
+    epsilon_a_->copy(*reference_wavefunction_->epsilon_a());
+    epsilon_b_->copy(*reference_wavefunction_->epsilon_b());
     Ca_->copy(reference_wavefunction_->Ca());
     Cb_->copy(reference_wavefunction_->Cb());
     moFa_->copy(reference_wavefunction_->Fa());

--- a/psi4/src/psi4/dct/dct_tau_RHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_RHF.cc
@@ -182,8 +182,8 @@ void DCTSolver::build_tau_R() {
         // Diagonalize and take a square root
         auto aocc_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Occupied)", nirrep_, naoccpi_, naoccpi_);
         auto avir_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Virtual)", nirrep_, navirpi_, navirpi_);
-        auto aocc_evals = std::make_shared<Vector>("Eigenvalues (Alpha Occupied)", nirrep_, naoccpi_);
-        auto avir_evals = std::make_shared<Vector>("Eigenvalues (Alpha Virtual)", nirrep_, navirpi_);
+        auto aocc_evals = std::make_shared<Vector>("Eigenvalues (Alpha Occupied)", naoccpi_);
+        auto avir_evals = std::make_shared<Vector>("Eigenvalues (Alpha Virtual)", navirpi_);
         aocc_tau_old.diagonalize(aocc_evecs, aocc_evals);
         avir_tau_old.diagonalize(avir_evecs, avir_evals);
 

--- a/psi4/src/psi4/dct/dct_tau_UHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_UHF.cc
@@ -643,8 +643,8 @@ void DCTSolver::print_opdm() {
     // Diagonalize OPDM to obtain NOs
     auto aevecs = std::make_shared<Matrix>("Eigenvectors (Alpha)", nirrep_, nmopi_, nmopi_);
     auto bevecs = std::make_shared<Matrix>("Eigenvectors (Beta)", nirrep_, nmopi_, nmopi_);
-    auto aevals = std::make_shared<Vector>("Eigenvalues (Alpha)", nirrep_, nmopi_);
-    auto bevals = std::make_shared<Vector>("Eigenvalues (Beta)", nirrep_, nmopi_);
+    auto aevals = std::make_shared<Vector>("Eigenvalues (Alpha)", nmopi_);
+    auto bevals = std::make_shared<Vector>("Eigenvalues (Beta)", nmopi_);
 
     a_opdm->diagonalize(aevecs, aevals, descending);
     b_opdm->diagonalize(bevecs, bevals, descending);
@@ -818,10 +818,10 @@ void DCTSolver::build_tau_U() {
         auto bocc_evecs = std::make_shared<Matrix>("Eigenvectors (Beta Occupied)", nirrep_, nboccpi_, nboccpi_);
         auto avir_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Virtual)", nirrep_, navirpi_, navirpi_);
         auto bvir_evecs = std::make_shared<Matrix>("Eigenvectors (Beta Virtual)", nirrep_, nbvirpi_, nbvirpi_);
-        auto aocc_evals = std::make_shared<Vector>("Eigenvalues (Alpha Occupied)", nirrep_, naoccpi_);
-        auto bocc_evals = std::make_shared<Vector>("Eigenvalues (Beta Occupied)", nirrep_, nboccpi_);
-        auto avir_evals = std::make_shared<Vector>("Eigenvalues (Alpha Virtual)", nirrep_, navirpi_);
-        auto bvir_evals = std::make_shared<Vector>("Eigenvalues (Beta Virtual)", nirrep_, nbvirpi_);
+        auto aocc_evals = std::make_shared<Vector>("Eigenvalues (Alpha Occupied)", naoccpi_);
+        auto bocc_evals = std::make_shared<Vector>("Eigenvalues (Beta Occupied)", nboccpi_);
+        auto avir_evals = std::make_shared<Vector>("Eigenvalues (Alpha Virtual)", navirpi_);
+        auto bvir_evals = std::make_shared<Vector>("Eigenvalues (Beta Virtual)", nbvirpi_);
         aocc_tau_old->diagonalize(aocc_evecs, aocc_evals);
         bocc_tau_old->diagonalize(bocc_evecs, bocc_evals);
         avir_tau_old->diagonalize(avir_evecs, avir_evals);

--- a/psi4/src/psi4/dct/dct_triples.cc
+++ b/psi4/src/psi4/dct/dct_triples.cc
@@ -140,8 +140,8 @@ void DCTSolver::dump_semicanonical() {
     // Diagonalize F0 to get transformation matrix to semicanonical basis
     auto a_evecs = std::make_shared<Matrix>("F0 Eigenvectors (Alpha)", nirrep_, nmopi_, nmopi_);
     auto b_evecs = std::make_shared<Matrix>("F0 Eigenvectors (Beta)", nirrep_, nmopi_, nmopi_);
-    auto a_evals = std::make_shared<Vector>("F0 Eigenvalues (Alpha)", nirrep_, nmopi_);
-    auto b_evals = std::make_shared<Vector>("F0 Eigenvalues (Beta)", nirrep_, nmopi_);
+    auto a_evals = std::make_shared<Vector>("F0 Eigenvalues (Alpha)", nmopi_);
+    auto b_evals = std::make_shared<Vector>("F0 Eigenvalues (Beta)", nmopi_);
 
     Ftilde_a_->diagonalize(a_evecs, a_evals);
     Ftilde_a_->zero();
@@ -1059,7 +1059,7 @@ double DCTSolver::compute_triples_aaa() {
 
                                 global_dpd_->sort_3d(WBCA, WABC, nirrep_, Gijk, I_OVVV.params->coltot,
                                                      I_OVVV.params->colidx, I_OVVV.params->colorb, I_OVVV.params->rsym,
-                                                     I_OVVV.params->ssym, avir_off_, avir_off_, navirpi_, avir_off_,
+                                                     I_OVVV.params->ssym, avir_off_.data(), avir_off_.data(), navirpi_, avir_off_.data(),
                                                      I_OVVV.params->colidx, cab, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -1189,7 +1189,7 @@ double DCTSolver::compute_triples_aaa() {
 
                                 global_dpd_->sort_3d(WACB, WABC, nirrep_, Gijk, I_OVVV.params->coltot,
                                                      I_OVVV.params->colidx, I_OVVV.params->colorb, I_OVVV.params->rsym,
-                                                     I_OVVV.params->ssym, avir_off_, avir_off_, navirpi_, avir_off_,
+                                                     I_OVVV.params->ssym, avir_off_.data(), avir_off_.data(), navirpi_, avir_off_.data(),
                                                      I_OVVV.params->colidx, acb, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -1552,7 +1552,7 @@ double DCTSolver::compute_triples_aab() {
 
                                 global_dpd_->sort_3d(WBcA, WABc, nirrep_, Gijk, I_OvVv.params->coltot,
                                                      I_OvVv.params->colidx, I_OvVv.params->colorb, I_OvVv.params->rsym,
-                                                     I_OvVv.params->ssym, avir_off_, bvir_off_, navirpi_, avir_off_,
+                                                     I_OvVv.params->ssym, avir_off_.data(), bvir_off_.data(), navirpi_, avir_off_.data(),
                                                      I_OVVV.params->colidx, cab, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -1644,7 +1644,7 @@ double DCTSolver::compute_triples_aab() {
 
                                 global_dpd_->sort_3d(WAcB, WABc, nirrep_, Gijk, I_OvVv.params->coltot,
                                                      I_OvVv.params->colidx, I_OvVv.params->colorb, I_OvVv.params->rsym,
-                                                     I_OvVv.params->ssym, avir_off_, bvir_off_, navirpi_, avir_off_,
+                                                     I_OvVv.params->ssym, avir_off_.data(), bvir_off_.data(), navirpi_, avir_off_.data(),
                                                      I_OVVV.params->colidx, acb, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -1699,7 +1699,7 @@ double DCTSolver::compute_triples_aab() {
 
                                 global_dpd_->sort_3d(WcBA, WABc, nirrep_, Gijk, I_oVvV.params->coltot,
                                                      I_oVvV.params->colidx, I_oVvV.params->colorb, I_oVvV.params->rsym,
-                                                     I_oVvV.params->ssym, bvir_off_, avir_off_, navirpi_, avir_off_,
+                                                     I_oVvV.params->ssym, bvir_off_.data(), avir_off_.data(), navirpi_, avir_off_.data(),
                                                      I_OVVV.params->colidx, cba, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -1753,7 +1753,7 @@ double DCTSolver::compute_triples_aab() {
 
                                 global_dpd_->sort_3d(WcAB, WABc, nirrep_, Gijk, I_oVvV.params->coltot,
                                                      I_oVvV.params->colidx, I_oVvV.params->colorb, I_oVvV.params->rsym,
-                                                     I_oVvV.params->ssym, bvir_off_, avir_off_, navirpi_, avir_off_,
+                                                     I_oVvV.params->ssym, bvir_off_.data(), avir_off_.data(), navirpi_, avir_off_.data(),
                                                      I_OVVV.params->colidx, bca, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -2056,7 +2056,7 @@ double DCTSolver::compute_triples_abb() {
 
                                 global_dpd_->sort_3d(WAcb, WAbc, nirrep_, Gijk, I_OvVv.params->coltot,
                                                      I_OvVv.params->colidx, I_OvVv.params->colorb, I_OvVv.params->rsym,
-                                                     I_OvVv.params->ssym, avir_off_, bvir_off_, nbvirpi_, bvir_off_,
+                                                     I_OvVv.params->ssym, avir_off_.data(), bvir_off_.data(), nbvirpi_, bvir_off_.data(),
                                                      I_OvVv.params->colidx, acb, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -2148,7 +2148,7 @@ double DCTSolver::compute_triples_abb() {
 
                                 global_dpd_->sort_3d(WbcA, WAbc, nirrep_, Gijk, I_ovvv.params->coltot,
                                                      I_ovvv.params->colidx, I_ovvv.params->colorb, I_ovvv.params->rsym,
-                                                     I_ovvv.params->ssym, bvir_off_, bvir_off_, navirpi_, avir_off_,
+                                                     I_ovvv.params->ssym, bvir_off_.data(), bvir_off_.data(), navirpi_, avir_off_.data(),
                                                      I_OvVv.params->colidx, cab, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -2240,7 +2240,7 @@ double DCTSolver::compute_triples_abb() {
 
                                 global_dpd_->sort_3d(WcAb, WAbc, nirrep_, Gijk, I_oVvV.params->coltot,
                                                      I_oVvV.params->colidx, I_oVvV.params->colorb, I_oVvV.params->rsym,
-                                                     I_oVvV.params->ssym, bvir_off_, avir_off_, nbvirpi_, bvir_off_,
+                                                     I_oVvV.params->ssym, bvir_off_.data(), avir_off_.data(), nbvirpi_, bvir_off_.data(),
                                                      I_OvVv.params->colidx, bca, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -2332,7 +2332,7 @@ double DCTSolver::compute_triples_abb() {
 
                                 global_dpd_->sort_3d(WbAc, WAbc, nirrep_, Gijk, I_oVvV.params->coltot,
                                                      I_oVvV.params->colidx, I_oVvV.params->colorb, I_oVvV.params->rsym,
-                                                     I_oVvV.params->ssym, bvir_off_, avir_off_, nbvirpi_, bvir_off_,
+                                                     I_oVvV.params->ssym, bvir_off_.data(), avir_off_.data(), nbvirpi_, bvir_off_.data(),
                                                      I_OvVv.params->colidx, bac, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -2748,7 +2748,7 @@ double DCTSolver::compute_triples_bbb() {
 
                                 global_dpd_->sort_3d(WBCA, WABC, nirrep_, Gijk, I_ovvv.params->coltot,
                                                      I_ovvv.params->colidx, I_ovvv.params->colorb, I_ovvv.params->rsym,
-                                                     I_ovvv.params->ssym, bvir_off_, bvir_off_, nbvirpi_, bvir_off_,
+                                                     I_ovvv.params->ssym, bvir_off_.data(), bvir_off_.data(), nbvirpi_, bvir_off_.data(),
                                                      I_ovvv.params->colidx, cab, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {
@@ -2878,7 +2878,7 @@ double DCTSolver::compute_triples_bbb() {
 
                                 global_dpd_->sort_3d(WACB, WABC, nirrep_, Gijk, I_ovvv.params->coltot,
                                                      I_ovvv.params->colidx, I_ovvv.params->colorb, I_ovvv.params->rsym,
-                                                     I_ovvv.params->ssym, bvir_off_, bvir_off_, nbvirpi_, bvir_off_,
+                                                     I_ovvv.params->ssym, bvir_off_.data(), bvir_off_.data(), nbvirpi_, bvir_off_.data(),
                                                      I_ovvv.params->colidx, acb, 1);
 
                                 for (Gab = 0; Gab < nirrep_; Gab++) {

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -1039,7 +1039,7 @@ void CIWavefunction::pitzer_to_ci_order_onel(SharedMatrix src, SharedVector dest
 }
 void CIWavefunction::pitzer_to_ci_order_twoel(SharedMatrix src, SharedVector dest) {
     if ((src->nirrep() != 1) || dest->nirrep() != 1) {
-        throw PSIEXCEPTION("CIWavefunciton::pitzer_to_ci_order_twoel irreped matrices are not supported.");
+        throw PSIEXCEPTION("CIWavefunciton::pitzer_to_ci_order_twoel irrepped matrices are not supported.");
     }
     if (dest->dim(0) != CalcInfo_->num_ci_tri2) {
         throw PSIEXCEPTION("CIWavefunciton::pitzer_to_ci_order_onel: Destination vector must be of size ncitri2.");

--- a/psi4/src/psi4/dlpno/mp2.cc
+++ b/psi4/src/psi4/dlpno/mp2.cc
@@ -849,7 +849,7 @@ void DLPNOMP2::pno_transform() {
 
         // Diagonalization of pair density gives PNOs (in basis of the LMO's virtual domain) and PNO occ numbers
         auto X_pno_ij = std::make_shared<Matrix>("eigenvectors", nvir_ij, nvir_ij);
-        auto pno_occ = Vector("eigenvalues", nvir_ij);
+        Vector pno_occ("eigenvalues", nvir_ij);
         D_ij->diagonalize(X_pno_ij, pno_occ, descending);
 
         int nvir_ij_final = 0;

--- a/psi4/src/psi4/dlpno/mp2.cc
+++ b/psi4/src/psi4/dlpno/mp2.cc
@@ -849,23 +849,23 @@ void DLPNOMP2::pno_transform() {
 
         // Diagonalization of pair density gives PNOs (in basis of the LMO's virtual domain) and PNO occ numbers
         auto X_pno_ij = std::make_shared<Matrix>("eigenvectors", nvir_ij, nvir_ij);
-        SharedVector pno_occ = std::make_shared<Vector>("eigenvalues", nvir_ij);
+        auto pno_occ = Vector("eigenvalues", nvir_ij);
         D_ij->diagonalize(X_pno_ij, pno_occ, descending);
 
         int nvir_ij_final = 0;
         for (size_t a = 0; a < nvir_ij; ++a) {
-            if (fabs(pno_occ->get(a)) >= T_CUT_PNO_) {
+            if (fabs(pno_occ.get(a)) >= T_CUT_PNO_) {
                 nvir_ij_final++;
             }
         }
 
-        Dimension zero = Dimension(1);
-        Dimension dim_final = Dimension(1);
+        Dimension zero(1);
+        Dimension dim_final(1);
         dim_final.fill(nvir_ij_final);
 
         // This transformation gives orbitals that are orthonormal but not canonical
         X_pno_ij = X_pno_ij->get_block({zero, X_pno_ij->rowspi()}, {zero, dim_final});
-        pno_occ = pno_occ->get_block({zero, dim_final});
+        pno_occ = pno_occ.get_block({zero, dim_final});
 
         SharedMatrix pno_canon;
         SharedVector e_pno_ij;

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -97,7 +97,7 @@ void CoupledCluster::common_init() {
     Ca_ = SharedMatrix(reference_wavefunction_->Ca());
     Fa_ = SharedMatrix(reference_wavefunction_->Fa());
     epsilon_a_ = std::make_shared<Vector>(nsopi_);
-    epsilon_a_->copy(reference_wavefunction_->epsilon_a().get());
+    epsilon_a_->copy(*reference_wavefunction_->epsilon_a());
     nalpha_ = reference_wavefunction_->nalpha();
     nbeta_ = reference_wavefunction_->nbeta();
 

--- a/psi4/src/psi4/fnocc/ccsd.cc
+++ b/psi4/src/psi4/fnocc/ccsd.cc
@@ -96,7 +96,7 @@ void CoupledCluster::common_init() {
     Da_ = SharedMatrix(reference_wavefunction_->Da());
     Ca_ = SharedMatrix(reference_wavefunction_->Ca());
     Fa_ = SharedMatrix(reference_wavefunction_->Fa());
-    epsilon_a_ = std::make_shared<Vector>(nirrep_, nsopi_);
+    epsilon_a_ = std::make_shared<Vector>(nsopi_);
     epsilon_a_->copy(reference_wavefunction_->epsilon_a().get());
     nalpha_ = reference_wavefunction_->nalpha();
     nbeta_ = reference_wavefunction_->nbeta();

--- a/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
+++ b/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
@@ -287,7 +287,7 @@ void FrozenNO::ComputeNaturalOrbitals() {
     ints.reset();
 
     auto eigvec = std::make_shared<Matrix>("Dab eigenvectors", nirrep_, aVirOrbsPI, aVirOrbsPI, symmetry);
-    auto eigval = std::make_shared<Vector>("Dab eigenvalues", nirrep_, aVirOrbsPI);
+    auto eigval = std::make_shared<Vector>("Dab eigenvalues", aVirOrbsPI);
     D->diagonalize(eigvec, eigval, descending);
 
     // overwrite ao/mo C matrix with ao/no transformation
@@ -416,9 +416,9 @@ void FrozenNO::ComputeNaturalOrbitals() {
         int o = nalphapi_[h];
         int vnew = newVirOrbsPI[h];
         int vold = aVirOrbsPI[h];
-        double** Fnew = Fab->pointer(h);
-        double** cp = eigvec->pointer(h);
-        double* Fold = epsA->pointer(h);
+        auto Fnew = Fab->pointer(h);
+        auto cp = eigvec->pointer(h);
+        auto Fold = epsA->pointer(h);
         for (int a = 0; a < vnew; a++) {
             for (int b = 0; b < vnew; b++) {
                 double dum = 0.0;
@@ -432,16 +432,16 @@ void FrozenNO::ComputeNaturalOrbitals() {
 
     // semicanonicalize orbitals:
     auto eigvecF = std::make_shared<Matrix>("Fab eigenvectors", nirrep_, newVirOrbsPI, newVirOrbsPI, symmetry);
-    auto eigvalF = std::make_shared<Vector>("Fab eigenvalues", nirrep_, newVirOrbsPI);
+    auto eigvalF = std::make_shared<Vector>("Fab eigenvalues", newVirOrbsPI);
     Fab->diagonalize(eigvecF, eigvalF);
 
     // overwrite ao/no C matrix with ao/semicanonical no transformation:
     for (int h = 0; h < nirrep_; h++) {
         int v = newVirOrbsPI[h];
 
-        double** c_newv = eigvecF->pointer(h);
-        double** c_oldv = Ca_->pointer(h);
-        double** tp = temp->pointer(h);
+        auto c_newv = eigvecF->pointer(h);
+        auto c_oldv = Ca_->pointer(h);
+        auto tp = temp->pointer(h);
 
         for (int mu = 0; mu < nsopi_[h]; mu++) {
             for (int a = 0; a < v; a++) {
@@ -465,7 +465,7 @@ void FrozenNO::ComputeNaturalOrbitals() {
     }
 
     // put modified orbital energies back into epsilon_a
-    std::shared_ptr<Vector> eps = epsilon_a_;
+    auto eps = epsilon_a_;
     for (int h = 0; h < nirrep_; h++) {
         auto epsp = eps->pointer(h);
         auto eigp = eigvalF->pointer(h);

--- a/psi4/src/psi4/lib3index/fittingmetric.cc
+++ b/psi4/src/psi4/lib3index/fittingmetric.cc
@@ -307,8 +307,8 @@ void FittingMetric::form_fitting_metric() {
     }
 
     // Form indexing
-    pivots_ = std::make_shared<IntVector>(nauxpi.n(), nauxpi);
-    rev_pivots_ = std::make_shared<IntVector>(nauxpi.n(), nauxpi);
+    pivots_ = std::make_shared<IntVector>(nauxpi);
+    rev_pivots_ = std::make_shared<IntVector>(nauxpi);
     for (int h = 0; h < auxpet->nirrep(); h++) {
         int* piv = pivots_->pointer(h);
         int* rpiv = pivots_->pointer(h);

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -496,7 +496,7 @@ void DFJCOSK::build_J(std::vector<std::shared_ptr<Matrix>>& D, std::vector<std::
 
     for(size_t jki = 0; jki < njk; jki++) {
         for(size_t thread = 0; thread < nthreads_; thread++) {
-            H[jki]->add(GT[jki][thread]);
+            H[jki]->add(*GT[jki][thread]);
         }
         C_DGESV(nbf_aux, 1, J_metric_->clone()->pointer()[0], nbf_aux, ipiv.data(), H[jki]->pointer(), nbf_aux);
     }

--- a/psi4/src/psi4/libfock/hamiltonian.cc
+++ b/psi4/src/psi4/libfock/hamiltonian.cc
@@ -63,8 +63,8 @@ SharedMatrix RHamiltonian::explicit_hamiltonian() {
 
     auto H = std::make_shared<Matrix>("Explicit Hamiltonian", diag->nirrep(), diag->dimpi(), diag->dimpi());
 
-    std::shared_ptr<Vector> b(diag->clone());
-    std::shared_ptr<Vector> s(diag->clone());
+    auto b = std::make_shared<Vector>(std::move(diag->clone()));
+    auto s = std::make_shared<Vector>(std::move(diag->clone()));
     std::vector<std::shared_ptr<Vector> > bb;
     std::vector<std::shared_ptr<Vector> > ss;
     bb.push_back(b);

--- a/psi4/src/psi4/libfock/solver.cc
+++ b/psi4/src/psi4/libfock/solver.cc
@@ -253,7 +253,7 @@ void CGRSolver::guess() {
 }
 void CGRSolver::residual() {
     for (size_t N = 0; N < b_.size(); ++N) {
-        r_[N]->copy(Ap_[N].get());
+        r_[N]->copy(*Ap_[N]);
         r_[N]->scale(-1.0);
         r_[N]->add(*b_[N]);
     }

--- a/psi4/src/psi4/libfock/solver.cc
+++ b/psi4/src/psi4/libfock/solver.cc
@@ -255,7 +255,7 @@ void CGRSolver::residual() {
     for (size_t N = 0; N < b_.size(); ++N) {
         r_[N]->copy(Ap_[N].get());
         r_[N]->scale(-1.0);
-        r_[N]->add(b_[N]);
+        r_[N]->add(*b_[N]);
     }
 
     if (debug_) {
@@ -457,7 +457,7 @@ void CGRSolver::update_p() {
     for (size_t N = 0; N < b_.size(); ++N) {
         if (r_converged_[N]) continue;
         p_[N]->scale(beta_[N]);
-        p_[N]->add(z_[N]);
+        p_[N]->add(*z_[N]);
     }
 
     if (debug_) {

--- a/psi4/src/psi4/libmints/deriv.cc
+++ b/psi4/src/psi4/libmints/deriv.cc
@@ -90,7 +90,7 @@ class PSI_API CorrelatedFunctor {
     void finalize() {
         // Do summation over threads
         for (int i = 1; i < nthread; ++i) {
-            result[0]->add(result[i]);
+            result[0]->add(*result[i]);
         }
         delete[] tpdm_buffer_;
         delete[] buffer_sizes_;
@@ -155,7 +155,7 @@ class PSI_API ScfRestrictedFunctor {
     void finalize() {
         // Do summation over threads
         for (int i = 1; i < nthread; ++i) {
-            result[0]->add(result[i]);
+            result[0]->add(*result[i]);
         }
     }
 
@@ -228,7 +228,7 @@ class PSI_API ScfAndDfCorrelationRestrictedFunctor {
         scf_functor_.finalize();
         // Do summation over threads
         for (int i = 1; i < nthread; ++i) {
-            result_vec_[0]->add(result_vec_[i]);
+            result_vec_[0]->add(*result_vec_[i]);
         }
     }
 
@@ -338,7 +338,7 @@ class PSI_API ScfUnrestrictedFunctor {
 
     void finalize() {
         // Do summation over threads
-        for (int i = 1; i < nthread; ++i) result[0]->add(result[i]);
+        for (int i = 1; i < nthread; ++i) result[0]->add(*result[i]);
     }
 
     void operator()(int salc, int pabs, int qabs, int rabs, int sabs, int pirrep, int pso, int qirrep, int qso,

--- a/psi4/src/psi4/libmints/deriv.cc
+++ b/psi4/src/psi4/libmints/deriv.cc
@@ -76,7 +76,7 @@ class PSI_API CorrelatedFunctor {
     CorrelatedFunctor(SharedVector results) : psio_(_default_psio_lib_) {
         nthread = Process::environment.get_n_threads();
         result.push_back(results);
-        for (int i = 1; i < nthread; ++i) result.push_back(SharedVector(result[0]->clone()));
+        for (int i = 1; i < nthread; ++i) result.push_back(std::make_shared<Vector>(std::move(result[0]->clone())));
         size_t num_pairs = 0;
         psio_->read_entry(PSIF_AO_TPDM, "Num. Pairs", (char *)&num_pairs, sizeof(size_t));
         buffer_sizes_ = new size_t[num_pairs];
@@ -148,7 +148,7 @@ class PSI_API ScfRestrictedFunctor {
         nthread = Process::environment.get_n_threads();
         result.push_back(results);
 
-        for (int i = 1; i < nthread; ++i) result.push_back(SharedVector(result[0]->clone()));
+        for (int i = 1; i < nthread; ++i) result.push_back(std::make_shared<Vector>(std::move(results->clone())));
     }
     ~ScfRestrictedFunctor() {}
 
@@ -210,7 +210,7 @@ class PSI_API ScfAndDfCorrelationRestrictedFunctor {
         nthread = Process::environment.get_n_threads();
         result_vec_.push_back(results);
 
-        for (int i = 1; i < nthread; ++i) result_vec_.push_back(SharedVector(results->clone()));
+        for (int i = 1; i < nthread; ++i) result_vec_.push_back(std::make_shared<Vector>(std::move(results->clone())));
     }
 
     ScfAndDfCorrelationRestrictedFunctor() {
@@ -329,7 +329,7 @@ class PSI_API ScfUnrestrictedFunctor {
         : Da_(Da), Db_(Db) {
         nthread = Process::environment.get_n_threads();
         result.push_back(results);
-        for (int i = 1; i < nthread; ++i) result.push_back(SharedVector(result[0]->clone()));
+        for (int i = 1; i < nthread; ++i) result.push_back(std::make_shared<Vector>(std::move(result[0]->clone())));
     }
     ~ScfUnrestrictedFunctor() {}
 

--- a/psi4/src/psi4/libmints/electrostatic.h
+++ b/psi4/src/psi4/libmints/electrostatic.h
@@ -52,7 +52,7 @@ class ElectrostaticInt : public PotentialInt {
                      int deriv = 0);
     ~ElectrostaticInt() override;
 
-    void set_origin(const Vector3& _origin);
+    void set_origin(const Vector3& _origin) override;
 
 // Intel C++ 12 thinks we're trying to overload the "void compute_shell(int, int)" and warns us about it.
 // The following line is to shut it up.

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -219,6 +219,7 @@ TwoBodyAOInt* IntegralFactory::erd_eri(int deriv, bool use_shell_pairs, bool nee
 #ifdef ENABLE_Libint1t
     return new ERI(this, deriv, use_shell_pairs);
 #endif
+    throw PSIEXCEPTION("No ERI object to return.");
 }
 
 TwoBodyAOInt* IntegralFactory::eri(int deriv, bool use_shell_pairs, bool needs_exchange) {
@@ -239,6 +240,7 @@ TwoBodyAOInt* IntegralFactory::eri(int deriv, bool use_shell_pairs, bool needs_e
 #ifdef ENABLE_Libint1t
     return new ERI(this, deriv, use_shell_pairs);
 #endif
+    throw PSIEXCEPTION("No ERI object to return.");
 }
 
 TwoBodyAOInt* IntegralFactory::erf_eri(double omega, int deriv, bool use_shell_pairs, bool needs_exchange) {
@@ -249,6 +251,7 @@ TwoBodyAOInt* IntegralFactory::erf_eri(double omega, int deriv, bool use_shell_p
 #ifdef ENABLE_Libint1t
     return new ErfERI(omega, this, deriv, use_shell_pairs);
 #endif
+    throw PSIEXCEPTION("No ERI object to return.");
 }
 
 TwoBodyAOInt* IntegralFactory::erf_complement_eri(double omega, int deriv, bool use_shell_pairs, bool needs_exchange) {
@@ -259,6 +262,7 @@ TwoBodyAOInt* IntegralFactory::erf_complement_eri(double omega, int deriv, bool 
 #ifdef ENABLE_Libint1t
     return new ErfComplementERI(omega, this, deriv, use_shell_pairs);
 #endif
+    throw PSIEXCEPTION("No ERI object to return.");
 }
 
 TwoBodyAOInt* IntegralFactory::yukawa_eri(double zeta, int deriv, bool use_shell_pairs, bool needs_exchange) {

--- a/psi4/src/psi4/libmints/intvector.cc
+++ b/psi4/src/psi4/libmints/intvector.cc
@@ -34,69 +34,6 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 using namespace psi;
 
-IntVector::IntVector() {
-    name_ = "";
-}
-
-IntVector::IntVector(const IntVector &c) {
-    dimpi_ = c.dimpi_;
-    alloc();
-    copy(c);
-    name_ = c.name_;
-}
-
-IntVector::IntVector(const Dimension& dimpi) {
-    dimpi_ = dimpi;
-    alloc();
-}
-IntVector::IntVector(int dim) {
-    dimpi_ = Dimension(std::vector<int>{dim});
-    alloc();
-}
-IntVector::IntVector(const std::string &name, Dimension dimpi) {
-    dimpi_ = dimpi;
-    alloc();
-    name_ = name;
-}
-IntVector::IntVector(const std::string &name, int dim) {
-    dimpi_ = Dimension(std::vector<int>{dim});
-    alloc();
-    name_ = name;
-}
-
-IntVector::~IntVector() {
-    release();
-}
-
-void IntVector::alloc() {
-    if (vector_.size()) release();
-
-    int total = dimpi_.sum();
-    v_.resize(total);
-
-    release();
-    assign_pointer_offsets();
-}
-
-void IntVector::assign_pointer_offsets() {
-    // Resize just to be sure it's the correct size
-    vector_.resize(dimpi_.n(), 0);
-
-    size_t offset = 0;
-    for (int h = 0; h < nirrep(); ++h) {
-        if (dimpi_[h])
-            vector_[h] = &(v_[0]) + offset;
-        else
-            vector_[h] = nullptr;
-        offset += dimpi_[h];
-    }
-}
-
-void IntVector::release() {
-    std::fill(vector_.begin(), vector_.end(), (int*)0);
-    std::fill(v_.begin(), v_.end(), 0.0);
-}
-
 void IntVector::copy(const IntVector &other) {
     dimpi_ = other.dimpi_;
     v_ = other.v_;
@@ -135,15 +72,5 @@ IntVector IntVector::iota(const Dimension &dim) {
         std::iota(vec.pointer(h), vec.pointer(h) + dim[h], 0);
     }
     return vec;
-}
-
-void IntVector::sort(std::function<bool(int, int, int)> func) {
-    sort(func, Slice(Dimension(nirrep()), dimpi_));
-}
-
-void IntVector::sort(std::function<bool(int, int, int)> func, Slice slice) {
-    for (int h = 0; h < nirrep(); h++) {
-        std::stable_sort(vector_[h] + slice.begin()[h], vector_[h] + slice.end()[h], std::bind(func, h, std::placeholders::_1, std::placeholders::_2));
-    }
 }
 

--- a/psi4/src/psi4/libmints/intvector.cc
+++ b/psi4/src/psi4/libmints/intvector.cc
@@ -26,24 +26,10 @@
  * @END LICENSE
  */
 
-#include <cstdlib>
-#include <cstring>
 #include <numeric>
-#include "vector.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
-#include "psi4/libqt/qt.h"
-using namespace psi;
 
-void IntVector::print(std::string out) const {
-    int h;
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    printer->Printf("\n # %s #\n", name_.c_str());
-    for (h = 0; h < nirrep(); ++h) {
-        printer->Printf(" Irrep: %d\n", h + 1);
-        for (int i = 0; i < dimpi_[h]; ++i) printer->Printf("   %4d: %10d\n", i + 1, vector_[h][i]);
-        printer->Printf("\n");
-    }
-}
+#include "vector.h"
+using namespace psi;
 
 IntVector IntVector::iota(const Dimension &dim) {
     IntVector vec(dim);

--- a/psi4/src/psi4/libmints/intvector.cc
+++ b/psi4/src/psi4/libmints/intvector.cc
@@ -29,36 +29,15 @@
 #include <cstdlib>
 #include <cstring>
 #include <numeric>
-#include "psi4/libqt/qt.h"
 #include "vector.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libqt/qt.h"
 using namespace psi;
 
-void IntVector::copy(const IntVector &other) {
-    dimpi_ = other.dimpi_;
-    v_ = other.v_;
-    assign_pointer_offsets();
-}
-
-void IntVector::set(int *vec) {
-    int h, i, ij;
-
-    ij = 0;
-    for (h = 0; h < nirrep(); ++h) {
-        for (i = 0; i < dimpi_[h]; ++i) {
-            vector_[h][i] = vec[ij++];
-        }
-    }
-}
-
-void IntVector::print(std::string out, const char *extra) const {
+void IntVector::print(std::string out) const {
     int h;
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    if (extra == nullptr) {
-        printer->Printf("\n # %s #\n", name_.c_str());
-    } else {
-        printer->Printf("\n # %s %s #\n", name_.c_str(), extra);
-    }
+    printer->Printf("\n # %s #\n", name_.c_str());
     for (h = 0; h < nirrep(); ++h) {
         printer->Printf(" Irrep: %d\n", h + 1);
         for (int i = 0; i < dimpi_[h]; ++i) printer->Printf("   %4d: %10d\n", i + 1, vector_[h][i]);

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -1451,35 +1451,42 @@ void Matrix::axpy(double a, SharedMatrix X) {
     }
 }
 
-SharedMatrix Matrix::collapse(int dim) {
-    if (dim < 0 || dim > 1) throw PSIEXCEPTION("Matrix::collapse: dim must be 0 (row sum) or 1 (col sum)");
+SharedVector Matrix::gemv(bool transa, double alpha, const Vector& A) {
+    auto return_vec = std::make_shared<Vector>(transa ? colspi_ : rowspi_);
+    return_vec->gemv(transa, alpha, *this, A, 0);
+    return return_vec;
+}
+
+SharedVector Matrix::collapse(Dimension dim, int target) const {
+    if (target < 0 || target > 1) throw PSIEXCEPTION("Matrix::collapse: dim must be 0 (row sum) or 1 (col sum)");
 
     if (symmetry_) {
         throw PSIEXCEPTION("Matrix::collapse is not supported for this non-totally-symmetric thing.");
     }
 
-    Dimension ones(nirrep_);
-    for (int h = 0; h < nirrep_; h++) {
-        ones[h] = 1;
-    }
-
-    auto T = std::make_shared<Matrix>("T", ((dim == 0) ? colspi_ : rowspi_), ones);
+    auto T = std::make_shared<Vector>("T", ((target == 0) ? colspi_ : rowspi_));
 
     for (int h = 0; h < nirrep_; h++) {
         int nrow = rowspi_[h];
         int ncol = colspi_[h];
-        double **Mp = matrix_[h];
-        double **Tp = T->pointer(h);
-        if (dim == 0) {
+        auto Mp = matrix_[h];
+        auto Tp = T->pointer(h);
+        if (target == 0) {
+            if (dim.get(h) > nrow) {
+                throw PSIEXCEPTION("Matrix::collapse cannot collapse more rows than the matrix has..");
+            }
             for (int j = 0; j < ncol; j++) {
-                for (int i = 0; i < nrow; i++) {
-                    Tp[j][0] += Mp[i][j];
+                for (int i = 0; i < dim.get(h); i++) {
+                    Tp[j] += Mp[i][j];
                 }
             }
         } else {
+            if (dim.get(h) > ncol) {
+                throw PSIEXCEPTION("Matrix::collapse cannot collapse more rows than the matrix has..");
+            }
             for (int i = 0; i < nrow; i++) {
-                for (int j = 0; j < ncol; j++) {
-                    Tp[i][0] += Mp[i][j];
+                for (int j = 0; j < dim.get(h); j++) {
+                    Tp[i] += Mp[i][j];
                 }
             }
         }
@@ -1986,6 +1993,21 @@ SharedMatrix Matrix::canonical_orthogonalization(double delta, SharedMatrix eigv
     return X;
 }
 
+void Matrix::sort_cols(const IntVector& idxs) {
+    auto orig = clone();
+    if (colspi_ != idxs.dimpi()) {
+        throw PSIEXCEPTION("Matrix::sort Indexing vector and columns to sort must have the same dimension.");
+    }
+    // WARNING! Function also requires each irrep to be a permutation of 0, 1, 2...
+    for (int h = 0; h < nirrep_; h++) {
+        auto rows = rowspi_[h];
+        auto cols = colspi_[h];
+        auto idxh = idxs.pointer(h);
+        for (int a = 0; a < cols; a++) {
+            C_DCOPY(rows, &orig->pointer(h)[0][idxh[a]], cols, &(matrix_[h][0][a]), cols);
+        }
+    }
+}
 void Matrix::swap_rows(int h, int i, int j) {
     C_DSWAP(colspi_[h ^ symmetry_], &(matrix_[h][i][0]), 1, &(matrix_[h][j][0]), 1);
 }

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -43,6 +43,7 @@ struct dpdbuf4;
 
 class PSIO;
 class Vector;
+class IntVector;
 using SharedVector = std::shared_ptr<Vector>;
 class Dimension;
 class Molecule;
@@ -841,12 +842,24 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      */
     void axpy(double a, SharedMatrix X);
 
+    /**
+     * General matrix vector multiplication into this, alpha * AX + beta Y -> Y
+     *
+     * @ transa Do transpose A?
+     * @ alpha Scaling factor
+     * @ A Matrix to multiply by.
+     * @ X Vector to multiply by.
+     * @ beta Scaling factor for current input.
+     */
+    SharedVector gemv(bool transa, double alpha, const Vector& A);
+
     /** Summation collapse along either rows (0) or columns (1), always producing a column matrix
-     * \param dim 0 (row sum) or 1 (col sum)
-     * \return \sum_{i} M_{ij} => T_j if dim = 0 or
+     * @param target 0 (row sum) or 1 (col sum)
+     * @param dim Dimension. Sum over the first dim[h] elements of the row/col.
+     * @return \sum_{i} M_{ij} => T_j if dim = 0 or
      *         \sum_{j} M_{ij} => T_i if dim = 1
      */
-    SharedMatrix collapse(int dim = 0);
+    SharedVector collapse(const Dimension dim, int target = 0) const;
 
     /// @{
     /// Diagonalizes this, eigvectors and eigvalues must be created by caller.  Only for symmetric matrices.
@@ -1000,6 +1013,8 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      */
     void expm(int n = 2, bool scale = false);
 
+    ///
+    void sort_cols(const IntVector& sortvec);
     /// Swap rows i and j
     void swap_rows(int h, int i, int j);
     /// Swap cols i and j

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1784,13 +1784,13 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
         rho_block = point_func->point_values()["RHO_A"];
 
         if (!same_dens_) {
-            rho_block->add(point_func->point_values()["RHO_B"]);
+            rho_block->add(*point_func->point_values()["RHO_B"]);
         }
 
-        double* x = block->x();
-        double* y = block->y();
-        double* z = block->z();
-        double* w = block->w();
+        auto x = block->x();
+        auto y = block->y();
+        auto z = block->z();
+        auto w = block->w();
 
         for (size_t p = 0; p < num_points; p++) {
             x_points[running_points + p] = x[p];

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -264,8 +264,8 @@ void Prop::set_Db_mo(SharedMatrix D) {
 void OEProp::add(const std::string& prop) { tasks_.insert(prop); }
 void OEProp::add(std::vector<std::string> props) { tasks_.insert(props.begin(), props.end()); }
 void OEProp::clear() { tasks_.clear(); }
-SharedVector Prop::epsilon_a() { return SharedVector(epsilon_a_->clone()); }
-SharedVector Prop::epsilon_b() { return SharedVector(epsilon_b_->clone()); }
+SharedVector Prop::epsilon_a() { return std::make_shared<Vector>(std::move(epsilon_a_->clone())); }
+SharedVector Prop::epsilon_b() { return std::make_shared<Vector>(std::move(epsilon_b_->clone())); }
 SharedMatrix Prop::Da_ao() {
     std::vector<double> temp(AO2USO_->max_ncol() * AO2USO_->max_nrow());
     double* temp_ptr = temp.data();

--- a/psi4/src/psi4/libmints/vector.cc
+++ b/psi4/src/psi4/libmints/vector.cc
@@ -44,41 +44,11 @@
 
 namespace psi {
 
-void Vector::init(int nirreps, int *dimpi) {
-    dimpi_.init(nirreps);
-    dimpi_ = dimpi;
-    alloc();
-}
-
-void Vector::init(int nirreps, const int *dimpi, const std::string &name) {
-    name_ = name;
-    dimpi_.init(nirreps);
-    dimpi_ = dimpi;
-    alloc();
-}
-
-void Vector::init(const Dimension &v) {
-    name_ = v.name();
-    dimpi_ = v;
-    alloc();
-}
-
 std::unique_ptr<Vector> Vector::clone() const {
     auto temp = std::make_unique<Vector>(dimpi_);
-    temp->copy(this);
+    temp->copy(*this);
     return temp;
 }
-
-
-void Vector::copy_from(const Vector &other) {
-    dimpi_ = other.dimpi_;
-    v_ = other.v_;
-    assign_pointer_offsets();
-}
-
-void Vector::copy(const Vector *rhs) { copy_from(*rhs); }
-
-void Vector::copy(const Vector &rhs) { copy_from(rhs); }
 
 void Vector::sort(const IntVector& idxs) {
     auto orig = clone();
@@ -137,13 +107,9 @@ void Vector::set_block(const Slice &slice, const Vector& block) {
 
 void Vector::zero() { std::fill(v_.begin(), v_.end(), 0.0); }
 
-void Vector::print(std::string out, const char *extra) const {
+void Vector::print(std::string out) const {
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    if (extra == nullptr) {
-        printer->Printf("\n # %s #\n", name_.c_str());
-    } else {
-        printer->Printf("\n # %s %s #\n", name_.c_str(), extra);
-    }
+    printer->Printf("\n # %s #\n", name_.c_str());
     for (int h = 0; h < nirrep(); ++h) {
         printer->Printf(" Irrep: %d\n", h + 1);
         for (int i = 0; i < dimpi_[h]; ++i) printer->Printf("   %4d: %20.15f\n", i + 1, vector_[h][i]);

--- a/psi4/src/psi4/libmints/vector.cc
+++ b/psi4/src/psi4/libmints/vector.cc
@@ -42,19 +42,6 @@
 
 namespace psi {
 
-void Vector::sort(const IntVector& idxs) {
-    auto orig = clone();
-    if (dimpi_ != idxs.dimpi()) {
-        throw PSIEXCEPTION("Vector::sort Indexing vector and vector to sort must have the same dimension.");
-    }
-    // WARNING! Function also requires each irrep to be a permutation of 0, 1, 2...
-    for (int h = 0; h < nirrep(); h++) {
-        for (int i = 0; i < dimpi_[h]; i++) {
-            set(h, i, orig.get(h, idxs.get(h, i)));
-        }
-    }
-}
-
 void Vector::gemv(bool transa, double alpha, const Matrix& A, const Vector& X, double beta) {
     char trans = transa ? 't' : 'n';
 

--- a/psi4/src/psi4/libmints/vector.cc
+++ b/psi4/src/psi4/libmints/vector.cc
@@ -126,22 +126,12 @@ void Vector::gemv(bool transa, double alpha, const Matrix& A, const Vector& X, d
     }
 }
 
-double Vector::vector_dot(const SharedVector &other) { return vector_dot(*other.get()); }
-
 double Vector::vector_dot(const Vector &other) {
     if (v_.size() != other.v_.size()) {
         throw PSIEXCEPTION("Vector::vector_dot: Vector sizes do not match!");
     }
 
     return C_DDOT(v_.size(), v_.data(), 1, const_cast<double *>(other.v_.data()), 1);
-}
-
-double Vector::dot(Vector *X) {
-    if (v_.size() != X->v_.size()) {
-        throw PSIEXCEPTION("Vector::vector_dot: Vector sizes do not match!");
-    }
-
-    return C_DDOT(v_.size(), v_.data(), 1, X->v_.data(), 1);
 }
 
 double Vector::sum_of_squares() { return C_DDOT(v_.size(), v_.data(), 1, v_.data(), 1); }

--- a/psi4/src/psi4/libmints/vector.cc
+++ b/psi4/src/psi4/libmints/vector.cc
@@ -186,15 +186,9 @@ double Vector::rms() { return sqrt(sum_of_squares() / v_.size()); }
 
 void Vector::scale(double sc) { C_DSCAL(v_.size(), sc, v_.data(), 1); }
 
-void Vector::add(const SharedVector &other) { axpy(1.0, *other.get()); }
-
 void Vector::add(const Vector &other) { axpy(1.0, other); }
 
-void Vector::subtract(const SharedVector &other) { axpy(-1.0, *other.get()); }
-
 void Vector::subtract(const Vector &other) { axpy(-1.0, other); }
-
-void Vector::axpy(double scale, const SharedVector &other) { axpy(scale, *other.get()); }
 
 void Vector::axpy(double scale, const Vector &other) {
     if (v_.size() != other.v_.size()) {

--- a/psi4/src/psi4/libmints/vector.cc
+++ b/psi4/src/psi4/libmints/vector.cc
@@ -34,8 +34,6 @@
 #include <cstring>
 #include <cmath>
 
-#include "psi4/libqt/qt.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsio/psio.hpp"
 
 #include "dimension.h"
@@ -63,7 +61,7 @@ void Vector::sort(const IntVector& idxs) {
     }
 }
 
-SharedVector Vector::get_block(const Slice &slice) {
+SharedVector Vector::get_block(const Slice &slice) const {
     // check if slice is within bounds
     for (int h = 0; h < nirrep(); h++) {
         if (slice.end()[h] > dimpi_[h]) {
@@ -107,16 +105,6 @@ void Vector::set_block(const Slice &slice, const Vector& block) {
 
 void Vector::zero() { std::fill(v_.begin(), v_.end(), 0.0); }
 
-void Vector::print(std::string out) const {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    printer->Printf("\n # %s #\n", name_.c_str());
-    for (int h = 0; h < nirrep(); ++h) {
-        printer->Printf(" Irrep: %d\n", h + 1);
-        for (int i = 0; i < dimpi_[h]; ++i) printer->Printf("   %4d: %20.15f\n", i + 1, vector_[h][i]);
-        printer->Printf("\n");
-    }
-}
-
 void Vector::gemv(bool transa, double alpha, const Matrix& A, const Vector& X, double beta) {
     char trans = transa ? 't' : 'n';
 
@@ -126,7 +114,7 @@ void Vector::gemv(bool transa, double alpha, const Matrix& A, const Vector& X, d
     }
 }
 
-double Vector::vector_dot(const Vector &other) {
+double Vector::vector_dot(const Vector &other) const {
     if (v_.size() != other.v_.size()) {
         throw PSIEXCEPTION("Vector::vector_dot: Vector sizes do not match!");
     }
@@ -134,11 +122,11 @@ double Vector::vector_dot(const Vector &other) {
     return C_DDOT(v_.size(), v_.data(), 1, const_cast<double *>(other.v_.data()), 1);
 }
 
-double Vector::sum_of_squares() { return C_DDOT(v_.size(), v_.data(), 1, v_.data(), 1); }
+double Vector::sum_of_squares() const { return C_DDOT(v_.size(), v_.data(), 1, v_.data(), 1); }
 
-double Vector::norm() { return sqrt(sum_of_squares()); }
+double Vector::norm() const { return sqrt(sum_of_squares()); }
 
-double Vector::rms() { return sqrt(sum_of_squares() / v_.size()); }
+double Vector::rms() const { return sqrt(sum_of_squares() / v_.size()); }
 
 void Vector::scale(double sc) { C_DSCAL(v_.size(), sc, v_.data(), 1); }
 
@@ -154,7 +142,7 @@ void Vector::axpy(double scale, const Vector &other) {
     C_DAXPY(v_.size(), scale, const_cast<double *>(other.v_.data()), 1, v_.data(), 1);
 }
 
-void Vector::save(psi::PSIO *const psio, size_t fileno) {
+void Vector::save(psi::PSIO *const psio, size_t fileno) const {
     // Check to see if the file is open
     bool already_open = false;
     if (psio->open_check(fileno)) {

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -83,7 +83,7 @@ T get_block(const T& self, const Slice& slice) {
 }
 
 template <class T>
-class IrrepedVector {
+class IrreppedVector {
    protected:
     /// Actual data, of size dimpi_.sum()
     std::vector<T> v_;
@@ -128,36 +128,36 @@ class IrrepedVector {
     };
 
    public:
-    explicit IrrepedVector(int dim) : dimpi_(1) {
+    explicit IrreppedVector(int dim) : dimpi_(1) {
         dimpi_[0] = dim;
         alloc();
     };
 
-    explicit IrrepedVector(const std::string & name, int dim) : dimpi_(1) {
+    explicit IrreppedVector(const std::string & name, int dim) : dimpi_(1) {
         dimpi_[0] = dim;
         alloc();
         name_ = name;
     };
 
-    explicit IrrepedVector(const Dimension &dimpi) {
+    explicit IrreppedVector(const Dimension &dimpi) {
         dimpi_ = dimpi;
         alloc();
         name_ = dimpi.name();
     };
 
-    explicit IrrepedVector(const std::string &name, const Dimension &dimpi) {
+    explicit IrreppedVector(const std::string &name, const Dimension &dimpi) {
         dimpi_ = dimpi;
         alloc();
         name_ = name;
     };
 
     /// Copy constructor
-    IrrepedVector(const IrrepedVector<T>& vector) {
+    IrreppedVector(const IrreppedVector<T>& vector) {
         name_ = vector.name_;
         copy(vector);
     }
 
-    ~IrrepedVector() { release(); }
+    ~IrreppedVector() { release(); }
 
     /// Re-initialize the vector. Should usually prefer creating new object.
     void init(const Dimension &v) {
@@ -166,14 +166,14 @@ class IrrepedVector {
         alloc();
     };
 
-    /// Copy IrrepedVector's data into this.
-    void copy(const IrrepedVector<T>& vector) {
+    /// Copy IrreppedVector's data into this.
+    void copy(const IrreppedVector<T>& vector) {
         dimpi_ = vector.dimpi_;
         v_ = vector.v_;
         assign_pointer_offsets();
     }
 
-    IrrepedVector<T> clone() { return IrrepedVector<T>(*this) ; }
+    IrreppedVector<T> clone() { return IrreppedVector<T>(*this) ; }
 
     T &operator()(int i) { return vector_[0][i]; }
     const T &operator()(int i) const { return vector_[0][i]; }
@@ -254,12 +254,12 @@ class IrrepedVector {
         }
     }
 
-    void sort(const IrrepedVector<int>& idxs) {
+    void sort(const IrreppedVector<int>& idxs) {
         auto orig = clone();
         if (dimpi_ != idxs.dimpi()) {
             throw PSIEXCEPTION("Indexing vector and vector to sort must have the same dimension.");
         }
-        // WARNING! Function also requires each irreped block to be a permutation of 0, 1, 2...
+        // WARNING! Function also requires each irrepped block to be a permutation of 0, 1, 2...
         for (int h = 0; h < nirrep(); h++) {
             for (int i = 0; i < dimpi_[h]; i++) {
                 set(h, i, orig.get(h, idxs.get(h, i)));
@@ -278,8 +278,8 @@ class IrrepedVector {
         }
     }
 
-    IrrepedVector<T> get_block(const Slice &slice) const { return psi::get_block(*this, slice); };
-    void set_block(const Slice &slice, const IrrepedVector<T>& block) {
+    IrreppedVector<T> get_block(const Slice &slice) const { return psi::get_block(*this, slice); };
+    void set_block(const Slice &slice, const IrreppedVector<T>& block) {
         // check if slice is within bounds
         for (int h = 0; h < nirrep(); h++) {
             if (slice.end()[h] > dimpi_[h]) {
@@ -302,18 +302,18 @@ class IrrepedVector {
 };
 
 /*! \ingroup MINTS */
-class PSI_API Vector final : public IrrepedVector<double> {
+class PSI_API Vector final : public IrreppedVector<double> {
    protected:
 
     /// Numpy Shape
     std::vector<int> numpy_shape_;
 
    public:
-    explicit Vector(int dim) : IrrepedVector<double>(dim) {}; 
-    explicit Vector(const std::string& name, int dim) : IrrepedVector<double>(name, dim) {}; 
-    explicit Vector(const Dimension &dimpi) : IrrepedVector<double>(dimpi) {}; 
-    explicit Vector(const std::string& name, const Dimension &dimpi) : IrrepedVector<double>(name, dimpi) {}; 
-    Vector(const Vector& vector) : IrrepedVector<double>(vector) {};
+    explicit Vector(int dim) : IrreppedVector<double>(dim) {};
+    explicit Vector(const std::string& name, int dim) : IrreppedVector<double>(name, dim) {};
+    explicit Vector(const Dimension &dimpi) : IrreppedVector<double>(dimpi) {};
+    explicit Vector(const std::string& name, const Dimension &dimpi) : IrreppedVector<double>(name, dimpi) {};
+    Vector(const Vector& vector) : IrreppedVector<double>(vector) {};
 
     // Convert occ's Array1d into Vector.
     // Defined in occ/arrays.cc. Remove when no longer needed.
@@ -323,8 +323,8 @@ class PSI_API Vector final : public IrrepedVector<double> {
     Vector get_block(const Slice &slice) const { return psi::get_block(*this, slice); };
 
     /// Adds other elt/vector to this
-    void add(int m, double val) { IrrepedVector<double>::add(m, val); }
-    void add(int h, int m, double val) { IrrepedVector<double>::add(h, m, val); }
+    void add(int m, double val) { IrreppedVector<double>::add(m, val); }
+    void add(int h, int m, double val) { IrreppedVector<double>::add(h, m, val); }
     void add(const Vector &other);
 
     /// Subtracts other vector from this
@@ -332,7 +332,7 @@ class PSI_API Vector final : public IrrepedVector<double> {
 
     void axpy(double scale, const Vector &other);
 
-    void print(std::string outfile = "outfile") const { IrrepedVector<double>::print(outfile, "%20.15f"); };
+    void print(std::string outfile = "outfile") const { IrreppedVector<double>::print(outfile, "%20.15f"); };
 
     /**
      * General matrix vector multiplication into this, alpha * AX + beta Y -> Y
@@ -370,18 +370,18 @@ class PSI_API Vector final : public IrrepedVector<double> {
 };
 
 /*! \ingroup MINTS */
-class PSI_API IntVector : public IrrepedVector<int> {
+class PSI_API IntVector : public IrreppedVector<int> {
    public:
-    explicit IntVector(int dim) : IrrepedVector<int>(dim) {}; 
-    explicit IntVector(const std::string& name, int dim) : IrrepedVector<int>(name, dim) {};
-    explicit IntVector(const Dimension &dimpi) : IrrepedVector<int>(dimpi) {}; 
-    explicit IntVector(const std::string& name, const Dimension &dimpi) : IrrepedVector<int>(name, dimpi) {};
-    IntVector(const IntVector& vector) : IrrepedVector<int>(vector) {};
+    explicit IntVector(int dim) : IrreppedVector<int>(dim) {};
+    explicit IntVector(const std::string& name, int dim) : IrreppedVector<int>(name, dim) {};
+    explicit IntVector(const Dimension &dimpi) : IrreppedVector<int>(dimpi) {};
+    explicit IntVector(const std::string& name, const Dimension &dimpi) : IrreppedVector<int>(name, dimpi) {};
+    IntVector(const IntVector& vector) : IrreppedVector<int>(vector) {};
 
     IntVector clone() { return IntVector(*this) ; }
     IntVector get_block(const Slice &slice) const { return psi::get_block(*this, slice); };
 
-    void print(std::string outfile = "outfile") const { IrrepedVector<int>::print(outfile, "%10d"); };
+    void print(std::string outfile = "outfile") const { IrreppedVector<int>::print(outfile, "%10d"); };
 
     static IntVector iota(const Dimension &dim);
 };

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -212,14 +212,11 @@ class PSI_API Vector final : public IrrepedVector<double> {
     void add(int h, int m, double val) { vector_[h][m] += val; }
 
     /// Adds other vector to this
-    void add(const SharedVector &other);
     void add(const Vector &other);
 
     /// Subtracts other vector from this
-    void subtract(const SharedVector &other);
     void subtract(const Vector &other);
 
-    void axpy(double scale, const SharedVector &other);
     void axpy(double scale, const Vector &other);
 
     /// Zeros the vector out

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <string>

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -152,7 +152,7 @@ class IrrepedVector {
     };
 
     /// Copy constructor
-    explicit IrrepedVector(const IrrepedVector<T>& vector) {
+    IrrepedVector(const IrrepedVector<T>& vector) {
         name_ = vector.name_;
         copy(vector);
     }

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -221,8 +221,6 @@ class PSI_API Vector final : public IrrepedVector<double> {
      */
     void set_block(const Slice &slice, const Vector& block);
 
-    void print_out() { print("outfile"); }
-
     /**
      * Print the matrix using print_mat
      *
@@ -246,9 +244,7 @@ class PSI_API Vector final : public IrrepedVector<double> {
     void gemv(bool transa, double alpha, const Matrix& A, const Vector& X, double beta);
 
     /// Vector dot product
-    double vector_dot(const SharedVector &other);
     double vector_dot(const Vector &other);
-    double dot(Vector *X);
 
     /// Vector norm
     double norm();
@@ -279,9 +275,6 @@ class PSI_API IntVector : public IrrepedVector<int> {
     explicit IntVector(const Dimension &dimpi) : IrrepedVector<int>(dimpi) {}; 
     explicit IntVector(const std::string& name, const Dimension &dimpi) : IrrepedVector<int>(name, dimpi) {};
     IntVector(const IntVector& vector) : IrrepedVector<int>(vector) {};
-
-    /// Python compatible printer
-    void print_out() { print("outfile"); }
 
     /**
      * Print the matrix using print_mat

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -184,7 +184,13 @@ class IrrepedVector {
     T *pointer(int h = 0) { return vector_[h]; }
     const T *pointer(int h = 0) const { return vector_[h]; }
 
-    T get(int m) const { return get(0, m); }
+    // Exploit contiguous memory storage to handle elements across all irreps.
+    T get(int m) const {
+        if (m >= dimpi_.sum()) {
+            throw PSIEXCEPTION("Cannot get element " + std::to_string(m) +  " since there are only " + std::to_string(dimpi_.sum()) +  " elements.");
+        }
+        return v_[m];
+    }
     T get(int h, int m) const {
         if (h >= nirrep()) {
             throw PSIEXCEPTION("Cannot get an element of irrep " + std::to_string(h) +  ", since there are only " + std::to_string(nirrep()) +  " irreps.");
@@ -195,7 +201,13 @@ class IrrepedVector {
         return vector_[h][m];
     }
 
-    void set(int m, T val) { set(0, m, val); }
+    // Exploit contiguous memory storage to handle elements across all irreps.
+    void set(int m, T val) {
+        if (m >= dimpi_.sum()) {
+            throw PSIEXCEPTION("Cannot set element " + std::to_string(m) +  " since there are only " + std::to_string(dimpi_.sum()) +  " elements.");
+        }
+        v_[m] = val;
+    }
     void set(int h, int m, T val) {
         if (h >= nirrep()) {
             throw PSIEXCEPTION("Cannot set an element of irrep " + std::to_string(h) +  ", since there are only " + std::to_string(nirrep()) +  " irreps.");
@@ -206,7 +218,13 @@ class IrrepedVector {
         vector_[h][m] = val;
     }
 
-    void add(int m, T val) { add(0, m, val); }
+    // Exploit contiguous memory storage to handle elements across all irreps.
+    void add(int m, T val) {
+        if (m >= dimpi_.sum()) {
+            throw PSIEXCEPTION("Cannot add to element " + std::to_string(m) +  " since there are only " + std::to_string(dimpi_.sum()) +  " elements.");
+        }
+        v_[m] += val;
+    }
     void add(int h, int m, T val) {
         if (h >= nirrep()) {
             throw PSIEXCEPTION("Cannot add to an element of irrep " + std::to_string(h) +  ", since there are only " + std::to_string(nirrep()) +  " irreps.");

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -182,14 +182,38 @@ class IrrepedVector {
     T *pointer(int h = 0) { return vector_[h]; }
     const T *pointer(int h = 0) const { return vector_[h]; }
 
-    T get(int m) const { return vector_[0][m]; }
-    T get(int h, int m) const { return vector_[h][m]; }
+    T get(int m) const { return get(0, m); }
+    T get(int h, int m) const {
+        if (h >= nirrep()) {
+            throw PSIEXCEPTION("Cannot get an element of irrep " + std::to_string(h) +  ", since there are only " + std::to_string(nirrep()) +  " irreps.");
+        }
+        if (m >= dim(h)) {
+            throw PSIEXCEPTION("Cannot get element " + std::to_string(m) +  " of irrep " + std::to_string(h) +  " which only has " + std::to_string(dim(h)) +  " elements.");
+        }
+        return vector_[h][m];
+    }
 
-    void set(int m, T val) { vector_[0][m] = val; }
-    void set(int h, int m, T val) { vector_[h][m] = val; }
+    void set(int m, T val) { set(0, m, val); }
+    void set(int h, int m, T val) {
+        if (h >= nirrep()) {
+            throw PSIEXCEPTION("Cannot set an element of irrep " + std::to_string(h) +  ", since there are only " + std::to_string(nirrep()) +  " irreps.");
+        }
+        if (m >= dim(h)) {
+            throw PSIEXCEPTION("Cannot set element " + std::to_string(m) +  " of irrep " + std::to_string(h) +  " which only has " + std::to_string(dim(h)) +  " elements.");
+        }
+        vector_[h][m] = val;
+    }
 
-    void add(int m, T val) { vector_[0][m] += val; }
-    void add(int h, int m, T val) { vector_[h][m] += val; }
+    void add(int m, T val) { add(0, m, val); }
+    void add(int h, int m, T val) {
+        if (h >= nirrep()) {
+            throw PSIEXCEPTION("Cannot add to an element of irrep " + std::to_string(h) +  ", since there are only " + std::to_string(nirrep()) +  " irreps.");
+        }
+        if (m >= dim(h)) {
+            throw PSIEXCEPTION("Cannot add to element " + std::to_string(m) +  " of irrep " + std::to_string(h) +  " which only has " + std::to_string(dim(h)) +  " elements.");
+        }
+        vector_[h][m] += val;
+    }
 
     void zero() { std::fill(v_.begin(), v_.end(), 0); }
 
@@ -335,6 +359,7 @@ class PSI_API IntVector : public IrrepedVector<int> {
     IntVector(const IntVector& vector) : IrrepedVector<int>(vector) {};
 
     IntVector clone() { return IntVector(*this) ; }
+    IntVector get_block(const Slice &slice) const { return psi::get_block(*this, slice); };
 
     void print(std::string outfile = "outfile") const { IrrepedVector<int>::print(outfile, "%10d"); };
 

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -28,8 +28,8 @@
 
 #pragma once
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include "dimension.h"
 
@@ -46,66 +46,158 @@ namespace occwave {
 class Array1d;
 }
 
-/*! \ingroup MINTS */
-class PSI_API Vector final {
+template <class T>
+class IrrepedVector {
    protected:
     /// Actual data, of size dimpi_.sum()
-    std::vector<double> v_;
+    std::vector<T> v_;
     /// Pointer offsets into v_, of size dimpi_.n()
-    std::vector<double *> vector_;
+    std::vector<T*> vector_;
     /// Dimensions per irrep
     Dimension dimpi_;
     /// Name
     std::string name_;
 
     /// Allocates vector_
-    void alloc();
+    void alloc() {
+        if (vector_.size()) release();
+
+        int total = dimpi_.sum();
+        v_.resize(total);
+
+        release();
+
+        assign_pointer_offsets();
+    };
 
     /// Releases vector_
-    void release();
+    void release() {
+        std::fill(vector_.begin(), vector_.end(), (T *) 0);
+        std::fill(v_.begin(), v_.end(), 0);
+    };
+
+    /// Assign pointer offsets in vector_ from v_.
+    void assign_pointer_offsets() {
+        // Resize just to be sure it's the correct size
+        vector_.resize(dimpi_.n(), 0);
+
+        size_t offset = 0;
+        for (int h = 0; h < nirrep(); ++h) {
+            if (dimpi_[h])
+                vector_[h] = &(v_[0]) + offset;
+            else
+                vector_[h] = nullptr;
+            offset += dimpi_[h];
+        }
+    };
+
+   public:
+    explicit IrrepedVector(int dim) : dimpi_(1) {
+        dimpi_[0] = dim;
+        alloc();
+    };
+
+    explicit IrrepedVector(const std::string & name, int dim) : dimpi_(1) {
+        dimpi_[0] = dim;
+        alloc();
+    };
+
+    explicit IrrepedVector(const Dimension &dimpi) {
+        dimpi_ = dimpi;
+        alloc();
+        name_ = dimpi.name();
+    };
+
+    explicit IrrepedVector(const std::string &name, const Dimension &dimpi) {
+        dimpi_ = dimpi;
+        alloc();
+        name_ = name;
+    };
+
+    /// Copy constructor
+    explicit IrrepedVector(const IrrepedVector<T>& vector) {
+        name_ = vector.name_;
+        dimpi_ = vector.dimpi_;
+        v_ = vector.v_;
+        assign_pointer_offsets();
+    }
+
+    ~IrrepedVector() { release(); }
+
+    T &operator()(int i) { return vector_[0][i]; }
+    const T &operator()(int i) const { return vector_[0][i]; }
+    T &operator[](int i) { return vector_[0][i]; }
+    const T &operator[](int i) const { return vector_[0][i]; }
+
+    /// Returns a pointer to irrep h
+    T *pointer(int h = 0) { return vector_[h]; }
+    const T *pointer(int h = 0) const { return vector_[h]; }
+
+    /// Returns the dimension per irrep h
+    int dim(int h = 0) const { return dimpi_[h]; }
+
+    /// Returns a single element value
+    T get(int m) const { return vector_[0][m]; }
+
+    /// Sets a single element value
+    void set(int m, T val) { vector_[0][m] = val; }
+
+    /// Returns a single element value
+    T get(int h, int m) const { return vector_[h][m]; }
+
+    /// Sets a single element value
+    void set(int h, int m, T val) { vector_[h][m] = val; }
+
+    /// Returns the dimension array
+    const Dimension &dimpi() const { return dimpi_; }
+
+    /// Returns the number of irreps
+    int nirrep() const { return dimpi_.n(); }
+
+    /**
+     * Sets the name of the vector, used in print(...)
+     *
+     * @param name New name to use.
+     */
+    void set_name(const std::string &name) { name_ = name; }
+
+    /**
+     * Gets the name of the matrix.
+     */
+    std::string name() const { return name_; }
+
+    /// Python compatible printer
+    //
+    void sort(std::function<bool(int, T, T)> func) {;
+        sort(func, Slice(Dimension(nirrep()), dimpi_));
+    };
+    void sort(std::function<bool(int, T, T)> func, Slice slice) {
+        for (int h = 0; h < nirrep(); h++) {
+            std::stable_sort(vector_[h] + slice.begin()[h], vector_[h] + slice.end()[h], std::bind(func, h, std::placeholders::_1, std::placeholders::_2));
+        }
+    };
+};
+
+/*! \ingroup MINTS */
+class PSI_API Vector final : public IrrepedVector<double> {
+   protected:
 
     /// Copies data to vector_
     void copy_from(const Vector &other);
-
-    /// Assign pointer offsets in vector_ from v_.
-    void assign_pointer_offsets();
 
     /// Numpy Shape
     std::vector<int> numpy_shape_;
 
    public:
-    /// Default constructor, zeros everything out
-    Vector();
-
-    /// Copy constructor
-    Vector(const Vector &copy);
-
-    /// Constructor, allocates memory
-    /// (this should be deprecated in favor of the Dimension-based version)
-    explicit Vector(int nirrep, int *dimpi);
-
-    /// Constructor, convenience for 1 irrep
-    explicit Vector(int dim);
-
-    /// Constructor, allocates memory
-    /// (this should be deprecated in favor of the Dimension-based version)
-    explicit Vector(const std::string &name, int nirrep, int *dimpi);
-
-    /// Constructor, convenience for 1 irrep
-    explicit Vector(const std::string &name, int dim);
-
-    /// Constructor, takes Dimension object
-    explicit Vector(const Dimension &dimpi);
-
-    /// Constructor, takes Dimension object
-    explicit Vector(const std::string &name, const Dimension &dimpi);
+    explicit Vector(int dim) : IrrepedVector<double>(dim) {}; 
+    explicit Vector(const std::string& name, int dim) : IrrepedVector<double>(name, dim) {}; 
+    explicit Vector(const Dimension &dimpi) : IrrepedVector<double>(dimpi) {}; 
+    explicit Vector(const std::string& name, const Dimension &dimpi) : IrrepedVector<double>(name, dimpi) {}; 
+    Vector(const Vector& vector) : IrrepedVector<double>(vector) {};
 
     // Convert occ's Array1d into Vector.
     // Defined in occ/arrays.cc. Remove when no longer needed.
     explicit Vector(const Dimension &dimpi, const occwave::Array1d &array);
-
-    /// Destructor, frees memory
-    ~Vector();
 
     void init(int nirrep, int *dimpi);
 
@@ -114,23 +206,6 @@ class PSI_API Vector final {
     void init(const Dimension &v);
 
     std::unique_ptr<Vector> clone() const;
-
-    /// Returns a pointer to irrep h
-    double *pointer(int h = 0) { return vector_[h]; }
-
-    const double *pointer(int h = 0) const { return vector_[h]; }
-
-    /// Returns a single element value
-    double get(int m) const { return vector_[0][m]; }
-
-    /// Sets a single element value
-    void set(int m, double val) { vector_[0][m] = val; }
-
-    /// Returns a single element value
-    double get(int h, int m) const { return vector_[h][m]; }
-
-    /// Sets a single element value
-    void set(int h, int m, double val) { vector_[h][m] = val; }
 
     void add(int m, double val) { vector_[0][m] += val; }
 
@@ -166,36 +241,6 @@ class PSI_API Vector final {
      */
     void set_block(const Slice &slice, const Vector& block);
 
-    double &operator()(int i) { return vector_[0][i]; }
-
-    const double &operator()(int i) const { return vector_[0][i]; }
-
-    double &operator[](int i) { return vector_[0][i]; }
-
-    const double &operator[](int i) const { return vector_[0][i]; }
-
-    /// Returns the dimension per irrep h
-    int dim(int h = 0) const { return dimpi_[h]; }
-
-    /// Returns the dimension array
-    const Dimension &dimpi() const { return dimpi_; }
-
-    /// Returns the number of irreps
-    int nirrep() const { return dimpi_.n(); }
-
-    /**
-     * Sets the name of the vector, used in print(...)
-     *
-     * @param name New name to use.
-     */
-    void set_name(const std::string &name) { name_ = name; }
-
-    /**
-     * Gets the name of the matrix.
-     */
-    std::string name() const { return name_; }
-
-    /// Python compatible printer
     void print_out() { print("outfile"); }
 
     /**
@@ -211,9 +256,6 @@ class PSI_API Vector final {
 
     /// Copies rhs to this
     void copy(const Vector &rhs);
-
-    IntVector get_sort_vector(std::function<bool(const Vector&, int, int, int)> func);
-    IntVector get_sort_vector(std::function<bool(const Vector&, int, int, int)> func, Slice slice);
 
     /// Sort the vector according to the re-indexing vector.
     void sort(const IntVector& idxs);
@@ -256,81 +298,16 @@ class PSI_API Vector final {
 };
 
 /*! \ingroup MINTS */
-class PSI_API IntVector {
-   protected:
-    /// Actual data, of size dimpi_.sum()
-    std::vector<int> v_;
-    /// Pointer offsets into v_, of size dimpi_.n()
-    std::vector<int *> vector_;
-    /// Dimensions per irrep
-    Dimension dimpi_;
-    /// Name of the IntVector
-    std::string name_;
-
-    /// Fill v_ with zero and (re)populate vector_.
-    void alloc();
-
-    /// Assign pointer offsets in vector_ from v_.
-    void assign_pointer_offsets();
-
-    /// Releases vector_
-    void release();
-
+class PSI_API IntVector : public IrrepedVector<int> {
    public:
-    /// Default constructor, zeros everything out
-    IntVector();
-
-    /// Copy constructor
-    IntVector(const IntVector &copy);
-
-    /// Constructor, allocates memory
-    IntVector(const Dimension& dimpi);
-
-    /// Constructor, convenience for 1 irrep
-    IntVector(int dim);
-
-    /// Constructor, allocates memory
-    IntVector(const std::string &name, Dimension dimpi);
-
-    /// Constructor, convenience for 1 irrep
-    IntVector(const std::string &name, int dim);
-
-    /// Destructor, frees memory
-    virtual ~IntVector();
+    explicit IntVector(int dim) : IrrepedVector<int>(dim) {}; 
+    explicit IntVector(const std::string& name, int dim) : IrrepedVector<int>(name, dim) {};
+    explicit IntVector(const Dimension &dimpi) : IrrepedVector<int>(dimpi) {}; 
+    explicit IntVector(const std::string& name, const Dimension &dimpi) : IrrepedVector<int>(name, dimpi) {};
+    IntVector(const IntVector& vector) : IrrepedVector<int>(vector) {};
 
     /// Sets the vector_ to the data in vec
     void set(int *vec);
-
-    /// Returns a pointer to irrep h
-    int *pointer(int h = 0) { return vector_[h]; }
-    const int *pointer(int h = 0) const { return vector_[h]; }
-
-    /// Returns a single element value
-    int get(int h, int m) const { return vector_[h][m]; }
-
-    /// Sets a single element value
-    void set(int h, int m, int val) { vector_[h][m] = val; }
-
-    /// Returns the dimension per irrep h
-    int dim(int h = 0) const { return dimpi_[h]; }
-
-    /// Returns the dimension array
-    Dimension dimpi() const { return dimpi_; }
-
-    /// Returns the number of irreps
-    int nirrep() const { return dimpi_.n(); }
-
-    /**
-     * Sets the name of the vector, used in print(...)
-     *
-     * @param name New name to use.
-     */
-    void set_name(const std::string &name) { name_ = name; }
-
-    /**
-     * Gets the name of the matrix.
-     */
-    std::string name() const { return name_; }
 
     /// Python compatible printer
     void print_out() { print("outfile"); }
@@ -350,8 +327,6 @@ class PSI_API IntVector {
     void copy(const IntVector &rhs);
 
     static IntVector iota(const Dimension &dim);
-    void sort(std::function<bool(int, int, int)> func);
-    void sort(std::function<bool(int, int, int)> func, Slice slice);
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/vector.h
+++ b/psi4/src/psi4/libmints/vector.h
@@ -210,6 +210,19 @@ class IrrepedVector {
         }
     }
 
+    void sort(const IrrepedVector<int>& idxs) {
+        auto orig = clone();
+        if (dimpi_ != idxs.dimpi()) {
+            throw PSIEXCEPTION("Indexing vector and vector to sort must have the same dimension.");
+        }
+        // WARNING! Function also requires each irreped block to be a permutation of 0, 1, 2...
+        for (int h = 0; h < nirrep(); h++) {
+            for (int i = 0; i < dimpi_[h]; i++) {
+                set(h, i, orig.get(h, idxs.get(h, i)));
+            }
+        }
+    }
+
     void print(const std::string& out, const std::string& fmt) const {
         const auto printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
         printer->Printf("\n # %s #\n", name_.c_str());
@@ -227,7 +240,7 @@ class IrrepedVector {
         for (int h = 0; h < nirrep(); h++) {
             if (slice.end()[h] > dimpi_[h]) {
                 std::string msg =
-                    "Invalid call to Vector::set_block(): Slice is out of bounds. Irrep = " + std::to_string(h);
+                    "Invalid call to get_block(): Slice is out of bounds. Irrep = " + std::to_string(h);
                 throw PSIEXCEPTION(msg);
             }
         }
@@ -241,7 +254,6 @@ class IrrepedVector {
             }
         }
     }
-
 
 };
 
@@ -277,9 +289,6 @@ class PSI_API Vector final : public IrrepedVector<double> {
     void axpy(double scale, const Vector &other);
 
     void print(std::string outfile = "outfile") const { IrrepedVector<double>::print(outfile, "%20.15f"); };
-
-    /// Sort the vector according to the re-indexing vector.
-    void sort(const IntVector& idxs);
 
     /**
      * General matrix vector multiplication into this, alpha * AX + beta Y -> Y

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -320,8 +320,8 @@ void Wavefunction::deep_copy(const Wavefunction *other) {
     if (other->Db_) Db_ = other->Db_->clone();
     if (other->Fa_) Fa_ = other->Fa_->clone();
     if (other->Fb_) Fb_ = other->Fb_->clone();
-    if (other->epsilon_a_) epsilon_a_ = SharedVector(other->epsilon_a_->clone());
-    if (other->epsilon_b_) epsilon_b_ = SharedVector(other->epsilon_b_->clone());
+    if (other->epsilon_a_) epsilon_a_ = std::make_shared<Vector>(std::move(other->epsilon_a_->clone()));
+    if (other->epsilon_b_) epsilon_b_ = std::make_shared<Vector>(std::move(other->epsilon_b_->clone()));
 
     if (other->gradient_) gradient_ = other->gradient_->clone();
     if (other->hessian_) hessian_ = other->hessian_->clone();

--- a/psi4/src/psi4/libpsipcm/psipcm.cc
+++ b/psi4/src/psi4/libpsipcm/psipcm.cc
@@ -206,7 +206,7 @@ PCM::PCM(const PCM *other) {
     ntessirr_ = other->ntessirr_;
     tesspi_ = other->tesspi_;
     tess_Zxyz_ = other->tess_Zxyz_->clone();
-    MEP_n_ = SharedVector(other->MEP_n_->clone());
+    MEP_n_ = std::make_shared<Vector>(std::move(other->MEP_n_->clone()));
     basisset_ = other->basisset_;
     my_aotoso_ = other->my_aotoso_->clone();
     potential_int_ = other->potential_int_;
@@ -275,7 +275,7 @@ SharedMatrix PCM::compute_V(const SharedMatrix &D) {
 
 double PCM::compute_E_total(const SharedVector &MEP_e) const {
     // Combine the nuclear and electronic potentials at each tessera
-    MEP_e->add(MEP_n_);
+    MEP_e->add(*MEP_n_);
     std::string MEP_label("TotMEP");
     std::string ASC_label("TotASC");
     pcmsolver_set_surface_function(context_.get(), ntess_, MEP_e->pointer(0), MEP_label.c_str());
@@ -325,7 +325,7 @@ double PCM::compute_E_separate(const SharedVector &MEP_e) const {
                             ASC_n->get(0, tess), MEP_e->get(0, tess), ASC_e->get(0, tess));
     }
 
-    MEP_e->add(MEP_n_);
+    MEP_e->add(*MEP_n_);
     pcmsolver_set_surface_function(context_.get(), ntess_, MEP_e->pointer(0), MEP_label.c_str());
     pcmsolver_compute_asc(context_.get(), MEP_label.c_str(), ASC_label.c_str(), irrep);
 

--- a/psi4/src/psi4/libqt/blas_intfc.cc
+++ b/psi4/src/psi4/libqt/blas_intfc.cc
@@ -74,7 +74,7 @@ extern void F_DSYMV(char *uplo, int *n, double *alpha, double *A, int *lda, doub
                     double *Y, int *inc_y);
 extern void F_DSPMV(char *uplo, int *n, double *alpha, double *A, double *X, int *inc_x, double *beta, double *Y,
                     int *inc_y);
-extern double F_DDOT(int *n, double *x, int *incx, double *y, int *incy);
+extern double F_DDOT(int *n, const double *x, int *incx, const double *y, int *incy);
 extern double F_DNRM2(int *n, double *x, int *incx);
 extern double F_DASUM(int *n, double *x, int *incx);
 extern int F_IDAMAX(int *n, double *x, int *incx);
@@ -211,7 +211,7 @@ void PSI_API C_DROT(size_t length, double *x, int inc_x, double *y, int inc_y, d
  * \ingroup QT
  */
 
-double PSI_API C_DDOT(size_t length, double *x, int inc_x, double *y, int inc_y) {
+double PSI_API C_DDOT(size_t length, const double* const x, int inc_x, const double* const y, int inc_y) {
     if (length == 0) return 0.0;
 
     double reg = 0.0;
@@ -219,8 +219,8 @@ double PSI_API C_DDOT(size_t length, double *x, int inc_x, double *y, int inc_y)
     int big_blocks = (int)(length / INT_MAX);
     int small_size = (int)(length % INT_MAX);
     for (int block = 0; block <= big_blocks; block++) {
-        double *x_s = &x[static_cast<size_t>(block) * inc_x * INT_MAX];
-        double *y_s = &y[static_cast<size_t>(block) * inc_y * INT_MAX];
+        const double *x_s = &x[static_cast<size_t>(block) * inc_x * INT_MAX];
+        const double *y_s = &y[static_cast<size_t>(block) * inc_y * INT_MAX];
         signed int length_s = (block == big_blocks) ? small_size : INT_MAX;
         reg += ::F_DDOT(&length_s, x_s, &inc_x, y_s, &inc_y);
     }

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -110,7 +110,7 @@ void C_DSWAP(size_t length, double* x, int incx, double* y, int inc_y);
 void C_DSCAL(size_t len, double alpha, double* vec, int inc);
 void C_DCOPY(size_t length, double* x, int inc_x, double* y, int inc_y);
 void C_DAXPY(size_t length, double a, const double* x, int inc_x, double* y, int inc_y);
-double C_DDOT(size_t n, double* X, int inc_x, double* Y, int inc_y);
+double C_DDOT(size_t n, const double* const X, int inc_x, const double* const Y, int inc_y);
 double C_DNRM2(size_t n, double* X, int inc_x);
 double C_DASUM(size_t n, double* X, int inc_x);
 size_t C_IDAMAX(size_t n, double* X, int inc_x);

--- a/psi4/src/psi4/libsapt_solver/fdds_disp.cc
+++ b/psi4/src/psi4/libsapt_solver/fdds_disp.cc
@@ -350,7 +350,7 @@ std::vector<SharedMatrix> FDDS_Dispersion::project_densities(std::vector<SharedM
     std::vector<SharedVector> aux_dens_inv;
     for (size_t i = 0; i < densities.size(); i++) {
         aux_dens_inv.push_back(std::make_shared<Vector>(naux));
-        aux_dens_inv[i]->gemv(false, 1.0, metric_inv_.get(), aux_dens[i].get(), 0.0);
+        aux_dens_inv[i]->gemv(false, 1.0, *metric_inv_, *aux_dens[i], 0.0);
     }
 
     // ==> Contract (PQS) S -> PQ <== //

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -761,7 +761,9 @@ void HF::form_Shalf() {
     epsilon_a_->init(nmopi_);
     Ca_->init(nirrep_, nsopi_, nmopi_, "Alpha MO coefficients");
     epsilon_b_->init(nmopi_);
-    Cb_->init(nirrep_, nsopi_, nmopi_, "Beta MO coefficients");
+    if (!same_a_b_orbs_) {
+        Cb_->init(nirrep_, nsopi_, nmopi_, "Beta MO coefficients");
+    }
 
     // Extra matrix dimension changes for specific derived classes
     prepare_canonical_orthogonalization();

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -588,7 +588,7 @@ void HF::form_H() {
 
                     basisset_->compute_phi(phi_ao.pointer(), x, y, z);
                     // Transform phi_ao to SO basis
-                    phi_so.gemv(true, 1.0, &u, &phi_ao, 0.0);
+                    phi_so.gemv(true, 1.0, u, phi_ao, 0.0);
                     for (int i = 0; i < nso; i++)
                         for (int j = 0; j < nso; j++) V_eff.add(i, j, w * v * phi_so[i] * phi_so[j]);
                 }  // npoints
@@ -629,7 +629,7 @@ void HF::form_H() {
 
                             basisset_->compute_phi(phi_ao.pointer(), x, y, z);
 
-                            phi_so.gemv(true, 1.0, &u, &phi_ao, 0.0);
+                            phi_so.gemv(true, 1.0, u, phi_ao, 0.0);
 
                             for (int i = 0; i < nso; i++)
                                 for (int j = 0; j < nso; j++)

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -182,6 +182,8 @@ class HF : public Wavefunction {
     void MOM();
     /// Start the MOM algorithm (requires one iteration worth of setup)
     void MOM_start();
+    /// Perform MOM operations for a single spincase
+    void MOM_spincase(const Dimension& npi, Vector& orb_energies, Matrix& old_C, Matrix& new_C);
 
     /// Fractional occupation UHF/UKS
     void frac();

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -119,7 +119,7 @@ void ROHF::semicanonicalize() {
         throw PSIEXCEPTION("Wavefunction: Semicanonicalize called, but orbital energies are not the same.");
     // Now, make space for the new orbitals
     Cb_ = SharedMatrix(Ca_->clone());
-    epsilon_b_->copy(*epsilon_a_);
+    epsilon_b_ = std::make_shared<Vector>(std::move(epsilon_b_->clone()));
     Ca_->set_name("Alpha semicanonical orbitals");
     Cb_->set_name("Beta semicanonical orbitals");
     epsilon_a_->set_name("Alpha semicanonical orbital energies");

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -119,7 +119,7 @@ void ROHF::semicanonicalize() {
         throw PSIEXCEPTION("Wavefunction: Semicanonicalize called, but orbital energies are not the same.");
     // Now, make space for the new orbitals
     Cb_ = SharedMatrix(Ca_->clone());
-    epsilon_b_ = SharedVector(epsilon_b_->clone());
+    epsilon_b_->copy(*epsilon_a_);
     Ca_->set_name("Alpha semicanonical orbitals");
     Cb_->set_name("Beta semicanonical orbitals");
     epsilon_a_->set_name("Alpha semicanonical orbital energies");

--- a/psi4/src/psi4/occ/arrays.cc
+++ b/psi4/src/psi4/occ/arrays.cc
@@ -1056,7 +1056,6 @@ int Array3i::get(int h, int i, int j) { return A3i_[h][i][j]; }  //
 /********************************************************************************************/
 }
 Vector::Vector(const Dimension& dimpi, const occwave::Array1d& array) {
-    nirrep_ = dimpi.n();
     dimpi_ = dimpi;
     name_ = array.name();
     v_ = std::vector<double>(array.array(), array.array() + array.dim1());

--- a/psi4/src/psi4/occ/arrays.cc
+++ b/psi4/src/psi4/occ/arrays.cc
@@ -1055,10 +1055,7 @@ int Array3i::get(int h, int i, int j) { return A3i_[h][i][j]; }  //
 /********************************************************************************************/
 /********************************************************************************************/
 }
-Vector::Vector(const Dimension& dimpi, const occwave::Array1d& array) {
-    dimpi_ = dimpi;
-    name_ = array.name();
+Vector::Vector(const Dimension& dimpi, const occwave::Array1d& array) : Vector(dimpi) {
     v_ = std::vector<double>(array.array(), array.array() + array.dim1());
-    assign_pointer_offsets();
 }
 }  // End Namespaces

--- a/psi4/src/psi4/occ/ekt_ea.cc
+++ b/psi4/src/psi4/occ/ekt_ea.cc
@@ -135,13 +135,13 @@ void OCCWave::ekt_ea() {
     auto PSA = std::make_shared<Matrix>("Alpha pole strength matrix", nirrep_, nmopi_, nmopi_);
     auto gc_transA = std::make_shared<Matrix>("Alpha C'*g", nirrep_, nmopi_, nmopi_);
     auto tempA = std::make_shared<Matrix>("Alpha temp", nirrep_, nmopi_, nmopi_);
-    auto Diag_g1A = std::make_shared<Vector>("Diag OO-block OPDM", nirrep_, nmopi_);
-    auto ps_vecA = std::make_shared<Vector>("alpha pole strength vector", nirrep_, nmopi_);
-    auto eorbA = std::make_shared<Vector>("eorbA", nirrep_, nmopi_);
+    Vector Diag_g1A("Diag OO-block OPDM", nmopi_);
+    Vector ps_vecA("alpha pole strength vector", nmopi_);
+    Vector eorbA("eorbA", nmopi_);
 
     // Diagonalize OPDM
     UvecA->zero();
-    Diag_g1A->zero();
+    Diag_g1A.zero();
     if (reference_ == "RESTRICTED")
         G1tilde->diagonalize(UvecA, Diag_g1A);
     else if (reference_ == "UNRESTRICTED")
@@ -150,21 +150,21 @@ void OCCWave::ekt_ea() {
     // Make sure all eigenvalues are positive
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nmopi_[h]; ++i) {
-            if (Diag_g1A->get(h, i) < 0.0) Diag_g1A->set(h, i, -1.0 * Diag_g1A->get(h, i));
+            if (Diag_g1A.get(h, i) < 0.0) Diag_g1A.set(h, i, -1.0 * Diag_g1A.get(h, i));
         }
     }
 
     // Form g^(-1/2)
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nmopi_[h]; ++i) {
-            Diag_g1A->set(h, i, 1 / sqrt(Diag_g1A->get(h, i)));
+            Diag_g1A.set(h, i, 1 / sqrt(Diag_g1A.get(h, i)));
         }
     }
 
     g1HalfA->zero();
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nmopi_[h]; ++i) {
-            g1HalfA->set(h, i, i, Diag_g1A->get(h, i));
+            g1HalfA->set(h, i, i, Diag_g1A.get(h, i));
         }
     }
 
@@ -181,7 +181,7 @@ void OCCWave::ekt_ea() {
     GFock_primeA->gemm(false, false, 1.0, tempA, g1HalfA, 0.0);
 
     // Diagonalize GFock to get orbital energies
-    eorbA->zero();
+    eorbA.zero();
     Uvec_primeA->zero();
     GFock_primeA->diagonalize(Uvec_primeA, eorbA);
     UvecA->gemm(false, false, 1.0, g1HalfA, Uvec_primeA, 0.0);
@@ -195,29 +195,29 @@ void OCCWave::ekt_ea() {
         tempA->gemm(false, false, 1.0, G1tildeA, UvecA, 0.0);
     gc_transA = tempA->transpose();
     PSA->gemm(false, false, 1.0, gc_transA, tempA, 0.0);
-    ps_vecA->zero();
+    ps_vecA.zero();
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nmopi_[h]; ++i) {
-            ps_vecA->set(h, i, PSA->get(h, i, i));
+            ps_vecA.set(h, i, PSA->get(h, i, i));
         }
     }
-    if (reference_ == "RESTRICTED") ps_vecA->scale(0.5);
+    if (reference_ == "RESTRICTED") ps_vecA.scale(0.5);
 
     // Sort pole strength
-    Array1d *evals_A = new Array1d("Alpha ORB C1", nmo_);
-    Array1d *ps_vec2A = new Array1d("Sorted Pole strength", nmo_);
-    Array1i *irrep_A = new Array1i("IrrepA", nmo_);
-    evals_A->zero();
-    ps_vec2A->zero();
-    irrep_A->zero();
+    Array1d evals_A("Alpha ORB C1", nmo_);
+    Array1d ps_vec2A("Sorted Pole strength", nmo_);
+    Array1i irrep_A("IrrepA", nmo_);
+    evals_A.zero();
+    ps_vec2A.zero();
+    irrep_A.zero();
 
     // Copy ps vec
     int count = 0;
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nmopi_[h]; ++i) {
-            evals_A->set(count, eorbA->get(h, i));
-            ps_vec2A->set(count, ps_vecA->get(h, i));
-            irrep_A->set(count, h);
+            evals_A.set(count, eorbA.get(h, i));
+            ps_vec2A.set(count, ps_vecA.get(h, i));
+            irrep_A.set(count, h);
             count++;
         }
     }
@@ -225,52 +225,52 @@ void OCCWave::ekt_ea() {
     // Sort to descending order
     for (int i = 0; i < nmo_; ++i) {
         for (int j = nmo_ - 1; j > i; --j) {
-            if (ps_vec2A->get(j - 1) < ps_vec2A->get(j)) {
-                double dum = evals_A->get(j - 1);
-                evals_A->set(j - 1, evals_A->get(j));
-                evals_A->set(j, dum);
+            if (ps_vec2A.get(j - 1) < ps_vec2A.get(j)) {
+                double dum = evals_A.get(j - 1);
+                evals_A.set(j - 1, evals_A.get(j));
+                evals_A.set(j, dum);
 
-                int dum2 = irrep_A->get(j - 1);
-                irrep_A->set(j - 1, irrep_A->get(j));
-                irrep_A->set(j, dum2);
+                int dum2 = irrep_A.get(j - 1);
+                irrep_A.set(j - 1, irrep_A.get(j));
+                irrep_A.set(j, dum2);
 
-                double dum3 = ps_vec2A->get(j - 1);
-                ps_vec2A->set(j - 1, ps_vec2A->get(j));
-                ps_vec2A->set(j, dum3);
+                double dum3 = ps_vec2A.get(j - 1);
+                ps_vec2A.set(j - 1, ps_vec2A.get(j));
+                ps_vec2A.set(j, dum3);
             }
         }
     }
 
     // Re-Sort virtual orbitals to energy order
-    Array1d *evirA = new Array1d("Alpha virtual orb", nvoA);
-    Array1d *ps_virA = new Array1d("occupied Pole strength", nvoA);
-    Array1i *irrep_virA = new Array1i("virtual IrrepA", nvoA);
-    evirA->zero();
-    ps_virA->zero();
-    irrep_virA->zero();
+    Array1d evirA("Alpha virtual orb", nvoA);
+    Array1d ps_virA("occupied Pole strength", nvoA);
+    Array1i irrep_virA("virtual IrrepA", nvoA);
+    evirA.zero();
+    ps_virA.zero();
+    irrep_virA.zero();
 
     // Copy
     for (int i = 0; i < nvoA; ++i) {
-        evirA->set(i, evals_A->get(i + nooA));
-        ps_virA->set(i, ps_vec2A->get(i + nooA));
-        irrep_virA->set(i, irrep_A->get(i + nooA));
+        evirA.set(i, evals_A.get(i + nooA));
+        ps_virA.set(i, ps_vec2A.get(i + nooA));
+        irrep_virA.set(i, irrep_A.get(i + nooA));
     }
 
     // Sort to ascending order
     for (int i = 0; i < nvoA; ++i) {
         for (int j = nvoA - 1; j > i; --j) {
-            if (evirA->get(j - 1) > evirA->get(j)) {
-                double dum = evirA->get(j - 1);
-                evirA->set(j - 1, evirA->get(j));
-                evirA->set(j, dum);
+            if (evirA.get(j - 1) > evirA.get(j)) {
+                double dum = evirA.get(j - 1);
+                evirA.set(j - 1, evirA.get(j));
+                evirA.set(j, dum);
 
-                int dum2 = irrep_virA->get(j - 1);
-                irrep_virA->set(j - 1, irrep_virA->get(j));
-                irrep_virA->set(j, dum2);
+                int dum2 = irrep_virA.get(j - 1);
+                irrep_virA.set(j - 1, irrep_virA.get(j));
+                irrep_virA.set(j, dum2);
 
-                double dum3 = ps_virA->get(j - 1);
-                ps_virA->set(j - 1, ps_virA->get(j));
-                ps_virA->set(j, dum3);
+                double dum3 = ps_virA.get(j - 1);
+                ps_virA.set(j - 1, ps_virA.get(j));
+                ps_virA.set(j, dum3);
             }
         }
     }
@@ -289,9 +289,9 @@ void OCCWave::ekt_ea() {
         outfile->Printf("\t------------------------------------------------------------------- \n");
 
         for (int i = 0; i < nvoA; ++i) {
-            int h = irrep_virA->get(i);
-            outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evirA->get(i),
-                            -evirA->get(i) * pc_hartree2ev, ps_virA->get(i));
+            int h = irrep_virA.get(i);
+            outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evirA.get(i),
+                            -evirA.get(i) * pc_hartree2ev, ps_virA.get(i));
         }
         outfile->Printf("\t------------------------------------------------------------------- \n");
 
@@ -302,9 +302,9 @@ void OCCWave::ekt_ea() {
         outfile->Printf("\t------------------------------------------------------------------- \n");
 
         for (int i = 0; i < nmo_; ++i) {
-            int h = irrep_A->get(i);
-            outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evals_A->get(i),
-                            -evals_A->get(i) * pc_hartree2ev, ps_vec2A->get(i));
+            int h = irrep_A.get(i);
+            outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evals_A.get(i),
+                            -evals_A.get(i) * pc_hartree2ev, ps_vec2A.get(i));
         }
         outfile->Printf("\t------------------------------------------------------------------- \n");
 
@@ -322,33 +322,33 @@ void OCCWave::ekt_ea() {
         auto PSB = std::make_shared<Matrix>("Beta pole strength matrix", nirrep_, nmopi_, nmopi_);
         auto gc_transB = std::make_shared<Matrix>("Beta C'*g", nirrep_, nmopi_, nmopi_);
         auto tempB = std::make_shared<Matrix>("Beta temp", nirrep_, nmopi_, nmopi_);
-        auto Diag_g1B = std::make_shared<Vector>("DiagA OO-block OPDM", nirrep_, nmopi_);
-        auto ps_vecB = std::make_shared<Vector>("Beta pole strength vector", nirrep_, nmopi_);
-        auto eorbB = std::make_shared<Vector>("eorbB", nirrep_, nmopi_);
+        Vector Diag_g1B("DiagA OO-block OPDM", nmopi_);
+        Vector ps_vecB("Beta pole strength vector", nmopi_);
+        auto eorbB = std::make_shared<Vector>("eorbB", nmopi_);
 
         // Diagonalize OPDM
         UvecB->zero();
-        Diag_g1B->zero();
+        Diag_g1B.zero();
         G1tildeB->diagonalize(UvecB, Diag_g1B);
 
         // Make sure all eigenvalues are positive
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < nmopi_[h]; ++i) {
-                if (Diag_g1B->get(h, i) < 0.0) Diag_g1B->set(h, i, -1.0 * Diag_g1B->get(h, i));
+                if (Diag_g1B.get(h, i) < 0.0) Diag_g1B.set(h, i, -1.0 * Diag_g1B.get(h, i));
             }
         }
 
         // Form g^(-1/2)
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < nmopi_[h]; ++i) {
-                Diag_g1B->set(h, i, 1 / sqrt(Diag_g1B->get(h, i)));
+                Diag_g1B.set(h, i, 1 / sqrt(Diag_g1B.get(h, i)));
             }
         }
 
         g1HalfB->zero();
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < nmopi_[h]; ++i) {
-                g1HalfB->set(h, i, i, Diag_g1B->get(h, i));
+                g1HalfB->set(h, i, i, Diag_g1B.get(h, i));
             }
         }
 
@@ -373,28 +373,28 @@ void OCCWave::ekt_ea() {
         tempB->gemm(false, false, 1.0, G1tildeB, UvecB, 0.0);
         gc_transB = tempB->transpose();
         PSB->gemm(false, false, 1.0, gc_transB, tempB, 0.0);
-        ps_vecB->zero();
+        ps_vecB.zero();
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < nmopi_[h]; ++i) {
-                ps_vecB->set(h, i, PSB->get(h, i, i));
+                ps_vecB.set(h, i, PSB->get(h, i, i));
             }
         }
 
         // Sort pole strength
-        Array1d *evals_B = new Array1d("Alpha ORB C1", nmo_);
-        Array1d *ps_vec2B = new Array1d("Sorted Pole strength", nmo_);
-        Array1i *irrep_B = new Array1i("IrrepB", nmo_);
-        evals_B->zero();
-        ps_vec2B->zero();
-        irrep_B->zero();
+        Array1d evals_B("Alpha ORB C1", nmo_);
+        Array1d ps_vec2B("Sorted Pole strength", nmo_);
+        Array1i irrep_B("IrrepB", nmo_);
+        evals_B.zero();
+        ps_vec2B.zero();
+        irrep_B.zero();
 
         // Copy ps vec
         int count = 0;
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < nmopi_[h]; ++i) {
-                evals_B->set(count, eorbB->get(h, i));
-                ps_vec2B->set(count, ps_vecB->get(h, i));
-                irrep_B->set(count, h);
+                evals_B.set(count, eorbB->get(h, i));
+                ps_vec2B.set(count, ps_vecB.get(h, i));
+                irrep_B.set(count, h);
                 count++;
             }
         }
@@ -402,52 +402,52 @@ void OCCWave::ekt_ea() {
         // Sort to descending order
         for (int i = 0; i < nmo_; ++i) {
             for (int j = nmo_ - 1; j > i; --j) {
-                if (ps_vec2B->get(j - 1) < ps_vec2B->get(j)) {
-                    double dum = evals_B->get(j - 1);
-                    evals_B->set(j - 1, evals_B->get(j));
-                    evals_B->set(j, dum);
+                if (ps_vec2B.get(j - 1) < ps_vec2B.get(j)) {
+                    double dum = evals_B.get(j - 1);
+                    evals_B.set(j - 1, evals_B.get(j));
+                    evals_B.set(j, dum);
 
-                    int dum2 = irrep_B->get(j - 1);
-                    irrep_B->set(j - 1, irrep_B->get(j));
-                    irrep_B->set(j, dum2);
+                    int dum2 = irrep_B.get(j - 1);
+                    irrep_B.set(j - 1, irrep_B.get(j));
+                    irrep_B.set(j, dum2);
 
-                    double dum3 = ps_vec2B->get(j - 1);
-                    ps_vec2B->set(j - 1, ps_vec2B->get(j));
-                    ps_vec2B->set(j, dum3);
+                    double dum3 = ps_vec2B.get(j - 1);
+                    ps_vec2B.set(j - 1, ps_vec2B.get(j));
+                    ps_vec2B.set(j, dum3);
                 }
             }
         }
 
         // Re-Sort virtual orbitals to energy order
-        Array1d *evirB = new Array1d("Alpha virtual orb", nvoB);
-        Array1d *ps_virB = new Array1d("occupied Pole strength", nvoB);
-        Array1i *irrep_virB = new Array1i("virtual IrrepA", nvoB);
-        evirB->zero();
-        ps_virB->zero();
-        irrep_virB->zero();
+        Array1d evirB("Alpha virtual orb", nvoB);
+        Array1d ps_virB("occupied Pole strength", nvoB);
+        Array1i irrep_virB("virtual IrrepA", nvoB);
+        evirB.zero();
+        ps_virB.zero();
+        irrep_virB.zero();
 
         // Copy
         for (int i = 0; i < nvoB; ++i) {
-            evirB->set(i, evals_B->get(i + nooB));
-            ps_virB->set(i, ps_vec2B->get(i + nooB));
-            irrep_virB->set(i, irrep_B->get(i + nooB));
+            evirB.set(i, evals_B.get(i + nooB));
+            ps_virB.set(i, ps_vec2B.get(i + nooB));
+            irrep_virB.set(i, irrep_B.get(i + nooB));
         }
 
         // Sort to ascending order
         for (int i = 0; i < nvoB; ++i) {
             for (int j = nvoB - 1; j > i; --j) {
-                if (evirB->get(j - 1) > evirB->get(j)) {
-                    double dum = evirB->get(j - 1);
-                    evirB->set(j - 1, evirB->get(j));
-                    evirB->set(j, dum);
+                if (evirB.get(j - 1) > evirB.get(j)) {
+                    double dum = evirB.get(j - 1);
+                    evirB.set(j - 1, evirB.get(j));
+                    evirB.set(j, dum);
 
-                    int dum2 = irrep_virB->get(j - 1);
-                    irrep_virB->set(j - 1, irrep_virB->get(j));
-                    irrep_virB->set(j, dum2);
+                    int dum2 = irrep_virB.get(j - 1);
+                    irrep_virB.set(j - 1, irrep_virB.get(j));
+                    irrep_virB.set(j, dum2);
 
-                    double dum3 = ps_virB->get(j - 1);
-                    ps_virB->set(j - 1, ps_virB->get(j));
-                    ps_virB->set(j, dum3);
+                    double dum3 = ps_virB.get(j - 1);
+                    ps_virB.set(j - 1, ps_virB.get(j));
+                    ps_virB.set(j, dum3);
                 }
             }
         }
@@ -462,9 +462,9 @@ void OCCWave::ekt_ea() {
             outfile->Printf("\t------------------------------------------------------------------- \n");
 
             for (int i = 0; i < nvoB; ++i) {
-                int h = irrep_virB->get(i);
-                outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evirB->get(i),
-                                -evirB->get(i) * pc_hartree2ev, ps_virB->get(i));
+                int h = irrep_virB.get(i);
+                outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evirB.get(i),
+                                -evirB.get(i) * pc_hartree2ev, ps_virB.get(i));
             }
             outfile->Printf("\t------------------------------------------------------------------- \n");
 
@@ -475,9 +475,9 @@ void OCCWave::ekt_ea() {
             outfile->Printf("\t------------------------------------------------------------------- \n");
 
             for (int i = 0; i < nmo_; ++i) {
-                int h = irrep_B->get(i);
-                outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evals_B->get(i),
-                                -evals_B->get(i) * pc_hartree2ev, ps_vec2B->get(i));
+                int h = irrep_B.get(i);
+                outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evals_B.get(i),
+                                -evals_B.get(i) * pc_hartree2ev, ps_vec2B.get(i));
             }
             outfile->Printf("\t------------------------------------------------------------------- \n");
 
@@ -490,16 +490,7 @@ void OCCWave::ekt_ea() {
         PSB.reset();
         gc_transB.reset();
         tempB.reset();
-        Diag_g1B.reset();
-        ps_vecB.reset();
         eorbB.reset();
-
-        delete irrep_B;
-        delete ps_vec2B;
-        delete evals_B;
-        delete irrep_virB;
-        delete ps_virB;
-        delete evirB;
 
     }  // if (reference_ == "UNRESTRICTED")
 
@@ -519,18 +510,6 @@ void OCCWave::ekt_ea() {
     PSA.reset();
     gc_transA.reset();
     tempA.reset();
-    Diag_g1A.reset();
-    ps_vecA.reset();
-    eorbA.reset();
-
-    delete irrep_A;
-    delete ps_vec2A;
-    delete evals_A;
-    delete irrep_virA;
-    delete ps_virA;
-    delete evirA;
-
-    // outfile->Printf("\n ekt_ea is done. \n");
 
 }  // end ekt_ip
 }

--- a/psi4/src/psi4/occ/ep2_ip.cc
+++ b/psi4/src/psi4/occ/ep2_ip.cc
@@ -49,7 +49,7 @@ void OCCWave::ep2_ip() {
     //===========================================================================================
     if (reference_ == "RESTRICTED") {
         // Memory allocation for diagonal self-energy
-        auto eOccOrbA = std::make_shared<Vector>("eOccOrbA", nirrep_, occpiA);
+        auto eOccOrbA = std::make_shared<Vector>("eOccOrbA", occpiA);
 
         dpdbuf4 K, T, D;
 
@@ -57,8 +57,8 @@ void OCCWave::ep2_ip() {
         psio_->open(PSIF_OCC_DPD, PSIO_OPEN_OLD);
 
         // Build denominators D_jk^ia = E_j + E_k - E_i - E_a
-        auto *aOccEvals = new double[nacooA];
-        auto *aVirEvals = new double[nacvoA];
+        auto aOccEvals = std::vector<double>(nacooA);
+        auto aVirEvals = std::vector<double>(nacvoA);
 
         // Pick out the diagonal elements of the Fock matrix, making sure that they are in the order
         // used by the DPD library, i.e. starting from zero for each space and ordering by irrep
@@ -253,8 +253,8 @@ void OCCWave::ep2_ip() {
         outfile->Printf("\t----------------------------------------------- \n");
 
         Molecule &mol = *reference_wavefunction_->molecule().get();
-        CharacterTable ct = mol.point_group()->char_table();
-        std::string pgroup = mol.point_group()->symbol();
+        auto ct = mol.point_group()->char_table();
+        auto pgroup = mol.point_group()->symbol();
 
         // print alpha occ orb energy
         outfile->Printf("\tAlpha occupied orbitals\n");
@@ -269,8 +269,6 @@ void OCCWave::ep2_ip() {
         eOccOrbA.reset();
         delete evals_A;
         delete irrep_A;
-        delete[] aOccEvals;
-        delete[] aVirEvals;
 
     }  // end if (reference_ == "RESTRICTED")
 
@@ -279,8 +277,8 @@ void OCCWave::ep2_ip() {
     //===========================================================================================
     else if (reference_ == "UNRESTRICTED") {
         // Memory allocation
-        auto eOccOrbA = std::make_shared<Vector>("eOccOrbA", nirrep_, occpiA);
-        auto eOccOrbB = std::make_shared<Vector>("eOccOrbB", nirrep_, occpiB);
+        auto eOccOrbA = std::make_shared<Vector>("eOccOrbA", occpiA);
+        auto eOccOrbB = std::make_shared<Vector>("eOccOrbB", occpiB);
         eOccOrbA->zero();
         eOccOrbB->zero();
 

--- a/psi4/src/psi4/occ/occ_iterations.cc
+++ b/psi4/src/psi4/occ/occ_iterations.cc
@@ -491,10 +491,10 @@ void OCCWave::compute_orbital_step() {
     // Update the orbital amplitude. Trust the rest of the program to DIIS when ready.
     // DIIS is tied to both orbitals and amplitudes, so having stepped orbitals isn't enough.
     const auto kappaA_vec = std::make_shared<Vector>(idp_dimensions_[SpinType::Alpha], *kappaA);
-    kappa_bar_[SpinType::Alpha]->add(kappaA_vec);
+    kappa_bar_[SpinType::Alpha]->add(*kappaA_vec);
     if (reference_ == "UNRESTRICTED") {
         const auto kappaB_vec = std::make_shared<Vector>(idp_dimensions_[SpinType::Beta], *kappaB);
-        kappa_bar_[SpinType::Beta]->add(kappaB_vec);
+        kappa_bar_[SpinType::Beta]->add(*kappaB_vec);
     }
 }
 

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -510,7 +510,7 @@ void OCCWave::nbo() {
     outfile->Printf("\n");
 
     auto Udum = std::make_shared<Matrix>("Udum", nirrep_, nmopi_, nmopi_);
-    auto diag = std::make_shared<Vector>("Natural orbital occupation numbers", nirrep_, nmopi_);
+    auto diag = std::make_shared<Vector>("Natural orbital occupation numbers", nmopi_);
 
     // Diagonalizing Alpha-OPDM
     Udum->zero();

--- a/psi4/src/psi4/occ/omp3_ip_poles.cc
+++ b/psi4/src/psi4/occ/omp3_ip_poles.cc
@@ -66,8 +66,8 @@ void OCCWave::omp3_ip_poles() {
     //===========================================================================================
     if (reference_ == "RESTRICTED") {
         // Memory allocation
-        auto eOccOrbA = std::make_shared<Vector>("eOccOrbA", nirrep_, occpiA);
-        eOccOrbA->zero();
+        Vector eOccOrbA("eOccOrbA", occpiA);
+        eOccOrbA.zero();
 
         dpdbuf4 K, T, D;
 
@@ -75,8 +75,8 @@ void OCCWave::omp3_ip_poles() {
         psio_->open(PSIF_OCC_DPD, PSIO_OPEN_OLD);
 
         // Build denominators D_jk^ia = E_j + E_k - E_i - E_a
-        auto *aOccEvals = new double[nacooA];
-        auto *aVirEvals = new double[nacvoA];
+        std::vector<double> aOccEvals(nacooA);
+        std::vector<double> aVirEvals(nacvoA);
 
         // Pick out the diagonal elements of the Fock matrix, making sure that they are in the order
         // used by the DPD library, i.e. starting from zero for each space and ordering by irrep
@@ -109,9 +109,6 @@ void OCCWave::omp3_ip_poles() {
         }
         global_dpd_->buf4_close(&D);
 
-        delete[] aOccEvals;
-        delete[] aVirEvals;
-
         // NOTE:! The followings are MP2 amplitudes, they should be MP3 amplitudes.
         // Build T_IA^JK
         // T_IA^JK = <IA||JK> / D_IA^JK
@@ -131,7 +128,7 @@ void OCCWave::omp3_ip_poles() {
         // e_I = F_II : reference contribution
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < occpiA[h]; ++i) {
-                eOccOrbA->set(h, i, FockA->get(h, i, i));
+                eOccOrbA.set(h, i, FockA->get(h, i, i));
             }
         }
 
@@ -153,7 +150,7 @@ void OCCWave::omp3_ip_poles() {
                 int ii = i - occ_offA[hi];
                 for (int ab = 0; ab < K.params->coltot[h]; ++ab) {
                     double value = ((2.0 * T.matrix[h][ij][ab]) - T.matrix[h][ji][ab]) * K.matrix[h][ij][ab];
-                    eOccOrbA->add(hi, ii, value);
+                    eOccOrbA.add(hi, ii, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -181,7 +178,7 @@ void OCCWave::omp3_ip_poles() {
                     int hi = K.params->rsym[i];
                     int ii = i - occ_offA[hi];
                     double value = ((2.0 * T.matrix[h][ia][jk]) - T.matrix[h][ia][kj]) * K.matrix[h][jk][ia];
-                    eOccOrbA->add(hi, ii, value);
+                    eOccOrbA.add(hi, ii, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -194,17 +191,17 @@ void OCCWave::omp3_ip_poles() {
         psio_->close(PSIF_OCC_DPD, 1);
 
         // Sort orbitals
-        Array1d *evals_A = new Array1d("Alpha OCC ORB C1", nooA);
-        Array1i *irrep_A = new Array1i("IrrepA", nooA);
-        evals_A->zero();
-        irrep_A->zero();
+        Array1d evals_A("Alpha OCC ORB C1", nooA);
+        Array1i irrep_A("IrrepA", nooA);
+        evals_A.zero();
+        irrep_A.zero();
 
         // Sort Alpha spin-case
         int count = 0;
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < occpiA[h]; ++i) {
-                evals_A->set(count, eOccOrbA->get(h, i));
-                irrep_A->set(count, h);
+                evals_A.set(count, eOccOrbA.get(h, i));
+                irrep_A.set(count, h);
                 count++;
             }
         }
@@ -213,13 +210,13 @@ void OCCWave::omp3_ip_poles() {
 
         for (int i = 0; i < nooA; ++i) {
             for (int j = nooA - 1; j > i; --j) {
-                if (evals_A->get(j - 1) > evals_A->get(j)) {
-                    double dum = evals_A->get(j - 1);
-                    evals_A->set(j - 1, evals_A->get(j));
-                    evals_A->set(j, dum);
-                    int dum2 = irrep_A->get(j - 1);
-                    irrep_A->set(j - 1, irrep_A->get(j));
-                    irrep_A->set(j, dum2);
+                if (evals_A.get(j - 1) > evals_A.get(j)) {
+                    double dum = evals_A.get(j - 1);
+                    evals_A.set(j - 1, evals_A.get(j));
+                    evals_A.set(j, dum);
+                    int dum2 = irrep_A.get(j - 1);
+                    irrep_A.set(j - 1, irrep_A.get(j));
+                    irrep_A.set(j, dum2);
                 }
             }
         }
@@ -239,16 +236,11 @@ void OCCWave::omp3_ip_poles() {
         outfile->Printf("\tAlpha occupied orbitals\n");
         count = 1;
         for (int i = 0; i < nooA; ++i) {
-            int h = irrep_A->get(i);
-            outfile->Printf("\t%3d (%-3s) %20.10f \n", count, ct.gamma(h).symbol(), evals_A->get(i));
+            int h = irrep_A.get(i);
+            outfile->Printf("\t%3d (%-3s) %20.10f \n", count, ct.gamma(h).symbol(), evals_A.get(i));
 
             count++;
         }
-
-        eOccOrbA.reset();
-        delete evals_A;
-        delete irrep_A;
-
     }  // end if (reference_ == "RESTRICTED")
 
     //===========================================================================================
@@ -256,10 +248,10 @@ void OCCWave::omp3_ip_poles() {
     //===========================================================================================
     else if (reference_ == "UNRESTRICTED") {
         // Memory allocation
-        auto eOccOrbA = std::make_shared<Vector>("eOccOrbA", nirrep_, occpiA);
-        auto eOccOrbB = std::make_shared<Vector>("eOccOrbB", nirrep_, occpiB);
-        eOccOrbA->zero();
-        eOccOrbB->zero();
+        Vector eOccOrbA("eOccOrbA", occpiA);
+        Vector eOccOrbB("eOccOrbB", occpiB);
+        eOccOrbA.zero();
+        eOccOrbB.zero();
 
         dpdbuf4 K, T, D;
 
@@ -267,10 +259,10 @@ void OCCWave::omp3_ip_poles() {
         psio_->open(PSIF_OCC_DPD, PSIO_OPEN_OLD);
 
         // Build denominators D_jk^ia = E_j + E_k - E_i - E_a
-        auto *aOccEvals = new double[nacooA];
-        auto *bOccEvals = new double[nacooB];
-        auto *aVirEvals = new double[nacvoA];
-        auto *bVirEvals = new double[nacvoB];
+        std::vector<double> aOccEvals(nacooA);
+        std::vector<double> bOccEvals(nacooB);
+        std::vector<double> aVirEvals(nacvoA);
+        std::vector<double> bVirEvals(nacvoB);
 
         // Pick out the diagonal elements of the Fock matrix, making sure that they are in the order
         // used by the DPD library, i.e. starting from zero for each space and ordering by irrep
@@ -362,11 +354,6 @@ void OCCWave::omp3_ip_poles() {
         }
         global_dpd_->buf4_close(&D);
 
-        delete[] aOccEvals;
-        delete[] bOccEvals;
-        delete[] aVirEvals;
-        delete[] bVirEvals;
-
         // Build T_IA^JK
         // T_IA^JK = <IA||JK> / D_IA^JK
         global_dpd_->buf4_init(&K, PSIF_LIBTRANS_DPD, 0, ID("[O,O]"), ID("[O,V]"), ID("[O,O]"), ID("[O,V]"), 0,
@@ -424,7 +411,7 @@ void OCCWave::omp3_ip_poles() {
         // e_I = F_II : reference contribution
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < occpiA[h]; ++i) {
-                eOccOrbA->set(h, i, FockA->get(h, i, i));
+                eOccOrbA.set(h, i, FockA->get(h, i, i));
             }
         }
 
@@ -443,7 +430,7 @@ void OCCWave::omp3_ip_poles() {
                 int hi = K.params->psym[i];
                 int ii = i - occ_offA[hi];
                 for (int ab = 0; ab < K.params->coltot[h]; ++ab) {
-                    eOccOrbA->add(hi, ii, 0.5 * K.matrix[h][ij][ab] * T.matrix[h][ij][ab]);
+                    eOccOrbA.add(hi, ii, 0.5 * K.matrix[h][ij][ab] * T.matrix[h][ij][ab]);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -467,7 +454,7 @@ void OCCWave::omp3_ip_poles() {
                 int hi = K.params->psym[i];
                 int ii = i - occ_offA[hi];
                 for (int ab = 0; ab < K.params->coltot[h]; ++ab) {
-                    eOccOrbA->add(hi, ii, K.matrix[h][ij][ab] * T.matrix[h][ij][ab]);
+                    eOccOrbA.add(hi, ii, K.matrix[h][ij][ab] * T.matrix[h][ij][ab]);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -491,7 +478,7 @@ void OCCWave::omp3_ip_poles() {
                     int i = K.params->colorb[h][ia][0];
                     int hi = K.params->rsym[i];
                     int ii = i - occ_offA[hi];
-                    eOccOrbA->add(hi, ii, 0.5 * K.matrix[h][jk][ia] * T.matrix[h][ia][jk]);
+                    eOccOrbA.add(hi, ii, 0.5 * K.matrix[h][jk][ia] * T.matrix[h][ia][jk]);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -515,7 +502,7 @@ void OCCWave::omp3_ip_poles() {
                     int i = K.params->colorb[h][ia][0];
                     int hi = K.params->rsym[i];
                     int ii = i - occ_offA[hi];
-                    eOccOrbA->add(hi, ii, K.matrix[h][jk][ia] * T.matrix[h][ia][jk]);
+                    eOccOrbA.add(hi, ii, K.matrix[h][jk][ia] * T.matrix[h][ia][jk]);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -528,7 +515,7 @@ void OCCWave::omp3_ip_poles() {
         // e_i = F_ii : reference contribution
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < occpiB[h]; ++i) {
-                eOccOrbB->set(h, i, FockB->get(h, i, i));
+                eOccOrbB.set(h, i, FockB->get(h, i, i));
             }
         }
 
@@ -547,7 +534,7 @@ void OCCWave::omp3_ip_poles() {
                 int hi = K.params->psym[i];
                 int ii = i - occ_offB[hi];
                 for (int ab = 0; ab < K.params->coltot[h]; ++ab) {
-                    eOccOrbB->add(hi, ii, 0.5 * K.matrix[h][ij][ab] * T.matrix[h][ij][ab]);
+                    eOccOrbB.add(hi, ii, 0.5 * K.matrix[h][ij][ab] * T.matrix[h][ij][ab]);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -571,7 +558,7 @@ void OCCWave::omp3_ip_poles() {
                 int hi = K.params->qsym[i];
                 int ii = i - occ_offB[hi];
                 for (int ab = 0; ab < K.params->coltot[h]; ++ab) {
-                    eOccOrbB->add(hi, ii, K.matrix[h][ji][ab] * T.matrix[h][ji][ab]);
+                    eOccOrbB.add(hi, ii, K.matrix[h][ji][ab] * T.matrix[h][ji][ab]);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -595,7 +582,7 @@ void OCCWave::omp3_ip_poles() {
                     int i = K.params->colorb[h][ia][0];
                     int hi = K.params->rsym[i];
                     int ii = i - occ_offB[hi];
-                    eOccOrbB->add(hi, ii, 0.5 * K.matrix[h][jk][ia] * T.matrix[h][ia][jk]);
+                    eOccOrbB.add(hi, ii, 0.5 * K.matrix[h][jk][ia] * T.matrix[h][ia][jk]);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -619,7 +606,7 @@ void OCCWave::omp3_ip_poles() {
                     int i = K.params->colorb[h][ai][1];
                     int hi = K.params->ssym[i];
                     int ii = i - occ_offB[hi];
-                    eOccOrbB->add(hi, ii, K.matrix[h][jk][ai] * T.matrix[h][ai][jk]);
+                    eOccOrbB.add(hi, ii, K.matrix[h][jk][ai] * T.matrix[h][ai][jk]);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&K, h);
@@ -632,21 +619,21 @@ void OCCWave::omp3_ip_poles() {
         psio_->close(PSIF_OCC_DPD, 1);
 
         // Sort orbitals
-        Array1d *evals_A = new Array1d("Alpha OCC ORB C1", nooA);
-        Array1d *evals_B = new Array1d("Beta OCC ORB C1", nooB);
-        Array1i *irrep_A = new Array1i("IrrepA", nooA);
-        Array1i *irrep_B = new Array1i("IrrepA", nooB);
-        evals_A->zero();
-        evals_B->zero();
-        irrep_A->zero();
-        irrep_B->zero();
+        Array1d evals_A("Alpha OCC ORB C1", nooA);
+        Array1d evals_B("Beta OCC ORB C1", nooB);
+        Array1i irrep_A("IrrepA", nooA);
+        Array1i irrep_B("IrrepA", nooB);
+        evals_A.zero();
+        evals_B.zero();
+        irrep_A.zero();
+        irrep_B.zero();
 
         // Sort Alpha spin-case
         int count = 0;
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < occpiA[h]; ++i) {
-                evals_A->set(count, eOccOrbA->get(h, i));
-                irrep_A->set(count, h);
+                evals_A.set(count, eOccOrbA.get(h, i));
+                irrep_A.set(count, h);
                 count++;
             }
         }
@@ -655,13 +642,13 @@ void OCCWave::omp3_ip_poles() {
 
         for (int i = 0; i < nooA; ++i) {
             for (int j = nooA - 1; j > i; --j) {
-                if (evals_A->get(j - 1) > evals_A->get(j)) {
-                    double dum = evals_A->get(j - 1);
-                    evals_A->set(j - 1, evals_A->get(j));
-                    evals_A->set(j, dum);
-                    int dum2 = irrep_A->get(j - 1);
-                    irrep_A->set(j - 1, irrep_A->get(j));
-                    irrep_A->set(j, dum2);
+                if (evals_A.get(j - 1) > evals_A.get(j)) {
+                    double dum = evals_A.get(j - 1);
+                    evals_A.set(j - 1, evals_A.get(j));
+                    evals_A.set(j, dum);
+                    int dum2 = irrep_A.get(j - 1);
+                    irrep_A.set(j - 1, irrep_A.get(j));
+                    irrep_A.set(j, dum2);
                 }
             }
         }
@@ -670,20 +657,20 @@ void OCCWave::omp3_ip_poles() {
         count = 0;
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < occpiB[h]; ++i) {
-                evals_B->set(count, eOccOrbB->get(h, i));
-                irrep_B->set(count, h);
+                evals_B.set(count, eOccOrbB.get(h, i));
+                irrep_B.set(count, h);
                 count++;
             }
         }
         for (int i = 0; i < nooB; ++i) {
             for (int j = nooB - 1; j > i; --j) {
-                if (evals_B->get(j - 1) > evals_B->get(j)) {
-                    double dum = evals_B->get(j - 1);
-                    evals_B->set(j - 1, evals_B->get(j));
-                    evals_B->set(j, dum);
-                    int dum2 = irrep_B->get(j - 1);
-                    irrep_B->set(j - 1, irrep_B->get(j));
-                    irrep_B->set(j, dum2);
+                if (evals_B.get(j - 1) > evals_B.get(j)) {
+                    double dum = evals_B.get(j - 1);
+                    evals_B.set(j - 1, evals_B.get(j));
+                    evals_B.set(j, dum);
+                    int dum2 = irrep_B.get(j - 1);
+                    irrep_B.set(j - 1, irrep_B.get(j));
+                    irrep_B.set(j, dum2);
                 }
             }
         }
@@ -703,8 +690,8 @@ void OCCWave::omp3_ip_poles() {
         outfile->Printf("\tAlpha occupied orbitals\n");
         count = 1;
         for (int i = 0; i < nooA; ++i) {
-            int h = irrep_A->get(i);
-            outfile->Printf("\t%3d (%-3s) %20.10f \n", count, ct.gamma(h).symbol(), evals_A->get(i));
+            int h = irrep_A.get(i);
+            outfile->Printf("\t%3d (%-3s) %20.10f \n", count, ct.gamma(h).symbol(), evals_A.get(i));
 
             count++;
         }
@@ -713,19 +700,11 @@ void OCCWave::omp3_ip_poles() {
         outfile->Printf("\n\tBeta occupied orbitals\n");
         count = 1;
         for (int i = 0; i < nooB; ++i) {
-            int h = irrep_B->get(i);
-            outfile->Printf("\t%3d (%-3s) %20.10f \n", count, ct.gamma(h).symbol(), evals_B->get(i));
+            int h = irrep_B.get(i);
+            outfile->Printf("\t%3d (%-3s) %20.10f \n", count, ct.gamma(h).symbol(), evals_B.get(i));
 
             count++;
         }
-
-        eOccOrbA.reset();
-        eOccOrbB.reset();
-        delete evals_A;
-        delete evals_B;
-        delete irrep_A;
-        delete irrep_B;
-
     }  // end if (reference_ == "UNRESTRICTED")
     // outfile->Printf("\n omp3_ip_poles is done. \n");
 }  // end omp3_ip_poles

--- a/psi4/src/psi4/occ/semi_canonic.cc
+++ b/psi4/src/psi4/occ/semi_canonic.cc
@@ -44,8 +44,8 @@ void OCCWave::semi_canonic() {
     auto UvvA = std::make_shared<Matrix>(nirrep_, virtpiA, virtpiA);
     auto FockooA = std::make_shared<Matrix>(nirrep_, occpiA, occpiA);
     auto FockvvA = std::make_shared<Matrix>(nirrep_, virtpiA, virtpiA);
-    auto eigooA = std::make_shared<Vector>(nirrep_, occpiA);
-    auto eigvvA = std::make_shared<Vector>(nirrep_, virtpiA);
+    Vector eigooA(occpiA);
+    Vector eigvvA(virtpiA);
 
     UooA->zero();
     UvvA->zero();
@@ -55,14 +55,14 @@ void OCCWave::semi_canonic() {
     // OCC-OCC
     for (int h = 0; h < nirrep_; h++) {
         for (int i = 0; i < occpiA[h]; i++) {
-            eigooA->set(h, i, 0.0);
+            eigooA.set(h, i, 0.0);
         }
     }
 
     // VIR-VIR
     for (int h = 0; h < nirrep_; h++) {
         for (int i = 0; i < virtpiA[h]; i++) {
-            eigvvA->set(h, i, 0.0);
+            eigvvA.set(h, i, 0.0);
         }
     }
 
@@ -106,7 +106,7 @@ void OCCWave::semi_canonic() {
         for (int h = 0; h < nirrep_; h++) {
             int count = 1;
             for (int i = 0; i < occpiA[h]; i++) {
-                outfile->Printf("\t %2d%-3s %20.10f \n", count, ct.gamma(h).symbol(), eigooA->get(h, i));
+                outfile->Printf("\t %2d%-3s %20.10f \n", count, ct.gamma(h).symbol(), eigooA.get(h, i));
 
                 count++;
             }  // end loop over occpi
@@ -117,7 +117,7 @@ void OCCWave::semi_canonic() {
         for (int h = 0; h < nirrep_; h++) {
             int count = 1;
             for (int i = 0; i < virtpiA[h]; i++) {
-                outfile->Printf("\t %2d%-3s %20.10f \n", count, ct.gamma(h).symbol(), eigvvA->get(h, i));
+                outfile->Printf("\t %2d%-3s %20.10f \n", count, ct.gamma(h).symbol(), eigvvA.get(h, i));
 
                 count++;
             }  // end loop over occpi
@@ -170,8 +170,6 @@ void OCCWave::semi_canonic() {
     UvvA.reset();
     FockooA.reset();
     FockvvA.reset();
-    eigooA.reset();
-    eigvvA.reset();
 
     // UHF REFERENCE
     if (reference_ == "UNRESTRICTED") {
@@ -179,8 +177,8 @@ void OCCWave::semi_canonic() {
         auto UvvB = std::make_shared<Matrix>(nirrep_, virtpiB, virtpiB);
         auto FockooB = std::make_shared<Matrix>(nirrep_, occpiB, occpiB);
         auto FockvvB = std::make_shared<Matrix>(nirrep_, virtpiB, virtpiB);
-        auto eigooB = std::make_shared<Vector>(nirrep_, occpiB);
-        auto eigvvB = std::make_shared<Vector>(nirrep_, virtpiB);
+        Vector eigooB(occpiB);
+        Vector eigvvB(virtpiB);
 
         UooB->zero();
         UvvB->zero();
@@ -190,14 +188,14 @@ void OCCWave::semi_canonic() {
         // occ-occ
         for (int h = 0; h < nirrep_; h++) {
             for (int i = 0; i < occpiB[h]; i++) {
-                eigooB->set(h, i, 0.0);
+                eigooB.set(h, i, 0.0);
             }
         }
 
         // vir-vir
         for (int h = 0; h < nirrep_; h++) {
             for (int i = 0; i < virtpiB[h]; i++) {
-                eigvvB->set(h, i, 0.0);
+                eigvvB.set(h, i, 0.0);
             }
         }
 
@@ -241,7 +239,7 @@ void OCCWave::semi_canonic() {
             for (int h = 0; h < nirrep_; h++) {
                 int count = 1;
                 for (int i = 0; i < occpiB[h]; i++) {
-                    outfile->Printf("\t %2d%-3s %20.10f \n", count, ct.gamma(h).symbol(), eigooB->get(h, i));
+                    outfile->Printf("\t %2d%-3s %20.10f \n", count, ct.gamma(h).symbol(), eigooB.get(h, i));
 
                     count++;
                 }  // end loop over occpi
@@ -252,7 +250,7 @@ void OCCWave::semi_canonic() {
             for (int h = 0; h < nirrep_; h++) {
                 int count = 1;
                 for (int i = 0; i < virtpiB[h]; i++) {
-                    outfile->Printf("\t %2d%-3s %20.10f \n", count, ct.gamma(h).symbol(), eigvvB->get(h, i));
+                    outfile->Printf("\t %2d%-3s %20.10f \n", count, ct.gamma(h).symbol(), eigvvB.get(h, i));
 
                     count++;
                 }  // end loop over occpi
@@ -303,8 +301,6 @@ void OCCWave::semi_canonic() {
         UvvB.reset();
         FockooB.reset();
         FockvvB.reset();
-        eigooB.reset();
-        eigvvB.reset();
     }  // end uhf
 }
 }

--- a/tests/pytests/test_vector.py
+++ b/tests/pytests/test_vector.py
@@ -80,10 +80,11 @@ def test_set(tested_class):
 
 def test_int_vs_float():
     dim = Dimension(1)
+    foo = IntVector(dim)
     with pytest.raises(TypeError):
-        IntVector.set(0, 0.1)
+        foo.set(0, 0.1)
     with pytest.raises(TypeError):
-        IntVector.add(0, 0.1)
+        foo.add(0, 0.1)
 
 def test_iota():
     dim = Dimension([5, 3, 2])

--- a/tests/pytests/test_vector.py
+++ b/tests/pytests/test_vector.py
@@ -4,7 +4,7 @@ Tests for Vector class.
 
 import pytest
 
-from psi4.core import Dimension, Vector
+from psi4.core import Dimension, Vector, IntVector
 
 pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.quick]
 
@@ -16,17 +16,17 @@ def check_dense_vec(v, exp_d, exp_name=None):
     assert v.nirrep() == 1
 
 
-def test_constructors():
+@pytest.mark.parametrize("tested_class", [pytest.param(i) for i in [Vector, IntVector]])
+def test_constructors(tested_class):
     int_d = 10
 
     # unnamed 1-irrep vector
-    v1 = Vector(int_d)
+    v1 = tested_class(int_d)
     check_dense_vec(v1, int_d)
 
     # named 1-irrep vector
-    v2 = Vector("v2", int_d)
+    v2 = tested_class("v2", int_d)
     check_dense_vec(v2, int_d, "v2")
-
 
 def check_block_vec(v, exp_nirrep, exp_d, exp_name=None):
     assert v.nirrep() == exp_nirrep
@@ -51,8 +51,67 @@ def test_constructors_w_symmetry(name, dim):
     v = Vector(name, dim)
     check_block_vec(v, dim.n(), dim, name)
 
-def test_clone():
+@pytest.mark.parametrize("tested_class", [pytest.param(i) for i in [Vector, IntVector]])
+def test_clone(tested_class):
     dim = Dimension([1, 2, 3])
-    vec = Vector(dim)
+    vec = tested_class(dim)
     copy = vec.clone()
     assert copy.dimpi() == dim
+
+@pytest.mark.parametrize("tested_class", [pytest.param(i) for i in [Vector, IntVector]])
+def test_add(tested_class):
+    dim = Dimension([1, 2, 3])
+    vec = tested_class(dim)
+    vec.add(0, 5)
+    vec.add(0, 5)
+    vec.add(2, 2, 7)
+    assert vec.get(0) == 10
+    assert vec.get(2, 2) == 7
+
+@pytest.mark.parametrize("tested_class", [pytest.param(i) for i in [Vector, IntVector]])
+def test_set(tested_class):
+    dim = Dimension([1, 2, 3])
+    vec = tested_class(dim)
+    vec.set(0, 5)
+    vec.set(0, 5) # Deliberately doing this twice.
+    vec.set(2, 2, 7)
+    assert vec.get(0) == 5
+    assert vec.get(2, 2) == 7
+
+def test_int_vs_float():
+    dim = Dimension(1)
+    with pytest.raises(TypeError):
+        IntVector.set(0, 0.1)
+    with pytest.raises(TypeError):
+        IntVector.add(0, 0.1)
+
+def test_iota():
+    dim = Dimension([5, 3, 2])
+    iota_vec = IntVector.iota(dim)
+    for h in range(iota_vec.nirrep()):
+        for i in range(iota_vec.dim(h)):
+            assert iota_vec.get(h, i) == i
+
+@pytest.mark.parametrize("tested_class", [pytest.param(i) for i in [Vector, IntVector]])
+def test_init(tested_class):
+    dim = Dimension([1, 2, 3])
+    vec = tested_class(dim)
+    vec.set(0, 5)
+    vec.set(0, 5) # Deliberately doing this twice.
+    vec.set(2, 2, 7)
+    vec.init(Dimension(5))
+    assert vec.nirrep() == 5
+    assert vec.dim(2) == 0
+
+@pytest.mark.parametrize("tested_class", [pytest.param(i) for i in [Vector, IntVector]])
+def test_copy(tested_class):
+    dim = Dimension([1, 2, 3])
+    vec = tested_class(dim)
+    vec.set(0, 5)
+    vec.set(0, 5) # Deliberately doing this twice.
+    vec.set(2, 2, 7)
+    vec2 = tested_class(Dimension(5))
+    vec.copy(vec2)
+    assert vec.nirrep() == 5
+    assert vec.dim(2) == 0
+

--- a/tests/pytests/test_vector.py
+++ b/tests/pytests/test_vector.py
@@ -173,3 +173,7 @@ def test_bounds(tested_class):
     with pytest.raises(RuntimeError):
         vec.set(0, 1000, 0)
 
+    vec.set(1, 1000)
+    assert 1000 == vec.get(1)
+    vec.add(1, 1000)
+    assert 2000 == vec.get(1)


### PR DESCRIPTION
## Description
**What?** This PR creates the `IrrepedVector` class template. The `Vector` and `IntVector` classes now inherit from this, adding on methods that only make sense for that particular template instance.

**Why?** During a refactor of the MOM code, I had to use `Vector` and `IntVector` features heavily and found this synchronization of the classes necessary to keep my sanity.

**Who cares?** Obligatory pings to @hokru (who may want to create `FloatVector` for faster `dfocc` operations) and @lothian (who may want to create `ComplexVector` for magnetic spectroscopies). No reviews required.

**How do I review this?** The changes to `export_mints.cc`, `vector.h`, `vector.cc`, `intvector.cc`, and `test_vector.py` are the heart of this PR. The rest are either compatibility changes or general code cleanup. Be warned that `iota` and the `sort` functions are needed for my upcoming MOM changes and are currently unused, and I've changed some functions to not use pointers.

## Todos
- [x] Created `IrrepedVector<T>`
- [x] `Vector` and `IntVector` inherit from `IrrepedVector<T>`
- [x] `Vector` and `IntVector` now have identical code logic
- [x] `iota` and `sort` methods are added
- [x]   `IntVector` now has more functionality
- [x] Added bounds checking to several `IrrepedVector<T>` methods.
- [x] Increased test coverage of `Vector`
- [x] Added test coverage of `IntVector`
- [x] Silenced compiler warning about missing override
- [x] Removed several pointers from parameter types
- [x] Removed several pointers from return types
- [x] Changed convention from "irreped" to "irrepped"

## Checklist
- [x] Full ctest passed (before some trivial edits)
- [x] `test_vector.py` passed 

## Status
- [x] Ready for review
- [x] Ready for merge **SQUASH**; Jet approval **required** before merge
