### PR TITLE
BCCD and CC docs

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -2790,6 +2790,8 @@ def run_bccd(name, **kwargs):
     else:
         raise ValidationError("proc.py:run_bccd name %s not recognized" % name)
 
+    if (corl_type := method_algorithm_type(name).now) != "CONV":
+        raise ValidationError(f"Invalid type {corl_type} for CCENERGY energy through `run_bccd`. See Capabilities Table")
 
     # Bypass routine scf if user did something special to get it to converge
     ref_wfn = kwargs.get('ref_wfn', None)
@@ -2816,6 +2818,21 @@ def run_bccd(name, **kwargs):
         except Exception:
             raise PastureRequiredError("RUN_CCTRANSORT")
 
+    hold_qcvars = {
+        "MP2 TOTAL ENERGY": None,
+        "MP2 CORRELATION ENERGY": None,
+        "MP2 SAME-SPIN CORRELATION ENERGY": None,
+        "MP2 OPPOSITE-SPIN CORRELATION ENERGY": None,
+        "MP2 SINGLES ENERGY": None,
+        "MP2 DOUBLES ENERGY": None,
+        "CCSD TOTAL ENERGY": None,
+        "CCSD CORRELATION ENERGY": None,
+        "CCSD SAME-SPIN CORRELATION ENERGY": None,
+        "CCSD OPPOSITE-SPIN CORRELATION ENERGY": None,
+        "CCSD SINGLES ENERGY": None,
+        "CCSD DOUBLES ENERGY": None,
+    }
+
     while True:
         sort_func(ref_wfn)
 
@@ -2830,11 +2847,48 @@ def run_bccd(name, **kwargs):
             break
         bcc_iter_cnt += 1
 
+        if bcc_iter_cnt == 1:
+            for pv in hold_qcvars:
+                hold_qcvars[pv] = ref_wfn.variable(pv)
+
+    ref_wfn.set_variable("BCCD TOTAL ENERGY", ref_wfn.variable("CCSD TOTAL ENERGY"))
+    ref_wfn.set_variable("BCCD CORRELATION ENERGY", ref_wfn.variable("BCCD TOTAL ENERGY") - ref_wfn.variable("SCF TOTAL ENERGY"))
+    ref_wfn.set_variable("CURRENT CORRELATION ENERGY", ref_wfn.variable("BCCD CORRELATION ENERGY"))
+
+    # copy back canonical MP2 and CCSD from initial iteration
+    for pv, v in hold_qcvars.items():
+        if v is not None:
+            ref_wfn.set_variable(pv, v)
+            core.set_variable(pv, v)
+
     if name == 'bccd(t)':
         core.cctriples(ref_wfn)
+        ref_wfn.set_variable("B(T) CORRECTION ENERGY", ref_wfn.variable("(T) CORRECTION ENERGY"))
+        ref_wfn.set_variable("BCCD(T) TOTAL ENERGY", ref_wfn.variable("CCSD(T) TOTAL ENERGY"))
+        ref_wfn.set_variable("BCCD(T) CORRELATION ENERGY", ref_wfn.variable("BCCD(T) TOTAL ENERGY") - ref_wfn.variable("SCF TOTAL ENERGY"))  # note != CCSD(T) CORRELATION ENERGY
+        ref_wfn.set_variable("CURRENT CORRELATION ENERGY", ref_wfn.variable("BCCD(T) CORRELATION ENERGY"))
+
+        for pv in ["(T) CORRECTION ENERGY", "CCSD(T) TOTAL ENERGY", "CCSD(T) CORRELATION ENERGY"]:
+            ref_wfn.del_variable(pv)
+            core.del_variable(pv)
+
+    for pv in [
+        "BCCD TOTAL ENERGY",
+        "BCCD CORRELATION ENERGY",
+        "B(T) CORRECTION ENERGY",
+        "BCCD(T) TOTAL ENERGY",
+        "BCCD(T) CORRELATION ENERGY",
+        "CURRENT CORRELATION ENERGY",
+    ]:
+        if ref_wfn.has_variable(pv):
+            core.set_variable(pv, ref_wfn.variable(pv))
+
+    # Notes
+    # * BCCD or BCCD(T) correlation energy is total energy of last Brueckner iteration minus HF energy of first Brueckner iteration
 
     optstash.restore()
     return ref_wfn
+
 
 def run_tdscf_excitations(wfn,**kwargs):
 

