### PR TITLE
Fix `c1_deep_copy`

### DIFF
--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -910,7 +910,7 @@ SharedMatrix Wavefunction::C_subset_helper(SharedMatrix C, const Dimension &nocc
 
 SharedVector Wavefunction::epsilon_subset_helper(SharedVector epsilon, const Dimension &noccpi,
                                                  const std::string &basis, const std::string &subset) const {
-    std::vector<std::vector<int>> positions = subset_occupation(noccpi, subset);
+    auto positions = subset_occupation(noccpi, subset);
 
     Dimension nmopi(nirrep_);
     for (int h = 0; h < (int)positions.size(); h++) {

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -209,8 +209,21 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Helpers for C/D/epsilon transformers
     SharedMatrix C_subset_helper(SharedMatrix C, const Dimension& noccpi, SharedVector epsilon,
                                  const std::string& basis, const std::string& subset) const;
+    // Return the desired subset of orbital energies.
+    // @param epsilon The vector of orbital energies
+    // @param noccpi The dimension of "occupied" orbitals for the case of interest.
+    //               Usual use case: nalphapi_ or nbetapi_?
+    // @param basis "AO", "SO", or "MO" - should the return vector use symmetry
+    // @param subset A label appended to the return vector name, "Epsilon {basis} {subset}"
     SharedVector epsilon_subset_helper(SharedVector epsilon, const Dimension& noccpi, const std::string& basis,
                                        const std::string& subset) const;
+    // Helper function needed by the helper functions.
+    // Return the desired MO indices, per irrep.
+    // @param noccpi The dimension of occupied indices used as the source-of-
+    //               truth for the dimension of occupied orbitals.
+    // @param subset "FROZEN_OCC", "FROZEN_VIR", "ACTIVE_OCC", "ACTIVE_VIR"
+    //               "ACTIVE", "OCC", "VIR", or "ALL". The space, the indices
+    //                of which are to be returned.
     std::vector<std::vector<int>> subset_occupation(const Dimension& noccpi, const std::string& subset) const;
 
     /// Should nuclear electrostatic potentials be available, they will be here

--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -404,8 +404,8 @@ std::shared_ptr<CUHF> CUHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
     if (Db_) hf_wfn->Db_ = Db_subset("AO");
     if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
     if (Fb_) hf_wfn->Fb_ = Fb_subset("AO");
-    if (epsilon_a_) hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
-    if (epsilon_b_) hf_wfn->epsilon_b_ = epsilon_subset_helper(epsilon_b_, nsopi_, "AO", "ALL");
+    if (epsilon_a_) hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nalphapi_, "AO", "ALL");
+    if (epsilon_b_) hf_wfn->epsilon_b_ = epsilon_subset_helper(epsilon_b_, nbetapi_, "AO", "ALL");
     // H_ ans X_ reset in the HF constructor, copy them over here
     SharedMatrix SO2AO = aotoso()->transpose();
     if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -992,7 +992,7 @@ bool RHF::stability_analysis() {
 }
 
 std::shared_ptr<RHF> RHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
-    std::shared_ptr<Wavefunction> wfn = Wavefunction::c1_deep_copy(basis);
+    auto wfn = Wavefunction::c1_deep_copy(basis);
     auto hf_wfn = std::make_shared<RHF>(wfn, functional_, wfn->options(), wfn->psio());
     // now just have to copy the matrices that RHF initializes
     // include only those that are not temporary (some deleted in finalize())
@@ -1009,11 +1009,11 @@ std::shared_ptr<RHF> RHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
         hf_wfn->Fb_ = hf_wfn->Fa_;
     }
     if (epsilon_a_) {
-        hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+        hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nalphapi_, "AO", "ALL");
         hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
     }
     // H_ ans X_ reset in the HF constructor, copy them over here
-    SharedMatrix SO2AO = aotoso()->transpose();
+    auto SO2AO = aotoso()->transpose();
     if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
     if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
 

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -1285,7 +1285,7 @@ bool ROHF::stability_analysis() {
 }
 
 std::shared_ptr<ROHF> ROHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
-    std::shared_ptr<Wavefunction> wfn = Wavefunction::c1_deep_copy(basis);
+    auto wfn = Wavefunction::c1_deep_copy(basis);
     auto hf_wfn = std::make_shared<ROHF>(wfn, functional_, wfn->options(), wfn->psio());
 
     // now just have to copy the matrices that RHF initializes
@@ -1299,11 +1299,11 @@ std::shared_ptr<ROHF> ROHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
     if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
     if (Fb_) hf_wfn->Fb_ = Fb_subset("AO");
     if (epsilon_a_) {
-        hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
+        hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nalphapi_, "AO", "ALL");
         hf_wfn->epsilon_b_ = hf_wfn->epsilon_a_;
     }
     // H_ ans X_ reset in the HF constructor, copy them over here
-    SharedMatrix SO2AO = aotoso()->transpose();
+    auto SO2AO = aotoso()->transpose();
     if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
     if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
 

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -1254,7 +1254,7 @@ void UHF::compute_nos() {
 }
 
 std::shared_ptr<UHF> UHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
-    std::shared_ptr<Wavefunction> wfn = Wavefunction::c1_deep_copy(basis);
+    auto wfn = Wavefunction::c1_deep_copy(basis);
     auto hf_wfn = std::make_shared<UHF>(wfn, functional_, wfn->options(), wfn->psio());
 
     // now just have to copy the matrices that UHF initializes
@@ -1265,10 +1265,10 @@ std::shared_ptr<UHF> UHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
     if (Db_) hf_wfn->Db_ = Db_subset("AO");
     if (Fa_) hf_wfn->Fa_ = Fa_subset("AO");
     if (Fb_) hf_wfn->Fb_ = Fb_subset("AO");
-    if (epsilon_a_) hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nsopi_, "AO", "ALL");
-    if (epsilon_b_) hf_wfn->epsilon_b_ = epsilon_subset_helper(epsilon_b_, nsopi_, "AO", "ALL");
+    if (epsilon_a_) hf_wfn->epsilon_a_ = epsilon_subset_helper(epsilon_a_, nalphapi_, "AO", "ALL");
+    if (epsilon_b_) hf_wfn->epsilon_b_ = epsilon_subset_helper(epsilon_b_, nbetapi_, "AO", "ALL");
     // H_ ans X_ reset in the HF constructor, copy them over here
-    SharedMatrix SO2AO = aotoso()->transpose();
+    auto SO2AO = aotoso()->transpose();
     if (H_) hf_wfn->H_->remove_symmetry(H_, SO2AO);
     if (X_) hf_wfn->X_->remove_symmetry(X_, SO2AO);
 


### PR DESCRIPTION
## Description
`c1_deep_copy` sent `nsopi_` to `Wavefunction::epsilon_subset_helper` in place of the number of occupied orbitals. When `nsopi_[h] > nmopi_[h]` for some `h`, this led to accessing out-of-bounds memory. No more.

## Checklist
- [x] `fnocc7` (which alerted us to this issue) passes again

## Status
- [x] Ready for review
- [x] Ready for merge
