### PR TITLE
Remove confusing dash/minus character from stability analysis text

### DIFF
--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -980,9 +980,9 @@ bool RHF::stability_analysis() {
             free(evals);
         }
 
-        outfile->Printf("    Lowest singlet (RHF->RHF) stability eigenvalues:-\n");
+        outfile->Printf("    Lowest singlet (RHF->RHF) stability eigenvalues:\n");
         print_stability_analysis(singlet_eval_sym);
-        outfile->Printf("    Lowest triplet (RHF->UHF) stability eigenvalues:-\n");
+        outfile->Printf("    Lowest triplet (RHF->UHF) stability eigenvalues:\n");
         print_stability_analysis(triplet_eval_sym);
         psio_->close(PSIF_LIBTRANS_DPD, 1);
     }

--- a/tests/scf-coverage/output.ref
+++ b/tests/scf-coverage/output.ref
@@ -242,7 +242,7 @@ compare_matrices(ref_nos, scf_wfn.Ca(), 8, "Water Anion UHF NOS")
 	First half integral transformation complete.
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-    Lowest singlet (RHF->RHF) stability eigenvalues:-
+    Lowest singlet (RHF->RHF) stability eigenvalues:
      B2u 0.087722       B3u 0.087722       B1u 0.087722       B1u 0.215168  
      B2u 0.215168       B3u 0.215168        Ag 0.221210        Ag 0.360268  
      B1g 0.360268       B2g 0.360268       B3g 0.360268        Ag 0.360268  
@@ -250,7 +250,7 @@ compare_matrices(ref_nos, scf_wfn.Ca(), 8, "Water Anion UHF NOS")
      B1u 2.330381       B2u 2.330381       B3u 2.330381        Ag 2.492258  
      B1g 2.492258       B2g 2.492258       B3g 2.492258      
 
-    Lowest triplet (RHF->UHF) stability eigenvalues:-
+    Lowest triplet (RHF->UHF) stability eigenvalues:
      B1u -0.031105      B2u -0.031105      B3u -0.031105       Ag 0.096444  
      B1u 0.120856       B2u 0.120856       B3u 0.120856        Ag 0.277388  
      B1g 0.277388       B2g 0.277388       B3g 0.277388        Ag 0.277388  

--- a/tests/stability2/output.ref
+++ b/tests/stability2/output.ref
@@ -226,7 +226,7 @@ compare_matrices(ref, stab, 2, "Stability eigenvalues with symmetry")           
 	First half integral transformation complete.
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-    Lowest ROHF->ROHF stability eigenvalues:-
+    Lowest ROHF->ROHF stability eigenvalues:
       B1 0.022220        B2 0.022220        A1 0.094068        B1 0.194516  
       B2 0.194516        A1 0.213961        A2 0.213961        A1 0.338722  
       A2 0.359135        A1 0.387962        A1 0.413653        B2 0.434411  


### PR DESCRIPTION
## Description
Currently the RHF stability analysis output looks something like this:
```
    Lowest singlet (RHF->RHF) stability eigenvalues:-
       A 0.070763         A 0.085714         A 0.095974         A 0.097368
```
Note the '-' character after the colon. What does that mean? I think it means nothing at all, but it is in a context where a stray '-' can have a lot of meaning.

This PR removes the spurious and potentially confusing '-' from the code and reference outputs.

## Todos
- [X] Do not print a spurious '-' character in RHF stability analysis

## Questions
- [ ] It must be just a typo, right?

## Status
- [x] Ready for review
- [x] Ready for merge
