### PR TITLE
Renovate the psio_error(...) function

### DIFF
--- a/psi4/src/psi4/libpsio/error.cc
+++ b/psi4/src/psi4/libpsio/error.cc
@@ -31,13 +31,10 @@
  ** \ingroup PSIO
  */
 
-#include <cstdio>
-#include <cstdlib>
+#include <iostream>
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
-#include "psi4/psi4-dec.h"
 
 namespace psi {
 
@@ -46,91 +43,93 @@ namespace psi {
  **
  ** PSIO_ERROR(): Print out an error message for libpsio.
  **
- ** \param unit   = file number
- ** \param errval = error code (defined symbolically, PSIO_ERROR_XXX)
+ ** \param unit     = file number
+ ** \param errval   = error code (defined symbolically, PSIO_ERROR_XXX)
+ ** \param prev_msg = (optional) A previous error message that should be prepended to the text from this function.
  **
  */
-void psio_error(size_t unit, size_t errval) {
-    int i;
-    fprintf(stderr, "PSIO_ERROR: unit = %zu, errval = %zu\n", unit, errval);
+void psio_error(size_t unit, size_t errval, std::string prev_msg /* = ""*/) {
+    std::cerr << "PSIO_ERROR: unit = " << unit << ", errval = " << errval << std::endl;
     /* Try to save the TOCs for all open units */
     /* psio_tocwrite() does not call psio_error() so this is OK */
-    for (i = 0; i < PSIO_MAXUNIT; i++) psio_tocwrite(i);
-    auto msg = new char[800];
+    for (int i = 0; i < PSIO_MAXUNIT; i++) psio_tocwrite(i);
+    if ((prev_msg.length() > 0) && (prev_msg.back() != '\n')) {
+        prev_msg += '\n';
+    }
     switch (errval) {
         case PSIO_ERROR_INIT:
-            sprintf(msg,"PSIO_ERROR: %d (I/O inititalization failed)\n", PSIO_ERROR_INIT);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_INIT) + " (I/O inititalization failed)\n";
             break;
         case PSIO_ERROR_DONE:
-            sprintf(msg,"PSIO_ERROR: %d (I/O cleanup failed)\n", PSIO_ERROR_DONE);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_DONE) + " (I/O cleanup failed)\n";
             break;
         case PSIO_ERROR_MAXVOL:
-            sprintf(msg,"PSIO_ERROR: %d (maximum number of volumes exceeded)\n", PSIO_ERROR_MAXVOL);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_MAXVOL) + " (maximum number of volumes exceeded)\n";
             break;
         case PSIO_ERROR_NOVOLPATH:
-            sprintf(msg,"PSIO_ERROR: %d (no volume path given)\n", PSIO_ERROR_NOVOLPATH);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_NOVOLPATH) + " (no volume path given)\n";
             break;
         case PSIO_ERROR_IDENTVOLPATH:
-            sprintf(msg,"PSIO_ERROR: %d (two identical volume paths)\n", PSIO_ERROR_IDENTVOLPATH);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_IDENTVOLPATH) + " (two identical volume paths)\n";
             break;
         case PSIO_ERROR_OPEN:
-            sprintf(msg,"PSIO_ERROR: %d (open call failed)\n\n"
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_OPEN) + " (open call failed)\n\n"
                         " Check the location of your scratch directory which can be\n"
                         " specified via the $PSI_SCRATCH environment variable.\n"
-                        " A local (non-network) scratch disk is strongly preferred.\n\n"
+                        " A fast, local (non-network) scratch disk is strongly preferred.\n\n"
                         " Please note that the scratch directory must exist, be\n"
-                        " writable by Psi4, and have available space.\n", PSIO_ERROR_OPEN);
+                        " writable by Psi4, and have available space.\n";
             break;
         case PSIO_ERROR_REOPEN:
-            sprintf(msg,"PSIO_ERROR: %d (file is already open)\n", PSIO_ERROR_REOPEN);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_REOPEN) + " (file is already open)\n";
             break;
         case PSIO_ERROR_CLOSE:
-            sprintf(msg,"PSIO_ERROR: %d (file close failed)\n", PSIO_ERROR_CLOSE);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_CLOSE) + " (file close failed)\n";
             break;
         case PSIO_ERROR_RECLOSE:
-            sprintf(msg,"PSIO_ERROR: %d (file is already closed)\n", PSIO_ERROR_RECLOSE);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_RECLOSE) + " (file is already closed)\n";
             break;
         case PSIO_ERROR_OSTAT:
-            sprintf(msg,"PSIO_ERROR: %d (invalid status flag for file open)\n", PSIO_ERROR_OSTAT);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_OSTAT) + " (invalid status flag for file open)\n";
             break;
         case PSIO_ERROR_LSEEK:
-            sprintf(msg,"PSIO_ERROR: %d (lseek failed)\n", PSIO_ERROR_LSEEK);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_LSEEK) + " (lseek failed)\n";
             break;
         case PSIO_ERROR_NOTOCENT:
