### PR TITLE
Chip away at MOInfo (2/???)

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -159,6 +159,8 @@ void CCEnergyWavefunction::get_moinfo() {
         moinfo_.virtpi = init_int_array(nirreps);
         psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)moinfo_.occpi, sizeof(int) * nirreps);
         psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)moinfo_.virtpi, sizeof(int) * nirreps);
+        act_occpi_ = Dimension(std::vector<int>(moinfo_.occpi, moinfo_.occpi + nirreps));
+        act_virpi_ = Dimension(std::vector<int>(moinfo_.virtpi, moinfo_.virtpi + nirreps));
         moinfo_.occ_sym = init_int_array(nactive);
         moinfo_.vir_sym = init_int_array(nactive);
         psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Symmetry", (char *)moinfo_.occ_sym, sizeof(int) * nactive);

--- a/psi4/src/psi4/cc/ccenergy/t1.cc
+++ b/psi4/src/psi4/cc/ccenergy/t1.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "Params.h"
-#include "MOInfo.h"
 #include "psi4/cc/ccwave.h"
 
 namespace psi {
@@ -105,7 +104,7 @@ void CCEnergyWavefunction::t1_build() {
         global_dpd_->file2_mat_rd(&newtIA);
         global_dpd_->buf4_init(&T2, PSIF_CC_TAMPS, 0, 0, 5, 0, 5, 0, "2 tIjAb - tIjBa");
         global_dpd_->buf4_init(&F, PSIF_CC_FINTS, 0, 10, 5, 10, 5, 0, "F <ia|bc>");
-        for (int Gma = 0; Gma < moinfo_.nirreps; Gma++) {
+        for (int Gma = 0; Gma < nirrep_; Gma++) {
             Gmi = Gma; /* T1 is totally symmetric */
 
             global_dpd_->buf4_mat_irrep_row_init(&F, Gma);
@@ -122,12 +121,12 @@ void CCEnergyWavefunction::t1_build() {
                 Gi = Ga; /* T1 is totally symmetric */
                 A = a - F.params->qoff[Ga];
 
-                nrows = moinfo_.occpi[Gi];
+                nrows = act_occpi_[Gi];
                 ncols = F.params->coltot[Gma];
 
-                if (nrows && ncols && moinfo_.virtpi[Ga])
+                if (nrows && ncols && act_virpi_[Ga])
                     C_DGEMV('n', nrows, ncols, 1.0, T2.matrix[Gmi][T2.row_offset[Gmi][m]], ncols, F.matrix[Gma][0], 1,
-                            1.0, &newtIA.matrix[Gi][0][A], moinfo_.virtpi[Ga]);
+                            1.0, &newtIA.matrix[Gi][0][A], act_virpi_[Ga]);
             }
 
             global_dpd_->buf4_mat_irrep_close(&T2, Gmi);

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -199,6 +199,8 @@ class CCEnergyWavefunction : public Wavefunction {
     void diis_invert_B(double **B, double *C, int dimension, double tolerance);
 
     /* member variables */
+    Dimension act_occpi_;
+    Dimension act_virpi_;
     MOInfo moinfo_;
     Params params_;
     Local local_;


### PR DESCRIPTION
## Description
Replace an old-style call to `moinfo_` in `cc` with something more modern: get your number of irreps and orbital space information from the wavefunction. Once this is in, I can batch MOInfo elimination from several more files.

## Checklist
- [x] `cc` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
