### PR TITLE
Fix memory leak in ROHF stability

### DIFF
--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -1254,6 +1254,7 @@ bool ROHF::stability_analysis() {
             double** temp = block_matrix(npairs, npairs);
             C_DGEMM('n', 'n', npairs, npairs, npairs, 1.0, A.matrix[h][0], npairs, U[0], npairs, 0.0, temp[0], npairs);
             C_DGEMM('n', 'n', npairs, npairs, npairs, 1.0, U[0], npairs, temp[0], npairs, 0.0, A.matrix[h][0], npairs);
+            free_block(temp);
 
             auto* evals = new double[rank];
             double** evecs = block_matrix(rank, rank);


### PR DESCRIPTION
## Description
Fixes a memory leak in the ROHF stability check.
This is a tiny shard of the #2642 mega-PR that can be merged independently.

## Todos
- [x] Stop leaking `npairs^2` doubles per irrep per stability check

## Status
- [x] Ready for review
- [x] Ready for merge
