### PR TITLE
Change COSX default

### DIFF
--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -782,10 +782,10 @@ a cutoff for the value of basis functions at grid points. This keyword is
 used to determine the radial extent of the each basis shell, and it is the
 COSX analogue to |scf__dft_basis_tolerance|.
 
-The |scf__cosx_incfock| keyword (defaults to ``true``) increases performance
+The |scf__cosx_incfock| keyword (defaults to ``false``) increases performance
 by constructing the Fock matrix from differences in the density matrix, which
-are more amenable to screening. Consider disabling this keyword if SCF energy
-convergence issues are observed, particularly when using diffuse basis functions.
+are more amenable to screening. This option is disabled by default because of
+potential SCF convergence issues, particularly when using diffuse basis functions.
 The |scf__cosx_overlap_fitting| keyword (defaults to ``true``) reduces numerical
 integration errors using the method described in [Izsak:2011:144105]_ and is
 always recommended.

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1569,7 +1569,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Do reduce numerical COSX errors with overlap fitting? !expert -*/
         options.add_bool("COSX_OVERLAP_FITTING", true);
         /*- Do allow for improved COSX screening performance by constructing the Fock matrix incrementally? !expert -*/
-        options.add_bool("COSX_INCFOCK", true);
+        options.add_bool("COSX_INCFOCK", false);
 
         /*- SUBSECTION SAD Guess Algorithm -*/
 


### PR DESCRIPTION
## Description
Changes a setting in the COSX JK algorithm to a more conservative default.

Previously, the incremental fock option (`cosx_incfock`) was enabled by default. This gave a minor speedup, but it came at the risk of possible SCF convergence issues when using diffuse basis sets. This PR disables this option, so the COSX algorithm will be slightly slower, but more robust by default.

## Todos
- [x] Changed `cosx_incfock` default

## Checklist
- [x] COSX tests still pass

## Status
- [x] Ready for review
- [x] Ready for merge
