### PR TITLE
Remove unused diagonalizers and linear solvers from occwave::Array2d and occwave::SymBlockMatrix

### DIFF
--- a/psi4/src/psi4/occ/arrays.cc
+++ b/psi4/src/psi4/occ/arrays.cc
@@ -372,11 +372,6 @@ void Array2d::gemm(bool transa, bool transb, double alpha, const Array2d* a, con
     }
 }  //
 
-void Array2d::davidson(int n_eigval, Array2d* eigvectors, Array1d* eigvalues, double cutoff, int print) {
-    david(A2d_, dim1_, n_eigval, eigvalues->A1d_, eigvectors->A2d_, cutoff, print);
-
-}  //
-
 void Array2d::add(const Array2d* Adum) {
     double *lhs, *rhs;
     size_t size = dim1_ * dim2_;
@@ -446,32 +441,6 @@ void Array2d::copy(double** a) {
     if (size) memcpy(&(A2d_[0][0]), &(a[0][0]), size);
 }
 
-void Array2d::diagonalize(Array2d* eigvectors, Array1d* eigvalues, double cutoff) {
-    sq_rsp(dim1_, dim2_, A2d_, eigvalues->A1d_, 1, eigvectors->A2d_, cutoff);
-
-}  //
-
-void Array2d::cdsyev(char jobz, char uplo, Array2d* eigvectors, Array1d* eigvalues) {
-    if (dim1_) {
-        int lwork = 3 * dim2_;
-        double** work = block_matrix(dim1_, lwork);
-        memset(work[0], 0.0, sizeof(double) * dim1_ * lwork);
-        C_DSYEV(jobz, uplo, dim1_, &(A2d_[0][0]), dim2_, eigvalues->A1d_, &(work[0][0]), lwork);
-        free_block(work);
-    }
-}  //
-
-void Array2d::cdgesv(Array1d* Xvec) {
-    if (dim1_) {
-        int errcod;
-        int* ipiv = init_int_array(dim1_);
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec->A1d_, dim2_);
-        free(ipiv);
-    }
-}  //
-
 void Array2d::cdgesv(Array1d* Xvec, int errcod) {
     if (dim1_) {
         int* ipiv = init_int_array(dim1_);
@@ -482,48 +451,15 @@ void Array2d::cdgesv(Array1d* Xvec, int errcod) {
     }
 }  //
 
-void Array2d::cdgesv(double* Xvec) {
-    if (dim1_) {
-        int errcod;
-        int* ipiv = init_int_array(dim1_);
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec, dim2_);
-        free(ipiv);
-    }
-}  //
-
-void Array2d::cdgesv(double* Xvec, int errcod) {
-    if (dim1_) {
-        int* ipiv = init_int_array(dim1_);
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec, dim2_);
-        free(ipiv);
-    }
-}  //
-
 void Array2d::lineq_flin(Array1d* Xvec, double* det) {
     if (dim1_) {
         flin(A2d_, Xvec->A1d_, dim1_, 1, det);
     }
 }  //
 
-void Array2d::lineq_flin(double* Xvec, double* det) {
-    if (dim1_) {
-        flin(A2d_, Xvec, dim1_, 1, det);
-    }
-}  //
-
 void Array2d::lineq_pople(Array1d* Xvec, int num_vecs, double cutoff) {
     if (dim1_) {
         pople(A2d_, Xvec->A1d_, dim1_, num_vecs, cutoff, "outfile", 0);
-    }
-}  //
-
-void Array2d::lineq_pople(double* Xvec, int num_vecs, double cutoff) {
-    if (dim1_) {
-        pople(A2d_, Xvec, dim1_, num_vecs, cutoff, "outfile", 0);
     }
 }  //
 