--- a/psi4/src/psi4/cc/ccenergy/get_params.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_params.cc
@@ -161,7 +161,7 @@ void CCEnergyWavefunction::get_params(Options &options) {
     if (options["BRUECKNER_ORBS_R_CONVERGENCE"].has_changed())
         params_.bconv = options.get_double("BRUECKNER_ORBS_R_CONVERGENCE");
     else
-        params_.bconv = 100.0 * params_.e_convergence;
+        params_.bconv = 50.0 * params_.e_convergence;
 
     params_.print_mp2_amps = options.get_bool("MP2_AMPS_PRINT");
     params_.print_pair_energies = options.get_bool("PAIR_ENERGIES_PRINT");

--- a/tests/cc15/input.dat
+++ b/tests/cc15/input.dat
@@ -17,5 +17,5 @@ escf = -76.021997876298414 #TEST
 ebccd = -76.228456597086762 #TEST
 ebccd_t = -76.231452929871523 #TEST
 compare_values(escf, variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
-compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 6, "B-CCD energy") #TEST
-compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energy") #TEST
+compare_values(ebccd, variable("BCCD TOTAL ENERGY"), 6, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("BCCD(T) TOTAL ENERGY"), 6, "B-CCD(T) energy") #TEST

--- a/tests/cc16/input.dat
+++ b/tests/cc16/input.dat
@@ -21,8 +21,8 @@ escf = -38.917378694797030 #TEST
 ebccd = -39.030833895315020 #TEST
 ebccd_t = -39.032691827829460 #TEST
 compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
-compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
+compare_values(ebccd, variable("BCCD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("BCCD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
 
 
 # We should obtain the same result as above, but start with different orbitals
@@ -36,5 +36,5 @@ escf = -38.91341670976116 #TEST
 ebccd = -39.030807046983838 #TEST
 ebccd_t = -39.032665163463861 #TEST
 compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
-compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
+compare_values(ebccd, variable("BCCD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("BCCD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST


### PR DESCRIPTION
## Description

@lothian, I was looking at the qcvars set by the Brueckner methods. For review, cc* module has been storing the HF energy of the first Brueckner iteration as `SCF TOTAL ENERGY` and the quantities from the final B iteration as `CCSD TOTAL ENERGY`, `CCSD(T) TOTAL ENERGY`, and `(T) CORRECTION ENERGY`. In the below, I've reworked it so:
* final B energies get their own qcvars `(BCCD|BCCD(T)) (TOTAL|CORRELATION) ENERGY` in accordance with the principle that `energy(mtd)` should set `mtd TOTAL ENERGY`
* MP2 and CCSD qcvars are now collected from the first B iteration, not the last, so they have canonical values. `SCF TOTAL ENERGY` still from first B iteration.
* `(BCCD|BCCD(T)) CORRELATION ENERGY` now defined as total E of last B iteration minus HF of first B iteration. This is in accordance with the pattern that `mtd CORRELATION ENERGY` = `mtd TOTAL ENERGY` - `SCF TOTAL ENERGY`, but it is admittedly wacky when applied to Brueckner. It is, however, the same way the orbital-optimized methods of occ/dfocc have been handled. The OO methods additionally set a `mtd REFERENCE CORRECTION ENERGY` so that one can recover the ref/corl split of the final OO iteration. That could be added to the BCCD methods.

Does the above sound ok, or does it need further reworking? I also tightened up the B r_conv formula a bit because the standard tests (not shown in PR) weren't matching (to 1.e-6) the highly converged values under default conditions (e_conv = 6 --> brueckner_r_conv =4).

I've also been on a rampage of late to better (and automatically) document what methods are available under what detailed conditions (e.g., dertype, reference, conv/df/cd type, all-electron/frozen-core). I'd like to add the table snapshotted below to the main [CC docs page](https://psicode.org/psi4manual/master/cc.html). Unfortunately, it doesn't cover excited states or properties, so it can't replace the existing summary table, but it does provide more detail. Does it look ok, and are there any cc* capabilities in the ground-state realm that I've missed?

**Note:** No worries if the CI on this fails. I've copied over the stuff that's important to look at, not necessarily all needed to run.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Add and change definitions of qcvars for BCCD and BCCD(T)
- [x] Tighten default Brueckner convergence

<img width="921" alt="Screen Shot 2022-08-30 at 12 34 26 AM" src="https://user-images.githubusercontent.com/2314730/187350163-42fff29c-3159-404f-9177-ae4cf8e48dff.png">

## Status
- [ ] Ready for review
- [ ] Ready for merge
