### PR TITLE
Remove unused diagonalizers and linear solvers from dfoccwave::Tensor2d and dfoccwave::Array2d

### DIFF
--- a/psi4/src/psi4/dfocc/arrays.cc
+++ b/psi4/src/psi4/dfocc/arrays.cc
@@ -468,11 +468,6 @@ void Array2d::contract233(bool transa, bool transb, int m, int n, const Array2d 
     }
 }  //
 
-void Array2d::davidson(int n_eigval, Array2d *eigvectors, Array1d *eigvalues, double cutoff, int print) {
-    david(A2d_, dim1_, n_eigval, eigvalues->A1d_, eigvectors->A2d_, cutoff, print);
-
-}  //
-
 void Array2d::add(const Array2d *Adum) {
     double *lhs, *rhs;
     size_t size = dim1_ * dim2_;
@@ -550,87 +545,6 @@ void Array2d::copy(double **a) {
     size_t size = dim1_ * dim2_ * sizeof(double);
     if (size) memcpy(&(A2d_[0][0]), &(a[0][0]), size);
 }
-
-void Array2d::diagonalize(Array2d *eigvectors, Array1d *eigvalues, double cutoff) {
-    sq_rsp(dim1_, dim2_, A2d_, eigvalues->A1d_, 1, eigvectors->A2d_, cutoff);
-
-}  //
-
-void Array2d::cdsyev(char jobz, char uplo, Array2d *eigvectors, Array1d *eigvalues) {
-    if (dim1_) {
-        int lwork = 3 * dim2_;
-        double **work = block_matrix(dim1_, lwork);
-        memset(work[0], 0.0, sizeof(double) * dim1_ * lwork);
-        C_DSYEV(jobz, uplo, dim1_, &(A2d_[0][0]), dim2_, eigvalues->A1d_, &(work[0][0]), lwork);
-        free_block(work);
-    }
-}  //
-
-void Array2d::cdgesv(Array1d *Xvec) {
-    if (dim1_) {
-        int errcod;
-        int *ipiv = new int[dim1_];
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec->A1d_, dim2_);
-        delete[] ipiv;
-    }
-}  //
-
-void Array2d::cdgesv(Array1d *Xvec, int errcod) {
-    if (dim1_) {
-        int *ipiv = new int[dim1_];
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec->A1d_, dim2_);
-        delete[] ipiv;
-    }
-}  //
-
-void Array2d::cdgesv(double *Xvec) {
-    if (dim1_) {
-        int errcod;
-        int *ipiv = new int[dim1_];
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec, dim2_);
-        delete[] ipiv;
-    }
-}  //
-
-void Array2d::cdgesv(double *Xvec, int errcod) {
-    if (dim1_) {
-        int *ipiv = new int[dim1_];
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec, dim2_);
-        delete[] ipiv;
-    }
-}  //
-
-void Array2d::lineq_flin(Array1d *Xvec, double *det) {
-    if (dim1_) {
-        flin(A2d_, Xvec->A1d_, dim1_, 1, det);
-    }
-}  //
-
-void Array2d::lineq_flin(double *Xvec, double *det) {
-    if (dim1_) {
-        flin(A2d_, Xvec, dim1_, 1, det);
-    }
-}  //
-
-void Array2d::lineq_pople(Array1d *Xvec, int num_vecs, double cutoff) {
-    if (dim1_) {
-        pople(A2d_, Xvec->A1d_, dim1_, num_vecs, cutoff, "outfile", 0);
-    }
-}  //
-
-void Array2d::lineq_pople(double *Xvec, int num_vecs, double cutoff) {
-    if (dim1_) {
-        pople(A2d_, Xvec, dim1_, num_vecs, cutoff, "outfile", 0);
-    }
-}  //
 
 void Array2d::level_shift(double value) {
     for (int i = 0; i < dim1_; ++i) {

--- a/psi4/src/psi4/dfocc/arrays.h
+++ b/psi4/src/psi4/dfocc/arrays.h
@@ -136,23 +136,6 @@ class Array2d {
     Array2d *transpose();
     void copy(const Array2d *Adum);
     void copy(double **a);
-    // diagonalize: diagonalize via rsp
-    void diagonalize(Array2d *eigvectors, Array1d *eigvalues, double cutoff);
-    // cdsyev: diagonalize via lapack
-    void cdsyev(char jobz, char uplo, Array2d *eigvectors, Array1d *eigvalues);
-    // davidson: diagonalize via davidson algorithm
-    void davidson(int n_eigval, Array2d *eigvectors, Array1d *eigvalues, double cutoff, int print);
-    // cdgesv: solve a linear equation via lapack
-    void cdgesv(Array1d *Xvec);
-    void cdgesv(double *Xvec);
-    void cdgesv(Array1d *Xvec, int errcod);
-    void cdgesv(double *Xvec, int errcod);
-    // lineq_flin: solve a linear equation via FLIN
-    void lineq_flin(Array1d *Xvec, double *det);
-    void lineq_flin(double *Xvec, double *det);
-    // lineq_pople: solve a linear equation via Pople's algorithm
-    void lineq_pople(Array1d *Xvec, int num_vecs, double cutoff);
-    void lineq_pople(double *Xvec, int num_vecs, double cutoff);
     // gemm: matrix multiplication C = A * B
     void gemm(bool transa, bool transb, const Array2d *a, const Array2d *b, double alpha, double beta);
     // contract: general contraction C(m,n) = \sum_{k} A(m,k) * B(k,n)

--- a/psi4/src/psi4/dfocc/tensors.cc
+++ b/psi4/src/psi4/dfocc/tensors.cc
@@ -1550,12 +1550,6 @@ void Tensor2d::gemv(bool transa, const SharedTensor2d &a, const SharedTensor2d &
     }
 }  //
 
-void Tensor2d::davidson(int n_eigval, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff,
-                        int print) {
-    david(A2d_, dim1_, n_eigval, eigvalues->A1d_, eigvectors->A2d_, cutoff, print);
-
-}  //
-
 void Tensor2d::add(const SharedTensor2d &a) {
     size_t length = (size_t)dim1_ * (size_t)dim2_;
     C_DAXPY(length, 1.0, a->A2d_[0], 1, A2d_[0], 1);
@@ -1750,16 +1744,6 @@ void Tensor2d::diagonalize(int dim, const SharedTensor2d &eigvectors, const Shar
 
 }  //
 
-void Tensor2d::cdsyev(char jobz, char uplo, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues) {
-    if (dim1_) {
-        int lwork = 3 * dim2_;
-        double **work = block_matrix(dim1_, lwork);
-        memset(work[0], 0.0, sizeof(double) * dim1_ * lwork);
-        C_DSYEV(jobz, uplo, dim1_, &(A2d_[0][0]), dim2_, eigvalues->A1d_, &(work[0][0]), lwork);
-        free_block(work);
-    }
-}  //
-
 void Tensor2d::cdgesv(const SharedTensor1d &Xvec) {
     if (dim1_) {
         int errcod;
@@ -1781,48 +1765,15 @@ void Tensor2d::cdgesv(const SharedTensor1d &Xvec, int errcod) {
     }
 }  //
 
-void Tensor2d::cdgesv(double *Xvec) {
-    if (dim1_) {
-        int errcod;
-        auto *ipiv = new int[dim1_];
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec, dim2_);
-        delete[] ipiv;
-    }
-}  //
-
-void Tensor2d::cdgesv(double *Xvec, int errcod) {
-    if (dim1_) {
-        auto *ipiv = new int[dim1_];
-        memset(ipiv, 0, sizeof(int) * dim1_);
-        errcod = 0;
-        errcod = C_DGESV(dim1_, 1, &(A2d_[0][0]), dim2_, &(ipiv[0]), Xvec, dim2_);
-        delete[] ipiv;
-    }
-}  //
-
 void Tensor2d::lineq_flin(const SharedTensor1d &Xvec, double *det) {
     if (dim1_) {
         flin(A2d_, Xvec->A1d_, dim1_, 1, det);
     }
 }  //
 
-void Tensor2d::lineq_flin(double *Xvec, double *det) {
-    if (dim1_) {
-        flin(A2d_, Xvec, dim1_, 1, det);
-    }
-}  //
-
 void Tensor2d::lineq_pople(const SharedTensor1d &Xvec, int num_vecs, double cutoff) {
     if (dim1_) {
         pople(A2d_, Xvec->A1d_, dim1_, num_vecs, cutoff, "outfile", 0);
-    }
-}  //
-
-void Tensor2d::lineq_pople(double *Xvec, int num_vecs, double cutoff) {
-    if (dim1_) {
-        pople(A2d_, Xvec, dim1_, num_vecs, cutoff, "outfile", 0);
     }
 }  //
 

--- a/psi4/src/psi4/dfocc/tensors.cc
+++ b/psi4/src/psi4/dfocc/tensors.cc
@@ -1722,6 +1722,28 @@ void Tensor2d::diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1
 
 }  //
 
+void Tensor2d::diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff,
+                           bool ascending) {
+    int matz;
+    if (ascending)
+        matz = 1;
+    else
+        matz = 3;
+    sq_rsp(dim1_, dim2_, A2d_, eigvalues->A1d_, matz, eigvectors->A2d_, cutoff);
+
+}  //
+
+void Tensor2d::diagonalize(int dim, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff,
+                           bool ascending) {
+    int matz;
+    if (ascending)
+        matz = 1;
+    else
+        matz = 3;
+    sq_rsp(dim, dim, A2d_, eigvalues->A1d_, matz, eigvectors->A2d_, cutoff);
+
+}  //
+
 void Tensor2d::cdgesv(const SharedTensor1d &Xvec) {
     if (dim1_) {
         int errcod;

--- a/psi4/src/psi4/dfocc/tensors.cc
+++ b/psi4/src/psi4/dfocc/tensors.cc
@@ -1722,28 +1722,6 @@ void Tensor2d::diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1
 
 }  //
 
-void Tensor2d::diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff,
-                           bool ascending) {
-    int matz;
-    if (ascending)
-        matz = 1;
-    else
-        matz = 3;
-    sq_rsp(dim1_, dim2_, A2d_, eigvalues->A1d_, matz, eigvectors->A2d_, cutoff);
-
-}  //
-
-void Tensor2d::diagonalize(int dim, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff,
-                           bool ascending) {
-    int matz;
-    if (ascending)
-        matz = 1;
-    else
-        matz = 3;
-    sq_rsp(dim, dim, A2d_, eigvalues->A1d_, matz, eigvectors->A2d_, cutoff);
-
-}  //
-
 void Tensor2d::cdgesv(const SharedTensor1d &Xvec) {
     if (dim1_) {
         int errcod;

--- a/psi4/src/psi4/dfocc/tensors.h
+++ b/psi4/src/psi4/dfocc/tensors.h
@@ -213,22 +213,13 @@ class Tensor2d {
     void diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff);
     void diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff, bool ascending);
     void diagonalize(int dim, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff, bool ascending);
-    // cdsyev: diagonalize via lapack
-    void cdsyev(char jobz, char uplo, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues);
-    // davidson: diagonalize via davidson algorithm
-    void davidson(int n_eigval, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff,
-                  int print);
     // cdgesv: solve a linear equation via lapack
     void cdgesv(const SharedTensor1d &Xvec);
-    void cdgesv(double *Xvec);
     void cdgesv(const SharedTensor1d &Xvec, int errcod);
-    void cdgesv(double *Xvec, int errcod);
     // lineq_flin: solve a linear equation via FLIN
     void lineq_flin(const SharedTensor1d &Xvec, double *det);
-    void lineq_flin(double *Xvec, double *det);
     // pople: solve a linear equation via Pople's algorithm
     void lineq_pople(const SharedTensor1d &Xvec, int num_vecs, double cutoff);
-    void lineq_pople(double *Xvec, int num_vecs, double cutoff);
 
     // gemm: matrix multiplication C = A * B
     void gemm(bool transa, bool transb, const SharedTensor2d &a, const SharedTensor2d &b, double alpha, double beta);

--- a/psi4/src/psi4/dfocc/tensors.h
+++ b/psi4/src/psi4/dfocc/tensors.h
@@ -211,8 +211,6 @@ class Tensor2d {
     double get_max_element();
     // diagonalize: diagonalize via rsp
     void diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff);
-    void diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff, bool ascending);
-    void diagonalize(int dim, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff, bool ascending);
     // cdgesv: solve a linear equation via lapack
     void cdgesv(const SharedTensor1d &Xvec);
     void cdgesv(const SharedTensor1d &Xvec, int errcod);

--- a/psi4/src/psi4/dfocc/tensors.h
+++ b/psi4/src/psi4/dfocc/tensors.h
@@ -211,6 +211,8 @@ class Tensor2d {
     double get_max_element();
     // diagonalize: diagonalize via rsp
     void diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff);
+    void diagonalize(const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff, bool ascending);
+    void diagonalize(int dim, const SharedTensor2d &eigvectors, const SharedTensor1d &eigvalues, double cutoff, bool ascending);
     // cdgesv: solve a linear equation via lapack
     void cdgesv(const SharedTensor1d &Xvec);
     void cdgesv(const SharedTensor1d &Xvec, int errcod);


### PR DESCRIPTION
## Description
Much like `occ` (PR #2679), `dfocc` also has these functions that are never called anywhere C++-side, and not `PSI_API`.
This is another shard of the https://github.com/psi4/psi4/pull/2642 mega-PR that can be merged independently.

## Todos
- [x] Unused code is removed from dfoccwave::Array2d
- [x] Unused code is removed from dfoccwave::Tensor2d

## Status
- [x] Ready for review
- [x] Ready for merge