-            sprintf(msg,"PSIO_ERROR: %d (no such TOC entry)\n", PSIO_ERROR_NOTOCENT);
-            // sprintf(msg,"PSIO_ERROR: %d (no such TOC entry)\n", PSIO_ERROR_NOTOCENT);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_NOTOCENT) + " (no such TOC entry)\n";
             break;
         case PSIO_ERROR_TOCENTSZ:
-            sprintf(msg,"PSIO_ERROR: %d (TOC entry size mismatch)\n", PSIO_ERROR_TOCENTSZ);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_TOCENTSZ) + " (TOC entry size mismatch)\n";
             break;
         case PSIO_ERROR_KEYLEN:
-            sprintf(msg,"PSIO_ERROR: %d (TOC key too long)\n", PSIO_ERROR_KEYLEN);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_KEYLEN) + " (TOC key too long)\n";
             break;
         case PSIO_ERROR_BLKSIZ:
-            sprintf(msg,"PSIO_ERROR: %d (Requested blocksize invalid)\n", PSIO_ERROR_BLKSIZ);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_BLKSIZ) + " (Requested blocksize invalid)\n";
             break;
         case PSIO_ERROR_BLKSTART:
-            sprintf(msg,"PSIO_ERROR: %d (Incorrect block start address)\n", PSIO_ERROR_BLKSTART);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_BLKSTART) + " (Incorrect block start address)\n";
             break;
         case PSIO_ERROR_BLKEND:
-            sprintf(msg,"PSIO_ERROR: %d (Incorrect block end address)\n", PSIO_ERROR_BLKEND);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_BLKEND) + " (Incorrect block end address)\n";
             break;
         case PSIO_ERROR_WRITE:
-            sprintf(msg,"PSIO_ERROR: %d (error writing to file)\n", PSIO_ERROR_WRITE);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_WRITE) + " (error writing to file)\n";
             break;
         case PSIO_ERROR_MAXUNIT:
-            sprintf(msg,"PSIO_ERROR: %d (Maximum unit number exceeded)\n"
-                        " Open failed because unit %zu exceeds "
-                        " PSIO_MAXUNIT = %d.\n",PSIO_ERROR_MAXUNIT, unit, PSIO_MAXUNIT);
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_MAXUNIT) + " (Maximum unit number exceeded)\n";
+            prev_msg += " Open failed because unit " + std::to_string(unit) + " exceeds PSIO_MAXUNIT = ";
+            prev_msg += std::to_string(PSIO_MAXUNIT) + ".\n";
             break;
         case PSIO_ERROR_UNOPENED:
-            sprintf(msg,"PSIO_ERROR: %d (File not opened)\n" 
-                        " You need to open file %zu before you attempt this operation,\n"
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_UNOPENED) + " (File not opened)\n";
+            prev_msg += " You need to open file " + std::to_string(unit) +
+                        " before you attempt this operation,\n"
                         " If you're a user, contact developers immediately. This is a bug.\n"
-                        " If you're a developer, get yourself some coffee.\n", PSIO_ERROR_UNOPENED,  unit);
+                        " If you're a developer, get yourself some coffee.\n";
             break;
     }
-    throw PSIEXCEPTION(msg);
+    throw PSIEXCEPTION(prev_msg);
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libpsio/error.cc
+++ b/psi4/src/psi4/libpsio/error.cc
@@ -116,7 +116,7 @@ void psio_error(size_t unit, size_t errval, std::string prev_msg /* = ""*/) {
             prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_WRITE) + " (error writing to file)\n";
             break;
         case PSIO_ERROR_MAXUNIT:
-            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_MAXUNIT) + " (Maximum unit number exceeded)\n";
+            prev_msg += "PSIO_ERROR: " + std::to_string(PSIO_ERROR_MAXUNIT) + " (Maximum unit number exceeded)\n";
             prev_msg += " Open failed because unit " + std::to_string(unit) + " exceeds PSIO_MAXUNIT = ";
             prev_msg += std::to_string(PSIO_MAXUNIT) + ".\n";
             break;

--- a/psi4/src/psi4/libpsio/error.cc
+++ b/psi4/src/psi4/libpsio/error.cc
@@ -34,7 +34,6 @@
 #include <iostream>
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libpsio/psio.hpp"
 
 namespace psi {
 

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -39,7 +39,7 @@ int psio_init();
 int psio_ipv1_config();
 int psio_state();
 int psio_done();
-void psio_error(size_t unit, size_t errval);
+void psio_error(size_t unit, size_t errval, std::string prev_msg = "");
 int psio_open(size_t unit, int status);
 int psio_close(size_t unit, int keep);
 std::string psio_getpid();


### PR DESCRIPTION
## Description
Errors in PSIO should probably be handled by calling `psio_error(...)`, instead of printing the error messages from the function where the error happens.

This PR renovates this function to something more C++-style, and adds a new string argument that defaults to the empty string. This allows the callers of the function to prepend their own error messages to the text that eventually ends up in the error box, such as OS supplied error messages when a read/write/lseek system call fails.

This should make it easier to clean up `wt_toclen` etc. (see #2700)

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] `psio_error(...)` can now take a string argument that will be printed first
- [x] Unnecessary includes are removed
- [x] Fixed size char array and C-style string manipulation is gone

## Status
- [x] Ready for review
- [x] Ready for merge