--- a/psi4/src/psi4/occ/arrays.h
+++ b/psi4/src/psi4/occ/arrays.h
@@ -133,23 +133,12 @@ class Array2d {
     Array2d* transpose();
     void copy(const Array2d* Adum);
     void copy(double** a);
-    // diagonalize: diagonalize via rsp
-    void diagonalize(Array2d* eigvectors, Array1d* eigvalues, double cutoff);
-    // cdsyev: diagonalize via lapack
-    void cdsyev(char jobz, char uplo, Array2d* eigvectors, Array1d* eigvalues);
-    // davidson: diagonalize via davidson algorithm
-    void davidson(int n_eigval, Array2d* eigvectors, Array1d* eigvalues, double cutoff, int print);
     // cdgesv: solve a linear equation via lapack
-    void cdgesv(Array1d* Xvec);
-    void cdgesv(double* Xvec);
     void cdgesv(Array1d* Xvec, int errcod);
-    void cdgesv(double* Xvec, int errcod);
     // lineq_flin: solve a linear equation via FLIN
     void lineq_flin(Array1d* Xvec, double* det);
-    void lineq_flin(double* Xvec, double* det);
     // lineq_pople: solve a linear equation via Pople's algorithm
     void lineq_pople(Array1d* Xvec, int num_vecs, double cutoff);
-    void lineq_pople(double* Xvec, int num_vecs, double cutoff);
     // gemm: matrix multiplication
     void gemm(bool transa, bool transb, double alpha, const Array2d* a, const Array2d* b, double beta);
     // level_shift: A[i][i] = A[i][i] - value

--- a/psi4/src/psi4/occ/dpd.cc
+++ b/psi4/src/psi4/occ/dpd.cc
@@ -479,66 +479,6 @@ bool SymBlockMatrix::load(std::shared_ptr<psi::PSIO> psio, int itap, const char 
     return true;
 }  //
 
-void SymBlockMatrix::diagonalize(SymBlockMatrix *eigvectors, SymBlockVector *eigvalues) {
-    for (int h = 0; h < nirreps_; h++) {
-        if (rowspi_[h]) {
-            sq_rsp(rowspi_[h], colspi_[h], matrix_[h], eigvalues->vector_[h], 1, eigvectors->matrix_[h], 1.0e-14);
-        }
-    }
-}  //
-
-void SymBlockMatrix::cdsyev(char jobz, char uplo, SymBlockMatrix *eigvectors, SymBlockVector *eigvalues) {
-    for (int h = 0; h < nirreps_; h++) {
-        if (rowspi_[h]) {
-            int lwork = 3 * rowspi_[h];
-            double **work = block_matrix(nirreps_, lwork);
-            memset(work[0], 0.0, sizeof(double) * nirreps_ * lwork);
-            C_DSYEV(jobz, uplo, rowspi_[h], &(matrix_[h][0][0]), colspi_[h], eigvalues->vector_[h], &(work[h][0]),
-                    lwork);
-        }
-    }
-}  //
-
-void SymBlockMatrix::davidson(int n_eigval, SymBlockMatrix *eigvectors, SymBlockVector *eigvalues, double cutoff,
-                              int print) {
-    for (int h = 0; h < nirreps_; h++) {
-        if (rowspi_[h]) {
-            david(matrix_[h], rowspi_[h], n_eigval, eigvalues->vector_[h], eigvectors->matrix_[h], cutoff, print);
-        }
-    }
-}  //
-
-void SymBlockMatrix::cdgesv(SymBlockVector *Xvec) {
-    for (int h = 0; h < nirreps_; h++) {
-        if (rowspi_[h]) {
-            int errcod;
-            int *ipiv = init_int_array(rowspi_[h]);
-            memset(ipiv, 0, sizeof(int) * rowspi_[h]);
-            errcod = 0;
-            errcod = C_DGESV(rowspi_[h], 1, &(matrix_[h][0][0]), colspi_[h], &(ipiv[0]), Xvec->vector_[h], colspi_[h]);
-            delete[] ipiv;
-        }
-    }
-}  //
-
-// void flin(double **a, double *b, int in, int im, double *det)
-void SymBlockMatrix::lineq_flin(SymBlockVector *Xvec, double *det) {
-    for (int h = 0; h < nirreps_; h++) {
-        if (rowspi_[h]) {
-            flin(matrix_[h], Xvec->vector_[h], rowspi_[h], 1, det);
-        }
-    }
-}  //
-
-// int pople(double **A, double *x, int dimen, int num_vecs, double tolerance, std::string out_fname, int print_lvl)
-void SymBlockMatrix::lineq_pople(SymBlockVector *Xvec, int num_vecs, double cutoff) {
-    for (int h = 0; h < nirreps_; h++) {
-        if (rowspi_[h]) {
-            pople(matrix_[h], Xvec->vector_[h], rowspi_[h], num_vecs, cutoff, "outfile", 0);
-        }
-    }
-}  //
-
 void SymBlockMatrix::mgs() {
     double rmgs1, rmgs2, sum1;
 

--- a/psi4/src/psi4/occ/dpd.h
+++ b/psi4/src/psi4/occ/dpd.h
@@ -93,13 +93,6 @@ class SymBlockMatrix {
     void read(std::shared_ptr<psi::PSIO> psio, int itap, const char *label, bool readSubBlocks);
     void mgs();  // Modified Gram-Schmidt
     void gs();   // Gram-Schmidt
-    void diagonalize(SymBlockMatrix *eigvectors, SymBlockVector *eigvalues);
-    void cdsyev(char jobz, char uplo, SymBlockMatrix *eigvectors, SymBlockVector *eigvalues);  // diagonalize via acml
-    void davidson(int n_eigval, SymBlockMatrix *eigvectors, SymBlockVector *eigvalues, double cutoff,
-                  int print);                                             // diagonalize via davidson alg.
-    void cdgesv(SymBlockVector *Xvec);                                    // solve lineq via acml
-    void lineq_flin(SymBlockVector *Xvec, double *det);                   // solve lineq via flin
-    void lineq_pople(SymBlockVector *Xvec, int num_vecs, double cutoff);  // solve lineq via pople
     void read_oooo(std::shared_ptr<psi::PSIO> psio, int itap, int *mosym, int *qt2pitzer, int *occ_off, int *occpi,
                    Array3i *oo_pairidx);
     void read_oovv(std::shared_ptr<psi::PSIO> psio, int itap, int nocc, int *mosym, int *qt2pitzer, int *occ_off,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
These functions are never called anywhere C++-side, and not `PSI_API`.
This is another shard of the https://github.com/psi4/psi4/pull/2642 mega-PR that can be merged independently.

## Todos
- [x] Unused code is removed from occwave::Array2d
- [x] Unused code is removed from occwave::SymBlockMatrix

## Status
- [x] Ready for review
- [x] Ready for merge
