### PR TITLE
Use Libxc setters for omega

### DIFF
--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -222,7 +222,7 @@ void LibXCFunctional::set_omega(double omega) {
     bool match = false;
     for (int ipar = 0; ipar < npars; ipar++) {
         const char* name = xc_func_info_get_ext_params_name(xc_functional_.get()->info, ipar);
-        if (stricmp(name, "_omega") == 0) match = true;
+        if (std::string(name) == std::string("_omega")) match = true;
     }
 
     if (match) {

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.h
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.h
@@ -98,6 +98,6 @@ class LibXCFunctional : public Functional {
     double vv10_c() { return vv10_c_; }
     double density_cutoff() { return density_cutoff_; }
 };
-}
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/libfunctional/factory.cc
+++ b/psi4/src/psi4/libfunctional/factory.cc
@@ -50,4 +50,4 @@ std::shared_ptr<Functional> Functional::build_base(const std::string& alias) {
 
     return std::shared_ptr<Functional>(fun);
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfunctional/functional.cc
+++ b/psi4/src/psi4/libfunctional/functional.cc
@@ -84,6 +84,6 @@ void Functional::compute_functional(const std::map<std::string, SharedVector>& i
                                     const std::map<std::string, SharedVector>& out, int npoints, int deriv) {
     throw PSIEXCEPTION("Functional: pseudo-abstract class.");
 }
-double Functional::query_density_cutoff(){throw PSIEXCEPTION("Functional: pseudo-abstract class.");}
-void Functional::set_density_cutoff(double cut){throw PSIEXCEPTION("Functional: pseudo-abstract class.");}
-}
+double Functional::query_density_cutoff() { throw PSIEXCEPTION("Functional: pseudo-abstract class."); }
+void Functional::set_density_cutoff(double cut) { throw PSIEXCEPTION("Functional: pseudo-abstract class."); }
+}  // namespace psi

--- a/psi4/src/psi4/libfunctional/functional.h
+++ b/psi4/src/psi4/libfunctional/functional.h
@@ -117,10 +117,10 @@ class Functional {
         omega_ = omega;
         lrc_ = (omega_ != 0.0);
     }
-    void set_name(const std::string &name) { name_ = name; }
-    void set_description(const std::string &description) { description_ = description; }
-    void set_citation(const std::string &citation) { citation_ = citation; }
-    void set_xclib_description(const std::string &description) { xclib_description_ = description; }
+    void set_name(const std::string& name) { name_ = name; }
+    void set_description(const std::string& description) { description_ = description; }
+    void set_citation(const std::string& citation) { citation_ = citation; }
+    void set_xclib_description(const std::string& description) { xclib_description_ = description; }
 
     void set_lsda_cutoff(double cut) { lsda_cutoff_ = cut; }
     void set_meta_cutoff(double cut) { meta_cutoff_ = cut; }
@@ -151,6 +151,6 @@ class Functional {
     void py_print() const { print("outfile", 1); }
     void py_print_detail(int level) const { print("outfile", level); }
 };
-}
+}  // namespace psi
 
 #endif

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -288,7 +288,7 @@ void SuperFunctional::print(std::string out, int level) const {
         }
     }
 
-    print_density_threshold("outfile",1);
+    print_density_threshold("outfile", 1);
 
     if (needs_grac_) {
         printer->Printf("   => Asymptotic Correction <=\n\n");
@@ -394,26 +394,26 @@ void SuperFunctional::add_c_functional(std::shared_ptr<Functional> fun) {
 }
 void SuperFunctional::set_density_tolerance(double cut) {
     density_tolerance_ = cut;
-        for (int Q = 0; Q < c_functionals_.size(); Q++) {
-            c_functionals_[Q]->set_density_cutoff(density_tolerance_);
-        };
-        for (int Q = 0; Q < x_functionals_.size(); Q++) {
-            x_functionals_[Q]->set_density_cutoff(density_tolerance_);
-        };
+    for (int Q = 0; Q < c_functionals_.size(); Q++) {
+        c_functionals_[Q]->set_density_cutoff(density_tolerance_);
+    };
+    for (int Q = 0; Q < x_functionals_.size(); Q++) {
+        x_functionals_[Q]->set_density_cutoff(density_tolerance_);
+    };
 }
 void SuperFunctional::print_density_threshold(std::string out, int level) const {
     if (level < 1) return;
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
     printer->Printf("   => LibXC Density Thresholds  <==\n\n");
     double val = 0.0;
-        for (int Q = 0; Q < c_functionals_.size(); Q++) {
-            val = c_functionals_[Q]->query_density_cutoff();
-            printer->Printf("    %s:  %6.2E \n", c_functionals_[Q]->name().c_str(), val);
-        };
-        for (int Q = 0; Q < x_functionals_.size(); Q++) {
-            val = x_functionals_[Q]->query_density_cutoff();
-            printer->Printf("    %s:  %6.2E \n", x_functionals_[Q]->name().c_str(), val);
-        };
+    for (int Q = 0; Q < c_functionals_.size(); Q++) {
+        val = c_functionals_[Q]->query_density_cutoff();
+        printer->Printf("    %s:  %6.2E \n", c_functionals_[Q]->name().c_str(), val);
+    };
+    for (int Q = 0; Q < x_functionals_.size(); Q++) {
+        val = x_functionals_[Q]->query_density_cutoff();
+        printer->Printf("    %s:  %6.2E \n", x_functionals_[Q]->name().c_str(), val);
+    };
     printer->Printf("\n");
 }
 std::shared_ptr<Functional> SuperFunctional::c_functional(const std::string& name) {
@@ -751,8 +751,8 @@ std::map<std::string, SharedVector> SuperFunctional::compute_vv10_cache(const st
     double* rhop = vals.find("RHO_A")->second->pointer();
     double* gammap = vals.find("GAMMA_AA")->second->pointer();
 
-// Eh, worth a shot
-// clang 10 on Mac objects at runtime: #pragma omp simd
+    // Eh, worth a shot
+    // clang 10 on Mac objects at runtime: #pragma omp simd
     for (size_t i = 0; i < npoints; i++) {
         if (rhop[i] < rho_thresh) continue;
 
@@ -972,4 +972,4 @@ int SuperFunctional::ansatz() const {
     if (is_gga()) return 1;
     return 0;
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libfunctional/superfunctional.h
+++ b/psi4/src/psi4/libfunctional/superfunctional.h
@@ -240,6 +240,6 @@ class SuperFunctional {
     void py_print() const { print("outfile", 1); }
     void py_print_detail(int level) const { print("outfile", level); }
 };
-}
+}  // namespace psi
 
 #endif


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR removes the hardcoded list of functionals that contain omega and allows setting omega for any Libxc functional that contains it.

Solves an issue described in #2641.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Omega can be set for any functional

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
