### PR TITLE
Remove false uses of ERISieve, also dfmp2 cleanup

### DIFF
--- a/psi4/src/psi4/dfmp2/corr_grad.cc
+++ b/psi4/src/psi4/dfmp2/corr_grad.cc
@@ -60,7 +60,7 @@ std::shared_ptr<CorrGrad> CorrGrad::build_CorrGrad(std::shared_ptr<MintsHelper> 
     Options& options = Process::environment.options;
 
     if (options.get_str("SCF_TYPE").find("DF") != std::string::npos) {
-        DFCorrGrad* jk = new DFCorrGrad(mints);
+        auto jk = std::make_shared<DFCorrGrad>(mints);
 
         if (options["INTS_TOLERANCE"].has_changed()) jk->set_cutoff(options.get_double("INTS_TOLERANCE"));
         if (options["PRINT"].has_changed()) jk->set_print(options.get_int("PRINT"));
@@ -70,7 +70,7 @@ std::shared_ptr<CorrGrad> CorrGrad::build_CorrGrad(std::shared_ptr<MintsHelper> 
         if (options["DF_INTS_NUM_THREADS"].has_changed())
             jk->set_df_ints_num_threads(options.get_int("DF_INTS_NUM_THREADS"));
 
-        return std::shared_ptr<CorrGrad>(jk);
+        return jk;
 
     } else {
         throw PSIEXCEPTION("CorrGrad::build_CorrGrad: Unknown SCF Type");

--- a/psi4/src/psi4/dfmp2/corr_grad.h
+++ b/psi4/src/psi4/dfmp2/corr_grad.h
@@ -35,7 +35,6 @@
 
 namespace psi {
 
-class ERISieve;
 class BasisSet;
 class PSIO;
 class MintsHelper;
@@ -159,9 +158,6 @@ class DFCorrGrad : public CorrGrad {
     int df_ints_num_threads_;
     /// Condition cutoff in fitting metric, defaults to 1.0E-12
     double condition_;
-
-    /// Sieve, must be static throughout the life of the object
-    std::shared_ptr<ERISieve> sieve_;
 
     void common_init();
 

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -44,7 +44,6 @@ namespace psi {
 class BasisSet;
 class Options;
 class Matrix;
-class ERISieve;
 class TwoBodyAOInt;
 
 // COMMON VARIABLE NAMES

--- a/psi4/src/psi4/scfgrad/jk_grad.h
+++ b/psi4/src/psi4/scfgrad/jk_grad.h
@@ -36,7 +36,6 @@
 
 namespace psi {
 
-class ERISieve;
 class BasisSet;
 class PSIO;
 class TwoBodyAOInt;
@@ -63,9 +62,6 @@ protected:
     int deriv_;
 
     std::shared_ptr<BasisSet> primary_;
-
-    /// Sieve, must be static throughout the life of the object
-    std::shared_ptr<ERISieve> sieve_;
 
     SharedMatrix Ca_;
     SharedMatrix Cb_;


### PR DESCRIPTION
## Description
Remove mention of `ERISieve` from some modules that no longer use it. `libfock` still uses it, but that's a problem for another day.

Also, `dfmp2` cleanup. No more `new`!

## Checklist
- [x] `dfmp2` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
