### PR TITLE
dftensor memory estimation overrun

### DIFF
--- a/psi4/src/psi4/fnocc/df_ccsd.cc
+++ b/psi4/src/psi4/fnocc/df_ccsd.cc
@@ -607,11 +607,11 @@ void DFCoupledCluster::AllocateMemory() {
                        : (nfzv + ndocc + nvirt) * ndocc * nQmax;
     double df_memory = nQ * (o * o + o * v) + max;
 
-    total_memory *= 8. / 1024. / 1024.;
-    df_memory *= 8. / 1024. / 1024.;
+    total_memory *= 8. / 1024. / 1024. / 1024.;
+    df_memory *= 8. / 1024. / 1024. / 1024.;
 
-    double available_memory = (double)memory / 1024.0 / 1024.0;
-    double size_of_t2 = 8.0 * o * o * v * v / 1024.0 / 1024.0;
+    double available_memory = (double)memory / 1024.0 / 1024.0 / 1024.;
+    double size_of_t2 = 8.0 * o * o * v * v / 1024.0 / 1024.0 / 1024.;
 
     if (available_memory < total_memory + df_memory) {
         if (available_memory > total_memory + df_memory - size_of_t2) {
@@ -631,11 +631,11 @@ void DFCoupledCluster::AllocateMemory() {
     }
 
     outfile->Printf("  ==> Memory <==\n\n");
-    outfile->Printf("        Total memory available:          %9.2lf mb\n", available_memory);
-    outfile->Printf("        CCSD memory requirements:        %9.2lf mb\n",
+    outfile->Printf("        Total memory available:          %9.3lf [GiB]\n", available_memory);
+    outfile->Printf("        CCSD memory requirements:        %9.3lf [GiB]\n",
                     df_memory + total_memory - size_of_t2 * t2_on_disk);
-    outfile->Printf("            3-index integrals:           %9.2lf mb\n", df_memory);
-    outfile->Printf("            CCSD intermediates:          %9.2lf mb\n", total_memory - size_of_t2 * t2_on_disk);
+    outfile->Printf("            3-index integrals:           %9.3lf [GiB]\n", df_memory);
+    outfile->Printf("            CCSD intermediates:          %9.3lf [GiB]\n", total_memory - size_of_t2 * t2_on_disk);
 
     if (options_.get_bool("COMPUTE_TRIPLES")) {
         int nthreads = Process::environment.get_n_threads();
@@ -644,7 +644,7 @@ void DFCoupledCluster::AllocateMemory() {
             isLowMemory = true;
             mem_t = 8. * (2L * o * o * v * v + o * o * o * v + o * v + 5L * o * o * o * nthreads);
         }
-        outfile->Printf("        (T) algorithm:                   %9.2lf mb (%s-memory)\n", mem_t / 1024. / 1024., isLowMemory ? "low" : "high");
+        outfile->Printf("        (T) algorithm:                   %9.3lf [GiB] (%s-memory)\n", mem_t / (1024. * 1024. * 1024.), isLowMemory ? "low" : "high");
 
     }
     outfile->Printf("\n");

--- a/psi4/src/psi4/lib3index/dftensor.cc
+++ b/psi4/src/psi4/lib3index/dftensor.cc
@@ -107,12 +107,15 @@ void DFTensor::common_init() {
 
     // Qso construction requires Aso+Bso+metric to be held in core. For a small safety margin we take 95% of the total
     // memory. In practice this only becomes an issue for heavy (>1000 bfs) calculations with large aux sets.
-    double required_mem = (nbf_ * nbf_ * naux_ * 2 + naux_ * naux_) * sizeof(double) / (1024.0 * 1024.0 * 1024.0);
+    double required_mem = (size_t(nbf_) * nbf_ * naux_ * 2 + size_t(naux_) * naux_) * sizeof(double) / (1024.0 * 1024.0 * 1024.0);
     double memory = (double)Process::environment.get_memory() / (1024.0 * 1024.0 * 1024.0) * 0.95;
-    outfile->Printf("  The DF Tensor (Qso) construction requires %.3f GiB of memory. \n", required_mem);
+    outfile->Printf("  DFTensor Memory: Qso construction needs %.3f GiB; user supplied %.3f GiB. \n", required_mem, memory);
     if (required_mem > memory) {
-        outfile->Printf("\t !! The Qso DFTensor requires %.3f GiB of memory but only %.3f GiB (95/% of total) are available !! ", required_mem, memory);
-        throw PSIEXCEPTION("Out of memory for the Qso DF Tensor!");
+        std::stringstream error;
+        error << "DFTensor: The Qso requires at least " << required_mem
+              << "[GiB].  We need that plus some more, but we only got " << memory
+              << "[GiB].";
+        throw PSIEXCEPTION(error.str().c_str());
     }
 
     build_metric();


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] cast in DFTensor memory estimation so that one can perform a fno-df-cc on 6 heavy atoms with aqz in 31 GiB of memory, not 17179869183.261 GiB . (How did this bug live this long?) Improve printing to match DFHelper
- [x] start converting existing mem printing to GiB from mega. afaict, the fnocc values were already mebibytes, though labeled MB
- change in printing for identical calc below:

```
<   The DF Tensor (Qso) construction requires 31.261 GiB of memory. 
---
>   DFTensor Memory: Qso construction needs 31.261 GiB; user supplied 35.390 GiB. 
```
```
<         Total memory available:           38146.97 mb
<         CCSD memory requirements:         35113.77 mb
<             3-index integrals:            10081.38 mb
<             CCSD intermediates:           25032.39 mb
<         (T) algorithm:                     9055.34 mb (low-memory)
---
>         Total memory available:             37.253 [GiB]
>         CCSD memory requirements:           34.291 [GiB]
>             3-index integrals:               9.845 [GiB]
>             CCSD intermediates:             24.446 [GiB]
>         (T) algorithm:                       8.843 [GiB] (low-memory)
```

## Checklist
- ~Tests added for any new features~
- ~[All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)~

## Status
- [x] Ready for review
- [x] Ready for merge
