### PR TITLE
Close #2712

### DIFF
--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -52,6 +52,7 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libscf_solver/hf.h"
 #include "psi4/libqt/qt.h"
 
 #include "python_data_type.h"
@@ -211,10 +212,10 @@ SharedWavefunction gdma_interface(SharedWavefunction, Options&, const std::strin
 
 // Matrix returns
 namespace scfgrad {
-SharedMatrix scfgrad(SharedWavefunction, Options&);
+SharedMatrix scfgrad(std::shared_ptr<scf::HF>, Options&);
 }
 namespace scfgrad {
-SharedMatrix scfhess(SharedWavefunction, Options&);
+SharedMatrix scfhess(std::shared_ptr<scf::HF>, Options&);
 }
 
 // Does not create a wavefunction
@@ -325,12 +326,12 @@ void py_psi_opt_clean(void) { opt::opt_clean(); }
 //     return mints::mints(Process::environment.options);
 // }
 
-SharedMatrix py_psi_scfgrad(SharedWavefunction ref_wfn) {
+SharedMatrix py_psi_scfgrad(std::shared_ptr<scf::HF> ref_wfn) {
     py_psi_prepare_options_for_module("SCF");
     return scfgrad::scfgrad(ref_wfn, Process::environment.options);
 }
 
-SharedMatrix py_psi_scfhess(SharedWavefunction ref_wfn) {
+SharedMatrix py_psi_scfhess(std::shared_ptr<scf::HF> ref_wfn) {
     py_psi_prepare_options_for_module("SCF");
     return scfgrad::scfhess(ref_wfn, Process::environment.options);
 }

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -73,14 +73,13 @@ extern bool brianEnableDFT;
 namespace psi {
 namespace scfgrad {
 
-SCFDeriv::SCFDeriv(SharedWavefunction ref_wfn, Options& options) :
+SCFDeriv::SCFDeriv(std::shared_ptr<scf::HF> ref_wfn, Options& options) :
     Wavefunction(options)
 {
     shallow_copy(ref_wfn);
     common_init();
-    scf::HF* scfwfn = (scf::HF*)ref_wfn.get();
-    functional_ = scfwfn->functional();
-    potential_ = scfwfn->V_potential();
+    functional_ = ref_wfn->functional();
+    potential_ = ref_wfn->V_potential();
     if (ref_wfn->has_array_variable("-D Gradient")) {
         gradients_["-D Gradient"] = ref_wfn->array_variable("-D Gradient");
     }

--- a/psi4/src/psi4/scfgrad/scf_grad.h
+++ b/psi4/src/psi4/scfgrad/scf_grad.h
@@ -29,9 +29,10 @@
 #ifndef SCF_GRAD_H
 #define SCF_GRAD_H
 
+#include "psi4/libfock/jk.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/typedefs.h"
-#include "psi4/libfock/jk.h"
+#include "psi4/libscf_solver/hf.h"
 
 namespace psi {
 class SuperFunctional;
@@ -55,7 +56,7 @@ protected:
     std::map<std::string, SharedMatrix> hessians_;
 
 public:
-    SCFDeriv(SharedWavefunction ref_wfn, Options& options);
+    SCFDeriv(std::shared_ptr<scf::HF> ref_wfn, Options& options);
     ~SCFDeriv() override;
 
     double compute_energy() override { throw PSIEXCEPTION("SCFDeriv not implemented for the requested reference type."); }
@@ -68,7 +69,7 @@ class RSCFDeriv : public SCFDeriv {
 protected:
     std::shared_ptr<scf::RHF> rhf_wfn_;
 public:
-    RSCFDeriv(std::shared_ptr<scf::RHF> rhf_wfn, Options& options): SCFDeriv(std::dynamic_pointer_cast<Wavefunction>(rhf_wfn), options), rhf_wfn_(rhf_wfn) {}
+    RSCFDeriv(std::shared_ptr<scf::RHF> rhf_wfn, Options& options): SCFDeriv(std::static_pointer_cast<scf::HF>(rhf_wfn), options), rhf_wfn_(rhf_wfn) {}
     ~RSCFDeriv() override {}
     virtual SharedMatrix hessian_response() override;
 };
@@ -132,7 +133,7 @@ protected:
                             int nso, int n1occ, int n2occ, int n1vir);
 
 public:
-    USCFDeriv(std::shared_ptr<scf::UHF> uhf_wfn, Options& options): SCFDeriv(std::dynamic_pointer_cast<Wavefunction>(uhf_wfn), options), uhf_wfn_(uhf_wfn) {}
+    USCFDeriv(std::shared_ptr<scf::UHF> uhf_wfn, Options& options): SCFDeriv(std::static_pointer_cast<scf::HF>(uhf_wfn), options), uhf_wfn_(uhf_wfn) {}
     ~USCFDeriv() override {}
     virtual SharedMatrix hessian_response() override;
 };

--- a/psi4/src/psi4/scfgrad/wrapper.cc
+++ b/psi4/src/psi4/scfgrad/wrapper.cc
@@ -38,7 +38,7 @@
 namespace psi{
 namespace scfgrad {
 
-SharedMatrix scfgrad(SharedWavefunction ref_wfn, Options &options)
+SharedMatrix scfgrad(std::shared_ptr<scf::HF> ref_wfn, Options &options)
 {
     tstart();
 
@@ -49,17 +49,17 @@ SharedMatrix scfgrad(SharedWavefunction ref_wfn, Options &options)
     return G;
 }
 
-SharedMatrix scfhess(SharedWavefunction ref_wfn, Options &options)
+SharedMatrix scfhess(std::shared_ptr<scf::HF> ref_wfn, Options &options)
 {
     tstart();
 
     SharedMatrix H;
     if( ref_wfn->same_a_b_orbs() && ref_wfn->same_a_b_dens()) {
         // RHF
-        RSCFDeriv hessian_computer(std::dynamic_pointer_cast<scf::RHF>(ref_wfn), options);
+        RSCFDeriv hessian_computer(std::static_pointer_cast<scf::RHF>(ref_wfn), options);
         H = hessian_computer.compute_hessian();
     } else {
-        USCFDeriv hessian_computer(std::dynamic_pointer_cast<scf::UHF>(ref_wfn), options);
+        USCFDeriv hessian_computer(std::static_pointer_cast<scf::UHF>(ref_wfn), options);
         H = hessian_computer.compute_hessian();
     }
     ref_wfn->set_hessian(H);

--- a/psi4/src/psi4/scfgrad/wrapper.cc
+++ b/psi4/src/psi4/scfgrad/wrapper.cc
@@ -56,10 +56,10 @@ SharedMatrix scfhess(std::shared_ptr<scf::HF> ref_wfn, Options &options)
     SharedMatrix H;
     if( ref_wfn->same_a_b_orbs() && ref_wfn->same_a_b_dens()) {
         // RHF
-        RSCFDeriv hessian_computer(std::static_pointer_cast<scf::RHF>(ref_wfn), options);
+        RSCFDeriv hessian_computer(std::dynamic_pointer_cast<scf::RHF>(ref_wfn), options);
         H = hessian_computer.compute_hessian();
     } else {
-        USCFDeriv hessian_computer(std::static_pointer_cast<scf::UHF>(ref_wfn), options);
+        USCFDeriv hessian_computer(std::dynamic_pointer_cast<scf::UHF>(ref_wfn), options);
         H = hessian_computer.compute_hessian();
     }
     ref_wfn->set_hessian(H);

--- a/tests/pytests/test_gradients.py
+++ b/tests/pytests/test_gradients.py
@@ -59,3 +59,16 @@ def test_gradient(inp):
     assert compare_values(findif_gradient, analytic_gradient, 5, "analytic vs. findif gradient")
     assert compare_values(reference_gradient, analytic_gradient.np, 5, "analytic vs. reference gradient")
 
+def test_gradient_ref():
+    h2o = psi4.geometry("""
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+    """)
+
+    psi4.set_options({"basis": "cc-pVDZ"})
+    mp2_wfn = psi4.energy("mp2", return_wfn=True)[1]
+    with pytest.raises(TypeError):
+        psi4.gradient("scf", ref_wfn=mp2_wfn)
+    scf_wfn = psi4.energy("scf", return_wfn=True)[1]
+    psi4.gradient("scf", ref_wfn=scf_wfn)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Closes #2712. Please do not use C-style casting for complicated types.

## Release Notes Delta
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] **Bugfix:** Seeding an SCF gradient with a ref_wfn that isn't SCF now raises an error rather than a segfault.

## Checklist
- [x] `grad` and `hess` ctests pass.

## Status
- [x] Ready for review
- [x] Ready for merge
