### PR TITLE
Remove commented out code from mcscf

### DIFF
--- a/psi4/src/psi4/mcscf/scf_energy.cc
+++ b/psi4/src/psi4/mcscf/scf_energy.cc
@@ -26,17 +26,9 @@
  * @END LICENSE
  */
 
-#include <iostream>
 #include <cmath>
-
-#include "psi4/libmoinfo/libmoinfo.h"
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libpsi4util/libpsi4util.h"
-
 #include "scf.h"
-#include "sblock_matrix.h"
-
-extern FILE* outfile;
 
 namespace psi {
 namespace mcscf {
@@ -60,34 +52,6 @@ double SCF::energy(int cycle, double old_energy) {
     total_energy = electronic_energy + moinfo_scf->get_nuclear_energy();
 
     if (reference == tcscf) {
-        //     SBlockMatrix Dtc_sum("Dtc sum",nirreps,sopi,sopi);
-        //
-        //     // Compute diagonal elements of H
-        //     for(int I = 0 ; I < nci; ++I){
-        //       Dtc_sum  = Dc;
-        //       Dtc_sum += Dtc[I];
-        //       construct_G(Dtc_sum,G,"PK");
-        //       T  = H;
-        //       T.scale(2.0);
-        //       T += G;
-        //       H_tcscf[I][I] = dot(Dtc_sum,T) + moinfo_scf->get_nuclear_energy();
-        //     }
-        //
-        //     // Compute off-diagonal elements of H
-        //     for(int I = 0 ; I < nci; ++I){
-        //       for(int J = I + 1; J < nci; ++J){
-        //         construct_G(Dtc[I],G,"K");
-        //         H_tcscf[I][J] = H_tcscf[J][I] = - dot(Dtc[J],G);
-        //       }
-        //     }
-
-        //     outfile->Printf("\n  Hamiltonian");
-        //     for(int I = 0 ; I < nci; ++I){
-        //       outfile->Printf("\n    ");
-        //       for(int J = 0 ; J < nci; ++J)
-        //         outfile->Printf(" %11.8f ",H_tcscf[I][J]);
-        //     }
-
         // Compute the CI gradient
         norm_ci_grad = 0.0;
         for (int I = 0; I < nci; ++I) {


### PR DESCRIPTION
## Description
mcscf::SCF::energy(...) has a block of commented out code for TCSCF references.
Removing it also allows the removal of unused `#include`s and an `extern FILE* outfile` declaration.
This is another shard of the https://github.com/psi4/psi4/pull/2642 mega-PR that can be merged independently.

## Todos
- [X] Unused code is removed from `psi4/src/psi4/mcscf/scf_energy.cc`

## Status
- [X] Ready for review
- [X] Ready for merge
