### PR TITLE
Add customizable FREEZE_CORE policy option

### DIFF
--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -121,12 +121,12 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
     /*- Specifies a custom frozen-core policy on a per-element basis. Input
     should be a list of integers representing the number of orbitals to freeze
-    for each atomic number. For example, to specify that elements H-Be should
-    have 0 frozen orbitals, B-Mg should have 1, and Al should have 2, you would
-    provide the input ``[0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2]``. Please
-    make sure to fill in the list up to the highest atomic number included in
-    any calculations. This option is only used if |globals__freeze_core| is set
-    to ``POLICY``. -*/
+    for each atomic number MINUS one (so H is 0, He is 1, etc). For example, to
+    specify that elements H-Be should have 0 frozen orbitals, B-Mg should have
+    1, and Al should have 2, you would provide the input ``[0, 0, 0, 0, 1, 1,
+    1, 1, 1, 1, 1, 1, 2]``. Please make sure to fill in the list up to the
+    highest atomic number included in any calculations. This option is only
+    used if |globals__freeze_core| is set to ``POLICY``. -*/
     options.add("FREEZE_CORE_POLICY", new ArrayType());
 
     options.add("NUM_GPUS", 1);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -114,8 +114,20 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     number of frozen orbitals can be attained by using the keywords
     |globals__num_frozen_docc| (gives the total number of orbitals to freeze,
     program picks the lowest-energy orbitals) or |globals__frozen_docc| (gives
-    the number of orbitals to freeze per irreducible representation) -*/
-    options.add_str("FREEZE_CORE", "FALSE", "FALSE TRUE 1 0 -1 -2 -3");
+    the number of orbitals to freeze per irreducible representation) or by
+    the option ``POLICY`` in combination with appropriate inputs to
+    |globals__freeze_core_policy| -*/
+    options.add_str("FREEZE_CORE", "FALSE", "FALSE TRUE 1 0 -1 -2 -3 POLICY");
+
+    /*- Specifies a custom frozen-core policy on a per-element basis. Input
+    should be a list of integers representing the number of orbitals to freeze
+    for each atomic number. For example, to specify that elements H-Be should
+    have 0 frozen orbitals, B-Mg should have 1, and Al should have 2, you would
+    provide the input ``[0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2]``. Please
+    make sure to fill in the list up to the highest atomic number included in
+    any calculations. This option is only used if |globals__freeze_core| is set
+    to ``POLICY``. -*/
+    options.add("FREEZE_CORE_POLICY", new ArrayType());
 
     options.add("NUM_GPUS", 1);
     /*- Do use pure angular momentum basis functions?

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -116,17 +116,19 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     program picks the lowest-energy orbitals) or |globals__frozen_docc| (gives
     the number of orbitals to freeze per irreducible representation) or by
     the option ``POLICY`` in combination with appropriate inputs to
-    |globals__freeze_core_policy| -*/
+    |globals__freeze_core_policy|. At present, ``POLICY`` is an experimental
+    option and is subject to change.-*/
     options.add_str("FREEZE_CORE", "FALSE", "FALSE TRUE 1 0 -1 -2 -3 POLICY");
 
