### PR TITLE
Remove another use of ERISieve

### DIFF
--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -518,7 +518,7 @@ void PKMgrDisk::initialize_wK() {
 void PKMgrDisk::batch_sizing() {
     double batch_thresh = 0.1;
 
-    ijklBasisIterator AOintsiter(nbf(), sieve());
+    ijklBasisIterator AOintsiter(nbf());
 
     size_t old_pq = 0;
     size_t old_max = 0;

--- a/psi4/src/psi4/libfock/PKmanagers.h
+++ b/psi4/src/psi4/libfock/PKmanagers.h
@@ -52,7 +52,6 @@ typedef std::shared_ptr<PKWorker> SharedPKWrkr;
   ijklBasisIterator: Iterator that goes through all two-electron integral
   indices, in increasing order of canonical index ijkl.
   Used to determine what goes in which bucket for PK.
-  Will be extended to include sieving.
 -*/
 
 class ijklBasisIterator {
@@ -60,11 +59,10 @@ class ijklBasisIterator {
     int nbas_;
     int i_, j_, k_, l_;
     bool done_;
-    std::shared_ptr<ERISieve> sieve_;
 
    public:
     // Constructor
-    ijklBasisIterator(int nbas, std::shared_ptr<ERISieve> sieve) : nbas_(nbas), done_(false), sieve_(sieve) {}
+    ijklBasisIterator(int nbas) : nbas_(nbas), done_(false) {}
 
     // Iterator functions
     void first();


### PR DESCRIPTION
## Description
Slowly replacing `ERISieve` entirely...

## Checklist
- [x] Quick tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
