### PR TITLE
DFHelper Readability 2

### DIFF
--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -96,7 +96,6 @@ void DFHelper::prepare_blocking() {
 void DFHelper::AO_filename_maker(size_t i) {
     std::string name = start_filename("dfh.AO" + std::to_string(i));
     AO_names_.push_back(name);
-    AO_files_[name] = name;
 }
 
 std::string DFHelper::start_filename(std::string start) {
@@ -416,7 +415,7 @@ void DFHelper::prepare_AO() {
     // prepare files
     AO_filename_maker(1);
     AO_filename_maker(2);
-    std::string putf = AO_files_[AO_names_[1]];
+    std::string putf = AO_names_[1];
     std::string op = "ab";
 
     // Contract metric according to previously calculated scheme
@@ -1376,7 +1375,7 @@ void DFHelper::grab_AO(const size_t start, const size_t stop, double* Mp) {
     size_t begin = Qshell_aggs_[start];
     size_t end = Qshell_aggs_[stop + 1] - 1;
     size_t block_size = end - begin + 1;
-    std::string getf = AO_files_[AO_names_[1]];
+    auto getf = AO_names_[1];
 
     // presumably not thread safe or inherently sequential, but could revisit
     for (size_t i = 0, sta = 0; i < nbf_; i++) {
@@ -1738,8 +1737,7 @@ void DFHelper::clear_all() {
     files_.clear();
     sizes_.clear();
     tsizes_.clear();
-    transf_.clear();
-    transf_core_.clear();
+    clear_transformations();
 }
 
 std::pair<size_t, size_t> DFHelper::identify_order() {
@@ -1830,7 +1828,7 @@ void DFHelper::transform() {
     size_t wfinal = std::get<1>(info_);
 
     // prep AO file stream if STORE + !AO_core_
-    if (!direct_iaQ_ && !direct_ && !AO_core_) stream_check(AO_files_[AO_names_[1]], "rb");
+    if (!direct_iaQ_ && !direct_ && !AO_core_) stream_check(AO_names_[1], "rb");
 
     // get Q blocking scheme
     std::vector<std::pair<size_t, size_t>> Qsteps;
@@ -3013,7 +3011,7 @@ void DFHelper::compute_JK(std::vector<SharedMatrix> Cleft, std::vector<SharedMat
     size_t totsb = std::get<1>(info);
 
     // prep stream, blocking
-    if (!direct_ && !AO_core_) stream_check(AO_files_[AO_names_[1]], "rb");
+    if (!direct_ && !AO_core_) stream_check(AO_names_[1], "rb");
 
     std::vector<std::vector<double>> C_buffers(nthreads_);
 

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -94,7 +94,7 @@ void DFHelper::prepare_blocking() {
 }
 
 void DFHelper::AO_filename_maker(size_t i) {
-    std::string name = start_filename("dfh.AO" + std::to_string(i));
+    auto name = start_filename("dfh.AO" + std::to_string(i));
     AO_names_.push_back(name);
 }
 
@@ -106,29 +106,28 @@ std::string DFHelper::start_filename(std::string start) {
     return name;
 }
 
-void DFHelper::filename_maker(std::string name, size_t a0, size_t a1, size_t a2, size_t op) {
-    std::string pfilename = start_filename("dfh.p" + name);
-    std::string filename = start_filename("dfh" + name);
+void DFHelper::filename_maker(std::string name, size_t Q, size_t p, size_t q, size_t op) {
+    auto pfilename = start_filename("dfh.p" + name);
+    auto filename = start_filename("dfh" + name);
 
-    std::tuple<std::string, std::string> files(pfilename.c_str(), filename.c_str());
+    std::tuple<std::string, std::string> files(pfilename, filename);
     files_[name] = files;
 
     bool is_transf = transf_.count(name);
 
     // direct_iaQ is special, because it has two different sizes
     if (direct_iaQ_ && is_transf) {
-        sizes_[pfilename] = std::make_tuple(a0, a1, a2);
-        sizes_[filename] = std::make_tuple(a1, a2, a0);
+        sizes_[pfilename] = std::make_tuple(Q, p, q);
+        sizes_[filename] = std::make_tuple(p, q, Q);
 
     } else {
-        // op = (0 if Qpq, 1 if pQq, 2 if pqQ)
         std::tuple<size_t, size_t, size_t> sizes;
         if (op == 0) {
-            sizes = std::make_tuple(a0, a1, a2);
+            sizes = std::make_tuple(Q, p, q);
         } else if (op == 1) {
-            sizes = std::make_tuple(a1, a0, a2);
+            sizes = std::make_tuple(p, Q, q);
         } else {
-            sizes = std::make_tuple(a1, a2, a0);
+            sizes = std::make_tuple(p, q, Q);
         }
 
         sizes_[pfilename] = sizes;
@@ -1387,9 +1386,9 @@ void DFHelper::grab_AO(const size_t start, const size_t stop, double* Mp) {
 }
 void DFHelper::prepare_metric_core() {
     timer_on("DFH: metric construction");
-    auto Jinv = std::make_shared<FittingMetric>(aux_, true);
-    Jinv->form_fitting_metric();
-    metrics_[1.0] = Jinv->get_metric();
+    FittingMetric J(aux_, true);
+    J.form_fitting_metric();
+    metrics_[1.0] = J.get_metric();
     timer_off("DFH: metric construction");
 }
 double* DFHelper::metric_prep_core(double m_pow) {
@@ -1416,17 +1415,15 @@ double* DFHelper::metric_prep_core(double m_pow) {
 }
 void DFHelper::prepare_metric() {
     // construct metric
-    auto Jinv = std::make_shared<FittingMetric>(aux_, true);
-    Jinv->form_fitting_metric();
-    SharedMatrix metric = Jinv->get_metric();
-    double* Mp = metric->pointer()[0];
+    FittingMetric J(aux_, true);
+    J.form_fitting_metric();
+    auto metric = J.get_metric();
+    auto Mp = metric->pointer()[0];
 
     // create file
-    std::string filename = "metric";
-    filename.append(".");
-    filename.append(std::to_string(1.0));
+    std::string filename = "metric.1.0";
     filename_maker(filename, naux_, naux_, 1);
-    metric_keys_.push_back(std::make_pair(1.0, filename));
+    metric_keys_.emplace_back(1.0, filename);
     // store
     std::string putf = std::get<0>(files_[filename]);
     put_tensor(putf, Mp, 0, naux_ - 1, 0, naux_ - 1, "wb");

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -359,6 +359,7 @@ class PSI_API DFHelper {
     // => in-core machinery <=
     void AO_core();
     std::unique_ptr<double[]> Ppq_;
+    // Maps x -> (P|Q) ^ x.
     std::map<double, SharedMatrix> metrics_;
 
     // => in-core wK machinery <=
@@ -447,7 +448,9 @@ class PSI_API DFHelper {
 
     // => Coulomb metric handling <=
     std::vector<std::pair<double, std::string>> metric_keys_;
+    // Create J and write it to disk.
     void prepare_metric();
+    // Create J and cache it in metrics_.
     void prepare_metric_core();
     double* metric_prep_core(double m_pow);
     std::string return_metfile(double m_pow);
@@ -515,13 +518,23 @@ class PSI_API DFHelper {
     void get_tensor_AO(std::string file, double* Mp, size_t size, size_t start);
 
     // => internal handlers for FILE IO <=
+    // Map a base filename to the fullname of the p variant and then the original tensor.
     std::map<std::string, std::tuple<std::string, std::string>> files_;
+    // Map a full filename to the size of its three indices.
     std::map<std::string, std::tuple<size_t, size_t, size_t>> sizes_;
     std::map<std::string, std::tuple<size_t, size_t, size_t>> tsizes_;
     std::vector<size_t> AO_file_sizes_;
     std::vector<std::string> AO_names_;
+    // Given the base of a filename, return the full filename.
+    // "full" filename adds parts to the base to prevent files from overwriting each other.
     std::string start_filename(std::string start);
-    void filename_maker(std::string name, size_t a0, size_t a1, size_t a2, size_t op = 0);
+    // Given a base filename and the indices of its three dimensions, register the
+    // filename in files_ and the dimensions in sizes_. Creates an entry for both
+    // the tensor and the p variant. (The distinction is important for direct_iaQ.)
+    // Q = aux, p = left primary, q = right primary
+    // op = 0 if Qpq, 1 if pQq, 2 if pqQ
+    void filename_maker(std::string name, size_t Q, size_t p, size_t q, size_t op = 0);
+    // Store a filename for the i'th AO quantity is AO_names_.
     void AO_filename_maker(size_t i);
     void check_file_key(std::string);
     void check_file_tuple(std::string name, std::pair<size_t, size_t> t0, std::pair<size_t, size_t> t1,

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -415,15 +415,18 @@ class PSI_API DFHelper {
     // Used for "p" indexing.
     std::vector<size_t> symm_big_skips_;
 
-    // => shell info and blocking <=
+    // => Shell info and blocking : no screening involved <=
     // Number of primary shells
     size_t pshells_;
     // Number of auxiliary shells
     size_t Qshells_;
     // greatest number of functions in an aux_ shell
     double Qshell_max_;
+    // When we start primary shell i, how many functions have we passed? Length pshells_ + 1.
     std::vector<size_t> pshell_aggs_;
+    // When we start primary shell i, how many functions have we passed? Length Qshells_ + 1.
     std::vector<size_t> Qshell_aggs_;
+    // Populate all variables in this section. Should only ever be called by the constructor.
     void prepare_blocking();
 
     // => generalized blocking <=
@@ -515,7 +518,6 @@ class PSI_API DFHelper {
     std::map<std::string, std::tuple<std::string, std::string>> files_;
     std::map<std::string, std::tuple<size_t, size_t, size_t>> sizes_;
     std::map<std::string, std::tuple<size_t, size_t, size_t>> tsizes_;
-    std::map<std::string, std::string> AO_files_;
     std::vector<size_t> AO_file_sizes_;
     std::vector<std::string> AO_names_;
     std::string start_filename(std::string start);

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -425,7 +425,7 @@ class PSI_API DFHelper {
     double Qshell_max_;
     // When we start primary shell i, how many functions have we passed? Length pshells_ + 1.
     std::vector<size_t> pshell_aggs_;
-    // When we start primary shell i, how many functions have we passed? Length Qshells_ + 1.
+    // When we start auxilliary shell i, how many functions have we passed? Length Qshells_ + 1.
     std::vector<size_t> Qshell_aggs_;
     // Populate all variables in this section. Should only ever be called by the constructor.
     void prepare_blocking();
@@ -534,7 +534,7 @@ class PSI_API DFHelper {
     // Q = aux, p = left primary, q = right primary
     // op = 0 if Qpq, 1 if pQq, 2 if pqQ
     void filename_maker(std::string name, size_t Q, size_t p, size_t q, size_t op = 0);
-    // Store a filename for the i'th AO quantity is AO_names_.
+    // Store a filename for the i'th AO quantity in AO_names_.
     void AO_filename_maker(size_t i);
     void check_file_key(std::string);
     void check_file_tuple(std::string name, std::pair<size_t, size_t> t0, std::pair<size_t, size_t> t1,


### PR DESCRIPTION
## Description
The next batch of readability fixes to `dfhelper.cc`. The potentially contentious issue here is that I remove the `AO_files_` variable, which was just an identity mapping.

Plenty more cleanup to go!

## Checklist
- [x] Quick tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