-    /*- Specifies a custom frozen-core policy on a per-element basis. Input
-    should be a list of integers representing the number of orbitals to freeze
-    for each atomic number MINUS one (so H is 0, He is 1, etc). For example, to
-    specify that elements H-Be should have 0 frozen orbitals, B-Mg should have
-    1, and Al should have 2, you would provide the input ``[0, 0, 0, 0, 1, 1,
-    1, 1, 1, 1, 1, 1, 2]``. Please make sure to fill in the list up to the
-    highest atomic number included in any calculations. This option is only
-    used if |globals__freeze_core| is set to ``POLICY``. -*/
+    /*- NOTE: This is an experimental feature and subject to change! Specifies
+    a custom frozen-core policy on a per-element basis. Input should be a list
+    of integers representing the number of orbitals to freeze for each atomic
+    number MINUS one (so H is 0, He is 1, etc). For example, to specify that
+    elements H-Be should have 0 frozen orbitals, B-Mg should have 1, and Al
+    should have 2, you would provide the input ``[0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
+    1, 1, 2]``. Please make sure to fill in the list up to the highest atomic
+    number included in any calculations. This option is only used if
+    |globals__freeze_core| is set to ``POLICY``. -*/
     options.add("FREEZE_CORE_POLICY", new ArrayType());
 
     options.add("NUM_GPUS", 1);

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -92,8 +92,8 @@ core_policy[50] = 5
 psi4.set_options({'freeze_core_policy': core_policy})
 E, wfn = energy("mp2/def2-svp", return_wfn=True, molecule=sbh3)
 
-compare_values(wfn.nfrzc(), 5, 1, "Number of frozen orbitals with freeze_core_policy = {H: 0, Sb: 2}")
-compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core_policy = {H: 0, Sb: 2}")
+compare_values(wfn.nfrzc(), 5, 1, "Number of frozen orbitals with freeze_core_policy = {H: 0, Sb: 5}")
+compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core_policy = {H: 0, Sb: 5}")
 
 molecule hi {
   0 1

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -85,7 +85,9 @@ compare_values(wfn.nfrzc(), 4, 1, "Number of frozen orbitals with freeze_core = 
 compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core = 1")
 
 set freeze_core policy
+# Our largest element is Z=51, but freeze_core_policy is 0-indexed (H=0, He=1, etc)
 core_policy = [0 for _ in range(51)]
+# So we need to set Z-1 here to set Sb, which is 50
 core_policy[50] = 5
 psi4.set_options({'freeze_core_policy': core_policy})
 E, wfn = energy("mp2/def2-svp", return_wfn=True, molecule=sbh3)

--- a/tests/dfmp2-ecp/input.dat
+++ b/tests/dfmp2-ecp/input.dat
@@ -84,6 +84,15 @@ E, wfn = energy("mp2/def2-svp", return_wfn=True, molecule=sbh3)
 compare_values(wfn.nfrzc(), 4, 1, "Number of frozen orbitals with freeze_core = 1")
 compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core = 1")
 
+set freeze_core policy
+core_policy = [0 for _ in range(51)]
+core_policy[50] = 5
+psi4.set_options({'freeze_core_policy': core_policy})
+E, wfn = energy("mp2/def2-svp", return_wfn=True, molecule=sbh3)
+
+compare_values(wfn.nfrzc(), 5, 1, "Number of frozen orbitals with freeze_core_policy = {H: 0, Sb: 2}")
+compare_values(sum(wfn.doccpi()), 13, 1, "Number of occupied orbitals with freeze_core_policy = {H: 0, Sb: 2}")
+
 molecule hi {
   0 1
   H 0 0 0


### PR DESCRIPTION
## Description
This patch adds an option to FREEZE_CORE called "policy", which enables frozen core settings to be looked up from a list specified in the global variable FREEZE_CORE_POLICY. This is more flexible than NUM_FROZEN_DOCC for situations like SAPT where multiple molecules are run in the same command and may require different individual numbers of frozen cores, with settings more customizable than TRUE/FALSE/1/0/-1/-2

This patch addresses some (but not all) issues raised in #2631 by allowing for more flexible policies to be set appropriate to multi-part calculations. 

## Todos
- [x] Add POLICY as option to FREEZE_CORE
- [x] Add global variable FREEZE_CORE_POLICY to hold custom frozen-core policy

## Checklist
- [x] A functionality test for this flag has been added to `tests/dfmp2-ecp/input.dat`
- [x] `ctest -L quick` runs successfully, which includes the above listed test
- [ ] `ctest ` still in-flight but given the scope of this patch I don't expect any issues

## Status
- [x] Ready for review
- [ ] Ready for merge
